### PR TITLE
Fix pylint 2.2 errors "Unnecessary pass statement"

### DIFF
--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -57,7 +57,6 @@ class CryptoProvider(six.with_metaclass(abc.ABCMeta, object)):
 
     def __init__(self):
         """ Constructor """
-        pass
 
     @abc.abstractmethod
     def initialize(self):
@@ -382,7 +381,6 @@ class CryptographyCryptoProvider(CryptoProvider):
         Any operations here that need to be performed before crypto
         operations.
         """
-        pass
 
     def get_supported_algorithm_keyset(self):
         """ returns highest supported algorithm keyset """

--- a/base/common/python/pki/key.py
+++ b/base/common/python/pki/key.py
@@ -1116,7 +1116,6 @@ class KeyClient(object):
 
            The function will return the tuple (KeyData, None)
         """
-        pass
 
     @pki.handle_exceptions()
     def retrieve_key_by_pkcs12(self, key_id, certificate, passphrase):


### PR DESCRIPTION
There is no need to have a pass statement in functions or classes
with a doc string.

Fixes: https://pagure.io/dogtagpki/issue/3089
Signed-off-by: Stanislav Levin <slev@altlinux.org>