### PR TITLE
Refactoring `cert-create` module

### DIFF
--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -27,17 +27,13 @@ import getopt
 import getpass
 import logging
 import os
-import re
-import shutil
-import subprocess
 import sys
-import tempfile
 
-import pki.cli
-import pki.server as server
-import pki.client as client
 import pki.cert
+import pki.cli
 import pki.nssdb
+
+import pki.server as server
 
 logger = logging.getLogger(__name__)
 
@@ -87,24 +83,6 @@ class CertCLI(pki.cli.CLI):
     @staticmethod
     def convert_millis_to_date(millis):
         return datetime.datetime.fromtimestamp(millis / 1000.0).strftime("%a %b %d %H:%M:%S %Y")
-
-    @staticmethod
-    def split_cert_id(cert_id):
-        """
-        Return cert_tag and corresponding subsystem details from cert_id
-        :param cert_id: Cert ID
-        :type cert_id: str
-        :returns: (subsystem_name, cert_tag)
-        :rtype: (str, str)
-        """
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
-        return subsystem_name, cert_tag
 
 
 class CertFindCLI(pki.cli.CLI):
@@ -277,7 +255,7 @@ class CertShowCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -376,7 +354,7 @@ class CertUpdateCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -485,34 +463,33 @@ class CertCreateCLI(pki.cli.CLI):
             sys.exit(1)
 
         instance_name = 'pki-tomcat'
-        create_temp_cert = False
+        temp_cert = False
         serial = None
-        client_nssdb_location = os.getenv('HOME') + '/.dogtag/nssdb'
-        client_nssdb_password = None
-        client_nssdb_pass_file = None
-        client_cert = None
+        c_nssdb = os.getenv('HOME') + '/.dogtag/nssdb'
+        c_nssdb_password = None
+        c_nssdb_pass_file = None
+        c_cert = None
         output = None
         renew = False
-        connection = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
                 instance_name = a
 
             elif o == '-d':
-                client_nssdb_location = a
+                c_nssdb = a
 
             elif o == '-c':
-                client_nssdb_password = a
+                c_nssdb_password = a
 
             elif o == '-C':
-                client_nssdb_pass_file = a
+                c_nssdb_pass_file = a
 
             elif o == '-n':
-                client_cert = a
+                c_cert = a
 
             elif o == '--temp':
-                create_temp_cert = True
+                temp_cert = True
 
             elif o == '--serial':
                 # string containing the dec or hex value for the identifier
@@ -547,9 +524,9 @@ class CertCreateCLI(pki.cli.CLI):
             self.print_help()
             sys.exit(1)
 
-        if not create_temp_cert:
+        if not temp_cert:
             # For permanent certificate, password of NSS db is required.
-            if not client_nssdb_password and not client_nssdb_pass_file:
+            if not c_nssdb_password and not c_nssdb_pass_file:
                 logger.error('NSS database password is required.')
                 self.print_help()
                 sys.exit(1)
@@ -565,345 +542,13 @@ class CertCreateCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name = None
-        cert_tag = cert_id
-
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
-
-        # If cert ID is instance specific, get it from first subsystem
-        if not subsystem_name:
-            subsystem_name = instance.subsystems[0].name
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error(
-                'No %s subsystem in instance %s.',
-                subsystem_name, instance_name)
-            sys.exit(1)
-
-        nssdb = instance.open_nssdb()
-        tmpdir = tempfile.mkdtemp()
         try:
-            cert_folder = os.path.join(pki.CONF_DIR, instance_name, 'certs')
-            if not os.path.exists(cert_folder):
-                os.makedirs(cert_folder)
-            new_cert_file = os.path.join(cert_folder, cert_id + '.crt')
+            instance.cert_create(cert_id, c_cert, c_nssdb, c_nssdb_password,
+                                  c_nssdb_pass_file, serial, temp_cert, renew, output)
 
-            if output:
-                new_cert_file = output
-
-            if create_temp_cert:
-                if not serial:
-                    # If admin doesn't provide a serial number, find the highest in NSS db
-                    # and add 1 to it
-                    serial = 0
-                    for sub in instance.subsystems:
-                        for n_cert in sub.find_system_certs():
-                            if int(n_cert['serial_number']) > serial:
-                                serial = int(n_cert['serial_number'])
-
-                    # Add 1 and then rewrap it as a string
-                    serial = str(serial + 1)
-
-            else:
-                # Create permanent certificate
-                if not renew:
-                    # Fixme: Support rekey
-                    raise Exception('Rekey is not supported yet.')
-
-                connection = self.setup_authentication(subsystem=subsystem,
-                                                       c_nssdb_pass=client_nssdb_password,
-                                                       c_cert=client_cert,
-                                                       c_nssdb_pass_file=client_nssdb_pass_file,
-                                                       c_nssdb=client_nssdb_location,
-                                                       tmpdir=tmpdir)
-
-            if cert_tag == 'sslserver':
-                self.create_ssl_cert(instance=instance, subsystem=subsystem,
-                                     is_temp_cert=create_temp_cert,
-                                     new_cert_file=new_cert_file, nssdb=nssdb, serial=serial,
-                                     tmpdir=tmpdir, connection=connection)
-
-            elif cert_tag == 'subsystem':
-                self.create_subsystem_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                           subsystem=subsystem, new_cert_file=new_cert_file,
-                                           connection=connection)
-
-            elif cert_id in ['ca_ocsp_signing', 'ocsp_signing']:
-                self.create_ocsp_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                      subsystem=subsystem, new_cert_file=new_cert_file,
-                                      connection=connection)
-
-            elif cert_tag == 'audit_signing':
-                self.create_audit_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                       subsystem=subsystem, new_cert_file=new_cert_file,
-                                       connection=connection)
-
-            else:
-                # renewal not yet supported
-                raise Exception('Renewal for %s not yet supported.' % cert_id)
-
-        finally:
-            nssdb.close()
-            shutil.rmtree(tmpdir)
-
-    @staticmethod
-    def setup_temp_renewal(instance, subsystem, tmpdir, cert_id):
-
-        csr_file = os.path.join(tmpdir, cert_id + '.csr')
-        ca_cert_file = os.path.join(tmpdir, 'ca_certificate.crt')
-
-        logger.debug('Exporting CSR for %s cert', cert_id)
-
-        cert_request = subsystem.get_subsystem_cert(cert_id).get('request', None)
-        if cert_request is None:
-            logger.error('Unable to find CSR for %s cert', cert_id)
+        except server.PKIServerException as e:
+            logger.error(str(e))
             sys.exit(1)
-
-        csr_data = pki.nssdb.convert_csr(cert_request, 'base64', 'pem')
-        with open(csr_file, 'w') as f:
-            f.write(csr_data)
-
-        logger.debug('Extracting SKI from CA cert')
-        # TODO: Support remote CA.
-
-        ca_signing_cert = instance.get_subsystem('ca').get_subsystem_cert('signing')
-        ca_cert_data = ca_signing_cert.get('data', None)
-        if ca_cert_data is None:
-            logger.error('Unable to find certificate data for CA signing certificate.')
-            sys.exit(1)
-
-        ca_cert = pki.nssdb.convert_cert(ca_cert_data, 'base64', 'pem')
-        with open(ca_cert_file, 'w') as f:
-            f.write(ca_cert)
-
-        ca_cert_retrieve_cmd = [
-            'openssl',
-            'x509',
-            '-in', ca_cert_file,
-            '-noout',
-            '-text'
-        ]
-
-        logger.debug('Command: %s', ' '.join(ca_cert_retrieve_cmd))
-        ca_cert_details = subprocess.check_output(ca_cert_retrieve_cmd).decode('utf-8')
-
-        aki = re.search(r'Subject Key Identifier.*\n.*?(.*?)\n', ca_cert_details).group(1)
-
-        # Add 0x to represent this is a Hex
-        aki = '0x' + aki.strip().replace(':', '')
-        logger.debug('AKI: %s', aki)
-
-        return ca_signing_cert, aki, csr_file
-
-    def setup_authentication(self, subsystem, c_nssdb_pass, c_nssdb_pass_file, c_cert,
-                             c_nssdb, tmpdir):
-        temp_auth_p12 = os.path.join(tmpdir, 'auth.p12')
-        temp_auth_cert = os.path.join(tmpdir, 'auth.pem')
-
-        if not c_cert:
-            logger.error('Client cert nickname is required.')
-            self.print_help()
-            sys.exit(1)
-
-        # Create a PKIConnection object that stores the details of subsystem.
-        connection = client.PKIConnection('https', os.environ['HOSTNAME'], '8443', subsystem.name)
-
-        # Create a p12 file using
-        # pk12util -o <p12 file name> -n <cert nick name> -d <NSS db path>
-        # -W <pkcs12 password> -K <NSS db pass>
-        cmd_generate_pk12 = [
-            'pk12util',
-            '-o', temp_auth_p12,
-            '-n', c_cert,
-            '-d', c_nssdb
-        ]
-
-        # The pem file used for authentication. Created from a p12 file using the
-        # command:
-        # openssl pkcs12 -in <p12_file_path> -out /tmp/auth.pem -nodes
-        cmd_generate_pem = [
-            'openssl',
-            'pkcs12',
-            '-in', temp_auth_p12,
-            '-out', temp_auth_cert,
-            '-nodes',
-
-        ]
-
-        if c_nssdb_pass_file:
-            # Use the same password file for the generated pk12 file
-            cmd_generate_pk12.extend(['-k', c_nssdb_pass_file,
-                                      '-w', c_nssdb_pass_file])
-            cmd_generate_pem.extend(['-passin', 'file:' + c_nssdb_pass_file])
-        else:
-            # Use the same password for the generated pk12 file
-            cmd_generate_pk12.extend(['-K', c_nssdb_pass,
-                                      '-W', c_nssdb_pass])
-            cmd_generate_pem.extend(['-passin', 'pass:' + c_nssdb_pass])
-
-        res_pk12 = subprocess.check_output(cmd_generate_pk12, stderr=subprocess.STDOUT)
-        logger.info(res_pk12)
-
-        res_pem = subprocess.check_output(cmd_generate_pem, stderr=subprocess.STDOUT)
-        logger.info(res_pem)
-
-        # Bind the authentication with the connection object
-        connection.set_authentication_cert(temp_auth_cert)
-
-        return connection
-
-    def renew_system_certificate(self, connection,
-                                 output, serial):
-
-        # Instantiate the CertClient
-        cert_client = pki.cert.CertClient(connection)
-
-        inputs = dict()
-        inputs['serial_num'] = serial
-
-        # request: CertRequestInfo object for request generated.
-        # cert: CertData object for certificate generated (if any)
-        ret = cert_client.enroll_cert(inputs=inputs, profile_id='caManualRenewal')
-
-        request_data = ret[0].request
-        cert_data = ret[0].cert
-
-        logger.info('Request ID: %s', request_data.request_id)
-        logger.info('Request Status: %s', request_data.request_status)
-
-        if not cert_data:
-            raise Exception('Unable to renew system certificate for serial: %s' % serial)
-
-        # store cert_id for usage later
-        cert_id = cert_data.serial_number
-        if not cert_id:
-            raise Exception('Unable to retrieve serial number of renewed certificate.')
-
-        logger.info('Serial Number: %s', cert_id)
-        logger.info('Issuer: %s', cert_data.issuer_dn)
-        logger.info('Subject: %s', cert_data.subject_dn)
-        logger.info('Pretty Print:')
-        logger.info(cert_data.pretty_repr)
-
-        new_cert_data = cert_client.get_cert(cert_serial_number=cert_id)
-        with open(output, 'w') as f:
-            f.write(new_cert_data.encoded)
-
-    def create_ssl_cert(self, instance, subsystem, serial, is_temp_cert, tmpdir,
-                        new_cert_file, nssdb, connection):
-
-        logger.info('Creating SSL server certificate.')
-
-        if is_temp_cert:
-
-            logger.info('Generate temp SSL certificate')
-
-            ca_signing_cert, aki, csr_file = self.setup_temp_renewal(
-                instance=instance, subsystem=subsystem, tmpdir=tmpdir, cert_id='sslserver')
-
-            # --keyUsage
-            key_usage_ext = {
-                'digitalSignature': True,
-                'nonRepudiation': True,
-                'keyEncipherment': True,
-                'dataEncipherment': True,
-                'critical': True
-            }
-
-            # -3
-            aki_ext = {
-                'auth_key_id': aki
-            }
-
-            # --extKeyUsage
-            ext_key_usage_ext = {
-                'serverAuth': True
-            }
-
-            rc = nssdb.create_cert(
-                issuer=ca_signing_cert['nickname'],
-                request_file=csr_file,
-                cert_file=new_cert_file,
-                serial=serial,
-                key_usage_ext=key_usage_ext,
-                aki_ext=aki_ext,
-                ext_key_usage_ext=ext_key_usage_ext)
-            if rc:
-                raise Exception('Failed to generate CA-signed temp SSL certificate. '
-                                'RC: %d' % rc)
-
-        else:
-
-            logger.info('Renewing SSL certificate')
-
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('sslserver')["serial_number"]
-
-            logger.info('Serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    def create_ocsp_cert(self, subsystem, is_temp_cert, new_cert_file, serial, connection):
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for OCSP is not supported.')
-
-        else:
-            cert_tag = 'ocsp_signing'
-            if subsystem.name is 'ocsp':
-                cert_tag = 'signing'
-
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert(cert_tag)["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    def create_subsystem_cert(self, subsystem, is_temp_cert, new_cert_file, serial,
-                              connection):
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for subsystem is not supported.')
-
-        else:
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('subsystem')["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    def create_audit_cert(self, subsystem, is_temp_cert, new_cert_file, serial, connection):
-
-        logger.info('Creating audit certificate')
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for audit signing is not supported.')
-        else:
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('audit_signing')["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
 
 
 class CertImportCLI(pki.cli.CLI):
@@ -982,7 +627,7 @@ class CertImportCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1153,7 +798,7 @@ class CertExportCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1183,7 +828,7 @@ class CertExportCLI(pki.cli.CLI):
                 token = None
 
             else:
-                nickname = full_name[i+1:]
+                nickname = full_name[i + 1:]
                 token = full_name[:i]
 
         else:
@@ -1326,7 +971,7 @@ class CertRemoveCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:


### PR DESCRIPTION
- The `cert-create` module has been refactored to accommodate the
  future `cert-fix` module
- This is patch no. 4 and is a break down of PR #56 

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`