### PR TITLE
CRLIssuingPoint: reinit from LDAP when re-enabled

### DIFF
--- a/base/ca/src/com/netscape/ca/CRLIssuingPoint.java
+++ b/base/ca/src/com/netscape/ca/CRLIssuingPoint.java
@@ -375,6 +375,17 @@ public class CRLIssuingPoint implements ICRLIssuingPoint, Runnable {
         if (!enable && mEnable) {
             clearCRLCache();
             updateCRLCacheRepository();
+        } else if (enable && !mEnable) {
+            // Mark the CRLIP as NotInitialized so that the CRL
+            // entry will be read afresh when it is reinitialised.
+            // This ensures monotonicity of the CRL number, if some
+            // other clone was issuing CRLs in the meantime.
+            //
+            // See also:
+            //   https://pagure.io/dogtagpki/issue/3085
+            //   https://pagure.io/freeipa/issue/7815
+            //
+            mInitialized = CRLIssuingPointStatus.NotInitialized;
         }
         mEnable = enable;
         setAutoUpdates();

--- a/base/ca/src/com/netscape/ca/CRLIssuingPoint.java
+++ b/base/ca/src/com/netscape/ca/CRLIssuingPoint.java
@@ -371,7 +371,7 @@ public class CRLIssuingPoint implements ICRLIssuingPoint, Runnable {
     }
 
     public void enableCRLIssuingPoint(boolean enable) {
-        if ((!enable) && (mEnable ^ enable)) {
+        if (!enable && mEnable) {
             clearCRLCache();
             updateCRLCacheRepository();
         }
@@ -1792,9 +1792,6 @@ public class CRLIssuingPoint implements ICRLIssuingPoint, Runnable {
                     if (mInitialized == CRL_IP_NOT_INITIALIZED)
                         initCRL();
 
-                    if (mInitialized == CRL_IP_INITIALIZED && (!mEnable))
-                        break;
-
                     if ((mEnableCRLUpdates && mDoManualUpdate) || mDoLastAutoUpdate) {
                         delay = 0;
                     } else if (scheduledUpdates) {
@@ -1900,25 +1897,8 @@ public class CRLIssuingPoint implements ICRLIssuingPoint, Runnable {
 
     /**
      * Updates CRL and publishes it.
-     * If time elapsed since last CRL update is less than
-     * minUpdateInterval silently returns.
-     * Otherwise determines nextUpdate by adding autoUpdateInterval or
-     * minUpdateInterval to the current time. If neither of the
-     * intervals are defined nextUpdate will be null.
-     * Then using specified configuration parameters it formulates new
-     * CRL, signs it, updates CRLIssuingPointRecord in the database
-     * and publishes CRL in the directory.
-     * <P>
      */
     private void updateCRL() throws EBaseException {
-        /*
-        if (mEnableUpdateFreq && mAutoUpdateInterval > 0 &&
-            (System.currentTimeMillis() - mLastUpdate.getTime() <
-                mMinUpdateInterval)) {
-            // log or alternatively throw an Exception
-            return;
-        }
-        */
         if (mDoManualUpdate && mSignatureAlgorithmForManualUpdate != null) {
             updateCRLNow(mSignatureAlgorithmForManualUpdate);
         } else {

--- a/base/common/src/com/netscape/certsrv/ca/ICRLIssuingPoint.java
+++ b/base/common/src/com/netscape/certsrv/ca/ICRLIssuingPoint.java
@@ -67,9 +67,8 @@ public interface ICRLIssuingPoint {
     public static final int CRL_UPDATE_STARTED = 1;
     public static final int CRL_PUBLISHING_STARTED = 2;
 
-    public static final int CRL_IP_NOT_INITIALIZED = 0;
-    public static final int CRL_IP_INITIALIZED = 1;
-    public static final int CRL_IP_INITIALIZATION_FAILED = -1;
+    public enum CRLIssuingPointStatus {
+        NotInitialized, Initialized, InitializationFailed };
 
     /**
      * Returns true if CRL issuing point is enabled.
@@ -123,9 +122,10 @@ public interface ICRLIssuingPoint {
     /**
      * Returns CRL issuing point initialization status.
      *
-     * @return status of CRL issuing point initialization
+     * @return true if CRL issuing point hsa been successfully
+     *         initialized, otherwise false.
      */
-    public int isCRLIssuingPointInitialized();
+    public boolean isCRLIssuingPointInitialized();
 
     /**
      * Checks if manual update is set.

--- a/base/server/cms/src/com/netscape/cms/servlet/cert/UpdateCRL.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/cert/UpdateCRL.java
@@ -344,8 +344,7 @@ public class UpdateCRL extends CMSServlet {
         if (clearCache != null && clearCache.equals("true") &&
                 crlIssuingPoint.isCRLGenerationEnabled() &&
                 crlIssuingPoint.isCRLUpdateInProgress() == ICRLIssuingPoint.CRL_UPDATE_DONE &&
-                crlIssuingPoint.isCRLIssuingPointInitialized()
-                            == ICRLIssuingPoint.CRL_IP_INITIALIZED) {
+                crlIssuingPoint.isCRLIssuingPointInitialized()) {
 
             CMS.debug("UpdateCRL: clearing CRL cache");
             crlIssuingPoint.clearCRLCache();
@@ -354,10 +353,9 @@ public class UpdateCRL extends CMSServlet {
         if (!(waitForUpdate != null && waitForUpdate.equals("true") &&
                 crlIssuingPoint.isCRLGenerationEnabled() &&
                 crlIssuingPoint.isCRLUpdateInProgress() == ICRLIssuingPoint.CRL_UPDATE_DONE &&
-                crlIssuingPoint.isCRLIssuingPointInitialized()
-                            == ICRLIssuingPoint.CRL_IP_INITIALIZED)) {
+                crlIssuingPoint.isCRLIssuingPointInitialized())) {
 
-            if (crlIssuingPoint.isCRLIssuingPointInitialized() != ICRLIssuingPoint.CRL_IP_INITIALIZED) {
+            if (!crlIssuingPoint.isCRLIssuingPointInitialized()) {
 
                 CMS.debug("UpdateCRL: CRL issuing point not initialized");
                 header.addStringValue("crlUpdate", "notInitialized");


### PR DESCRIPTION
Dogtag only reads from LDAP when it initializes the CRLIssuingPoint object.
After the object is initizialized, the plugin never syncs back from LDAP.
In the following scenario, this can cause the CRL number to jump back (a
violation of RFC 5280; the CRL number must monotonically increase):

- disabled MasterCRL on one server with:

```
OP_TYPE=OP_MODIFY&OP_SCOPE=crlIPs&id=MasterCRL&description=CRL&enable=false
request to /ca/caadmin
```

- enable MasterCRL on another PKI clone

- reverse settings on both servers after some CRLs have been generated by the second server

This patch resolves the issue by forcing the CRLIssuingPoint to read the CRL
from LDAP each time its update thread (re)starts.

Fixes: https://pagure.io/dogtagpki/issue/3085
Related: https://pagure.io/freeipa/issue/7815

This PR also includes some minor cleanup and refactor commits.