### PR TITLE
Pki server CLI automation in pytest-ansible

### DIFF
--- a/tests/dogtag/pytest-ansible/.gitlab-ci.yml
+++ b/tests/dogtag/pytest-ansible/.gitlab-ci.yml
@@ -90,6 +90,7 @@ ca_authplugins:
   stage: tier1
   <<: *job_definition
   script:
+  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/auth_plugins/ -q -s --junitxml $CI_PROJECT_DIR/auth_plugins_junit.xml -vvvv
   artifacts:
@@ -100,6 +101,7 @@ securitydomain-cli:
   stage: tier1
   <<: *job_definition
   script:
+  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master tests/dogtag/pytest-ansible/pytest/ca/securitydomain/ -q -s --junitxml $CI_PROJECT_DIR/securitydomain_junit.xml -vvvv
   artifacts:
@@ -110,6 +112,7 @@ pki-pkcs12-cli:
   <<: *job_definition
   stage: tier1
   script:
+  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master  --ansible-playbook-inventory $HOSTFILE --ansible-playbook-directory $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ -qsvv --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_junit.xml
@@ -121,6 +124,7 @@ pki_server:
   <<: *job_definition
   stage: tier1
   script:
+  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvvvvvvvv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_server/ -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_ca_junit.xml -vv

--- a/tests/dogtag/pytest-ansible/.gitlab-ci.yml
+++ b/tests/dogtag/pytest-ansible/.gitlab-ci.yml
@@ -110,9 +110,30 @@ pki-pkcs12-cli:
   <<: *job_definition
   stage: tier1
   script:
-  - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master  --ansible-playbook-inventory $HOSTFILE --ansible-playbook-directory $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ $CI_PROJECT_DIR/pytest/ca/pki_pkcs12/ -qsvv --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_junit.xml
+  - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master  --ansible-playbook-inventory $HOSTFILE --ansible-playbook-directory $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ -qsvv --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_junit.xml
   artifacts:
     paths:
     - $CI_PROJECT_DIR/*_junit.xml
+
+pki_server:
+  <<: *job_definition
+  stage: tier1
+  script:
+  - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvvvvvvvv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_server/ -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_ca_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/kra/pki_server/ -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_kra_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ocsp/pki_server/ -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_ocsp_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_instance_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_subsystem_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_migrate.py $CI_PROJECT_DIR/pytest/pki_server/test_pki_server_db*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_migrate_db_junit.xml -vv
+  artifacts:
+    paths:
+    - $CI_PROJECT_DIR/${CI_JOB_NAME}_ca_junit.xml
+    - $CI_PROJECT_DIR/${CI_JOB_NAME}_kra_junit.xml
+    - $CI_PROJECT_DIR/${CI_JOB_NAME}_ocsp_junit.xml
+    - $CI_PROJECT_DIR/${CI_JOB_NAME}_instance_junit.xml
+    - $CI_PROJECT_DIR/${CI_JOB_NAME}_subsystem_junit.xml
+    - $CI_PROJECT_DIR/${CI_JOB_NAME}_migrate_db_junit.xml

--- a/tests/dogtag/pytest-ansible/.gitlab-ci.yml
+++ b/tests/dogtag/pytest-ansible/.gitlab-ci.yml
@@ -32,6 +32,9 @@ before_script:
   - sleep 30s
   - wget -O repo.yml $POST_PROV --no-check-certificate
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE repo.yml -e 'ansible_python_interpreter="/usr/bin/python3"' -vv
+  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - export ANSIBLE_LIBRARY=$CI_PROJECT_DIR/tests/dogtag/pytest-ansible/common-modules/
+
 
 after_script:
   - linchpin -w linchpin-openstack --creds-path linchpin-openstack/credentials destroy
@@ -48,96 +51,75 @@ banner-cli:
   <<: *job_definition
   script:
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master tests/dogtag/pytest-ansible/pytest/banner/test_banner_cli.py -q -s --junitxml bannercli_junit.xml -vvvv
+  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/banner/test_banner_cli.py -q -s --junitxml $CI_PROJECT_DIR/bannercli_junit.xml -vvvv
 
 tps-config-cli:
   stage: tier1
   <<: *job_definition
   script:
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master tests/dogtag/pytest-ansible/pytest/tps/tps_config -q -s --junitxml tps_config_cli_junit.xml -vv
-  artifacts:
-    paths:
-    - tps_config_cli_junit.xml
+  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/tps/tps_config/*.py -q -s --junitxml $CI_PROJECT_DIR/tps_config_cli_junit.xml -vv
+
 
 tps-activity-cli:
   stage: tier1
   <<: *job_definition
   script:
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
-  - cd $CI_PROJECT_DIR/pki/tests/dogtag/pytest-ansible/pytest/tps/tps_activity/
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE . -q -s --junitxml tps_activity_junit.xml -vv
-  artifacts:
-    paths:
-    - tps_activity_junit.xml
+  - cd $CI_PROJECT_DIR/pki/tests/dogtag/pytest-ansible/
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/tps/tps_activity/*.py -q -s --junitxml $CI_PROJECT_DIR/tps_activity_junit.xml -vv
+
 
 ca-bugzillas:
   stage: tier1
   <<: *job_definition
   script:
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master tests/dogtag/pytest-ansible/pytest/ca/ocsp/test_bug_1523443_HAProxy_rejection.py -q -s --junitxml BZ_1523443_junit.xml -vv
-  - cd $CI_PROJECT_DIR/pki/tests/dogtag/pytest-ansible/pytest/ca/bugzilla/
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master test_bug_1465103_missing_JDAP_filters.py -q -s --junitxml BZ_1465103_junit.xml -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master test_bug_1539198_inconsistent_cert_req_outcomes.py -q -s --junitxml BZ_1539198_junit.xml -vv
-  artifacts:
-    paths:
-    - BZ_1523443_junit.xml
-    - BZ_1465103_junit.xml
-    - BZ_1539198_junit.xml
+  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/ocsp/test_bug_1523443_HAProxy_rejection.py -q -s --junitxml $CI_PROJECT_DIR/BZ_1523443_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/bugzilla/test_bug_1465103_missing_JDAP_filters.py -q -s --junitxml $CI_PROJECT_DIR/BZ_1465103_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/bugzilla/test_bug_1539198_inconsistent_cert_req_outcomes.py -q -s --junitxml $CI_PROJECT_DIR/BZ_1539198_junit.xml -vv
 
 ca_authplugins:
   stage: tier1
   <<: *job_definition
   script:
-  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/auth_plugins/ -q -s --junitxml $CI_PROJECT_DIR/auth_plugins_junit.xml -vvvv
-  artifacts:
-    paths:
-    - $CI_PROJECT_DIR/*_junit.xml
+  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/auth_plugins/*.py -q -s --junitxml $CI_PROJECT_DIR/auth_plugins_junit.xml -vvvv
+
 
 securitydomain-cli:
   stage: tier1
   <<: *job_definition
   script:
-  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master tests/dogtag/pytest-ansible/pytest/ca/securitydomain/ -q -s --junitxml $CI_PROJECT_DIR/securitydomain_junit.xml -vvvv
-  artifacts:
-    paths:
-    - $CI_PROJECT_DIR/*_junit.xml
+  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/securitydomain/*.py -q -s --junitxml $CI_PROJECT_DIR/securitydomain_junit.xml -vvvv
 
 pki-pkcs12-cli:
   <<: *job_definition
   stage: tier1
   script:
-  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master  --ansible-playbook-inventory $HOSTFILE --ansible-playbook-directory $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ -qsvv --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_junit.xml
-  artifacts:
-    paths:
-    - $CI_PROJECT_DIR/*_junit.xml
+  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE --ansible-playbook-directory $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ pytest/ca/pki_pkcs12/*.py -qsvv --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_junit.xml
 
 pki_server:
   <<: *job_definition
   stage: tier1
   script:
-  - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
   - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvvvvvvvv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_server/ -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_ca_junit.xml -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/kra/pki_server/ -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_kra_junit.xml -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ocsp/pki_server/ -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_ocsp_junit.xml -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_instance_junit.xml -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_subsystem_junit.xml -vv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_migrate.py $CI_PROJECT_DIR/pytest/pki_server/test_pki_server_db*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_migrate_db_junit.xml -vv
-  artifacts:
-    paths:
-    - $CI_PROJECT_DIR/${CI_JOB_NAME}_ca_junit.xml
-    - $CI_PROJECT_DIR/${CI_JOB_NAME}_kra_junit.xml
-    - $CI_PROJECT_DIR/${CI_JOB_NAME}_ocsp_junit.xml
-    - $CI_PROJECT_DIR/${CI_JOB_NAME}_instance_junit.xml
-    - $CI_PROJECT_DIR/${CI_JOB_NAME}_subsystem_junit.xml
-    - $CI_PROJECT_DIR/${CI_JOB_NAME}_migrate_db_junit.xml
+  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvvv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/ca/pki_server/*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_ca_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/kra/pki_server/*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_kra_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/ocsp/pki_server/*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_ocsp_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/pki_server/test_pki_server_instance*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_instance_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/pki_server/test_pki_server_subsystem*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_subsystem_junit.xml -vv
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/pki_server/test_pki_server_migrate.py pytest/pki_server/test_pki_server_db*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_migrate_db_junit.xml -vv
+  only:
+    - pki_server

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/files/config_templates/ansible_constants.py
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/files/config_templates/ansible_constants.py
@@ -1,4 +1,5 @@
 #common to all subsystems
+NSSDB = '/opt/pki/nssdb'
 CLIENT_PKCS12_PASSWORD = 'Secret123'
 CLIENT_DIR_PASSWORD = 'Secret123'
 BACKUP_PASSWORD = 'Secret123'

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/files/config_templates/ansible_constants.py
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/files/config_templates/ansible_constants.py
@@ -1,5 +1,5 @@
 #common to all subsystems
-NSSDB = '/opt/pki/nssdb'
+NSSDB = '/opt/pki/certdb'
 CLIENT_PKCS12_PASSWORD = 'Secret123'
 CLIENT_DIR_PASSWORD = 'Secret123'
 BACKUP_PASSWORD = 'Secret123'

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/config_templates/ansible_constants.py
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/config_templates/ansible_constants.py
@@ -1,4 +1,5 @@
 #common to all subsystems
+NSSDB = '/opt/pki/nssdb'
 CLIENT_PKCS12_PASSWORD = 'Secret123'
 CLIENT_DIR_PASSWORD = 'Secret123'
 BACKUP_PASSWORD = 'Secret123'

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/config_templates/ansible_constants.py
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/config_templates/ansible_constants.py
@@ -1,5 +1,5 @@
 #common to all subsystems
-NSSDB = '/opt/pki/nssdb'
+NSSDB = '/opt/pki/certdb'
 CLIENT_PKCS12_PASSWORD = 'Secret123'
 CLIENT_DIR_PASSWORD = 'Secret123'
 BACKUP_PASSWORD = 'Secret123'

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/test/constants.py
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/test/constants.py
@@ -1,4 +1,5 @@
 #common to all subsystems
+NSSDB = '/opt/pki/nssdb'
 CLIENT_PKCS12_PASSWORD = 'Secret123'
 CLIENT_DIR_PASSWORD = 'Secret123'
 BACKUP_PASSWORD = 'Secret123'

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/test/constants.py
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/test/constants.py
@@ -1,5 +1,5 @@
 #common to all subsystems
-NSSDB = '/opt/pki/nssdb'
+NSSDB = '/opt/pki/certdb'
 CLIENT_PKCS12_PASSWORD = 'Secret123'
 CLIENT_DIR_PASSWORD = 'Secret123'
 BACKUP_PASSWORD = 'Secret123'

--- a/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca.py
+++ b/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca.py
@@ -1,0 +1,158 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI SERVER  CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server cli commands needs to be tested:
+#   pki-server
+#   pki-server ca
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+from subprocess import CalledProcessError
+
+import pytest
+from pki.testlib.common import utils
+
+
+def test_pki_server(ansible_module):
+    """
+    :id: 6f671d63-283c-4599-9289-6977529b6634
+    :Title: Test pki-server command
+    :CaseComponent: \-
+    :Requirement: Pki Server CA
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server command shows ca, kra, ocsp, tks, tps, instance, 
+        subsystem, migrate, nuxwdog commands
+    """
+
+    try:
+        server_out = ansible_module.command('pki-server --help')
+        for result in server_out.values():
+            assert "-v, --verbose                Run in verbose mode." in result['stdout']
+            assert "--debug                  Show debug messages." in result['stdout']
+            assert "--help                   Show help message." in result['stdout']
+            assert "ca                            CA management commands" in result['stdout']
+            assert "kra                           KRA management commands" in result['stdout']
+            assert "ocsp                          OCSP management commands" in result['stdout']
+            assert "tks                           TKS management commands" in result['stdout']
+            assert "tps                           TPS management commands" in result['stdout']
+            assert "instance                      Instance management commands" in result['stdout']
+            assert "subsystem                     Subsystem management commands" in result['stdout']
+            assert "migrate                       Migrate system" in result['stdout']
+            assert "nuxwdog                       Nuxwdog related commands" in result['stdout']
+    except CalledProcessError:
+        pytest.xfail("Failed to run pki-server command.")
+
+
+def test_pki_server_junk(ansible_module):
+    """
+    :id: 140f53a4-d3ed-4d21-bc4e-996a6a1232a6
+    :Title: Test pki-server with junk sub-command
+    :Requirement: test pki-server  command
+    :CaseComponent: \-
+    :Requirement: Pki Server CA
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server command fails with junk option
+    """
+    junk = utils.get_random_string(len=10)
+    junk_out = ansible_module.command('pki-server {}'.format(junk))
+    for result in junk_out.values():
+        if result['rc'] >= 1:
+            assert junk in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server {} option.".format(junk))
+
+
+@pytest.mark.parametrize('subsystems', ['ca', 'kra', 'ocsp', 'tks', 'tps'])
+def test_pki_server_ca(ansible_module, subsystems):
+    """
+    :id: 2bb0595f-e25c-4ddf-890b-b2e4a3e0323b
+    :Title: Test pki-server ca command
+    :Description: Test pki-server ca command
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults: 
+        1. Verify whether pki-server ca command shows ca-cert, ca-clone commands
+    """
+    try:
+        pki_ca_out = ansible_module.command('pki-server {}'.format(subsystems))
+        for result in pki_ca_out.values():
+            if subsystems == 'ca':
+                assert "ca-cert                       CA certificates management commands" in \
+                       result['stdout']
+                assert "ca-clone                      CA clone management commands" in \
+                       result['stdout']
+                assert "ca-audit                      Audit management commands" in result['stdout']
+            elif subsystems == 'kra':
+                assert "kra-clone                     KRA clone management commands" in \
+                       result['stdout']
+                assert "kra-db                        KRA database management commands" in \
+                       result['stdout']
+                assert "kra-audit                     Audit management commands" in result['stdout']
+            elif subsystems == 'ocsp':
+                assert "ocsp-clone                    OCSP clone management commands" in \
+                       result['stdout']
+                assert "ocsp-audit                    Audit management commands" in result['stdout']
+            elif subsystems == 'tks':
+                assert "tks-clone                     TKS clone management commands" in \
+                       result['stdout']
+                assert "tks-audit                     Audit management commands" in result['stdout']
+            elif subsystems == 'tps':
+                assert "tps-clone                     TPS clone management commands" in \
+                       result['stdout']
+                assert "tps-db                        TPS database management commands" in \
+                       result['stdout']
+                assert "tps-audit                     Audit management commands" in result['stdout']
+    except CalledProcessError:
+        pytest.xfail("Failed to run pki-server ca command.")
+
+
+@pytest.mark.parametrize('subsystem', ['ca', 'kra', 'ocsp', 'tks', 'tps'])
+def test_pki_server_with_junk(ansible_module, subsystem):
+    """
+    :id: 37df246a-68bf-4cf5-893e-a3d17b033968
+    :Title: Test pki-server with junk subsystem command.
+    :Description: Test pki-server with junk subsystem command
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1.
+    :ExpectedResults:
+        1. Verify whether pki-server command fails with junk option
+    """
+    junk = utils.get_random_string(len=50)
+    junk_output = ansible_module.shell('pki-server {} {}'.format(subsystem, junk))
+    for result in junk_output.values():
+        if result['rc'] >= 1:
+            assert "ERROR: Invalid module \"{}\"".format(junk) in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server with junk option.")

--- a/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca_cert_chain_export.py
+++ b/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca_cert_chain_export.py
@@ -1,0 +1,246 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI SERVER  CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server cli commands needs to be tested:
+#   pki-server ca-cert
+#   pki-server ca-cert-chain
+#   pki-server ca-cert-chain-export
+#   pki-server ca-cert-request
+#   pki-server ca-cert-request-find
+#   pki-server ca-cert-request-show
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+from pki.testlib.common import utils
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_ca_cert(ansible_module):
+    """
+    :id: 75bb5b8d-f65b-4205-8d96-b39c0983298d
+    :Title: Test pki-server ca-cert command
+    :Description: Test pki-server ca-cert command
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert command shows ca-cert-chain, ca-cert-request commands
+    """
+
+    ca_cert_out = ansible_module.command('pki-server ca-cert')
+    for result in ca_cert_out.values():
+        if result['rc'] == 0:
+            assert "ca-cert-chain                 CA certificate chain " \
+                   "management commands" in result['stdout']
+            assert "ca-cert-request               CA certificate requests " \
+                   "management commands" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server ca-cert command..!!")
+
+
+def test_pki_server_ca_cert_chain(ansible_module):
+    """
+    :id: 13cb6d5c-bc67-4912-a7a9-8530ed834fd0
+    :Title: Test pki-server ca-cert-chain command
+    :Description: Test pki-server ca-cert-chain command
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults:
+            1. Verify whether pki-server ca-cert-chain command shows
+                ca-cert-chain-export commands
+    """
+
+    output = ansible_module.command('pki-server ca-cert-chain')
+
+    for result in output.values():
+        if result['rc'] == 0:
+            assert "ca-cert-chain-export          Export certificate chain" in \
+                   result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server ca-cert-chain command..!!")
+
+
+def test_pki_server_ca_cert_chain_export_help(ansible_module):
+    """
+    :id: 635fccb9-828c-4bec-aa91-ad0e0f53dee1
+    :Title: Test pki-server ca-cert-chain-export --help command.
+    :Description: Test pki-server ca-cert-chain-export --help command.
+    :Requirement: Pki Server CA
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-chain-export command exports ca cert chain
+    """
+
+    help_out = ansible_module.command('pki-server ca-cert-chain-export --help')
+    for result in help_out.values():
+        if result['rc'] == 0:
+            assert "-i, --instance <instance ID>       Instance ID " \
+                   "(default: pki-tomcat)" in result['stdout']
+            assert "--pkcs12-file <path>           PKCS #12 file to store " \
+                   "certificates and keys" in result['stdout']
+            assert "--pkcs12-password <password>   Password for the " \
+                   "PKCS #12 file" in result['stdout']
+            assert "--pkcs12-password-file <path>  File containing the " \
+                   "PKCS #12 password" in result['stdout']
+            assert "-v, --verbose                      Run in verbose mode" \
+                   in result['stdout']
+            assert "--help                         Show help message" in \
+                   result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server ca-cert-chain-export "
+                         "--help command.")
+
+
+def test_pki_server_ca_cert_chain_export(ansible_module):
+    """
+    :id:a874013b-4e39-4a1c-aab1-4fd33281e722
+    :Title: Test pki-server ca-cert-chain-export export CA Cert Chain Command
+    :Description: Test pki-server ca-cert-chain-export export CA cert chain command
+    :Requirement: Pki Server CA
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-chain-export command exports
+        ca cert chain
+    """
+    cmd = 'pki-server ca-cert-chain-export -i {} ' \
+          '--pkcs12-file /tmp/ca_cert_chain.p12' \
+          '--pkcs12-password {}'.format(constants.CA_INSTANCE_NAME,
+                                        constants.CLIENT_PKCS12_PASSWORD)
+    password = 'pass:{}'.format(constants.CLIENT_PKCS12_PASSWORD)
+    openssl_cmd = 'openssl pkcs12 -info -in /tmp/ca_cert_chain.p12 -password {}'
+    export_out = ansible_module.command(cmd)
+    for result in export_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            assert "Deleted certificate" in result['stdout']
+            status = ansible_module.stat(path='/tmp/ca_cert_chain.p12')
+            for res in status.values():
+                if res['stat']['exists']:
+
+                    output = ansible_module.command(
+                        openssl_cmd.format(password))
+                    for r1 in output.values():
+                        assert "-----BEGIN CERTIFICATE-----" in r1['stdout']
+                        assert "-----END CERTIFICATE-----" in r1['stdout']
+                else:
+                    pytest.xfail("Failed to run pki-server "
+                                 "ca-cert-chain-export command.")
+
+
+def test_pki_server_ca_cert_chain_export_password_file(ansible_module):
+    """
+    :id: 4dd04a92-ace0-46c8-b054-21ce8de895d4
+    :Title: Test pki-server ca-cert-chain-export export CA Cert Chain with password file command.
+    :Description: Test pki-server ca-cert-chain-export export CA cert chian with password file.
+    :CaseComponent: \-
+    :Requirement: Pki Server CA
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-chain-export command exports ca cert chain
+    """
+    chain_export = 'pki-server ca-cert-chain-export -i {} ' \
+                   '--pkcs12-file /tmp/ca_cert_chain.p12 ' \
+                   '--pkcs12-password-file /tmp/password.txt'.format(constants.CA_INSTANCE_NAME)
+    password = 'pass:{}'.format(constants.CLIENT_PKCS12_PASSWORD)
+    openssl_cmd = 'openssl pkcs12 -info -in /tmp/ca_cert_chain.p12 -password {}'
+
+    ansible_module.command("echo '{}' /tmp/password.txt".format(
+        constants.CLIENT_PKCS12_PASSWORD))
+    export_out = ansible_module.command(chain_export)
+    for result in export_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            assert "Deleted certificate" in result['stdout']
+            status = ansible_module.stat(path='/tmp/ca_cert_chain.p12')
+            for res in status.values():
+                if res['stat']['exists']:
+
+                    output = ansible_module.command(
+                        openssl_cmd.format(password))
+                    for r1 in output.values():
+                        assert "-----BEGIN CERTIFICATE-----" in r1['stdout']
+                        assert "-----END CERTIFICATE-----" in r1['stdout']
+                else:
+                    pytest.xfail("Failed to run pki-server "
+                                 "ca-cert-chain-export command.")
+
+
+def test_pki_server_ca_cert_chain_export_with_incorrect_db_pass(ansible_module):
+    """
+    :id: d82dab88-022a-4b3b-b759-6a2f8ba1125f
+    :Title: Test pki-server ca-cert-chain-export with incorrect db password
+    :Description: Test pki-server ca-cert-chain-export with incorrect db password
+    :Requirement: Pki Server CA
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-chain-export command throws error with wrong password
+    """
+
+    password = utils.get_random_string(len=8)
+    chain_export = 'pki-server ca-cert-chain-export -i {} ' \
+                   '--pkcs12-file /tmp/ca_cert_chain.p12 ' \
+                   '--pkcs12-password {}'.format(constants.CA_INSTANCE_NAME, password)
+
+    openssl_cmd = 'openssl pkcs12 -info -in /tmp/ca_cert_chain.p12 -password pass:{}'
+
+    ansible_module.command("echo '{}' /tmp/password.txt".format(
+        constants.CLIENT_PKCS12_PASSWORD))
+    status = ansible_module.stat(path='/tmp/ca_cert_chain.p12')
+    for r1 in status.values():
+        if r1['stat']['exists']:
+            ansible_module.command('rm -rf /tmp/ca_cert_chain.p12')
+            export_out = ansible_module.command(chain_export)
+            for result in export_out.values():
+                if result['rc'] == 0:
+                    assert "Export complete" in result['stdout']
+                    assert "Deleted certificate" in result['stdout']
+                    status = ansible_module.stat(path='/tmp/ca_cert_chain.p12')
+                    for res in status.values():
+                        if res['stat']['exists']:
+                            output = ansible_module.command(openssl_cmd.format(password))
+                            for r1 in output.values():
+                                assert "-----BEGIN CERTIFICATE-----" in r1['stdout']
+                                assert "-----END CERTIFICATE-----" in r1['stdout']
+                        else:
+                            pytest.xfail("Failed to run pki-server "
+                                         "ca-cert-chain-export command.")

--- a/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca_cert_request_find.py
+++ b/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca_cert_request_find.py
@@ -1,0 +1,217 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: Pki Server CA-CERT-REQUEST CLI TESTS
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server cli commands needs to be tested:
+#   pki-server ca-cert-request
+#   pki-server ca-cert-request-find
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import random
+import sys
+
+import os
+import pytest
+
+from pki.testlib.common import utils
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+userop = utils.UserOperations(nssdb=constants.NSSDB)
+
+BASE_DB_DIR = '/var/lib/pki/{}/alias'
+
+
+def create_cert(ansible_module):
+    """
+    Return a base 64 encoded certificate.
+    """
+    no = random.randint(11, 999989)
+    user = 'testuser{}'.format(no)
+    subject = 'UID={},CN={}'.format(user, user)
+
+    cert_id = userop.process_certificate_request(ansible_module, subject=subject)
+    if cert_id:
+        cert_file = "/tmp/{}.pem".format(user)
+        ansible_module.command('pki -d {} -c {} -p {} client-cert-import "{}" '
+                               '--serial {}'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                                    constants.CA_HTTP_PORT, user, cert_id))
+        ansible_module.command('pki -d {} -c {} client-cert-show "{}" '
+                               '--cert /tmp/{}.pem '.format(constants.NSSDB,
+                                                            constants.CLIENT_DIR_PASSWORD,
+                                                            user, user))
+        ansible_module.command('pki -d {} -c {} client-cert-del '
+                               '"{}"'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                             user))
+        return [cert_id, cert_file]
+
+
+def test_pki_server_ca_cert_request(ansible_module):
+    """
+    :id: 5ac753d1-b815-4086-af23-6aca3cd7a864
+    :Title: Test pki-server ca-cert-request command
+    :Description: test pki-server ca-cert-request command
+    :Requirement: Pki Server CA
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-request command shows ca-cert-request-find,
+           ca-cert-request-find commands.
+    """
+    ca_cert_out = ansible_module.command('pki-server ca-cert-request')
+    for result in ca_cert_out.values():
+        if result['rc'] == 0:
+            assert "ca-cert-request-find          Find CA certificate requests" in result['stdout']
+            assert "ca-cert-request-show          Show CA certificate request" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server ca-cert-request-find command.")
+
+
+def test_pki_server_ca_cert_request_find(ansible_module):
+    """
+    :id: 1d2a3723-3fb4-4f22-af11-e9519cfa8a66
+    :Title: Bug - 1289605 : Test pki-server ca-cert-request-find command should find
+            the certificate request with the default pki-tomcat instance.
+    :Description: Bug-1289605, Test pki-server ca-cert-request-find command should find
+        the certificate request with the default pki-tomcat instance.
+    :Requirement: Pki Server CA
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-request-find command shows the cert
+           request with default pki-tomcat instance.
+    """
+    cmd = 'pki-server ca-cert-request-find'
+    request_out = ansible_module.command(cmd)
+    for result in request_out.values():
+        if result['rc'] >= 1:
+            assert "ERROR: Invalid instance pki-tomcat." in result['stdout']
+        else:
+            assert "entries matched" in result['stdout']
+            assert "Request ID:" in result['stdout']
+            assert "Type: enrollment" in result['stdout']
+            assert "Status: " in result['stdout']
+
+
+@pytest.mark.parametrize("instance_name", [constants.CA_INSTANCE_NAME,
+                                           "invalid_instance"])
+def test_pki_server_ca_cert_request_find_with_instance_name(ansible_module, instance_name):
+    """
+    :id: 30b662b4-4371-4829-86c9-4d84dc8f4b09
+    :Title: Test pki-server ca-cert-request-find -i <instance_name> command
+    :Description: Test pki-server ca-cert-request-find -i <instance_name> command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement: Pki Server CA
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-request-find -i <instance_name> command
+           shows the cert request.
+    """
+    cmd = 'pki-server ca-cert-request-find -i {}'.format(instance_name)
+
+    request_out = ansible_module.command(cmd)
+    for result in request_out.values():
+        if result['rc'] >= 1:
+            if 'Invalid' in result['stdout']:
+                assert "ERROR: Invalid instance %s" % instance_name in result['stdout']
+            else:
+                assert "ERROR: 'extdata-cert--005frequest'" in result['stdout']
+        else:
+            assert "entries matched" in result['stdout']
+            assert "Request ID:" in result['stdout']
+            assert "Type: enrollment" in result['stdout']
+            assert "Status: " in result['stdout']
+
+
+@pytest.mark.xfail(reason="Not implemented correctly")
+def test_pki_server_ca_cert_request_find_with_cert_option(ansible_module):
+    """
+    :id: 08997b38-1f9c-4b18-8863-10efd400302a
+    :Title: Test pki-server ca-cert-request-find with --cert option.
+    :Description: Test pki-server ca-cert-request-find with --cert option.
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :Expectedresults:
+                1. Command should show the certificate request after passing the certificate.
+    """
+    cert_id, cert_file = create_cert(ansible_module)
+
+    cert_out = ansible_module.command('pki-server ca-cert-request-find '
+                                      '-i {} --cert {}'.format(constants.CA_INSTANCE_NAME,
+                                                               cert_id))
+
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            if '0 entries matched' in result['stdout']:
+                pytest.xfail("Failed to run pki-server ca-cert-request-find.")
+            elif '0 entries matched' not in result['stdout']:
+                assert 'Request ID: ' in result['stdout']
+                assert 'Type:' in result['stdout']
+                assert 'Status:' in result['stdout']
+            else:
+                pytest.xfail("Failed to run pki-server ca-cert-request-find.")
+
+
+@pytest.mark.xfail(reason="Not implemented correctly")
+def test_pki_server_ca_cert_request_find_with_cert_file_option(ansible_module):
+    """
+    :id: 3237f537-b262-4698-b10f-4b907fa4a961
+    :Title: Test pki-server ca-cert-request-find with cert-file option
+    :Description: Test pki-server ca-cert-request-find with cert-file option.
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :Expectedresults:
+        1. It should show the certificate request when certificate file is passed.
+    """
+    cert_id, cert_file = create_cert(ansible_module)
+
+    cert_out = ansible_module.command('pki-server ca-cert-request-find '
+                                      '-i {} --cert {}'.format(constants.CA_INSTANCE_NAME,
+                                                               cert_id))
+
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            if '0 entries matched' in result['stdout']:
+                pytest.xfail("Failed to run pki-server ca-cert-request-find.")
+            elif '0 entries matched' not in result['stdout']:
+                assert 'Request ID: ' in result['stdout']
+                assert 'Type:' in result['stdout']
+                assert 'Status:' in result['stdout']
+            else:
+                pytest.xfail("Failed to run pki-server ca-cert-request-find.")

--- a/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca_cert_request_show.py
+++ b/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca_cert_request_show.py
@@ -1,0 +1,164 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: Pki Server CA-CERT-REQUEST CLI TESTS
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server cli commands needs to be tested:
+#   pki-server ca-cert-request
+#   pki-server ca-cert-request-find
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import random
+import sys
+
+import os
+import pytest
+
+from pki.testlib.common import utils
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+userop = utils.UserOperations(nssdb=constants.NSSDB)
+
+BASE_DB_DIR = '/var/lib/pki/{}/alias'
+
+
+def create_cert(ansible_module):
+    """
+    Return a base 64 encoded certificate.
+    """
+    no = random.randint(11, 999989)
+    user = 'testuser{}'.format(no)
+    subject = 'UID={},CN={}'.format(user, user)
+
+    cert_id = userop.process_certificate_request(ansible_module, subject=subject)
+    if cert_id:
+        cert_file = "/tmp/{}.pem".format(user)
+        ansible_module.command('pki -d {} -c {} -p {} client-cert-import "{}" '
+                               '--serial {}'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                                    constants.CA_HTTP_PORT, user, cert_id))
+        ansible_module.command('pki -d {} -c {} client-cert-show "{}" '
+                               '--cert /tmp/{}.pem '.format(constants.NSSDB,
+                                                            constants.CLIENT_DIR_PASSWORD,
+                                                            user, user))
+        ansible_module.command('pki -d {} -c {} client-cert-del '
+                               '"{}"'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                             user))
+        return [cert_id, cert_file]
+
+
+@pytest.mark.parametrize("instance_name", [constants.CA_INSTANCE_NAME, "invalid_instance"])
+def test_pki_server_ca_cert_request_show(ansible_module, instance_name):
+    """
+    :id: 5b1aaaac-1cf3-4b5b-a6ba-f86db04a4042
+    :Title: Test pki-server ca-cert-request-show command, BZ: 1289605
+    :Description: Test pki-server ca-cert-request-show command. BZ: 1289605
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :Requirement: Pki Server CA
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-request-show command shows the
+           specified request id.
+    """
+    cmd = 'pki-server ca-cert-request-show 1 -i {}'.format(instance_name)
+
+    cmd_out = ansible_module.command(cmd)
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Request ID:" in result['stdout']
+            assert "Type: enrollment" in result['stdout']
+            assert "Status: complete" in result['stdout']
+            assert "Request:" in result['stdout']
+        else:
+            assert "ERROR: Invalid instance %s" % instance_name in result['stdout']
+
+
+@pytest.mark.parametrize("instance_name", [constants.CA_INSTANCE_NAME,
+                                           "invalid_instance"])
+def test_pki_server_ca_cert_request_show_with_instance_name(ansible_module, instance_name):
+    """
+    :id: 791544da-d5eb-42b5-8b4a-8728f10064bd
+    :Title: Bug - 1289605 : Test pki-server ca-cert-request-show -i <instance_name>
+            command, it should fail on invalid instance name.
+    :Description: Test pki-server ca-cert-request-show -i <instance> command. Should failed with
+            invalid instance name.
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement: Pki Server CA
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-cert-request-show -i <instance_name> command shows
+            the specified request id, and should fail on invalid instance name.
+    """
+    cmd = 'pki-server ca-cert-request-show 1 -i {}'.format(instance_name)
+
+    cmd_out = ansible_module.command(cmd)
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Request ID: 1" in result['stdout']
+            assert "Type: enrollment" in result['stdout']
+            assert "Status: complete" in result['stdout']
+            assert "Request:" in result['stdout']
+        else:
+            assert "ERROR: Invalid instance %s." % instance_name in result['stdout']
+
+
+def test_pki_server_ca_cert_request_show_with_output_file(ansible_module):
+    """
+    :id: 72679079-f7ae-4452-9a54-df9bd1e0d862
+    :Title: Test pki-server ca-cert-request-show with --output-file
+    :Description: Test pki-server ca-cert-request-show with --output-file
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :Expectedresults:
+            1. Certificate request get stored in the output file.
+    """
+
+    cmd = 'pki-server ca-cert-request-show 1 -i {} ' \
+          '--output-file /tmp/request1.req'.format(constants.CA_INSTANCE_NAME)
+
+    req_out = ansible_module.command(cmd)
+    for result in req_out.values():
+        if result['rc'] == 0:
+            is_file = ansible_module.stat(path='/tmp/request1.req')
+            for res in is_file.values():
+                assert res['stat']['exists']
+
+            print_file = ansible_module.command('cat /tmp/request1.req')
+            for res in print_file.values():
+                if res['rc'] == 0:
+                    assert '-----BEGIN CERTIFICATE REQUEST-----' in res['stdout']
+                    assert '-----END CERTIFICATE REQUEST-----' in res['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server ca-cert-request-show --output-file.")

--- a/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca_clone_prepare.py
+++ b/tests/dogtag/pytest-ansible/pytest/ca/pki_server/test_pki_server_ca_clone_prepare.py
@@ -1,0 +1,152 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI SERVER  CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server cli commands needs to be tested:
+#   pki-server ca-clone
+#   pki-server ca-clone-prepare
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_ca_clone(ansible_module):
+    """
+    :id: d2e47e97-5096-4e56-a856-021a659289a2
+    :Title: Test pki-server ca-clone command
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1.Verify whether pki-server ca-clone shows ca-clone-prepare command
+    """
+    clone_out = ansible_module.command('pki-server ca-clone')
+    for result in clone_out.values():
+        if result['rc'] == 0:
+            assert "ca-clone-prepare              Prepare CA clone" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server ca-clone command.")
+
+
+def test_pki_server_ca_clone_prepare_help(ansible_module):
+    """
+    :id: 2720f206-d4ec-4455-bd16-937f6e5611f0
+    :Title: Test pki-server ca-clone-prepare --help command
+    :Description: Test pki-server ca-clone-prepare --help command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement: Pki Server CA
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-clone-prepare --help command shows help option
+    """
+    help_out = ansible_module.command('pki-server ca-clone-prepare --help')
+    for result in help_out.values():
+        if result['rc'] == 0:
+            assert "-i, --instance <instance ID>       Instance ID (default: pki-tomcat)" in \
+                   result['stdout']
+            assert "--pkcs12-file <path>           PKCS #12 file to store certificates and keys" \
+                   in result['stdout']
+            assert "--pkcs12-password <password>   Password for the PKCS #12 file" in \
+                   result['stdout']
+            assert "--pkcs12-password-file <path>  File containing the PKCS #12 password" in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode" in result['stdout']
+            assert "--help                         Show help message" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server ca-clone-prepare --help command..!!")
+
+
+def test_pki_server_ca_clone_prepare(ansible_module):
+    """
+    :id: 63d0c7fe-bb25-4f33-9929-4eb2f24c60d9
+    :Title: Test pki-server ca-clone-prepare command
+    :Description: Test pki-server ca-clone-prepare command
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-clone-prepare command exports ca backup keys
+    """
+    cmd = 'pki-server ca-clone-prepare -i {} --pkcs12-file /tmp/ca_backup_keys.p12 ' \
+          '--pkcs12-password {}'.format(constants.CA_INSTANCE_NAME,
+                                        constants.CLIENT_PKCS12_PASSWORD)
+    export_out = ansible_module.command(cmd)
+    for result in export_out.values():
+        if result['rc'] == 0:
+            assert "Added certificate" in result['stdout']
+            isfile = ansible_module.stat(path='/tmp/ca_backup_keys.p12')
+            for res in isfile.values():
+                assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server ca-clone-prepare command..!!")
+
+
+def test_pki_server_ca_clone_prepare_password_file(ansible_module):
+    """
+    :id: 4f2cc61a-7167-4781-b8f1-5898b30d6bca
+    :Title: Test pki-server ca-clone-prepare command.
+    :Description: Test pki-server ca-clone-prepare command
+    :Requirement: Pki Server CA
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-clone-prepare command with password file
+           exports ca backup keys.
+    """
+    cmd = 'pki-server ca-clone-prepare -i {} --pkcs12-file /tmp/ca_backup_keys.p12 ' \
+          '--pkcs12-password-file /tmp/password.txt'.format(constants.CA_INSTANCE_NAME,
+                                                            constants.CLIENT_PKCS12_PASSWORD)
+    ansible_module.shell("echo '{}' > /tmp/password.txt".format(constants.CLIENT_PKCS12_PASSWORD))
+    status = ansible_module.stat(path='/tmp/ca_backup_keys.p12')
+    for r1 in status.values():
+        if r1['stat']['exists']:
+            ansible_module.command('rm -rf /tmp/ca_backup_keys.p12')
+
+        export_out = ansible_module.command(cmd)
+        for result in export_out.values():
+            if result['rc'] == 0:
+                assert "Added certificate" in result['stdout']
+                isfile = ansible_module.stat(path='/tmp/ca_backup_keys.p12')
+                for res in isfile.values():
+                    assert res['stat']['exists']
+            else:
+                pytest.xfail("Failed to run pki-server ca-clone-prepare command.")

--- a/tests/dogtag/pytest-ansible/pytest/installation/test_bug_1523410_1534030_non_pkiuser_owned_instances.py
+++ b/tests/dogtag/pytest-ansible/pytest/installation/test_bug_1523410_1534030_non_pkiuser_owned_instances.py
@@ -61,7 +61,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkispawn_ca(ansible_module):
 
     :Description: This automation tests if a CA instance can be configured with a non pkiuser ownership.
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :Setup:
 	Have all the required packages installed.
@@ -124,7 +124,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkispawn_kra(ansible_module):
 
     :Description: This automation tests if a KRA instance can be configured with a non pkiuser ownership.
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :CaseComponent: \-
 
@@ -181,7 +181,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkispawn_ocsp(ansible_module):
 
     :Description: This automation tests if a OCSP instance can be configured with a non pkiuser ownership.
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :CaseComponent: \-
 
@@ -238,7 +238,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkispawn_tks(ansible_module):
 
     :Description: This automation tests if a TKS instance can be configured with a non pkiuser ownership.
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :CaseComponent: \-
 
@@ -295,7 +295,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkispawn_tps(ansible_module):
 
     :Description: This automation tests if a TKS instance can be configured with a non pkiuser ownership.
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :CaseComponent: \-
 
@@ -355,7 +355,7 @@ def test_bug_1523410_non_pkiuser_owned_pkidestroy_tps(ansible_module):
 
     :Description: This automation tests pkidestroy of TPS when nuxwdog is enabled
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :CaseComponent: \-
 
@@ -390,7 +390,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkidestroy_tks(ansible_module):
 
     :Description: This automation tests pkidestroy of TKS when nuxwdog is enabled
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Req Installation and Deployment
 
     :CaseComponent: \-
 
@@ -425,7 +425,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkidestroy_ocsp(ansible_module):
 
     :Description: This automation tests pkidestroy of OCSP when nuxwdog is enabled
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :CaseComponent: \-
 
@@ -460,7 +460,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkidestroy_kra(ansible_module):
 
     :Description: This automation tests pkidestroy of KRA when nuxwdog is enabled
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :CaseComponent: \-
 
@@ -495,7 +495,7 @@ def test_bug_1523410_1534030_non_pkiuser_owned_pkidestroy_ca(ansible_module):
 
     :Description: This automation tests pkidestroy of CA when nuxwdog is enabled
 
-    :Requirement: RHCS-REQ Installation and Deployment
+    :Requirement: Installation and Deployment
 
     :CaseComponent: \-
 

--- a/tests/dogtag/pytest-ansible/pytest/kra/pki_server/test_pki_server_kra_clone_prepare.py
+++ b/tests/dogtag/pytest-ansible/pytest/kra/pki_server/test_pki_server_kra_clone_prepare.py
@@ -1,0 +1,152 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI SERVER  CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server cli commands needs to be tested:
+#   pki-server kra-clone
+#   pki-server kra-clone-prepare
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_kra_clone(ansible_module):
+    """
+    :id: d2e47e97-5096-4e56-a856-021a659289a2
+    :Title: Test pki-server kra-clone command
+    :Requirement:
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1.Verify whether pki-server kra-clone shows kra-clone-prepare command
+    """
+    clone_out = ansible_module.command('pki-server kra-clone')
+    for result in clone_out.values():
+        if result['rc'] == 0:
+            assert "kra-clone-prepare              Prepare CA clone" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server kra-clone command.")
+
+
+def test_pki_server_kra_clone_prepare_help(ansible_module):
+    """
+    :id: 2720f206-d4ec-4455-bd16-937f6e5611f0
+    :Title: Test pki-server kra-clone-prepare --help command
+    :Description: Test pki-server kra-clone-prepare --help command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement:
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server kra-clone-prepare --help command shows help option
+    """
+    help_out = ansible_module.command('pki-server kra-clone-prepare --help')
+    for result in help_out.values():
+        if result['rc'] == 0:
+            assert "-i, --instance <instance ID>       Instance ID (default: pki-tomcat)" in \
+                   result['stdout']
+            assert "--pkcs12-file <path>           PKCS #12 file to store certificates and keys" \
+                   in result['stdout']
+            assert "--pkcs12-password <password>   Password for the PKCS #12 file" in \
+                   result['stdout']
+            assert "--pkcs12-password-file <path>  File containing the PKCS #12 password" in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode" in result['stdout']
+            assert "--help                         Show help message" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server kra-clone-prepare --help command..!!")
+
+
+def test_pki_server_kra_clone_prepare(ansible_module):
+    """
+    :id: 63d0c7fe-bb25-4f33-9929-4eb2f24c60d9
+    :Title: Test pki-server kra-clone-prepare command
+    :Description: Test pki-server kra-clone-prepare command
+    :Requirement:
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server kra-clone-prepare command exports ca backup keys
+    """
+    cmd = 'pki-server kra-clone-prepare -i {} --pkcs12-file /tmp/kra_backup_keys.p12 ' \
+          '--pkcs12-password {}'.format(constants.KRA_INSTANCE_NAME,
+                                        constants.CLIENT_PKCS12_PASSWORD)
+    export_out = ansible_module.command(cmd)
+    for result in export_out.values():
+        if result['rc'] == 0:
+            assert "Added certificate" in result['stdout']
+            isfile = ansible_module.stat(path='/tmp/kra_backup_keys.p12')
+            for res in isfile.values():
+                assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server kra-clone-prepare command..!!")
+
+
+def test_pki_server_kra_clone_prepare_password_file(ansible_module):
+    """
+    :id: 4f2cc61a-7167-4781-b8f1-5898b30d6bca
+    :Title: Test pki-server kra-clone-prepare command.
+    :Description: Test pki-server kra-clone-prepare command
+    :Requirement:
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server kra-clone-prepare command with password file
+           exports ca backup keys.
+    """
+    cmd = 'pki-server kra-clone-prepare -i {} --pkcs12-file /tmp/kra_backup_keys.p12 ' \
+          '--pkcs12-password-file /tmp/password.txt'.format(constants.KRA_INSTANCE_NAME,
+                                                            constants.CLIENT_PKCS12_PASSWORD)
+    ansible_module.shell("echo '{}' > /tmp/password.txt".format(constants.CLIENT_PKCS12_PASSWORD))
+    status = ansible_module.stat(path='/tmp/kra_backup_keys.p12')
+    for r1 in status.values():
+        if r1['stat']['exists']:
+            ansible_module.command('rm -rf /tmp/kra_backup_keys.p12')
+
+        export_out = ansible_module.command(cmd)
+        for result in export_out.values():
+            if result['rc'] == 0:
+                assert "Added certificate" in result['stdout']
+                isfile = ansible_module.stat(path='/tmp/kra_backup_keys.p12')
+                for res in isfile.values():
+                    assert res['stat']['exists']
+            else:
+                pytest.xfail("Failed to run pki-server kra-clone-prepare command.")

--- a/tests/dogtag/pytest-ansible/pytest/ocsp/pki_server/test_pki_server_ca_clone_prepare.py
+++ b/tests/dogtag/pytest-ansible/pytest/ocsp/pki_server/test_pki_server_ca_clone_prepare.py
@@ -1,0 +1,152 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI SERVER  CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server cli commands needs to be tested:
+#   pki-server ca-clone
+#   pki-server ca-clone-prepare
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_ca_clone(ansible_module):
+    """
+    :id: d2e47e97-5096-4e56-a856-021a659289a2
+    :Title: Test pki-server ca-clone command
+    :Requirement:
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1.Verify whether pki-server ca-clone shows ca-clone-prepare command
+    """
+    clone_out = ansible_module.command('pki-server ca-clone')
+    for result in clone_out.values():
+        if result['rc'] == 0:
+            assert "ca-clone-prepare              Prepare CA clone" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server ca-clone command.")
+
+
+def test_pki_server_ca_clone_prepare_help(ansible_module):
+    """
+    :id: 2720f206-d4ec-4455-bd16-937f6e5611f0
+    :Title: Test pki-server ca-clone-prepare --help command
+    :Description: Test pki-server ca-clone-prepare --help command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement:
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-clone-prepare --help command shows help option
+    """
+    help_out = ansible_module.command('pki-server ca-clone-prepare --help')
+    for result in help_out.values():
+        if result['rc'] == 0:
+            assert "-i, --instance <instance ID>       Instance ID (default: pki-tomcat)" in \
+                   result['stdout']
+            assert "--pkcs12-file <path>           PKCS #12 file to store certificates and keys" \
+                   in result['stdout']
+            assert "--pkcs12-password <password>   Password for the PKCS #12 file" in \
+                   result['stdout']
+            assert "--pkcs12-password-file <path>  File containing the PKCS #12 password" in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode" in result['stdout']
+            assert "--help                         Show help message" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server ca-clone-prepare --help command..!!")
+
+
+def test_pki_server_ca_clone_prepare(ansible_module):
+    """
+    :id: 63d0c7fe-bb25-4f33-9929-4eb2f24c60d9
+    :Title: Test pki-server ca-clone-prepare command
+    :Description: Test pki-server ca-clone-prepare command
+    :Requirement:
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-clone-prepare command exports ca backup keys
+    """
+    cmd = 'pki-server ca-clone-prepare -i {} --pkcs12-file /tmp/ca_backup_keys.p12 ' \
+          '--pkcs12-password {}'.format(constants.CA_INSTANCE_NAME,
+                                        constants.CLIENT_PKCS12_PASSWORD)
+    export_out = ansible_module.command(cmd)
+    for result in export_out.values():
+        if result['rc'] == 0:
+            assert "Added certificate" in result['stdout']
+            isfile = ansible_module.stat(path='/tmp/ca_backup_keys.p12')
+            for res in isfile.values():
+                assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server ca-clone-prepare command..!!")
+
+
+def test_pki_server_ca_clone_prepare_password_file(ansible_module):
+    """
+    :id: 4f2cc61a-7167-4781-b8f1-5898b30d6bca
+    :Title: Test pki-server ca-clone-prepare command.
+    :Description: Test pki-server ca-clone-prepare command
+    :Requirement:
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server ca-clone-prepare command with password file
+           exports ca backup keys.
+    """
+    cmd = 'pki-server ca-clone-prepare -i {} --pkcs12-file /tmp/ca_backup_keys.p12 ' \
+          '--pkcs12-password-file /tmp/password.txt'.format(constants.CA_INSTANCE_NAME,
+                                                            constants.CLIENT_PKCS12_PASSWORD)
+    ansible_module.shell("echo '{}' > /tmp/password.txt".format(constants.CLIENT_PKCS12_PASSWORD))
+    status = ansible_module.stat(path='/tmp/ca_backup_keys.p12')
+    for r1 in status.values():
+        if r1['stat']['exists']:
+            ansible_module.command('rm -rf /tmp/ca_backup_keys.p12')
+
+        export_out = ansible_module.command(cmd)
+        for result in export_out.values():
+            if result['rc'] == 0:
+                assert "Added certificate" in result['stdout']
+                isfile = ansible_module.stat(path='/tmp/ca_backup_keys.p12')
+                for res in isfile.values():
+                    assert res['stat']['exists']
+            else:
+                pytest.xfail("Failed to run pki-server ca-clone-prepare command.")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_db_schema_upgrade.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_db_schema_upgrade.py
@@ -1,0 +1,313 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server db-schema commands needs to be tested:
+#   pki-server db-schema-upgrade --help
+#   pki-server db-schema-upgrade
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+@pytest.fixture(autouse=False)
+def ds_instance(ansible_module):
+    instance_name = '{}-testingmaster'.format("-".join(constants.CA_INSTANCE_NAME.split("-")[:-1]))
+    stop_ds = 'systemctl stop dirsrv@slapd-{}'.format(instance_name)
+    ansible_module.command(stop_ds)
+    yield
+    start_ds = 'systemctl start dirsrv@slapd-{}'.format(instance_name)
+    ansible_module.command(start_ds)
+
+
+@pytest.fixture(autouse=False)
+def stop_pki_instance(ansible_module):
+    instance = constants.CA_INSTANCE_NAME
+    stop_instance = 'pki-server instance-stop {}'.format(instance)
+    start_instance = 'pki-server instance-start {}'.format(instance)
+    ansible_module.command(stop_instance)
+    yield instance
+    ansible_module.command(start_instance)
+
+
+def test_pki_server_db_schema_upgrade_help_command(ansible_module):
+    """
+    :id: 5e257ffc-2487-470f-8167-a15896c1426a
+    :Title: Test pki-server db-schema-upgrade --help command
+    :Description: Test pki-server db-schema-upgrade --help command
+    :Requirement: Pki Server Db 
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server db-schema-upgrade --help command shows the following commands.
+
+     Usage: pki-server db-schema-upgrade [OPTIONS]
+
+       -i, --instance <instance ID>       Instance ID (default: pki-tomcat).
+       -D, --bind-dn <Bind DN>            Connect DN (default: cn=Directory Manager).
+       -w, --bind-password <password>     Password to connect to DB.
+       -v, --verbose                      Run in verbose mode.
+           --help                         Show help message.
+
+    """
+    help_command = 'pki-server db-schema-upgrade --help'
+
+    cmd_output = ansible_module.command(help_command)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server db-schema-upgrade [OPTIONS]" in result['stdout']
+            assert "  -i, --instance <instance ID>       Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "  -D, --bind-dn <Bind DN>            Connect DN (default: cn=Directory " \
+                   "Manager)." in result['stdout']
+            assert "  -w, --bind-password <password>     Password to connect to DB." in \
+                   result['stdout']
+            assert "  -v, --verbose                      Run in verbose mode." in result['stdout']
+            assert "      --help                         Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server db-schema-upgrade --help command.")
+
+
+def test_pki_server_db_schema_upgrade_command(ansible_module):
+    """
+    :id: f5d66360-1c0d-4c12-afe0-9645ec13569f
+    :Title: Test pki-server db-schema-upgrade command
+    :Description: Test pki-server db-schema-upgrade command
+    :Requirement: Pki Server Db
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server db-schema-upgrade command upgrade the pki server database.
+    """
+
+    subsystem = ['ca', 'kra', 'ocsp', 'tks', 'tps']
+    bind_dn = "'cn=Directory Manager'"
+    bind_pass = constants.CLIENT_DIR_PASSWORD
+    for system in subsystem:
+        instance = None
+        try:
+            instance = eval("constants.{}_INSTANCE_NAME".format(system.upper()))
+        except:
+            pytest.skip("Instance is not present")
+        db_upgrade = 'pki-server db-schema-upgrade -i {} -D {} -w {}'.format(instance, bind_dn,
+                                                                             bind_pass)
+        cmd_output = ansible_module.command(db_upgrade)
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                assert "Upgrade complete" in result['stdout']
+            else:
+                pytest.xfail("Failed to run pki-server db-schema-upgrade command for "
+                             "instance %s." % system)
+
+
+def test_pki_server_db_schema_upgrade_when_password_is_wrong(ansible_module):
+    """
+    :id: 4f814b5c-c450-46f9-818c-0aca3d5b0f21
+    :Title: Test pki-server db-schema-upgrade command when db password is wrong.
+    :Description: Test pki-server db-schema-upgrade command when db password is wrong.
+    :Requirement: Pki Server Db
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server db-schema-upgrade command do not upgrade the pki server
+           database when password is wrong.
+    """
+    subsystem = ['ca', 'kra', 'ocsp', 'tks', 'tps']
+    bind_dn = "cn=Directory Manager"
+    bind_pass = "Secret123231"
+
+    for system in subsystem:
+        instance = None
+        try:
+            instance = eval("constants.{}_INSTANCE_NAME".format(system.upper()))
+        except:
+            pytest.skip("Instance is not present")
+        db_schema_upgrade = 'pki-server db-schema-upgrade -i {} -D {} -w {}'.format(instance,
+                                                                                    bind_dn,
+                                                                                    bind_pass)
+        cmd_output = ansible_module.command(db_schema_upgrade)
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                assert "Upgrade complete" in result['stdout']
+                pytest.xfail("Failed to run pki-server db-schema-upgrade command for "
+                             "instance %s." % system)
+            else:
+                assert "ERROR: ldap_bind: Invalid credentials (49)" in result['stdout']
+
+
+def test_pki_server_db_schema_upgrade_when_bind_DN_is_wrong(ansible_module):
+    """
+    :id: 2d24ef4d-c99d-46dd-942e-2493775aadb1
+    :Title: Test pki-server db-schema-upgrade command when bind DN is wrong.
+    :Description: Test pki-server db-schema-upgrade command when bind DN is wrong.
+    :Requirement: Pki Server Db
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server db-schema-upgrade command do not upgrade the
+            pki server database when bind DN is wrong.
+
+    """
+    subsystem = ['ca', 'kra', 'ocsp', 'tks', 'tps']
+    bind_dn = "cn=Data Manager"
+    bind_pass = constants.CLIENT_DIR_PASSWORD
+
+    for system in subsystem:
+
+        instance = None
+        try:
+            instance = eval("constants.{}_INSTANCE_NAME".format(system.upper()))
+        except:
+            pytest.skip("Instance is not present")
+        db_schema_upgrade = 'pki-server db-schema-upgrade -i {} -D {} -w {}'.format(instance,
+                                                                                    bind_dn,
+                                                                                    bind_pass)
+        cmd_output = ansible_module.command(db_schema_upgrade)
+
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                assert "Upgrade complete" in result['stdout']
+                pytest.xfail("Failed to run pki-server db-schema-upgrade command for "
+                             "instance %s." % system)
+            else:
+                assert "ERROR: ldap_bind: Invalid credentials (49)" in result['stdout']
+
+
+def test_pki_server_db_schema_upgrade_while_ds_instance_is_down(ansible_module, ds_instance):
+    """
+    :id: cfe68e55-1926-410c-9157-e22eb5412283
+    :Title: Test pki-server db-schema-upgrade command when ds instance is down.
+    :Description: Test pki-server db-schema-upgrade command when ds instance is down.
+    :Requirement: Pki Server Db
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server db-schema-upgrade command do not upgrade the pki server
+            database while directory server instance is down, it throws Error.
+
+    """
+
+    subsystem = ['ca', 'kra', 'ocsp', 'tks', 'tps']
+
+    bind_dn = "cn=Data Manager"
+    bind_pass = constants.CLIENT_DIR_PASSWORD
+
+    for system in subsystem:
+        instance = None
+        try:
+            instance = eval("constants.{}_INSTANCE_NAME".format(system.upper()))
+        except:
+            pytest.skip("Instance is not present")
+
+        db_schema_upgrade = 'pki-server db-schema-upgrade -i {} -D {} -w {}'.format(instance,
+                                                                                    bind_dn,
+                                                                                    bind_pass)
+        cmd_output = ansible_module.command(db_schema_upgrade)
+
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                assert "Upgrade complete" in result['stdout']
+                pytest.xfail("Failed to run pki-server db-schema-upgrade command.")
+            else:
+                assert "ERROR: ldap_bind: Invalid credentials (49)" in result['stdout']
+
+
+def test_pki_server_db_schema_upgrade_with_wrong_instance(ansible_module):
+    """
+    :id: 3f9cae23-f435-4f09-b3b3-3344b0e1ca15
+    :Title: Test pki-server db-schema-upgrade command with invalid instance.
+    :Description: Test pki-server db-schema-upgrade command with invalid instance
+    :Requirement: Pki Server Db
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server db-schema-upgrade command do not upgrade the pki server
+         database while specifying wrong instance it should throw error.
+    """
+
+    subsystem = ["RoootCAA", "RoooTKRA", "RootOcSp", "RooTtKS", "RoOtTpS"]
+    bind_dn = "cn=Directory Manager"
+    bind_pass = constants.CLIENT_DIR_PASSWORD
+
+    for system in subsystem:
+        db_schema_upgrade = 'pki-server db-schema-upgrade -i {} -D {} -w {}'.format(system,
+                                                                                    bind_dn,
+                                                                                    bind_pass)
+        cmd_output = ansible_module.command(db_schema_upgrade)
+
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                assert "Upgrade complete" in result['stdout']
+                pytest.xfail("Failed to run pki-server db-schema-upgrade command.")
+            else:
+                assert "ERROR: Invalid instance {}".format(system) in result['stdout']
+
+
+def test_pki_server_db_schema_upgrade_with_stopped_instance(ansible_module, stop_pki_instance):
+    """
+    :id: 1a03f42d-934f-409e-8249-74d864081172
+    :Title: Test pki-server db-schema-upgrade with stopped instance
+    :Description: Test pki-server db-schema-upgrade with stopped instance.
+    :Requirement: Pki Server Db
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server db-schema-upgrade command upgrade the pki server database
+           when instance is stopped.
+
+    """
+    bind_dn = "cn=Directory Manager"
+    bind_pass = constants.CLIENT_DIR_PASSWORD
+    instance = stop_pki_instance
+    db_schema_upgrade = 'pki-server db-schema-upgrade -i {} -D {} -w {}'.format(instance,
+                                                                                bind_dn,
+                                                                                bind_pass)
+    cmd_output = ansible_module.command(db_schema_upgrade)
+
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Upgrade complete" in result['stdout']
+            pytest.xfail("Failed to run pki-server db-schema-upgrade command.")
+        else:
+            assert "ERROR: ldap_bind: Invalid credentials (49)" in result['stdout']

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_db_upgrade.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_db_upgrade.py
@@ -1,0 +1,199 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki db-upgrade commands needs to be tested:
+#   pki-server db-upgrade --help
+#   pki-server db-upgrade
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+from subprocess import CalledProcessError
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+@pytest.fixture(autouse=False)
+def ds_instance(ansible_module):
+    """
+    Start/stop ds instance
+    """
+    instance_name = '{}-testingmaster'.format("-".join(constants.CA_INSTANCE_NAME.split("-")[:-1]))
+    stop_ds = 'systemctl stop dirsrv@slapd-{}'.format(instance_name)
+    ansible_module.command(stop_ds)
+    yield
+    start_ds = 'systemctl start dirsrv@slapd-{}'.format(instance_name)
+    ansible_module.command(start_ds)
+
+
+@pytest.fixture(autouse=False)
+def stop_pki_instance(ansible_module):
+    "start/stop pki-instance fixture."
+    instance = constants.CA_INSTANCE_NAME
+    stop_instance = 'pki-server instance-stop {}'.format(instance)
+    start_instance = 'pki-server instance-start {}'.format(instance)
+    ansible_module.command(stop_instance)
+    yield instance
+    ansible_module.command(start_instance)
+
+
+def test_pki_server_db_upgrade_help_command(ansible_module):
+    """
+    :id: e2f152bb-e69e-4e0f-8381-b5af02d0b645
+    :Title: Test pki-server db-upgrade --help command
+    :Description: Test pki-server db-upgrade --help command
+    :Requirement: Pki Server Db
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResult: 
+        1. Verify whether pki-server db-upgrade --help command shows the following commands.
+             Usage: pki-server db-upgrade [OPTIONS]
+        
+              -i, --instance <instance ID>       Instance ID (default: pki-tomcat).
+              -v, --verbose                      Run in verbose mode.
+                  --help                         Show help message.
+
+    """
+    help_command = 'pki-server db-upgrade --help'
+
+    cmd_output = ansible_module.command(help_command)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server db-upgrade [OPTIONS]" in result['stdout']
+            assert " -i, --instance <instance ID>       Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert " -v, --verbose                      Run in verbose mode." in result['stdout']
+            assert "     --help                         Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server db-upgrade --help command.")
+
+
+def test_pki_server_db_upgrade_command(ansible_module):
+    """
+    :id: 89711623-2338-4e4e-bc3c-3569c4c110e9
+    :Title: Test pki-server db-upgrade command
+    :Description: Test pki-server db-upgrade command
+    :Requirement: Pki Server Db
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResult:
+        1. Verify whether pki-server db-upgrade command upgrade the pki server database.
+    """
+    db_upgrade = 'pki-server db-upgrade -i {} ca'.format(constants.CA_INSTANCE_NAME)
+    cmd_output = ansible_module.command(db_upgrade)
+
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Upgrade complete" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server db-upgrade command.")
+
+
+def test_pki_server_db_upgrade_while_ds_instance_is_down(ansible_module, ds_instance):
+    """
+    :id: 9f691554-51d9-40c3-b6b6-c538a509dcfc
+    :Title: Test pki-server db-upgrade command when instance is down.
+    :Requirement: Pki Server Db
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResult:
+        1. Verify whether pki-server db-upgrade command do not upgrade the pki server database
+            while directory server instance is down.
+
+    """
+    # Store commands in veriables.
+    db_upgrade = 'pki-server db-upgrade -i {} ca'.format(constants.CA_INSTANCE_NAME)
+
+    cmd_output = ansible_module.command(db_upgrade)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Upgrade complete" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server db-upgrade command.")
+
+
+def test_pki_server_db_upgrade_with_wrong_instance(ansible_module):
+    """
+    :id: 1cd3e385-b037-470a-9512-d70490828caf
+    :Title: Test pki-server db-upgrade command with wrong instance.
+    :Description: Test pki-server db-upgrade command with wrong instance.
+    :Requirement: Pki Server Db
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResult:
+        1. Verify whether pki-server db-upgrade command do not upgrade the pki server database
+        while specifying wrong instance.
+
+    """
+    subsystem = [constants.KRA_INSTANCE_NAME, constants.OCSP_INSTANCE_NAME,
+                 constants.TKS_INSTANCE_NAME, constants.TPS_INSTANCE_NAME]
+
+    for system in subsystem:
+        db_upgrade = 'pki-server db-upgrade -i {} ca'.format(system)
+        cmd_output = ansible_module.command(db_upgrade)
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                assert "Upgrade complete" in result['stdout']
+                pytest.xfail("Failed to run pki-server db-upgrade command for "
+                             "instance %s ." % system)
+            else:
+                assert "ERROR: No CA subsystem in instance {}.".format(system) in result['stdout']
+
+
+def test_pki_server_db_upgrade_with_stopped_instance(ansible_module, stop_pki_instance):
+    """
+    :id: 795f34af-2b14-4007-bd68-2db96eeec847
+    :Title: Test pki-server db-upgrade command with stopped instance.
+    :Description: Test pki-server db-upgrade command with stopped instance.
+    :Requirement: Pki Server Db
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResult:
+        1. Verify whether pki-server db-upgrade command upgrade the pki server database
+           when instance is stopped.
+    """
+    # Store commands in veriables.
+    db_upgrade = 'pki-server db-upgrade -i {} ca'.format(constants.CA_INSTANCE_NAME)
+
+    cmd_output = ansible_module.command(db_upgrade)
+
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Upgrade complete" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server db-upgrade command when instance stopped.")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance.py
@@ -1,0 +1,82 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki securitydomain commands needs to be tested:
+#   pki-server instance 
+#   pki-server instance --help
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import pytest
+
+
+def test_pki_server_instance_command(ansible_module):
+    """
+    :id: f86ab34f-1d77-465d-9c61-f7bc65b03e84
+    :Title: Test pki-server instance --help command
+    :Description:
+        test pki-server instance --help command
+        This test also verifies bugzilla id : 1339263
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        Verify whether pki-server instance --help command shows the following commands.
+
+        Commands:
+         instance-cert                 Instance certificate management commands
+         instance-find                 Find instances
+         instance-show                 Show instance
+         instance-start                Start instance
+         instance-stop                 Stop instance
+         instance-migrate              Migrate instance
+         instance-nuxwdog-enable       Instance enable nuxwdog
+         instance-nuxwdog-disable      Instance disable nuxwdog
+         instance-externalcert-add     Add external certificate or chain to the instance
+         instance-externalcert-del     Delete external certificate from the instance
+
+    """
+    cmd_output = ansible_module.command('pki-server instance --help')
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Commands:" in result['stdout']
+            assert "instance-cert                 Instance certificate management commands" in \
+                   result['stdout']
+            assert "instance-find                 Find instances" in result['stdout']
+            assert "instance-show                 Show instance" in result['stdout']
+            assert "instance-start                Start instance" in result['stdout']
+            assert "instance-stop                 Stop instance" in result['stdout']
+            assert "instance-migrate              Migrate instance" in result['stdout']
+            assert "instance-nuxwdog-enable       Instance enable nuxwdog" in result['stdout']
+            assert "instance-nuxwdog-disable      Instance disable nuxwdog" in result['stdout']
+            assert "instance-externalcert-add     Add external certificate or chain to the " \
+                   "instance" in result['stdout']
+            assert "instance-externalcert-del     Delete external certificate from the " \
+                   "instance" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance --help commnad")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_cert.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_cert.py
@@ -69,8 +69,8 @@ def test_pki_server_instance_cert_command(ansible_module):
 def test_pki_server_instance_cert_command_with_help(ansible_module):
     """
     :id: d8f26419-1d25-4ba3-8887-2bd477fcca09
-    :Title: RHCS-TC Test pki-server instance-cert --help command. BZ: 1339263
-    :Description: RHCS-TC Test pki-server instance-cert --help command. BZ: 1339263
+    :Title: Test pki-server instance-cert --help command. BZ: 1339263
+    :Description: Test pki-server instance-cert --help command. BZ: 1339263
     :Requirement: Pki Server Instance
     :CaseComponent: \-
     :Setup: Use the subsystems setup in ansible to run subsystem commands
@@ -158,8 +158,8 @@ def test_pki_server_instance_cert_export_command(ansible_module, systems):
 def test_pki_server_instance_cert_export_command_with_password_file(ansible_module, systems):
     """
     :id: cbdd77a4-b4f7-497c-b247-3ae8b9f5f8a2
-    :Title: RHCS-TC Test pki-server instance-cert-export command with wrong password file.
-    :Description: RHCS-TC Test pki-server instance-cert-export command with wrong password file.
+    :Title: Test pki-server instance-cert-export command with wrong password file.
+    :Description: Test pki-server instance-cert-export command with wrong password file.
     :Requirement: Pki Server Instance
     :CaseComponent: \-
     :Setup: Use the subsystems setup in ansible to run subsystem commands
@@ -223,7 +223,7 @@ def test_pki_server_instance_cert_export_command_when_instance_does_not_exists(a
 def test_pki_server_instance_cert_export_command_when_instance_is_stopped(ansible_module, systems):
     """
     :id: 5c7e9354-8262-480a-bab9-695bb114bf66
-    :Title: RHCS-TC Test pki-server instance-cert-export command when instance is stopped.
+    :Title: Test pki-server instance-cert-export command when instance is stopped.
     :Requirement: Pki Server Instance
     :CaseComponent: \-
     :Setup: Use the subsystems setup in ansible to run subsystem commands

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_cert.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_cert.py
@@ -1,0 +1,394 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki securitydomain commands needs to be tested:
+#   pki-server instance-cert-export --help
+#   pki-server instance-cert-export
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import os
+import sys
+from subprocess import CalledProcessError
+
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_instance_cert_command(ansible_module):
+    """
+    :id: 2cab6061-fc45-4403-977b-0c4f619c5ffc
+    :Title: Test pki-server instance-cert command
+    :Description: Test pki-server instance-cert command
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Steps:
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults: Verify whether pki-server instance-cert --help command shows
+        the instance-cert-export.
+    """
+    instance_cert = 'pki-server instance-cert'
+    cmd_output = ansible_module.command(instance_cert)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "instance-cert-export          Export system certificates " in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-cert command")
+
+
+def test_pki_server_instance_cert_command_with_help(ansible_module):
+    """
+    :id: d8f26419-1d25-4ba3-8887-2bd477fcca09
+    :Title: RHCS-TC Test pki-server instance-cert --help command. BZ: 1339263
+    :Description: RHCS-TC Test pki-server instance-cert --help command. BZ: 1339263
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert --help command shows the instance-cert-export.
+    """
+    instance_cert_help = 'pki-server instance-cert --help'
+    cmd_output = ansible_module.command(instance_cert_help)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "instance-cert-export          Export system certificates " in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-cert --help command")
+
+
+def test_pki_server_instance_cert_export_command_with_help(ansible_module):
+    """
+    :id: 234eb46c-66bd-46d7-8895-795d33d8ea5e
+    :Title: Test pki-server instance-cert-export --help command, BZ:1339263
+    :Description: Test pki-server instance-cert-export --help command, BZ:1339263
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert-export --help command shows the
+            instance-cert-export.
+    """
+    instance_cert_export = 'pki-server instance-cert-export --help'
+    cmd_output = ansible_module.command(instance_cert_export)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server instance-cert-export [OPTIONS] [nicknames...]" in result[
+                'stdout']
+            assert "-i, --instance <instance ID>       Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "--pkcs12-file <path>           Output file to store the exported certificate " \
+                   "and key in PKCS #12 format." in result['stdout']
+            assert "--pkcs12-password <password>   Password for the PKCS #12 file." in result[
+                'stdout']
+            assert "--pkcs12-password-file <path>  Input file containing the password for the " \
+                   "PKCS #12 file." in result['stdout']
+            assert "--append                       Append into an existing PKCS #12 file." \
+                   in result['stdout']
+            assert "--no-trust-flags               Do not include trust flags" in result['stdout']
+            assert "--no-key                       Do not include private key" in result['stdout']
+            assert "--no-chain                     Do not include certificate chain" in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode." in result['stdout']
+            assert "--debug                        Run in debug mode." in result['stdout']
+            assert "--help                         Show help message." in result['stdout']
+        else:  # If fail display error and exit
+            pytest.xfail("Failed to run pki-server instance-cert-export --help command")
+
+
+@pytest.mark.parametrize('systems', ['ca', 'kra', 'ocsp', 'tks', 'tps'])
+def test_pki_server_instance_cert_export_command(ansible_module, systems):
+    """
+    :id: c6770e1a-8efc-41e5-b4ce-cf68ffbb874b
+    :Title: Test pki-server instance-cert-export command.
+    :Description: Test pki-server instance-cert-export command.
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert-export command shows the export
+           certificate in p12 format.
+    """
+    instance = eval("constants.{}_INSTANCE_NAME".format(systems.upper()))
+    p12_file = '/tmp/{}_admin_cert.p12'.format(systems)
+    instance_cert_export = 'pki-server instance-cert-export -i {} --pkcs12-file ' \
+                           '{} --pkcs12-password {}'.format(instance, p12_file,
+                                                            constants.CLIENT_PKCS12_PASSWORD)
+
+    cmd_output = ansible_module.command(instance_cert_export)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-cert-export command")
+
+
+@pytest.mark.parametrize('systems', ['ca', 'kra', 'ocsp', 'tks', 'tps'])
+def test_pki_server_instance_cert_export_command_with_password_file(ansible_module, systems):
+    """
+    :id: cbdd77a4-b4f7-497c-b247-3ae8b9f5f8a2
+    :Title: RHCS-TC Test pki-server instance-cert-export command with wrong password file.
+    :Description: RHCS-TC Test pki-server instance-cert-export command with wrong password file.
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert-export command shows the export
+        certificate in p12 format.
+    """
+    password = constants.CLIENT_DIR_PASSWORD
+    password_file = "/tmp/password.txt"
+    instance = eval("constants.{}_INSTANCE_NAME".format(systems.upper()))
+
+    ansible_module.shell('echo "{}" > {}'.format(password, password_file))
+
+    instance_cert_export = 'pki-server instance-cert-export -i {} --pkcs12-file /tmp/{}.p12 ' \
+                           '--pkcs12-password-file {} --no-chain --no-key ' \
+                           '--no-trust-flags'.format(instance, systems, password_file)
+
+    cmd_output = ansible_module.command(instance_cert_export)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-cert-export command with "
+                         "password file.")
+
+
+def test_pki_server_instance_cert_export_command_when_instance_does_not_exists(ansible_module):
+    """
+    :id: ac9c6e53-46a0-4fa4-9d1b-72e762117e25
+    :Title: Test pki-server instance-cert-export command when instance does not exists.
+    :Description: test pki-server instance-cert-export command, This test also verifies
+                  bugzilla id : 1348433
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert-export command failed to the export
+        certificate in p12 format and throws error.
+    """
+    subsystems = "ABcCA"
+    password = constants.CLIENT_DIR_PASSWORD
+    password_file = "/tmp/password.txt"
+    ansible_module.shell('echo "{}" > {}'.format(password, password_file))
+    instance_cert_export = 'pki-server instance-cert-export -i {} --pkcs12-file /tmp/{}.p12 ' \
+                           '--pkcs12-password-file {} --no-chain --no-key ' \
+                           '--no-trust-flags'.format(subsystems, subsystems, password_file)
+
+    cmd_output = ansible_module.command(instance_cert_export)
+    for result in cmd_output.values():
+        if result['rc'] >= 1:
+            assert "ERROR: Invalid instance %s." % subsystems in result['stdout']
+        else:
+            assert "Export complete" in result['stdout']
+            pytest.xfail("Failed to run pki-server instance-cert-export command when "
+                         "instance is invalid.")
+
+
+@pytest.mark.parametrize('systems', ['ca', 'kra', 'ocsp', 'tks', 'tps'])
+def test_pki_server_instance_cert_export_command_when_instance_is_stopped(ansible_module, systems):
+    """
+    :id: 5c7e9354-8262-480a-bab9-695bb114bf66
+    :Title: RHCS-TC Test pki-server instance-cert-export command when instance is stopped.
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert-export command shows the export certificate
+        in p12 format when instance is stopped.
+    """
+    password = constants.CLIENT_DIR_PASSWORD
+    password_file = "/tmp/password.txt"
+    instance = eval("constants.{}_INSTANCE_NAME".format(systems.upper()))
+    stop_instance_cmd = 'pki-server instance-stop {}'.format(instance)
+    start_instance_cmd = 'pki-server instance-start {}'.format(instance)
+
+    cert_export_command = 'pki-server instance-cert-export -i {} --pkcs12-file /tmp/{}.p12 ' \
+                          '--pkcs12-password-file /tmp/password.txt --no-chain --no-key ' \
+                          '--no-trust-flags'.format(instance, systems)
+    ansible_module.shell('echo "{}" > {}'.format(password, password_file))
+    ansible_module.command(stop_instance_cmd)
+
+    cmd_output = ansible_module.command(cert_export_command)
+
+    ansible_module.command(start_instance_cmd)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-cert-export command when "
+                         "instance is stopped.")
+
+
+@pytest.mark.xfail(raises=CalledProcessError)
+def test_pki_server_instance_cert_export_command_client_dir_invalid_path(ansible_module):
+    """
+    :id: 3ee08cea-2801-4e69-a154-c1f057589980
+    :Title: Test pki-server instance-cert-export with invalid client directory path BZ: 1348433
+    :Description:
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert-export command shows the
+        FileNotFoundException: file not found and return code == 1 .
+    """
+    password = constants.CLIENT_DIR_PASSWORD
+    password_file = "/tmp/password.txt"
+
+    ansible_module.shell('echo "{}" > {}'.format(password, password_file))
+
+    cert_export_command = 'pki-server instance-cert-export -i {} --pkcs12-file /sdf/{}.p12 ' \
+                          '--pkcs12-password-file /tmp/password.txt --no-chain --no-key ' \
+                          '--no-trust-flags'.format(constants.CA_INSTANCE_NAME,
+                                                    constants.CA_INSTANCE_NAME)
+    cmd_output = ansible_module.command(cert_export_command)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            pytest.xfail("Failed to run pki-server instance-cert-export with invalid path.")
+        else:
+            is_file = ansible_module.stat(path='/sdf/{}.p12'.format(constants.CA_INSTANCE_NAME))
+            for result in is_file.values():
+                assert result['stat']['exists'] is False
+
+
+def test_pki_server_instance_cert_export_command_with_append(ansible_module):
+    """
+    :id: 5ef57c14-364a-467d-84e8-b60c22642f8c
+    :Title: Test pki-server instance-cert-export, append to existing certificate.
+    :Description: Test pki-server instance-cert-export, append to existing certificate
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert-export command shows the export certificate
+        in p12 format and append option append the certificates to existing file.
+    """
+    # Store all subsystems in list
+    subsystems = [constants.KRA_INSTANCE_NAME, constants.OCSP_INSTANCE_NAME,
+                  constants.TKS_INSTANCE_NAME, constants.TPS_INSTANCE_NAME]
+    password = constants.CLIENT_DIR_PASSWORD
+    password_file = "/tmp/password.txt"
+    ansible_module.shell('echo "{}" > {}'.format(password, password_file))
+    pkcs12_file = "/tmp/%s.p12" % constants.CA_INSTANCE_NAME
+
+    cert_export = 'pki-server instance-cert-export -i {} --pkcs12-file {} ' \
+                  '--pkcs12-password-file {}'
+
+    ca_cert = ansible_module.command(cert_export.format(constants.CA_INSTANCE_NAME,
+                                                        pkcs12_file, password_file))
+
+    for result in ca_cert.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+
+    cert_export_command = 'pki-server instance-cert-export "subsystemCert cert-{}" -i {} ' \
+                          '--pkcs12-file {} --pkcs12-password-file {} --no-chain --no-key ' \
+                          '--no-trust-flags --append'
+    for system in subsystems:
+
+        cmd_output = ansible_module.command(cert_export_command.format(system, system, pkcs12_file,
+                                                                       password_file))
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                assert 'Export complete' in result['stdout']
+            else:
+                pytest.xfail("Failed to run pki-server instance-cert-export command with "
+                             "--append option.")
+    is_file = ansible_module.stat(path=pkcs12_file)
+    for res in is_file.values():
+        if res['stat']['exists']:
+            ansible_module.command('pki -d /tmp/n -c {} client-init '
+                                   '--force'.format(constants.CLIENT_PKCS12_PASSWORD))
+            ansible_module.command('pki -d /tmp/n -c {} client-cert-import --pkcs12 {}'
+                                   ' --pkcs12-password-file {}'.format(
+                constants.CLIENT_PKCS12_PASSWORD, pkcs12_file, password_file))
+            a = ansible_module.command('certutil -L -d /tmp/n')
+            ansible_module.command('rm -rf /tmp/n')
+            for result in a.values():
+                for system in subsystems:
+                    assert "subsystemCert cert-{}".format(system) in result['stdout']
+
+
+def test_pki_server_instance_cert_export_command_with_invalid_password(ansible_module):
+    """
+    :id: 75c8e6fc-bbed-4f62-8971-a261493c6516
+    :Title: Test pki-server instance-cert-export with invalid password, BZ:1348433
+    :Description: Test pki-server instance-cert-export with invalid password, BZ: 1348433
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-cert-export command shows the error message
+           "ERROR: option --pkcs12-password requires argument".
+    """
+
+    instance_cert_export = 'pki-server instance-cert-export -i {} --pkcs12-file /tmp/cert.p12 ' \
+                           '--pkcs12-password'
+
+    cmd_output = ansible_module.command(instance_cert_export)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert 'Export complete' in result['stdout']
+        else:
+            assert "ERROR: option --pkcs12-password requires argument" in result['stdout']
+            assert "Usage: pki-server instance-cert-export [OPTIONS] [nicknames...]" in \
+                   result['stdout']
+            assert "-i, --instance <instance ID>       Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "--pkcs12-file <path>           Output file to store the exported " \
+                   "certificate and key in PKCS #12 format." in result['stdout']
+            assert "--pkcs12-password <password>   Password for the PKCS #12 file." in \
+                   result['stdout']
+            assert "--pkcs12-password-file <path>  Input file containing the password for " \
+                   "the PKCS #12 file." in result['stdout']
+            assert "--append                       Append into an existing PKCS #12 file." in \
+                   result['stdout']
+            assert "--no-trust-flags               Do not include trust flags" in \
+                   result['stdout']
+            assert "--no-key                       Do not include private key" in \
+                   result['stdout']
+            assert "--no-chain                     Do not include certificate chain" in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode." in \
+                   result['stdout']
+            assert "--debug                        Run in debug mode." in result['stdout']
+            assert "--help                         Show help message." in result['stdout']

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_externalcert_add.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_externalcert_add.py
@@ -1,0 +1,461 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server instance-externalcert commands needs to be tested:
+#    pki-server instance-externalcert-add --help
+#    pki-server instance-externalcert-add
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import os
+import random
+import sys
+from subprocess import CalledProcessError
+
+import pytest
+
+from pki.testlib.common import utils
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+userop = utils.UserOperations(nssdb=constants.NSSDB)
+
+BASE_DB_DIR = '/var/lib/pki/{}/alias'
+
+
+def create_cert(ansible_module):
+    """
+    Return a base 64 encoded certificate.
+    """
+    no = random.randint(11, 999989)
+    user = 'testuser{}'.format(no)
+    subject = 'UID={},CN={}'.format(user, user)
+
+    cert_id = userop.process_certificate_request(ansible_module, subject=subject)
+    if cert_id:
+        cert_file = "/tmp/{}.pem".format(user)
+        ansible_module.command('pki -d {} -c {} -p {} client-cert-import "{}" '
+                               '--serial {}'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                                    constants.CA_HTTP_PORT, user, cert_id))
+        ansible_module.command('pki -d {} -c {} client-cert-show "{}" '
+                               '--cert /tmp/{}.pem '.format(constants.NSSDB,
+                                                            constants.CLIENT_DIR_PASSWORD,
+                                                            user, user))
+        ansible_module.command('pki -d {} -c {} client-cert-del '
+                               '"{}"'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                             user))
+        return [cert_id, cert_file]
+
+
+def test_pki_server_instance_externalcert_add_help_command(ansible_module):
+    """
+    :id: ea41448f-31e5-4aeb-9656-b6788387f4ab
+    :Title: Test pki-server instance-externalcert-add --help command, BZ: 1339263
+    :Description: Test pki-server instance-externalcert-add --help command, This test also 
+                  verifies bugzilla id : 1339263
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults: Verify whether pki-server instance-externalcert --help command shows the 
+            following output.
+
+        Usage: pki-server instance-externalcert-add [OPTIONS]
+    
+          -i, --instance <instance ID>       Instance ID (default: pki-tomcat).
+              --cert-file <path>             Input file containing the external certificate or 
+              certificate chain.
+              --trust-args <trust-args>      Trust args (default ",,").
+              --nickname <nickname>          Nickname to be used.
+              --token <token_name>           Token (default: internal).
+          -v, --verbose                      Run in verbose mode.
+              --help                         Show help message.
+    """
+
+    help_command = 'pki-server instance-externalcert-add --help'
+    cmd_output = ansible_module.command(help_command)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server instance-externalcert-add [OPTIONS]" in result['stdout']
+            assert "-i, --instance <instance ID>       Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "--cert-file <path>             Input file containing the external " \
+                   "certificate or certificate chain." in result['stdout']
+            assert '--trust-args <trust-args>      Trust args (default ",,").' in \
+                   result['stdout']
+            assert "--nickname <nickname>          Nickname to be used." in result['stdout']
+            assert "--token <token_name>           Token (default: internal)." in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode." in \
+                   result['stdout']
+            assert "--help                         Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-externalcert-add --help command.")
+
+
+def test_pki_server_instance_externalcert_add_command(ansible_module):
+    """
+    :id: 6d6ae4d1-b5d5-423d-bd62-81b274ff4c9d
+    :Title: Test pki-server instance-externalcert-add command 
+    :Description: Test pki-server instance-externalcert-add command
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-add command add the certificate
+            to the instance.
+    """
+    cert_id, cert_file = create_cert(ansible_module)
+    user_id = cert_file.split("/")[-1].split(".")[0]
+
+    certificate_add_cmd = 'pki-server instance-externalcert-add -i {} --cert-file ' \
+                          ' {} --trust-args "u,u,u" --nickname "{}" ' \
+                          '--token internal'.format(constants.CA_INSTANCE_NAME, cert_file,
+                                                    user_id)
+
+    certutil_cmd = 'certutil -L -d {} | ' \
+                   'grep \"{}\"'.format(BASE_DB_DIR.format(constants.CA_INSTANCE_NAME), user_id)
+
+    del_cert = 'pki-server instance-externalcert-del -i {} --nickname "{}" ' \
+               '--token internal'.format(constants.CA_INSTANCE_NAME, user_id)
+
+    cmd_output = ansible_module.command(certificate_add_cmd)
+
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate imported for instance {}".format(constants.CA_INSTANCE_NAME) in \
+                   result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-externalcert-add command")
+    certImported = ansible_module.shell(certutil_cmd)
+    for res in certImported.values():
+        if res['rc'] == 0:
+            assert user_id in res['stdout']
+
+    ansible_module.command('rm -rf {}'.format(cert_file))
+    cmd_output = ansible_module.command(del_cert)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate removed from " \
+                   "instance {}.".format(constants.CA_INSTANCE_NAME) in result['stdout']
+
+
+@pytest.mark.xfail(raises=CalledProcessError)
+def test_pki_server_instance_externalcert_add_with_invalid_args(ansible_module):
+    """
+    :id: d677121b-a2d4-4c54-956c-ccd75b918a52
+    :Title: Test pki-server instance-externalcert-add with invalid args command, BZ:1348433
+    :Description: test pki-server instance-externalcert-add command
+        This test also verifies bugzilla id : 1348433
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-add command add the certificate to the
+        instance without trust args expected to fail.
+    """
+    cert_id, file_name = create_cert(ansible_module)
+    user_id = file_name.split("/")[-1].split(".")[0]
+
+    certificate_add_cmd = 'pki-server instance-externalcert-add -i {} --cert-file {} --nickname ' \
+                          '"{}" --token internal'.format(constants.CA_INSTANCE_NAME,
+                                                         file_name, user_id)
+
+    certutil_cmd = 'certutil -L -d  {} | grep \"{}\"'.format(BASE_DB_DIR.format(
+        constants.CA_INSTANCE_NAME), user_id)
+
+    cmd_output = ansible_module.command(certificate_add_cmd)
+    for result in cmd_output.values():
+        if result['rc'] >= 1:
+            assert "certutil: unable to decode trust string: SEC_ERROR_INVALID_ARGS: security " \
+                   "library: invalid arguments." in result['stderr']
+        else:
+            assert "Certificate imported for instance {}".format(constants.CA_INSTANCE_NAME) in \
+                   result['stdout']
+    certutil_out = ansible_module.shell(certutil_cmd)
+    for result in certutil_out.values():
+        if result['rc'] == 0:
+            pytest.xfail("Failed to run pki-server instance-externalcert-add without trust.")
+
+    ansible_module.command('rm -rf {}'.format(file_name))
+
+
+def test_pki_server_instance_externalcert_add_without_nickname(ansible_module):
+    """
+    :id: ec7571a0-045a-471d-b441-3a43f66c4a50
+    :Title: Test pki-server instance-externalcert-add without nickname, BZ : 1348433
+    :Description:
+        test pki-server instance-externalcert-add command, BZ : 1348433
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-add command should not add an external
+        cert to the nssdb when nickname is missing.
+    """
+
+    cert_id, file_name = create_cert(ansible_module)
+    user_id = file_name.split("/")[-1].split(".")[0]
+
+    certificate_add_cmd = 'pki-server instance-externalcert-add -i {} --cert-file {} ' \
+                          '--token internal'.format(constants.CA_INSTANCE_NAME, file_name)
+
+    certutil_cmd = 'certutil -L -d  {} | grep \"{}\"'.format(BASE_DB_DIR.format(
+        constants.CA_INSTANCE_NAME), user_id)
+
+    cmd_output = ansible_module.command(certificate_add_cmd)
+    for result in cmd_output.values():
+        if result['rc'] >= 1:
+            assert "ERROR: missing nickname" in result['stdout']
+            assert "Usage: pki-server instance-externalcert-add [OPTIONS]" in result['stdout']
+            assert " -i, --instance <instance ID>       Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "--cert-file <path>             Input file containing the external " \
+                   "certificate or certificate chain." in result['stdout']
+            assert '--trust-args <trust-args>      Trust args (default ",,").' in \
+                   result['stdout']
+            assert "--nickname <nickname>          Nickname to be used."
+            assert "--token <token_name>           Token (default: internal)." in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode." in \
+                   result['stdout']
+            assert "--help                         Show help message." in result['stdout']
+
+        else:
+            assert "Certificate imported for instance {}".format(constants.CA_INSTANCE_NAME) \
+                   in result['stdout']
+            certImported = ansible_module.command(certutil_cmd)
+            for res in certImported.values():
+                if res['rc'] == 0:
+                    assert user_id in res['stdout']
+
+    ansible_module.command('rm -rf {}'.format(file_name))
+
+
+@pytest.mark.xfail(raises=CalledProcessError)
+def test_pki_server_instance_externalcert_add_with_invalid_instance(ansible_module):
+    """
+    :id: 11b2567b-23ae-49f7-bd4c-061d5dce7ef7
+    :Title: Test pki-server instance-externalcert-add with invalid instance, BZ: 1348433
+    :Description: test pki-server instance-externalcert-add command, This test also verifies
+            bugzilla id : 1348433
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-add command add the certificate to
+        the instance which is does not exists.
+    """
+
+    cert_id, file_name = create_cert(ansible_module)
+    user_id = file_name.split("/")[-1].split(".")[0]
+
+    certificate_add_cmd = 'pki-server instance-externalcert-add -i ROOTCA --cert-file {} ' \
+                          '--token internal --nickname "{}"'.format(file_name, user_id)
+
+    certutil_cmd = 'certutil -L -d  {} | grep \"{}\"'.format(BASE_DB_DIR.format(
+        constants.CA_INSTANCE_NAME), user_id)
+
+    cmd_output = ansible_module.command(certificate_add_cmd)
+    for result in cmd_output.values():
+        if result['rc'] >= 1:
+            assert "ERROR: Invalid instance ROOTCA." in result['stdout']
+        else:
+            assert "Certificate imported for instance {}".format(constants.CA_INSTANCE_NAME) \
+                   in result['stdout']
+            certImported = ansible_module.command(certutil_cmd)
+            for res in certImported.values():
+                if res['rc'] == 0:
+                    assert user_id in res['stdout']
+
+    ansible_module.command('rm -rf {}'.format(file_name))
+
+
+def test_pki_server_instance_externalcert_add_when_instance_is_stopped(ansible_module):
+    """
+    :id: 90a7464f-fc9a-4461-a07e-94160bdcba36
+    :Title: Test pki-server instance-externalcert-add when instance is stopped
+    :Description: test pki-server instance-externalcert-add command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-add command add the certificate to
+        the instance when instance is stopped.
+    """
+
+    cert_id, file_name = create_cert(ansible_module)
+    user_id = file_name.split("/")[-1].split(".")[0]
+
+    instance = constants.CA_INSTANCE_NAME
+    stop_instance = 'pki-server instance-stop {}'.format(instance)
+    start_instance = 'pki-server instance-start {}'.format(instance)
+    ansible_module.command(stop_instance)
+
+    certificate_add_cmd = 'pki-server instance-externalcert-add -i {} --cert-file {} ' \
+                          '--token internal --nickname "{}" ' \
+                          '--trust-args "u,u,u"'.format(constants.CA_INSTANCE_NAME,
+                                                        file_name, user_id)
+
+    certutil_cmd = 'certutil -L -d  {} | grep \"{}\"'.format(BASE_DB_DIR.format(
+        constants.CA_INSTANCE_NAME), user_id)
+
+    del_cert = 'pki-server instance-externalcert-del -i {} --nickname "{}" ' \
+               '--token internal'.format(constants.CA_INSTANCE_NAME, user_id)
+
+    cmd_output = ansible_module.command(certificate_add_cmd)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate imported for instance {}".format(constants.CA_INSTANCE_NAME) \
+                   in result['stdout']
+
+    certImported = ansible_module.command(certutil_cmd)
+    for res in certImported.values():
+        if res['rc'] == 0:
+            assert user_id in res['stdout']
+
+    ansible_module.command('rm -rf {}'.format(file_name))
+
+    cmd_output = ansible_module.command(del_cert)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate removed from " \
+                   "instance {}.".format(constants.CA_INSTANCE_NAME) in result['stdout']
+    ansible_module.command(start_instance)
+
+
+@pytest.mark.xfail(reason=CalledProcessError)
+def test_pki_server_instance_externalcert_add_with_invalid_token(ansible_module):
+    """
+    :id: 056914db-11e3-4809-8be3-17a621106bf9
+    :Title: Test pki-server instance-externalcert-add with invalid token, BZ:1348433
+    :Description: test pki-server instance-externalcert-add command
+        This test also verifies bugzilla id : 1348433
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-add command add the certificate to the
+        instance when token is invalid.
+    """
+
+    cert_id, file_name = create_cert(ansible_module)
+    user_id = file_name.split("/")[-1].split(".")[0]
+
+    certificate_add_cmd = 'pki-server instance-externalcert-add -i {} --cert-file {} ' \
+                          '--token INVALID --nickname "{}" ' \
+                          '--trust-args "u,u,u"'.format(constants.CA_INSTANCE_NAME,
+                                                        file_name, user_id)
+
+    certutil_cmd = 'certutil -L -d  {} | grep \"{}\"'.format(BASE_DB_DIR.format(
+        constants.CA_INSTANCE_NAME), user_id)
+
+    add_cmd_output = ansible_module.expect(command=certificate_add_cmd,
+                                           responses={"Enter password for INVALID: ":
+                                                          constants.CLIENT_DIR_PASSWORD})
+    for result in add_cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate imported for instance " + constants.CA_INSTANCE_NAME in \
+                   result['stdout']
+
+            certImported = ansible_module.command(certutil_cmd)
+            for res in certImported.values():
+                if res['rc'] == 0:
+                    assert user_id in res['stdout']
+                else:
+                    pytest.xfail("Failed to run pki-server instance-external-cert-add "
+                                 "command with invalid token")
+        else:
+            assert "certutil: could not find the slot Invalid: SEC_ERROR_NO_TOKEN: " \
+                   "The security card or token does not exist, needs to be initialized, " \
+                   "or has been removed." in result['stdout']
+    ansible_module.command('rm -rf {}'.format(file_name))
+
+
+@pytest.mark.xfail(reason=CalledProcessError)
+def test_pki_server_instance_externalcert_add_with_token_NHSM6000(ansible_module):
+    """
+    :id: d0965f54-8ade-448e-805f-a28aae51df14
+    :Title: Test pki-server instance-externalcert-add with NHSM6000 token.
+    :Description: test pki-server instance-externalcert-add command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-add command add the certificate to
+        the instance when token is NHSM6000.
+        2. It should return 0 code.
+    """
+
+    cert_id, file_name = create_cert
+    user_id = file_name.split("/")[-1].split(".")[0]
+
+    certificate_add_cmd = 'pki-server instance-externalcert-add -i {} --cert-file {} ' \
+                          '--token NHSM6000 --nickname "{}"'.format(constants.CA_INSTANCE_NAME,
+                                                                    file_name, user_id)
+
+    certutil_cmd = 'certutil -L -d  {} -h nfast | grep \"{}\"'.format(BASE_DB_DIR.format(
+        constants.CA_INSTANCE_NAME), user_id)
+
+    del_cert = 'pki-server instance-externalcert-del -i {} --nickname "{}" ' \
+               '--token internal'.format(constants.CA_INSTANCE_NAME, user_id)
+
+    add_cmd_output = ansible_module.command(certificate_add_cmd)
+    for result in add_cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate imported for instance " + constants.CA_INSTANCE_NAME in \
+                   result['stdout']
+
+            certImported = ansible_module.expect(command=certutil_cmd,
+                                                 responses="SECret.579")
+            for res in certImported.values():
+                if res['rc'] == 0:
+                    assert user_id in res['stdout']
+                else:
+                    pytest.xfail("Failed to run pki-server instance-external-cert-add "
+                                 "command with NHSM6000 token")
+        else:
+            assert "certutil: could not find the slot Invalid: SEC_ERROR_NO_TOKEN: " \
+                   "The security card or token does not exist, needs to be initialized, " \
+                   "or has been removed." in result['stdout']
+    ansible_module.command('rm -rf {}'.format(file_name))
+    cmd_output = ansible_module.command(del_cert)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate removed from " \
+                   "instance {}.".format(constants.CA_INSTANCE_NAME) in result['stdout']

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_externalcert_del.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_externalcert_del.py
@@ -1,0 +1,276 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server instance-externalcert commands needs to be tested:
+#   pki-server instance-externalcert-del --help
+#   pki-server instance-externalcert-del
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import random
+import sys
+
+import os
+import pytest
+
+from pki.testlib.common import utils
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+userop = utils.UserOperations(nssdb=constants.NSSDB)
+
+BASE_DB_DIR = '/var/lib/pki/{}/alias'
+
+
+def create_cert(ansible_module):
+    """
+    Return a base 64 encoded certificate.
+    """
+    # pass_file = '/var/lib/pki/{}/conf/password.conf'.format(constants.CA_INSTANCE_NAME)
+    # internal_pass = ''
+    no = random.randint(11, 999989)
+    user = 'testuser{}'.format(no)
+    subject = 'UID={},CN={}'.format(user, user)
+
+    cert_id = userop.process_certificate_request(ansible_module, subject=subject)
+    if cert_id:
+        cert_file = "/tmp/{}.pem".format(user)
+        ansible_module.command('pki -d {} -c {} -p {} client-cert-import "{}" '
+                               '--serial {}'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                                    constants.CA_HTTP_PORT, user, cert_id))
+        ansible_module.command('pki -d {} -c {} client-cert-show "{}" '
+                               '--cert /tmp/{}.pem '.format(constants.NSSDB,
+                                                            constants.CLIENT_DIR_PASSWORD,
+                                                            user, user))
+        return [cert_id, cert_file]
+
+
+def test_pki_server_instance_externalcert_del_help_command(ansible_module):
+    """
+    :id: fa751f20-f2f2-4f29-bf92-b9f755f6f2ad
+    :Title: Test pki-server instance-externalcert-del --help command, BZ:1339263
+    :Description: test pki-server instance-externalcert-del --help command, This test also verifies 
+     bugzilla id : 1339263
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server instance-externalcert-del --help command shows the 
+        following output.
+            Usage: pki-server instance-externalcert-del [OPTIONS]
+        
+            -i, --instance <instance ID>       Instance ID (default: pki-tomcat).
+            --nickname <nickname>          Nickname to be used.
+            --token <token_name>           Token (default: internal).
+            -v, --verbose                      Run in verbose mode.
+            --help                         Show help message.
+    """
+    help_cmd = 'pki-server instance-externalcert-del --help'
+
+    cmd_output = ansible_module.command(help_cmd)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server instance-externalcert-del [OPTIONS]" in result['stdout']
+            assert "-i, --instance <instance ID>       Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "--nickname <nickname>          Nickname to be used." in result['stdout']
+            assert "--token <token_name>           Token (default: internal)." in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode." in \
+                   result['stdout']
+            assert "--help                         Show help message." in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server instance-externalcert-del --help command")
+
+
+def test_pki_server_instance_externalcert_del_command(ansible_module):
+    """
+    :id: 496bee04-9e13-4821-9467-be928128f50c
+    :Title: Test pki-server instance-externalcert-del command
+    :Description: test pki-server instance-externalcert-del command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-del command delete the certificate
+        from the instance.
+    """
+    cert_id, cert_file = create_cert(ansible_module)
+    user_id = cert_file.split("/")[-1].split(".")[0]
+
+    cert_add = 'pki-server instance-externalcert-add -i {} --cert-file {} --trust-args ' \
+               '"u,u,u" --nickname "{}" --token internal'.format(constants.CA_INSTANCE_NAME,
+                                                                 cert_file, user_id)
+
+    del_cert = 'pki-server instance-externalcert-del -i {} --nickname "{}" ' \
+               '--token internal'.format(constants.CA_INSTANCE_NAME, user_id)
+
+    certutil_cmd = 'certutil -L -d {} | ' \
+                   'grep \"{}\"'.format(BASE_DB_DIR.format(constants.CA_INSTANCE_NAME), user_id)
+
+    cmd_output = ansible_module.command(cert_add)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate imported for instance " + constants.CA_INSTANCE_NAME \
+                   in result['stdout']
+        else:
+            assert "ERROR: Certificate already imported for instance %s." % \
+                   constants.CA_INSTANCE_NAME in result['stdout']
+
+    certImported = ansible_module.command(certutil_cmd)
+    for res in certImported.values():
+        if res['rc'] == 0:
+            assert user_id in res['stdout']
+
+    cmd_output = ansible_module.command(del_cert)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate removed from instance " + constants.CA_INSTANCE_NAME + "." in \
+                   result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server instance-externalcert-del command")
+
+
+def test_pki_server_instance_externalcert_del_when_instance_is_stopped(ansible_module):
+    """
+    :id: b78d6ef9-3438-44f6-998c-ea1795da490f
+    :Title: Test pki-server instance-externalcert-del when instance is stopped
+    :Description: test pki-server instance-externalcert-del command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-del command delete the certificate to
+        the instance when instance is stopped.
+    """
+
+    cert_id, cert_file = create_cert(ansible_module)
+    user_id = cert_file.split("/")[-1].split(".")[0]
+
+    instance = constants.CA_INSTANCE_NAME
+    stop_instance = 'pki-server instance-stop {}'.format(instance)
+    start_instance = 'pki-server instance-start {}'.format(instance)
+    ansible_module.command(stop_instance)
+
+    cert_add = 'pki-server instance-externalcert-add -i {} --cert-file {} --trust-args ' \
+               '"u,u,u" --nickname "{}" --token internal'.format(constants.CA_INSTANCE_NAME,
+                                                                 cert_file, user_id)
+
+    del_cert = 'pki-server instance-externalcert-del -i {} --nickname "{}" ' \
+               '--token internal'.format(constants.CA_INSTANCE_NAME, user_id)
+
+    certutil_cmd = 'certutil -L -d {} | ' \
+                   'grep \"{}\"'.format(BASE_DB_DIR.format(constants.CA_INSTANCE_NAME), user_id)
+
+    cmd_output = ansible_module.command(cert_add)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate imported for instance " + constants.CA_INSTANCE_NAME \
+                   in result['stdout']
+        else:
+            assert "ERROR: Certificate already imported for instance %s." % \
+                   constants.CA_INSTANCE_NAME in result['stdout']
+
+    certImported = ansible_module.command(certutil_cmd)
+    for res in certImported.values():
+        if res['rc'] == 0:
+            assert user_id in res['stdout']
+
+    cmd_output = ansible_module.command(del_cert)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate removed from instance " + constants.CA_INSTANCE_NAME + "." in \
+                   result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server instance-externalcert-del command")
+    ansible_module.command(start_instance)
+
+
+def test_pki_server_instance_externalcert_del_with_token_NHSM6000(ansible_module):
+    """
+    :id: e25f9d90-aa85-4579-bcb9-867bdd7acb68
+    :Title: Test pki-server instance-externalcert-del with NHSM6000 token
+    :Description: test pki-server instance-externalcert-del command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-externalcert-del command delete the certificate to
+        the instance when the token is NHSM6000.
+    """
+
+    cert_id, file_name = create_cert(ansible_module)
+    user_id = file_name.split("/")[-1].split(".")[0]
+
+    certificate_add_cmd = 'pki-server instance-externalcert-add -i {} --cert-file {} ' \
+                          '--token NHSM6000 --nickname "{}"'.format(constants.CA_INSTANCE_NAME,
+                                                                    file_name, user_id)
+
+    certutil_cmd = 'certutil -L -d  {} | grep \"{}\"'.format(BASE_DB_DIR.format(
+        constants.CA_INSTANCE_NAME), user_id)
+
+    del_cert = 'pki-server instance-externalcert-del -i {} --nickname "{}" ' \
+               '--token NHSM6000'.format(constants.CA_INSTANCE_NAME, user_id)
+
+    add_cmd_output = ansible_module.expect(command=certificate_add_cmd,
+                                           responses={
+                                               "Enter password for NHSM6000: ": "SECret.579"})
+    for result in add_cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate imported for instance " + constants.CA_INSTANCE_NAME in \
+                   result['stdout']
+
+            certImported = ansible_module.command(certutil_cmd)
+            for res in certImported.values():
+                if res['rc'] == 0:
+                    assert user_id in res['stdout']
+                else:
+                    pytest.xfail("Failed to run pki-server instance-external-cert-add "
+                                 "command with NHSM6000 token")
+        else:
+            assert "certutil: could not find the slot NHSM6000: SEC_ERROR_NO_TOKEN: The security " \
+                   "card or token does not exist, needs to be initialized, or has " \
+                   "been removed." in result['stdout']
+    ansible_module.command('rm -rf {}'.format(file_name))
+    cmd_output = ansible_module.expect(command=del_cert,
+                                       responses={
+                                           "Enter password for NHSM6000: ": "SECret.579"})
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Certificate removed from " \
+                   "instance {}.".format(constants.CA_INSTANCE_NAME) in result['stdout']

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_find.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_find.py
@@ -1,0 +1,159 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server instance-find commands needs to be tested:
+#   pki-server instance-find --help
+#   pki-server instance-find
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+import sys
+from subprocess import CalledProcessError
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+def test_pki_server_instance_find_command_with_help(ansible_module):
+    """
+    :id: 9c21a336-17ca-4565-bb28-c66c789fb56e
+    :Title: Test pki-server instance-find --help command, BZ: 1339263
+    :Description: test pki-server instance-find --help command,  This test also verifies
+                  bugzilla id : 1339263
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server instance-find --help command shows the following commands.
+
+        Usage: pki-server instance-find [OPTIONS]
+
+          -v, --verbose                Run in verbose mode.
+                --help                   Show help message.
+    """
+    help_command = 'pki-server instance-find --help'
+
+    cmd_output = ansible_module.command(help_command)
+    for result in cmd_output.values():
+        if result['rc'] >= 1:
+            pytest.xfail("Failed to run pki-server instance-find --help command")
+        else:
+            assert "Usage: pki-server instance-find [OPTIONS]" in result['stdout']
+            assert "-v, --verbose                Run in verbose mode." in result['stdout']
+            assert "--help                   Show help message." in result['stdout']
+
+
+def test_pki_server_instance_find_command(ansible_module):
+    """
+    :id: 37b93717-7968-4d85-8eff-7aaca9329f68
+    :Title: Test pki-server instance-find command
+    :Description: test pki-server instance-find command
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-find command shows the instace name and state.
+    """
+    subsystems = ['ca', 'kra', 'ocsp', 'tks', 'tps']
+
+    cmd_output = ansible_module.command('pki-server instance-find')
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            for system in subsystems:
+                instance = None
+                try:
+                    instance = eval("constants.{}_INSTANCE_NAME".format(system.upper()))
+                except:
+                    pytest.skip("Instance is not present")
+
+                assertsuccess = "Instance ID: " + instance
+                try:
+                    assert assertsuccess in result['stdout']
+                except CalledProcessError as e:
+                    pytest.xfail("Failed to run pki-server instance-find command")
+        else:
+            pytest.xfail("Failed to run pki-server instance-find command.")
+
+
+def test_pki_server_instance_find_with_more_instance_stopped(ansible_module):
+    """
+    :id: 9cedb8b2-40cc-4204-9d9b-c889e5fe3fef
+    :Title: Test pki-server instance-find command when one or more instance is stopped
+    :Description: test pki-server instance-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-find command shows the instace name and state.
+    """
+    subsystems = ['ca', 'kra', 'ocsp', 'tks', 'tps']
+
+    for system in subsystems:
+        instance = None
+        try:
+            instance = eval("constants.{}_INSTANCE_NAME".format(system.upper()))
+        except:
+            pytest.skip("Instance is not present")
+
+        ansible_module.command('pki-server instance-stop {}'.format(instance))
+
+    cmd_output = ansible_module.command('pki-server instance-find')
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            for system in subsystems:
+                instance = None
+                try:
+                    instance = eval("constants.{}_INSTANCE_NAME".format(system.upper()))
+                except:
+                    pytest.skip("Instance is not present")
+
+                assertInstanceID = "Instance ID: {}".format(instance)
+                assertFalse = "Active: False"
+                try:
+                    assert assertInstanceID in result['stdout']
+                    assert assertFalse in result['stdout']
+                except CalledProcessError:
+                    pytest.xfail("Failed to run pki-server instance-find command")
+
+    for system in subsystems:
+        instance = None
+        try:
+            instance = eval("constants.{}_INSTANCE_NAME".format(system.upper()))
+        except:
+            pytest.skip("Instance is not present")
+
+        ansible_module.command('pki-server instance-start {}'.format(instance))

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_migrate.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_migrate.py
@@ -1,0 +1,154 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server instance commands needs to be tested:
+#   pki-server instance-migrate
+#   pki-server instance-migrate --help
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+from subprocess import CalledProcessError
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_instance_migrate_help_command(ansible_module):
+    """
+    :id: 989538e6-3099-4f2c-a7e3-6bb849491162
+    :Title: Test pki-server instance-migrate --help command, BZ:1339263
+    :Description: test pki-server instance-migrate command, This command verifies the 
+                  bugzilla id : 1339263
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance 
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server instance-migrate --help command shows the following output.
+
+            Usage: pki-server instance-migrate [OPTIONS] <instance ID>
+        
+            --tomcat <version>       Use the specified Tomcat version.
+            -v, --verbose                Run in verbose mode.
+            --debug                  Show debug messages.
+            --help                   Show help message.
+
+    """
+    help_cmd = 'pki-server instance-migrate --help'
+
+    cmd_output = ansible_module.command(help_cmd)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert 'Usage: pki-server instance-migrate [OPTIONS] <instance ID>' in \
+                   result['stdout']
+            assert '--tomcat <version>       Use the specified Tomcat version.' in \
+                   result['stdout']
+            assert '-v, --verbose                Run in verbose mode.' in result['stdout']
+            assert '--debug                  Show debug messages.' in result['stdout']
+            assert '--help                   Show help message.' in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-migrate --help command.")
+
+
+@pytest.mark.xfail(raises=CalledProcessError)
+def test_pki_server_instance_migrate_without_tomcat_command(ansible_module):
+    """
+    :id: b03eaa9e-4ad1-4c1f-ae6c-12d8629d6ca7
+    :Title: Test pki-server instance-migrate without tomcat, BZ:1348433
+    :Description: pki-server instance-migrate command This test also verifies bugzilla id : 1348433
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults:
+        1. Verify whether pki-server instance-migrate command migrate the instance
+        without tomcat version.
+    """
+    # Store command in variable
+    migrate = 'pki-server instance-migrate {} --tomcat'.format(constants.CA_INSTANCE_NAME)
+
+    cmd_output = ansible_module.command(migrate)
+    for result in cmd_output.values():
+        if result['rc'] >= 1:
+            assert "ERROR: option --tomcat requires argument" in result['stdout']
+            assert 'Usage: pki-server instance-migrate [OPTIONS] <instance ID>' in \
+                   result['stdout']
+            assert '--tomcat <version>       Use the specified Tomcat version.' in \
+                   result['stdout']
+            assert '-v, --verbose                Run in verbose mode.' in result['stdout']
+            assert '--debug                  Show debug messages.' in result['stdout']
+            assert '--help                   Show help message.' in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-migrate without tomcat version.")
+
+
+def test_pki_server_instance_migrate_command(ansible_module):
+    """
+    :id: 9f101b62-9ba2-4b88-bea1-a75bac9f694f
+    :Title: Test pki-server instance-migrate command
+    :Description: Test pki-server instance-migrate command
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-migrate command migrate,
+        2. All the instances to the next or previous tomcat version if it is supported by
+           RHEL and CS.
+    """
+    # Store subsystems in list
+    subsystems = [constants.CA_INSTANCE_NAME, constants.KRA_INSTANCE_NAME,
+                  constants.OCSP_INSTANCE_NAME, constants.TKS_INSTANCE_NAME,
+                  constants.TPS_INSTANCE_NAME]
+
+    # Check tomcat version.
+    rpm_cmd = 'rpm -qa tomcat'
+    cmd_output = ansible_module.command(rpm_cmd)
+    version = None
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            version = int(result['stdout'].split("-")[1].split(".")[0])
+
+    for system in subsystems:
+        cmd_output = ansible_module.command('pki-server instance-migrate '
+                                            '--tomcat {} {}'.format(str(version + 1), system))
+        for res in cmd_output.values():
+            if res['rc'] == 0:
+                assert system + " instance migrated" in res['stdout']
+
+            else:
+                pytest.xfail("Failed to run pki-server instance-start " + system + " command")
+        else:
+            ansible_module.command('pki-server instance-migrate '
+                                   '--tomcat {} {}'.format(str(version + 1), system))

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_show.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_show.py
@@ -1,0 +1,212 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server instance commands needs to be tested:
+#   pki-server instance-show --help
+#   pki-server instance-show
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+from subprocess import CalledProcessError
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_instance_show_command(ansible_module):
+    """
+    :id: 9361795f-ef9d-49d5-a706-b0d55b362600
+    :Title: Test pki-server instance-show command
+    :Description: test pki-server instance-show command
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server instance-show command shows
+        the instance is present or not.
+    """
+    subsystems = [constants.CA_INSTANCE_NAME, constants.KRA_INSTANCE_NAME,
+                  constants.OCSP_INSTANCE_NAME, constants.TKS_INSTANCE_NAME,
+                  constants.TPS_INSTANCE_NAME]
+
+    for system in subsystems:
+        instance_show = 'pki-server instance-show {}'.format(system)
+
+        cmd_output = ansible_module.command(instance_show)
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                assert "Instance ID: {}".format(system) in result['stdout']
+                assert "Active: True" in result['stdout']
+            else:
+                pytest.xfail("Failed to run pki-server instance-show " + system + " command")
+
+
+def test_pki_server_instance_show_with_help_command(ansible_module):
+    """
+    :id: ffd9f829-00cf-4cd0-9ad7-78d20218fcf3
+    :Title: Test pki-server instance-show --help command, BZ: 1339263
+    :Description: test pki-server instance-show --help command.
+                 This test also verifies bugzilla id : 1339263
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Setup:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-show --help command shows
+        the following commands.
+
+        Usage: pki-server instance-show [OPTIONS] <instance ID>
+
+          -v, --verbose                Run in verbose mode.
+              --help                   Show help message.
+    """
+
+    help_command = 'pki-server instance-show --help'
+
+    cmd_output = ansible_module.command(help_command)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server instance-show [OPTIONS] <instance ID>" in \
+                   result['stdout']
+            assert "  -v, --verbose                Run in verbose mode." in result['stdout']
+            assert "      --help                   Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-show --help command")
+
+
+def test_pki_server_instance_show_when_instance_is_disabled(ansible_module):
+    """
+    :id: 397d050b-7fe3-4aa8-99d3-ddcbb666dbe5
+    :Title: Test pki-server instance-show command when instance is disabled.
+    :Description: test pki-server instance-show command
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-show command shows the instance name and active
+        status False when it is disabled.
+    """
+    subsystems = [constants.CA_INSTANCE_NAME, constants.KRA_INSTANCE_NAME,
+                  constants.OCSP_INSTANCE_NAME, constants.TKS_INSTANCE_NAME,
+                  constants.TPS_INSTANCE_NAME]
+
+    for system in subsystems:
+        instance_stop = 'pki-server instance-stop {}'.format(system)
+        instance_start = 'pki-server instance-start {}'.format(system)
+        instance_show = 'pki-server instance-show {}'.format(system)
+
+        stop_instance = ansible_module.command(instance_stop)
+        for result in stop_instance.values():
+            if result['rc'] == 0:
+                assert "stopped" in result['stdout']
+
+        show_instance = ansible_module.command(instance_show)
+        for result in show_instance.values():
+            if result['rc'] == 0:
+                assert 'Instance ID: {}'.format(system) in result['stdout']
+                assert 'Active: False' in result['stdout']
+            else:
+                pytest.xfail("Failed to ran pki-server instance-show command when instance "
+                             "is disabled.")
+
+        ansible_module.command(instance_start)
+
+
+@pytest.mark.xfail(raises=CalledProcessError)
+def test_pki_server_instance_show_when_instance_is_not_present(ansible_module):
+    """
+    :id: d7dd5455-9f48-494e-b9c3-bae1bd897bda
+    :Title: Test pki-server instance-show command when instance is not present, BZ: 1348433
+    :Description: test pki-server instance-show command. This test also verifies
+                  bugzilla id : 1348433
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server instance-show command shows
+        the instance name and active status False when it is disabled.
+
+    """
+    system = "ABcCA"
+
+    instance_show = 'pki-server instance-show {}'.format(system)
+
+    cmd_show = ansible_module.command(instance_show)
+    for result in cmd_show.values():
+        if result['rc'] == 0:
+            assert "Instance ID: " + system in result['stdout']
+            assert "Active: False" in result['stdout']
+            pytest.xfail("Failed to ran pki-server instance-show command with invalid instance.")
+
+
+def test_pki_server_instance_show_when_instance_is_enabled(ansible_module):
+    """
+    :id: e2b4410d-896b-420e-9331-1e3744a7c26b
+    :Title: Test pki-server instance-show command when instance is enabled
+    :Description: test pki-server instance-show command
+    :Requirement: Pki Server Instance
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-show command shows the instance name and
+        active status True when it is enabled.
+    """
+    # Store subsystems in list
+    subsystems = [constants.CA_INSTANCE_NAME, constants.KRA_INSTANCE_NAME,
+                  constants.OCSP_INSTANCE_NAME, constants.TKS_INSTANCE_NAME,
+                  constants.TPS_INSTANCE_NAME]
+
+    for system in subsystems:
+        # Store commands in list
+        instance_start = 'pki-server instance-start {}'.format(system)
+        instance_show = 'pki-server instance-show {}'.format(system)
+
+        cmd_output = ansible_module.command(instance_start)
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                if 'already started' not in result['stdout']:
+                    assert system + " instance started" in result['stdout']
+                else:
+                    assert system + " instance already started" in result['stdout']
+        cmd_show = ansible_module.command(instance_show)
+        for result in cmd_show.values():
+            if result['rc'] == 0:
+                assert 'Instance ID: ' + system in result['stdout']
+                assert 'Active: True' in result['stdout']
+            else:
+                pytest.xfail("Failed to ran pki-server instance-show command when instance "
+                             "is disabled.")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_start.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_start.py
@@ -1,0 +1,168 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki securitydomain commands needs to be tested:
+#   pki-server instance-start
+#   pki-server instance-start --help
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+import sys
+from subprocess import CalledProcessError
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_instance_start_help_command(ansible_module):
+    """
+    :id: 15012942-15ea-4312-8f29-b0e33e8cb89b
+    :Title: Test pki-server instance-start --help command, BZ: 1339263
+    :Description: test pki-server instance-start --help command, This test also 
+                  verifies bugzilla id : 1339263
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server instance-start --help command shows the following
+    output.
+        Usage: pki-server instance-start [OPTIONS] <instance ID>
+    
+          -v, --verbose                Run in verbose mode.
+                --help                   Show help message.
+    """
+    help_command = 'pki-server instance-start --help'
+
+    cmd_output = ansible_module.command(help_command)
+
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server instance-start [OPTIONS] <instance ID>" in \
+                   result['stdout']
+            assert "  -v, --verbose                Run in verbose mode." in result['stdout']
+            assert "      --help                   Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to ran pki-server instance-start --help command")
+
+
+def test_pki_server_instance_start_command(ansible_module):
+    """
+    :id: a18dc103-0991-41f4-88d2-5c20cbd40cfc
+    :Title: Test pki-server instance-start command
+    :Description: test pki-server instance-start command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-start command start the instance.
+    """
+    subsystems = [constants.CA_INSTANCE_NAME, constants.KRA_INSTANCE_NAME,
+                  constants.OCSP_INSTANCE_NAME, constants.TKS_INSTANCE_NAME,
+                  constants.TPS_INSTANCE_NAME]
+
+    for system in subsystems:
+
+        stop_command = 'pki-server instance-stop {}'.format(system)
+        start_command = 'pki-server instance-start {}'.format(system)
+        # Start the instance
+        start_instance = ansible_module.command(start_command)
+        for result in start_instance.values():
+            if result['rc'] == 0:
+                if " instance already started" in result['stdout']:
+                    assert '{} instance already started'.format(system) in result['stdout']
+                else:
+                    assertstr = system + " instance started"
+                    assert assertstr in result['stdout']
+            else:
+                pytest.xfail("Failed to ran pki-server instance-start " + system + " command")
+
+
+@pytest.mark.exfail(raises=CalledProcessError)
+def test_pki_server_instance_start_command_when_instance_does_not_exists(ansible_module):
+    """
+    :id: 7f3f4fc3-86a1-4042-913d-dc92de4886b7
+    :Title: Test pki-server instance-start command when instance does not exits, BZ: 1384833
+    :Description: test pki-server instance-start command
+        This test also verifies bugzilla id : 1384833
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-start command start the instance which are not exits.
+    """
+    system = "ABcCA"
+
+    start_command = 'pki-server instance-start {}'.format(system)
+    cmd_output = ansible_module.command(start_command)
+
+    for result in cmd_output.values():
+        if result['rc'] >= 1:
+            assertstr = "ERROR: Invalid instance %s." % system
+            assert assertstr in result['stdout']
+        else:
+            pytest.xfail("Failed to ran pki-server instance-start command")
+
+
+def test_pki_server_instance_start_command_when_it_is_already_started(ansible_module):
+    """
+    :id: 93691558-151c-45f4-986e-9d94326592ca
+    :Title: Test pki-server instance-start command when it is alreary started
+    :Description: test pki-server instance-start command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-start command start the instance.
+    """
+    subsystems = [constants.CA_INSTANCE_NAME, constants.KRA_INSTANCE_NAME,
+                  constants.OCSP_INSTANCE_NAME, constants.TKS_INSTANCE_NAME,
+                  constants.TPS_INSTANCE_NAME]
+
+    for system in subsystems:
+        start_command = 'pki-server instance-start {}'.format(system)
+
+        cmd_output = ansible_module.command(start_command)
+        assertstr = system + " instance already started"
+        assertstr2 = system + " instance start"
+        for result in cmd_output.values():
+            if result['rc'] == 0:
+                if assertstr in result['stdout']:
+                    assert assertstr in result['stdout']
+                else:
+                    assert assertstr2 in result['stdout']
+
+            else:
+                pytest.xfail("Failed to ran pki-server instance-start " + system + " command")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_stop.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_instance_stop.py
@@ -1,0 +1,169 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server instance commands needs to be tested:
+#   pki-server instance-stop
+#   pki-server instance-stop --help
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+from subprocess import CalledProcessError
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_instance_stop_help_command(ansible_module):
+    """
+    :id: 42cd278d-2c98-4479-853f-047dc5d07bcd
+    :Title: Test pki-server instace-stop --help command, BZ: 1339263
+    :Description: test pki-server instance-stop --help command, This test also verifies bugzilla
+                  id : 1339263
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-stop --help command shows the following output.
+    
+        Usage: pki-server instance-stop [OPTIONS] <instance ID>
+        -v, --verbose                Run in verbose mode.
+        --help                   Show help message.
+    """
+    help_command = 'pki-server instance-stop --help'
+    cmd_output = ansible_module.command(help_command)
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server instance-stop [OPTIONS] <instance ID>" in result['stdout']
+            assert "  -v, --verbose                Run in verbose mode." in result['stdout']
+            assert "      --help                   Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-stop --help command")
+
+
+def test_pki_server_instance_stop_command(ansible_module):
+    """
+    :id: 42cd278d-2c98-4479-853f-047dc5d07bcd
+    :Title: Test pki-server instace-stop command
+    :Description: test pki-server instance-stop command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server instance-stop command stop the instance.
+    """
+
+    # Store subsystems in list
+    subsystems = [constants.CA_INSTANCE_NAME, constants.KRA_INSTANCE_NAME,
+                  constants.OCSP_INSTANCE_NAME, constants.TKS_INSTANCE_NAME,
+                  constants.TPS_INSTANCE_NAME]
+
+    for system in subsystems:
+
+        stop_command = 'pki-server instance-stop {}'.format(system)
+        start_command = 'pki-server instance-start {}'.format(system)
+        # Start the instance
+        stop_instance = ansible_module.command(stop_command)
+        for result in stop_instance.values():
+            if result['rc'] == 0:
+                if " instance already stopped" in result['stdout']:
+                    assert '{} instance already stopped'.format(system) in result['stdout']
+                else:
+                    assertstr = system + " instance stopped"
+                    assert assertstr in result['stdout']
+            else:
+                pytest.xfail("Failed to ran pki-server instance-start " + system + " command")
+        ansible_module.command(start_command)
+
+
+def test_pki_server_instance_stop_command_when_instance_already_stop(ansible_module):
+    """
+    :id: bd751cdb-1dc6-4880-8d88-63c8f2814696
+    :Title: Test pki-server instance-stop command when instance already stopped.
+    :Description: test pki-server instance-stop command
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server instance-stop command stop the instance.
+    """
+    subsystems = [constants.CA_INSTANCE_NAME, constants.KRA_INSTANCE_NAME,
+                  constants.OCSP_INSTANCE_NAME, constants.TKS_INSTANCE_NAME,
+                  constants.TPS_INSTANCE_NAME]
+
+    for system in subsystems:
+
+        stop_command = 'pki-server instance-stop {}'.format(system)
+        start_command = 'pki-server instance-start {}'.format(system)
+        # Start the instance
+        ansible_module.command(stop_command)
+        stop_instance = ansible_module.command(stop_command)
+        for result in stop_instance.values():
+            if result['rc'] == 0:
+                if " instance already stopped" in result['stdout']:
+                    assert '{} instance already stopped'.format(system) in result['stdout']
+                else:
+                    assertstr = system + " instance stopped"
+                    assert assertstr in result['stdout']
+            else:
+                pytest.xfail("Failed to ran pki-server instance-start " + system + " command")
+        ansible_module.command(start_command)
+
+
+@pytest.mark.xfail(raises=CalledProcessError)
+def test_pki_server_instance_stop_command_when_instance_not_exists(ansible_module):
+    """
+    :id: 62faea70-344f-4b04-9460-a7ed254c24b5
+    :Title: Test pki-server instace-stop command when instance does not exits, BZ:1348433
+    :Description: test pki-server instance-stop command This test also verifies BZ: 1348433
+    :CaseComponent: \-
+    :Requirement: Pki Server Instance
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server instance-stop command stop the instance when the 
+           instance is does not exists.
+    """
+    subsystems = "ABcCA"
+
+    instance_stop = 'pki-server instance-stop {}'.format(subsystems)
+
+    cmd_output = ansible_module.command(instance_stop)
+    for result in cmd_output.values():
+        if result['rc'] >= 0:
+            assert "ERROR: Invalid instance {}".format(subsystems) in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server instance-stop " + subsystems + " command")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_migrate.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_migrate.py
@@ -1,0 +1,114 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Description: PKI-SERVER CLI tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server commands needs to be tested:
+#   pki-server migrate 
+#   pki-server migrate --help
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_migrate_help_command(ansible_module):
+    """
+    :id: 3f7defc2-7494-4f07-9942-702cf50a93fc
+    :Title: Test pki-server migrate --help command.
+    :Description: test pki-server migrate command, This test also verifies bugzilla id : 1339263
+    :CaseComponent: \-
+    :Requirement: Pki Server Migrate
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server migrate --help command shows the following options.
+            Usage: pki-server migrate [OPTIONS]
+        
+                  --tomcat <version>       Use the specified Tomcat version.
+              -v, --verbose                Run in verbose mode.
+                  --debug                  Show debug messages.
+                  --help                   Show help message.
+    """
+
+    cmd_output = ansible_module.command('pki-server migrate --help')
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server migrate [OPTIONS" in result['stdout']
+            assert "--tomcat <version>       Use the specified Tomcat version." in result['stdout']
+            assert "-v, --verbose                Run in verbose mode." in result['stdout']
+            assert "--debug                  Show debug messages." in result['stdout']
+            assert "--help                   Show help message." in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server migrate --help command")
+
+
+def test_pki_server_migrate_command(ansible_module):
+    """
+    :id: 2659a948-ed42-4564-b89a-781858e23a8a
+    :Title: Test pki-server migrate command
+    :Description: test pki-server migrate command
+    :CaseComponent: \-
+    :Requirement:
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server migrate command migrate the all the instances to the
+            next or previous tomcat version if it is supported by RHEL and CS.
+    """
+    version = None
+    cmd_output = ansible_module.command('rpm -qa tomcat')
+    for result in cmd_output.values():
+        if result['rc'] == 0:
+            version = result['stdout'].split("-")[1].split(".")[0]
+            version_old = int(version)
+            version_new = version_old + 1
+
+            cmdstr = "pki-server migrate --tomcat {}"
+            if version_old < 8:
+                cmd_output = ansible_module.command(cmdstr.format(version_new))
+                for res in cmd_output.values():
+                    if res['rc'] == 0:
+                        assert "System migrated" in res['stdout']
+            else:
+                cmd_output = ansible_module.command(cmdstr.format(version_old))
+                for res in cmd_output.values():
+                    if res['rc'] == 0:
+                        assert "System migrated" in res['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server migrate --tomcat " + version + " command")
+    ansible_module.command('pki-server migrate --tomcat {}'.format(version))

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem.py
@@ -1,0 +1,87 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+from pki.testlib.common import utils
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+def test_pki_server_subsystem(ansible_module):
+    """
+    :id: 990d3ac6-b879-47cb-a4e7-ddd62c80562b
+    :Title: Test pki-server subsystem command
+    :Description: test pki-server subsystem command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem 
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem command shows subsystem-disable,subsystem-enable,
+           subsystem-find, subsystem-show, subsystem-cert commands
+    """
+    sub_out = ansible_module.command('pki-server subsystem')
+    for result in sub_out.values():
+        if result['rc'] == 0:
+            assert "subsystem-disable             Disable subsystem" in result['stdout']
+            assert "subsystem-enable              Enable subsystem" in result['stdout']
+            assert "subsystem-find                Find subsystems" in result['stdout']
+            assert "subsystem-show                Show subsystem" in result['stdout']
+            assert "subsystem-cert                Subsystem certificate management commands" in \
+                   result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem command..!!")
+
+
+def test_pki_server_subsystem_junk(ansible_module):
+    """
+    :id: 990d3ac6-b879-47cb-a4e7-ddd62c80562b
+    :Title: Test pki-server subsystem with junk sub command.
+    :Description: test pki-server subsystem command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server subsystem command throws error with junk option.
+    """
+    junk = utils.get_random_string(len=10)
+    junk_exception = 'ERROR: Invalid module "%s"' % junk
+    subsystem_junk_output = ansible_module.command('pki-server subsystem {}'.format(junk))
+    for result in subsystem_junk_output.values():
+        if result['rc'] >= 1:
+            assert junk_exception in result['stdout']

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert.py
@@ -1,0 +1,488 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem-cert
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+@pytest.mark.xfail(reason='BZ-1340718')
+def test_pki_server_subsystem_cert_find_help(ansible_module):
+    """
+    :id: 23181198-bd7d-410d-8f36-d5179440956a
+    :Title: Test pki-server subsystem-cert-find --help command
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server subsystem-cert-find command shows help options.
+    """
+    find_out = ansible_module.command('pki-server subsystem-cert-find --help')
+    for result in find_out.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server subsystem-cert-find [OPTIONS] <subsystem ID>" in \
+                   result['stdout']
+            assert "-i, --instance <instance ID>    Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "--show-all                  Show all attributes." in result['stdout']
+            assert "-v, --verbose                   Run in verbose mode." in result['stdout']
+            assert "--help                      Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find --help command..!!")
+
+
+def test_pki_server_subsystem_cert(ansible_module):
+    """
+    :id: e639c88a-c9e5-45b8-9c54-1e6aed722b29
+    :Title: Test pki-server subsystem-cert command 
+    :Description: test pki-server subsystem-cert command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert command shows subsystem-cert-find,
+        subsystem-cert-show, subsystem-cert-export, subsystem-cert-update commands.
+    """
+    find_out = ansible_module.command('pki-server subsystem-cert')
+    for result in find_out.values():
+        if result['rc'] == 0:
+            assert "subsystem-cert-find           Find subsystem certificates" in \
+                   result['stdout']
+            assert "subsystem-cert-show           Show subsystem certificate" in \
+                   result['stdout']
+            assert "subsystem-cert-export         Export subsystem certificate" in \
+                   result['stdout']
+            assert "subsystem-cert-update         Update subsystem certificate" in \
+                   result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert command..!!")
+
+
+def test_pki_server_subsystem_cert_find_ca(ansible_module):
+    """
+    :id: 081fe0d7-a747-4d68-8331-261efcf2c7ea
+    :Title: Test pki-server subsystem-cert-find ca command.
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        Verify whether pki-server subsystem-cert-find command lists the ca subsystem certificates.
+    """
+    find_out = ansible_module.command('pki-server subsystem-cert-find '
+                                      '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+    for result in find_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: signing" in result['stdout']
+            assert "Nickname: caSigningCert cert-" + constants.CA_INSTANCE_NAME + " CA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: ocsp_signing" in result['stdout']
+            assert "Nickname: ocspSigningCert cert-" + constants.CA_INSTANCE_NAME + " CA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.CA_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.CA_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.CA_INSTANCE_NAME + " CA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+def test_pki_server_subsystem_cert_find_kra(ansible_module):
+    """
+    :id: fa55c65e-c2d1-4138-b8b5-c2857938cca7
+    :Title: Test pki-server subsystem-cert-find kra command
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-find command lists the kra 
+            subsystem certificates.
+    """
+    kra_out = ansible_module.command('pki-server subsystem-cert-find '
+                                     '-i {} kra'.format(constants.KRA_INSTANCE_NAME))
+
+    for result in kra_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: transport" in result['stdout']
+            assert "Nickname: transportCert cert-" + constants.KRA_INSTANCE_NAME + " KRA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: storage" in result['stdout']
+            assert "Nickname: storageCert cert-" + constants.KRA_INSTANCE_NAME + " KRA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.KRA_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.KRA_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.KRA_INSTANCE_NAME + " KRA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+def test_pki_server_subsystem_cert_find_ocsp(ansible_module):
+    """
+    :id: 28cbd84b-6817-47dc-bfea-aaec6d07a95e
+    :Title: Test pki-server subsystem-cert-find ocsp command
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        Verify whether pki-server subsystem-cert-find command lists the OCSP subsystem certificates.
+    """
+    ocsp_out = ansible_module.command('pki-server subsystem-cert-find '
+                                      '-i {} ocsp'.format(constants.OCSP_INSTANCE_NAME))
+    for result in ocsp_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: signing" in result['stdout']
+            assert "Nickname: ocspSigningCert cert-" + constants.OCSP_INSTANCE_NAME + " OCSP" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.OCSP_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.OCSP_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.OCSP_INSTANCE_NAME + " OCSP" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+def test_pki_server_subsystem_cert_find_tks(ansible_module):
+    """
+    :id: b8d08e42-cc2e-453b-b7c1-72c1356c4e04
+    :Title: Test pki-server subsystem-cert-find tks command
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-find command lists the tks 
+           subsystem certificates.
+    """
+    tks_out = ansible_module.command('pki-server subsystem-cert-find '
+                                     '-i {} tks'.format(constants.TKS_INSTANCE_NAME))
+    for result in tks_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.TKS_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.TKS_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.TKS_INSTANCE_NAME + " TKS" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+def test_pki_server_subsystem_cert_find_tps(ansible_module):
+    """
+    :id: 81ddf075-8456-4515-ae77-536ce15dd8b8
+    :Title: Test pki-server subsystem-cert-find tps command
+    :Description: test pki-server subsystem-cert-find tps command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-find command lists the tps 
+            subsystem certificates.
+    """
+    tps_out = ansible_module.command('pki-server subsystem-cert-find '
+                                     '-i {} tps'.format(constants.TPS_INSTANCE_NAME))
+    for result in tps_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.TPS_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.TPS_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.TPS_INSTANCE_NAME + " TPS" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_cert_find_clone_ca(ansible_module):
+    """
+    :id: 520d1ea5-b1db-4adf-afc9-b4b3e886093f
+    :Title: Test pki-server subsystem-cert-find clone ca command
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem 
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-find command lists the ca subsystem 
+        certificates.
+    """
+    clone_ca = ansible_module.command('pki-server subsystem-cert-find '
+                                      '-i {} ca'.format(constants.CLONECA1_INSTANCE_NAME))
+    for result in clone_ca.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: signing" in result['stdout']
+            assert "Nickname: caSigningCert cert-" + constants.CLONECA1_INSTANCE_NAME + " CA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: ocsp_signing" in result['stdout']
+            assert "Nickname: ocspSigningCert cert-" + constants.CLONECA1_INSTANCE_NAME + " CA" \
+                   in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.CLONECA1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.CLONECA1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.CLONECA1_INSTANCE_NAME + " CA" \
+                   in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_cert_find_clone_kra(ansible_module):
+    """
+    :id: 1aec4676-7707-4d9c-a990-b9b80b2d2236
+    :Title: Test pki-server subsystem-find clone KRA command.
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-find command lists the clone 
+            kra subsystem certificates.
+    """
+    kra_out = ansible_module.command('pki-server subsystem-cert-find '
+                                     '-i {} kra'.format(constants.CLONEKRA1_INSTANCE_NAME))
+    for result in kra_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: transport" in result['stdout']
+            assert "Nickname: transportCert cert-" + constants.CLONEKRA1_INSTANCE_NAME + " KRA" \
+                   in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: storage" in result['stdout']
+            assert "Nickname: storageCert cert-" + constants.CLONEKRA1_INSTANCE_NAME + " KRA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.CLONEKRA1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.CLONEKRA1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.CLONEKRA1_INSTANCE_NAME + " KRA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_cert_find_clone_ocsp(ansible_module):
+    """
+    :id: 9176c1b4-5703-4396-8c58-d3048467f6cb
+    :Title: Test pki-server subsystem-cert-find clone ocsp command
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-find command lists the clone OCSP 
+           subsystem certificates.
+    """
+    ocsp_out = ansible_module.command('pki-server subsystem-cert-find '
+                                      '-i {} ocsp'.format(constants.CLONEOCSP1_INSTANCE_NAME))
+    for result in ocsp_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: signing" in result['stdout']
+            assert "Nickname: ocspSigningCert cert-" + constants.CLONEOCSP1_INSTANCE_NAME + " OCSP" \
+                   in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.CLONEOCSP1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.CLONEOCSP1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + \
+                   constants.CLONEOCSP1_INSTANCE_NAME + " OCSP" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_cert_find_clone_tks(ansible_module):
+    """
+    :id: d454a71c-2562-4dfc-8434-65c9cfa5390e
+    :Title: Test pki-server subystem-cert-find clone tks command
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem 
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-find command lists the clone tks 
+           subsystem certificates.
+    """
+    clone_tks = ansible_module.command('pki-server subsystem-cert-find '
+                                       '-i {} tks'.format(constants.CLONETKS1_INSTANCE_NAME))
+    for result in clone_tks.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.CLONEiTKS1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.CLONETKS1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + \
+                   constants.CLONETKS1_INSTANCE_NAME + " TKS" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_cert_find_subca(ansible_module):
+    """
+    :id: 68592172-ec7a-44c6-ad62-5779442d25c6
+    :Title: Test pki-server subsystem-cert-find subca command
+    :Description: test pki-server subsystem-cert-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-find command lists the subca subsystem
+        certificates.
+    """
+    ca_out = ansible_module.command('pki-server subsystem-cert-find '
+                                    '-i {} ca'.format(constants.SUBCA1_INSTANCE_NAME))
+    for result in ca_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Cert ID: signing" in result['stdout']
+            assert "Nickname: caSigningCert cert-" + constants.SUBCA1_INSTANCE_NAME + " CA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: ocsp_signing" in result['stdout']
+            assert "Nickname: ocspSigningCert cert-" + constants.SUBCA1_INSTANCE_NAME + " CA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: sslserver" in result['stdout']
+            assert "Nickname: Server-Cert cert-" + constants.SUBCA1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: subsystem" in result['stdout']
+            assert "Nickname: subsystemCert cert-" + constants.SUBCA1_INSTANCE_NAME in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.SUBCA1_INSTANCE_NAME + " CA" in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-find command..!!")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert_export.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert_export.py
@@ -1,0 +1,667 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem-cert-export
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+def test_pki_server_subsystem_cert_export_help(ansible_module):
+    """
+    :id: e61d2329-a42d-40a1-8beb-acf8722ea804
+    :Title: Test pki-server subsystem-cert-export --help command, BZ: 1340718
+    :Description: test pki-server subsystem-cert-export --help command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-export command exports --help shows help
+        options.
+    """
+    help_out = ansible_module.command('pki-server subsystem-cert-export --help')
+    for result in help_out.values():
+        if result['rc'] == 0:
+
+            assert "-i, --instance <instance ID>       Instance ID (default: pki-tomcat)" in \
+                   result['stdout']
+            assert "--cert-file <path>             Output file to store the exported certificate " \
+                   "in PEM format" in result['stdout']
+            assert "--csr-file <path>              Output file to store the exported CSR " \
+                   "in PEM format" in result['stdout']
+            assert "--pkcs12-file <path>           Output file to store the exported certificate " \
+                   "and key in PKCS #12 format" in result['stdout']
+            assert "--pkcs12-password <password>   Password for the PKCS #12 file" in \
+                   result['stdout']
+            assert "--pkcs12-password-file <path>  Input file containing the password for " \
+                   "the PKCS #12 file" in result['stdout']
+            assert "--append                       Append into an existing PKCS #12 file" in \
+                   result['stdout']
+            assert "--no-trust-flags               Do not include trust flags" in \
+                   result['stdout']
+            assert "--no-key                       Do not include private key" in \
+                   result['stdout']
+            assert "--no-chain                     Do not include certificate chain" in \
+                   result['stdout']
+            assert "-v, --verbose                      Run in verbose mode" in result['stdout']
+            assert "--debug                        Run in debug mode" in result['stdout']
+            assert "--help                         Show help message" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export --help command.")
+
+
+@pytest.mark.parametrize('cert_id', ('signing', 'ocsp_signing', 'sslserver',
+                                     'subsystem', 'audit_signing'))
+def test_pki_server_subsystem_cert_export_ca_certs(ansible_module, cert_id):
+    """
+    :id: 34a8fe13-4654-479b-a775-3898c2ba4d69
+    :Title: Test pki-server subsystem-cert-export CA Signing certificate export
+    :Description: Test pki-server subsystem-cert-export command, will export signing, ocsp_signing,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether signing certificate got exported in .pem .req and .p12 file.
+        2. Verify whether ocsp_signing certificate got exported in .pem .req and .p12 file.
+        3. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        4. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        5. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/ca_{}.pem'.format(cert_id)
+    csr_file = '/tmp/ca_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/ca_{}.p12'.format(cert_id)
+    instance = constants.CA_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'ca {}'.format(instance, cert_file, csr_file, p12_file,
+                                 constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.parametrize('cert_id', ('transport', 'storage', 'sslserver', 'subsystem',
+                                     'audit_signing'))
+def test_pki_server_subsystem_cert_export_kra_certs(ansible_module, cert_id):
+    """
+    :id: 723c88c4-126e-4581-8726-406190f1dc85
+    :Title: Test pki-server subsystem-cert-export KRA certificates
+    :Description: Test pki-server subsystem-cert-export command, will export transport, storage,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether transport certificate got exported in .pem .req and .p12 file.
+        2. Verify whether storage certificate got exported in .pem .req and .p12 file.
+        3. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        4. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        5. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/kra_{}.pem'.format(cert_id)
+    csr_file = '/tmp/kra_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/kra_{}.p12'.format(cert_id)
+    instance = constants.KRA_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'kra {}'.format(instance, cert_file, csr_file, p12_file,
+                                  constants.CLIENT_PKCS12_PASSWORD, cert_id)
+
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.parametrize('cert_id', ('signing', 'sslserver', 'subsystem', 'audit_signing'))
+def test_pki_server_subsystem_cert_export_ocsp_certs(ansible_module, cert_id):
+    """
+    :id: 80778f63-1139-42c1-92b3-59c74005605a
+    :Title: Test pki-server subsystem-cert-export OCSP certificates export
+    :Description: Test pki-server subsystem-cert-export command, will export signing,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether signing certificate got exported in .pem .req and .p12 file.
+        2. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        3. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        4. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/ocsp_{}.pem'.format(cert_id)
+    csr_file = '/tmp/ocsp_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/ocsp_{}.p12'.format(cert_id)
+    instance = constants.OCSP_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'ocsp {}'.format(instance, cert_file, csr_file, p12_file,
+                                   constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.parametrize('cert_id', ('sslserver', 'subsystem', 'audit_signing'))
+def test_pki_server_subsystem_cert_export_tks_subsystem(ansible_module, cert_id):
+    """
+    :id: 8709e5ee-d9c5-4cb4-972a-b0458548fd62
+    :Title: Test pki-server subsystem-cert-export TKS Subsystem certificate export
+    :Description: Test pki-server subsystem-cert-export command, will export signing,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether signing certificate got exported in .pem .req and .p12 file.
+        2. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        3. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        4. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/tks_{}.pem'.format(cert_id)
+    csr_file = '/tmp/tks_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/tks_{}.p12'.format(cert_id)
+    instance = constants.TKS_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'tks {}'.format(instance, cert_file, csr_file, p12_file,
+                                  constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.parametrize('cert_id', ('sslserver', 'subsystem', 'audit_signing'))
+def test_pki_server_subsystem_cert_export_tps_subsystem(ansible_module, cert_id):
+    """
+    :id: fff185ff-f5d9-47ae-8bcb-02c19c54aa73
+    :Title: Test pki-server subsystem-cert-export TPS Subsystem certificate export
+    :Description: Test pki-server subsystem-cert-export command, will export signing,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether signing certificate got exported in .pem .req and .p12 file.
+        2. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        3. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        4. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/tps_{}.pem'.format(cert_id)
+    csr_file = '/tmp/tps_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/tps_{}.p12'.format(cert_id)
+    instance = constants.TPS_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'tps {}'.format(instance, cert_file, csr_file, p12_file,
+                                  constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id', ('signing', 'ocsp_signing', 'sslserver',
+                                     'subsystem', 'audit_signing'))
+def test_pki_server_subsystem_cert_export_clone_ca_certs(ansible_module, cert_id):
+    """
+    :id: 32607193-db74-49d9-aff9-2e18c2f6cd61
+    :Title: Test pki-server subsystem-cert-export Clone CA Signing certificate export
+    :Description: Test pki-server subsystem-cert-export command, will export signing,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether signing certificate got exported in .pem .req and .p12 file.
+        2. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        3. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        4. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/ca_{}.pem'.format(cert_id)
+    csr_file = '/tmp/ca_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/ca_{}.p12'.format(cert_id)
+    instance = constants.CLONECA1_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'ca {}'.format(instance, cert_file, csr_file, p12_file,
+                                 constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id', ('transport', 'storage', 'sslserver', 'subsystem',
+                                     'audit_signing'))
+def test_pki_server_subsystem_cert_export_clone_kra_certs(ansible_module, cert_id):
+    """
+    :id: bc037e47-a133-42e3-ade5-50924fe2d561
+    :Title: Test pki-server subsystem-cert-export Clone KRA Transport certificate export
+    :Description: Test pki-server subsystem-cert-export command, will export transport, storage,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether transport certificate got exported in .pem .req and .p12 file.
+        2. Verify whether storage certificate got exported in .pem .req and .p12 file.
+        3. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        4. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        5. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/kra_{}.pem'.format(cert_id)
+    csr_file = '/tmp/kra_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/kra_{}.p12'.format(cert_id)
+    instance = constants.CLONEKRA1_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'kra {}'.format(instance, cert_file, csr_file, p12_file,
+                                  constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id', ('signing', 'sslserver', 'subsystem', 'audit_signing'))
+def test_pki_server_subsystem_cert_export_clone_ocsp_certs(ansible_module, cert_id):
+    """
+    :id: 21a4f700-68ef-4d1d-8183-d9d5d9ba4d7d
+    :Title: Test pki-server subsystem-cert-export Clone OCSP Signing certificate export
+    :Description: Test pki-server subsystem-cert-export command, will export signing,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether signing certificate got exported in .pem .req and .p12 file.
+        2. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        3. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        4. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/ocsp_{}.pem'.format(cert_id)
+    csr_file = '/tmp/ocsp_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/ocsp_{}.p12'.format(cert_id)
+    instance = constants.CLONEOCSP1_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'ocsp {}'.format(instance, cert_file, csr_file, p12_file,
+                                   constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id', ('signing', 'sslserver', 'subsystem', 'audit_signing'))
+def test_pki_server_subsystem_cert_export_clone_tks_sslserver(ansible_module, cert_id):
+    """
+    :id: 72fd03d8-8db2-4f9e-973a-34e97656eeea
+    :Title: Test pki-server subsystem-cert-export Clone tks sslserver certificate export
+    :Description: Test pki-server subsystem-cert-export command, will export signing,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether signing certificate got exported in .pem .req and .p12 file.
+        2. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        3. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        4. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/tks_{}.pem'.format(cert_id)
+    csr_file = '/tmp/tks_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/tks_{}.p12'.format(cert_id)
+    instance = constants.TKS_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'tks {}'.format(instance, cert_file, csr_file, p12_file,
+                                  constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id', ('signing', 'ocsp_signing', 'sslserver',
+                                     'subsystem', 'audit_signing'))
+def test_pki_server_subsystem_cert_export_subca_signing(ansible_module, cert_id):
+    """
+    :id: 8694fa09-78fe-4938-8306-db11b329ccf3
+    :Title: Test pki-server subsystem-cert-export Sub CA Audit Signing certificate export
+    :Description: Test pki-server subsystem-cert-export command, will export signing, ocsp_signing,
+                  SSLServer, Subsystem and Audit Signing certificate
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether signing certificate got exported in .pem .req and .p12 file.
+        2. Verify whether ocsp_signing certificate got exported in .pem .req and .p12 file.
+        3. Verify whether sslserver certificate got exported in .pem .req and .p12 file.
+        4. Verify whether subsystem certificate got exported in .pem .req and .p12 file.
+        5. Verify whether audit_signing certificate got exported in .pem .req and .p12 file.
+    """
+    cert_file = '/tmp/subca_{}.pem'.format(cert_id)
+    csr_file = '/tmp/subca_{}_csr.pem'.format(cert_id)
+    p12_file = '/tmp/subca_{}.p12'.format(cert_id)
+    instance = constants.SUBCA1_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --cert-file {} --csr-file {} ' \
+                  '--pkcs12-file {} --pkcs12-password {} ' \
+                  'ca {}'.format(instance, cert_file, csr_file, p12_file,
+                                 constants.CLIENT_PKCS12_PASSWORD, cert_id)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [cert_file, csr_file, p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+    for f in [cert_file, csr_file, p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+def test_pki_server_subsystem_cert_export_with_append(ansible_module):
+    """
+    :id: 1a91071b-7059-4f6a-b42b-cc2909384177
+    :Title: Test pki-server subsystem-cert-export --append subsystem certificate to one file.
+    :Description: Test pki-server subsystem-cert-export command, will export all subsystem
+                  certificate to the one file.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether CA subsystem certificate got exported in .p12 file.
+        2. Verify whether KRA subsystem certificate got exported in .p12 file.
+        3. Verify whether OCSP subsystem certificate got exported in .p12 file.
+        4. Verify whether TKS subsystem certificate got exported in .p12 file.
+        5. Verify whether TPS subsystem certificate got exported in .p12 file.
+    """
+    tmp_dir = '/tmp/subsystem_cert/'
+    p12_file = '/tmp/all_subsystem.p12'
+
+    client_cert_find = 'pki pkcs12-cert-find --pkcs12-file {} ' \
+                       '--pkcs12-password {}'.format(p12_file, constants.CLIENT_PKCS12_PASSWORD)
+    for subsystem in ['ca', 'kra', 'ocsp', 'tks', 'tps']:
+        instance = eval("constants.{}_INSTANCE_NAME".format(subsystem.upper()))
+        cert_export = 'pki-server subsystem-cert-export -i {} --pkcs12-file {} --pkcs12-password ' \
+                      '{} {} subsystem --append'.format(instance, p12_file,
+                                                        constants.CLIENT_PKCS12_PASSWORD, subsystem)
+        signing_out = ansible_module.command(cert_export)
+        for result in signing_out.values():
+            if result['rc'] == 0:
+                assert "Export complete" in result['stdout']
+                for f in [p12_file]:
+                    exists = ansible_module.stat(path=f)
+                    for res in exists.values():
+                        assert res['stat']['exists']
+            else:
+                pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+
+    cert_find = ansible_module.command(client_cert_find)
+    for result in cert_find.values():
+        if result['rc'] == 0:
+            for s in ['ca', 'kra', 'ocsp', 'tks', 'tps']:
+                instance = eval("constants.{}_INSTANCE_NAME".format(s.upper()))
+                assert 'Nickname: subsystemCert cert-{}'.format(instance) in result['stdout']
+    for f in [p12_file, tmp_dir]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+def test_pki_server_subsystem_cert_export_with_pkcs12_password_file(ansible_module):
+    """
+    :id: 8d5d1f82-f932-471c-9428-768ca909cfdb
+    :Title: Test pki-server subsystem-cert-export with pkcs12-password-file option.
+    :Description: Test pki-server subsystem-cert-export command, will export subsystem certificate
+                  in to the file using --pkcs12-password-file.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether CA subsystem certificate got exported in .p12 file.
+    """
+    password_file = '/tmp/password.txt'
+    p12_file = '/tmp/ca_subsystem.p12'
+    ansible_module.shell('echo "{}" > {}'.format(constants.CLIENT_PKCS12_PASSWORD, password_file))
+
+    instance = constants.CA_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --pkcs12-file {} ' \
+                  '--pkcs12-password-file {} ' \
+                  'ca subsystem'.format(instance, p12_file, password_file)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+
+    client_cert_find = 'pki pkcs12-cert-find --pkcs12-file {} ' \
+                       '--pkcs12-password-file {}'.format(p12_file, password_file)
+    cert_find = ansible_module.command(client_cert_find)
+    for result in cert_find.values():
+        if result['rc'] == 0:
+            for s in ['ca']:
+                instance = eval("constants.{}_INSTANCE_NAME".format(s.upper()))
+                assert 'Nickname: subsystemCert cert-{}'.format(instance) in result['stdout']
+    for f in [p12_file, password_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+def test_pki_server_subsystem_cert_export_with_no_key_option(ansible_module):
+    """
+    :id: df0d4c33-c6f8-4c35-84e2-346338c9ae22
+    :Title: Test pki-server subsystem-cert-export with no-key option.
+    :Description: While run pki-server subsystem-cert-export with --no-key then it should not export
+                  certificate key in to the file.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :Expectedresults:
+                1. It should not export private key in to the p12 file.
+    """
+    p12_file = '/tmp/ca_subsystem.p12'
+    instance = constants.CA_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --pkcs12-file {} --pkcs12-password ' \
+                  '{} ca subsystem --no-key'.format(instance, p12_file,
+                                                    constants.CLIENT_PKCS12_PASSWORD)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+
+    client_cert_find = 'pki pkcs12-cert-find --pkcs12-file {} ' \
+                       '--pkcs12-password {}'.format(p12_file, constants.CLIENT_PKCS12_PASSWORD)
+    cert_find = ansible_module.command(client_cert_find)
+    for result in cert_find.values():
+        if result['rc'] == 0:
+            for s in ['ca']:
+                instance = eval("constants.{}_INSTANCE_NAME".format(s.upper()))
+                assert 'Nickname: subsystemCert cert-{}'.format(instance) in result['stdout']
+                assert 'Has Key: false'
+    for f in [p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))
+
+
+def test_pki_server_subsystem_cert_export_with_no_chain_option(ansible_module):
+    """
+    :id: 0ac1dfc3-e98d-43b0-b3ba-a95f78a1b741
+    :Title: Test pki-server subsystem-cert-export with no-chain option.
+    :Description: While run pki-server subsystem-cert-export with --no-chain then it should
+                  not export certificate with chain.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :Expectedresults:
+                1. It should not export CA certificate in to the p12 file.
+    """
+    p12_file = '/tmp/ca_subsystem.p12'
+    instance = constants.CA_INSTANCE_NAME
+    cert_export = 'pki-server subsystem-cert-export -i {} --pkcs12-file {} --pkcs12-password ' \
+                  '{} ca subsystem --no-chain'.format(instance, p12_file,
+                                                      constants.CLIENT_PKCS12_PASSWORD)
+    signing_out = ansible_module.command(cert_export)
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Export complete" in result['stdout']
+            for f in [p12_file]:
+                exists = ansible_module.stat(path=f)
+                for res in exists.values():
+                    assert res['stat']['exists']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-export command.")
+
+    client_cert_find = 'pki pkcs12-cert-find --pkcs12-file {} ' \
+                       '--pkcs12-password {}'.format(p12_file, constants.CLIENT_PKCS12_PASSWORD)
+    cert_find = ansible_module.command(client_cert_find)
+    for result in cert_find.values():
+        if result['rc'] == 0:
+            instance = constants.CA_INSTANCE_NAME
+            assert 'Nickname: subsystemCert cert-{}'.format(instance) in result['stdout']
+            assert 'Has Key: true' in result['stdout']
+            assert 'Nickname: CA Signing Certificate' not in result['stdout']
+            assert 'Trust Flags: CT,C,C' not in result['stdout']
+    for f in [p12_file]:
+        ansible_module.command('rm -rf {}'.format(f))

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert_show.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert_show.py
@@ -1,0 +1,444 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem-cert-show
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+@pytest.mark.xfail(reason='BZ-1340718')
+def test_pki_server_subsystem_cert_show_help(ansible_module):
+    """
+    :id: 7c87ea5e-aee8-49d5-856e-a707cd3ca0eb
+    :Title: Test pki-server subsystem-cert-show --help command
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-show --help command shows the help option.
+    """
+    help_out = ansible_module.command('pki-server subsystem-cert-show --help')
+    for result in help_out.values():
+        if result['rc'] == 0:
+
+            assert "Usage: pki-server subsystem-cert-show [OPTIONS] " \
+                   "<subsystem ID> <cert ID>" in result['stdout']
+            assert "-i, --instance <instance ID>    Instance ID " \
+                   "(default: pki-tomcat)." in result['stdout']
+            assert "--show-all                  Show all attributes." in result['stdout']
+            assert "-v, --verbose                   Run in verbose mode." in result['stdout']
+            assert "--help                      Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show --help command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'caSigningCert cert-{} CA'],
+                                          ['ocsp_signing', 'ocspSigningCert cert-{} CA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} CA']))
+def test_pki_server_subsystem_cert_show_ca_signing(ansible_module, cert_id, nick):
+    """
+    :id: 96c570e8-bd95-4b2b-9064-b02afcce0428
+    :Title: Test pki-server subsystem-cert-show ca signing certificate command.
+    :Description: Test pki-server subsystem-cert-show  ca singing certificate command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. run pki-server subsystem-cert-show ca signing
+        2. run pki-server subsystem-cert-show ca ocsp_signing
+        3. run pki-server subsystem-cert-show ca sslserver
+        4. run pki-server subsystem-cert-show ca subsystem
+        5. run pki-server subsystem-cert-show ca audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the ca signing certificate info.
+        2. pki-server subsystem-cert-show should show the ocsp_signing certificate info.
+        3. pki-server subsystem-cert-show should show the sslserver certificate info.
+        4. pki-server subsystem-cert-show should show the subsystem certificate info.
+        5. pki-server subsystem-cert-show should show the audit_signing certificate info.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} ca {}'.format(constants.CA_INSTANCE_NAME,
+                                                              cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CA_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['transport', 'transportCert cert-{} KRA'],
+                                          ['storage', 'storageCert cert-{} KRA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} KRA']))
+def test_pki_server_subsystem_cert_show_kra_certs(ansible_module, cert_id, nick):
+    """
+    :id: 4d096f8b-da7e-4b54-9e6a-2d67142b3ed6
+    :Title: Test pki-server subsystem cert show kra transport certificate
+    :Description: test pki-server subsystem-cert-show show kra transport certificate command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. pki-server subsystem-cert-show kra transport
+        2. pki-server subsystem-cert-show kra storage
+        3. pki-server subsystem-cert-show kra sslserver
+        4. pki-server subsystem-cert-show kra subsystem
+        5. pki-server subsystem-cert-show kra audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the kra transport certificate info.
+        2. pki-server subsystem-cert-show should show the kra storage certificate info.
+        3. pki-server subsystem-cert-show should show the kra sslserver certificate info.
+        4. pki-server subsystem-cert-show should show the kra subsystem certificate info.
+        5. pki-server subsystem-cert-show should show the kra audit_signing certificate info.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} kra {}'.format(constants.KRA_INSTANCE_NAME,
+                                                               cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.KRA_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'ocspSigningCert cert-{} OCSP'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} OCSP']))
+def test_pki_server_subsystem_cert_show_ocsp_certs(ansible_module, cert_id, nick):
+    """
+    :id: a3b94b99-254e-409a-b3ab-8d5276ad509a
+    :Title: Test pki-server subsystemc-cert-show ocsp certificates
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. pki-server subsystem-cert-show ocsp transport
+        2. pki-server subsystem-cert-show ocsp sslserver
+        3. pki-server subsystem-cert-show ocsp subsystem
+        4. pki-server subsystem-cert-show ocsp audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the ocsp transport certificate info.
+        2. pki-server subsystem-cert-show should show the ocsp sslserver certificate info.
+        3. pki-server subsystem-cert-show should show the ocsp subsystem certificate info.
+        4. pki-server subsystem-cert-show should show the ocsp audit_signing certificate info.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} ocsp {}'.format(constants.OCSP_INSTANCE_NAME,
+                                                                cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.OCSP_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} TKS']))
+def test_pki_server_subsystem_cert_show_tks_sslserver(ansible_module, cert_id, nick):
+    """
+    :id: b5f676e9-72cb-4313-bada-5444f694fc1c
+    :Title: Test pki-server subsystem-cert-show TKS SSL Server certificate
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. pki-server subsystem-cert-show tks sslserver
+        2. pki-server subsystem-cert-show tks subsystem
+        3. pki-server subsystem-cert-show tks audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the tks sslserver certificate info.
+        2. pki-server subsystem-cert-show should show the tks subsystem certificate info.
+        3. pki-server subsystem-cert-show should show the tks audit_signing certificate info.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} tks {}'.format(constants.TKS_INSTANCE_NAME,
+                                                               cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.TKS_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} TPS']))
+def test_pki_server_subsystem_cert_show_tps_sslserver(ansible_module, cert_id, nick):
+    """
+    :id: db63f6c2-20ac-43a9-afdd-2cb9a8a1bcd1
+    :Title: Test pki-server subsystem-cert-show TPS SSL Server Certificate
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. pki-server subsystem-cert-show tps sslserver
+        2. pki-server subsystem-cert-show tps subsystem
+        3. pki-server subsystem-cert-show tps audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the tps sslserver certificate info.
+        2. pki-server subsystem-cert-show should show the tps subsystem certificate info.
+        3. pki-server subsystem-cert-show should show the tps audit_signing certificate info.
+
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} tps {}'.format(constants.TPS_INSTANCE_NAME,
+                                                               cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.TPS_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'caSigningCert cert-{} CA'],
+                                          ['ocsp_signing', 'ocspSigningCert cert-{} CA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} CA']))
+def test_pki_server_subsystem_cert_show_clone_ca_certs(ansible_module, cert_id, nick):
+    """
+    :id: c5d8273f-1b41-439f-92ee-f5603df83d8a
+    :Title: Test pki-server subsystem-cert-show Clone CA Signing Certificate
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. run pki-server subsystem-cert-show ca signing
+        2. run pki-server subsystem-cert-show ca ocsp_signing
+        3. run pki-server subsystem-cert-show ca sslserver
+        4. run pki-server subsystem-cert-show ca subsystem
+        5. run pki-server subsystem-cert-show ca audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the ca signing certificate info.
+        2. pki-server subsystem-cert-show should show the ocsp_signing certificate info.
+        3. pki-server subsystem-cert-show should show the sslserver certificate info.
+        4. pki-server subsystem-cert-show should show the subsystem certificate info.
+        5. pki-server subsystem-cert-show should show the audit_signing certificate info.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} ca {}'.format(constants.CLONECA1_INSTANCE_NAME,
+                                                              cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONECA1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['transport', 'transportCert cert-{} KRA'],
+                                          ['storage', 'storageCert cert-{} KRA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} KRA']))
+def test_pki_server_subsystem_cert_show_clone_kra_certs(ansible_module, cert_id, nick):
+    """
+    :id: \9f9bb78d-1596-4cd7-89ef-621e426bb025
+    :Title: Test pki-server subsystem-cert-show Clone KRA Transport Certificate
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. pki-server subsystem-cert-show kra transport
+        2. pki-server subsystem-cert-show kra storage
+        3. pki-server subsystem-cert-show kra sslserver
+        4. pki-server subsystem-cert-show kra subsystem
+        5. pki-server subsystem-cert-show kra audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the kra transport certificate info.
+        2. pki-server subsystem-cert-show should show the kra storage certificate info.
+        3. pki-server subsystem-cert-show should show the kra sslserver certificate info.
+        4. pki-server subsystem-cert-show should show the kra subsystem certificate info.
+        5. pki-server subsystem-cert-show should show the kra audit_signing certificate info.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} kra {}'.format(constants.CLONEKRA1_INSTANCE_NAME,
+                                                               cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONEKRA1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'ocspSigningCert cert-{} OCSP'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} OCSP']))
+def test_pki_server_subsystem_cert_show_clone_ocsp_certs(ansible_module, cert_id, nick):
+    """
+    :id: 13354952-e637-4596-b9d7-c9f8530f02fd
+    :Title: Test pki-server subsystem-cert-show Clone OCSP Signing Certificate
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. pki-server subsystem-cert-show ocsp transport
+        2. pki-server subsystem-cert-show ocsp sslserver
+        3. pki-server subsystem-cert-show ocsp subsystem
+        4. pki-server subsystem-cert-show ocsp audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the ocsp transport certificate info.
+        2. pki-server subsystem-cert-show should show the ocsp sslserver certificate info.
+        3. pki-server subsystem-cert-show should show the ocsp subsystem certificate info.
+        4. pki-server subsystem-cert-show should show the ocsp audit_signing certificate info.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} ocsp {}'.format(constants.CLONEOCSP1_INSTANCE_NAME,
+                                                                cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONEOCSP1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} TKS']))
+def test_pki_server_subsystem_cert_show_clone_tks_certs(ansible_module, cert_id, nick):
+    """
+    :id: ae75df62-3a5a-45e0-ae09-835ccd8e6cea
+    :Title: Test pki-server subsystem-cert-show TKS SSL Server Certificate
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. pki-server subsystem-cert-show tks sslserver
+        2. pki-server subsystem-cert-show tks subsystem
+        3. pki-server subsystem-cert-show tks audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the tks sslserver certificate info.
+        2. pki-server subsystem-cert-show should show the tks subsystem certificate info.
+        3. pki-server subsystem-cert-show should show the tks audit_signing certificate info.
+
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} tks {}'.format(constants.CLONETKS1_INSTANCE_NAME,
+                                                               cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONETKS1_INSTANCE_NAMENE)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'caSigningCert cert-{} CA'],
+                                          ['ocsp_signing', 'ocspSigningCert cert-{} CA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} CA']))
+def test_pki_server_subsystem_cert_show_subca_signing(ansible_module, cert_id, nick):
+    """
+    :id: ae75df62-3a5a-45e0-ae09-835ccd8e6cea
+    :Title: Test pki-server subsystem-cert-show Sub CA Signing Certificate
+    :Description: test pki-server subsystem-cert-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. run pki-server subsystem-cert-show ca signing
+        2. run pki-server subsystem-cert-show ca ocsp_signing
+        3. run pki-server subsystem-cert-show ca sslserver
+        4. run pki-server subsystem-cert-show ca subsystem
+        5. run pki-server subsystem-cert-show ca audit_signing
+    :ExpectedResults:
+        1. pki-server subsystem-cert-show should show the ca signing certificate info.
+        2. pki-server subsystem-cert-show should show the ocsp_signing certificate info.
+        3. pki-server subsystem-cert-show should show the sslserver certificate info.
+        4. pki-server subsystem-cert-show should show the subsystem certificate info.
+        5. pki-server subsystem-cert-show should show the audit_signing certificate info.
+
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-show '
+                                         '-i {} ca {}'.format(constants.CLONECA1_INSTANCE_NAME,
+                                                              cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONECA1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-show command.")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert_update.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert_update.py
@@ -1,0 +1,289 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem-cert-update
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import sys
+
+import os
+import pytest
+import re
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+
+@pytest.mark.xfail(reason='BZ-1340718')
+def test_pki_server_subsystem_cert_update_help(ansible_module):
+    """
+    :id: 39e76a9d-ddec-4d64-aa14-dfe123bad278
+    :Title: Test pki-server subsystem-cert-udpate --help command
+    :Description: test pki-server subsystem-cert-update --help command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :Expectedresults: 
+        1. Verify whether pki-server subsystem-cert-update --help command shows help options.
+    """
+
+    cert_update_help = ansible_module.command('pki-server subsystem-cert-update --help')
+    for result in cert_update_help.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server subsystem-cert-update [OPTIONS] <subsystem ID> <cert ID>" \
+                   in result['stdout']
+            assert "-i, --instance <instance ID>    Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "-v, --verbose                   Run in verbose mode." in \
+                   result['stdout']
+            assert "--help                      Show help message." in result['stdout']
+            assert "--cert <certificate>        New certificate to be added" in \
+                   result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-update --help command.")
+
+
+@pytest.mark.xfail(reason='BZ-1340455')
+def test_pki_server_subsystem_cert_update(ansible_module):
+    """
+    :id: e990a3bb-88c2-45d1-a4d3-b7b0015bf40c
+    :Title: Test pki-server subsystem-cert-update command
+    :Description: test pki-server subsystem-cert-update command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :Expectedresults:
+        1. Verify whether pki-server subsystem-cert-update command updates the certificate.
+    """
+    cert_update = ansible_module.command('pki-server subsystem-cert-update '
+                                         '-i {} ca signing'.format(constants.CA_INSTANCE_NAME))
+    for result in cert_update.values():
+        if result['rc'] == 0:
+            assert 'Updated "signing" subsystem certificate' in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-update command.")
+
+
+def test_pki_server_subsystem_cert_update_with_CA_instance(ansible_module):
+    """
+    :id: 89d27adf-9089-4a2e-bb7e-b8b9325c613a
+    :Title: Test pki-server subsystem-cert-update with CA certificate.
+    :Description: This test case will update the existing certificate with new certificate.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+        1. Create certificate renew request: pki client-cert-request --serial <serial> --renewal
+        2. Approve the certificate request
+        3. Get the certificate in to the database and export it to the pem file.
+        4. Update the certificate: pki-server subsystem-cert-update ca <cert_id> --cert cert.pem
+    :ExpectedResults:
+        1.  Certificate should get updated in to the database.
+    """
+    request_id = None
+    certificate_id = None
+    new_subsystem_cert = '/tmp/certificate_{}.pem'
+    subject = "CN=CA Subsystem Certificate,OU={},O={}".format(constants.CA_INSTANCE_NAME,
+                                                              constants.CA_SECURITY_DOMAIN_NAME)
+
+    client_cert_request = 'pki -d {} -c {} -p {} -P https client-cert-request ' \
+                          '--profile caSubsystemCert ' \
+                          ' "{}"'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                         constants.CA_HTTPS_PORT, subject)
+
+    create_req = ansible_module.command(client_cert_request)
+    for result in create_req.values():
+        if result['rc'] == 0:
+            stdout = re.findall('Request ID: [\w].*', result['stdout'])
+            request_id = stdout[0].split(":")[1].strip()
+        else:
+            pytest.xfail("Failed to create certificate request.")
+    if request_id:
+        cert_request_review = 'pki -d {} -c {} -p {} -P https -n "{}" ca-cert-request-review {} ' \
+                              '--action approve'.format(constants.NSSDB,
+                                                        constants.CLIENT_DIR_PASSWORD,
+                                                        constants.CA_HTTPS_PORT,
+                                                        constants.CA_ADMIN_NICK, request_id)
+        review = ansible_module.command(cert_request_review)
+        for result in review.values():
+            if result['rc'] == 0:
+                stdout = re.findall('Certificate ID: [\w].*', result['stdout'])
+                certificate_id = stdout[0].split(":")[1].strip()
+                new_subsystem_cert = new_subsystem_cert.format(certificate_id)
+                ansible_module.command('pki -d {} -c {} -p {} client-cert-import '
+                                       '"Subsystem Cert" '
+                                       '--serial {}'.format(constants.NSSDB,
+                                                            constants.CLIENT_DIR_PASSWORD,
+                                                            constants.CA_HTTP_PORT,
+                                                            certificate_id))
+
+                ansible_module.command('pki -d {} -c {} client-cert-show --cert {} '
+                                       '"Subsystem Cert"'.format(constants.NSSDB,
+                                                                 constants.CLIENT_DIR_PASSWORD,
+                                                                 new_subsystem_cert))
+    if certificate_id:
+        cert_update = ansible_module.command('pki-server subsystem-cert-update ca subsystem -i {} '
+                                             '--cert {}'.format(constants.CA_INSTANCE_NAME,
+                                                                new_subsystem_cert))
+        for result in cert_update.values():
+            if result['rc'] == 0:
+                assert 'Updated "subsystem" subsystem certificate' in result['stdout']
+                ansible_module.command('systemctl restart pki-tomcatd@{}'.format(
+                    constants.CA_INSTANCE_NAME))
+                is_active = ansible_module.command('systemctl is-active pki-tomcatd@{}'.format(
+                    constants.CA_INSTANCE_NAME))
+                for res in is_active.values():
+                    if res['rc'] == 0:
+                        assert 'active' in res['stdout']
+                    else:
+                        pytest.xfail("Failed to restart the server.")
+
+
+def test_pki_server_subsystem_cert_update_with_invalid_instance(ansible_module):
+    """
+    :id: 9fa1a364-8477-4997-bdae-95ec255b8df0
+    :Title: Test pki server subsystem cert update with invalid instance.
+    :Description:  Test pki server subsytem cert update with invalid instance.
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+    """
+    ansible_module.command('pki -p {} -P https cert-show 0x2 --encoded '
+                           '--output /tmp/certificate_0x2.pem')
+    pki_subsystem_cmd = 'pki-server subsystem-cert-update  ca ocsp_signing -i  invalid_instance ' \
+                        '--cert /tmp/certificate_0x2.pem'
+    cmd_out = ansible_module.command(pki_subsystem_cmd)
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            pytest.xfail("Failed to run pki-server subsystem cert command with "
+                         "invalid instance.")
+        else:
+            assert "ERROR: Invalid instance invalid_instance" in result['stdout']
+
+
+def test_pki_server_subsystem_cert_update_without_subsystem_id(ansible_module):
+    """
+    :id: 18ddae4c-76d8-4606-a715-28ee363e298e
+    :Title: Test pki server subsystem cert update without subsystem id.
+    :Description:  Test pki server subsytem cert update without subsystem id.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+    """
+    ansible_module.command('pki -p {} -P https cert-show 0x2 --encoded '
+                           '--output /tmp/certificate_0x2.pem')
+    pki_subsystem_cmd = 'pki-server subsystem-cert-update  ocsp_signing -i  invalid_instance ' \
+                        '--cert /tmp/certificate_0x2.pem'
+    cmd_out = ansible_module.command(pki_subsystem_cmd)
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            pytest.xfail("Failed to run pki-server subsystem cert command with "
+                         "invalid instance.")
+        else:
+            assert "ERROR: missing cert ID" in result['stdout']
+
+
+def test_pki_server_subsystem_cert_update_without_cert_id(ansible_module):
+    """
+    :id: 61ad9a42-ad5d-42f9-98ca-72943d5e77aa
+    :Title: Test pki server subsystem cert update without cert id.
+    :Description: This test should fail if cert id is not provided.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+    """
+    ansible_module.command('pki -p {} -P https cert-show 0x2 --encoded '
+                           '--output /tmp/certificate_0x2.pem')
+    pki_subsystem_cmd = 'pki-server subsystem-cert-update ca -i  invalid_instance ' \
+                        '--cert /tmp/certificate_0x2.pem'
+    cmd_out = ansible_module.command(pki_subsystem_cmd)
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            pytest.xfail("Failed to run pki-server subsystem cert command with "
+                         "invalid instance.")
+        else:
+            assert "ERROR: missing cert ID" in result['stdout']
+
+
+def test_pki_server_subsystem_cert_update_invalid_subsystem_id(ansible_module):
+    """
+    :id: c9036c14-0510-4e34-9785-a0e9e9f41a6c
+    :Title: Test pki server subsystem cert update with invalid subsystem id.
+    :Description: This test should fail if subsystem id is invalid.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Type:
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+    """
+    ansible_module.command('pki -p {} -P https cert-show 0x2 --encoded '
+                           '--output /tmp/certificate_0x2.pem')
+    pki_subsystem_cmd = 'pki-server subsystem-cert-update not_exists ocsp_signing ' \
+                        '-i  {} --cert /tmp/certificate_0x2.pem'.format(constants.CA_INSTANCE_NAME)
+    cmd_out = ansible_module.command(pki_subsystem_cmd)
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            pytest.xfail("Failed to run pki-server subsystem cert command with "
+                         "invalid instance.")
+        else:
+            assert "ERROR: No not_exists subsystem in " \
+                   "instance {}.".format(constants.CA_INSTANCE_NAME) in result['stdout']
+
+
+def test_pki_server_subsystem_cert_update_when_file_does_not_exists(ansible_module):
+    """
+    :id: 50d80688-46bd-4af6-9084-9117b25702e5
+    :Title: Test pki server subsystem cert update when file does not exists.
+    :Description: This test should fail if file does not exists.
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+    """
+    pki_subsystem_cmd = 'pki-server subsystem-cert-update ca ocsp_signing -i {} ' \
+                        '--cert /tmp/dosjf.pem'.format(constants.CA_INSTANCE_NAME)
+
+    pki_subsystem_out = ansible_module.command(pki_subsystem_cmd)
+    for result in pki_subsystem_out.values():
+        if result['rc'] == 0:
+            pytest.xfail("Failed to run pki-server subsystem cert command when cert file does "
+                         "not exists.")
+        else:
+            assert "ERROR: /tmp/dosjf.pem certificate does not exist." in result['stdout']

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert_validate.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_cert_validate.py
@@ -1,0 +1,513 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem-cert-validate
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akaht@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import random
+import string
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+@pytest.mark.xfail(reason='BZ-1340718')
+def test_pki_server_subsystem_cert_validate_help(ansible_module):
+    """
+    :id: 210358d0-9a7d-4678-8440-0c125e694a5a
+    :Title: Test pki-server subsystem-cert-validate --help command
+    :Description: test pki-server subsystem-cert-validate --help command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-validate --help command shows help options.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-validate --help')
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server subsystem-cert-validate [OPTIONS] <subsystem ID> [" \
+                   "<cert_id>]" in result['stdout']
+            assert "-i, --instance <instance ID>    Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "-v, --verbose                   Run in verbose mode." in result['stdout']
+            assert "--help                      Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate --help command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'caSigningCert cert-{} CA'],
+                                          ['ocsp_signing', 'ocspSigningCert cert-{} CA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} CA']))
+def test_pki_server_subsystem_cert_validate_ca_certs(ansible_module, cert_id, nick):
+    """
+    :id: 230008fd-a5fe-4dee-809b-408e47fd6429
+    :Title: Test pki-server subsystem-cert-validate CA Signing certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-validate command validates the
+        signing certificate.
+    """
+    signing_out = ansible_module.command('pki-server subsystem-cert-validate '
+                                         '-i {} ca {}'.format(constants.CA_INSTANCE_NAME, cert_id))
+    for result in signing_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CA_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['transport', 'transportCert cert-{} KRA'],
+                                          ['storage', 'storageCert cert-{} KRA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} KRA']))
+def test_pki_server_subsystem_cert_validate_kra_certs(ansible_module, cert_id, nick):
+    """
+    :id: 1dd9f42a-5fe0-47f4-a497-930b722e35c9
+    :Title: Test pki-server subsystem-cert-validate KRA Transport certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-validate command validates the kra
+        transport certificate.
+    """
+
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} kra {}'.format(constants.KRA_INSTANCE_NAME,
+                                                             cert_id))
+    for result in cert_out.values():
+
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.KRA_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'ocspSigningCert cert-{} OCSP'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} OCSP']))
+def test_pki_server_subsystem_cert_validate_ocsp_certs(ansible_module, cert_id, nick):
+    """
+    :id: 9a4de285-fe51-45b0-a4fd-3b858a71b2f9
+    :Title: Test pki-server subsystem-cert-validate OCSP Signing certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-validate command validates the OCSP
+        signing certificate.
+    """
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} ocsp {}'.format(constants.OCSP_INSTANCE_NAME,
+                                                              cert_id))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.OCSP_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} TKS']))
+def test_pki_server_subsystem_cert_validate_tks_certs(ansible_module, cert_id, nick):
+    """
+    :id: 2aa1e537-52a5-48ce-b3fc-a67e4cc9cbb1
+    :Title: Test pki-server subsystem-cert-validate TKS SSL Server certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Requirement: Pki Server Subsystem
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-validate command validates the tks
+        sslserver certificate.
+    """
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} tks {}'.format(constants.TKS_INSTANCE_NAME, cert_id))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.TKS_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.parametrize('cert_id,nick', (['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} TPS']))
+def test_pki_server_subsystem_cert_validate_tps_certs(ansible_module, cert_id, nick):
+    """
+    :id: b22b93d1-fe4d-489d-a121-b0315e1f234f
+    :Title: Test pki-server subsystem-cert-validate TPS SSL Server certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-validate command validates the tps sslserver
+        certificate.
+    """
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} tps {}'.format(constants.TPS_INSTANCE_NAME, cert_id))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.TPS_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'caSigningCert cert-{} CA'],
+                                          ['ocsp_signing', 'ocspSigningCert cert-{} CA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} CA']))
+def test_pki_server_subsystem_cert_validate_ca_clone_certs(ansible_module, cert_id, nick):
+    """
+    :id: 04ab4e2f-85ab-4698-88be-5eee41645044
+    :Title: Test pki-server subsystemc-ert-validate CA Clone Signing certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-validate command validates the Clone ca
+            signing certificate.
+    """
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} ca {}'.format(constants.CLONECA1_INSTANCE_NAME,
+                                                            cert_id))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONECA1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['transport', 'transportCert cert-{} KRA'],
+                                          ['storage', 'storageCert cert-{} KRA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} KRA']))
+def test_pki_server_subsystem_cert_validate_kra_clone_certs(ansible_module, cert_id, nick):
+    """
+    :id: e7938f86-bbd6-46a8-83da-dfef5c559e2b
+    :Title: Test pki-server subsystem-cert-validate KRA Clone Transport certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-validate command validates the clone kra 
+        transport certificate.
+    """
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} kra {}'.format(constants.CLONEKRA1_INSTANCE_NAME,
+                                                             cert_id))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONEKRA1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'ocspSigningCert cert-{} OCSP'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} OCSP']))
+def test_pki_server_subsystem_cert_validate_ocsp_clone_certs(ansible_module, cert_id, nick):
+    """
+    :id: bd9eda31-ce6d-4d3c-a778-bf89b612c630
+    :Title: Test pki-server subsystem-cert-validate OCSP Clone Signing certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-validate command validates the clone OCSP
+        signing certificate.
+    """
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} ocsp {}'.format(constants.CLONEOCSP1_INSTANCE_NAME,
+                                                              cert_id))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONEOCSP1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} TKS']))
+def test_pki_server_subsystem_cert_validate_tks_clone_certs(ansible_module, cert_id, nick):
+    """
+    :id: 01dc0c2d-b962-4793-8a76-00c2e55bade0
+    :Title: Test pki-server subsystem-cert-validate TKS Clone Subsystem certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-validate command validates the clone tks 
+        subsystem certificate.
+    """
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} tks {}'.format(constants.CLONETKS1_INSTANCE_NAME,
+                                                              cert_id))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.CLONETKS1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+@pytest.mark.parametrize('cert_id,nick', (['signing', 'caSigningCert cert-{} CA'],
+                                          ['ocsp_signing', 'ocspSigningCert cert-{} CA'],
+                                          ['sslserver', 'Server-Cert cert-{}'],
+                                          ['subsystem', 'subsystemCert cert-{}'],
+                                          ['audit_signing', 'auditSigningCert cert-{} CA']))
+def test_pki_server_subsystem_cert_validate_subca_certs(ansible_module, cert_id, nick):
+    """
+    :id: 92dd4213-d2d7-4aec-b85f-1e397270ca20
+    :Title: Test pki-server subsystem-cert-validate Sub CA Signing certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Requirement: Pki Server Subsystem 
+    :CaseComponent: \-
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-validate command validates the subca signing 
+        certificate.
+    """
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} ca {}'.format(constants.SUBCA1_INSTANCE_NAME,
+                                                              cert_id))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Cert ID: {}".format(cert_id) in result['stdout']
+            assert "Nickname: {}".format(nick.format(constants.SUBCA1_INSTANCE_NAME)) in \
+                   result['stdout']
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+
+
+def test_pki_server_subsystem_cert_validate_junk_instance(ansible_module):
+    """
+    :id: 8c844041-0ba6-4651-a562-209a85eff2cb
+    :Title: Test pki-server subsystem-cert-validate junk instance name.
+    :Description: test pki-server subsystem-cert-validate command
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-validate command throws error when junk 
+        Instance name is supplied.
+    """
+    junk_instance = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                            for _ in range(10))
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} ca signing'.format(junk_instance))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+        else:
+            assert "ERROR: Invalid instance {}".format(junk_instance) in result['stdout']
+
+
+def test_pki_server_subsystem_cert_validate_junk_subsystemType(ansible_module):
+    """
+    :id: 90e232ef-7515-4e99-b7fc-9d7ab4cb7454
+    :Title: Test pki-server subsystem-cert-validate Junk subsystem type
+    :Description: test pki-server subsystem-cert-validate command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-cert-validate command throws error when junk 
+        subsystem type is supplied.
+    """
+    junk_instance = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                            for _ in range(10))
+    cert_out = ansible_module.command('pki-server subsystem-cert-validate'
+                                      ' -i {} {} signing'.format(constants.CA_INSTANCE_NAME,
+                                                                 junk_instance))
+    for result in cert_out.values():
+        if result['rc'] == 0:
+            assert "Usage:" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command.")
+        else:
+            assert "ERROR: No {} subsystem in instance {}.".format(junk_instance,
+                                                                   constants.CA_INSTANCE_NAME) in \
+                   result['stdout']
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_cert_validate_junk_certID(ansible_module):
+    """
+    :id: 8f365f88-3e33-43c4-b477-feea74acd28d
+    :Title: Test pki-server subsystem-cert-validate with junk cert-id
+    :Description: test pki-server subsystem-cert-validate command
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Requirement: Pki Server Subsystem
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-validate command throws error when
+        junk cert ID is supplied.
+    """
+    junk_certID = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                          for _ in range(10))
+    cert_validate_output = ansible_module.command('pki-server subsystem-cert-validate -i {} '
+                                                  'ca {}'.format(constants.CA_INSTANCE_NAME,
+                                                                 junk_certID))
+    for result in cert_validate_output.values():
+        if result['rc'] == 0:
+            assert "Validation failed" in result['stdout']
+
+        else:
+            pytest.xfail("Failed: Validated the cert with junk cert ID.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_cert_validate_disabled_subsystem(ansible_module):
+    """
+    :id: c667bbbd-b9dd-4c20-bdfd-a81fa2117e44
+    :Title: Test pki-server subsystem-cert-validate disabled subsystem certificate
+    :Description: test pki-server subsystem-cert-validate command
+    :Requirement: Pki Server Subsystem
+    :CaseComponent: \-
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-cert-validate command validates the cert
+        when subsystem is disabled.
+    """
+    ansible_module.command('pki-server  subsystem-disable '
+                           '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+    cert_validate_output = ansible_module.command('pki-server subsystem-cert-validate '
+                                                  '-i {} ca audit_signing'.format(
+        constants.CA_INSTANCE_NAME))
+    for result in cert_validate_output.values():
+        if result['rc'] == 0:
+            assert "Cert ID: audit_signing" in result['stdout']
+            assert "Nickname: auditSigningCert cert-" + constants.CA_INSTANCE_NAME + " CA" in \
+                   result['stdout']
+            assert "Usage: ObjectSigner" in result['stdout']
+            assert "Token: Internal Key Storage Token" in result['stdout']
+            assert "Status: VALID" in result['stdout']
+            assert "Validation succeeded" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-cert-validate command when "
+                         "subsystem is disabled.")
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'ca'.format(constants.CA_INSTANCE_NAME))

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_disable.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_disable.py
@@ -1,0 +1,368 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem-disable
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import random
+import string
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+@pytest.mark.xfail(reason='BZ-1340718')
+def test_pki_server_subsystem_disable_help(ansible_module):
+    """
+    :id: 256f92da-931f-4384-a002-72c480619fc7
+    :Title: Test pki-server subsystem-disable --help command
+    :Description: test pki-server subsystem-disable --help command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem 
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server subsystem-disable --help command shows help option.
+    """
+
+    help_out = ansible_module.command('pki-server subsystem-disable --help')
+    for result in help_out.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server subsystem-disable [OPTIONS] <subsystem ID>" in \
+                   result['stdout']
+            assert "-i, --instance <instance ID>    Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "-v, --verbose                   Run in verbose mode." in result['stdout']
+            assert "--help                      Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run subsystem --help command.")
+
+
+def test_pki_server_subsystem_disable_ca(ansible_module):
+    """
+    :id: 4d4064e9-e1d2-4302-8e66-2c68325aa962
+    :Title: Test pki-server subsystem-disable CA Subsystem
+    :Description: test pki-server subsystem-disable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem 
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-disable command disables the ca subsystem.
+    """
+    create_req = 'pki -d {} -c {} -h {} -p {} client-cert-request ' \
+                 '"UID=foo1,CN=foo1"'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                             'localhost', constants.CA_HTTP_PORT)
+    ca_out = ansible_module.command('pki-server subsystem-disable '
+                                    '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+    for result in ca_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.CA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: False" in result['stdout']
+            stat_out = ansible_module.command(create_req)
+            for res in stat_out.values():
+                if res['rc'] >= 1:
+                    assert "PKIException: Not Found" in res['stderr']
+        else:
+            pytest.xfail("Failed to disable subsystem.")
+
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+
+
+@pytest.mark.parametrize('subsystem', ['kra','ocsp', 'tks', 'tps'])
+def test_pki_server_subsystem_disable_other_subsytems(ansible_module, subsystem):
+    """
+    :id: ff9aaf8b-608c-48d0-ab67-2f271f581f31
+    :Title: Test pki-server subsystem-disable KRA,OCSP,TKS,TPS subsystem
+    :Description: This test will disable each instance one by one and enable it again.
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-disable command disables the kra subsystem.
+    """
+    instance = eval("constants.{}_INSTANCE_NAME".format(subsystem.upper()))
+    cmd_out = ansible_module.command('pki-server subsystem-disable '
+                                     '-i {} {}'.format(instance, subsystem))
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: {}".format(subsystem) in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: False" in result['stdout']
+        else:
+            pytest.xfail("Failed to disable subsystem.")
+
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} {}'.format(instance, subsystem))
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_disable_clone_ca(ansible_module):
+    """
+    :id: cefc6759-6d79-4242-9ceb-d7928feb8b72
+    :Title: Test pki-server subsystem-disable Clone CA subsystem
+    :Description: This test will disable the CA subsystem
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-disable command disables the clone ca subsystem.
+    """
+    create_req = 'pki -d {} -c {} -h {} -p {} client-cert-request ' \
+                 '"UID=foo1,CN=foo1"'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                             'localhost', constants.CLONECA1_HTTP_PORT)
+    ca_out = ansible_module.command('pki-server subsystem-disable '
+                                    '-i {} ca'.format(constants.CLONECA1_INSTANCE_NAME))
+    for result in ca_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.CLONECA1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: False" in result['stdout']
+            stat_out = ansible_module.command(create_req)
+            for res in stat_out.values():
+                if res['rc'] >= 1:
+                    assert "Error: CSR generation failed" in res['stdout']
+        else:
+            pytest.xfail("Failed to disable subsystem.")
+
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_disable_sub_ca(ansible_module):
+    """
+    :id: cefc6759-6d79-4242-9ceb-d7928feb8b72
+    :Title: Test pki-server subsystem-disable Sub CA subsystem
+    :Description: This test will disable the Sub CA subsystem
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-disable command disables the Sub CA subsystem.
+    """
+    http_port = constants.CA_HTTP_PORT
+
+    create_req = 'pki -d {} -c {} -h {} -p {} client-cert-request ' \
+                 '"UID=foo1,CN=foo1"'.format(constants.NSSDB, constants.CLIENT_DIR_PASSWORD,
+                                             'localhost', constants.SUBCA1_HTTP_PORT)
+    ca_out = ansible_module.command('pki-server subsystem-disable '
+                                    '-i {} ca'.format(constants.SUBCA1_INSTANCE_NAME))
+    for result in ca_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.SUBCA1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: False" in result['stdout']
+            stat_out = ansible_module.command(create_req)
+            for res in stat_out.values():
+                if res['rc'] >= 1:
+                    assert "Error: CSR generation failed" in res['stdout']
+        else:
+            pytest.xfail("Failed to disable subsystem.")
+
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} ca'.format(constants.SUBCA1_INSTANCE_NAME))
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_disable_clone_kra_subsystems(ansible_module):
+    """
+    :id: 60da7e66-0ea6-4e01-b3ea-584ebc81076c
+    :Title: Test pki-server subsystem-disable Clone KRA, subsystem
+    :Description: test pki-server subsystem-disable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-disable command disables the clone kra subsystem.
+    """
+    instance = constants.CLONEKRA1_INSTANCE_NAME
+    subsystem = 'kra'
+    cmd_out = ansible_module.command('pki-server subsystem-disable '
+                                     '-i {} {}'.format(instance, subsystem))
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: kra" in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: False" in result['stdout']
+        else:
+            pytest.xfail("Failed to disable subsystem.")
+
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} {}'.format(instance, subsystem))
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_disable_clone_ocsp_subsystems(ansible_module):
+    """
+    :id: feb5dcc6-08bd-43cd-a9fe-fd059df1eb17
+    :Title: Test pki-server subsystem-disable Clone OCSP, subsystem
+    :Description: test pki-server subsystem-disable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-disable command disables the clone OCSP subsystem.
+    """
+    instance = constants.CLONEOCSP1_INSTANCE_NAME
+    subsystem = 'ocsp'
+    cmd_out = ansible_module.command('pki-server subsystem-disable '
+                                     '-i {} {}'.format(instance, subsystem))
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ocsp" in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: False" in result['stdout']
+        else:
+            pytest.xfail("Failed to disable subsystem.")
+
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} {}'.format(instance, subsystem))
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_disable_clone_tks_subsystems(ansible_module):
+    """
+    :id: 5bce91ac-e076-451f-98bb-15e5e407e6cb
+    :Title: Test pki-server subsystem-disable Clone TKS, subsystem
+    :Description: test pki-server subsystem-disable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-disable command disables the clone TKS subsystem.
+    """
+    instance = constants.CLONETKS1_INSTANCE_NAME
+    subsystem = 'tks'
+    cmd_out = ansible_module.command('pki-server subsystem-disable '
+                                     '-i {} {}'.format(instance, subsystem))
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: tks" in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: False" in result['stdout']
+        else:
+            pytest.xfail("Failed to disable subsystem.")
+
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} {}'.format(instance, subsystem))
+
+
+def test_pki_server_subsystem_disable_invald_instance(ansible_module):
+    """
+    :id: f4677d13-1af9-48cd-955d-e690bce2e9ac
+    :Title: Test pki-server subsystem-disable with invalid instance.
+    :Description: test pki-server subsystem-disable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem 
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-disable command throws error when non existing 
+        instance name is supplied.
+    """
+    junk_instance = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                            for _ in range(10))
+    ca_out = ansible_module.command('pki-server subsystem-disable -i {} ca'.format(junk_instance))
+    for result in ca_out.values():
+        if result['rc'] >= 1:
+            assert "ERROR: Invalid instance " + junk_instance in result['stdout']
+        else:
+            pytest.xfail("Failed: Disabled the Invalid subsystem")
+
+
+@pytest.mark.xfail(reason='BZ=1356588')
+def test_pki_server_subsystem_disable_invald_subsystemType(ansible_module):
+    """
+    :id: 896ffd77-718d-4100-9210-19c457191c4f
+    :Title: Test pki-server subsystem-disable with invalid subsystem.
+    :Description: test pki-server subsystem-disable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults: 
+        1.Verify whether pki-server subsystem-disable command throws error when non existing 
+        instance type is supplied.
+    """
+    junk_subsystemType = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                                 for _ in range(10))
+    ca_out = ansible_module.command('pki-server subsystem-disable '
+                                    '-i {} {}'.format(constants.CA_INSTANCE_NAME,
+                                                      junk_subsystemType))
+    for result in ca_out.values():
+        if result['rc'] >= 1:
+            assert "ERROR: No %s subsystem in instance %s." % (junk_subsystemType,
+                                                               constants.CA_INSTANCE_NAME) in \
+                   result['stdout']
+        else:
+            pytest.xfail("Failed: Disabled the subsystem with invalid subsystem type")
+
+
+@pytest.mark.xfail(reason='BZ=1356588')
+def test_pki_server_subsystem_disable_disabled_subsystem(ansible_module):
+    """
+    :id: c272cc50-4bd1-417e-8e29-65b87e087b8e
+    :Title: Test pki-server subsystem-disable cli with disabled subsystem.
+    :Description: test pki-server subsystem-disable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-disable command throws error when trying to disable
+        the disabled subsystem.
+    """
+    ansible_module.command('pki-server subsystem-disable '
+                           '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+    ca_out = ansible_module.command('pki-server subsystem-disable '
+                                    '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+    for result in ca_out.values():
+        if result['rc'] == 0:
+            assert 'Subsystem "ca" is already disabled' in result['stdout']
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.CA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: False" in result['stdout']
+        else:
+            pytest.xfail("Failed: Disabled the already disabled subsystem")
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} ca'.format(constants.CA_INSTANCE_NAME))

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_enable.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_enable.py
@@ -1,0 +1,356 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem-enable
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import os
+import random
+import string
+import sys
+import time
+
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+@pytest.mark.xfail(reason='BZ-1340718')
+def test_pki_server_subsystem_enable_help(ansible_module):
+    """
+    :id: 7aca2cd6-ab26-455d-8aff-08115e64d94d
+    :Title: Test pki-server subsystem-enable --help command
+    :Description: test pki-server subsystem-enable --help command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-enable --help command enables the subsystem
+    """
+    enable_help = ansible_module.command('pki-server subsystem-enable --help')
+    for result in enable_help.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server subsystem-enable [OPTIONS] <subsystem ID>" in \
+                   result['stdout']
+            assert "-i, --instance <instance ID>    Instance ID (default: pki-tomcat)" in \
+                   result['stdout']
+            assert "-v, --verbose                   Run in verbose mode." in result['stdout']
+            assert "--help                      Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-enable --help command.")
+
+
+def test_pki_server_subsystem_enable_ca(ansible_module):
+    """
+    :id: 0aba6d96-47be-46a8-a719-c0a0739011db
+    :Title: Test pki-server subsystem-enable with CA subsystem
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-enable command enables the ca subsystem
+    """
+    cert_request = 'pki -d {} -c {} -h localhost -p {} client-cert-request ' \
+                   '"UID=foo1,E=example.org"'.format(constants.NSSDB,
+                                                     constants.CLIENT_DIR_PASSWORD,
+                                                     constants.CA_HTTP_PORT)
+    ca_out = ansible_module.command('pki-server subsystem-enable -i {} '
+                                    'ca'.format(constants.CA_INSTANCE_NAME))
+    for result in ca_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: %s" % constants.CA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+            time.sleep(20)
+            request_out = ansible_module.command(cert_request)
+            for res in request_out.values():
+                if res['rc'] == 0:
+                    assert "Submitted certificate request" in res['stdout']
+                    assert "Type: enrollment" in res['stdout']
+                    assert "Request Status: pending" in res['stdout']
+                    assert "Operation Result: success" in res['stdout']
+                else:
+                    pytest.xfail("Failed to run pki-server subsystem-enable command.")
+
+
+@pytest.mark.parametrize('subsystem', ['kra', 'ocsp', 'tks', 'tps'])
+def test_pki_server_subsystem_enable_other_systems(ansible_module, subsystem):
+    """
+    :id: 0f6b9e9e-7e2b-4307-8bc3-d7f99fa8d1b4
+    :Title: Test pki-server subsystem-enable with KRA subsystem
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server subsystem-enable command enables the kra subsystem
+    """
+    instance = eval("constants.{}_INSTANCE_NAME".format(subsystem.upper()))
+    cmd_out = ansible_module.command('pki-server subsystem-enable '
+                                     '-i {} {}'.format(instance, subsystem))
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: {}".format(subsystem) in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: True" in result['stdout']
+        else:
+            pytest.xfail("Failed to enable subsystem.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_enable_clone_ca(ansible_module):
+    """
+    :id: a1f12120-b798-482a-ab9b-90d4f94c9e84
+    :Title: Test pki-server subsystem-enable with Clone CA subsystem
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-enable command enables the clone ca subsystem
+    """
+    cert_request = 'pki -d {} -c {} -h localhost -p {} client-cert-request ' \
+                   '"UID=foo1,E=example.org"'.format(constants.NSSDB,
+                                                     constants.CLIENT_DIR_PASSWORD,
+                                                     constants.CLONECA1_HTTP_PORT)
+
+    ca_output = ansible_module.command('pki-server subsystem-enable '
+                                       '-i {} ca'.format(constants.CLONECA1_INSTANCE_NAME))
+    for result in ca_output.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: %s" % constants.CLONECA1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+            stat_out = ansible_module.command(cert_request)
+            for res in stat_out.values():
+                if res['rc'] == 0:
+                    assert "Submitted certificate request" in result['stdout']
+                    assert "Type: enrollment" in result['stdout']
+                    assert "Request Status: pending" in result['stdout']
+                    assert "Operation Result: success" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-enable command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_enable_clone_kra(ansible_module):
+    """
+    :id: eca4b6c8-7dfc-42e8-9c7a-9a3d67472994
+    :Title: Test pki-server subsystem-enable with Clone KRA subsystem
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-enable command enables the clone kra subsystem
+    """
+    instance = constants.CLONEKRA1_INSTANCE_NAME
+    subsystem = 'kra'
+    cmd_out = ansible_module.command('pki-server subsystem-enable '
+                                     '-i {} {}'.format(instance, subsystem))
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: kra" in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: True" in result['stdout']
+        else:
+            pytest.xfail("Failed to enable subsystem.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_enable_clone_ocsp(ansible_module):
+    """
+    :id: e782a486-5656-4e0b-bc16-784603bd1260
+    :Title: Test pki-server subsystem-enable with Clone OCSP subsystem
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-enable command enables the clone ocsp subsystem
+    """
+    instance = constants.CLONEOCSP1_INSTANCE_NAME
+    subsystem = 'ocsp'
+    cmd_out = ansible_module.command('pki-server subsystem-enable '
+                                     '-i {} {}'.format(instance, subsystem))
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ocsp" in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: True" in result['stdout']
+        else:
+            pytest.xfail("Failed to enable subsystem.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_enable_clone_tks(ansible_module):
+    """
+    :id: 8dcbdb47-1431-40ab-ae51-be434f620d2d
+    :Title: Test pki-server subsystem-enable with Clone TKS subsystem
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-enable command enables the clone tks subsystem
+    """
+    instance = constants.CLONETKS1_INSTANCE_NAME
+    subsystem = 'tks'
+    cmd_out = ansible_module.command('pki-server subsystem-enable '
+                                     '-i {} {}'.format(instance, subsystem))
+    for result in cmd_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ocsp" in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: True" in result['stdout']
+        else:
+            pytest.xfail("Failed to enable subsystem.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_enable_clone_subca(ansible_module):
+    """
+    :id: a1508386-07c0-4920-b758-e14cdfaae646
+    :Title: Test pki-server subsystem-enable with Clone CA subsystem
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-enable command enables the subca subsystem
+    """
+    cert_request = 'pki -d {} -c {} -h localhost -p {} client-cert-request ' \
+                   '"UID=foo1,E=example.org"'.format(constants.NSSDB,
+                                                     constants.CLIENT_DIR_PASSWORD,
+                                                     constants.SUBCA_HTTP_PORT)
+
+    ca_output = ansible_module.command('pki-server subsystem-enable '
+                                       '-i {} ca'.format(constants.SUBCA_INSTANCE_NAME))
+    for result in ca_output.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: %s" % constants.SUBCA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+            stat_out = ansible_module.command(cert_request)
+            for res in stat_out.values():
+                if res['rc'] == 0:
+                    assert "Submitted certificate request" in result['stdout']
+                    assert "Type: enrollment" in result['stdout']
+                    assert "Request Status: pending" in result['stdout']
+                    assert "Operation Result: success" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-enable command.")
+
+
+def test_pki_server_subsystem_enable_invalid_instance(ansible_module):
+    """
+    :id: 6be6c100-d4b5-44ec-9824-920e7362a719
+    :Title: Test pki-server subsystem-enable with invalid instance
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-enable command throws error when non existing
+        instance name is supplied.
+    """
+    junk_instance = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                            for _ in range(10))
+    ca_out = ansible_module.command('pki-server subsystem-enable -i {} ca'.format(junk_instance))
+    for result in ca_out.values():
+        if result['rc'] >= 1:
+            assert "ERROR: Invalid instance " + junk_instance in result['stdout']
+        else:
+            pytest.xfail("Failed: Disabled the Invalid subsystem.")
+
+
+@pytest.mark.xfail(reason="BZ=1356609")
+def test_pki_server_subsystem_enable_invalid_subsystemType(ansible_module):
+    """
+    :id: 485e589a-8f7f-4c81-b652-a4ca8b05b7da
+    :Title: Test pki-server subsystem-enable with invalid subsystem type
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-enable command throws error when non existing
+        subsystem type is supplied.
+    """
+    junk_subsystemType = ''.join(random.choice(string.ascii_uppercase + string.digits)
+                                 for _ in range(10))
+    subsystem_enable = 'pki-server subsystem-enable -i {} ' \
+                       '{}'.format(constants.CA_INSTANCE_NAME, junk_subsystemType)
+    ca_out = ansible_module.command(subsystem_enable)
+    for result in ca_out.values():
+        if result['rc'] >= 1:
+            assert "ERROR: No {} subsystem in " \
+                   "instance {}".format(junk_subsystemType,
+                                        constants.CA_INSTANCE_NAME) in result['stderr']
+        else:
+            pytest.xfail("Failed: Disabled the subsystem with invalid subsystem type.")
+
+
+def test_pki_server_subsystem_enable_enabled_subsystem(ansible_module):
+    """
+    :id: 79ff6e10-87fa-4d34-a495-870c5fc0d8a8
+    :Title: Test pki-server subsystem-enable with enabled subsystem
+    :Description: test pki-server subsystem-enable command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-enable command throws error when trying to enable
+        the enabled subsystem.
+    """
+    ansible_module.command('pki-server subsystem-enable '
+                           '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+    ca_out = ansible_module.command('pki-server subsystem-enable '
+                                    '-i {} ca'.format(constants.CA_INSTANCE_NAME))
+    for result in ca_out.values():
+        if result['stdout'] == 0:
+            assert 'Subsystem "ca" is already enabled' in result['stdout']
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: %s" % constants.CA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+        else:
+            pytest.xfail("Failed to enable the already enabled subsystem")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_find.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_find.py
@@ -1,0 +1,216 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server subsystem-find
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import os
+import random
+import string
+import sys
+
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+@pytest.mark.xfail(reason='BZ-1340718')
+def test_pki_server_subsystem_find_help(ansible_module):
+    """
+    :id: 35f3979a-0dea-4c15-97b1-579e378fea20
+    :Title: Test pki-server subsystem-find --help command
+    :Description: test pki-server subsystem-find --help command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server subsystem-find --help shows help options.
+    """
+    find_out = ansible_module.command('pki-server subsystem-find --help')
+    for result in find_out.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server subsystem-find [OPTIONS]" in \
+                   result['stdout']
+            assert "-i, --instance <instance ID>    Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "-v, --verbose                   Run in verbose mod" in result['stdout']
+            assert "--help                      Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-find command.")
+
+
+@pytest.mark.skipif("Topology != 1")
+def test_pki_server_subsystem_find_shared_tomcat(ansible_module):
+    """
+    :id: 3ecea9f3-536b-4c4c-bc66-a7f67058a9a4
+    :Title: Test pki-server subsystem-find shared tomcat instance
+    :Description: test pki-server subsystem-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+            It assumes that all the subsystem ca, kra, ocsp, tks and tps installed
+            with shared tomcat instance.
+    :Steps:
+    :ExpectedResults: Verify whether pki-server subsystem-find command list the subsystem.
+    """
+
+    find_out = ansible_module.command(
+        'pki-server subsystem-find -i {}'.format(constants.CA_INSTANCE_NAME))
+    for result in find_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.CA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+            assert "Subsystem ID: kra" in result['stdout']
+            assert "Instance ID: " + constants.KRA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+            assert "Subsystem ID: ocsp" in result['stdout']
+            assert "Instance ID: " + constants.OCSP_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+            assert "Subsystem ID: tks" in result['stdout']
+            assert "Instance ID: " + constants.TKS_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+            assert "Subsystem ID: tps" in result['stdout']
+            assert "Instance ID: " + constants.TPS_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-find command.")
+
+
+@pytest.mark.parametrize('subsystem', ['ca', 'kra', 'ocsp', 'tks', 'tps'])
+def test_pki_server_subsystem_find_discrete_tomcat_ca(ansible_module, subsystem):
+    """
+    :id: 9994fa93-cd02-4d42-a19a-1d952fe9a186
+    :Title: Test pki-server subsystem-find discrete tomcat CA instances
+    :Description: test pki-server subsystem-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem command, It will setup
+            topology-02 which have all discrete tomcat instances.
+
+    :ExpectedResults: Verify whether pki-server subsystem-find command list the subsystem.
+    """
+    instance = eval("constants.{}_INSTANCE_NAME".format(subsystem.upper()))
+    ansible_module.command('pki-server subsystem-enable -i {} {}'.format(instance, subsystem))
+    find_output = ansible_module.command('pki-server subsystem-find '
+                                         '-i {}'.format(instance))
+    for result in find_output.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Subsystem ID: {}".format(subsystem) in result['stdout']
+            assert "Instance ID: " + instance in result['stdout']
+            assert "Enabled: " in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-find command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_find_clone_subsystems(ansible_module):
+    """
+    :id: 20305fe7-3dff-444f-a437-00ac7ddd386a
+    :Title: Test pki-server subsystem-find clone CA instance
+    :Description: test pki-server subsystem-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem command
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-find command list the clone ca subsystem info.
+    """
+    subsystems = [['ca', constants.CLONECA1_INSTANCE_NAME],
+                  ['kra', constants.CLONEKRA1_INSTANCE_NAME],
+                  ['ocsp', constants.CLONEOCSP1_INSTANCE_NAME],
+                  ['tks', constants.CLONETKS1_INSTANCE_NAME],
+                  ['tps', constants.CLONETKS1_INSTANCE_NAME]]
+    for subsystem, instance in subsystems:
+        find_out = ansible_module.command('pki-server subsystem-find -i {}'.format(instance))
+        for result in find_out.values():
+            if result['rc'] == 0:
+                assert "entries matched" in result['stdout']
+                assert "Subsystem ID: {}".format(subsystem) in result['stdout']
+                assert "Instance ID: " + instance in result['stdout']
+                assert "Enabled: True" in result['stdout']
+            else:
+                pytest.xfail("Failed to run pki-server subsystem-find command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_find_subca(ansible_module):
+    """
+    :id: 97efc8b2-7012-4d2d-8a49-866fcd6d19fd
+    :Title: Test pki-server subsystem-find Sub CA instance
+    :Description: test pki-server subsystem-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem command
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-find command list the subca subsystem
+    info.
+    """
+    find_out = ansible_module.command('pki-server subsystem-find '
+                                      '-i {}'.format(constants.SUBCA1_INSTANCE_NAME))
+    for result in find_out.values():
+        if result['rc'] == 0:
+            assert "entries matched" in result['stdout']
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.SUBCA1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-find command.")
+
+
+def test_pki_server_subsystem_find_junk(ansible_module):
+    """
+    :id: 474d4d9a-6fcd-4522-9aae-6f945c520670
+    :Title: Test pki-server subsystem-find invalid instance
+    :Description: test pki-server subsystem-find command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: Verify whether pki-server subsystem-find command list no subsystem.
+    """
+    junk = ''.join(random.choice(string.ascii_uppercase +
+                                 string.digits +
+                                 string.ascii_lowercase)
+                   for _ in range(50))
+    junk_out = ansible_module.command('pki-server subsystem-find -i {}'.format(junk))
+    for result in junk_out.values():
+        if result['rc'] >= 1:
+            assert "ERROR: Invalid instance %s" % junk in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-find command.")

--- a/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_show.py
+++ b/tests/dogtag/pytest-ansible/pytest/pki_server/test_pki_server_subsystem_show.py
@@ -1,0 +1,388 @@
+"""
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   The following pki-server subsystem cli commands needs to be tested:
+#   pki-server susbsystem-show
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Amol Kahat <akahat@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2018 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import random
+import string
+import sys
+
+import os
+import pytest
+
+try:
+    from pki.testlib.common import constants
+except Exception as e:
+    if os.path.isfile('/tmp/test_dir/constants.py'):
+        sys.path.append('/tmp/test_dir')
+        import constants
+
+Topology = int(''.join(constants.CA_INSTANCE_NAME.split("-")[1]))
+
+
+@pytest.mark.xfail(reason='BZ-1340718')
+def test_pki_server_subsystem_show_help(ansible_module):
+    """
+    :id: 120b145a-4fbd-4751-88f5-3d7f76ebbe5b
+    :Title: Test pki-server subsystem-show --help command 
+    :Description: test pki-server subsystem-show --help command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show --help command shows help options.
+    """
+    find_out = ansible_module.command('pki-server subsystem-show --help')
+    for result in find_out.values():
+        if result['rc'] == 0:
+            assert "Usage: pki-server subsystem-show [OPTIONS] <subsystem ID>" in \
+                   result['stdout']
+            assert "-i, --instance <instance ID>    Instance ID (default: pki-tomcat)." in \
+                   result['stdout']
+            assert "-v, --verbose                   Run in verbose mod" in result['stdout']
+            assert "--help                      Show help message." in result['stdout']
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show --help command.")
+
+
+def test_pki_server_subsystem_show_ca(ansible_module):
+    """
+    :id: ea11ea09-ce9c-49fd-906d-f7fe375392b1
+    :Title: Test pki-server subsystem-show CA subsystem 
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command shows ca subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'ca'.format(constants.CA_INSTANCE_NAME))
+    find_ca_out = ansible_module.command('pki-server subsystem-show -i {} '
+                                         'ca'.format(constants.CA_INSTANCE_NAME))
+    for result in find_ca_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.CA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+def test_pki_server_subsystem_show_kra(ansible_module):
+    """
+    :id: 70cfd06f-fbb9-4168-bec6-8a2c90dc7e16
+    :Title: Test pki-server subsystem-show KRA subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command shows the kra subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'kra'.format(constants.KRA_INSTANCE_NAME))
+    kra_out = ansible_module.command('pki-server subsystem-show -i {} '
+                                     'kra'.format(constants.KRA_INSTANCE_NAME))
+    for result in kra_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: kra" in result['stdout']
+            assert "Instance ID: " + constants.KRA_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+def test_pki_server_subsystem_show_ocsp(ansible_module):
+    """
+    :id: d9439026-75e6-4f38-a9b8-0ef14ee85da0
+    :Title: Test pki-server subsystem-show OCSP subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command shows the ocsp subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'ocsp'.format(constants.OCSP_INSTANCE_NAME))
+    ocsp_out = ansible_module.command('pki-server subsystem-show '
+                                      '-i {} ocsp'.format(constants.OCSP_INSTANCE_NAME))
+    for result in ocsp_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ocsp" in result['stdout']
+            assert "Instance ID: " + constants.OCSP_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+def test_pki_server_subsystem_show_tks(ansible_module):
+    """
+    :id: c9513c73-68a7-4d1a-8c6c-c431c426b723
+    :Title: Test pki-server subsystem-show TKS Subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command shows the tks subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'tks'.format(constants.TKS_INSTANCE_NAME))
+    tks_out = ansible_module.command(
+        'pki-server subsystem-show -i {} tks'.format(constants.TKS_INSTANCE_NAME))
+    for result in tks_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: tks" in result['stdout']
+            assert "Instance ID: " + constants.TKS_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+def test_pki_server_subsystem_show_tps(ansible_module):
+    """
+    :id: 4383e7a2-1367-42d3-a163-b6d7667c9d0f
+    :Title: Test pki-server subsystem-show TPS subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command shows the tps subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'tps'.format(constants.TPS_INSTANCE_NAME))
+    tps_out = ansible_module.command(
+        'pki-server subsystem-show -i {} tps'.format(constants.TPS_INSTANCE_NAME))
+    for result in tps_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: tps" in result['stdout']
+            assert "Instance ID: " + constants.TPS_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_show_ca_clone(ansible_module):
+    """
+    :id: 8559f050-4ddb-4a53-8d5a-f5d1129bb234
+    :Title: Test pki-server subsystem-show CA Clone subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command shows ca clone subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'ca'.format(constants.CLONECA1_INSTANCE_NAME))
+    clone_ca_out = ansible_module.command('pki-server subsystem-show '
+                                          '-i {} ca'.format(constants.CLONECA1_INSTANCE_NAME))
+    for result in clone_ca_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.CLONECA1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_show_kra_clone(ansible_module):
+    """
+    :id: 476b35d1-283c-41be-addf-3b87f89d017f
+    :Title: Test pki-server subsystem-show KRA Clone subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-show command shows the kra clone subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'kra'.format(constants.CLONEKRA1_INSTANCE_NAME))
+    clone_kra_out = ansible_module.command('pki-server subsystem-show '
+                                           '-i {} kra'.format(constants.CLONEKRA1_INSTANCE_NAME))
+    for result in clone_kra_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: kra" in result['stdout']
+            assert "Instance ID: " + constants.CLONEKRA1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_show_ocsp_clone(ansible_module):
+    """
+    :id: 2331fecb-88fe-497d-9bfb-3f0ee26fb812
+    :Title: Test pki-server subsystem-show OCSP Clone subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command shows the ocsp clone subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'ocsp'.format(constants.CLONEOCSP1_INSTANCE_NAME))
+    ocsp_output = ansible_module.command(
+        'pki-server subsystem-show -i {} ocsp'.format(constants.CLONEOCSP1_INSTANCE_NAME))
+    for result in ocsp_output.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ocsp" in result['stdout']
+            assert "Instance ID: " + constants.CLONEOCSP1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_show_tks_clone(ansible_module):
+    """
+    :id: e015d890-3b13-449b-8726-01f1103a9c52
+    :Title: Test pki-server subsystem-show TKS Clone subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command shows the tks clone subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'tks'.format(constants.CLONETKS1_INSTANCE_NAME))
+    tks_out = ansible_module.command(
+        'pki-server subsystem-show -i {} tks'.format(constants.CLONETKS1_INSTANCE_NAME))
+    for result in tks_out.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: tks" in result['stdout']
+            assert "Instance ID: " + constants.CLONETKS1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_show_subca(ansible_module):
+    """
+    :id: 723434f4-297b-4f8c-9d68-1e26ba2a9ca1
+    :Title: Test pki-server subsystem-show Sub CA subsystem
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-show command shows the subca subsystem info.
+    """
+    ansible_module.command('pki-server subsystem-enable -i {} '
+                           'ca'.format(constants.SUBCA1_INSTANCE_NAME))
+    tks_output = ansible_module.command(
+        'pki-server subsystem-show -i {} ca'.format(constants.SUBCA1_INSTANCE_NAME))
+    for result in tks_output.values():
+        if result['rc'] == 0:
+            assert "Subsystem ID: ca" in result['stdout']
+            assert "Instance ID: " + constants.SUBCA1_INSTANCE_NAME in result['stdout']
+            assert "Enabled: True" in result['stdout']
+
+        else:
+            pytest.xfail("Failed to run pki-server subsystem-show command.")
+
+
+@pytest.mark.skipif("Topology <= 3")
+def test_pki_server_subsystem_show_invalid_instance(ansible_module):
+    """
+    :id: 7febdbae-0b25-496e-bcbe-aa9b56233c14
+    :Title: Test pki-server subsystem-show invalid instance
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults:
+        1. Verify whether pki-server subsystem-show command throws error when ran with the
+        non-existing instance name.
+    """
+    junk_instance = ''.join(random.choice(string.ascii_uppercase +
+                                          string.digits) for _ in range(10))
+    subsystem_show_output = ansible_module.command('pki-server subsystem-show '
+                                                   '-i {} ca'.format(junk_instance))
+    for result in subsystem_show_output.values():
+        if result['rc'] >= 1:
+            assert "ERROR: Invalid instance " + junk_instance in result['stdout']
+        else:
+            pytest.xfail("Failed: Ran the command with non-existing subsystem.")
+
+
+@pytest.mark.xfail(reason='BZ=1356918')
+def test_pki_server_subsystem_show_invalid_subsystemType(ansible_module):
+    """
+    :id: c0730d09-9f78-4988-9dd5-8011bca12825
+    :Title: Test pki-server subsystem-show invalid subsystem type
+    :Description: test pki-server subsystem-show command
+    :CaseComponent: \-
+    :Requirement: Pki Server Subsystem 
+    :Setup: Use the subsystems setup in ansible to run subsystem commands
+    :Steps:
+    :ExpectedResults: 
+        1. Verify whether pki-server subsystem-show command throws error when ran with the 
+        invalid subsystem type.
+    """
+    junk_subsystemType = ''.join(random.choice(string.ascii_uppercase +
+                                               string.digits) for _ in range(10))
+    subsystem_show_output = ansible_module.command('pki-server subsystem-show '
+                                                   '-i {} {}'.format(constants.CA_INSTANCE_NAME,
+                                                                     junk_subsystemType))
+    for result in subsystem_show_output.values():
+        if result['rc'] >= 1:
+            assert "ERROR: No {} subsystem in instance {}.".format(junk_subsystemType,
+                                                                   constants.CA_INSTANCE_NAME) in \
+                   result['stdout']
+        else:
+            pytest.xfail("Failed: Ran the command with non-existing subsystem.")

--- a/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py
+++ b/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py
@@ -72,10 +72,10 @@ def test_ca_audit_with_role_users(ansible_module, certnick, expected):
     """
     contacted = ansible_module.pki(
         cli='ca-audit-show',
-        nssdb='/opt/pki/certdb',
+        nssdb=constants.NSSDB,
+        port=constants.CA_HTTPS_PORT,
         protocol='https',
-        certnick=certnick
-        )
+        certnick=certnick)
     for result in contacted.values():
         for iter in expected:
             if certnick == "CA_AdminV":


### PR DESCRIPTION
`pki-server` CLI automation in pytest-anisble
This job will include following CLI automation
- `pki-server ca`
- `pki-server kra`
- `pki-server ocsp`
- `pki-server instance`
- `pki-server migrate`
- `pki-server subsystem`
- `pki-server db`
