### PR TITLE
Add make to BuildRequires in pki.spec

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -169,6 +169,7 @@ fi;
 
 # autosetup
 BuildRequires:    git
+BuildRequires:    make
 
 BuildRequires:    cmake >= 2.8.9-1
 BuildRequires:    gcc-c++


### PR DESCRIPTION
Amazing what clean installs will tell you...

CMake is a generator and needs a backend build system to generate to. Usually that's `make` or `ninja`. Since our spec is already set up to use  `make`, add it as a `BuildRequires`. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`