### PR TITLE
Fix cloning failures caused by range depletion

### DIFF
--- a/base/ca/src/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/com/netscape/ca/CertificateAuthority.java
@@ -1086,7 +1086,7 @@ public class CertificateAuthority
     public String getStartSerial() {
         try {
             BigInteger serial =
-                    mCertRepot.getTheSerialNumber();
+                    mCertRepot.peekNextSerialNumber();
 
             if (serial == null)
                 return "";

--- a/base/common/src/com/netscape/certsrv/dbs/repository/IRepository.java
+++ b/base/common/src/com/netscape/certsrv/dbs/repository/IRepository.java
@@ -50,7 +50,7 @@ public interface IRepository {
      * @return serial number
      * @exception EBaseException failed to retrieve next serial number
      */
-    public BigInteger getTheSerialNumber() throws EBaseException;
+    public BigInteger peekNextSerialNumber() throws EBaseException;
 
     /**
      * Set the maximum serial number.

--- a/base/server/cms/src/com/netscape/cms/servlet/csadmin/UpdateNumberRange.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/csadmin/UpdateNumberRange.java
@@ -193,7 +193,7 @@ public class UpdateNumberRange extends CMSServlet {
             beginNum = endNum.subtract(decrement).add(oneNum);
             logger.debug("UpdateNumberRange: beginNum: " + beginNum);
 
-            if (beginNum.compareTo(repo.getTheSerialNumber()) < 0) {
+            if (beginNum.compareTo(repo.peekNextSerialNumber()) < 0) {
 
                 logger.debug("UpdateNumberRange: Transferring from the end of on-deck range");
 

--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/CertificateRepository.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/CertificateRepository.java
@@ -253,47 +253,45 @@ public class CertificateRepository extends Repository
 
     private Object nextSerialNumberMonitor = new Object();
 
-    public BigInteger getNextSerialNumber() throws
-            EBaseException {
+    public synchronized BigInteger getNextSerialNumber()
+            throws EBaseException {
 
         BigInteger nextSerialNumber = null;
         BigInteger randomNumber = null;
 
-        synchronized (nextSerialNumberMonitor) {
-            super.initCacheIfNeeded();
-            CMS.debug("CertificateRepository: getNextSerialNumber  mEnableRandomSerialNumbers="+mEnableRandomSerialNumbers);
+        super.initCacheIfNeeded();
+        CMS.debug("CertificateRepository: getNextSerialNumber  mEnableRandomSerialNumbers="+mEnableRandomSerialNumbers);
 
-            if (mEnableRandomSerialNumbers) {
-                int i = 0;
-                do {
-                    if (i > 0) {
-                        CMS.debug("CertificateRepository: getNextSerialNumber  regenerating serial number");
-                    }
-                    randomNumber = getRandomNumber();
-                    nextSerialNumber = getRandomSerialNumber(randomNumber);
-                    nextSerialNumber = checkSerialNumbers(randomNumber, nextSerialNumber);
-                    i++;
-                } while (nextSerialNumber == null && i < mMaxCollisionRecoveryRegenerations);
-
-                if (nextSerialNumber == null) {
-                    CMS.debug("CertificateRepository: in getNextSerialNumber  nextSerialNumber is null");
-                    throw new EBaseException( "nextSerialNumber is null" );
+        if (mEnableRandomSerialNumbers) {
+            int i = 0;
+            do {
+                if (i > 0) {
+                    CMS.debug("CertificateRepository: getNextSerialNumber  regenerating serial number");
                 }
+                randomNumber = getRandomNumber();
+                nextSerialNumber = getRandomSerialNumber(randomNumber);
+                nextSerialNumber = checkSerialNumbers(randomNumber, nextSerialNumber);
+                i++;
+            } while (nextSerialNumber == null && i < mMaxCollisionRecoveryRegenerations);
 
-                if (mCounter.compareTo(BigInteger.ZERO) >= 0 &&
-                    mMinSerialNo != null && mMaxSerialNo != null &&
-                    nextSerialNumber != null &&
-                    nextSerialNumber.compareTo(mMinSerialNo) >= 0 &&
-                    nextSerialNumber.compareTo(mMaxSerialNo) <= 0) {
-                    mCounter = mCounter.add(BigInteger.ONE);
-                }
-                CMS.debug("CertificateRepository: getNextSerialNumber  nextSerialNumber="+
-                          nextSerialNumber+"  mCounter="+mCounter);
-
-                super.checkRange();
-            } else {
-                nextSerialNumber = super.getNextSerialNumber();
+            if (nextSerialNumber == null) {
+                CMS.debug("CertificateRepository: in getNextSerialNumber  nextSerialNumber is null");
+                throw new EBaseException( "nextSerialNumber is null" );
             }
+
+            if (mCounter.compareTo(BigInteger.ZERO) >= 0 &&
+                mMinSerialNo != null && mMaxSerialNo != null &&
+                nextSerialNumber != null &&
+                nextSerialNumber.compareTo(mMinSerialNo) >= 0 &&
+                nextSerialNumber.compareTo(mMaxSerialNo) <= 0) {
+                mCounter = mCounter.add(BigInteger.ONE);
+            }
+            CMS.debug("CertificateRepository: getNextSerialNumber  nextSerialNumber="+
+                      nextSerialNumber+"  mCounter="+mCounter);
+
+            super.checkRange();
+        } else {
+            nextSerialNumber = super.getNextSerialNumber();
         }
 
         return nextSerialNumber;

--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
@@ -346,7 +346,7 @@ public abstract class Repository implements IRepository {
      * Returns null if the next number exceeds the current range and
      * there is not a next range.
      */
-    public BigInteger getTheSerialNumber() throws EBaseException {
+    public BigInteger peekNextSerialNumber() throws EBaseException {
 
         CMS.debug("Repository:In getTheSerialNumber ");
         if (mLastSerialNo == null)

--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
@@ -298,6 +298,25 @@ public abstract class Repository implements IRepository {
         BigInteger theSerialNo = null;
         theSerialNo = getLastSerialNumberInRange(mMinSerialNo, mMaxSerialNo);
 
+        if (theSerialNo == null) {
+            // This arises when range has been depleted by servicing
+            // UpdateNumberRange requests for clones.  Attempt to
+            // move to next range.
+            CMS.debug(
+                "Repository: failed to get last serial number in range "
+                + mMinSerialNo + ".." + mMaxSerialNo);
+
+            if (hasNextRange()) {
+                CMS.debug("Repository: switching to next range.");
+                switchToNextRange();
+                CMS.debug("Repository: new range: " + mMinSerialNo + ".." + mMaxSerialNo);
+                // try again with updated range
+                theSerialNo = getLastSerialNumberInRange(mMinSerialNo, mMaxSerialNo);
+            } else {
+                CMS.debug("Repository: next range not available.");
+            }
+        }
+
         if (theSerialNo != null) {
 
             mLastSerialNo = new BigInteger(theSerialNo.toString());

--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
@@ -185,7 +185,7 @@ public abstract class Repository implements IRepository {
      * @param serial maximum number
      * @exception EBaseException failed to set maximum serial number
      */
-    public void setMaxSerial(String serial) throws EBaseException {
+    public synchronized void setMaxSerial(String serial) throws EBaseException {
         BigInteger maxSerial = null;
         CMS.debug("Repository:setMaxSerial " + serial);
 
@@ -211,7 +211,7 @@ public abstract class Repository implements IRepository {
      * @param serial maximum number in next range
      * @exception EBaseException failed to set maximum serial number in next range
      */
-    public void setNextMaxSerial(String serial) throws EBaseException {
+    public synchronized void setNextMaxSerial(String serial) throws EBaseException {
         BigInteger maxSerial = null;
         CMS.debug("Repository:setNextMaxSerial " + serial);
 
@@ -346,7 +346,7 @@ public abstract class Repository implements IRepository {
      * Returns null if the next number exceeds the current range and
      * there is not a next range.
      */
-    public BigInteger peekNextSerialNumber() throws EBaseException {
+    public synchronized BigInteger peekNextSerialNumber() throws EBaseException {
 
         CMS.debug("Repository:In getTheSerialNumber ");
         if (mLastSerialNo == null)


### PR DESCRIPTION
Tickets
- https://pagure.io/dogtagpki/issue/3055
- https://pagure.io/freeipa/issue/7654

This issue addresses several problems related to range management that can cause **cloning failure** and **startup failure**.

How to reproduce
----------------

1. Install a master (called **A**).

2. Install a clone from **A** (called **B**).

3. Install a clone from **B** (called **C**).

4. Install another clone from **B** (called **D**).  Cloning fails due to `NullPointerException` on **B** while servicing `UpdateNumberRange` request.

5. Further observe that **B** fails to restart due to an error initialising the range cache:

```
2018-09-03 15:12:16 [localhost-startStop-1] SEVERE: Unable to start CMS engine: Error in obtaining the last serial number in the repository!
Error in obtaining the last serial number in the repository!
        at com.netscape.cmscore.dbs.Repository.initCache(Repository.java:308)
        at com.netscape.cmscore.dbs.Repository.checkRanges(Repository.java:498)
        at com.netscape.cmscore.apps.CMSEngine.startup(CMSEngine.java:1309)
```

Fix description
---------------

The fix consists of a number of parts (addressed in separate commits).

1. A method to peek at the next serial number (without comsuming it) returned `null` when the current number range was depleted (even when a next range was available).  This was the cause of the NPE resulting in cloning failure.  This method was updated to return a number from the next range (if available).

2. Range cache initialisation was updated to switch to the next range (if available) when the current range is exhausted. This avoids the startup issue after the range has been exhausted.

3. A number of potential concurrency issues were addressed through use of `synchronized`.

4. A substantial amount of commentary was added, and some minor refactoring to improve readability.


Future plans
------------

The idea of a clone delegating part of its assigned range (current or next) to a new clone is fraught, as we see from these errors.  It would be better for the UpdateNumberRange servlet to create a full range assignment for the clone during creation.  This probably requires some changes to the UpdateNumberRange API, but is otherwise a straightforward change.  It should be implemented in a backwards compatible manner for a future release.  Ticket: https://pagure.io/dogtagpki/issue/3060.