### PR TITLE
Updated version number to PKI 10.6.8

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -15,7 +15,7 @@ License:          GPLv2 and LGPLv2
 ExcludeArch:      s390 s390x
 %endif
 
-Version:          10.6.7
+Version:          10.6.8
 Release:          1%{?_timestamp}%{?_commit_id}%{?dist}
 # global           _phase -a1
 
@@ -682,6 +682,9 @@ Requires:         tomcatjss >= 7.2.1-4
 %else
 Requires:         tomcatjss >= 7.3.6
 %endif
+
+# https://pagure.io/freeipa/issue/7742
+Conflicts:        freeipa-server < 4.7.1
 
 %description -n   pki-server
 The PKI Server Package contains libraries and utilities needed by the

--- a/travis/ipa-init.sh
+++ b/travis/ipa-init.sh
@@ -21,5 +21,8 @@
 #
 set -e
 
+# Enable IPA COPR repo
+dnf copr enable -y @freeipa/freeipa-4-7
+
 # Install latest IPA from official fedora/updates repository
 dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad python3-ipatests --best --allowerasing


### PR DESCRIPTION
The pki.spec has been modified to define a conflict between
pki-server package and freeipa-server < 4.7.1 due to IPA
ticket #7742.

The ipa-init.sh has been modified to enable IPA 4.7 COPR repo
in order to get freeipa-server 4.7.1 for F28 and F29.