### PR TITLE
Minor bug fix and refactoring of `cert_create` module

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -36,6 +36,7 @@ import tempfile
 import ldap
 import ldap.filter
 import pki
+import pki.client as client
 import pki.nssdb
 import pki.util
 import six
@@ -91,6 +92,84 @@ class PKIServer(object):
             subsystem_name = parts[0]
             cert_tag = parts[1]
         return subsystem_name, cert_tag
+
+    @staticmethod
+    def setup_authentication(c_nssdb_pass, c_nssdb_pass_file, c_cert,
+                             c_nssdb, tmpdir):
+        """
+        Utility method to set up a secure authenticated connection with the
+        PKI Server through PKI client
+
+        :param c_nssdb_pass: Client NSS db plain password
+        :type c_nssdb_pass: str
+        :param c_nssdb_pass_file: File containing client NSS db password
+        :type c_nssdb_pass_file: str
+        :param c_cert: Client Cert nick name
+        :type c_cert: str
+        :param c_nssdb: Client NSS db path
+        :type c_nssdb: str
+        :param tmpdir: Absolute path of temp dir to store p12 and pem files
+        :type tmpdir: str
+        :return: Authenticated secure connection to PKI server
+        """
+        temp_auth_p12 = os.path.join(tmpdir, 'auth.p12')
+        temp_auth_cert = os.path.join(tmpdir, 'auth.pem')
+
+        if not c_cert:
+            raise PKIServerException('Client cert nickname is required.')
+
+        # Create a PKIConnection object that stores the details of subsystem.
+        # NOTE: Renewal requests can be submitted only to 'ca'
+        connection = client.PKIConnection('https', os.environ['HOSTNAME'], '8443', 'ca')
+
+        # Create a p12 file using
+        # pk12util -o <p12 file name> -n <cert nick name> -d <NSS db path>
+        # -W <pkcs12 password> -K <NSS db pass>
+        cmd_generate_pk12 = [
+            'pk12util',
+            '-o', temp_auth_p12,
+            '-n', c_cert,
+            '-d', c_nssdb
+        ]
+
+        # The pem file used for authentication. Created from a p12 file using the
+        # command:
+        # openssl pkcs12 -in <p12_file_path> -out /tmp/auth.pem -nodes
+        cmd_generate_pem = [
+            'openssl',
+            'pkcs12',
+            '-in', temp_auth_p12,
+            '-out', temp_auth_cert,
+            '-nodes',
+
+        ]
+
+        if c_nssdb_pass_file:
+            # Use the same password file for the generated pk12 file
+            cmd_generate_pk12.extend(['-k', c_nssdb_pass_file,
+                                      '-w', c_nssdb_pass_file])
+            cmd_generate_pem.extend(['-passin', 'file:' + c_nssdb_pass_file])
+        else:
+            # Use the same password for the generated pk12 file
+            cmd_generate_pk12.extend(['-K', c_nssdb_pass,
+                                      '-W', c_nssdb_pass])
+            cmd_generate_pem.extend(['-passin', 'pass:' + c_nssdb_pass])
+
+        # Generate temp_auth_p12 file
+        res_pk12 = subprocess.check_output(cmd_generate_pk12,
+                                           stderr=subprocess.STDOUT).decode('utf-8')
+        logger.debug('Result of pk12 generation: %s', res_pk12)
+
+        # Use temp_auth_p12 generated in previous step to
+        # to generate temp_auth_cert PEM file
+        res_pem = subprocess.check_output(cmd_generate_pem,
+                                          stderr=subprocess.STDOUT).decode('utf-8')
+        logger.debug('Result of pem generation: %s', res_pem)
+
+        # Bind the authentication with the connection object
+        connection.set_authentication_cert(temp_auth_cert)
+
+        return connection
 
 
 @functools.total_ordering

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -28,15 +28,14 @@ import getpass
 import logging
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 
-import pki.cli
-import pki.server as server
-import pki.client as client
 import pki.cert
+import pki.cli
 import pki.nssdb
+
+import pki.server as server
 
 logger = logging.getLogger(__name__)
 
@@ -600,12 +599,12 @@ class CertCreateCLI(pki.cli.CLI):
                     # Fixme: Support rekey
                     raise Exception('Rekey is not supported yet.')
 
-                connection = self.setup_authentication(subsystem=subsystem,
-                                                       c_nssdb_pass=client_nssdb_password,
-                                                       c_cert=client_cert,
-                                                       c_nssdb_pass_file=client_nssdb_pass_file,
-                                                       c_nssdb=client_nssdb_location,
-                                                       tmpdir=tmpdir)
+                connection = server.PKIServer.setup_authentication(
+                    c_nssdb_pass=client_nssdb_password,
+                    c_cert=client_cert,
+                    c_nssdb_pass_file=client_nssdb_pass_file,
+                    c_nssdb=client_nssdb_location,
+                    tmpdir=tmpdir)
 
             if cert_tag == 'sslserver':
                 self.create_ssl_cert(subsystem=subsystem,
@@ -635,63 +634,6 @@ class CertCreateCLI(pki.cli.CLI):
         finally:
             nssdb.close()
             shutil.rmtree(tmpdir)
-
-    def setup_authentication(self, subsystem, c_nssdb_pass, c_nssdb_pass_file, c_cert,
-                             c_nssdb, tmpdir):
-        temp_auth_p12 = os.path.join(tmpdir, 'auth.p12')
-        temp_auth_cert = os.path.join(tmpdir, 'auth.pem')
-
-        if not c_cert:
-            logger.error('Client cert nickname is required.')
-            self.print_help()
-            sys.exit(1)
-
-        # Create a PKIConnection object that stores the details of subsystem.
-        connection = client.PKIConnection('https', os.environ['HOSTNAME'], '8443', subsystem.name)
-
-        # Create a p12 file using
-        # pk12util -o <p12 file name> -n <cert nick name> -d <NSS db path>
-        # -W <pkcs12 password> -K <NSS db pass>
-        cmd_generate_pk12 = [
-            'pk12util',
-            '-o', temp_auth_p12,
-            '-n', c_cert,
-            '-d', c_nssdb
-        ]
-
-        # The pem file used for authentication. Created from a p12 file using the
-        # command:
-        # openssl pkcs12 -in <p12_file_path> -out /tmp/auth.pem -nodes
-        cmd_generate_pem = [
-            'openssl',
-            'pkcs12',
-            '-in', temp_auth_p12,
-            '-out', temp_auth_cert,
-            '-nodes',
-
-        ]
-
-        if c_nssdb_pass_file:
-            # Use the same password file for the generated pk12 file
-            cmd_generate_pk12.extend(['-k', c_nssdb_pass_file,
-                                      '-w', c_nssdb_pass_file])
-            cmd_generate_pem.extend(['-passin', 'file:' + c_nssdb_pass_file])
-        else:
-            # Use the same password for the generated pk12 file
-            cmd_generate_pk12.extend(['-K', c_nssdb_pass,
-                                      '-W', c_nssdb_pass])
-            cmd_generate_pem.extend(['-passin', 'pass:' + c_nssdb_pass])
-
-        res_pk12 = subprocess.check_output(cmd_generate_pk12, stderr=subprocess.STDOUT)
-        logger.info(res_pk12)
-
-        res_pem = subprocess.check_output(cmd_generate_pem, stderr=subprocess.STDOUT)
-        logger.info(res_pem)
-
-        # Bind the authentication with the connection object
-        connection.set_authentication_cert(temp_auth_cert)
-
-        return connection
 
     def renew_system_certificate(self, connection,
                                  output, serial):
@@ -1084,7 +1026,7 @@ class CertExportCLI(pki.cli.CLI):
                 token = None
 
             else:
-                nickname = full_name[i+1:]
+                nickname = full_name[i + 1:]
                 token = full_name[:i]
 
         else:


### PR DESCRIPTION
- **Bug Fix:** Secured connection to PKI server is made ONLY to CA
- `setup_authentication` method in `cert_create` modules is refactored
  to accommodate the future `cert_fix` module
- This is a break down of PR #70 

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`