### PR TITLE
Add benign scripts and wrappers for new Nuxwdog

### DIFF
--- a/base/common/python/pki/keyring.py
+++ b/base/common/python/pki/keyring.py
@@ -1,0 +1,108 @@
+# Authors:
+#     Dinesh Prasanth M K <dmoluguw@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the Lesser GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+# All rights reserved.
+#
+
+
+"""
+Module that provides interface to access Kernel Keyring
+"""
+import subprocess
+
+
+class Keyring:
+    """
+    Utility class to deal with keyrings. This class is a simple wrapper
+    against the `keyutils` package. Defaults to user keyring `@u` and key
+    type `user`
+    """
+
+    def __init__(self, keyring='@u', key_type='user'):
+        self.keyring = keyring
+        self.key_type = key_type
+
+    def put_password(self, key_name, password):
+        """
+        Save a password to the keyring
+
+        :param key_name: Name of they key
+        :type key_name: str
+        :param password: Password value to be stored
+        :type password: bytearray
+        :return: Key ID, Error (if any)
+        :rtype: (bytearray, bytearray)
+        """
+
+        cmd = ['keyctl', 'padd', self.key_type, key_name, self.keyring]
+
+        p = subprocess.Popen(cmd,
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+
+        return p.communicate(input=password)
+
+    def get_key_id(self, key_name):
+        """
+        Retrieve key ID from the provided key name
+
+        :param key_name: Name of the key to search
+        :type key_name: str
+        :return: key_ID
+        :rtype: int
+        """
+
+        cmd = ['keyctl', 'search', self.keyring, self.key_type, key_name]
+
+        return subprocess.check_output(cmd).decode('utf-8').strip()
+
+    def get_password(self, key_name, output_format='raw'):
+        """
+        Retrieve password in the given format
+
+        :param key_name: The value of the key to be retrieved
+        :type key_name: str
+        :param output_format: Retrieval format: hex or raw (default)
+        :type output_format: str
+        :return: Value of the key in specified format
+        :rtype: str
+        """
+
+        if output_format.lower() == 'raw':
+            mode = 'pipe'
+        elif output_format.lower() == 'hex':
+            mode = 'read'
+        else:
+            raise AttributeError('output_format must be one of [\'raw\', \'hex\'].')
+
+        key_id = self.get_key_id(key_name)
+
+        cmd = ['keyctl', mode, key_id]
+
+        return subprocess.check_output(cmd).decode('utf-8')
+
+    def clear_keyring(self):
+        """
+        Clear the default keyring
+
+        :return: Return code
+        :rtype: int
+        """
+        cmd = ['keyctl', 'clear', self.keyring]
+        return subprocess.check_call(cmd)

--- a/base/server/scripts/nuxwdog
+++ b/base/server/scripts/nuxwdog
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+# Authors:
+#     Dinesh Prasanth M K <dmoluguw@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the Lesser GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+# All rights reserved.
+
+
+"""
+Script that prompts user for password during server startup
+and store them on user's keyring
+"""
+
+import getopt
+import logging
+import os
+import subprocess
+import sys
+
+import pki.server as server
+
+from pki.keyring import Keyring
+
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+tags = set()
+
+# Create a instance of Keyring
+keyring = Keyring()
+
+
+def split_entries(entry):
+    return entry.split(',')
+
+
+def print_help():
+    print('Usage: nuxwdog [OPTIONS]')
+    print()
+    print('      --clear                Clear values stored in keyring.')
+    print('      --help                 Show help message.')
+    print()
+
+
+try:
+    opts, _ = getopt.gnu_getopt(sys.argv, '', ['clear', 'help'])
+
+except getopt.GetoptError as e:
+    logger.error(e)
+    print_help()
+    sys.exit(1)
+
+for o, a in opts:
+
+    if o == '--clear':
+        keyring.clear_keyring()
+        sys.exit()
+
+    elif o == '--help':
+        print_help()
+        sys.exit()
+
+    else:
+        logger.error('option %s not recognized', o)
+        print_help()
+        sys.exit(1)
+
+# 1. Get <instance> name from env variable NAME set in systemd unit file
+instance_name = os.getenv('NAME', 'pki-tomcat')
+
+# 2. Gather list of passwords required
+# cms.tokenList,cms.token cms.passwordList --> For each subsystem in the <instance>
+
+# Load the instance
+instance = server.PKIInstance(instance_name)
+instance.load()
+
+subsystems = instance.subsystems
+
+tags.add('internal')
+
+for subsystem in subsystems:
+    if 'cms.passwordlist' in subsystem.config:
+        password_list = split_entries(subsystem.config['cms.passwordlist'])
+        tags.update(password_list)
+
+    if 'cms.tokenList' in subsystem.config:
+        token_list = split_entries(subsystem.config['cms.tokenList'])
+        tags.update('hardware-' + token_list)
+
+# 3a. Prompt the user using systemd-ask-password
+# 3b. Store the values in the keyring using keyctl
+
+for tag in sorted(iter(tags)):
+    if tag.startswith('hardware-'):
+        prompt_tag = tag[9:]
+    else:
+        prompt_tag = tag
+
+    prompt = '[' + instance_name + '] Please provide the password for ' + prompt_tag + ': '
+
+    cmd_ask_password = ['systemd-ask-password', prompt]
+
+    entered_pass = subprocess.check_output(cmd_ask_password)
+
+    key_name = instance_name + '/' + tag
+
+    keyring.put_password(key_name=key_name, password=entered_pass)

--- a/base/util/src/com/netscape/cmsutil/util/Keyring.java
+++ b/base/util/src/com/netscape/cmsutil/util/Keyring.java
@@ -1,0 +1,87 @@
+/** Authors:
+*     Dinesh Prasanth M K <dmoluguw@redhat.com>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the Lesser GNU General Public License as published by
+* the Free Software Foundation; either version 3 of the License or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+*  along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Copyright (C) 2018 Red Hat, Inc.
+* All rights reserved.
+**/
+
+package com.netscape.cmsutil.util;
+
+import java.io.IOException;
+
+public class Keyring {
+
+    private static String keyring = "@u";
+    private static String keyType = "user";
+
+    /**
+     * Get Key ID from keyname
+     *
+     * @param keyName   Name of the key
+     * @return  Key ID
+     */
+    public static long getKeyID(String keyName) {
+        String cmd = "keyctl search " + keyring + " " + keyType + " " + keyName;
+        try {
+            String output = Utils.exec(cmd, null);
+            return Long.parseLong(output);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return -1;
+    }
+
+    /**
+     * Get password from keyring
+     *
+     * @param keyName   Name of the key
+     * @param output_format     Output format
+     * @return  Value of the key available in keyring
+     * @throws IllegalArgumentException
+     */
+    public static String getPassword(String keyName, String output_format)
+            throws IllegalArgumentException {
+
+        // Assign a default value to retrieve
+        if (output_format.isEmpty())
+            output_format = "raw";
+
+        String mode;
+        if (output_format.toLowerCase() == "raw")
+            mode = "pipe";
+        else if (output_format.toLowerCase() == "hex")
+            mode = "read";
+        else
+            throw new IllegalArgumentException("output_format must be one of [\'raw\', \'hex\'].");
+
+        long keyID = getKeyID(keyName);
+
+        String cmd = "keyctl " + mode + " " + keyID;
+        try {
+            String output = Utils.exec(cmd, null);
+            return output;
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+
+    }
+
+}

--- a/base/util/src/com/netscape/cmsutil/util/Utils.java
+++ b/base/util/src/com/netscape/cmsutil/util/Utils.java
@@ -25,6 +25,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -94,6 +95,60 @@ public class Utils {
             Thread.currentThread().interrupt();
         }
         return false;
+    }
+
+    public static String readFromStream(InputStream inputStream) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader br = null;
+        try {
+            br = new BufferedReader(new InputStreamReader(inputStream));
+            String line = null;
+            while ((line = br.readLine()) != null) {
+                sb.append(line + System.getProperty("line.separator"));
+            }
+        } finally {
+            br.close();
+        }
+        return sb.toString().trim();
+    }
+
+    public static void writeToStream(OutputStream outputStream, String input) throws IOException {
+        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream));
+        writer.write(input);
+        writer.flush();
+        writer.close();
+    }
+
+    /**
+     * Utility method to execute system commands
+     *
+     * @param cmd       The command to be executed and its arguments
+     * @param input     The stdin input to be passed to the cmd
+     * @return stdout or stderr of the command executed
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public static String exec(String cmd, String input) throws IOException, InterruptedException {
+
+        ProcessBuilder pb = new ProcessBuilder(cmd.split(" "));
+
+        Process p = pb.start();
+
+        if (input != null) {
+            writeToStream(p.getOutputStream(), input);
+        }
+
+        p.waitFor();
+
+        String output;
+        if (p.exitValue() == 0) {
+            output = readFromStream(p.getInputStream());
+        } else {
+            output = readFromStream(p.getErrorStream());
+        }
+        p.destroy();
+
+        return output;
     }
 
     public static String SpecialURLDecode(String s) {
@@ -308,7 +363,6 @@ public class Utils {
     public static String base64encodeMultiLine(byte[] bytes) {
         return new Base64(64).encodeToString(bytes);
     }
-
 
     /**
      * Converts a byte array into a single-line Base-64 encoded string.

--- a/tests/python/test_pki_keyring.py
+++ b/tests/python/test_pki_keyring.py
@@ -1,0 +1,84 @@
+# Authors:
+#     Dinesh Prasanth M K <dmoluguw@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+# All rights reserved.
+#
+
+import unittest
+import subprocess
+
+from pki.keyring import Keyring
+
+
+class KeyringTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.keyring = Keyring()
+        cls.password = 'Secret.123'
+        cls.key_name = 'test-key'
+
+    def put_pass(self, key_name, password):
+        key_id, err = self.keyring.put_password(key_name=key_name,
+                                                password=bytearray(password))
+
+        key_id = key_id.decode('utf-8').strip()
+
+        self.assertTrue(key_id.isdigit())
+        self.assertIsNone(err)
+        return key_id
+
+    def get_key_id(self, key_name, orig_key_id):
+        retrieved_key_id = self.keyring.get_key_id(key_name=key_name)
+        self.assertEquals(retrieved_key_id, orig_key_id)
+
+    def get_key_value_raw(self, key_name, orig_pass):
+        retrieved_pass_raw = self.keyring.get_password(key_name=key_name, output_format='raw')
+        self.assertEqual(retrieved_pass_raw, orig_pass)
+
+    def get_key_value_hex(self, key_name, orig_pass):
+        retrieved_pass_hex = self.keyring.get_password(key_name=key_name, output_format='hex')
+
+        # Remove 1st line that reads 'xx bytes of data in key'
+        retrieved_pass_hex = retrieved_pass_hex.split('\n')[1]
+        # Remove spaces in the retrieved hex value
+        retrieved_pass_hex = retrieved_pass_hex.replace(' ', '')
+        self.assertEquals(retrieved_pass_hex.strip(), orig_pass.encode().hex())
+
+    def clear_pass(self, key_name):
+        self.keyring.clear_keyring()
+        self.assertRaises(subprocess.CalledProcessError, self.keyring.get_key_id, key_name)
+
+    def test_password(self):
+        # Test putting a value
+        orig_key_id = self.put_pass(self.key_name, self.password.encode())
+
+        # Test the keyID
+        self.get_key_id(self.key_name, orig_key_id)
+
+        # Test retrieving value in 'raw' format
+        self.get_key_value_raw(self.key_name, self.password)
+
+        # Test retrieving the value in 'hex' format
+        self.get_key_value_hex(self.key_name, self.password)
+
+        # Test clearing the keyring
+        self.clear_pass(self.key_name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR is the 1st breakdown of #131 and includes:
- `nuxwdog` script that is to be configured in `ExecStartPre=` and `ExecStopPost=` fields of systemd
  unit file
- Wrappers for kectl in both python and java
  -  Currently, only python supports saving password and clearing keyring
- Pytest to test the wrapper

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>