### PR TITLE
No missing token in verify_certificate_exists

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2436,11 +2436,6 @@ class Certutil:
             #   Specify the 'token'
             if token:
                 command.extend(["-h", token])
-            else:
-                config.pki_log.error(
-                    log.PKIHELPER_CERTUTIL_MISSING_TOKEN,
-                    extra=config.PKI_INDENTATION_LEVEL_2)
-                raise Exception(log.PKIHELPER_CERTUTIL_MISSING_TOKEN)
             #   Specify the nickname of this self-signed certificate
             if nickname:
                 command.extend(["-n", nickname])

--- a/base/server/python/pki/server/deployment/pkimessages.py
+++ b/base/server/python/pki/server/deployment/pkimessages.py
@@ -188,7 +188,6 @@ PKIHELPER_CERTUTIL_MISSING_PATH = "certutil:  Missing '-d path' option!"
 PKIHELPER_CERTUTIL_MISSING_SERIAL_NUMBER = \
     "certutil:  Missing '-m serial-number' option!"
 PKIHELPER_CERTUTIL_MISSING_SUBJECT = "certutil:  Missing '-s subject' option!"
-PKIHELPER_CERTUTIL_MISSING_TOKEN = "certutil:  Missing '-h token' option!"
 PKIHELPER_CERTUTIL_MISSING_TRUSTARGS = \
     "certutil:  Missing '-t trustargs' option!"
 PKIHELPER_CERTUTIL_MISSING_VALIDITY_PERIOD = \


### PR DESCRIPTION
Remove the missing token check from verify_certificate_exists. It was
the one place that was not adopted to use blank token as default.

Change-Id: Ic192e0699ff32af474976039af08e1503925dfd1
See: 17677ae4d2cda456b64ec67e2b25ba63f4a58a70
Fixes: https://pagure.io/dogtagpki/issue/3073
Signed-off-by: Christian Heimes <cheimes@redhat.com>