### PR TITLE
Fixed password prompt in pki CLI (PKI 10.5)

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -378,9 +378,6 @@ public class MainCLI extends CLI {
 
             if (passwordFile != null && password != null) {
                 throw new Exception("The '-W' and '-w' options are mutually exclusive.");
-
-            } else if (passwordFile == null && password == null) {
-                throw new Exception("Missing user password.");
             }
         }
 


### PR DESCRIPTION
The pki CLI has been modified not to throw an exception when the
user specifies a username without any password. The CLI will then
prompt for a password.

https://pagure.io/dogtagpki/issue/2840