### PR TITLE
Switch to new PKCS11 Interface

### DIFF
--- a/base/server/cms/src/com/netscape/cms/servlet/tks/SecureChannelProtocol.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/tks/SecureChannelProtocol.java
@@ -30,7 +30,7 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.cmscore.security.JssSubsystem;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
-import sun.security.pkcs11.wrapper.PKCS11Constants;
+import org.mozilla.jss.pkcs11.PKCS11Constants;
 
 public class SecureChannelProtocol {
 

--- a/base/server/cms/src/com/netscape/cms/servlet/tks/StandardKDF.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/tks/StandardKDF.java
@@ -7,7 +7,7 @@ import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.SymmetricKeyDeriver;
 import org.mozilla.jss.crypto.TokenException;
 
-import sun.security.pkcs11.wrapper.PKCS11Constants;
+import org.mozilla.jss.pkcs11.PKCS11Constants;
 
 import com.netscape.certsrv.apps.CMS;
 import com.netscape.certsrv.base.EBaseException;

--- a/base/tps/src/org/dogtagpki/server/tps/channel/SecureChannel.java
+++ b/base/tps/src/org/dogtagpki/server/tps/channel/SecureChannel.java
@@ -52,7 +52,7 @@ import org.dogtagpki.tps.main.Util;
 import org.dogtagpki.tps.msg.EndOpMsg.TPSStatus;
 import org.mozilla.jss.pkcs11.PK11SymKey;
 
-import sun.security.pkcs11.wrapper.PKCS11Constants;
+import org.mozilla.jss.pkcs11.PKCS11Constants;
 
 import com.netscape.certsrv.apps.CMS;
 import com.netscape.certsrv.base.EBaseException;

--- a/base/tps/src/org/dogtagpki/server/tps/main/ObjectSpec.java
+++ b/base/tps/src/org/dogtagpki/server/tps/main/ObjectSpec.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import org.dogtagpki.tps.main.TPSBuffer;
 import org.dogtagpki.tps.main.TPSException;
 
-import sun.security.pkcs11.wrapper.PKCS11Constants;
+import org.mozilla.jss.pkcs11.PKCS11Constants;
 
 import com.netscape.certsrv.apps.CMS;
 

--- a/base/tps/src/org/dogtagpki/server/tps/main/PKCS11Obj.java
+++ b/base/tps/src/org/dogtagpki/server/tps/main/PKCS11Obj.java
@@ -11,7 +11,7 @@ import org.dogtagpki.tps.main.TPSBuffer;
 import org.dogtagpki.tps.main.TPSException;
 import org.dogtagpki.tps.main.Util;
 
-import sun.security.pkcs11.wrapper.PKCS11Constants;
+import org.mozilla.jss.pkcs11.PKCS11Constants;
 
 import com.netscape.certsrv.apps.CMS;
 

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
@@ -51,6 +51,7 @@ import org.mozilla.jss.asn1.InvalidBERException;
 import org.mozilla.jss.crypto.InvalidKeyFormatException;
 import org.mozilla.jss.pkcs11.PK11PubKey;
 import org.mozilla.jss.pkcs11.PK11RSAPublicKey;
+import org.mozilla.jss.pkcs11.PKCS11Constants;
 import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
 
 import com.netscape.certsrv.apps.CMS;
@@ -66,7 +67,6 @@ import netscape.security.provider.RSAPublicKey;
 import netscape.security.util.BigInt;
 import netscape.security.x509.RevocationReason;
 import netscape.security.x509.X509CertImpl;
-import sun.security.pkcs11.wrapper.PKCS11Constants;
 
 public class TPSEnrollProcessor extends TPSProcessor {
 

--- a/pki.spec
+++ b/pki.spec
@@ -308,7 +308,7 @@ BuildRequires:    jpackage-utils >= 0:1.7.5-10
 BuildRequires:    jss >= 4.4.0-11
 BuildRequires:    tomcatjss >= 7.2.1-4
 %else
-BuildRequires:    jss >= 4.5.0-1
+BuildRequires:    jss >= 4.5.1
 BuildRequires:    tomcatjss >= 7.3.6
 %endif
 BuildRequires:    systemd-units
@@ -427,7 +427,7 @@ Requires:         jpackage-utils >= 0:1.7.5-10
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:         jss >= 4.4.0-11
 %else
-Requires:         jss >= 4.5.0-1
+Requires:         jss >= 4.5.1
 %endif
 Requires:         nss >= 3.38.0
 
@@ -538,7 +538,7 @@ Requires:         jpackage-utils >= 0:1.7.5-10
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:         jss >= 4.4.0-11
 %else
-Requires:         jss >= 4.5.0-1
+Requires:         jss >= 4.5.1
 %endif
 Requires:         ldapjdk >= 4.20
 Requires:         pki-base >= %{version}-%{release}


### PR DESCRIPTION
I'm marking this as WIP until a new JSS is released for Fedora so we can test this easily. This is the set of changes necessary for allowing PKI to use the JSS-provided PKCS11Constants. This can be tested now by doing a build of [jss](https://github.com/dogtagpki/jss) first, installing it, and then building and testing PKI. However, CI will fail in the meantime as a new JSS release hasn't been made yet. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`