### PR TITLE
Adding build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Dogtag PKI
 ==========
 
+[![Build Status](https://travis-ci.org/dogtagpki/pki-nightly-test.svg?branch=master)](https://travis-ci.org/dogtagpki/pki-nightly-test)
+
 (C) 2008 Red Hat, Inc.
 All rights reserved.
 


### PR DESCRIPTION
Build status icon is loaded from https://travis-ci.org/dogtagpki/pki-nightly-test

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>