### PR TITLE
Fixes password leak of Auth plugins to Audit Logs (#57) [Cherry-Pick]

### DIFF
--- a/base/common/src/com/netscape/certsrv/apps/CMS.java
+++ b/base/common/src/com/netscape/certsrv/apps/CMS.java
@@ -1562,4 +1562,34 @@ public final class CMS {
     public static boolean isExcludedLdapAttr(String key) {
         return _engine.isExcludedLdapAttr(key);
     }
+
+    /**
+     * Check whether the string is contains password
+     *
+     * @param name key string
+     * @return whether key is a password or not
+     */
+    public static boolean isSensitive(String name) {
+        return (name.startsWith("__") ||
+                name.endsWith("password") ||
+                name.endsWith("passwd") ||
+                name.endsWith("pwd") ||
+                name.equalsIgnoreCase("admin_password_again") ||
+                name.equalsIgnoreCase("directoryManagerPwd") ||
+                name.equalsIgnoreCase("bindpassword") ||
+                name.equalsIgnoreCase("bindpwd") ||
+                name.equalsIgnoreCase("passwd") ||
+                name.equalsIgnoreCase("password") ||
+                name.equalsIgnoreCase("pin") ||
+                name.equalsIgnoreCase("pwd") ||
+                name.equalsIgnoreCase("pwdagain") ||
+                name.equalsIgnoreCase("uPasswd") ||
+                name.equalsIgnoreCase("PASSWORD_CACHE_ADD") ||
+                name.startsWith("p12Password") ||
+                name.equalsIgnoreCase("host_challenge") ||
+                name.equalsIgnoreCase("card_challenge") ||
+                name.equalsIgnoreCase("card_cryptogram") ||
+                name.equalsIgnoreCase("drm_trans_desKey") ||
+                name.equalsIgnoreCase("cert_request"));
+    }
 }

--- a/base/server/cms/src/com/netscape/cms/servlet/admin/AdminServlet.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/admin/AdminServlet.java
@@ -203,21 +203,7 @@ public class AdminServlet extends HttpServlet {
             // __ (double underscores); however, in the event that
             // a security parameter slips through, we perform multiple
             // additional checks to insure that it is NOT displayed
-            if (pn.startsWith("__") ||
-                    pn.endsWith("password") ||
-                    pn.endsWith("passwd") ||
-                    pn.endsWith("pwd") ||
-                    pn.equalsIgnoreCase("admin_password_again") ||
-                    pn.equalsIgnoreCase("directoryManagerPwd") ||
-                    pn.equalsIgnoreCase("bindpassword") ||
-                    pn.equalsIgnoreCase("bindpwd") ||
-                    pn.equalsIgnoreCase("passwd") ||
-                    pn.equalsIgnoreCase("password") ||
-                    pn.equalsIgnoreCase("pin") ||
-                    pn.equalsIgnoreCase("pwd") ||
-                    pn.equalsIgnoreCase("pwdagain") ||
-                    pn.equalsIgnoreCase("uPasswd") ||
-                    pn.equalsIgnoreCase("PASSWORD_CACHE_ADD")) {
+            if (CMS.isSensitive(pn)) {
                 CMS.debug("AdminServlet::service() param name='" + pn +
                         "' value='(sensitive)'");
             } else {
@@ -992,7 +978,7 @@ public class AdminServlet extends HttpServlet {
             if (name.equals(Constants.RS_ID)) continue;
 
             String value = null;
-            if (name.equalsIgnoreCase("PASSWORD_CACHE_ADD"))
+            if (CMS.isSensitive(name))
                 value = "(sensitive)";
             else
                 value = req.getParameter(name);

--- a/base/server/cms/src/com/netscape/cms/servlet/base/CMSServlet.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/base/CMSServlet.java
@@ -403,26 +403,7 @@ public abstract class CMSServlet extends HttpServlet {
             // __ (double underscores); however, in the event that
             // a security parameter slips through, we perform multiple
             // additional checks to insure that it is NOT displayed
-            if (pn.startsWith("__") ||
-                    pn.endsWith("password") ||
-                    pn.endsWith("passwd") ||
-                    pn.endsWith("pwd") ||
-                    pn.equalsIgnoreCase("admin_password_again") ||
-                    pn.equalsIgnoreCase("directoryManagerPwd") ||
-                    pn.equalsIgnoreCase("bindpassword") ||
-                    pn.equalsIgnoreCase("bindpwd") ||
-                    pn.equalsIgnoreCase("passwd") ||
-                    pn.equalsIgnoreCase("password") ||
-                    pn.equalsIgnoreCase("pin") ||
-                    pn.equalsIgnoreCase("pwd") ||
-                    pn.equalsIgnoreCase("pwdagain") ||
-                    pn.startsWith("p12Password") ||
-                    pn.equalsIgnoreCase("uPasswd") ||
-                    pn.equalsIgnoreCase("host_challenge") ||
-                    pn.equalsIgnoreCase("card_challenge") ||
-                    pn.equalsIgnoreCase("card_cryptogram") ||
-                    pn.equalsIgnoreCase("drm_trans_desKey") ||
-                    pn.equalsIgnoreCase("cert_request")) {
+            if (CMS.isSensitive(pn)) {
                 CMS.debug("CMSServlet::service() param name='" + pn +
                         "' value='(sensitive)'");
             } else {

--- a/base/server/cms/src/com/netscape/cms/servlet/csadmin/BaseServlet.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/csadmin/BaseServlet.java
@@ -70,20 +70,7 @@ public class BaseServlet extends VelocityServlet {
             // __ (double underscores); however, in the event that
             // a security parameter slips through, we perform multiple
             // additional checks to insure that it is NOT displayed
-            if (pn.startsWith("__") ||
-                    pn.endsWith("password") ||
-                    pn.endsWith("passwd") ||
-                    pn.endsWith("pwd") ||
-                    pn.equalsIgnoreCase("admin_password_again") ||
-                    pn.equalsIgnoreCase("directoryManagerPwd") ||
-                    pn.equalsIgnoreCase("bindpassword") ||
-                    pn.equalsIgnoreCase("bindpwd") ||
-                    pn.equalsIgnoreCase("passwd") ||
-                    pn.equalsIgnoreCase("password") ||
-                    pn.equalsIgnoreCase("pin") ||
-                    pn.equalsIgnoreCase("pwd") ||
-                    pn.equalsIgnoreCase("pwdagain") ||
-                    pn.equalsIgnoreCase("uPasswd")) {
+            if (CMS.isSensitive(pn)) {
                 CMS.debug("BaseServlet::service() param name='" + pn +
                          "' value='(sensitive)'");
             } else {

--- a/base/server/cms/src/com/netscape/cms/servlet/processors/CAProcessor.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/processors/CAProcessor.java
@@ -258,21 +258,7 @@ public class CAProcessor extends Processor {
             // __ (double underscores); however, in the event that
             // a security parameter slips through, we perform multiple
             // additional checks to insure that it is NOT displayed
-            if (paramName.startsWith("__") ||
-                    paramName.endsWith("password") ||
-                    paramName.endsWith("passwd") ||
-                    paramName.endsWith("pwd") ||
-                    paramName.equalsIgnoreCase("admin_password_again") ||
-                    paramName.equalsIgnoreCase("directoryManagerPwd") ||
-                    paramName.equalsIgnoreCase("bindpassword") ||
-                    paramName.equalsIgnoreCase("bindpwd") ||
-                    paramName.equalsIgnoreCase("passwd") ||
-                    paramName.equalsIgnoreCase("password") ||
-                    paramName.equalsIgnoreCase("pin") ||
-                    paramName.equalsIgnoreCase("pwd") ||
-                    paramName.equalsIgnoreCase("pwdagain") ||
-                    paramName.equalsIgnoreCase("uPasswd") ||
-                    paramName.equalsIgnoreCase("cert_request")) {
+            if (CMS.isSensitive(paramName)) {
                 CMS.debug("CAProcessor: - " + paramName + ": (sensitive)");
             } else {
                 CMS.debug("CAProcessor: - " + paramName + ": " + entry.getValue());

--- a/base/server/cms/src/com/netscape/cms/servlet/profile/ProfileSubmitCMCServlet.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/profile/ProfileSubmitCMCServlet.java
@@ -306,20 +306,7 @@ public class ProfileSubmitCMCServlet extends ProfileServlet {
                 // __ (double underscores); however, in the event that
                 // a security parameter slips through, we perform multiple
                 // additional checks to insure that it is NOT displayed
-                if (paramName.startsWith("__") ||
-                        paramName.endsWith("password") ||
-                        paramName.endsWith("passwd") ||
-                        paramName.endsWith("pwd") ||
-                        paramName.equalsIgnoreCase("admin_password_again") ||
-                        paramName.equalsIgnoreCase("directoryManagerPwd") ||
-                        paramName.equalsIgnoreCase("bindpassword") ||
-                        paramName.equalsIgnoreCase("bindpwd") ||
-                        paramName.equalsIgnoreCase("passwd") ||
-                        paramName.equalsIgnoreCase("password") ||
-                        paramName.equalsIgnoreCase("pin") ||
-                        paramName.equalsIgnoreCase("pwd") ||
-                        paramName.equalsIgnoreCase("pwdagain") ||
-                        paramName.equalsIgnoreCase("uPasswd")) {
+                if (CMS.isSensitive(paramName)) {
                     CMS.debug("ProfileSubmitCMCServlet Input Parameter " +
                               paramName + "='(sensitive)'");
                 } else {


### PR DESCRIPTION
* Auth plugin adds `(sensitive)` instead of plain passwords to AuditLogs
* Added generic `isSensitive()` to identify Passwords before logging

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>