### PR TITLE
Fixed admin profile ID handling

### DIFF
--- a/base/common/src/com/netscape/certsrv/system/ConfigurationRequest.java
+++ b/base/common/src/com/netscape/certsrv/system/ConfigurationRequest.java
@@ -48,9 +48,6 @@ public class ConfigurationRequest {
     public static final String ECC_INTERNAL_SUBSYSTEM_CERT_PROFILE= "caECInternalAuthSubsystemCert";
     public static final String RSA_INTERNAL_SUBSYSTEM_CERT_PROFILE= "caInternalAuthSubsystemCert";
 
-    public static final String ECC_INTERNAL_ADMIN_CERT_PROFILE="caECAdminCert";
-    public static final String RSA_INTERNAL_ADMIN_CERT_PROFILE="caAdminCert";
-
     @XmlElement
     protected String pin;
 
@@ -176,6 +173,9 @@ public class ConfigurationRequest {
 
     @XmlElement
     protected String adminName;
+
+    @XmlElement
+    protected String adminKeyType;
 
     @XmlElement
     protected String adminProfileID;
@@ -795,25 +795,24 @@ public class ConfigurationRequest {
     }
 
     /**
+     * @return the admin key type
+     */
+    public String getAdminKeyType() {
+        return adminKeyType;
+    }
+
+    /**
+     * @param adminKeyType the admin key type
+     */
+    public void setAdminKeyType(String adminKeyType) {
+        this.adminKeyType = adminKeyType;
+    }
+
+    /**
      * @return the adminProfileID
      */
     public String getAdminProfileID() {
-
-        // Modify the value returned based on key type of the
-        // subsystem cert. If keyType not found take the default
-        // sent over the server. In the future we can make sure
-        // the correct value is sent over the server.
-        String keyType = this.getSystemCertKeyType("subsystem");
-        String actualAdminProfileID = adminProfileID;
-        if(keyType != null) {
-            if("ecc".equalsIgnoreCase(keyType)) {
-                actualAdminProfileID = ECC_INTERNAL_ADMIN_CERT_PROFILE;
-            } else if("rsa".equalsIgnoreCase(keyType)) {
-                actualAdminProfileID = RSA_INTERNAL_ADMIN_CERT_PROFILE;
-            }
-        }
-
-        return actualAdminProfileID;
+        return adminProfileID;
     }
 
     /**

--- a/base/server/cms/src/org/dogtagpki/server/rest/SystemConfigService.java
+++ b/base/server/cms/src/org/dogtagpki/server/rest/SystemConfigService.java
@@ -77,6 +77,9 @@ public class SystemConfigService extends PKIService implements SystemConfigResou
 
     public final static Logger logger = LoggerFactory.getLogger(SystemConfigService.class);
 
+    public static final String ECC_INTERNAL_ADMIN_CERT_PROFILE = "caECAdminCert";
+    public static final String RSA_INTERNAL_ADMIN_CERT_PROFILE = "caAdminCert";
+
     public IConfigStore cs;
     public String csType;
     public String csSubsystem;
@@ -719,10 +722,19 @@ public class SystemConfigService extends PKIService implements SystemConfigResou
             ca_port = cs.getInteger("securitydomain.httpseeport");
         }
 
-        logger.debug("SystemConfigService: profile: " + data.getAdminProfileID());
+        String keyType = data.getAdminKeyType();
+        String profileID;
+
+        if ("ecc".equalsIgnoreCase(keyType)) {
+            profileID = ECC_INTERNAL_ADMIN_CERT_PROFILE;
+        } else { // rsa
+            profileID = RSA_INTERNAL_ADMIN_CERT_PROFILE;
+        }
+
+        logger.debug("SystemConfigService: profile: " + profileID);
 
         String b64 = ConfigurationUtils.submitAdminCertRequest(ca_hostname, ca_port,
-                data.getAdminProfileID(), data.getAdminCertRequestType(),
+                profileID, data.getAdminCertRequestType(),
                 data.getAdminCertRequest(), adminSubjectDN);
 
         b64 = CryptoUtil.stripCertBrackets(b64.trim());

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -4407,6 +4407,7 @@ class ConfigClient:
         data.adminEmail = self.mdict['pki_admin_email']
         data.adminName = self.mdict['pki_admin_name']
         data.adminPassword = self.mdict['pki_admin_password']
+        data.adminKeyType = self.mdict['pki_admin_key_type']
         data.adminProfileID = self.mdict['pki_admin_profile_id']
         data.adminUID = self.mdict['pki_admin_uid']
         data.adminSubjectDN = self.mdict['pki_admin_subject_dn']


### PR DESCRIPTION
The code that determines the admin profile ID has been
moved from ConfigurationRequest.getAdminProfileID() into
SystemConfigService.createAdminCert().

Previously the code was using the subsystem cert's key
type to determine the profile ID. Now it the code will
use the admin's own key type.