### PR TITLE
Sync FindNSPR and FindNSS with JSS changes

### DIFF
--- a/cmake/Modules/FindNSPR.cmake
+++ b/cmake/Modules/FindNSPR.cmake
@@ -34,6 +34,7 @@ else (NSPR_LIBRARIES AND NSPR_INCLUDE_DIRS)
       /sw/include
     PATH_SUFFIXES
       nspr4
+      nspr
   )
 
   find_library(PLDS4_LIBRARY

--- a/cmake/Modules/FindNSS.cmake
+++ b/cmake/Modules/FindNSS.cmake
@@ -34,6 +34,7 @@ else (NSS_LIBRARIES AND NSS_INCLUDE_DIRS)
       /sw/include
     PATH_SUFFIXES
       nss3
+      nss
   )
 
   find_library(SSL3_LIBRARY


### PR DESCRIPTION
These changes were introduced in JSS to enable Debian builds; NSPR and NSS are in different directories than on RHEL-like systems in Debian Testing.

I'm not sure if we want to maintain this support in PKI, but since it works and is tested in JSS with minimal changes, I figured I'd propose it. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`