### PR TITLE
Auto-shutdown on signing audit logging failure (PKI 10.5)

### DIFF
--- a/base/common/src/com/netscape/certsrv/apps/CMS.java
+++ b/base/common/src/com/netscape/certsrv/apps/CMS.java
@@ -145,6 +145,10 @@ public final class CMS {
         _engine = engine;
     }
 
+    public static ICMSEngine getCMSEngine() {
+        return _engine;
+    }
+
     /**
      * This method is used for unit tests. It allows the underlying _engine
      * to be stubbed out.

--- a/base/server/cms/src/com/netscape/cms/logging/LogFile.java
+++ b/base/server/cms/src/com/netscape/cms/logging/LogFile.java
@@ -79,6 +79,7 @@ import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.logging.LogSource;
 import com.netscape.certsrv.logging.SignedAuditEvent;
 import com.netscape.certsrv.logging.SystemEvent;
+import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmsutil.util.Utils;
 
 import netscape.ldap.client.JDAPAVA;
@@ -422,20 +423,10 @@ public class LogFile implements ILogEventListener, IExtendedPluginInfo {
             // synchronized. We just want to avoid an infinite loop.
             mInSignedAuditLogFailureMode = true;
 
-            // Block all new incoming requests
-            if (CMS.areRequestsDisabled() == false) {
-                // XXX is this a race condition?
-                CMS.disableRequests();
-            }
+            CMS.debug("LogFile: Disabling subsystem due to signed logging failure");
 
-            // Terminate all requests in process
-            CMS.terminateRequests();
-
-            // Call graceful shutdown of the CMS server
-            // Call force shutdown to get added functionality of
-            // making sure to kill the web server.
-
-            CMS.forceShutdown();
+            CMSEngine engine = (CMSEngine) CMS.getCMSEngine();
+            engine.disableSubsystem();
         }
     }
 

--- a/base/server/cms/src/com/netscape/cms/servlet/admin/CMSAdminServlet.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/admin/CMSAdminServlet.java
@@ -73,6 +73,7 @@ import com.netscape.certsrv.selftests.ESelfTestException;
 import com.netscape.certsrv.selftests.ISelfTest;
 import com.netscape.certsrv.selftests.ISelfTestSubsystem;
 import com.netscape.certsrv.tks.ITKSAuthority;
+import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 import com.netscape.cmsutil.util.Cert;
 import com.netscape.cmsutil.util.Utils;
@@ -3194,10 +3195,10 @@ public final class CMSAdminServlet extends AdminServlet {
                                     + "\n";
                             sendResponse(ERROR, content, null, resp);
 
-                            CMS.debug("CMSAdminServlet.runSelfTestsOnDemand(): shutdown server");
+                            CMS.debug("CMSAdminServlet: Disabling subsystem due to selftest failure: " + e.getMessage());
 
-                            // shutdown the system gracefully
-                            CMS.shutdown();
+                            CMSEngine engine = (CMSEngine) CMS.getCMSEngine();
+                            engine.disableSubsystem();
 
                             return;
                         } else {

--- a/base/server/cmscore/src/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/apps/CMSEngine.java
@@ -2042,6 +2042,30 @@ public class CMSEngine implements ICMSEngine {
 
     }
 
+    public void disableSubsystem() {
+
+        String name = mConfig.get("cs.type");
+        String subsystemID = name.toLowerCase();
+
+        CMS.debug("CMSEngine: Disabling " + name + " subsystem");
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder("pki-server", "subsystem-disable", "-i", instanceId, subsystemID);
+            CMS.debug("Command: " + String.join(" ", pb.command()));
+
+            Process process = pb.inheritIO().start();
+            int rc = process.waitFor();
+
+            if (rc != 0) {
+                CMS.debug("CMSEngine: Unable to disable " + name + " subsystem. RC: " + rc);
+            }
+
+        } catch (Exception e) {
+            CMS.debug("CMSEngine: Unable to disable " + name + " subsystem: " + e.getMessage());
+            CMS.debug(e);
+        }
+    }
+
     /**
      * shuts down a subsystem list in reverse order.
      */

--- a/base/server/cmscore/src/com/netscape/cmscore/selftests/SelfTestSubsystem.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/selftests/SelfTestSubsystem.java
@@ -537,10 +537,11 @@ public class SelfTestSubsystem
                                     "CMSCORE_SELFTESTS_RUN_ON_DEMAND_FAILED",
                                     instanceFullName));
 
-                    CMS.debug("SelfTestSubsystem.runSelfTestsOnDemand(): shutdown server");
+                    CMS.debug("SelfTestSubsystem: Disabling subsystem due to selftest failure: " + e.getMessage());
+                    CMS.debug(e);
 
-                    // shutdown the system gracefully
-                    CMS.shutdown();
+                    CMSEngine engine = (CMSEngine) CMS.getCMSEngine();
+                    engine.disableSubsystem();
 
                     return;
                 }
@@ -1835,8 +1836,6 @@ public class SelfTestSubsystem
 
             CMS.debug("SelfTestSubsystem: Shutting down server due to selftest failure: " + e.getMessage());
             CMS.debug(e);
-
-            CMS.shutdown();
 
             CMSEngine engine = (CMSEngine) CMS.getCMSEngine();
             engine.disableSubsystem();

--- a/base/server/cmscore/src/com/netscape/cmscore/selftests/SelfTestSubsystem.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/selftests/SelfTestSubsystem.java
@@ -50,6 +50,7 @@ import com.netscape.certsrv.selftests.ISelfTest;
 import com.netscape.certsrv.selftests.ISelfTestSubsystem;
 import com.netscape.cms.logging.Logger;
 import com.netscape.cms.logging.SignedAuditLogger;
+import com.netscape.cmscore.apps.CMSEngine;
 
 //////////////////////
 // class definition //
@@ -1832,29 +1833,13 @@ public class SelfTestSubsystem
 
             audit(auditMessage);
 
-            CMS.debug("SelfTestSubsystem.startup(): shutdown server");
+            CMS.debug("SelfTestSubsystem: Shutting down server due to selftest failure: " + e.getMessage());
+            CMS.debug(e);
 
-            // shutdown the system gracefully
             CMS.shutdown();
 
-            IConfigStore cs = CMS.getConfigStore();
-            String instanceID = cs.get("instanceId");
-            String subsystemID = cs.get("cs.type").toLowerCase();
-
-            System.out.println("SelfTestSubsystem: Disabling \"" + subsystemID + "\" subsystem due to selftest failure.");
-
-            try {
-                ProcessBuilder pb = new ProcessBuilder("pki-server", "subsystem-disable", "-i", instanceID, subsystemID);
-                Process process = pb.inheritIO().start();
-                int rc = process.waitFor();
-
-                if (rc != 0) {
-                    System.out.println("SelfTestSubsystem: Unable to disable \"" + subsystemID + "\". RC: " + rc);
-                }
-
-            } catch (Exception e2) {
-                e.printStackTrace();
-            }
+            CMSEngine engine = (CMSEngine) CMS.getCMSEngine();
+            engine.disableSubsystem();
         }
     }
 

--- a/docs/admin/Signed_Audit_Logging_Failures.md
+++ b/docs/admin/Signed_Audit_Logging_Failures.md
@@ -1,0 +1,88 @@
+Signed Audit Logging Failures
+=============================
+
+## Overview
+
+If a PKI subsystem is unable to write signed audit log to disk,
+the subsystem will automatically shutdown to prevent it from
+receiving and executing additional operations that cannot be
+logged.
+
+This situation may happen when the disk is full. In that case
+the admin will need to provide additional disk space, then restart
+the subsystem.
+
+Note: auto-shutdown will only work if audit signing is enabled.
+
+## Verifying Auto-Shutdown
+
+To verify auto-shutdown on a CA instance, prepare a small
+partition and assign the proper permissions:
+
+```
+$ mkdir -p /tmp/audit
+$ mount -t tmpfs -o size=2M,mode=0755 tmpfs /tmp/audit
+$ chown pkiuser:pkiuser /tmp/audit
+$ semanage fcontext -a -t pki_tomcat_log_t /tmp/audit
+$ restorecon -vR /tmp/audit
+```
+
+Edit /etc/pki/pki-tomcat/ca/CS.cfg to enable audit signing
+and configure it to store the logs in the above partition:
+
+```
+log.instance.SignedAudit.logSigning=true
+log.instance.SignedAudit.fileName=/tmp/audit/ca_audit
+```
+
+Restart the server:
+
+```
+$ systemctl restart pki-tomcatd@pki-tomcat.service
+```
+
+Create a big file to fill up the partition:
+
+```
+$ dd if=/dev/zero of=/tmp/audit/bigfile bs=1M count=2
+```
+
+Execute some operations to generate audit logs, for example:
+
+```
+$ pki ca-cert-find
+```
+
+When the partition becomes full, the server will no longer able
+to write the signed audit log into the partition, so it will
+generate the following message in console or systemd journal
+(assuming the journal is stored in a different partition that
+is not full):
+
+```
+Failed to flush log "/tmp/audit/ca_audit", error: No space left on device
+```
+
+Then the CA subsystem will shutdown automatically. The server itself
+will still be running and accepting connections, but all requests
+going to the CA subsystem will fail.
+
+To resolve the issue, create more space in the partition by
+removing the big file:
+
+```
+$ rm -f /tmp/audit/bigfile
+```
+
+Then re-enable the CA subsystem with the following command:
+
+```
+$ pki-server subsystem-enable -i pki-tomcat ca
+```
+
+or by restarting the server:
+
+```
+$ systemctl restart pki-tomcatd@pki-tomcat.service
+```
+


### PR DESCRIPTION
If the signed audit log is enabled, when the disk partition that stores the signed audit log is full, the subsystem should shut itself down and refuse further client connections to make sure the subsystem does not perform any operation that cannot be logged.

https://pagure.io/dogtagpki/issue/3070