### PR TITLE
Fixes the 'byte to string' issue due to subprocess

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1,6 +1,6 @@
 # Authors:
 #     Endi S. Dewata <edewata@redhat.com>
-#     Dinesh Prasnath M K <dmoluguw@redhat.com>
+#     Dinesh Prasanth M K <dmoluguw@redhat.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the Lesser GNU General Public License as published by
@@ -928,7 +928,7 @@ class NSSDatabase(object):
                 logger.warning('certutil returned non-zero exit code (bug #1539996)')
 
             if output_format == 'base64':
-                cert_data = base64.b64encode(cert_data)
+                cert_data = base64.b64encode(cert_data).decode('utf-8')
             if output_text and not isinstance(cert_data, six.string_types):
                 cert_data = cert_data.decode('ascii')
 

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -595,10 +595,11 @@ class CASubsystem(PKISubsystem):
         attrs = entry[1]
 
         request = {}
-        request['id'] = attrs['cn'][0]
-        request['type'] = attrs['requestType'][0]
-        request['status'] = attrs['requestState'][0]
-        request['request'] = attrs['extdata-cert--005frequest'][0]
+        request['id'] = attrs['cn'][0].decode('utf-8')
+        request['type'] = attrs['requestType'][0].decode('utf-8')
+        request['status'] = attrs['requestState'][0].decode('utf-8')
+        request['request'] = attrs['extdata-cert--005frequest'][0]\
+            .decode('utf-8')
 
         return request
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1,5 +1,6 @@
 # Authors:
 #     Dinesh Prasanth M K <dmoluguw@redhat.com>
+#     Endi S. Dewata <edewata@redhat.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -699,7 +700,7 @@ class CertCreateCLI(pki.cli.CLI):
         ]
 
         logger.debug('Command: %s', ' '.join(ca_cert_retrieve_cmd))
-        ca_cert_details = subprocess.check_output(ca_cert_retrieve_cmd)
+        ca_cert_details = subprocess.check_output(ca_cert_retrieve_cmd).decode('utf-8')
 
         aki = re.search(r'Subject Key Identifier.*\n.*?(.*?)\n', ca_cert_details).group(1)
 

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -836,6 +836,8 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
                 nickname=subsystem_cert['nickname'],
                 cert_file=cert_file)
 
+        # Retrieve the cert info from NSSDB
+        # Note: This reloads `data` object if --cert option is provided
         data = nssdb.get_cert(
             nickname=subsystem_cert['nickname'],
             output_format='base64')


### PR DESCRIPTION
The subprocess command returns a 'byte string' instead of
the 'string' type. The output should be decoded using the
default "utf-8" type for common operations including (but not
limited to) updating of flat files like CS.cfg

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>