### PR TITLE
Added CLIs to manage PKCS #11 certs/keys

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertCLI.java
@@ -37,6 +37,7 @@ public class PKCS11CertCLI extends CLI {
 
         addModule(new PKCS11CertFindCLI(this));
         addModule(new PKCS11CertShowCLI(this));
+        addModule(new PKCS11CertRemoveCLI(this));
     }
 
     public static void printCertInfo(String alias, Certificate cert) throws CertificateEncodingException, CertificateException {

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertCLI.java
@@ -36,6 +36,7 @@ public class PKCS11CertCLI extends CLI {
         super("cert", "PKCS #11 certificate management commands", parent);
 
         addModule(new PKCS11CertFindCLI(this));
+        addModule(new PKCS11CertShowCLI(this));
     }
 
     public static void printCertInfo(String alias, Certificate cert) throws CertificateEncodingException, CertificateException {

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertRemoveCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertRemoveCLI.java
@@ -1,0 +1,91 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.pkcs11;
+
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.util.logging.PKILogger;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.provider.java.security.JSSLoadStoreParameter;
+
+import com.netscape.cmstools.cli.CLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS11CertRemoveCLI extends CLI {
+
+    public PKCS11CertRemoveCLI(PKCS11CertCLI parent) {
+        super("del", "Remove PKCS #11 certificate", parent);
+
+        createOptions();
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Cert ID>", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(String[] args) throws Exception {
+
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            printHelp();
+            return;
+        }
+
+        if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(PKILogger.Level.INFO);
+
+        } else if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+        }
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing cert ID.");
+        }
+
+        String alias = cmdArgs[0];
+
+        String tokenName = getConfig().getTokenName();
+        CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
+
+        KeyStore ks = KeyStore.getInstance("pkcs11");
+        ks.load(new JSSLoadStoreParameter(token));
+
+        Certificate cert = ks.getCertificate(alias);
+
+        if (cert == null) {
+            throw new Exception("Certificate not found: " + alias);
+        }
+
+        ks.deleteEntry(alias);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11CertShowCLI.java
@@ -1,0 +1,91 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.pkcs11;
+
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.util.logging.PKILogger;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.provider.java.security.JSSLoadStoreParameter;
+
+import com.netscape.cmstools.cli.CLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS11CertShowCLI extends CLI {
+
+    public PKCS11CertShowCLI(PKCS11CertCLI parent) {
+        super("show", "Show PKCS #11 certificate", parent);
+
+        createOptions();
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Cert ID>", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(String[] args) throws Exception {
+
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            printHelp();
+            return;
+        }
+
+        if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(PKILogger.Level.INFO);
+
+        } else if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+        }
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing cert ID.");
+        }
+
+        String alias = cmdArgs[0];
+
+        String tokenName = getConfig().getTokenName();
+        CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
+
+        KeyStore ks = KeyStore.getInstance("pkcs11");
+        ks.load(new JSSLoadStoreParameter(token));
+
+        Certificate cert = ks.getCertificate(alias);
+
+        if (cert == null) {
+            throw new Exception("Certificate not found: " + alias);
+        }
+
+        PKCS11CertCLI.printCertInfo(alias, cert);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyCLI.java
@@ -33,6 +33,7 @@ public class PKCS11KeyCLI extends CLI {
         super("key", "PKCS #11 key management commands", parent);
 
         addModule(new PKCS11KeyFindCLI(this));
+        addModule(new PKCS11KeyShowCLI(this));
     }
 
     public static void printKeyInfo(String alias, Key key) {

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyCLI.java
@@ -34,6 +34,7 @@ public class PKCS11KeyCLI extends CLI {
 
         addModule(new PKCS11KeyFindCLI(this));
         addModule(new PKCS11KeyShowCLI(this));
+        addModule(new PKCS11KeyRemoveCLI(this));
     }
 
     public static void printKeyInfo(String alias, Key key) {

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyRemoveCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyRemoveCLI.java
@@ -1,0 +1,91 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.pkcs11;
+
+import java.security.Key;
+import java.security.KeyStore;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.util.logging.PKILogger;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.provider.java.security.JSSLoadStoreParameter;
+
+import com.netscape.cmstools.cli.CLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS11KeyRemoveCLI extends CLI {
+
+    public PKCS11KeyRemoveCLI(PKCS11KeyCLI parent) {
+        super("del", "Remove PKCS #11 key", parent);
+
+        createOptions();
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Key ID>", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(String[] args) throws Exception {
+
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            printHelp();
+            return;
+        }
+
+        if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(PKILogger.Level.INFO);
+
+        } else if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+        }
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key ID.");
+        }
+
+        String alias = cmdArgs[0];
+
+        String tokenName = getConfig().getTokenName();
+        CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
+
+        KeyStore ks = KeyStore.getInstance("pkcs11");
+        ks.load(new JSSLoadStoreParameter(token));
+
+        Key key = ks.getKey(alias, null);
+
+        if (key == null) {
+            throw new Exception("Key not found: " + alias);
+        }
+
+        ks.deleteEntry(alias);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs11/PKCS11KeyShowCLI.java
@@ -1,0 +1,91 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.pkcs11;
+
+import java.security.Key;
+import java.security.KeyStore;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.util.logging.PKILogger;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.provider.java.security.JSSLoadStoreParameter;
+
+import com.netscape.cmstools.cli.CLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS11KeyShowCLI extends CLI {
+
+    public PKCS11KeyShowCLI(PKCS11KeyCLI parent) {
+        super("show", "Show PKCS #11 key", parent);
+
+        createOptions();
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Key ID>", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(String[] args) throws Exception {
+
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            printHelp();
+            return;
+        }
+
+        if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(PKILogger.Level.INFO);
+
+        } else if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+        }
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key ID.");
+        }
+
+        String alias = cmdArgs[0];
+
+        String tokenName = getConfig().getTokenName();
+        CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
+
+        KeyStore ks = KeyStore.getInstance("pkcs11");
+        ks.load(new JSSLoadStoreParameter(token));
+
+        Key key = ks.getKey(alias, null);
+
+        if (key == null) {
+            throw new Exception("Key not found: " + alias);
+        }
+
+        PKCS11KeyCLI.printKeyInfo(alias, key);
+    }
+}


### PR DESCRIPTION
The following CLIs have been added to manage PKSC #11 certs/keys:

* pki pkcs11-cert-show
* pki pkcs11-key-show
* pki pkcs11-cert-del
* pki pkcs11-key-del