### PR TITLE
pkispawn: log certutil output when cert creation fails

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2608,14 +2608,11 @@ class Certutil:
                     raise Exception(
                         log.PKI_FILE_MISSING_OR_NOT_A_FILE_1 % password_file)
             # Execute this "certutil" command
-            #
-            #     NOTE:  ALWAYS mask the command-line output of this command
-            #
-            with open(os.devnull, "w") as fnull:
-                subprocess.check_call(command, stdout=fnull, stderr=fnull)
+            subprocess.check_output(command, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as exc:
             config.pki_log.error(
-                log.PKI_SUBPROCESS_ERROR_1, exc,
+                log.PKI_SUBPROCESS_ERROR_2, exc,
+                "Output (incl. stderr):\n" + exc.output.decode('utf-8'),
                 extra=config.PKI_INDENTATION_LEVEL_2)
             if critical_failure:
                 raise

--- a/base/server/python/pki/server/deployment/pkimessages.py
+++ b/base/server/python/pki/server/deployment/pkimessages.py
@@ -98,6 +98,7 @@ PKI_ARCHIVE_MANIFEST_MESSAGE_1 = "archiving manifest into '%s'"
 PKI_OSERROR_1 = "OSError:  %s!"
 PKI_SHUTIL_ERROR_1 = "shutil.Error:  %s!"
 PKI_SUBPROCESS_ERROR_1 = "subprocess.CalledProcessError:  %s!"
+PKI_SUBPROCESS_ERROR_2 = "subprocess.CalledProcessError:  %s! %s"
 PKI_SYMLINK_ALREADY_EXISTS_1 = "Symlink '%s' already exists!"
 PKI_SYMLINK_ALREADY_EXISTS_NOT_A_SYMLINK_1 = \
     "Symlink '%s' already exists BUT it is NOT a symlink!"


### PR DESCRIPTION
When pkispawn fails due to certutil failure to create self-signed
certificate, the command output is suppressed and there is no
information (other than certutil process exit status) about what
went wrong.

Capture the command output and include it in the error message.

Part of: https://pagure.io/dogtagpki/issue/3081