### PR TITLE
Fixed CA signing cert importation

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -94,7 +94,7 @@ pki_ca_port=%(pki_security_domain_https_port)s
 pki_ca_signing_nickname=caSigningCert cert-%(pki_instance_name)s CA
 
 # DEPRECATED: Use 'pki_ca_signing_cert_path' instead.
-pki_external_ca_cert_path=%(pki_instance_configuration_path)s/external_ca.cert
+pki_external_ca_cert_path=
 pki_ca_signing_cert_path=%(pki_external_ca_cert_path)s
 
 pki_client_admin_cert_p12=%(pki_client_dir)s/%(pki_subsystem_type)s_admin_cert.p12

--- a/base/server/man/man5/pki_default.cfg.5
+++ b/base/server/man/man5/pki_default.cfg.5
@@ -413,7 +413,7 @@ Required for the second step of a stand-alone PKI process.  This is the location
 .PP
 .B pki_ca_signing_cert_path
 .IP
-Required for the second step of a stand-alone PKI process.  This is the location of the file containing the external CA's certificate chain (as issued by the external CA).  Defaults to '%(pki_instance_configuration_path)s/external_ca_chain.cert'.
+Required for the second step of a stand-alone PKI process.  This is the location of the file containing the external CA's certificate chain (as issued by the external CA).  Defaults to empty.
 .PP
 .B pki_external_admin_cert_path
 .IP

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -395,15 +395,16 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             self.import_system_cert_request(deployer, subsystem, 'subsystem')
             self.import_system_cert_request(deployer, subsystem, 'sslserver')
 
-    def import_ca_signing_cert(self, deployer, nssdb, subsystem):
+    def import_ca_signing_cert(self, deployer, nssdb):
 
         param = 'pki_ca_signing_cert_path'
         cert_file = deployer.mdict.get(param)
-        if not cert_file or not os.path.exists(cert_file):
-            if subsystem.name == 'ca':
-                raise Exception('Invalid certificate path: %s=%s' % (param, cert_file))
-            else:
-                return
+
+        if not cert_file:
+            return
+
+        if not os.path.exists(cert_file):
+            raise Exception('Invalid certificate path: %s=%s' % (param, cert_file))
 
         nickname = deployer.mdict['pki_ca_signing_nickname']
 
@@ -593,14 +594,14 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
     def import_system_certs(self, deployer, nssdb, subsystem):
 
         if subsystem.name == 'ca':
-            self.import_ca_signing_cert(deployer, nssdb, subsystem)
+            self.import_ca_signing_cert(deployer, nssdb)
             self.import_ca_ocsp_signing_cert(deployer, nssdb)
 
         if subsystem.name == 'kra':
             # Always import cert chain into internal token.
             internal_nssdb = subsystem.instance.open_nssdb()
             try:
-                self.import_ca_signing_cert(deployer, internal_nssdb, subsystem)
+                self.import_ca_signing_cert(deployer, internal_nssdb)
             finally:
                 internal_nssdb.close()
 
@@ -612,7 +613,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             # Always import cert chain into internal token.
             internal_nssdb = subsystem.instance.open_nssdb()
             try:
-                self.import_ca_signing_cert(deployer, internal_nssdb, subsystem)
+                self.import_ca_signing_cert(deployer, internal_nssdb)
             finally:
                 internal_nssdb.close()
 


### PR DESCRIPTION
The pki_ca_signing_cert_path param has been modified to have
an empty value by default.

The import_ca_signing_cert() has been modified such that if
the param is not specified, it will return silently. If the
param contains an invalid path, the method will fail. If the
param contains a valid path to the CA signing cert, the cert
will be imported into the NSS database.

https://pagure.io/dogtagpki/issue/3040
