### PR TITLE
Splitting cert and key IDs in PKCS12Util

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/pkcs12/PKCS12CertCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs12/PKCS12CertCLI.java
@@ -56,6 +56,10 @@ public class PKCS12CertCLI extends CLI {
             System.out.println("  Trust Flags: " + certInfo.getTrustFlags());
         }
 
-        System.out.println("  Has Key: " + (pkcs12.getKeyInfoByID(id) != null));
+        byte[] keyID = certInfo.getKeyID();
+        System.out.println("  Has Key: " + (keyID != null));
+        if (keyID != null) {
+            System.out.println("  Key ID: " + Hex.encodeHexString(keyID));
+        }
     }
 }

--- a/base/util/src/netscape/security/pkcs/PKCS12.java
+++ b/base/util/src/netscape/security/pkcs/PKCS12.java
@@ -143,6 +143,7 @@ public class PKCS12 {
     Map<BigInteger, PKCS12KeyInfo> keyInfosByID = new LinkedHashMap<BigInteger, PKCS12KeyInfo>();
 
     Map<BigInteger, PKCS12CertInfo> certInfosByID = new LinkedHashMap<BigInteger, PKCS12CertInfo>();
+    Map<BigInteger, PKCS12CertInfo> certInfosByKeyID = new LinkedHashMap<BigInteger, PKCS12CertInfo>();
 
     public PKCS12() {
     }
@@ -174,10 +175,19 @@ public class PKCS12 {
             return;
 
         certInfosByID.put(id, certInfo);
+
+        byte[] keyID = certInfo.getKeyID();
+        if (keyID == null) return;
+
+        certInfosByKeyID.put(new BigInteger(1, keyID), certInfo);
     }
 
     public PKCS12CertInfo getCertInfoByID(byte[] id) {
         return certInfosByID.get(new BigInteger(1, id));
+    }
+
+    public PKCS12CertInfo getCertInfoByKeyID(byte[] keyID) {
+        return certInfosByKeyID.get(new BigInteger(1, keyID));
     }
 
     public Collection<PKCS12CertInfo> getCertInfosByFriendlyName(String friendlyName) {
@@ -201,9 +211,15 @@ public class PKCS12 {
         }
 
         for (PKCS12CertInfo certInfo : result) {
+
             BigInteger id = new BigInteger(1, certInfo.getID());
             certInfosByID.remove(id);
-            keyInfosByID.remove(id);
+
+            byte[] keyID = certInfo.getKeyID();
+            if (keyID == null) continue;
+
+            certInfosByKeyID.remove(new BigInteger(1, keyID));
+            keyInfosByID.remove(new BigInteger(1, keyID));
         }
     }
 }

--- a/base/util/src/netscape/security/pkcs/PKCS12CertInfo.java
+++ b/base/util/src/netscape/security/pkcs/PKCS12CertInfo.java
@@ -25,6 +25,7 @@ public class PKCS12CertInfo {
     private X509CertImpl cert;
     private String friendlyName;
     private String trustFlags;
+    private byte[] keyID;
 
     public PKCS12CertInfo() {
     }
@@ -59,5 +60,13 @@ public class PKCS12CertInfo {
 
     public void setTrustFlags(String trustFlags) {
         this.trustFlags = trustFlags;
+    }
+
+    public byte[] getKeyID() {
+        return keyID;
+    }
+
+    public void setKeyID(byte[] keyID) {
+        this.keyID = keyID;
     }
 }


### PR DESCRIPTION
Previously PKCS12Util used the same ID to link a cert to its key
in the PKCS #12 file that it generated. This could become a problem
if there are multiple certs using the same key or if there are keys
without certs in the PKCS #12 file.

To solve the issue, a separated key ID field has been added into
PKCSCertInfo which will be used to link the cert to its key. The
cert ID will contain the SHA-1 hash of the certificate and the key
ID will contain the NSS key ID.