### PR TITLE
Offline cert renewal

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -102,7 +102,7 @@ class PKISubsystem(object):
             instance.conf_dir, 'Catalina', 'localhost', self.name + '.xml')
 
         self.config = {}
-        self.type = None    # e.g. CA, KRA
+        self.type = None  # e.g. CA, KRA
         self.prefix = None  # e.g. ca, kra
 
         # custom subsystem location
@@ -542,7 +542,7 @@ class PKISubsystem(object):
 
     def set_startup_tests(self, target_tests):
         # Remove unnecessary space, curly braces
-        self.config['selftests.container.order.startup'] = ", "\
+        self.config['selftests.container.order.startup'] = ", " \
             .join([(key + ':' + SELFTEST_CRITICAL if val else key)
                    for key, val in target_tests.items()])
 
@@ -561,6 +561,27 @@ class PKISubsystem(object):
         self.set_startup_tests(target_tests)
         # save the CS.cfg
         self.save()
+
+    def cert_del(self, cert_tag, remove_key=False):
+        """
+        Delete a cert from NSS db
+        :param cert_tag: Cert Tag
+        :param remove_key: Remove associate private key
+        """
+        cert = self.get_subsystem_cert(cert_tag)
+        nssdb = self.instance.open_nssdb()
+
+        try:
+            logger.debug('Removing %s certificate from NSS database for '
+                         'subsystem %s instance %s', cert_tag, self.name, self.instance)
+
+            nssdb.remove_cert(
+                nickname=cert['nickname'],
+                token=cert['token'],
+                remove_key=remove_key)
+
+        finally:
+            nssdb.close()
 
 
 class CASubsystem(PKISubsystem):
@@ -620,7 +641,7 @@ class CASubsystem(PKISubsystem):
         request['id'] = attrs['cn'][0].decode('utf-8')
         request['type'] = attrs['requestType'][0].decode('utf-8')
         request['status'] = attrs['requestState'][0].decode('utf-8')
-        request['request'] = attrs['extdata-cert--005frequest'][0]\
+        request['request'] = attrs['extdata-cert--005frequest'][0] \
             .decode('utf-8')
 
         return request
@@ -1065,17 +1086,6 @@ class PKIInstance(object):
 
         subprocess.check_call(cmd)
 
-    def cert_del(self, cert_id):
-
-        cmd = [
-            'pki-server', 'cert-del', '--instance', self.name
-        ]
-        if cert_id:
-            cmd.extend([cert_id])
-
-        logger.info('Executing CMD: %s', cmd)
-        subprocess.check_call(cmd)
-
 
 class PKIDatabaseConnection(object):
 
@@ -1109,11 +1119,9 @@ class PKIDatabaseConnection(object):
         self.temp_dir = tempfile.mkdtemp()
 
         if self.nssdb_dir:
-
             ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, self.nssdb_dir)
 
         if self.client_cert_nickname:
-
             password_file = os.path.join(self.temp_dir, 'password.txt')
             with open(password_file, 'w') as f:
                 f.write(self.nssdb_password)
@@ -1139,7 +1147,6 @@ class PKIServerException(pki.PKIException):
 
     def __init__(self, message, exception=None,
                  instance=None, subsystem=None):
-
         pki.PKIException.__init__(self, message, exception)
 
         self.instance = instance
@@ -1150,7 +1157,6 @@ class Tomcat(object):
 
     @classmethod
     def get_version(cls):
-
         # run "tomcat version"
         output = subprocess.check_output(['/usr/sbin/tomcat', 'version'])
         output = output.decode('utf-8')

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1008,7 +1008,7 @@ class PKIInstance(object):
     def set_self_test(self, status, subsystem):
 
         cmd = [
-                'pki-server'
+            'pki-server'
         ]
 
         if status:
@@ -1023,14 +1023,15 @@ class PKIInstance(object):
 
         subprocess.check_call(cmd)
 
-    def cert_create(self, cert_id, client_nssdb=None, client_nssdb_pass=None,
-                    client_nssdb_pass_file=None, admin_nick=None, temp=False):
+    def cert_create(self, cert_id, client_nssdb_location=None,
+                    client_nssdb_pass=None, client_nssdb_pass_file=None,
+                    client_cert=None, renew=False, temp=False):
         cmd = [
             'pki-server', 'cert-create', '--instance', self.name
         ]
 
-        if client_nssdb:
-            cmd.extend(['-d', client_nssdb])
+        if client_nssdb_location:
+            cmd.extend(['-d', client_nssdb_location])
 
         if client_nssdb_pass:
             cmd.extend(['-c', client_nssdb_pass])
@@ -1038,13 +1039,17 @@ class PKIInstance(object):
         if client_nssdb_pass_file:
             cmd.extend(['-C', client_nssdb_pass_file])
 
-        if admin_nick:
-            cmd.extend(['n', admin_nick])
+        if client_cert:
+            cmd.extend(['-n', client_cert])
 
         if cert_id:
             cmd.extend([cert_id])
+
         if temp:
             cmd.extend(['--temp'])
+
+        if renew:
+            cmd.extend(['--renew'])
 
         logger.info('Executing CMD: %s', cmd)
 
@@ -1061,7 +1066,18 @@ class PKIInstance(object):
         logger.info('Executing CMD: %s', cmd)
 
         subprocess.check_call(cmd)
-        
+
+    def cert_del(self, cert_id):
+
+        cmd = [
+            'pki-server', 'cert-del', '--instance', self.name
+        ]
+        if cert_id:
+            cmd.extend([cert_id])
+
+        logger.info('Executing CMD: %s', cmd)
+        subprocess.check_call(cmd)
+
 
 class PKIDatabaseConnection(object):
 

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1005,6 +1005,63 @@ class PKIInstance(object):
             return "Dogtag 9 " + self.name
         return self.name
 
+    def set_self_test(self, status, subsystem):
+
+        cmd = [
+                'pki-server'
+        ]
+
+        if status:
+            cmd.extend(['selftest-enable'])
+        else:
+            cmd.extend(['selftest-disable'])
+
+        if subsystem:
+            cmd.extend(['--subsystem', subsystem])
+
+        cmd.extend(['--instance', self.name])
+
+        subprocess.check_call(cmd)
+
+    def cert_create(self, cert_id, client_nssdb=None, client_nssdb_pass=None,
+                    client_nssdb_pass_file=None, admin_nick=None, temp=False):
+        cmd = [
+            'pki-server', 'cert-create', '--instance', self.name
+        ]
+
+        if client_nssdb:
+            cmd.extend(['-d', client_nssdb])
+
+        if client_nssdb_pass:
+            cmd.extend(['-c', client_nssdb_pass])
+
+        if client_nssdb_pass_file:
+            cmd.extend(['-C', client_nssdb_pass_file])
+
+        if admin_nick:
+            cmd.extend(['n', admin_nick])
+
+        if cert_id:
+            cmd.extend([cert_id])
+        if temp:
+            cmd.extend(['--temp'])
+
+        logger.info('Executing CMD: %s', cmd)
+
+        subprocess.check_call(cmd)
+
+    def cert_import(self, cert_id):
+
+        cmd = [
+            'pki-server', 'cert-import', '--instance', self.name
+        ]
+        if cert_id:
+            cmd.extend([cert_id])
+
+        logger.info('Executing CMD: %s', cmd)
+
+        subprocess.check_call(cmd)
+        
 
 class PKIDatabaseConnection(object):
 

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -763,8 +763,8 @@ class PKISubsystem(object):
             aki_ext=aki_ext,
             ext_key_usage_ext=ext_key_usage_ext)
         if rc:
-            raise Exception('Failed to generate CA-signed temp SSL certificate. '
-                            'RC: %d' % rc)
+            raise PKIServerException('Failed to generate CA-signed temp SSL '
+                                     'certificate. RC: %d' % rc)
 
     def setup_authentication(self, c_nssdb_pass, c_nssdb_pass_file, c_cert,
                              c_nssdb, tmpdir):
@@ -887,8 +887,8 @@ class PKISubsystem(object):
         with open(output, 'w') as f:
             f.write(new_cert_data.encoded)
 
-    def cert_create(self, cert_tag, c_cert, c_nssdb, c_nssdb_pass,
-                    c_nssdb_pass_file, serial=None, temp_cert=False, renew=False,
+    def cert_create(self, cert_tag, c_cert=None, c_nssdb=None, c_nssdb_pass=None,
+                    c_nssdb_pass_file=None, serial=None, temp_cert=False, renew=False,
                     output=None):
         """
         Create a new cert for the subsystem provided
@@ -930,7 +930,13 @@ class PKISubsystem(object):
                 # Create permanent certificate
                 if not renew:
                     # TODO: Support rekey
-                    raise Exception('Rekey is not supported yet.')
+                    raise PKIServerException('Rekey is not supported yet.')
+
+                if not c_cert:
+                    raise PKIServerException('Client cert nick name required.')
+
+                if not c_nssdb_pass or not c_nssdb_pass_file:
+                    raise PKIServerException('NSS db password required.')
 
                 connection = self.setup_authentication(c_nssdb_pass=c_nssdb_pass,
                                                        c_cert=c_cert,

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -546,6 +546,22 @@ class PKISubsystem(object):
             .join([(key + ':' + SELFTEST_CRITICAL if val else key)
                    for key, val in target_tests.items()])
 
+    def set_startup_test_critical(self, critical, test=None):
+
+        target_tests = self.get_startup_tests()
+        # Change the test level to critical
+        if test:
+            if test not in target_tests:
+                raise Exception('No such self test available for %s' % self.name)
+            target_tests[test] = critical
+        else:
+            for testID in target_tests:
+                target_tests[testID] = critical
+
+        self.set_startup_tests(target_tests)
+        # save the CS.cfg
+        self.save()
+
 
 class CASubsystem(PKISubsystem):
 
@@ -1004,24 +1020,6 @@ class PKIInstance(object):
         if self.type == 9:
             return "Dogtag 9 " + self.name
         return self.name
-
-    def set_self_test(self, status, subsystem):
-
-        cmd = [
-            'pki-server'
-        ]
-
-        if status:
-            cmd.extend(['selftest-enable'])
-        else:
-            cmd.extend(['selftest-disable'])
-
-        if subsystem:
-            cmd.extend(['--subsystem', subsystem])
-
-        cmd.extend(['--instance', self.name])
-
-        subprocess.check_call(cmd)
 
     def cert_create(self, cert_id, client_nssdb_location=None,
                     client_nssdb_pass=None, client_nssdb_pass_file=None,

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -648,6 +648,16 @@ class CertCreateCLI(pki.cli.CLI):
                                        subsystem=subsystem, new_cert_file=new_cert_file,
                                        connection=connection)
 
+            elif cert_tag == 'transport':
+                self.create_transport_cert(is_temp_cert=create_temp_cert, serial=serial,
+                                           subsystem=subsystem, new_cert_file=new_cert_file,
+                                           connection=connection)
+
+            elif cert_tag == 'storage':
+                self.create_storage_cert(is_temp_cert=create_temp_cert, serial=serial,
+                                         subsystem=subsystem, new_cert_file=new_cert_file,
+                                         connection=connection)
+
             else:
                 # renewal not yet supported
                 raise Exception('Renewal for %s not yet supported.' % cert_id)
@@ -855,6 +865,7 @@ class CertCreateCLI(pki.cli.CLI):
             self.renew_system_certificate(connection=connection,
                                           output=new_cert_file, serial=serial)
 
+    # TODO: Combine the following create_<name>_cert methods into generic method
     def create_ocsp_cert(self, subsystem, is_temp_cert, new_cert_file, serial, connection):
 
         if is_temp_cert:
@@ -862,6 +873,8 @@ class CertCreateCLI(pki.cli.CLI):
 
         else:
             cert_tag = 'ocsp_signing'
+            # if subsystem = OCSP, then reformat the cert_tag
+            # if susbsytem = CA, then cert_tag should remain the same
             if subsystem.name is 'ocsp':
                 cert_tag = 'signing'
 
@@ -900,6 +913,40 @@ class CertCreateCLI(pki.cli.CLI):
             if not serial:
                 # If serial number is not provided, get Serial Number from NSS db
                 serial = subsystem.get_subsystem_cert('audit_signing')["serial_number"]
+
+            logger.info('Renewing for certificate with serial number: %s', serial)
+
+            self.renew_system_certificate(connection=connection,
+                                          output=new_cert_file, serial=serial)
+
+    def create_transport_cert(self, subsystem, is_temp_cert, new_cert_file, serial,
+                              connection):
+
+        logger.info('Creating transport certificate')
+
+        if is_temp_cert:
+            raise Exception('Temp certificate for transport is not supported.')
+        else:
+            if not serial:
+                # If serial number is not provided, get Serial Number from NSS db
+                serial = subsystem.get_subsystem_cert('transport')["serial_number"]
+
+            logger.info('Renewing for certificate with serial number: %s', serial)
+
+            self.renew_system_certificate(connection=connection,
+                                          output=new_cert_file, serial=serial)
+
+    def create_storage_cert(self, subsystem, is_temp_cert, new_cert_file, serial,
+                              connection):
+
+        logger.info('Creating storage certificate')
+
+        if is_temp_cert:
+            raise Exception('Temp certificate for storage is not supported.')
+        else:
+            if not serial:
+                # If serial number is not provided, get Serial Number from NSS db
+                serial = subsystem.get_subsystem_cert('storage')["serial_number"]
 
             logger.info('Renewing for certificate with serial number: %s', serial)
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -27,15 +27,10 @@ import getopt
 import getpass
 import logging
 import os
-import re
-import shutil
-import subprocess
 import sys
-import tempfile
 
 import pki.cli
 import pki.server as server
-import pki.client as client
 import pki.cert
 import pki.nssdb
 
@@ -489,34 +484,33 @@ class CertCreateCLI(pki.cli.CLI):
             sys.exit(1)
 
         instance_name = 'pki-tomcat'
-        create_temp_cert = False
+        temp_cert = False
         serial = None
-        client_nssdb_location = os.getenv('HOME') + '/.dogtag/nssdb'
-        client_nssdb_password = None
-        client_nssdb_pass_file = None
-        client_cert = None
+        c_nssdb = os.getenv('HOME') + '/.dogtag/nssdb'
+        c_nssdb_password = None
+        c_nssdb_pass_file = None
+        c_cert = None
         output = None
         renew = False
-        connection = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
                 instance_name = a
 
             elif o == '-d':
-                client_nssdb_location = a
+                c_nssdb = a
 
             elif o == '-c':
-                client_nssdb_password = a
+                c_nssdb_password = a
 
             elif o == '-C':
-                client_nssdb_pass_file = a
+                c_nssdb_pass_file = a
 
             elif o == '-n':
-                client_cert = a
+                c_cert = a
 
             elif o == '--temp':
-                create_temp_cert = True
+                temp_cert = True
 
             elif o == '--serial':
                 # string containing the dec or hex value for the identifier
@@ -551,9 +545,9 @@ class CertCreateCLI(pki.cli.CLI):
             self.print_help()
             sys.exit(1)
 
-        if not create_temp_cert:
+        if not temp_cert:
             # For permanent certificate, password of NSS db is required.
-            if not client_nssdb_password and not client_nssdb_pass_file:
+            if not c_nssdb_password and not c_nssdb_pass_file:
                 logger.error('NSS database password is required.')
                 self.print_help()
                 sys.exit(1)
@@ -569,9 +563,6 @@ class CertCreateCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name = None
-        cert_tag = cert_id
-
         subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
@@ -586,361 +577,8 @@ class CertCreateCLI(pki.cli.CLI):
                 subsystem_name, instance_name)
             sys.exit(1)
 
-        nssdb = instance.open_nssdb()
-        tmpdir = tempfile.mkdtemp()
-        try:
-            cert_folder = os.path.join(pki.CONF_DIR, instance_name, 'certs')
-            if not os.path.exists(cert_folder):
-                os.makedirs(cert_folder)
-            new_cert_file = os.path.join(cert_folder, cert_id + '.crt')
-
-            if output:
-                new_cert_file = output
-
-            if create_temp_cert:
-                if not serial:
-                    # If admin doesn't provide a serial number, set the serial to
-                    # the same serial number available in the nssdb
-                    serial = subsystem.get_subsystem_cert('sslserver')["serial_number"]
-
-            else:
-                # Create permanent certificate
-                if not renew:
-                    # Fixme: Support rekey
-                    raise Exception('Rekey is not supported yet.')
-
-                connection = self.setup_authentication(c_nssdb_pass=client_nssdb_password,
-                                                       c_cert=client_cert,
-                                                       c_nssdb_pass_file=client_nssdb_pass_file,
-                                                       c_nssdb=client_nssdb_location,
-                                                       tmpdir=tmpdir)
-
-            if cert_tag == 'sslserver':
-                self.create_ssl_cert(instance=instance, subsystem=subsystem,
-                                     is_temp_cert=create_temp_cert,
-                                     new_cert_file=new_cert_file, nssdb=nssdb, serial=serial,
-                                     tmpdir=tmpdir, connection=connection)
-
-            elif cert_tag == 'subsystem':
-                self.create_subsystem_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                           subsystem=subsystem, new_cert_file=new_cert_file,
-                                           connection=connection)
-
-            elif cert_id in ['ca_ocsp_signing', 'ocsp_signing']:
-                self.create_ocsp_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                      subsystem=subsystem, new_cert_file=new_cert_file,
-                                      connection=connection)
-
-            elif cert_tag == 'audit_signing':
-                self.create_audit_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                       subsystem=subsystem, new_cert_file=new_cert_file,
-                                       connection=connection)
-
-            elif cert_tag == 'transport':
-                self.create_transport_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                           subsystem=subsystem, new_cert_file=new_cert_file,
-                                           connection=connection)
-
-            elif cert_tag == 'storage':
-                self.create_storage_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                         subsystem=subsystem, new_cert_file=new_cert_file,
-                                         connection=connection)
-
-            else:
-                # renewal not yet supported
-                raise Exception('Renewal for %s not yet supported.' % cert_id)
-
-        finally:
-            nssdb.close()
-            shutil.rmtree(tmpdir)
-
-    @staticmethod
-    def setup_temp_renewal(instance, subsystem, tmpdir, cert_id):
-
-        csr_file = os.path.join(tmpdir, cert_id + '.csr')
-        ca_cert_file = os.path.join(tmpdir, 'ca_certificate.crt')
-
-        logger.debug('Exporting CSR for %s cert', cert_id)
-
-        cert_request = subsystem.get_subsystem_cert(cert_id).get('request', None)
-        if cert_request is None:
-            logger.error('Unable to find CSR for %s cert', cert_id)
-            sys.exit(1)
-
-        csr_data = pki.nssdb.convert_csr(cert_request, 'base64', 'pem')
-        with open(csr_file, 'w') as f:
-            f.write(csr_data)
-
-        logger.debug('Extracting SKI from CA cert')
-        # TODO: Support remote CA.
-
-        ca_signing_cert = instance.get_subsystem('ca').get_subsystem_cert('signing')
-        ca_cert_data = ca_signing_cert.get('data', None)
-        if ca_cert_data is None:
-            logger.error('Unable to find certificate data for CA signing certificate.')
-            sys.exit(1)
-
-        ca_cert = pki.nssdb.convert_cert(ca_cert_data, 'base64', 'pem')
-        with open(ca_cert_file, 'w') as f:
-            f.write(ca_cert)
-
-        ca_cert_retrieve_cmd = [
-            'openssl',
-            'x509',
-            '-in', ca_cert_file,
-            '-noout',
-            '-text'
-        ]
-
-        logger.debug('Command: %s', ' '.join(ca_cert_retrieve_cmd))
-        ca_cert_details = subprocess.check_output(ca_cert_retrieve_cmd).decode('utf-8')
-
-        aki = re.search(r'Subject Key Identifier.*\n.*?(.*?)\n', ca_cert_details).group(1)
-
-        # Add 0x to represent this is a Hex
-        aki = '0x' + aki.strip().replace(':', '')
-        logger.debug('AKI: %s', aki)
-
-        return ca_signing_cert, aki, csr_file
-
-    def setup_authentication(self, c_nssdb_pass, c_nssdb_pass_file, c_cert,
-                             c_nssdb, tmpdir):
-        temp_auth_p12 = os.path.join(tmpdir, 'auth.p12')
-        temp_auth_cert = os.path.join(tmpdir, 'auth.pem')
-
-        if not c_cert:
-            logger.error('Client cert nickname is required.')
-            self.print_help()
-            sys.exit(1)
-
-        # Create a PKIConnection object that stores the details of subsystem.
-        # Note: Renewal requests can be submitted only to 'ca'
-        connection = client.PKIConnection('https', os.environ['HOSTNAME'], '8443', 'ca')
-
-        # Create a p12 file using
-        # pk12util -o <p12 file name> -n <cert nick name> -d <NSS db path>
-        # -W <pkcs12 password> -K <NSS db pass>
-        cmd_generate_pk12 = [
-            'pk12util',
-            '-o', temp_auth_p12,
-            '-n', c_cert,
-            '-d', c_nssdb
-        ]
-
-        # The pem file used for authentication. Created from a p12 file using the
-        # command:
-        # openssl pkcs12 -in <p12_file_path> -out /tmp/auth.pem -nodes
-        cmd_generate_pem = [
-            'openssl',
-            'pkcs12',
-            '-in', temp_auth_p12,
-            '-out', temp_auth_cert,
-            '-nodes',
-
-        ]
-
-        if c_nssdb_pass_file:
-            # Use the same password file for the generated pk12 file
-            cmd_generate_pk12.extend(['-k', c_nssdb_pass_file,
-                                      '-w', c_nssdb_pass_file])
-            cmd_generate_pem.extend(['-passin', 'file:' + c_nssdb_pass_file])
-        else:
-            # Use the same password for the generated pk12 file
-            cmd_generate_pk12.extend(['-K', c_nssdb_pass,
-                                      '-W', c_nssdb_pass])
-            cmd_generate_pem.extend(['-passin', 'pass:' + c_nssdb_pass])
-
-        res_pk12 = subprocess.check_output(cmd_generate_pk12, stderr=subprocess.STDOUT)
-        logger.info(res_pk12)
-
-        res_pem = subprocess.check_output(cmd_generate_pem, stderr=subprocess.STDOUT)
-        logger.info(res_pem)
-
-        # Bind the authentication with the connection object
-        connection.set_authentication_cert(temp_auth_cert)
-
-        return connection
-
-    def renew_system_certificate(self, connection,
-                                 output, serial):
-
-        # Instantiate the CertClient
-        cert_client = pki.cert.CertClient(connection)
-
-        inputs = dict()
-        inputs['serial_num'] = serial
-
-        # request: CertRequestInfo object for request generated.
-        # cert: CertData object for certificate generated (if any)
-        ret = cert_client.enroll_cert(inputs=inputs, profile_id='caManualRenewal')
-
-        request_data = ret[0].request
-        cert_data = ret[0].cert
-
-        logger.info('Request ID: %s', request_data.request_id)
-        logger.info('Request Status: %s', request_data.request_status)
-
-        if not cert_data:
-            raise Exception('Unable to renew system certificate for serial: %s' % serial)
-
-        # store cert_id for usage later
-        cert_id = cert_data.serial_number
-        if not cert_id:
-            raise Exception('Unable to retrieve serial number of renewed certificate.')
-
-        logger.info('Serial Number: %s', cert_id)
-        logger.info('Issuer: %s', cert_data.issuer_dn)
-        logger.info('Subject: %s', cert_data.subject_dn)
-        logger.info('Pretty Print:')
-        logger.info(cert_data.pretty_repr)
-
-        new_cert_data = cert_client.get_cert(cert_serial_number=cert_id)
-        with open(output, 'w') as f:
-            f.write(new_cert_data.encoded)
-
-    def create_ssl_cert(self, instance, subsystem, serial, is_temp_cert, tmpdir,
-                        new_cert_file, nssdb, connection):
-
-        logger.info('Creating SSL server certificate.')
-
-        if is_temp_cert:
-
-            logger.info('Generate temp SSL certificate')
-
-            ca_signing_cert, aki, csr_file = self.setup_temp_renewal(
-                instance=instance, subsystem=subsystem, tmpdir=tmpdir, cert_id='sslserver')
-
-            # --keyUsage
-            key_usage_ext = {
-                'digitalSignature': True,
-                'nonRepudiation': True,
-                'keyEncipherment': True,
-                'dataEncipherment': True,
-                'critical': True
-            }
-
-            # -3
-            aki_ext = {
-                'auth_key_id': aki
-            }
-
-            # --extKeyUsage
-            ext_key_usage_ext = {
-                'serverAuth': True
-            }
-
-            rc = nssdb.create_cert(
-                issuer=ca_signing_cert['nickname'],
-                request_file=csr_file,
-                cert_file=new_cert_file,
-                serial=serial,
-                key_usage_ext=key_usage_ext,
-                aki_ext=aki_ext,
-                ext_key_usage_ext=ext_key_usage_ext)
-            if rc:
-                raise Exception('Failed to generate CA-signed temp SSL certificate. '
-                                'RC: %d' % rc)
-
-        else:
-
-            logger.info('Renewing SSL certificate')
-
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('sslserver')["serial_number"]
-
-            logger.info('Serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    # TODO: Combine the following create_<name>_cert methods into generic method
-    def create_ocsp_cert(self, subsystem, is_temp_cert, new_cert_file, serial, connection):
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for OCSP is not supported.')
-
-        else:
-            cert_tag = 'ocsp_signing'
-            # if subsystem = OCSP, then reformat the cert_tag
-            # if susbsytem = CA, then cert_tag should remain the same
-            if subsystem.name == 'ocsp':
-                cert_tag = 'signing'
-
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert(cert_tag)["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    def create_subsystem_cert(self, subsystem, is_temp_cert, new_cert_file, serial,
-                              connection):
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for subsystem is not supported.')
-
-        else:
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('subsystem')["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    def create_audit_cert(self, subsystem, is_temp_cert, new_cert_file, serial, connection):
-
-        logger.info('Creating audit certificate')
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for audit signing is not supported.')
-        else:
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('audit_signing')["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    def create_transport_cert(self, subsystem, is_temp_cert, new_cert_file, serial,
-                              connection):
-
-        logger.info('Creating transport certificate')
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for transport is not supported.')
-        else:
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('transport')["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    def create_storage_cert(self, subsystem, is_temp_cert, new_cert_file, serial,
-                              connection):
-
-        logger.info('Creating storage certificate')
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for storage is not supported.')
-        else:
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('storage')["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
+        subsystem.cert_create(cert_tag, c_cert, c_nssdb, c_nssdb_password,
+                              c_nssdb_pass_file, serial, temp_cert, renew, output)
 
 
 class CertImportCLI(pki.cli.CLI):
@@ -1058,7 +696,8 @@ class CertExportCLI(pki.cli.CLI):
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
         print('      --cert-file <path>             Output file to store the exported certificate in PEM format.')
         print('      --csr-file <path>              Output file to store the exported CSR in PEM format.')
-        print('      --pkcs12-file <path>           Output file to store the exported certificate and key in PKCS #12 format.')
+        print(
+            '      --pkcs12-file <path>           Output file to store the exported certificate and key in PKCS #12 format.')
         print('      --pkcs12-password <password>   Password for the PKCS #12 file.')
         print('      --pkcs12-password-file <path>  Input file containing the password for the PKCS #12 file.')
         print('      --friendly-name <name>         Friendly name for the certificate in PKCS #12 file.')
@@ -1224,7 +863,7 @@ class CertExportCLI(pki.cli.CLI):
                 token = None
 
             else:
-                nickname = full_name[i+1:]
+                nickname = full_name[i + 1:]
                 token = full_name[:i]
 
         else:
@@ -1490,7 +1129,8 @@ class CertFixCLI(pki.cli.CLI):
                 # Retrieve the subsystem's system certificate
                 certs = subsystem.find_system_certs()
 
-                # Iterate on all subsystem's system certificate to prepend subsystem name to the ID
+                # Iterate on all subsystem's system certificate to prepend
+                # subsystem name to the ID
                 for cert in certs:
                     if cert['id'] != 'sslserver' and cert['id'] != 'subsystem':
                         cert['id'] = subsystem.name + '_' + cert['id']
@@ -1544,7 +1184,7 @@ class CertFixCLI(pki.cli.CLI):
                 str(x.name) for x in target_subsys))
 
             # 4a. Create temp SSL cert
-            instance.cert_create(cert_id='sslserver', temp=True)
+            target_subsys[0].cert_create(cert_id='sslserver', temp=True)
 
             # 4b. Load the first subsystem from target_sys (since sslserver is used
             #     by ALL subsystems) and Delete the existing SSL Cert
@@ -1561,11 +1201,18 @@ class CertFixCLI(pki.cli.CLI):
 
             # 6. Place renewal request for all certs in fix_certs
             for cert_id in fix_certs:
-                instance.cert_create(cert_id=cert_id,
-                                     client_nssdb_location=client_nssdb_location,
-                                     client_nssdb_pass=client_nssdb_password,
-                                     client_nssdb_pass_file=client_nssdb_pass_file,
-                                     client_cert=client_cert, renew=True)
+                subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
+
+                # If cert ID is instance specific, get it from first subsystem
+                if not subsystem_name:
+                    subsystem_name = instance.subsystems[0].name
+
+                subsystem = instance.get_subsystem(subsystem_name)
+                subsystem.cert_create(cert_id=cert_id,
+                                      client_nssdb_location=client_nssdb_location,
+                                      client_nssdb_pass=client_nssdb_password,
+                                      client_nssdb_pass_file=client_nssdb_pass_file,
+                                      client_cert=client_cert, renew=True)
 
             # 7. Stop the server
             instance.stop()

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -610,16 +610,9 @@ class CertCreateCLI(pki.cli.CLI):
 
             if create_temp_cert:
                 if not serial:
-                    # If admin doesn't provide a serial number, find the highest in NSS db
-                    # and add 1 to it
-                    serial = 0
-                    for sub in instance.subsystems:
-                        for n_cert in sub.find_system_certs():
-                            if int(n_cert['serial_number']) > serial:
-                                serial = int(n_cert['serial_number'])
-
-                    # Add 1 and then rewrap it as a string
-                    serial = str(serial + 1)
+                    # If admin doesn't provide a serial number, set the serial to
+                    # the same serial number available in the nssdb
+                    serial = subsystem.get_subsystem_cert('sslserver')["serial_number"]
 
             else:
                 # Create permanent certificate

--- a/base/server/python/pki/server/cli/selftest.py
+++ b/base/server/python/pki/server/cli/selftest.py
@@ -35,33 +35,6 @@ class SelfTestCLI(pki.cli.CLI):
         self.add_module(EnableSelfTestCLI())
         self.add_module(DisableSelftestCLI())
 
-    @staticmethod
-    def set_startup_test_critical(instance, subsystem, test, critical=False):
-
-        target_subsystems = []
-
-        # Load subsystem or subsystems
-        if not subsystem:
-            for subsys in instance.subsystems:
-                target_subsystems.append(subsys)
-        else:
-            target_subsystems.append(instance.get_subsystem(subsystem))
-
-        for subsys in target_subsystems:
-            target_tests = subsys.get_startup_tests()
-            # Change the test level to critical
-            if test:
-                if test not in target_tests:
-                    raise Exception('No such self test available for %s' % subsystem)
-                target_tests[test] = critical
-            else:
-                for testID in target_tests:
-                    target_tests[testID] = critical
-
-            subsys.set_startup_tests(target_tests)
-            # save the CS.cfg
-            subsys.save()
-
 
 class EnableSelfTestCLI(pki.cli.CLI):
     def __init__(self):
@@ -119,8 +92,17 @@ class EnableSelfTestCLI(pki.cli.CLI):
 
         instance.load()
 
-        SelfTestCLI.set_startup_test_critical(instance=instance,
-                                              subsystem=subsystem, test=test, critical=True)
+        target_subsystems = []
+
+        # Load subsystem or subsystems
+        if not subsystem:
+            for subsys in instance.subsystems:
+                target_subsystems.append(subsys)
+        else:
+            target_subsystems.append(instance.get_subsystem(subsystem))
+
+        for subsys in target_subsystems:
+            subsys.set_startup_test_critical(test=test, critical=True)
 
 
 class DisableSelftestCLI(pki.cli.CLI):
@@ -179,5 +161,14 @@ class DisableSelftestCLI(pki.cli.CLI):
 
         instance.load()
 
-        SelfTestCLI.set_startup_test_critical(instance=instance,
-                                              subsystem=subsystem, test=test)
+        target_subsystems = []
+
+        # Load subsystem or subsystems
+        if not subsystem:
+            for subsys in instance.subsystems:
+                target_subsystems.append(subsys)
+        else:
+            target_subsystems.append(instance.get_subsystem(subsystem))
+
+        for subsys in target_subsystems:
+            subsys.set_startup_test_critical(test=test, critical=False)


### PR DESCRIPTION
This patch adds the `cert-fix` module which can be used to renew
all expired certificates. The `cert-fix` module is built as a high level
CLI on top of existing `cert` module components.

Ticket: https://pagure.io/dogtagpki/issue/2776

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>