### PR TITLE
Merged ENCRYPT_DATA_REQUEST_PROCESSED events

### DIFF
--- a/base/common/src/com/netscape/certsrv/logging/AuditEvent.java
+++ b/base/common/src/com/netscape/certsrv/logging/AuditEvent.java
@@ -107,10 +107,6 @@ public class AuditEvent extends LogEvent {
             "LOGGING_SIGNED_AUDIT_DIVERSIFY_KEY_REQUEST_PROCESSED_FAILURE_13"; // AC: KDF SPEC CHANGE:  Need to log both KDD and CUID.  Also added TKSKeyset, OldKeyInfo_KeyVersion, NewKeyInfo_KeyVersion, NistSP800_108KdfOnKeyVersion, NistSP800_108KdfUseCuidAsKdd.
     public final static String ENCRYPT_DATA_REQUEST =
             "LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_5"; // AC: KDF SPEC CHANGE:  Need to log both KDD and CUID.
-    public final static String ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS =
-            "LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS_12";
-    public final static String ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE =
-            "LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE_13";
 
     public final static String SECURITY_DOMAIN_UPDATE =
             "LOGGING_SIGNED_AUDIT_SECURITY_DOMAIN_UPDATE_1";

--- a/base/common/src/com/netscape/certsrv/logging/event/EncryptDataRequestProcessedEvent.java
+++ b/base/common/src/com/netscape/certsrv/logging/event/EncryptDataRequestProcessedEvent.java
@@ -1,0 +1,100 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2018 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+package com.netscape.certsrv.logging.event;
+
+import com.netscape.certsrv.logging.ILogger;
+import com.netscape.certsrv.logging.SignedAuditEvent;
+
+public class EncryptDataRequestProcessedEvent extends SignedAuditEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    public final static String SUCCESS =
+            "LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS";
+
+    public final static String FAILURE =
+            "LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE";
+
+    public EncryptDataRequestProcessedEvent(String messageID) {
+        super(messageID);
+    }
+
+    public static EncryptDataRequestProcessedEvent success(
+            String CUID_decoded,
+            String KDD_decoded,
+            String status,
+            String agentID,
+            String isRandom,
+            String selectedToken,
+            String keyNickName,
+            String keySet,
+            String keyVersion,
+            String nistSP800_108KdfOnKeyVersion,
+            String nistSP800_108KdfUseCuidAsKdd) {
+
+        EncryptDataRequestProcessedEvent event = new EncryptDataRequestProcessedEvent(SUCCESS);
+
+        event.setAttribute("CUID_decoded", CUID_decoded);
+        event.setAttribute("KDD_decoded", KDD_decoded);
+        event.setAttribute("Outcome", ILogger.SUCCESS);
+        event.setAttribute("status", status);
+        event.setAttribute("AgentID", agentID);
+        event.setAttribute("isRandom", isRandom);
+        event.setAttribute("SelectedToken", selectedToken);
+        event.setAttribute("KeyNickName", keyNickName);
+        event.setAttribute("TKSKeyset", keySet);
+        event.setAttribute("KeyInfo_KeyVersion", keyVersion);
+        event.setAttribute("NistSP800_108KdfOnKeyVersion", nistSP800_108KdfOnKeyVersion);
+        event.setAttribute("NistSP800_108KdfUseCuidAsKdd", nistSP800_108KdfUseCuidAsKdd);
+
+        return event;
+    }
+
+    public static EncryptDataRequestProcessedEvent failure(
+            String CUID_decoded,
+            String KDD_decoded,
+            String status,
+            String agentID,
+            String isRandom,
+            String selectedToken,
+            String keyNickName,
+            String keySet,
+            String keyVersion,
+            String nistSP800_108KdfOnKeyVersion,
+            String nistSP800_108KdfUseCuidAsKdd,
+            String error) {
+
+        EncryptDataRequestProcessedEvent event = new EncryptDataRequestProcessedEvent(FAILURE);
+
+        event.setAttribute("CUID_decoded", CUID_decoded);
+        event.setAttribute("KDD_decoded", KDD_decoded);
+        event.setAttribute("Outcome", ILogger.FAILURE);
+        event.setAttribute("status", status);
+        event.setAttribute("AgentID", agentID);
+        event.setAttribute("isRandom", isRandom);
+        event.setAttribute("SelectedToken", selectedToken);
+        event.setAttribute("KeyNickName", keyNickName);
+        event.setAttribute("TKSKeyset", keySet);
+        event.setAttribute("KeyInfo_KeyVersion", keyVersion);
+        event.setAttribute("NistSP800_108KdfOnKeyVersion", nistSP800_108KdfOnKeyVersion);
+        event.setAttribute("NistSP800_108KdfUseCuidAsKdd", nistSP800_108KdfUseCuidAsKdd);
+        event.setAttribute("Error", error);
+
+        return event;
+    }
+}

--- a/base/server/cmsbundle/src/LogMessages.properties
+++ b/base/server/cmsbundle/src/LogMessages.properties
@@ -2429,7 +2429,7 @@ LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_5=<type=ENCRYPT_DATA_REQUEST>:[AuditEv
 # KeyInfo_KeyVersion is the key version number requested in hex.
 # NistSP800_108KdfOnKeyVersion lists the value of the corresponding setting in hex.
 # NistSP800_108KdfUseCuidAsKdd lists the value of the corresponding setting in hex.
-LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS_12=<type=ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS>:[AuditEvent=ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS][CUID_decoded={0}][KDD_decoded={1}][Outcome={2}][status={3}][AgentID={4}][isRandom={5}][SelectedToken={6}][KeyNickName={7}][TKSKeyset={8}][KeyInfo_KeyVersion={9}][NistSP800_108KdfOnKeyVersion={10}][NistSP800_108KdfUseCuidAsKdd={11}] TKS encrypt data request processed successfully
+LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS=<type=ENCRYPT_DATA_REQUEST_PROCESSED>:[AuditEvent=ENCRYPT_DATA_REQUEST_PROCESSED]{0} TKS encrypt data request processed successfully
 
 #
 # LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE
@@ -2452,7 +2452,7 @@ LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS_12=<type=ENCRYPT_DAT
 # KeyInfo_KeyVersion is the key version number requested in hex.
 # NistSP800_108KdfOnKeyVersion lists the value of the corresponding setting in hex.
 # NistSP800_108KdfUseCuidAsKdd lists the value of the corresponding setting in hex.
-LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE_13=<type=ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE>:[AuditEvent=ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE][CUID_decoded={0}][KDD_decoded={1}][Outcome={2}][status={3}][AgentID={4}][isRandom={5}][SelectedToken={6}][KeyNickName={7}][TKSKeyset={8}][KeyInfo_KeyVersion={9}][NistSP800_108KdfOnKeyVersion={10}][NistSP800_108KdfUseCuidAsKdd={11}][Error={12}] TKS encrypt data request failed
+LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE=<type=ENCRYPT_DATA_REQUEST_PROCESSED>:[AuditEvent=ENCRYPT_DATA_REQUEST_PROCESSED]{0} TKS encrypt data request failed
 #
 #
 # LOGGING_SIGNED_AUDIT_SECURITY_DOMAIN_UPDATE

--- a/base/tks/src/org/dogtagpki/server/tks/servlet/TokenServlet.java
+++ b/base/tks/src/org/dogtagpki/server/tks/servlet/TokenServlet.java
@@ -49,6 +49,7 @@ import com.netscape.certsrv.base.IPrettyPrintFormat;
 import com.netscape.certsrv.base.SessionContext;
 import com.netscape.certsrv.logging.AuditEvent;
 import com.netscape.certsrv.logging.ILogger;
+import com.netscape.certsrv.logging.event.EncryptDataRequestProcessedEvent;
 import com.netscape.cms.logging.Logger;
 import com.netscape.cms.servlet.base.CMSServlet;
 import com.netscape.cms.servlet.common.CMSRequest;
@@ -2215,9 +2216,9 @@ public class TokenServlet extends CMSServlet {
             // AC: KDF SPEC CHANGE - Log both CUID and KDD
             //                       Also added TKSKeyset, KeyInfo_KeyVersion, NistSP800_108KdfOnKeyVersion, NistSP800_108KdfUseCuidAsKdd
             //                       Finally, log CUID and KDD in ASCII-HEX format, as long as special-decoded version is available.
-            String[] logParams = { log_string_from_specialDecoded_byte_array(xCUID), // CUID_decoded
+            EncryptDataRequestProcessedEvent event = EncryptDataRequestProcessedEvent.success(
+                    log_string_from_specialDecoded_byte_array(xCUID), // CUID_decoded
                     log_string_from_specialDecoded_byte_array(xKDD), // KDD_decoded
-                    ILogger.SUCCESS, // Outcome
                     status, // status
                     agentId, // AgentID
                     s_isRandom, // isRandom
@@ -2227,15 +2228,17 @@ public class TokenServlet extends CMSServlet {
                     log_string_from_keyInfo(xkeyInfo), // KeyInfo_KeyVersion
                     "0x" + Integer.toHexString(nistSP800_108KdfOnKeyVersion & 0x000000FF), // NistSP800_108KdfOnKeyVersion
                     Boolean.toString(nistSP800_108KdfUseCuidAsKdd) // NistSP800_108KdfUseCuidAsKdd
-            };
-            auditMessage = CMS.getLogMessage(AuditEvent.ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS, logParams);
+            );
+
+            signedAuditLogger.log(event);
+
         } else {
             // AC: KDF SPEC CHANGE - Log both CUID and KDD
             //                       Also added TKSKeyset, KeyInfo_KeyVersion, NistSP800_108KdfOnKeyVersion, NistSP800_108KdfUseCuidAsKdd
             //                       Finally, log CUID and KDD in ASCII-HEX format, as long as special-decoded version is available.
-            String[] logParams = { log_string_from_specialDecoded_byte_array(xCUID), // CUID_decoded
+            EncryptDataRequestProcessedEvent event = EncryptDataRequestProcessedEvent.failure(
+                    log_string_from_specialDecoded_byte_array(xCUID), // CUID_decoded
                     log_string_from_specialDecoded_byte_array(xKDD), // KDD_decoded
-                    ILogger.FAILURE, // Outcome
                     status, // status
                     agentId, // AgentID
                     s_isRandom, // isRandom
@@ -2246,11 +2249,10 @@ public class TokenServlet extends CMSServlet {
                     "0x" + Integer.toHexString(nistSP800_108KdfOnKeyVersion & 0x000000FF), // NistSP800_108KdfOnKeyVersion
                     Boolean.toString(nistSP800_108KdfUseCuidAsKdd), // NistSP800_108KdfUseCuidAsKdd
                     errorMsg // Error
-            };
-            auditMessage = CMS.getLogMessage(AuditEvent.ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE, logParams);
-        }
+            );
 
-        audit(auditMessage);
+            signedAuditLogger.log(event);
+        }
     }
 
     /*


### PR DESCRIPTION
ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE and
ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS have been merged
into a single ENCRYPT_DATA_REQUEST_PROCESSED event with
different outcomes.

https://pagure.io/dogtagpki/issue/2686