### PR TITLE
Don't assume /bin -> /usr/bin symlink exists

### DIFF
--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -19,13 +19,13 @@ add_custom_target(pki-ca-lib ALL)
 add_custom_command(
     TARGET pki-ca-lib
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-ca.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-ca.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-ca.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-ca.jar
 )
 
 # install directories

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -35,10 +35,10 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/share/java/jaxb-api.jar lib/jaxb-api.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/lib/java/jss4.jar lib/jss4.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/share/java/ldapjdk.jar lib/ldapjdk.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-certsrv.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-cmsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-nsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-tools.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-tools.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-certsrv.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-cmsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-nsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-tools.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-tools.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${RESTEASY_LIB}/resteasy-atom-provider.jar lib/resteasy-atom-provider.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${RESTEASY_LIB}/resteasy-client.jar lib/resteasy-client.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${RESTEASY_LIB}/resteasy-jackson-provider.jar lib/resteasy-jackson-provider.jar

--- a/base/java-tools/src/com/netscape/cmstools/cli/HelpCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/HelpCLI.java
@@ -68,7 +68,7 @@ public class HelpCLI extends CLI {
         while (true) {
             // display man page for the command
             ProcessBuilder pb = new ProcessBuilder(
-                    "/bin/man",
+                    "/usr/bin/man",
                     manPage);
 
             pb.inheritIO();

--- a/base/java-tools/src/com/netscape/cmstools/client/ClientCertImportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/client/ClientCertImportCLI.java
@@ -333,7 +333,7 @@ public class ClientCertImportCLI extends CLI {
         }
 
         List<String> command = new ArrayList<>();
-        command.add("/bin/certutil");
+        command.add("/usr/bin/certutil");
         command.add("-A");
         command.add("-d");
         command.add(dbPath.getAbsolutePath());
@@ -541,7 +541,7 @@ public class ClientCertImportCLI extends CLI {
             String pkcs12PasswordFile) throws Exception {
 
         List<String> command = new ArrayList<>();
-        command.add("/bin/pk12util");
+        command.add("/usr/bin/pk12util");
         command.add("-d");
         command.add(dbPath.getAbsolutePath());
 

--- a/base/java-tools/src/com/netscape/cmstools/client/ClientCertShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/client/ClientCertShowCLI.java
@@ -193,7 +193,7 @@ public class ClientCertShowCLI extends CLI {
             String nickname) throws Exception {
 
         String[] command = {
-                "/bin/pk12util",
+                "/usr/bin/pk12util",
                 "-d", dbPath,
                 "-K", dbPassword,
                 "-o", pkcs12Path,
@@ -214,7 +214,7 @@ public class ClientCertShowCLI extends CLI {
             String certPath) throws Exception {
 
         String[] command = {
-                "/bin/openssl",
+                "/usr/bin/openssl",
                 "pkcs12",
                 "-clcerts", // certificate only
                 "-nokeys",
@@ -236,7 +236,7 @@ public class ClientCertShowCLI extends CLI {
             String privateKeyPath) throws Exception {
 
         String[] command = {
-                "/bin/openssl",
+                "/usr/bin/openssl",
                 "pkcs12",
                 "-nocerts", // private key only
                 "-nodes",   // no encryption
@@ -258,7 +258,7 @@ public class ClientCertShowCLI extends CLI {
             String clientCertPath) throws Exception {
 
         String[] command = {
-                "/bin/openssl",
+                "/usr/bin/openssl",
                 "pkcs12",
                 "-clcerts", // client certificate and private key
                 "-nodes",   // no encryption

--- a/base/kra/CMakeLists.txt
+++ b/base/kra/CMakeLists.txt
@@ -19,13 +19,13 @@ add_custom_target(pki-kra-lib ALL)
 add_custom_command(
     TARGET pki-kra-lib
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-kra.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-kra.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-kra.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-kra.jar
 )
 
 # install directories

--- a/base/ocsp/CMakeLists.txt
+++ b/base/ocsp/CMakeLists.txt
@@ -19,13 +19,13 @@ add_custom_target(pki-ocsp-lib ALL)
 add_custom_command(
     TARGET pki-ocsp-lib
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-ocsp.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-ocsp.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-ocsp.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-ocsp.jar
 )
 
 # install directories

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -117,7 +117,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/lib/java/jss4.jar common/lib/jss4.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/share/java/ldapjdk.jar common/lib/ldapjdk.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/lib/java/nuxwdog.jar common/lib/nuxwdog.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-tomcat.jar ${CMAKE_CURRENT_BINARY_DIR}/common/lib/pki-tomcat.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-tomcat.jar ${CMAKE_CURRENT_BINARY_DIR}/common/lib/pki-tomcat.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${RESTEASY_LIB}/resteasy-atom-provider.jar common/lib/resteasy-atom-provider.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${RESTEASY_LIB}/resteasy-client.jar common/lib/resteasy-client.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${RESTEASY_LIB}/resteasy-jackson-provider.jar common/lib/resteasy-jackson-provider.jar
@@ -127,7 +127,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/share/java/scannotation.jar common/lib/scannotation.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${SLF4J_API_JAR} common/lib/slf4j-api.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${SLF4J_JDK14_JAR} common/lib/slf4j-jdk14.jar
-    COMMAND /usr/bin/ln -sf /usr/lib/java/symkey.jar ${CMAKE_CURRENT_BINARY_DIR}/common/lib/symkey.jar
+    COMMAND /bin/ln -sf /usr/lib/java/symkey.jar ${CMAKE_CURRENT_BINARY_DIR}/common/lib/symkey.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/share/java/tomcatjss.jar common/lib/tomcatjss.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/share/java/velocity.jar common/lib/velocity.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink /usr/share/java/xerces-j2.jar common/lib/xerces-j2.jar
@@ -142,12 +142,12 @@ add_custom_target(pki-server-webapp-lib ALL)
 add_custom_command(
     TARGET pki-server-webapp-lib
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
 )
 
 install(

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -3082,7 +3082,7 @@ class KRAConnector:
     def execute_using_pki(
             self, caport, cahost, subsystemnick,
             token_pwd, krahost, kraport, critical_failure=False):
-        command = ["/bin/pki",
+        command = ["/usr/bin/pki",
                    "-p", str(caport),
                    "-h", cahost,
                    "-n", subsystemnick,
@@ -3227,7 +3227,7 @@ class TPSConnector:
     def execute_using_pki(
             self, tkshost, tksport, subsystemnick,
             token_pwd, tpshost, tpsport, critical_failure=False):
-        command = ["/bin/pki",
+        command = ["/usr/bin/pki",
                    "-p", str(tksport),
                    "-h", tkshost,
                    "-n", subsystemnick,

--- a/base/tks/CMakeLists.txt
+++ b/base/tks/CMakeLists.txt
@@ -19,13 +19,13 @@ add_custom_target(pki-tks-lib ALL)
 add_custom_command(
     TARGET pki-tks-lib
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-tks.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-tks.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-tks.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-tks.jar
 )
 
 # install directories

--- a/base/tps/CMakeLists.txt
+++ b/base/tps/CMakeLists.txt
@@ -21,13 +21,13 @@ add_custom_target(pki-tps-lib ALL)
 add_custom_command(
     TARGET pki-tps-lib
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
-    COMMAND /usr/bin/ln -sf /usr/share/java/pki/pki-tps.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-tps.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-nsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-nsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsutil.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmscore.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmscore.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-cmsbundle.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cmsbundle.jar
+    COMMAND /bin/ln -sf /usr/share/java/pki/pki-tps.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-tps.jar
 )
 
 # install manual pages

--- a/dogtag/common-ui/CMakeLists.txt
+++ b/dogtag/common-ui/CMakeLists.txt
@@ -5,15 +5,15 @@ add_custom_target(pki-server-theme-links ALL)
 add_custom_command(
     TARGET pki-server-theme-links
     COMMAND ${CMAKE_COMMAND} -E make_directory links
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/ca ${CMAKE_CURRENT_BINARY_DIR}/links/
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/css ${CMAKE_CURRENT_BINARY_DIR}/links/
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/esc ${CMAKE_CURRENT_BINARY_DIR}/links/
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/fonts ${CMAKE_CURRENT_BINARY_DIR}/links/
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/images ${CMAKE_CURRENT_BINARY_DIR}/links/
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/kra ${CMAKE_CURRENT_BINARY_DIR}/links/
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/ocsp ${CMAKE_CURRENT_BINARY_DIR}/links/
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/pki.properties ${CMAKE_CURRENT_BINARY_DIR}/links/pki.properties
-    COMMAND /usr/bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/tks ${CMAKE_CURRENT_BINARY_DIR}/links/
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/ca ${CMAKE_CURRENT_BINARY_DIR}/links/
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/css ${CMAKE_CURRENT_BINARY_DIR}/links/
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/esc ${CMAKE_CURRENT_BINARY_DIR}/links/
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/fonts ${CMAKE_CURRENT_BINARY_DIR}/links/
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/images ${CMAKE_CURRENT_BINARY_DIR}/links/
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/kra ${CMAKE_CURRENT_BINARY_DIR}/links/
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/ocsp ${CMAKE_CURRENT_BINARY_DIR}/links/
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/pki.properties ${CMAKE_CURRENT_BINARY_DIR}/links/pki.properties
+    COMMAND /bin/ln -sf ${DATA_INSTALL_DIR}/common-ui/tks ${CMAKE_CURRENT_BINARY_DIR}/links/
 )
 
 install(


### PR DESCRIPTION
Be more consistent with hardcoding paths, and use paths that work on
other distros too which don't have a /bin -> /usr/bin symlink.