### PR TITLE
Use javac for JDK8+ support

### DIFF
--- a/base/symkey/src/com/netscape/symkey/CMakeLists.txt
+++ b/base/symkey/src/com/netscape/symkey/CMakeLists.txt
@@ -41,10 +41,10 @@ add_custom_command(
     OUTPUT
         ${symkey_library_HDRS}
     COMMAND
-        ${Java_JAVAH_EXECUTABLE}
+        ${Java_JAVAC_EXECUTABLE}
             -classpath ${CMAKE_CURRENT_BINARY_DIR}/../../../classes:${JAVA_LIB_INSTALL_DIR}/jss4.jar
-            -jni -d ${CMAKE_CURRENT_BINARY_DIR}
-            com.netscape.symkey.SessionKey
+            -h ${CMAKE_CURRENT_BINARY_DIR}
+            ${CMAKE_CURRENT_SOURCE_DIR}/SessionKey.java
 )
 
 add_library(${SYMKEY_SHARED_LIBRARY} SHARED ${symkey_library_HDRS} ${symkey_library_SRCS})


### PR DESCRIPTION
One of a series of PRs that begin to introduce JDK8+ support to PKI.

This introduces a change already added to JSS and nuxwdog to support JNI compilation via `javac` instead of `javah`. Note that this change is compatible with JDK8+ as `javac` already supports the `-h` flag for several releases. I can't find a source for when it was introduced but on my system:

```
$ javac 2>&1 | grep '\-h'
  -h <directory>             Specify where to place generated native header files
  -help                      Print a synopsis of standard options
$ javac -version
javac 1.8.0_181
$ java -version
openjdk version "1.8.0_181"
OpenJDK Runtime Environment (build 1.8.0_181-b15)
OpenJDK 64-Bit Server VM (build 25.181-b15, mixed mode)
```


The `CMakeLists.txt` change was required for building with JDK11 on Rawhide but is backwards compatible with all JDK versions. It is possible that a later version of CMake will allow us to go back to `Java REQUIRED`, but I'm not sure.
