### PR TITLE
Rename `nuxwdog` script

### DIFF
--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -304,7 +304,7 @@ install(
 install(
     FILES
         scripts/pkidaemon
-        scripts/nuxwdog
+        scripts/pki-server-nuxwdog
     DESTINATION
         ${BIN_INSTALL_DIR}
     PERMISSIONS

--- a/base/server/scripts/pki-server-nuxwdog
+++ b/base/server/scripts/pki-server-nuxwdog
@@ -51,7 +51,7 @@ def split_entries(entry):
 
 
 def print_help():
-    print('Usage: nuxwdog [OPTIONS]')
+    print('Usage: pki-server-nuxwdog [OPTIONS]')
     print()
     print('      --clear                Clear values stored in keyring.')
     print('      --help                 Show help message.')

--- a/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
@@ -12,13 +12,13 @@ Environment="WD_PIPE_NAME=%i"
 EnvironmentFile=-/etc/sysconfig/%i
 
 ExecStartPre=+/usr/bin/setfacl -m u:pkiuser:wx /run/systemd/ask-password
-ExecStartPre=/usr/bin/nuxwdog
+ExecStartPre=/usr/bin/pki-server-nuxwdog
 ExecStartPre=/usr/sbin/pki-server migrate --instance %i
 ExecStartPre=/usr/bin/pkidaemon start %i
 ExecStartPost=+/usr/bin/setfacl -x u:pkiuser /run/systemd/ask-password
 ExecStart=/usr/libexec/tomcat/server start
 ExecStop=/usr/libexec/tomcat/server stop
-ExecStopPost=/usr/bin/nuxwdog --clear
+ExecStopPost=/usr/bin/pki-server-nuxwdog --clear
 KeyringMode=shared
 SuccessExitStatus=143
 TimeoutStartSec=180

--- a/docs/admin/Nuxwdog.md
+++ b/docs/admin/Nuxwdog.md
@@ -69,20 +69,20 @@ To disable Nuxwdog and use the plain password.conf
 
 ## Technical Implementation
 
-### `nuxwdog` python script
+### `pki-server-nuxwdog` python script
 
-[`nuxwdog`](base/server/scripts/nuxwdog) script is configured to run before the PKI server starts using [`systemd`
-unit file](base/server/scripts/nuxwdog). It uses `systemd-ask-password` to prompt the user for relevant passwords.
-The relevant passwords include `internal` and list of passwords defined in fields `cms.passwordlist` and
-`cms.tokenList` of every subsystem's `CS.cfg`. The passwords are stored on the Kernel Keyring provided by the
-`keyutils` package.
+[`pki-server-nuxwdog`](base/server/scripts/pki-server-nuxwdog) script is configured to run before the PKI server
+starts using [`systemd` unit file](base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service). It uses
+`systemd-ask-password` to prompt the user for relevant passwords. The relevant passwords include `internal` and
+list of passwords defined in fields `cms.passwordlist` and `cms.tokenList` of every subsystem's `CS.cfg`. The
+passwords are stored on the Kernel Keyring provided by the `keyutils` package.
 
 ### Kernel Keyring
 
 `Kernel Keyring` offers in-kernel key management and retention facility. Nuxwdog uses this component to cache the
 password on the `<pkiuser>'s user keyring`. The keys are cleared off when the PKI server is stopped.
 
-`keyctl` is interface provided by `keyutils` package to interact with kernel keyring.
+`keyctl` CLI is provided by `keyutils` package to interact with kernel keyring.
 
 ### Wrappers available
 

--- a/pki.spec
+++ b/pki.spec
@@ -191,9 +191,6 @@ BuildRequires:    slf4j-jdk14
 BuildRequires:    nspr-devel
 BuildRequires:    nss-devel >= 3.36.1
 
-# https://bugzilla.redhat.com/show_bug.cgi?id=1652269
-Conflicts: nuxwdog-client-java
-
 BuildRequires:    openldap-devel
 BuildRequires:    pkgconfig
 BuildRequires:    policycoreutils
@@ -598,9 +595,6 @@ BuildArch:        noarch
 
 Requires:         hostname
 Requires:         net-tools
-
-# https://bugzilla.redhat.com/show_bug.cgi?id=1652269
-Conflicts: nuxwdog-client-java
 
 Requires:         policycoreutils
 Requires:         procps-ng
@@ -1406,7 +1400,7 @@ fi
 %{_datadir}/pki/deployment/config/
 %{_datadir}/pki/scripts/operations
 %{_bindir}/pkidaemon
-%{_bindir}/nuxwdog
+%{_bindir}/pki-server-nuxwdog
 %dir %{_sysconfdir}/systemd/system/pki-tomcatd.target.wants
 %attr(644,-,-) %{_unitdir}/pki-tomcatd@.service
 %attr(644,-,-) %{_unitdir}/pki-tomcatd.target


### PR DESCRIPTION
`/usr/bin/nuxwdog` script is renamed to `pki-server-nuxwdog` to avoid CI failure.

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`