### PR TITLE
Refactoring `cert-del` module and generalizing split of `cert_id` field

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -560,6 +560,24 @@ class PKISubsystem(object):
                 target_tests[testID] = critical
         self.set_startup_tests(target_tests)
 
+    def cert_del(self, cert_tag, remove_key=False):
+        """
+        Delete a cert from NSS db
+        :param cert_tag: Cert Tag
+        :param remove_key: Remove associate private key
+        """
+        cert = self.get_subsystem_cert(cert_tag)
+        nssdb = self.instance.open_nssdb()
+        try:
+            logger.debug('Removing %s certificate from NSS database for '
+                         'subsystem %s instance %s', cert_tag, self.name, self.instance)
+            nssdb.remove_cert(
+                nickname=cert['nickname'],
+                token=cert['token'],
+                remove_key=remove_key)
+        finally:
+            nssdb.close()
+
 
 class CASubsystem(PKISubsystem):
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -88,6 +88,24 @@ class CertCLI(pki.cli.CLI):
     def convert_millis_to_date(millis):
         return datetime.datetime.fromtimestamp(millis / 1000.0).strftime("%a %b %d %H:%M:%S %Y")
 
+    @staticmethod
+    def get_cert_id_info(cert_id):
+        """
+        Return cert_tag and corresponding subsystem details from cert_id
+        :param cert_id: Cert ID
+        :type cert_id: str
+        :returns: (subsystem_name, cert_tag)
+        :rtype: (str, str)
+        """
+        if cert_id == 'sslserver' or cert_id == 'subsystem':
+            subsystem_name = None
+            cert_tag = cert_id
+        else:
+            parts = cert_id.split('_', 1)
+            subsystem_name = parts[0]
+            cert_tag = parts[1]
+        return subsystem_name, cert_tag
+
 
 class CertFindCLI(pki.cli.CLI):
     def __init__(self):
@@ -259,14 +277,7 @@ class CertShowCLI(pki.cli.CLI):
 
         instance.load()
 
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -365,17 +376,7 @@ class CertUpdateCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name = None
-        cert_tag = cert_id
-
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -989,14 +990,7 @@ class CertImportCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1214,17 +1208,7 @@ class CertExportCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name = None
-        cert_tag = cert_id
-
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1397,14 +1381,7 @@ class CertRemoveCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1418,17 +1395,5 @@ class CertRemoveCLI(pki.cli.CLI):
                 subsystem_name, instance_name)
             sys.exit(1)
 
-        cert = subsystem.get_subsystem_cert(cert_tag)
-
-        nssdb = instance.open_nssdb()
-
-        try:
-            logger.info('Removing %s certificate from NSS database', cert_id)
-
-            nssdb.remove_cert(
-                nickname=cert['nickname'],
-                token=cert['token'],
-                remove_key=remove_key)
-
-        finally:
-            nssdb.close()
+        logger.info('Removing %s certificate from NSS database', cert_id)
+        subsystem.cert_del(cert_tag=cert_tag, remove_key=remove_key)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -89,7 +89,7 @@ class CertCLI(pki.cli.CLI):
         return datetime.datetime.fromtimestamp(millis / 1000.0).strftime("%a %b %d %H:%M:%S %Y")
 
     @staticmethod
-    def get_cert_id_info(cert_id):
+    def split_cert_id(cert_id):
         """
         Return cert_tag and corresponding subsystem details from cert_id
         :param cert_id: Cert ID
@@ -277,7 +277,7 @@ class CertShowCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -376,7 +376,7 @@ class CertUpdateCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -990,7 +990,7 @@ class CertImportCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1208,7 +1208,7 @@ class CertExportCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1381,7 +1381,7 @@ class CertRemoveCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.get_cert_id_info(cert_id)
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:


### PR DESCRIPTION
- `cert-del` module is refactored to accomodate the future `cert-fix` module
- Different modules split `cert_id` to identify `cert_tag` and corresponding
  `subsystem`. A generalized method is aded for code reusability

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>