### PR TITLE
Allow log upload to transfer.sh fail

### DIFF
--- a/travis/ipa-test.sh
+++ b/travis/ipa-test.sh
@@ -25,7 +25,7 @@ exit_handler() {
 
     # Save systemd journal
     journalctl -b --no-pager > systemd_journal.txt
-    curl -k -w "\n" --upload systemd_journal.txt https://transfer.sh/systemd_journal.txt >> ${BUILDDIR}/pki/logs.txt
+    curl -k -w "\n" --upload systemd_journal.txt https://transfer.sh/systemd_journal.txt >> ${BUILDDIR}/pki/logs.txt || true
 
     # Save other logs
     LOGS_TAR_NAME="var_log.tar"
@@ -38,7 +38,7 @@ exit_handler() {
         /var/log/pki
 
     chown ${BUILDUSER_UID}:${BUILDUSER_GID} /tmp/${LOGS_TAR_NAME}
-    curl -k -w "\n" --upload /tmp/${LOGS_TAR_NAME} https://transfer.sh/${LOGS_TAR_NAME} >> ${BUILDDIR}/pki/logs.txt
+    curl -k -w "\n" --upload /tmp/${LOGS_TAR_NAME} https://transfer.sh/${LOGS_TAR_NAME} >> ${BUILDDIR}/pki/logs.txt || true
 }
 
 

--- a/travis/pki-build.sh
+++ b/travis/pki-build.sh
@@ -9,7 +9,7 @@ function compose {
 
 function upload {
     if test -f $BUILDLOG; then
-        curl -k -w "\n" --upload-file $BUILDLOG https://transfer.sh/pki-build.txt >> ${BUILDDIR}/pki/logs.txt
+        curl -k -w "\n" --upload-file $BUILDLOG https://transfer.sh/pki-build.txt >> ${BUILDDIR}/pki/logs.txt || true
         cat ${BUILDDIR}/pki/logs.txt
     fi
 }


### PR DESCRIPTION
- PKI build process isn't dependent on uploading logs to
  transfer.sh and so should not fail if the infrastructure is down

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>