### PR TITLE
Check for missing FQDNs during pkispawn

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -114,6 +114,21 @@ class PKIDeployer:
         self.config_client = util.ConfigClient(self)
         self.parser = parser
 
+    def validate(self):
+        # Validate environmental settings for the deployer;
+        # to be called before self.init().
+
+        blacklisted_hostnames = ['localhost', 'localhost.localdomain',
+                                 'localhost4', 'localhost4.localdomain4',
+                                 'localhost6', 'localhost6.localdomain6']
+
+        if self.hostname in blacklisted_hostnames:
+            raise Exception("This host has a localhost-like domain as its " +
+                            "FQDN. Please change this to a non-localhost " +
+                            "FQDN. Changes must be made in /etc/hosts; to " +
+                            "verify that they have applied run " +
+                            "`python -c 'import socket; print(socket.getfqdn())'`.")
+
     def flatten_master_dict(self):
 
         self.mdict.update(__name__="PKI Master Dictionary")

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -102,6 +102,12 @@ def main(argv):
         action='store_true',
         help='skip installation step')
 
+    parser.optional.add_argument(
+        '--enforce-hostname',
+        dest='enforce_hostname',
+        action='store_true',
+        help='enforce strict hostname/FQDN checks')
+
     args = parser.process_command_line_arguments()
 
     config.default_deployment_cfg = \
@@ -113,6 +119,12 @@ def main(argv):
             args.user_deployment_cfg).strip('[\']')
 
     parser.validate()
+
+    # Currently the only logic in deployer's validation is the
+    # hostname check; at some point this might need to be updated.
+    if args.enforce_hostname:
+        deployer.validate()
+
     interactive = False
 
     if config.user_deployment_cfg is None:


### PR DESCRIPTION
When installing via pkispawn on a system with no hostname set,
or hostname not correctly set in /etc/hosts, raise an exception
early in the install process. This prevents deploys where the
certificates are assigned to `localhost.localdomain`; in this
scenario, creating a clone from this CA will fail as the clone
cannot validate the certificates of the CA master.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`