### PR TITLE
Fixed the space in the token-label

### DIFF
--- a/base/server/cms/src/com/netscape/cms/servlet/csadmin/ConfigurationUtils.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/csadmin/ConfigurationUtils.java
@@ -131,6 +131,7 @@ import com.netscape.certsrv.usrgrp.IUGSubsystem;
 import com.netscape.certsrv.usrgrp.IUser;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 import com.netscape.cmsutil.ldap.LDAPUtil;
+import com.netscape.cmsutil.password.IPasswordStore;
 import com.netscape.cmsutil.util.Utils;
 import com.netscape.cmsutil.xml.XMLObject;
 
@@ -793,10 +794,9 @@ public class ConfigurationUtils {
                 String master_pwd = config.getString("preop.internaldb.master.ldapauth.password", "");
                 if (!master_pwd.equals("")) {
                     config.putString("preop.internaldb.master.ldapauth.bindPWPrompt", "master_internaldb");
-                    String passwordFile = config.getString("passwordFile");
-                    IConfigStore psStore = CMS.createFileConfigStore(passwordFile);
-                    psStore.putString("master_internaldb", master_pwd);
-                    psStore.commit(false);
+                    IPasswordStore psStore = CMS.getPasswordStore();
+                    psStore.putPassword("master_internaldb", master_pwd);
+                    psStore.commit();
                 }
 
                 return true;

--- a/base/server/cms/src/org/dogtagpki/server/rest/SystemConfigService.java
+++ b/base/server/cms/src/org/dogtagpki/server/rest/SystemConfigService.java
@@ -163,13 +163,20 @@ public class SystemConfigService extends PKIService implements SystemConfigResou
         }
         initializeDatabase(data);
 
+        logger.debug("=== System reinitializing ===");
         reinitSubsystems();
 
+        logger.debug("=== Configure CA Cert Chain ===");
         configureCACertChain(data, domainXML);
 
+        logger.debug("=== Process Certs ===");
         Collection<Cert> certs = new ArrayList<Cert>();
         processCerts(data, certList, certs);
+
+        logger.debug("=== Handle certs ===");
         handleCerts(certs);
+
+        logger.debug("=== Setting system Certs ===");
         response.setSystemCerts(SystemCertDataFactory.create(certs));
 
         // backup keys

--- a/base/server/cmscore/src/com/netscape/cmscore/base/SimpleProperties.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/base/SimpleProperties.java
@@ -88,11 +88,13 @@ public class SimpleProperties extends Hashtable<String, String> {
         return put(key, value);
     }
 
-    private static final String keyValueSeparators = "=: \t\r\n\f";
+    private static final String keyValueSeparators = "=:\t\r\n\f";
 
     private static final String strictKeyValueSeparators = "=:";
 
     private static final String whiteSpaceChars = " \t\r\n\f";
+
+    private static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SimpleProperties.class);
 
     /**
      * Reads a property list (key and element pairs) from the input stream.
@@ -107,7 +109,7 @@ public class SimpleProperties extends Hashtable<String, String> {
      * Every line other than a blank line or a comment line describes one property to be added to the table (except that
      * if a line ends with \, then the following line, if it exists, is treated as a continuation line, as described
      * below). The key consists of all the characters in the line starting with the first non-whitespace character and
-     * up to, but not including, the first ASCII <code>=</code>, <code>:</code>, or whitespace character. All of the key
+     * up to, but not including, the first ASCII <code>=</code>, or <code>:</code> character. All of the key
      * termination characters may be included in the key by preceding them with a \. Any whitespace after the key is
      * skipped; if the first non-whitespace character after the key is <code>=</code> or <code>:</code>, then it is
      * ignored and any whitespace characters after it are also skipped. All remaining characters on the line become part
@@ -128,25 +130,25 @@ public class SimpleProperties extends Hashtable<String, String> {
      * Truth			:Beauty
      * </pre>
      *
-     * As another example, the following three lines specify a single property:
+     * <p>
+     * As a second example, the line:
      * <p>
      *
      * <pre>
-     * fruits				apple, banana, pear, \
-     *                                  cantaloupe, watermelon, \
-     *                                  kiwi, mango
+     * green vegetables : broccoli, collards, \
+     *                          spinach, kale
      * </pre>
      *
-     * The key is <code>"fruits"</code> and the associated element is:
+     * The key is <code>"green vegetables"</code> and the associated element is:
      * <p>
      *
      * <pre>
-     * &quot;apple, banana, pear, cantaloupe, watermelon,kiwi, mango&quot;
-     * </pre>
+     * &quot;broccoli, collards, spinach, kale&quot;
      *
      * Note that a space appears before each <code>\</code> so that a space will appear after each comma in the final
      * result; the <code>\</code>, line terminator, and leading whitespace on the continuation line are merely discarded
      * and are <i>not</i> replaced by one or more other characters.
+     *
      * <p>
      * As a third example, the line:
      * <p>
@@ -165,6 +167,7 @@ public class SimpleProperties extends Hashtable<String, String> {
     public synchronized void load(InputStream inStream) throws IOException {
 
         BufferedReader in = new BufferedReader(new InputStreamReader(inStream, "8859_1"));
+        logger.debug("Loading properties into memory");
 
         while (true) {
             // Get next line
@@ -191,7 +194,6 @@ public class SimpleProperties extends Hashtable<String, String> {
                             if (whiteSpaceChars.indexOf(nextLine.charAt(startIndex)) == -1)
                                 break;
                         nextLine = nextLine.substring(startIndex, nextLine.length());
-
                         line = loppedLine + nextLine;
                     }
                     // Find start of key
@@ -300,7 +302,7 @@ public class SimpleProperties extends Hashtable<String, String> {
      * element string is examined to see whether it should be rendered as an escape sequence. The ASCII characters
      * <code>\</code>, tab, newline, and carriage return are written as <code>\\</code>, <code>\t</code>,
      * <code>\n</code>, and <code>\r</code>, respectively. Characters less than <code>\u0020</code> and characters
-     * greater than <code>\u007E</code> are written as <code>\\u</code><i>xxxx</i> for the appropriate hexadecimal value
+     * greater than <code>\u007E</code> are written a   s <code>\\u</code><i>xxxx</i> for the appropriate hexadecimal value
      * <i>xxxx</i>. Space characters, but not embedded or trailing space characters, are written with a preceding
      * <code>\</code>. The key and value characters <code>#</code>, <code>!</code>, <code>=</code>, and <code>:</code>
      * are written with a preceding slash to ensure that they are properly loaded.

--- a/base/server/cmscore/src/com/netscape/cmscore/base/SimpleProperties.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/base/SimpleProperties.java
@@ -88,13 +88,11 @@ public class SimpleProperties extends Hashtable<String, String> {
         return put(key, value);
     }
 
-    private static final String keyValueSeparators = "=:\t\r\n\f";
+    private static final String keyValueSeparators = "=: \t\r\n\f";
 
     private static final String strictKeyValueSeparators = "=:";
 
     private static final String whiteSpaceChars = " \t\r\n\f";
-
-    private static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SimpleProperties.class);
 
     /**
      * Reads a property list (key and element pairs) from the input stream.
@@ -109,7 +107,7 @@ public class SimpleProperties extends Hashtable<String, String> {
      * Every line other than a blank line or a comment line describes one property to be added to the table (except that
      * if a line ends with \, then the following line, if it exists, is treated as a continuation line, as described
      * below). The key consists of all the characters in the line starting with the first non-whitespace character and
-     * up to, but not including, the first ASCII <code>=</code>, or <code>:</code> character. All of the key
+     * up to, but not including, the first ASCII <code>=</code>, <code>:</code>, or whitespace character. All of the key
      * termination characters may be included in the key by preceding them with a \. Any whitespace after the key is
      * skipped; if the first non-whitespace character after the key is <code>=</code> or <code>:</code>, then it is
      * ignored and any whitespace characters after it are also skipped. All remaining characters on the line become part
@@ -130,25 +128,25 @@ public class SimpleProperties extends Hashtable<String, String> {
      * Truth			:Beauty
      * </pre>
      *
-     * <p>
-     * As a second example, the line:
+     * As another example, the following three lines specify a single property:
      * <p>
      *
      * <pre>
-     * green vegetables : broccoli, collards, \
-     *                          spinach, kale
+     * fruits				apple, banana, pear, \
+     *                                  cantaloupe, watermelon, \
+     *                                  kiwi, mango
      * </pre>
      *
-     * The key is <code>"green vegetables"</code> and the associated element is:
+     * The key is <code>"fruits"</code> and the associated element is:
      * <p>
      *
      * <pre>
-     * &quot;broccoli, collards, spinach, kale&quot;
+     * &quot;apple, banana, pear, cantaloupe, watermelon,kiwi, mango&quot;
+     * </pre>
      *
      * Note that a space appears before each <code>\</code> so that a space will appear after each comma in the final
      * result; the <code>\</code>, line terminator, and leading whitespace on the continuation line are merely discarded
      * and are <i>not</i> replaced by one or more other characters.
-     *
      * <p>
      * As a third example, the line:
      * <p>
@@ -167,7 +165,6 @@ public class SimpleProperties extends Hashtable<String, String> {
     public synchronized void load(InputStream inStream) throws IOException {
 
         BufferedReader in = new BufferedReader(new InputStreamReader(inStream, "8859_1"));
-        logger.debug("Loading properties into memory");
 
         while (true) {
             // Get next line
@@ -194,6 +191,7 @@ public class SimpleProperties extends Hashtable<String, String> {
                             if (whiteSpaceChars.indexOf(nextLine.charAt(startIndex)) == -1)
                                 break;
                         nextLine = nextLine.substring(startIndex, nextLine.length());
+
                         line = loppedLine + nextLine;
                     }
                     // Find start of key
@@ -302,7 +300,7 @@ public class SimpleProperties extends Hashtable<String, String> {
      * element string is examined to see whether it should be rendered as an escape sequence. The ASCII characters
      * <code>\</code>, tab, newline, and carriage return are written as <code>\\</code>, <code>\t</code>,
      * <code>\n</code>, and <code>\r</code>, respectively. Characters less than <code>\u0020</code> and characters
-     * greater than <code>\u007E</code> are written a   s <code>\\u</code><i>xxxx</i> for the appropriate hexadecimal value
+     * greater than <code>\u007E</code> are written as <code>\\u</code><i>xxxx</i> for the appropriate hexadecimal value
      * <i>xxxx</i>. Space characters, but not embedded or trailing space characters, are written with a preceding
      * <code>\</code>. The key and value characters <code>#</code>, <code>!</code>, <code>=</code>, and <code>:</code>
      * are written with a preceding slash to ensure that they are properly loaded.

--- a/base/server/test/CMakeLists.txt
+++ b/base/server/test/CMakeLists.txt
@@ -38,7 +38,7 @@ javac(pki-server-test-classes
         ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR} ${PKI_CMSCORE_JAR} ${PKI_CMSBUNDLE_JAR}
         ${LDAPJDK_JAR} ${SERVLET_JAR} ${VELOCITY_JAR} ${XALAN_JAR} ${XERCES_JAR}
         ${JSS_JAR} ${COMMONS_CODEC_JAR} ${SYMKEY_JAR}
-        ${HAMCREST_JAR} ${JUNIT_JAR}
+        ${HAMCREST_JAR} ${JUNIT_JAR} ${COMMONS_IO_JAR}
         ${CMAKE_BINARY_DIR}/test/classes
     OUTPUT_DIR
         ${CMAKE_BINARY_DIR}/test/classes
@@ -59,7 +59,7 @@ add_junit_test(test-pki-server
         ${LDAPJDK_JAR} ${SERVLET_JAR} ${VELOCITY_JAR}
         ${COMMONS_CODEC_JAR} ${COMMONS_LANG_JAR}
         ${JSS_JAR} ${SYMKEY_JAR}
-        ${HAMCREST_JAR} ${JUNIT_JAR}
+        ${HAMCREST_JAR} ${JUNIT_JAR} ${COMMONS_IO_JAR}
         ${CMAKE_BINARY_DIR}/test/classes
     TESTS
         # com.netscape.cmscore.authentication.AuthTokenTest
@@ -71,6 +71,7 @@ add_junit_test(test-pki-server
         com.netscape.cmscore.request.RequestQueueTest
         com.netscape.cmscore.request.RequestRecordTest
         # com.netscape.cmscore.request.RequestTest
+        com.netscape.cmscore.password.PlainPasswordFileTest
     REPORTS_DIR
         reports
     DEPENDS

--- a/base/server/test/com/netscape/cmscore/password/PlainPasswordFileTest.java
+++ b/base/server/test/com/netscape/cmscore/password/PlainPasswordFileTest.java
@@ -1,0 +1,129 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+package com.netscape.cmscore.password;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import com.netscape.cmsutil.password.PlainPasswordFile;
+
+/**
+ * @author Dinesh Prasanth M K <dmoluguw@redhat.com>
+ *
+ */
+public class PlainPasswordFileTest {
+
+    PlainPasswordFile pwdFile;
+    File createdFile;
+
+    // Successful cases
+    // Expected key-value pair
+    String[] refString1 = { "Truth", "Beauty" };
+    String[] testString1 = {
+            "Truth=Beauty", "Truth= Beauty", "Truth=Beauty ", "Truth= Beauty ",
+            "Truth =Beauty", "Truth = Beauty", "Truth =Beauty ", "Truth = Beauty ",
+            " Truth=Beauty", " Truth= Beauty", " Truth=Beauty ", " Truth= Beauty ",
+            " Truth =Beauty", " Truth = Beauty", " Truth =Beauty ", " Truth = Beauty "
+    };
+
+    String[] refString2 = { "Welcome Message", "Hello World" };
+    String[] testString2 = {
+            "Welcome Message=Hello World", "Welcome Message= Hello World",
+            "Welcome Message=Hello World ", "Welcome Message= Hello World ",
+
+            "Welcome Message =Hello World", "Welcome Message = Hello World",
+            "Welcome Message =Hello World ", "Welcome Message = Hello World ",
+
+            " Welcome Message=Hello World", " Welcome Message= Hello World",
+            " Welcome Message=Hello World ", " Welcome Message= Hello World ",
+
+            " Welcome Message =Hello World", " Welcome Message = Hello World",
+            " Welcome Message =Hello World ", " Welcome Message = Hello World "
+    };
+
+    String[] testString3 = { " \n", "# Ignored line 1", "   # Ignored line 2" };
+
+    // Negative cases
+    String[] testString4 = {
+            "hello",
+            "hello:world",
+            "hello world"
+    };
+
+    @Before
+    public void preTestSetup() throws IOException
+    {
+        pwdFile = new PlainPasswordFile();
+        createdFile = folder.newFile("tempPasswordFile");
+    }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException expectedException= ExpectedException.none();
+
+    @Test
+    public void testInitNormal() throws IOException {
+        writeToFileAndInit(createdFile, testString1);
+        // Since all all keys and values are equivalent, only 1 value should be loaded
+        Assert.assertEquals(1, pwdFile.getSize());
+        // Check whether the value is correctly stored and retrieved
+        Assert.assertEquals(refString1[1], pwdFile.getPassword(refString1[0], 0));
+
+    }
+
+    @Test
+    public void testInitWithSpace() throws IOException {
+        writeToFileAndInit(createdFile, testString2);
+        Assert.assertEquals(1, pwdFile.getSize());
+        Assert.assertEquals(refString2[1], pwdFile.getPassword(refString2[0], 0));
+
+    }
+
+    @Test
+    public void testComments() throws IOException {
+        writeToFileAndInit(createdFile, testString3);
+        // There should be no values present since the file contains only comments
+        // and newline
+        Assert.assertEquals(0, pwdFile.getSize());
+    }
+
+    @Test
+    public void testException() throws IOException {
+        expectedException.expect(IOException.class);
+        writeToFileAndInit(createdFile, testString4);
+    }
+
+    private void writeToFileAndInit(File file, String[] strArray) throws IOException {
+        for (String str : strArray) {
+            FileUtils.writeStringToFile(file, str + "\n", StandardCharsets.ISO_8859_1, true);
+        }
+        pwdFile.init(createdFile.getAbsolutePath());
+    }
+
+}

--- a/base/server/test/com/netscape/cmscore/password/PlainPasswordFileTest.java
+++ b/base/server/test/com/netscape/cmscore/password/PlainPasswordFileTest.java
@@ -39,44 +39,25 @@ public class PlainPasswordFileTest {
 
     PlainPasswordFile pwdFile;
     File createdFile;
+    private final int TESTCASE_ENTRY = 0;
+    private final int TESTCASE_KEY = 1;
+    private final int TESTCASE_VALUE = 2;
 
     // Successful cases
-    // Expected key-value pair
-    String[] refString1 = { "Truth", "Beauty" };
-    String[] testString1 = {
-            "Truth=Beauty", "Truth= Beauty", "Truth=Beauty ", "Truth= Beauty ",
-            "Truth =Beauty", "Truth = Beauty", "Truth =Beauty ", "Truth = Beauty ",
-            " Truth=Beauty", " Truth= Beauty", " Truth=Beauty ", " Truth= Beauty ",
-            " Truth =Beauty", " Truth = Beauty", " Truth =Beauty ", " Truth = Beauty "
-    };
-
-    String[] refString2 = { "Welcome Message", "Hello World" };
-    String[] testString2 = {
-            "Welcome Message=Hello World", "Welcome Message= Hello World",
-            "Welcome Message=Hello World ", "Welcome Message= Hello World ",
-
-            "Welcome Message =Hello World", "Welcome Message = Hello World",
-            "Welcome Message =Hello World ", "Welcome Message = Hello World ",
-
-            " Welcome Message=Hello World", " Welcome Message= Hello World",
-            " Welcome Message=Hello World ", " Welcome Message= Hello World ",
-
-            " Welcome Message =Hello World", " Welcome Message = Hello World",
-            " Welcome Message =Hello World ", " Welcome Message = Hello World "
-    };
-
-    String[] testString3 = { " \n", "# Ignored line 1", "   # Ignored line 2" };
-
-    // Negative cases
-    String[] testString4 = {
-            "hello",
-            "hello:world",
-            "hello world"
+    String[][] testCases = {
+            { "Truth=Beauty", "Truth", "Beauty" }, // No spaces
+            { " Truth = Beauty ", "Truth", "Beauty" }, // Check for spaces
+            { "Welcome Message=Hello World", "Welcome Message", "Hello World" }, // No spaces
+            { " Welcome Message = Hello World ", "Welcome Message", "Hello World" },
+            { "\n" }, // Empty line
+            { "# Ignored line 1" }, // Commented line
+            { "hello" },
+            { "hello:world" },
+            { "hello world" }
     };
 
     @Before
-    public void preTestSetup() throws IOException
-    {
+    public void preTestSetup() throws IOException {
         pwdFile = new PlainPasswordFile();
         createdFile = folder.newFile("tempPasswordFile");
     }
@@ -85,45 +66,70 @@ public class PlainPasswordFileTest {
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Rule
-    public ExpectedException expectedException= ExpectedException.none();
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testInitNormal() throws IOException {
-        writeToFileAndInit(createdFile, testString1);
-        // Since all all keys and values are equivalent, only 1 value should be loaded
-        Assert.assertEquals(1, pwdFile.getSize());
-        // Check whether the value is correctly stored and retrieved
-        Assert.assertEquals(refString1[1], pwdFile.getPassword(refString1[0], 0));
-
+        testHelper(0, false);
     }
 
     @Test
-    public void testInitWithSpace() throws IOException {
-        writeToFileAndInit(createdFile, testString2);
-        Assert.assertEquals(1, pwdFile.getSize());
-        Assert.assertEquals(refString2[1], pwdFile.getPassword(refString2[0], 0));
+    public void testInitNormalWithSpace() throws IOException {
+        testHelper(1, false);
+    }
+
+    @Test
+    public void testInitWithSpaceInside() throws IOException {
+        testHelper(2, false);
+    }
+
+    @Test
+    public void testInitWithSpaceInsideAndOutside() throws IOException {
+        testHelper(3, false);
+    }
+
+    @Test
+    public void testEmptyLine() throws IOException {
+        testHelper(4, true);
 
     }
 
     @Test
     public void testComments() throws IOException {
-        writeToFileAndInit(createdFile, testString3);
-        // There should be no values present since the file contains only comments
-        // and newline
-        Assert.assertEquals(0, pwdFile.getSize());
+        testHelper(5, true);
     }
 
     @Test
-    public void testException() throws IOException {
+    public void testNoValue() throws IOException {
         expectedException.expect(IOException.class);
-        writeToFileAndInit(createdFile, testString4);
+        testHelper(6, false);
     }
 
-    private void writeToFileAndInit(File file, String[] strArray) throws IOException {
-        for (String str : strArray) {
-            FileUtils.writeStringToFile(file, str + "\n", (Charset) null, true);
-        }
+    @Test
+    public void testWrongDelimiter() throws IOException {
+        expectedException.expect(IOException.class);
+        testHelper(7,  false);
+    }
+
+    @Test
+    public void testSpaceDelimiter() throws IOException {
+        expectedException.expect(IOException.class);
+        testHelper(8, false);
+    }
+
+    private void writeToFileAndInit(File file, String string) throws IOException {
+        FileUtils.writeStringToFile(file, string + "\n", (Charset) null, true);
         pwdFile.init(createdFile.getAbsolutePath());
+    }
+
+    private void testHelper(int testCaseId, boolean isEmpty) throws IOException {
+        writeToFileAndInit(createdFile, testCases[testCaseId][TESTCASE_ENTRY]);
+        if (isEmpty) {
+            Assert.assertEquals(0, pwdFile.getSize());
+        } else {
+            Assert.assertEquals(testCases[testCaseId][TESTCASE_VALUE],
+                    pwdFile.getPassword(testCases[testCaseId][TESTCASE_KEY], 0));
+        }
     }
 
 }

--- a/base/server/test/com/netscape/cmscore/password/PlainPasswordFileTest.java
+++ b/base/server/test/com/netscape/cmscore/password/PlainPasswordFileTest.java
@@ -19,7 +19,7 @@ package com.netscape.cmscore.password;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -121,7 +121,7 @@ public class PlainPasswordFileTest {
 
     private void writeToFileAndInit(File file, String[] strArray) throws IOException {
         for (String str : strArray) {
-            FileUtils.writeStringToFile(file, str + "\n", StandardCharsets.ISO_8859_1, true);
+            FileUtils.writeStringToFile(file, str + "\n", (Charset) null, true);
         }
         pwdFile.init(createdFile.getAbsolutePath());
     }

--- a/base/server/test/com/netscape/cmscore/password/PlainPasswordFileTest.java
+++ b/base/server/test/com/netscape/cmscore/password/PlainPasswordFileTest.java
@@ -49,8 +49,10 @@ public class PlainPasswordFileTest {
             { " Truth = Beauty ", "Truth", "Beauty" }, // Check for spaces
             { "Welcome Message=Hello World", "Welcome Message", "Hello World" }, // No spaces
             { " Welcome Message = Hello World ", "Welcome Message", "Hello World" },
-            { "\n" }, // Empty line
+            { "" }, // Empty line
+            { " " }, // Non-empty line
             { "# Ignored line 1" }, // Commented line
+            { " # Ignored line 2" }, // Commented line with leading space
             { "hello" },
             { "hello:world" },
             { "hello world" }
@@ -91,30 +93,39 @@ public class PlainPasswordFileTest {
     @Test
     public void testEmptyLine() throws IOException {
         testHelper(4, true);
+    }
 
+    @Test
+    public void testNonEmptyLine() throws IOException {
+        testHelper(5, true);
     }
 
     @Test
     public void testComments() throws IOException {
-        testHelper(5, true);
+        testHelper(6, true);
+    }
+
+    @Test
+    public void testCommentsWithLeadingSpace() throws IOException {
+        testHelper(7, true);
     }
 
     @Test
     public void testNoValue() throws IOException {
         expectedException.expect(IOException.class);
-        testHelper(6, false);
+        testHelper(8, false);
     }
 
     @Test
     public void testWrongDelimiter() throws IOException {
         expectedException.expect(IOException.class);
-        testHelper(7,  false);
+        testHelper(9, false);
     }
 
     @Test
     public void testSpaceDelimiter() throws IOException {
         expectedException.expect(IOException.class);
-        testHelper(8, false);
+        testHelper(10, false);
     }
 
     private void writeToFileAndInit(File file, String string) throws IOException {

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -555,13 +555,16 @@ public class CryptoUtil {
      */
     public static KeyPair generateRSAKeyPair(String tokenName, int keysize)
             throws Exception {
+        logger.debug("CryptoUtil: Generating RSA Key pair for tokenName: " + tokenName);
         CryptoToken token = getKeyStorageToken(tokenName);
         return generateRSAKeyPair(token, keysize);
     }
 
     public static KeyPair generateRSAKeyPair(CryptoToken token, int keysize) throws Exception {
         KeyPairGenerator kg = token.getKeyPairGenerator(KeyPairAlgorithm.RSA);
+        logger.debug("CryptoUtil: Keypair Generator initializing for: " + token.getName());
         kg.initialize(keysize);
+        logger.debug("CryptoUtil: Initialization complete");
         return kg.genKeyPair();
     }
 

--- a/base/util/src/com/netscape/cmsutil/password/PlainPasswordFile.java
+++ b/base/util/src/com/netscape/cmsutil/password/PlainPasswordFile.java
@@ -22,7 +22,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.Vector;
@@ -90,16 +89,14 @@ public class PlainPasswordFile implements IPasswordStore {
         // initialize mPwdStore
         mPwdPath = pwdPath;
 
-        FileInputStream file = null;
-        BufferedReader br = null;
-        try {
-            file = new FileInputStream(mPwdPath);
-            br = new BufferedReader(new InputStreamReader(file, StandardCharsets.ISO_8859_1));
+        try (FileInputStream file = new FileInputStream(mPwdPath);
+                InputStreamReader isr = new InputStreamReader(file);
+                BufferedReader br = new BufferedReader(isr)) {
 
             String line;
             int index = 1;
             while ((line = br.readLine()) != null) {
-                // Remove any trailing spaces
+                // Remove any leading or trailing spaces
                 line = line.trim();
 
                 if (line.startsWith("#") || line.isEmpty())
@@ -107,20 +104,12 @@ public class PlainPasswordFile implements IPasswordStore {
 
                 String[] parts = line.split("=", 2);
                 if (parts.length < 2) {
-                    br.close();
                     throw new IOException("Missing delimiter '=' in file " + mPwdPath + " in line " + index);
                 }
 
                 // Load key value into the password store
                 mPwdStore.put(parts[0].trim(), parts[1].trim());
                 index++;
-            }
-        } finally {
-            if (file != null) {
-                file.close();
-            }
-            if (br != null) {
-                br.close();
             }
         }
     }

--- a/base/util/src/com/netscape/cmsutil/password/PlainPasswordFile.java
+++ b/base/util/src/com/netscape/cmsutil/password/PlainPasswordFile.java
@@ -17,9 +17,12 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cmsutil.password;
 
+import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.Vector;
@@ -30,21 +33,94 @@ public class PlainPasswordFile implements IPasswordStore {
     private static final String PASSWORD_WRITER_HEADER = "";
     private String id;
 
+    private static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PlainPasswordFile.class);
+
     public PlainPasswordFile() {
         mPwdStore = new Properties();
     }
 
+    /**
+     * Initialization method to read passwords(key and element pairs) from a file.
+     * <p>
+     * Every property occupies one line of the input stream. Each line is terminated by a line terminator (
+     * <code>\n</code> or <code>\r</code> or <code>\r\n</code>). Lines are processed until end of
+     * file is reached.
+     * <p>
+     * A line that contains only whitespace or whose first non-whitespace character is an ASCII <code>#</code>
+     * is ignored (thus, <code>#</code> indicates comment line).
+     * <p>
+     * Every line other than a blank line or a comment line describes one property to be added to the table.
+     * The characters before the delimiter <code>=</code> forms the <code>key</code> and the characters after
+     * the <code>=</code> is assigned as <code>value</code> to the key.
+     * <p>
+     * As an example, each of the following lines specify the key <code>"Truth"</code> and the associated element
+     * value <code>"Beauty"</code>:
+     * <p>
+     *
+     * <pre>
+     * Truth = Beauty
+     * Truth= Beauty
+     * Truth                    =Beauty
+     * </pre>
+     *
+     * <p>
+     * Note that the space appearing before/after <code>=</code> is ignored. However, the space appearing in between are
+     * stored.
+     * <p>
+     * Example:
+     *
+     * <pre>
+     * Welcome Message  = Hello World
+     * </pre>
+     *
+     * assigns value <code>Hello World</code> to key <code>Welcome Message</code>
+     * <p>
+     *
+     * If the line doesn't have the delimiter <code>=</code>, the method throws an IOException
+     *
+     * @param pwdPath the input file path.
+     * @exception IOException if an error occurred when reading from the
+     *                input stream.
+     */
     public void init(String pwdPath)
             throws IOException {
+
+        logger.debug("PlainPasswordFile: Initializing PlainPasswordFile");
+
         // initialize mPwdStore
         mPwdPath = pwdPath;
+
         FileInputStream file = null;
+        BufferedReader br = null;
         try {
             file = new FileInputStream(mPwdPath);
-            mPwdStore.load(file);
+            br = new BufferedReader(new InputStreamReader(file, StandardCharsets.ISO_8859_1));
+
+            String line;
+            int index = 1;
+            while ((line = br.readLine()) != null) {
+                // Remove any trailing spaces
+                line = line.trim();
+
+                if (line.startsWith("#") || line.isEmpty())
+                    continue;
+
+                String[] parts = line.split("=", 2);
+                if (parts.length < 2) {
+                    br.close();
+                    throw new IOException("Missing delimiter '=' in file " + mPwdPath + " in line " + index);
+                }
+
+                // Load key value into the password store
+                mPwdStore.put(parts[0].trim(), parts[1].trim());
+                index++;
+            }
         } finally {
             if (file != null) {
                 file.close();
+            }
+            if (br != null) {
+                br.close();
             }
         }
     }
@@ -82,5 +158,9 @@ public class PlainPasswordFile implements IPasswordStore {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public int getSize() {
+        return mPwdStore.size();
     }
 }


### PR DESCRIPTION
password.conf included an unintended '=' if
a space is present in the token label.

https://pagure.io/dogtagpki/issue/3054

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>