### PR TITLE
Reorganizing CI script for nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
         - travis/post-test-started.sh
       install:
         - travis/builder-init.sh
+        - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-init.sh
         - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-build.sh
         - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-install.sh
       script:
@@ -51,6 +52,8 @@ jobs:
       install:
         # Setup the required build environment
         - travis/builder-init.sh
+        # Initialize PKI build env
+        - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-init.sh
         # Trigger build process
         - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-build.sh --with-pkgs=base,server,ca,kra
         # Initialize IPA test environment
@@ -76,6 +79,7 @@ jobs:
         - touch ${LOGS}
       install:
         - travis/builder-init.sh
+        - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-init.sh
         - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-build.sh
         - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-install.sh
       script:
@@ -108,6 +112,8 @@ jobs:
       install:
         # Setup the required build environment
         - travis/builder-init.sh
+        # Initialize PKI build env
+        - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-init.sh
         # Trigger build process
         - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-build.sh --with-pkgs=base,server,ca,kra
         # Initialize IPA test environment

--- a/travis/builder-init.sh
+++ b/travis/builder-init.sh
@@ -52,6 +52,3 @@ docker run \
 docker ps -a
 
 docker exec -i ${CONTAINER} /bin/ls -la ${BUILDDIR}
-
-# Initialize PKI build env
-docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-init.sh


### PR DESCRIPTION
- PKI build env setup is not needed for nightly. With this patch, nightly repo can reuse the same travis scripts to run IPA tests

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>