### PR TITLE
Support adding SKI to CSR during installation

### DIFF
--- a/base/server/man/man5/pki_default.cfg.5
+++ b/base/server/man/man5/pki_default.cfg.5
@@ -352,6 +352,12 @@ Sets whether the new CA will have a signing certificate that will be issued by a
 .IP
 Required in the first step of the external CA signing process.  The CSR will be printed to the screen and stored in this location.
 .PP
+.B pki_req_ski
+.IP
+Include a Subject Key Identifier extension in the CSR.  The value is either a
+hex-encoded byte string (\fBwithout\fR leading "0x"), or the string "DEFAULT"
+which will derive a value from the public key.
+.PP
 .B pki_external_step_two
 .IP
 Specifies that this is the second step of the external CA process.  Defaults to False.

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -457,6 +457,8 @@ class ConfigurationFile:
         # generic extension support in CSR - for external CA
         self.add_req_ext = config.str2bool(
             self.mdict['pki_req_ext_add'])
+        # include SKI extension in CSR - for external CA
+        self.req_ski = self.mdict.get('pki_req_ski')
 
         self.existing = config.str2bool(self.mdict['pki_existing'])
         self.external = config.str2bool(self.mdict['pki_external'])

--- a/base/server/python/pki/server/deployment/scriptlets/keygen.py
+++ b/base/server/python/pki/server/deployment/scriptlets/keygen.py
@@ -89,6 +89,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                      basic_constraints_ext=None,
                      key_usage_ext=None,
                      extended_key_usage_ext=None,
+                     subject_key_id=None,
                      generic_exts=None):
 
         cert_id = self.get_cert_id(subsystem, tag)
@@ -110,6 +111,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             basic_constraints_ext=basic_constraints_ext,
             key_usage_ext=key_usage_ext,
             extended_key_usage_ext=extended_key_usage_ext,
+            subject_key_id=subject_key_id,
             generic_exts=generic_exts)
 
         with open(csr_path) as f:
@@ -173,7 +175,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 csr_path,
                 basic_constraints_ext=basic_constraints_ext,
                 key_usage_ext=key_usage_ext,
-                generic_exts=generic_exts
+                generic_exts=generic_exts,
+                subject_key_id=subsystem.config.get(
+                    'preop.cert.signing.subject_key_id'),
             )
 
         finally:

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -248,6 +248,10 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 subsystem.config['preop.cert.signing.ext.critical'] = \
                     deployer.configuration_file.req_ext_critical.lower()
 
+            if deployer.configuration_file.req_ski:
+                subsystem.config['preop.cert.signing.subject_key_id'] = \
+                    deployer.configuration_file.req_ski
+
         subsystem.save()
 
         # Place 'slightly' less restrictive permissions on

--- a/pki.spec
+++ b/pki.spec
@@ -433,7 +433,7 @@ Requires:         jss >= 4.4.0-11
 %else
 Requires:         jss >= 4.5.0-1
 %endif
-Requires:         nss >= 3.36.1
+Requires:         nss >= 3.38.0
 
 %description -n   pki-symkey
 The PKI Symmetric Key Java Package supplies various native


### PR DESCRIPTION
Changes:

```
858cc0911 (Fraser Tweedale, 11 months ago)
   install: add pkispawn option for adding SKI to CSR

   For externally-signed CA installation, some users want to be able to
   generate a CSR with a Subject Key Identifier extension - either
   user-specified or a generated default.

   This commit adds the 'req_ski' pkispwan option for specifying that the CSR
   should bear the SKI extension.  It can either be a hex-encoded SKI value or
   the string "DEFAULT" which asks that the value be derived from the public
   key.

   Fixes: https://pagure.io/dogtagpki/issue/2854
   Change-Id: If1bf51a4935029483bba179a3f637833d0a25980

26a2772e2 (Fraser Tweedale, 11 months ago)
   install: support adding Subject Key ID to CSR

   For externally-signed CA installation, some users want to be able to
   generate a CSR with a Subject Key Identifier extension - either
   user-specified or a generated default.

   This commit adds support to NSSDatabase.create_request for generating a CSR
   with an SKI extension.  The process to achieve this is:

   1. Generate the key.  This behaviour has been extracted to a
     separate method (NSSDatabase.generate_key).

   2. If a "default" SKI is requested, generate a throw-away CSR and
     compute an SKI value from the public key contained therein.
     This is a "minimal" CSR whose only purpose is to get the public
     key in a convenient format.

   3. Generate the CSR and write it to the caller-specified file.
     This CSR contains all the extensions the caller asked for.

   This commit relies on an enhancement to the certutil(1) program that allows
   create a CSR for a private key specified by CKA_ID.

   Part-of: https://pagure.io/dogtagpki/issue/2854
   Change-Id: I3f03f9f01d3c8d5b8729b1ad972b1f066768d4f1
```