### PR TITLE
Warning Updates + Documentation

### DIFF
--- a/base/server/cms/src/com/netscape/cms/servlet/csadmin/ReplicationUtil.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/csadmin/ReplicationUtil.java
@@ -142,8 +142,10 @@ public class ReplicationUtil {
 
             String status = replicationStatus(replicadn, masterConn, masterAgreementName);
             if (!(status.startsWith("Error (0) ") || status.startsWith("0 "))) {
-                logger.error("ReplicationUtil: replication consumer initialization failed: " + status);
-                throw new IOException("Replication consumer initialization failed: " + status);
+                String message = "ReplicationUtil: replication consumer initialization failed " +
+                    "(against " + masterConn.getHost() + ":" + masterConn.getPort() + "): " + status;
+                logger.error(message);
+                throw new IOException(message);
             }
 
             // remove master ldap password from password.conf (if present)

--- a/base/server/cmscore/src/com/netscape/cmscore/ldapconn/LdapAnonConnFactory.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/ldapconn/LdapAnonConnFactory.java
@@ -206,7 +206,9 @@ public class LdapAnonConnFactory implements ILdapConnFactory {
                 }
             } else {
                 log(ILogger.LL_FAILURE,
-                        "Cannot connect to ldap server. error: " + e.toString());
+                        "Cannot connect to ldap server (" + mConnInfo.getHost() +
+				":" + mConnInfo.getPort() + "). " +
+				"error: " + e.toString());
                 String errmsg = e.errorCodeToString();
 
                 if (errmsg == null)

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -733,7 +733,8 @@ def check_ds(parser):
                 sys.exit(1)
 
     except ldap.LDAPError as e:
-        print('ERROR:  Unable to access directory server: ' +
+        server = parser.protocol + '://' + parser.hostname + ':' + parser.port
+        print('ERROR:  Unable to access directory server (' + server + '): ' +
               e.args[0]['desc'])
         sys.exit(1)
 

--- a/docs/installation/Installing_CA.md
+++ b/docs/installation/Installing_CA.md
@@ -6,6 +6,18 @@ Overview
 
 This page describes the process to install a CA subsystem with a self-signed CA signing certificate.
 
+Before beginning with the installation, please ensure that you have configured the directory
+server and added base entries. This step is described [here](http://www.dogtagpki.org/wiki/Installing_DS).
+
+Additionally, please verify that your FQDN is correctly reported by the following command:
+
+    python -c 'import socket; print(socket.getfqdn())'
+
+If it isn't, please add an entry at the beginning of the `/etc/hosts` file:
+
+    127.0.0.1 server.example.com
+    ::1 server.example.com
+
 CA Subsystem Installation
 -------------------------
 

--- a/docs/installation/Installing_CA_Clone.md
+++ b/docs/installation/Installing_CA_Clone.md
@@ -6,6 +6,25 @@ Overview
 
 This page describes the process to install a CA subsystem as a clone of an existing CA subsystem.
 
+Before beginning with the installation, please ensure that you have configured the directory
+server and added base entries. This step is described [here](http://www.dogtagpki.org/wiki/Installing_DS).
+
+Additionally, please verify that your FQDN is correctly reported by the following command:
+
+    python -c 'import socket; print(socket.getfqdn())'
+
+If it isn't, please add an entry at the beginning of the `/etc/hosts` file:
+
+    127.0.0.1 clone.example.com
+    ::1 clone.example.com
+
+Some useful tips:
+
+ - Make sure the firewall on the master allows external access to LDAP from the clone
+ - Make sure the firewall on the clone allows external access to LDAP from the master
+ - Not having a `dc=pki,dc=example,dc=com` entry in LDAP will give the same error as
+       not being able to connect to the LDAP server.
+
 Exporting Existing System Certificates
 --------------------------------------
 
@@ -63,6 +82,10 @@ pki_clone_uri=https://server.example.com:8443
 pki_clone_pkcs12_path=ca-certs.p12
 pki_clone_pkcs12_password=Secret.123
 ```
+
+In the above, replace `server.example.com` with the hostname of the
+master instance. Note that an alternate replica can be specified for
+the value of `pki_clone_uri`.
 
 Then execute the following command:
 


### PR DESCRIPTION
(Branch name is a little misleading as I decided to expand the scope.)

While working on #40, I've encountered several issues stemming from unfriendly errors and gaps in the documentation.

This corrects a few of them:
 - LDAP connections do not log the server they're connecting to. As the server and port shouldn't be considered sensitive information, there's no reason _not_ to log this information, _especially_ when logging a connection error. 
 - Describe firewall access briefly.
 - Describe hostname issues.