### PR TITLE
Reuse same instance log dirs (if exists)

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -373,18 +373,16 @@ class Namespace:
                     log.PKIHELPER_NAMESPACE_COLLISION_2 % (
                         self.mdict['pki_instance_name'],
                         self.mdict['pki_cgroup_cpu_systemd_service_path']))
+
         if os.path.exists(self.mdict['pki_instance_log_path']) and\
            os.path.exists(self.mdict['pki_subsystem_log_path']):
-            # Top-Level PKI log path collision
-            config.pki_log.error(
-                log.PKIHELPER_NAMESPACE_COLLISION_2,
+            # Check if logs already exist. If so, append to it. Log it as info
+            config.pki_log.info(
+                log.PKIHELPER_LOG_REUSE,
                 self.mdict['pki_instance_name'],
                 self.mdict['pki_instance_log_path'],
                 extra=config.PKI_INDENTATION_LEVEL_2)
-            raise Exception(
-                log.PKIHELPER_NAMESPACE_COLLISION_2 % (
-                    self.mdict['pki_instance_name'],
-                    self.mdict['pki_instance_log_path']))
+
         if os.path.exists(self.mdict['pki_instance_configuration_path']) and\
            os.path.exists(self.mdict['pki_subsystem_configuration_path']):
             # Top-Level PKI configuration path collision

--- a/base/server/python/pki/server/deployment/pkimessages.py
+++ b/base/server/python/pki/server/deployment/pkimessages.py
@@ -271,6 +271,8 @@ PKIHELPER_NAMESPACE_COLLISION_2 = \
     "PKI instance '%s' would produce a namespace collision with '%s'!"
 PKIHELPER_NAMESPACE_RESERVED_NAME_2 = \
     "PKI instance '%s' is already a reserved name under '%s'!"
+PKIHELPER_LOG_REUSE = \
+    "previous logs of PKI instance '%s' already exist. Appending logs to '%s'"
 PKIHELPER_NCIPHER_RESTART_1 = "executing '%s'"
 PKIHELPER_NOISE_FILE_2 = \
     "generating noise file called '%s' and filling it with '%d' random bytes"


### PR DESCRIPTION
- `pkidestroy` behaviour was changed in #79 which preserves the log
  by default. When `pkispawn` was run, it threw a name space collision
  error.
- This patch reuses the log dir and appends logs to the same log dir
  structure (if exists) and logs it accordingly.

Ticket: https://pagure.io/dogtagpki/issue/3077

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`