### PR TITLE
Fixed pki-server subsystem-cert-* commands

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -262,6 +262,18 @@ class PKISubsystem(object):
         for cert_id in cert_ids:
             yield self.get_subsystem_cert(cert_id)
 
+    def get_cert_infos(self):
+
+        cert_ids = self.config['%s.cert.list' % self.name].split(',')
+
+        certs = []
+
+        for cert_id in cert_ids:
+            cert = self.get_cert_info(cert_id)
+            certs.append(cert)
+
+        return certs
+
     def get_subsystem_cert(self, cert_id):
 
         cert = self.get_cert_info(cert_id)

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -283,15 +283,24 @@ class PKISubsystem(object):
         if not nickname:
             return cert
 
-        nssdb = self.instance.open_nssdb(token)
-        try:
-            cert_info = nssdb.get_cert_info(nickname)
-            if cert_info:
-                cert.update(cert_info)
-        finally:
-            nssdb.close()
+        cert_info = self.get_nssdb_cert_info(cert_id)
+        if cert_info:
+            cert.update(cert_info)
 
         return cert
+
+    def get_nssdb_cert_info(self, cert_id):
+
+        logger.info('Getting %s cert info for %s from NSS database', cert_id, self.name)
+
+        nickname = self.config.get('%s.%s.nickname' % (self.name, cert_id))
+        token = self.config.get('%s.%s.tokenname' % (self.name, cert_id))
+
+        nssdb = self.instance.open_nssdb(token)
+        try:
+            return nssdb.get_cert_info(nickname)
+        finally:
+            nssdb.close()
 
     def update_subsystem_cert(self, cert):
         cert_id = cert['id']

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -264,7 +264,19 @@ class PKISubsystem(object):
 
     def get_subsystem_cert(self, cert_id):
 
-        logger.info('Getting %s cert info for %s', cert_id, self.name)
+        cert = self.get_cert_info(cert_id)
+        if not cert['nickname']:
+            return cert
+
+        cert_info = self.get_nssdb_cert_info(cert_id)
+        if cert_info:
+            cert.update(cert_info)
+
+        return cert
+
+    def get_cert_info(self, cert_id):
+
+        logger.info('Getting %s cert info for %s from CS.cfg', cert_id, self.name)
 
         nickname = self.config.get('%s.%s.nickname' % (self.name, cert_id))
         token = self.config.get('%s.%s.tokenname' % (self.name, cert_id))
@@ -279,13 +291,6 @@ class PKISubsystem(object):
             '%s.%s.certreq' % (self.name, cert_id), None)
         cert['certusage'] = self.config.get(
             '%s.cert.%s.certusage' % (self.name, cert_id), None)
-
-        if not nickname:
-            return cert
-
-        cert_info = self.get_nssdb_cert_info(cert_id)
-        if cert_info:
-            cert.update(cert_info)
 
         return cert
 

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -377,7 +377,12 @@ class SubsystemCertCLI(pki.cli.CLI):
         print('  Serial No: %s' % cert['serial_number'])
         print('  Cert ID: %s' % cert['id'])
         print('  Nickname: %s' % cert['nickname'])
-        print('  Token: %s' % cert['token'])
+
+        token = cert['token']
+        if not token:
+            token = pki.nssdb.INTERNAL_TOKEN_FULL_NAME
+
+        print('  Token: %s' % token)
 
         if show_all:
             print('  Certificate: %s' % cert['data'])
@@ -1006,7 +1011,10 @@ class SubsystemCertValidateCLI(pki.cli.CLI):
 
         print('  Usage: %s' % usage)
 
-        token = cert.get('token', '')
+        token = cert['token']
+        if not token:
+            token = pki.nssdb.INTERNAL_TOKEN_FULL_NAME
+
         print('  Token: %s' % token)
 
         # normalize internal token into None

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -453,16 +453,22 @@ class SubsystemCertFindCLI(pki.cli.CLI):
             print('ERROR: No %s subsystem in instance '
                   '%s.' % (subsystem_name, instance_name))
             sys.exit(1)
-        results = subsystem.find_system_certs()
 
-        self.print_message('%s entries matched' % len(results))
+        certs = subsystem.get_cert_infos()
+
+        self.print_message('%s entries matched' % len(certs))
 
         first = True
-        for cert in results:
+        for cert in certs:
             if first:
                 first = False
             else:
                 print()
+
+            if cert['nickname']:
+                cert_info = subsystem.get_nssdb_cert_info(cert['id'])
+                if cert_info:
+                    cert.update(cert_info)
 
             SubsystemCertCLI.print_subsystem_cert(cert, show_all)
 


### PR DESCRIPTION
These patches fix regressions on pki-server subsystem-cert-* commands:
* pki-server subsystem-cert-find failed since it tries to call len() on a list generator
* pki-server subsystem-cert-find, pki-server subsystem-cert-show, and pki-server subsystem-cert-validate shows a blank for internal token.