### PR TITLE
Fixes Log rotation issue

### DIFF
--- a/base/server/share/conf/pki.policy
+++ b/base/server/share/conf/pki.policy
@@ -70,6 +70,10 @@ grant codeBase "file:/usr/share/java/servlet.jar" {
         permission java.security.AllPermission;
 };
 
+grant codeBase "file:/usr/share/java/slf4j/slf4j-jdk14.jar" {
+        permission java.security.AllPermission;
+};
+
 grant codeBase "file:/usr/share/java/tomcat/-" {
         permission java.security.AllPermission;
 };


### PR DESCRIPTION
Since we use slf4j to do log rotation, we need to
allow permissions for the corresponding slf4j.jar.

Ticket: https://pagure.io/dogtagpki/issue/3034

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>