### PR TITLE
Add Travis CI to compose core RPM packages

### DIFF
--- a/.travis.test
+++ b/.travis.test
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+WORKDIR="${BUILDDIR:-/tmp/builddir}"
+BUILDUSER=builduser
+BUILDUSER_UID=${UID:-1000}
+BUILDUSER_GID=${GID:-1000}
+
+. /etc/os-release
+
+echo "$NAME $VERSION $1"
+
+## compose_pki_core_packages doesn't run as root, create a build user
+groupadd --non-unique -g $BUILDUSER_GID ${BUILDUSER}
+useradd --non-unique -u $BUILDUSER_UID -g $BUILDUSER_GID ${BUILDUSER}
+
+## chown workdir and enter pki dir
+chown ${BUILDUSER}:${BUILDUSER} ${WORKDIR}
+cd ${WORKDIR}/pki
+
+## prepare additional build dependencies
+dnf copr -y enable @pki/10.4
+dnf builddep -y ./specs/pki-core.spec
+
+# update, container might be outdated
+dnf update -y
+
+## run tox and build
+# run make with --quiet to reduce log verbosity. Travis CI has a log limit
+# of 10,000 lines.
+sudo -u ${BUILDUSER} MAKEFLAGS="-j2 --quiet" -s -- ./scripts/compose_pki_core_packages rpms

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+language: python
+
+services:
+  - docker
+
+env:
+  - CONTAINER=dogtagpki/pki-ci-containers:f25_104
+  - CONTAINER=dogtagpki/pki-ci-containers:f26_104
+  - CONTAINER=dogtagpki/pki-ci-containers:rawhide
+
+script:
+  - docker pull $CONTAINER
+  - >
+    docker run
+    -v $(pwd):/tmp/workdir/pki
+    -e UID=$(id -u)
+    -e GID=$(id -g)
+    $CONTAINER
+    /tmp/workdir/pki/.travis.test $CONTAINER


### PR DESCRIPTION
The command "./scripts/compose_pki_core_packages rpms" is tested on
Fedora 25, 26 and rawhide. On 25 and 26, the COPR @pki/10.4 is enabled
to provide additional build dependencies.

Travis Ci is configured to use pre-populated Docker images from
https://github.com/dogtagpki/pki-ci-containers . The images contain
build dependencies.

Signed-off-by: Christian Heimes <cheimes@redhat.com>