### PR TITLE
Added pki pkcs11-cert-find

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -63,6 +63,7 @@ import com.netscape.cmstools.group.ProxyGroupCLI;
 import com.netscape.cmstools.key.KeyCLI;
 import com.netscape.cmstools.kra.KRACLI;
 import com.netscape.cmstools.ocsp.OCSPCLI;
+import com.netscape.cmstools.pkcs11.PKCS11CLI;
 import com.netscape.cmstools.pkcs12.PKCS12CLI;
 import com.netscape.cmstools.pkcs7.PKCS7CLI;
 import com.netscape.cmstools.system.SecurityDomainCLI;
@@ -120,6 +121,7 @@ public class MainCLI extends CLI {
         addModule(new TPSCLI(this));
 
         addModule(new PKCS7CLI(this));
+        addModule(new PKCS11CLI(this));
         addModule(new PKCS12CLI(this));
 
         createOptions();

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CLI.java
@@ -1,0 +1,43 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.pkcs11;
+
+import com.netscape.cmstools.cli.CLI;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS11CLI extends CLI {
+
+    public PKCS11CLI(CLI parent) {
+        super("pkcs11", "PKCS #11 utilities", parent);
+
+        addModule(new PKCS11CertCLI(this));
+    }
+
+    public String getFullName() {
+        if (parent instanceof MainCLI) {
+            // do not include MainCLI's name
+            return name;
+        } else {
+            return parent.getFullName() + "-" + name;
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertCLI.java
@@ -1,0 +1,53 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.pkcs11;
+
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+
+import com.netscape.certsrv.dbs.certdb.CertId;
+import com.netscape.cmstools.cli.CLI;
+
+import netscape.security.x509.X509CertImpl;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS11CertCLI extends CLI {
+
+    public PKCS11CertCLI(PKCS11CLI parent) {
+        super("cert", "PKCS #11 certificate management commands", parent);
+
+        addModule(new PKCS11CertFindCLI(this));
+    }
+
+    public static void printCertInfo(String alias, Certificate cert) throws CertificateEncodingException, CertificateException {
+
+        System.out.println("  Cert ID: " + alias);
+        System.out.println("  Type: " + cert.getType());
+
+        X509CertImpl certImpl = new X509CertImpl(cert.getEncoded());
+
+        CertId serialNumber = new CertId(certImpl.getSerialNumber());
+        System.out.println("  Serial Number: " + serialNumber.toHexString());
+        System.out.println("  Subject DN: " + certImpl.getSubjectDN());
+        System.out.println("  Issuer DN: " + certImpl.getIssuerDN());
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertFindCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertFindCLI.java
@@ -1,0 +1,98 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.pkcs11;
+
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.Enumeration;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.util.logging.PKILogger;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.provider.java.security.JSSLoadStoreParameter;
+
+import com.netscape.cmstools.cli.CLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS11CertFindCLI extends CLI {
+
+    public PKCS11CertFindCLI(PKCS11CertCLI parent) {
+        super("find", "Find PKCS #11 certificates", parent);
+
+        createOptions();
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(String[] args) throws Exception {
+
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            printHelp();
+            return;
+        }
+
+        if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(PKILogger.Level.INFO);
+
+        } else if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+        }
+
+        String tokenName = getConfig().getTokenName();
+        CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
+
+        KeyStore ks = KeyStore.getInstance("pkcs11");
+        ks.load(new JSSLoadStoreParameter(token));
+
+        Enumeration<String> aliases = ks.aliases();
+
+        boolean first = true;
+
+        while (aliases.hasMoreElements()) {
+
+            String alias = aliases.nextElement();
+
+            Certificate cert = ks.getCertificate(alias);
+            if (cert == null) {
+                continue;
+            }
+
+            if (first) {
+                first = false;
+            } else {
+                System.out.println();
+            }
+
+            PKCS11CertCLI.printCertInfo(alias, cert);
+        }
+    }
+}


### PR DESCRIPTION
A new pki pkcs11-cert-find CLI has been added to list the certs in
PKCS #11 keystore.

Change-Id: I718fa72a5b11de046f110f70c7b286e7df8eaf83