### PR TITLE
fix for ldap create using dscreate cli replacement for setup-ds.pl

### DIFF
--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_ldap.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_ldap.yml
@@ -1,20 +1,20 @@
 
 - name: Setup DS Service
-  shell: setup-ds.pl --silent --file=/tmp/test_dir/ldap.cfg
+  shell: dscreate fromfile /tmp/test_dir/ldap.cfg
   when: topology  == "topology-01" or topology == "topology-02" or topology == "topology-03" or topology == "topology-04" or topology  == "topology-05" or topology == "topology-ecc"
 
 - name: Setup DS Service
-  shell: setup-ds.pl --silent --file=/tmp/test_dir/ldap_kra.cfg
+  shell: dscreate fromfile /tmp/test_dir/ldap_kra.cfg
   when: topology  == "topology-05"
 
 - name: Setup DS Service
-  shell: setup-ds.pl --silent --file=/tmp/test_dir/ldap_ocsp.cfg
+  shell: dscreate fromfile /tmp/test_dir/ldap_ocsp.cfg
   when: topology  == "topology-05"
 
 - name: Setup DS Service
-  shell: setup-ds.pl --silent --file=/tmp/test_dir/ldap_tks.cfg
+  shell: dscreate fromfile /tmp/test_dir/ldap_tks.cfg
   when: topology  == "topology-05"
 
 - name: Setup DS Service
-  shell: setup-ds.pl --silent --file=/tmp/test_dir/ldap_tps.cfg
+  shell: dscreate fromfile /tmp/test_dir/ldap_tps.cfg
   when: topology  == "topology-05"

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/test/ldap.cfg
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/test/ldap.cfg
@@ -1,12 +1,209 @@
-[General]
-FullMachineName = SERVERNAME 
-SuiteSpotUserID = nobody
-SuiteSpotGroup = nobody
-ConfigDirectoryAdminID = admin
+
+; --- BEGIN COPYRIGHT BLOCK ---
+; Copyright (C) 2018 Red Hat, Inc.
+; All rights reserved.
+;
+; License: GPL (version 3 or any later version).
+; See LICENSE for details.
+; --- END COPYRIGHT BLOCK ---
+
+; This is a version 2 ds setup inf file.
+; It is used by the python versions of setup-ds-*
+; Most options map 1 to 1 to the original .inf file.
+; However, there are some differences that I envision
+; For example, note the split backend section.
+; You should be able to create, one, many or no backends in an install
+;
+; The special value {instance_name} is substituted at installation time.
+;
+; By default, all configuration parameters in this file are commented out.
+; To use an INF file with dscreate, you must at least set the parameters
+; flagged with [REQUIRED].
+
+[general]
+# config_version (int)
+# Description: Sets the format version of this INF file. To use the INF file with dscreate, you must set this parameter to "2".
+# Default value: 2
+;config_version = 2
+
+# defaults (str)
+# Description: Directory Server enables administrators to use the default values for cn=config entries from a specific version. If you set this parameter to "999999999", which is the default, the instance always uses the default values of the latest version. For example, to configure that the instance uses default values from version 1.3.5, set this parameter to "001003005". The format of this value is XXXYYYZZZ, where X is the major version, Y the minor version, and Z the patch level. Note that each part of the value uses 3 digits and must be filled with leading zeros if necessary.
+# Default value: 999999999
+;defaults = 999999999
+
+# full_machine_name (str)
+# Description: Sets the fully qualified hostname (FQDN) of this system. When installing this instance with GSSAPI authentication behind a load balancer, set this parameter to the FQDN of the load balancer and, additionally, set "strict_host_checking" to "false".
+# Default value: pki1.example.com
+full_machine_name = pki1.example.com
+
+# selinux (bool)
+# Description: Enables SELinux detection and integration during the installation of this instance. If set to "True", dscreate auto-detects whether SELinux is enabled. Set this parameter only to "False" in a development environment.
+# Default value: True
+selinux = True
+
+# strict_host_checking (bool)
+# Description: Sets whether the server verifies the forward and reverse record set in the "full_machine_name" parameter. When installing this instance with GSSAPI authentication behind a load balancer, set this parameter to "false".
+# Default value: True
+strict_host_checking = True
+
+# systemd (bool)
+# Description: Enables systemd platform features. If set to "True", dscreate auto-detects whether systemd is installed. Set this only to "False" in a development environment.
+# Default value: True
+systemd = True
 
 [slapd]
-ServerIdentifier = topology-testingmaster
-ServerPort = ldapServerPort 
-Suffix = dc=example,dc=org
-RootDN = CN=Directory Manager
-RootDNPwd = Secret123
+# backup_dir (str)
+# Description: Set the backup directory of the instance.
+# Default value: /var/lib/dirsrv/slapd-{instance_name}/bak
+backup_dir = /var/lib/dirsrv/slapd-{instance_name}/bak
+
+# bin_dir (str)
+# Description: Sets the location where the Directory Server binaries are stored. Only set this parameter in a development environment.
+# Default value: /usr/bin
+;bin_dir = /usr/bin
+
+# cert_dir (str)
+# Description: Sets the directory of the instance's Network Security Services (NSS) database.
+# Default value: /etc/dirsrv/slapd-{instance_name}
+cert_dir = /etc/dirsrv/slapd-{instance_name}
+
+# config_dir (str)
+# Description: Sets the configuration directory of the instance.
+# Default value: /etc/dirsrv/slapd-{instance_name}
+config_dir = /etc/dirsrv/slapd-{instance_name}
+
+# data_dir (str)
+# Description: Sets the location of Directory Server shared static data. Only set this parameter ina development environment.
+# Default value: /usr/share
+;data_dir = /usr/share
+
+# db_dir (str)
+# Description: Sets the database directory of the instance.
+# Default value: /var/lib/dirsrv/slapd-{instance_name}/db
+db_dir = /var/lib/dirsrv/slapd-{instance_name}/db
+
+# group (str)
+# Description: Sets the group name the ns-slapd process will use after the service started.
+# Default value: dirsrv
+group = dirsrv
+
+# initconfig_dir (str)
+# Description: Sets the directory of the operating system's rc configuration directory. Only set this parameter in a development environment.
+# Default value: /etc/sysconfig
+;initconfig_dir = /etc/sysconfig
+
+# inst_dir (str)
+# Description: Sets the directory of instance-specific scripts.
+# Default value: /usr/lib64/dirsrv/slapd-{instance_name}
+;inst_dir = /usr/lib64/dirsrv/slapd-{instance_name}
+
+# instance_name (str)
+# Description: Sets the name of the instance. You can refer to this value in other parameters of this INF file using the "{instance_name}" variable. Note that this name cannot be changed after the installation!
+# Default value: localhost
+instance_name = topology-02-testingmaster
+
+# ldif_dir (str)
+# Description: Sets the LDIF export and import directory of the instance.
+# Default value: /var/lib/dirsrv/slapd-{instance_name}/ldif
+ldif_dir = /var/lib/dirsrv/slapd-{instance_name}/ldif
+
+# lib_dir (str)
+# Description: Sets the location of Directory Server shared libraries. Only set this parameter in adevelopment environment.
+# Default value: /usr/lib64
+;lib_dir = /usr/lib64
+
+# local_state_dir (str)
+# Description: Sets the location of Directory Server variable data. Only set this parameter in a development environment.
+# Default value: /var
+;local_state_dir = /var
+
+# lock_dir (str)
+# Description: Sets the lock directory of the instance.
+# Default value: /var/lock/dirsrv/slapd-{instance_name}
+lock_dir = /var/lock/dirsrv/slapd-{instance_name}
+
+# log_dir (str)
+# Description: Sets the log directory of the instance.
+# Default value: /var/log/dirsrv/slapd-{instance_name}
+log_dir = /var/log/dirsrv/slapd-{instance_name}
+
+# port (int)
+# Description: Sets the TCP port the instance uses for LDAP connections.
+# Default value: 389
+port = 3389
+
+# prefix (str)
+# Description: Sets the file system prefix for all other directories. You can refer to this value in other fields using the {prefix} variable or the $PREFIX environment variable. Only set this parameter in a development environment.
+# Default value: /usr
+;prefix = /usr
+
+# root_dn (str)
+# Description: Sets the Distinquished Name (DN) of the administrator account for this instance.
+# Default value: cn=Directory Manager
+root_dn = cn=Directory Manager
+
+# root_password (str)
+# Description: Sets the password of the account specified in the "root_dn" parameter. You can either set this parameter to a plain text password dscreate hashes during the installation or to a "{algorithm}hash" string generated by the pwdhash utility. Note that setting a plain text password can be a security risk if unprivileged users can read this INF file!
+# Default value: Directory_Manager_Password
+root_password = Secret123
+
+# run_dir (str)
+# Description: Sets PID directory of the instance.
+# Default value: /var/run/dirsrv
+run_dir = /var/run/dirsrv
+
+# sbin_dir (str)
+# Description: Sets the location where the Directory Server administration binaries are stored. Only set this parameter in a development environment.
+# Default value: /usr/sbin
+;sbin_dir = /usr/sbin
+
+# schema_dir (str)
+# Description: Sets schema directory of the instance.
+# Default value: /etc/dirsrv/slapd-{instance_name}/schema
+schema_dir = /etc/dirsrv/slapd-{instance_name}/schema
+
+# secure_port (int)
+# Description: Sets the TCP port the instance uses for TLS-secured LDAP connections (LDAPS).
+# Default value: 636
+;secure_port = 636
+
+# self_sign_cert (bool)
+# Description: Sets whether the setup creates a self-signed certificate and enables TLS encryption during the installation. This is not suitable for production, but it enables administrators to use TLS right after the installation. You can replace the self-signed certificate with a certificate issued by a Certificate Authority.
+# Default value: True
+;self_sign_cert = True
+
+# self_sign_cert_valid_months (int)
+# Description: Set the number of months the issued self-signed certificate will be valid.
+# Default value: 24
+;self_sign_cert_valid_months = 24
+
+# sysconf_dir (str)
+# Description: Sets the location of the system's configuration directory. Only set this parameter in a development environment.
+# Default value: /etc
+;sysconf_dir = /etc
+
+# tmp_dir (str)
+# Description: Sets the temporary directory of the instance.
+# Default value: /tmp
+tmp_dir = /tmp
+
+# user (str)
+# Description: Sets the user name the ns-slapd process will use after the service started.
+# Default value: dirsrv
+user = dirsrv
+
+[backend-userroot]
+# require_index (bool)
+# Description: Sets this parameter to "True" to refuse unindexed searches in this database.
+# Default value: False
+;require_index = False
+
+# sample_entries (str)
+# Description: Set this parameter to 'yes' to add latest version of sample entries to this database.  Or, use '001003006' to use the 1.3.6 version sample entries.  Use this option, for example, to create a database for testing purposes.
+# Default value: no
+;sample_entries = no
+
+# suffix (str)
+# Description: Sets the root suffix stored in this database.
+# Default value: dc=example,dc=com
+suffix = dc=example,dc=com


### PR DESCRIPTION
fix for ldap create using dscreate cli replacement for setup-ds.pl

Signed-off-by: bbhavsar <bbhavsar@redhat.com>