### PR TITLE
[BACKPORT] Adding new flags to pkidestroy

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -135,20 +135,21 @@ class PKISubsystem(object):
     def load(self):
         self.config.clear()
 
-        lines = open(self.cs_conf).read().splitlines()
+        if os.path.exists(self.cs_conf):
+            lines = open(self.cs_conf).read().splitlines()
 
-        for index, line in enumerate(lines):
-            if not line or line.startswith('#'):
-                continue
-            parts = line.split('=', 1)
-            if len(parts) < 2:
-                raise Exception('Missing delimiter in %s line %d' % (self.cs_conf, index + 1))
-            name = parts[0]
-            value = parts[1]
-            self.config[name] = value
+            for index, line in enumerate(lines):
+                if not line or line.startswith('#'):
+                    continue
+                parts = line.split('=', 1)
+                if len(parts) < 2:
+                    raise Exception('Missing delimiter in %s line %d' % (self.cs_conf, index + 1))
+                name = parts[0]
+                value = parts[1]
+                self.config[name] = value
 
-        self.type = self.config['cs.type']
-        self.prefix = self.type.lower()
+            self.type = self.config['cs.type']
+            self.prefix = self.type.lower()
 
     def find_system_certs(self):
         certs = []

--- a/base/server/python/pki/server/deployment/pkiconfig.py
+++ b/base/server/python/pki/server/deployment/pkiconfig.py
@@ -39,9 +39,7 @@ PKI_DEPLOYMENT_DEFAULT_SHELL = "/sbin/nologin"
 PKI_DEPLOYMENT_DEFAULT_UID = 17
 PKI_DEPLOYMENT_DEFAULT_USER = "pkiuser"
 
-PKI_SUBSYSTEMS = ["CA", "KRA", "OCSP", "RA", "TKS", "TPS"]
-PKI_SIGNED_AUDIT_SUBSYSTEMS = ["CA", "KRA", "OCSP", "TKS", "TPS"]
-PKI_TOMCAT_SUBSYSTEMS = ["CA", "KRA", "OCSP", "TKS", "TPS"]
+PKI_SUBSYSTEMS = ["CA", "KRA", "OCSP", "TKS", "TPS"]
 PKI_BASE_RESERVED_NAMES = ["alias", "bin", "ca", "common", "conf", "kra",
                            "lib", "logs", "ocsp", "temp", "tks", "tps",
                            "webapps", "work"]

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -345,18 +345,16 @@ class Namespace:
                     log.PKIHELPER_NAMESPACE_COLLISION_2 % (
                         self.mdict['pki_instance_name'],
                         self.mdict['pki_cgroup_cpu_systemd_service_path']))
+
         if os.path.exists(self.mdict['pki_instance_log_path']) and\
            os.path.exists(self.mdict['pki_subsystem_log_path']):
-            # Top-Level PKI log path collision
-            config.pki_log.error(
-                log.PKIHELPER_NAMESPACE_COLLISION_2,
+            # Check if logs already exist. If so, append to it. Log it as info
+            config.pki_log.info(
+                log.PKIHELPER_LOG_REUSE,
                 self.mdict['pki_instance_name'],
                 self.mdict['pki_instance_log_path'],
                 extra=config.PKI_INDENTATION_LEVEL_2)
-            raise Exception(
-                log.PKIHELPER_NAMESPACE_COLLISION_2 % (
-                    self.mdict['pki_instance_name'],
-                    self.mdict['pki_instance_log_path']))
+
         if os.path.exists(self.mdict['pki_instance_configuration_path']) and\
            os.path.exists(self.mdict['pki_subsystem_configuration_path']):
             # Top-Level PKI configuration path collision

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -946,7 +946,7 @@ class Instance:
         # Return list of PKI subsystems in the specified tomcat instance
         rv = []
         try:
-            for subsystem in config.PKI_TOMCAT_SUBSYSTEMS:
+            for subsystem in config.PKI_SUBSYSTEMS:
                 path = os.path.join(
                     self.mdict['pki_instance_path'],
                     subsystem.lower()

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -947,8 +947,10 @@ class Instance:
         rv = []
         try:
             for subsystem in config.PKI_TOMCAT_SUBSYSTEMS:
-                path = self.mdict['pki_instance_path'] + \
-                    "/" + subsystem.lower()
+                path = os.path.join(
+                    self.mdict['pki_instance_path'],
+                    subsystem.lower()
+                )
                 if os.path.exists(path) and os.path.isdir(path):
                     rv.append(subsystem)
         except OSError as exc:

--- a/base/server/python/pki/server/deployment/pkimessages.py
+++ b/base/server/python/pki/server/deployment/pkimessages.py
@@ -277,6 +277,8 @@ PKIHELPER_NAMESPACE_COLLISION_2 = \
     "PKI instance '%s' would produce a namespace collision with '%s'!"
 PKIHELPER_NAMESPACE_RESERVED_NAME_2 = \
     "PKI instance '%s' is already a reserved name under '%s'!"
+PKIHELPER_LOG_REUSE = \
+    "previous logs of PKI instance '%s' already exist. Appending logs to '%s'"
 PKIHELPER_NCIPHER_RESTART_1 = "executing '%s'"
 PKIHELPER_NOISE_FILE_2 = \
     "generating noise file called '%s' and filling it with '%d' random bytes"

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -1274,9 +1274,4 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             raise RuntimeError("server failed to restart")
 
     def destroy(self, deployer):
-
-        config.pki_log.info(log.CONFIGURATION_DESTROY_1, __name__,
-                            extra=config.PKI_INDENTATION_LEVEL_1)
-        if len(deployer.instance.tomcat_instance_subsystems()) == 1:
-            if deployer.directory.exists(deployer.mdict['pki_client_dir']):
-                deployer.directory.delete(deployer.mdict['pki_client_dir'])
+        pass

--- a/base/server/python/pki/server/deployment/scriptlets/finalization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/finalization.py
@@ -68,19 +68,18 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                             deployer.mdict['pki_subsystem'],
                             deployer.mdict['pki_instance_name'],
                             extra=config.PKI_INDENTATION_LEVEL_0)
-        deployer.file.modify(deployer.mdict['pki_spawn_log'], silent=True)
 
     def destroy(self, deployer):
 
         config.pki_log.info(log.FINALIZATION_DESTROY_1, __name__,
                             extra=config.PKI_INDENTATION_LEVEL_1)
-        deployer.file.modify(deployer.mdict['pki_destroy_log'], silent=True)
         # If this is the last remaining PKI instance, ALWAYS remove the
         # link to start configured PKI instances upon system reboot
         if deployer.mdict['pki_subsystem'] in config.PKI_SUBSYSTEMS and\
            deployer.instance.pki_instance_subsystems() == 0:
             deployer.systemd.disable()
-        # Start this Tomcat PKI Process
+
+        # Start this Tomcat PKI Process back if there are any subsystems still existing
         if len(deployer.instance.tomcat_instance_subsystems()) >= 1:
             deployer.systemd.start()
         config.pki_log.info(log.PKIDESTROY_END_MESSAGE_2,

--- a/base/server/python/pki/server/deployment/scriptlets/initialization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/initialization.py
@@ -128,7 +128,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             deployer.security_domain.deregister(None)
 
         except Exception as e:  # pylint: disable=broad-except
-            config.pki_log.error(str(e))
+            config.pki_log.error(log.PKI_OSERROR_1, e,
+                                 extra=config.PKI_INDENTATION_LEVEL_0)
             # If it is a normal destroy, pass any exception
             if not deployer.mdict['pki_force_destroy']:
                 raise

--- a/base/server/python/pki/server/deployment/scriptlets/initialization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/initialization.py
@@ -86,45 +86,53 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         deployer.configuration_file.verify_ds_secure_connection_data()
 
     def destroy(self, deployer):
+        try:
+            # begin official logging
+            config.pki_log.info(log.PKIDESTROY_BEGIN_MESSAGE_2,
+                                deployer.mdict['pki_subsystem'],
+                                deployer.mdict['pki_instance_name'],
+                                extra=config.PKI_INDENTATION_LEVEL_0)
+            config.pki_log.info(log.INITIALIZATION_DESTROY_1, __name__,
+                                extra=config.PKI_INDENTATION_LEVEL_1)
+            # verify that this type of "subsystem" currently EXISTS
+            # for this "instance"
+            deployer.instance.verify_subsystem_exists()
+            # verify that the command-line parameters match the values
+            # that are present in the corresponding configuration file
+            deployer.configuration_file.verify_command_matches_configuration_file()
+            # establish 'uid' and 'gid'
+            deployer.identity.set_uid(deployer.mdict['pki_user'])
+            deployer.identity.set_gid(deployer.mdict['pki_group'])
+            # get ports to remove selinux context
+            deployer.configuration_file.populate_non_default_ports()
 
-        # begin official logging
-        config.pki_log.info(log.PKIDESTROY_BEGIN_MESSAGE_2,
-                            deployer.mdict['pki_subsystem'],
-                            deployer.mdict['pki_instance_name'],
-                            extra=config.PKI_INDENTATION_LEVEL_0)
-        config.pki_log.info(log.INITIALIZATION_DESTROY_1, __name__,
-                            extra=config.PKI_INDENTATION_LEVEL_1)
-        # verify that this type of "subsystem" currently EXISTS
-        # for this "instance"
-        deployer.instance.verify_subsystem_exists()
-        # verify that the command-line parameters match the values
-        # that are present in the corresponding configuration file
-        deployer.configuration_file.verify_command_matches_configuration_file()
-        # establish 'uid' and 'gid'
-        deployer.identity.set_uid(deployer.mdict['pki_user'])
-        deployer.identity.set_gid(deployer.mdict['pki_group'])
-        # get ports to remove selinux context
-        deployer.configuration_file.populate_non_default_ports()
+            # remove kra connector from CA if this is a KRA
+            deployer.kra_connector.deregister()
 
-        # remove kra connector from CA if this is a KRA
-        deployer.kra_connector.deregister()
+            # remove tps connector from TKS if this is a TPS
+            deployer.tps_connector.deregister()
 
-        # remove tps connector from TKS if this is a TPS
-        deployer.tps_connector.deregister()
+            # de-register instance from its Security Domain
+            #
+            #     NOTE:  Since the security domain of an instance must be up
+            #            and running in order to be de-registered, this step
+            #            must be done PRIOR to instance shutdown because this
+            #            instance's security domain may be a part of a
+            #            tightly-coupled shared instance.
+            #
 
-        # de-register instance from its Security Domain
-        #
-        #     NOTE:  Since the security domain of an instance must be up
-        #            and running in order to be de-registered, this step
-        #            must be done PRIOR to instance shutdown because this
-        #            instance's security domain may be a part of a
-        #            tightly-coupled shared instance.
-        #
+            # Previously we obtained the token through a command line interface
+            # no longer supported. Thus we assume no token and the deregister op will
+            # take place without the token using an alternate method.
 
-        # Previously we obtained the token through a command line interface
-        # no longer supported. Thus we assume no token and the deregister op will
-        # take place without the token using an alternate method.
+            deployer.security_domain.deregister(None)
 
-        deployer.security_domain.deregister(None)
-        # ALWAYS Stop this Tomcat PKI Process
-        deployer.systemd.stop()
+        except Exception as e:  # pylint: disable=broad-except
+            config.pki_log.error(str(e))
+            # If it is a normal destroy, pass any exception
+            if not deployer.mdict['pki_force_destroy']:
+                raise
+
+        finally:
+            # ALWAYS Stop this Tomcat PKI Process
+            deployer.systemd.stop()

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -199,8 +199,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         # remove Tomcat instance base
         deployer.directory.delete(deployer.mdict['pki_instance_path'])
-        # remove Tomcat instance logs
-        deployer.directory.delete(deployer.mdict['pki_instance_log_path'])
+
+        # remove Tomcat instance logs only if --remove-logs is specified
+        if deployer.mdict['pki_remove_logs']:
+            deployer.directory.delete(deployer.mdict['pki_instance_log_path'])
+
         # remove shared NSS security database path for this instance
         deployer.directory.delete(deployer.mdict['pki_database_path'])
         # remove Tomcat instance configuration

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -259,7 +259,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         config.pki_log.info(log.SECURITY_DATABASES_DESTROY_1, __name__,
                             extra=config.PKI_INDENTATION_LEVEL_1)
         if len(deployer.instance.tomcat_instance_subsystems()) == 0:
-            deployer.file.delete(deployer.mdict['pki_cert_database'])
-            deployer.file.delete(deployer.mdict['pki_key_database'])
-            deployer.file.delete(deployer.mdict['pki_secmod_database'])
+
+            if deployer.directory.exists(deployer.mdict['pki_client_dir']):
+                deployer.directory.delete(deployer.mdict['pki_client_dir'])
+
+            deployer.directory.delete(deployer.mdict['pki_database_path'])
             deployer.file.delete(deployer.mdict['pki_shared_password_conf'])

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -42,10 +42,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         deployer.directory.create(deployer.mdict['pki_subsystem_log_path'])
         deployer.directory.create(
             deployer.mdict['pki_subsystem_archive_log_path'])
-        if deployer.mdict['pki_subsystem'] in \
-                config.PKI_SIGNED_AUDIT_SUBSYSTEMS:
-            deployer.directory.create(
-                deployer.mdict['pki_subsystem_signed_audit_log_path'])
+
+        deployer.directory.create(
+            deployer.mdict['pki_subsystem_signed_audit_log_path'])
 
         # create /var/lib/pki/<instance>/<subsystem>/conf
         deployer.directory.create(
@@ -127,10 +126,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         # remove instance-based subsystem logs only if --remove-logs flag is specified
         if deployer.mdict['pki_remove_logs']:
-            if deployer.mdict['pki_subsystem'] in \
-                    config.PKI_SIGNED_AUDIT_SUBSYSTEMS:
-                deployer.directory.delete(
-                    deployer.mdict['pki_subsystem_signed_audit_log_path'])
+            deployer.directory.delete(
+                deployer.mdict['pki_subsystem_signed_audit_log_path'])
             deployer.directory.delete(
                 deployer.mdict['pki_subsystem_archive_log_path'])
             deployer.directory.delete(

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -124,15 +124,18 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             deployer.directory.delete(
                 deployer.mdict['pki_subsystem_profiles_path'])
         deployer.directory.delete(deployer.mdict['pki_subsystem_path'])
-        # remove instance-based subsystem logs
-        if deployer.mdict['pki_subsystem'] in \
-                config.PKI_SIGNED_AUDIT_SUBSYSTEMS:
+
+        # remove instance-based subsystem logs only if --remove-logs flag is specified
+        if deployer.mdict['pki_remove_logs']:
+            if deployer.mdict['pki_subsystem'] in \
+                    config.PKI_SIGNED_AUDIT_SUBSYSTEMS:
+                deployer.directory.delete(
+                    deployer.mdict['pki_subsystem_signed_audit_log_path'])
             deployer.directory.delete(
-                deployer.mdict['pki_subsystem_signed_audit_log_path'])
-        deployer.directory.delete(
-            deployer.mdict['pki_subsystem_archive_log_path'])
-        deployer.directory.delete(
-            deployer.mdict['pki_subsystem_log_path'])
+                deployer.mdict['pki_subsystem_archive_log_path'])
+            deployer.directory.delete(
+                deployer.mdict['pki_subsystem_log_path'])
+
         # remove instance-based subsystem configuration
         deployer.directory.delete(
             deployer.mdict['pki_subsystem_configuration_path'])

--- a/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
+++ b/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
@@ -70,7 +70,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         config.pki_log.info(log.WEBAPP_DEPLOYMENT_DESTROY_1, __name__,
                             extra=config.PKI_INDENTATION_LEVEL_1)
 
-        # Delete <instance>/conf/Catalina/localhost/<subsystem>.xml
+        # Delete <instance>/Catalina/localhost/<subsystem>.xml
         deployer.file.delete(
             os.path.join(
                 deployer.mdict['pki_instance_configuration_path'],

--- a/base/server/sbin/pkidestroy
+++ b/base/server/sbin/pkidestroy
@@ -95,6 +95,13 @@ def main(argv):
         nargs=1, metavar='<security domain password file>',
         help='security domain password file path')
 
+    parser.optional.add_argument(
+        '--force',
+        dest='pki_force_destroy',
+        action='store_true',
+        help='force removal of subsystem'
+    )
+
     args = parser.process_command_line_arguments()
 
     interactive = False
@@ -155,20 +162,26 @@ def main(argv):
                 pwd_file:
             config.pki_secdomain_pass = pwd_file.readline().strip('\n')
 
+    #   '--force'
+    force_destroy = args.pki_force_destroy
+
     # verify that previously deployed instance exists
-    deployed_pki_instance_path = \
-        config.pki_root_prefix + config.PKI_DEPLOYMENT_BASE_ROOT + "/" + \
-        config.pki_deployed_instance_name
-    if not os.path.exists(deployed_pki_instance_path):
+    deployed_pki_instance_path = os.path.join(
+        config.PKI_DEPLOYMENT_BASE_ROOT, config.pki_deployed_instance_name
+    )
+
+    if not os.path.exists(deployed_pki_instance_path) and not force_destroy:
         print("ERROR:  " + log.PKI_INSTANCE_DOES_NOT_EXIST_1 %
               deployed_pki_instance_path)
         print()
         parser.arg_parser.exit(-1)
 
     # verify that previously deployed subsystem for this instance exists
-    deployed_pki_subsystem_path = \
-        deployed_pki_instance_path + "/" + deployer.subsystem_name.lower()
-    if not os.path.exists(deployed_pki_subsystem_path):
+    deployed_pki_subsystem_path = os.path.join(
+        deployed_pki_instance_path, deployer.subsystem_name.lower()
+    )
+
+    if not os.path.exists(deployed_pki_subsystem_path) and not force_destroy:
         print("ERROR:  " + log.PKI_SUBSYSTEM_DOES_NOT_EXIST_2 %
               (deployer.subsystem_name, deployed_pki_instance_path))
         print()
@@ -178,11 +191,16 @@ def main(argv):
         config.PKI_DEPLOYMENT_DEFAULT_CONFIGURATION_FILE
 
     # establish complete path to previously deployed configuration file
-    config.user_deployment_cfg =\
-        deployed_pki_subsystem_path + "/" +\
-        "registry" + "/" +\
-        deployer.subsystem_name.lower() + "/" +\
+    config.user_deployment_cfg = os.path.join(
+        deployed_pki_subsystem_path,
+        "registry",
+        deployer.subsystem_name.lower(),
         config.USER_DEPLOYMENT_CONFIGURATION
+    )
+
+    if force_destroy and not os.path.exists(config.user_deployment_cfg):
+        # During force destroy, try to load the file. If file doesn't exist, we ignore it
+        config.user_deployment_cfg = None
 
     parser.validate()
     parser.init_config()
@@ -213,6 +231,10 @@ def main(argv):
     parser.compose_pki_master_dictionary()
     parser.mdict['pki_destroy_log'] = \
         config.pki_log_dir + "/" + config.pki_log_name
+
+    # Add force_destroy to master dictionary
+    parser.mdict['pki_force_destroy'] = force_destroy
+
     config.pki_log.debug(log.PKI_DICTIONARY_MASTER,
                          extra=config.PKI_INDENTATION_LEVEL_0)
     config.pki_log.debug(pkilogging.log_format(parser.mdict),

--- a/base/server/sbin/pkidestroy
+++ b/base/server/sbin/pkidestroy
@@ -102,6 +102,13 @@ def main(argv):
         help='force removal of subsystem'
     )
 
+    parser.optional.add_argument(
+        '--remove-logs',
+        dest='pki_remove_logs',
+        action='store_true',
+        help='remove subsystem logs'
+    )
+
     args = parser.process_command_line_arguments()
 
     interactive = False
@@ -164,6 +171,9 @@ def main(argv):
 
     #   '--force'
     force_destroy = args.pki_force_destroy
+
+    #   '--remove-logs'
+    remove_logs = args.pki_remove_logs
 
     # verify that previously deployed instance exists
     deployed_pki_instance_path = os.path.join(
@@ -234,6 +244,9 @@ def main(argv):
 
     # Add force_destroy to master dictionary
     parser.mdict['pki_force_destroy'] = force_destroy
+
+    # Add remove logs to master dictionary
+    parser.mdict['pki_remove_logs'] = remove_logs
 
     config.pki_log.debug(log.PKI_DICTIONARY_MASTER,
                          extra=config.PKI_INDENTATION_LEVEL_0)


### PR DESCRIPTION
This PR is basically a squash of changes in master:
#79  - Add `--force` and `--remove-logs`  flag to pki-destroy
#85  - Remove obsolete code
#92 - Reuse same instance log dirs (if exists)

The changes in this PR were **hand-picked** and **not cherry-picked**. A significant *new change* introduced by this PR:
- Remove the `pki_database_path` dir instead of removing *contents* of the dir
    - This is moved to `security_database.py` instead of `configuration.py`

This PR resolves:
Bugs: `1372056`, `1644769` and indirectly `1458010`
Tickets: [1172](https://pagure.io/dogtagpki/issue/1172), [3077](https://pagure.io/dogtagpki/issue/3077)

**PS:** This PR will be rebased to 10_5 branch to maintain commit history.