### PR TITLE
ReplicationUtil: support new format for nsds5replicaLastInitStatus value

### DIFF
--- a/base/server/cms/src/com/netscape/cms/servlet/csadmin/ReplicationUtil.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/csadmin/ReplicationUtil.java
@@ -141,7 +141,7 @@ public class ReplicationUtil {
             }
 
             String status = replicationStatus(replicadn, masterConn, masterAgreementName);
-            if (!status.startsWith("0 ")) {
+            if (!(status.startsWith("Error (0) ") || status.startsWith("0 "))) {
                 logger.error("ReplicationUtil: replication consumer initialization failed: " + status);
                 throw new IOException("Replication consumer initialization failed: " + status);
             }


### PR DESCRIPTION
pkispawn is reading the attribute nsds5replicaLastInitStatus in
cn=masterAgreement1-$hostname-pki-tomcat,cn=replica,cn=o\3Dipaca,cn=mapping
tree,cn=config in order to find the replication status.  The new format
(in 389-ds-base-1.3.7) for this attribute is "Error (0) Total update
succeeded" but pkispawn is expecting "0 Total update succeeded"

389-ds-base introduced this change with https://pagure.io/389-ds-base/issue/49599

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1596629