### PR TITLE
Added pki pkcs11-key-find

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyCLI.java
@@ -18,27 +18,39 @@
 
 package com.netscape.cmstools.pkcs11;
 
+import java.security.Key;
+
+import org.mozilla.jss.crypto.PrivateKey;
+
 import com.netscape.cmstools.cli.CLI;
-import com.netscape.cmstools.cli.MainCLI;
 
 /**
  * @author Endi S. Dewata
  */
-public class PKCS11CLI extends CLI {
+public class PKCS11KeyCLI extends CLI {
 
-    public PKCS11CLI(CLI parent) {
-        super("pkcs11", "PKCS #11 utilities", parent);
+    public PKCS11KeyCLI(PKCS11CLI parent) {
+        super("key", "PKCS #11 key management commands", parent);
 
-        addModule(new PKCS11CertCLI(this));
-        addModule(new PKCS11KeyCLI(this));
+        addModule(new PKCS11KeyFindCLI(this));
     }
 
-    public String getFullName() {
-        if (parent instanceof MainCLI) {
-            // do not include MainCLI's name
-            return name;
-        } else {
-            return parent.getFullName() + "-" + name;
+    public static void printKeyInfo(String alias, Key key) {
+
+        System.out.println("  Key ID: " + alias);
+
+        if (key instanceof PrivateKey) {
+            PrivateKey privateKey = (PrivateKey) key;
+
+            PrivateKey.Type keyType = privateKey.getType();
+            System.out.println("  Type: " + keyType);
+        }
+
+        System.out.println("  Algorithm: " + key.getAlgorithm());
+
+        String format = key.getFormat();
+        if (format != null) {
+            System.out.println("  Format: " + format);
         }
     }
 }

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyFindCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyFindCLI.java
@@ -1,0 +1,102 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.pkcs11;
+
+import java.security.Key;
+import java.security.KeyStore;
+import java.util.Enumeration;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.util.logging.PKILogger;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.provider.java.security.JSSLoadStoreParameter;
+
+import com.netscape.cmstools.cli.CLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS11KeyFindCLI extends CLI {
+
+    public PKCS11KeyFindCLI(PKCS11KeyCLI parent) {
+        super("find", "Find PKCS #11 keys", parent);
+
+        createOptions();
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(String[] args) throws Exception {
+
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            printHelp();
+            return;
+        }
+
+        if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(PKILogger.Level.INFO);
+
+        } else if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+        }
+
+        String tokenName = getConfig().getTokenName();
+        CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
+
+        KeyStore ks = KeyStore.getInstance("pkcs11");
+        ks.load(new JSSLoadStoreParameter(token));
+
+        Enumeration<String> aliases = ks.aliases();
+
+        boolean first = true;
+
+        while (aliases.hasMoreElements()) {
+
+            String alias = aliases.nextElement();
+
+            if (ks.isCertificateEntry(alias)) {
+                continue;
+            }
+
+            Key key = ks.getKey(alias, null);
+            if (key == null) {
+                continue;
+            }
+
+            if (first) {
+                first = false;
+            } else {
+                System.out.println();
+            }
+
+            PKCS11KeyCLI.printKeyInfo(alias, key);
+        }
+    }
+}


### PR DESCRIPTION
A new pki pkcs11-key-find CLI has been added to list the keys in
PKCS #11 keystore.

Change-Id: I3d0a3aa35b18064cce776734f5dbf2a84589353e