### PR TITLE
Fix doctag in RequestStatusAdapter

### DIFF
--- a/base/common/src/com/netscape/certsrv/request/RequestStatusAdapter.java
+++ b/base/common/src/com/netscape/certsrv/request/RequestStatusAdapter.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 import org.apache.commons.lang.StringUtils;
 
 /**
- * The RevocationReasonAdapter class provides custom marshaling for RevocationReason.
+ * The RequestStatusAdapter class provides custom marshaling for RequestStatus.
  *
  * @author Endi S. Dewata
  */


### PR DESCRIPTION
Noticed this while looking for uses of `RevocationReasonAdapter`...

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`