### PR TITLE
Fix CMake PKI_CMSBUNDLE_JAR variable type

### DIFF
--- a/base/server/cmsbundle/src/CMakeLists.txt
+++ b/base/server/cmsbundle/src/CMakeLists.txt
@@ -27,4 +27,4 @@ install(
         ${JAVA_JAR_INSTALL_DIR}/pki
 )
 
-set(PKI_CMSBUNDLE_JAR ${CMAKE_BINARY_DIR}/dist/pki-cmsbundle.jar INTERNAL "pki-cmsbundle jar file")
+set(PKI_CMSBUNDLE_JAR ${CMAKE_BINARY_DIR}/dist/pki-cmsbundle.jar CACHE INTERNAL "pki-cmsbundle jar file")


### PR DESCRIPTION
Currently PKI_CMSBUNDLE_JAR variable is defined as NORMAL, but with TYPE INTERNAL.
Therefore, in my case, it equals to `'/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/dist/pki-cmsbundle.jarINTERNALpki-cmsbundle jar file'`

There are messages like below while building:

`cd /usr/src/RPM/BUILD/pki-core-10.5.3/base/server/test && /usr/lib/jvm/java/bin/javac -encoding UTF-8 -cp :/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/dist/pki-nsutil.jar:/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/dist/pki-cmsutil.jar:/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/dist/pki-certsrv.jar:/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/dist/pki-cms.jar:/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/dist/pki-cmscore.jar:`**PKI_CMSBUNDLE_JAR-NOTFOUND**`:/usr/share/java/ldapjdk.jar:/usr/share/java/servlet.jar:/usr/share/java/velocity.jar:/usr/share/java/xalan-j2.jar:/usr/share/java/xerces-j2.jar:/usr/lib/java/jss4.jar:/usr/share/java/commons-codec.jar:/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/dist/symkey.jar:/usr/share/java/hamcrest/core.jar:/usr/share/java/junit.jar:/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/test/classes -d /usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/test/classes @/usr/src/RPM/BUILD/pki-core-10.5.3/BUILD/base/server/test/pki-server-test-classes.files`

CMake version:
```
cmake --version
cmake version 3.9.2
```

I guess there is a typo and variable should be a CACHE INTERNAL type.

  