### PR TITLE
Fixed the space in the token-label - Part 2

### DIFF
--- a/base/server/cms/src/org/dogtagpki/server/rest/SystemConfigService.java
+++ b/base/server/cms/src/org/dogtagpki/server/rest/SystemConfigService.java
@@ -64,6 +64,7 @@ import com.netscape.cmscore.dbs.DBSubsystem;
 import com.netscape.cmscore.security.JssSubsystem;
 import com.netscape.cmscore.usrgrp.UGSubsystem;
 import com.netscape.cmsutil.crypto.CryptoUtil;
+import com.netscape.cmsutil.password.IPasswordStore;
 import com.netscape.cmsutil.util.Utils;
 
 import netscape.security.x509.X509CertImpl;
@@ -752,15 +753,13 @@ public class SystemConfigService extends PKIService implements SystemConfigResou
                 replicationPassword = Integer.toString(random.nextInt());
             }
 
-            IConfigStore psStore = null;
-            String passwordFile = null;
-            passwordFile = cs.getString("passwordFile");
-            psStore = CMS.createFileConfigStore(passwordFile);
-            psStore.putString("internaldb", data.getBindpwd());
-            if (StringUtils.isEmpty(psStore.getString("replicationdb", null))) {
-                psStore.putString("replicationdb", replicationPassword);
+            IPasswordStore psStore = null;
+            psStore = CMS.getPasswordStore();
+            psStore.putPassword("internaldb", data.getBindpwd());
+            if (StringUtils.isEmpty(psStore.getPassword("replicationdb", 0))) {
+                psStore.putPassword("replicationdb", replicationPassword);
             }
-            psStore.commit(false);
+            psStore.commit();
 
             ConfigurationUtils.enableUSNPlugin();
             ConfigurationUtils.populateDB();

--- a/base/util/src/com/netscape/cmsutil/password/PlainPasswordFile.java
+++ b/base/util/src/com/netscape/cmsutil/password/PlainPasswordFile.java
@@ -133,22 +133,20 @@ public class PlainPasswordFile implements IPasswordStore {
         return mPwdStore.setProperty(tag, password);
     }
 
-    public void commit()
+    public synchronized void commit()
             throws IOException, ClassCastException, NullPointerException {
         try (FileOutputStream file = new FileOutputStream(mPwdPath);
                 OutputStreamWriter osw = new OutputStreamWriter(file);
                 BufferedWriter bw = new BufferedWriter(osw)) {
 
-            // To avoid race condition
-            synchronized (this) {
-                for (Enumeration<?> e = mPwdStore.keys(); e.hasMoreElements();) {
-                    String key = ((String)e.nextElement()).trim();
-                    String val = ((String)mPwdStore.get(key)).trim();
-                    bw.write(key + "=" + val);
-                    bw.newLine();
-                }
+            for (Enumeration<?> e = mPwdStore.keys(); e.hasMoreElements();) {
+                String key = ((String) e.nextElement()).trim();
+                String val = ((String) mPwdStore.get(key)).trim();
+                bw.write(key + "=" + val);
+                bw.newLine();
             }
         }
+
     }
 
     public String getId() {


### PR DESCRIPTION
- This is a continuation of patch #35. The commit
needs to be re-written (instead of using the
Properties.store()

- The password.conf is being overwritten at multiple places

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>