### PR TITLE
Do not override system-wide crypto policy

### DIFF
--- a/base/console/src/com/netscape/admin/certsrv/connection/JSSConnection.java
+++ b/base/console/src/com/netscape/admin/certsrv/connection/JSSConnection.java
@@ -47,6 +47,8 @@ import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 import org.mozilla.jss.ssl.SSLClientCertificateSelectionCallback;
 import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
 import org.mozilla.jss.ssl.SSLSocket;
+import org.mozilla.jss.ssl.SSLSocket.SSLVersionRange;
+import org.mozilla.jss.ssl.SSLVersion;
 import org.mozilla.jss.ssl.SSLSocketListener;
 import org.mozilla.jss.util.Password;
 import org.mozilla.jss.util.PasswordCallback;
@@ -54,7 +56,6 @@ import org.mozilla.jss.util.PasswordCallbackInfo;
 
 import com.netscape.admin.certsrv.CMSAdminResources;
 import com.netscape.cmsutil.crypto.CryptoUtil;
-import com.netscape.cmsutil.crypto.CryptoUtil.SSLVersion;
 import com.netscape.management.client.util.AbstractDialog;
 import com.netscape.management.client.util.Debug;
 import com.netscape.management.client.util.GridBagUtil;
@@ -124,8 +125,10 @@ public class JSSConnection implements IConnection, SSLCertificateApprovalCallbac
         } catch (Exception e) {
         }
 
-        CryptoUtil.setSSLStreamVersionRange(SSLVersion.TLS_1_0, SSLVersion.TLS_1_2);
-        CryptoUtil.setSSLDatagramVersionRange(SSLVersion.TLS_1_1, SSLVersion.TLS_1_2);
+        SSLVersionRange streamRange = CryptoUtil.boundSSLStreamVersionRange(SSLVersion.TLS_1_0, SSLVersion.TLS_1_2);
+        SSLVersionRange datagramRange = CryptoUtil.boundSSLDatagramVersionRange(SSLVersion.TLS_1_1, SSLVersion.TLS_1_2);
+        CryptoUtil.setSSLStreamVersionRange(streamRange.getMinVersion(), streamRange.getMaxVersion());
+        CryptoUtil.setSSLDatagramVersionRange(datagramRange.getMinVersion(), datagramRange.getMaxVersion());
         CryptoUtil.setDefaultSSLCiphers();
 
         s = new SSLSocket(host, port, null, 0, this, this);

--- a/base/java-tools/src/com/netscape/cmstools/HttpClient.java
+++ b/base/java-tools/src/com/netscape/cmstools/HttpClient.java
@@ -39,10 +39,11 @@ import org.mozilla.jss.crypto.X509Certificate;
 import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
 import org.mozilla.jss.ssl.SSLHandshakeCompletedListener;
 import org.mozilla.jss.ssl.SSLSocket;
+import org.mozilla.jss.ssl.SSLSocket.SSLVersionRange;
+import org.mozilla.jss.ssl.SSLVersion;
 import org.mozilla.jss.util.Password;
 
 import com.netscape.cmsutil.crypto.CryptoUtil;
-import com.netscape.cmsutil.crypto.CryptoUtil.SSLVersion;
 import com.netscape.cmsutil.util.Utils;
 
 /**
@@ -125,8 +126,10 @@ public class HttpClient {
 
                 SSLHandshakeCompletedListener listener = new ClientHandshakeCB(this);
 
-                CryptoUtil.setSSLStreamVersionRange(SSLVersion.TLS_1_0, SSLVersion.TLS_1_2);
-                CryptoUtil.setSSLDatagramVersionRange(SSLVersion.TLS_1_1, SSLVersion.TLS_1_2);
+                SSLVersionRange streamRange = CryptoUtil.boundSSLStreamVersionRange(SSLVersion.TLS_1_0, SSLVersion.TLS_1_2);
+                SSLVersionRange datagramRange = CryptoUtil.boundSSLDatagramVersionRange(SSLVersion.TLS_1_1, SSLVersion.TLS_1_2);
+                CryptoUtil.setSSLStreamVersionRange(streamRange.getMinVersion(), streamRange.getMaxVersion());
+                CryptoUtil.setSSLDatagramVersionRange(datagramRange.getMinVersion(), datagramRange.getMaxVersion());
                 CryptoUtil.setDefaultSSLCiphers();
 
                 sslSocket = new SSLSocket(_host, _port);

--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -49,6 +49,8 @@ import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
+import org.mozilla.jss.ssl.SSLSocket.SSLVersionRange;
+import org.mozilla.jss.ssl.SSLVersion;
 import org.mozilla.jss.util.IncorrectPasswordException;
 import org.mozilla.jss.util.Password;
 
@@ -71,7 +73,6 @@ import com.netscape.cmstools.tks.TKSCLI;
 import com.netscape.cmstools.tps.TPSCLI;
 import com.netscape.cmstools.user.ProxyUserCLI;
 import com.netscape.cmsutil.crypto.CryptoUtil;
-import com.netscape.cmsutil.crypto.CryptoUtil.SSLVersion;
 
 /**
  * @author Endi S. Dewata
@@ -557,18 +558,20 @@ public class MainCLI extends CLI {
         String streamVersionMin = System.getenv("SSL_STREAM_VERSION_MIN");
         String streamVersionMax = System.getenv("SSL_STREAM_VERSION_MAX");
 
-        CryptoUtil.setSSLStreamVersionRange(
+        SSLVersionRange streamRange = CryptoUtil.boundSSLStreamVersionRange(
                 streamVersionMin == null ? SSLVersion.TLS_1_0 : SSLVersion.valueOf(streamVersionMin),
                 streamVersionMax == null ? SSLVersion.TLS_1_2 : SSLVersion.valueOf(streamVersionMax)
         );
+        CryptoUtil.setSSLStreamVersionRange(streamRange.getMinVersion(), streamRange.getMaxVersion());
 
         String datagramVersionMin = System.getenv("SSL_DATAGRAM_VERSION_MIN");
         String datagramVersionMax = System.getenv("SSL_DATAGRAM_VERSION_MAX");
 
-        CryptoUtil.setSSLDatagramVersionRange(
+        SSLVersionRange datagramRange = CryptoUtil.boundSSLDatagramVersionRange(
                 datagramVersionMin == null ? SSLVersion.TLS_1_1 : SSLVersion.valueOf(datagramVersionMin),
                 datagramVersionMax == null ? SSLVersion.TLS_1_2 : SSLVersion.valueOf(datagramVersionMax)
         );
+        CryptoUtil.setSSLDatagramVersionRange(datagramRange.getMinVersion(), datagramRange.getMaxVersion());
 
         String defaultCiphers = System.getenv("SSL_DEFAULT_CIPHERS");
         if (defaultCiphers == null || Boolean.parseBoolean(defaultCiphers)) {

--- a/base/native-tools/src/sslget/sslget.c
+++ b/base/native-tools/src/sslget/sslget.c
@@ -587,7 +587,7 @@ client_main(
     SSLCipherSuiteInfo info;
     SSLVersionRange versions = {
         SSL_LIBRARY_VERSION_TLS_1_1,
-        SSL_LIBRARY_VERSION_TLS_1_2
+        SSL_LIBRARY_VERSION_TLS_1_3
     };
     SECStatus status;
 

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -123,6 +123,7 @@ import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
 import org.mozilla.jss.ssl.SSLSocket;
 import org.mozilla.jss.ssl.SSLSocket.SSLProtocolVariant;
 import org.mozilla.jss.ssl.SSLSocket.SSLVersionRange;
+import org.mozilla.jss.ssl.SSLVersion;
 import org.mozilla.jss.util.Base64OutputStream;
 import org.mozilla.jss.util.Password;
 import org.slf4j.Logger;
@@ -169,19 +170,6 @@ import netscape.security.x509.X509Key;
 public class CryptoUtil {
 
     private static Logger logger = LoggerFactory.getLogger(CryptoUtil.class);
-
-    public static enum SSLVersion {
-        SSL_3_0(SSLVersionRange.ssl3),
-        TLS_1_0(SSLVersionRange.tls1_0),
-        TLS_1_1(SSLVersionRange.tls1_1),
-        TLS_1_2(SSLVersionRange.tls1_2);
-
-        public int value;
-
-        SSLVersion(int value) {
-            this.value = value;
-        }
-    }
 
     public final static int KEY_ID_LENGTH = 20;
 
@@ -745,13 +733,23 @@ public class CryptoUtil {
         return pair;
     }
 
+    public static SSLVersionRange boundSSLStreamVersionRange(SSLVersion min, SSLVersion max) throws SocketException {
+        SSLVersionRange range = new SSLVersionRange(min, max);
+        return SSLSocket.boundSSLVersionRange(SSLProtocolVariant.STREAM, range);
+    }
+
+    public static SSLVersionRange boundSSLDatagramVersionRange(SSLVersion min, SSLVersion max) throws SocketException {
+        SSLVersionRange range = new SSLVersionRange(min, max);
+        return SSLSocket.boundSSLVersionRange(SSLProtocolVariant.DATA_GRAM, range);
+    }
+
     public static void setSSLStreamVersionRange(SSLVersion min, SSLVersion max) throws SocketException {
-        SSLVersionRange range = new SSLVersionRange(min.value, max.value);
+        SSLVersionRange range = new SSLVersionRange(min, max);
         SSLSocket.setSSLVersionRangeDefault(SSLProtocolVariant.STREAM, range);
     }
 
     public static void setSSLDatagramVersionRange(SSLVersion min, SSLVersion max) throws SocketException {
-        SSLVersionRange range = new SSLVersionRange(min.value, max.value);
+        SSLVersionRange range = new SSLVersionRange(min, max);
         SSLSocket.setSSLVersionRangeDefault(SSLProtocolVariant.DATA_GRAM, range);
     }
 

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -185,7 +185,10 @@ public class CryptoUtil {
         SSLSocket.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
         SSLSocket.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
         SSLSocket.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-        SSLSocket.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        SSLSocket.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        SSLSocket.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        SSLSocket.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        SSLSocket.TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
     };
     static public List<Integer> clientECCipherList = new ArrayList<Integer>(Arrays.asList(clientECCiphers));
 
@@ -953,6 +956,19 @@ public class CryptoUtil {
         cipherMap.put("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
                 SSLSocket.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
 
+        // TLSv1_3
+        cipherMap.put("TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+                SSLSocket.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256);
+        cipherMap.put("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                SSLSocket.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256);
+        cipherMap.put("TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+                SSLSocket.TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256);
+        cipherMap.put("TLS_AES_128_GCM_SHA256",
+                SSLSocket.TLS_AES_128_GCM_SHA256);
+        cipherMap.put("TLS_AES_256_GCM_SHA384",
+                SSLSocket.TLS_AES_256_GCM_SHA384);
+        cipherMap.put("TLS_CHACHA20_POLY1305_SHA256",
+                SSLSocket.TLS_CHACHA20_POLY1305_SHA256);
     }
 
     public static void setClientCiphers(String list) throws SocketException {


### PR DESCRIPTION
System-wide crypto policy may dictate use of TLS 1.3. Instead of
overriding existing crypto policy, check that it makes sense:
 - make sure minimal TLS version is at least TLS 1.1
 - make sure maximum TLS version is at least TLS 1.2

We don't need to override a policy that passes these checks.