### PR TITLE
Adding `--force` and `--remove-logs` option to pki-destroy

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -953,8 +953,10 @@ class Instance:
         rv = []
         try:
             for subsystem in config.PKI_TOMCAT_SUBSYSTEMS:
-                path = self.mdict['pki_instance_path'] + \
-                    "/" + subsystem.lower()
+                path = os.path.join(
+                    self.mdict['pki_instance_path'],
+                    subsystem.lower()
+                )
                 if os.path.exists(path) and os.path.isdir(path):
                     rv.append(subsystem)
         except OSError as exc:

--- a/base/server/python/pki/server/deployment/scriptlets/finalization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/finalization.py
@@ -70,19 +70,18 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         logger.info(log.PKISPAWN_END_MESSAGE_2,
                     deployer.mdict['pki_subsystem'],
                     deployer.mdict['pki_instance_name'])
-        deployer.file.modify(deployer.mdict['pki_spawn_log'], silent=True)
 
     def destroy(self, deployer):
 
         logger.info('Finalizing subsystem removal')
 
-        deployer.file.modify(deployer.mdict['pki_destroy_log'], silent=True)
         # If this is the last remaining PKI instance, ALWAYS remove the
         # link to start configured PKI instances upon system reboot
         if deployer.mdict['pki_subsystem'] in config.PKI_SUBSYSTEMS and\
            deployer.instance.pki_instance_subsystems() == 0:
             deployer.systemd.disable()
-        # Start this Tomcat PKI Process
+
+        # Start this Tomcat PKI Process back if there are any subsystems still existing
         if len(deployer.instance.tomcat_instance_subsystems()) >= 1:
             deployer.systemd.start()
         logger.info(log.PKIDESTROY_END_MESSAGE_2,

--- a/base/server/python/pki/server/deployment/scriptlets/initialization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/initialization.py
@@ -115,44 +115,52 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         deployer.configuration_file.verify_ds_secure_connection_data()
 
     def destroy(self, deployer):
+        try:
+            logger.info(log.PKIDESTROY_BEGIN_MESSAGE_2,
+                        deployer.mdict['pki_subsystem'],
+                        deployer.mdict['pki_instance_name'])
 
-        logger.info(log.PKIDESTROY_BEGIN_MESSAGE_2,
-                    deployer.mdict['pki_subsystem'],
-                    deployer.mdict['pki_instance_name'])
+            logger.info('Initialization')
 
-        logger.info('Initialization')
+            # verify that this type of "subsystem" currently EXISTS
+            # for this "instance"
+            deployer.instance.verify_subsystem_exists()
+            # verify that the command-line parameters match the values
+            # that are present in the corresponding configuration file
+            deployer.configuration_file.verify_command_matches_configuration_file()
+            # establish 'uid' and 'gid'
+            deployer.identity.set_uid(deployer.mdict['pki_user'])
+            deployer.identity.set_gid(deployer.mdict['pki_group'])
+            # get ports to remove selinux context
+            deployer.configuration_file.populate_non_default_ports()
 
-        # verify that this type of "subsystem" currently EXISTS
-        # for this "instance"
-        deployer.instance.verify_subsystem_exists()
-        # verify that the command-line parameters match the values
-        # that are present in the corresponding configuration file
-        deployer.configuration_file.verify_command_matches_configuration_file()
-        # establish 'uid' and 'gid'
-        deployer.identity.set_uid(deployer.mdict['pki_user'])
-        deployer.identity.set_gid(deployer.mdict['pki_group'])
-        # get ports to remove selinux context
-        deployer.configuration_file.populate_non_default_ports()
+            # remove kra connector from CA if this is a KRA
+            deployer.kra_connector.deregister()
 
-        # remove kra connector from CA if this is a KRA
-        deployer.kra_connector.deregister()
+            # remove tps connector from TKS if this is a TPS
+            deployer.tps_connector.deregister()
 
-        # remove tps connector from TKS if this is a TPS
-        deployer.tps_connector.deregister()
+            # de-register instance from its Security Domain
+            #
+            #     NOTE:  Since the security domain of an instance must be up
+            #            and running in order to be de-registered, this step
+            #            must be done PRIOR to instance shutdown because this
+            #            instance's security domain may be a part of a
+            #            tightly-coupled shared instance.
+            #
 
-        # de-register instance from its Security Domain
-        #
-        #     NOTE:  Since the security domain of an instance must be up
-        #            and running in order to be de-registered, this step
-        #            must be done PRIOR to instance shutdown because this
-        #            instance's security domain may be a part of a
-        #            tightly-coupled shared instance.
-        #
+            # Previously we obtained the token through a command line interface
+            # no longer supported. Thus we assume no token and the deregister op will
+            # take place without the token using an alternate method.
 
-        # Previously we obtained the token through a command line interface
-        # no longer supported. Thus we assume no token and the deregister op will
-        # take place without the token using an alternate method.
+            deployer.security_domain.deregister(None)
 
-        deployer.security_domain.deregister(None)
-        # ALWAYS Stop this Tomcat PKI Process
-        deployer.systemd.stop()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(str(e))
+            # If it is a normal destroy, pass any exception
+            if not deployer.mdict['pki_force_destroy']:
+                raise
+
+        finally:
+            # ALWAYS Stop this Tomcat PKI Process
+            deployer.systemd.stop()

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -251,8 +251,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         # remove Tomcat instance base
         deployer.directory.delete(deployer.mdict['pki_instance_path'])
-        # remove Tomcat instance logs
-        deployer.directory.delete(deployer.mdict['pki_instance_log_path'])
+
+        # remove Tomcat instance logs only if --remove-logs is specified
+        if deployer.mdict['pki_remove_logs']:
+            deployer.directory.delete(deployer.mdict['pki_instance_log_path'])
+
         # remove shared NSS security database path for this instance
         deployer.directory.delete(deployer.mdict['pki_server_database_path'])
         # remove Tomcat instance configuration

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 import logging
 import os
-import shutil
 
 import pki.nssdb
 import pki.pkcs12
@@ -308,5 +307,5 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             if deployer.directory.exists(deployer.mdict['pki_client_dir']):
                 deployer.directory.delete(deployer.mdict['pki_client_dir'])
 
-            shutil.rmtree(deployer.mdict['pki_server_database_path'])
+            deployer.directory.delete(deployer.mdict['pki_server_database_path'])
             deployer.file.delete(deployer.mdict['pki_shared_password_conf'])

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -135,15 +135,17 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             deployer.directory.delete(
                 deployer.mdict['pki_subsystem_profiles_path'])
         deployer.directory.delete(deployer.mdict['pki_subsystem_path'])
-        # remove instance-based subsystem logs
-        if deployer.mdict['pki_subsystem'] in \
-                config.PKI_SIGNED_AUDIT_SUBSYSTEMS:
+        # remove instance-based subsystem logs only if --remove-logs flag is specified
+        if deployer.mdict['pki_remove_logs']:
+            if deployer.mdict['pki_subsystem'] in \
+                    config.PKI_SIGNED_AUDIT_SUBSYSTEMS:
+                deployer.directory.delete(
+                    deployer.mdict['pki_subsystem_signed_audit_log_path'])
             deployer.directory.delete(
-                deployer.mdict['pki_subsystem_signed_audit_log_path'])
-        deployer.directory.delete(
-            deployer.mdict['pki_subsystem_archive_log_path'])
-        deployer.directory.delete(
-            deployer.mdict['pki_subsystem_log_path'])
+                deployer.mdict['pki_subsystem_archive_log_path'])
+            deployer.directory.delete(
+                deployer.mdict['pki_subsystem_log_path'])
+
         # remove instance-based subsystem configuration
         deployer.directory.delete(
             deployer.mdict['pki_subsystem_configuration_path'])

--- a/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
+++ b/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
@@ -71,7 +71,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         logger.info('Removing webapp')
 
-        # Delete <instance>/conf/Catalina/localhost/<subsystem>.xml
+        # Delete <instance>/Catalina/localhost/<subsystem>.xml
         deployer.file.delete(
             os.path.join(
                 deployer.mdict['pki_instance_configuration_path'],

--- a/base/server/python/pki/server/pkidestroy.py
+++ b/base/server/python/pki/server/pkidestroy.py
@@ -98,7 +98,14 @@ def main(argv):
         '--force',
         dest='pki_force_destroy',
         action='store_true',
-        help='force remove all installed files'
+        help='force removal of subsystem'
+    )
+
+    parser.optional.add_argument(
+        '--remove-logs',
+        dest='pki_remove_logs',
+        action='store_true',
+        help='remove subsystem logs'
     )
 
     args = parser.process_command_line_arguments()
@@ -164,6 +171,9 @@ def main(argv):
     #   '--force'
     force_destroy = args.pki_force_destroy
 
+    #   '--remove-logs'
+    remove_logs = args.pki_remove_logs
+
     # verify that previously deployed instance exists
     deployed_pki_instance_path = os.path.join(
         config.PKI_DEPLOYMENT_BASE_ROOT, config.pki_deployed_instance_name
@@ -189,13 +199,16 @@ def main(argv):
         config.PKI_DEPLOYMENT_DEFAULT_CONFIGURATION_FILE
 
     # establish complete path to previously deployed configuration file
-    if not force_destroy:
-        config.user_deployment_cfg = os.path.join(
-            deployed_pki_subsystem_path,
-            "registry",
-            deployer.subsystem_name.lower(),
-            config.USER_DEPLOYMENT_CONFIGURATION
-        )
+    config.user_deployment_cfg = os.path.join(
+        deployed_pki_subsystem_path,
+        "registry",
+        deployer.subsystem_name.lower(),
+        config.USER_DEPLOYMENT_CONFIGURATION
+    )
+
+    if force_destroy and not os.path.exists(config.user_deployment_cfg):
+        # During force destroy, try to load the file. If file doesn't exist, we ignore it
+        config.user_deployment_cfg = None
 
     parser.validate()
     parser.init_config()
@@ -228,6 +241,9 @@ def main(argv):
 
     # Add force_destroy to master dictionary
     parser.mdict['pki_force_destroy'] = force_destroy
+
+    # Add remove logs to master dictionary
+    parser.mdict['pki_remove_logs'] = remove_logs
 
     config.pki_log.debug(log.PKI_DICTIONARY_MASTER,
                          extra=config.PKI_INDENTATION_LEVEL_0)


### PR DESCRIPTION
This PR introduces the following things:
* Fixes `bz-1372056` and `bz-1458010`
* `pki-destroy` and `pki-spawn` logs are now owned by `root`
  rather than the configured pkiuser
* Ensure dir path joins are made using Python's `os.path.join()` to
  ensure platform independence
* By default, keep logs. Remove logs when `--remove-logs` flag is
  specified
* `--force` flag tries to do a normal destroy. If destroy ran partially before,
  it forces removal of remnant files 

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`