### PR TITLE
Fix flake8 3.6.0 errors

### DIFF
--- a/base/common/python/pki/cli/password.py
+++ b/base/common/python/pki/cli/password.py
@@ -43,7 +43,7 @@ class PasswordGenerateCLI(pki.cli.CLI):
         super(PasswordGenerateCLI, self).__init__(
             'generate', 'Generate secure random password')
 
-    def print_help(self):  # flake8: noqa
+    def print_help(self):
         print('Usage: pki password-generate [OPTIONS]')
         print()
         print('  -v, --verbose                      Run in verbose mode.')

--- a/base/common/python/pki/cli/pkcs12.py
+++ b/base/common/python/pki/cli/pkcs12.py
@@ -50,10 +50,11 @@ class PKCS12ImportCLI(pki.cli.CLI):
         super(PKCS12ImportCLI, self).__init__(
             'import', 'Import PKCS #12 file into NSS database')
 
-    def print_help(self):  # flake8: noqa
+    def print_help(self):
         print('Usage: pki pkcs12-import [OPTIONS]')
         print()
-        print('      --pkcs12-file <path>           PKCS #12 file containing certificates and keys.')
+        print('      --pkcs12-file <path>           PKCS #12 file containing certificates and '
+              'keys.')
         print('      --pkcs12-password <password>   Password for the PKCS #12 file.')
         print('      --pkcs12-password-file <path>  containing the PKCS #12 password.')
         print('      --no-trust-flags               Do not include trust flags')

--- a/base/common/python/setup.py
+++ b/base/common/python/setup.py
@@ -49,8 +49,8 @@ from distutils.cmd import Command
 class VersionInfo(Command):
     user_options = []
 
-    version_re = re.compile('^Version:\s*(\d+\.\d+\.\d+)')
-    release_re = re.compile('^Release:.*?([\d\.]+)')
+    version_re = re.compile(r'^Version:\s*(\d+\.\d+\.\d+)')
+    release_re = re.compile(r'^Release:.*?([\d\.]+)')
     specfile = '../../../pki.spec'
 
     def initialize_options(self):

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -644,19 +644,25 @@ class CertExportCLI(pki.cli.CLI):
         super(CertExportCLI, self).__init__(
             'export', 'Export system certificate.')
 
-    def print_help(self):  # flake8: noqa
+    def print_help(self):
         print('Usage: pki-server cert-export [OPTIONS] <Cert ID>')
         print()
         print('Specify at least one output file: certificate, CSR, or PKCS #12.')
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
-        print('      --cert-file <path>             Output file to store the exported certificate in PEM format.')
-        print('      --csr-file <path>              Output file to store the exported CSR in PEM format.')
-        print('      --pkcs12-file <path>           Output file to store the exported certificate and key in PKCS #12 format.')
+        print('      --cert-file <path>             Output file to store the exported certificate '
+              'in PEM format.')
+        print('      --csr-file <path>              Output file to store the exported CSR in PEM '
+              'format.')
+        print('      --pkcs12-file <path>           Output file to store the exported certificate '
+              'and key in PKCS #12 format.')
         print('      --pkcs12-password <password>   Password for the PKCS #12 file.')
-        print('      --pkcs12-password-file <path>  Input file containing the password for the PKCS #12 file.')
-        print('      --friendly-name <name>         Friendly name for the certificate in PKCS #12 file.')
-        print('      --cert-encryption <algorithm>  Certificate encryption algorithm (default: none).')
+        print('      --pkcs12-password-file <path>  Input file containing the password for the '
+              'PKCS #12 file.')
+        print('      --friendly-name <name>         Friendly name for the certificate in PKCS #12 '
+              'file.')
+        print('      --cert-encryption <algorithm>  Certificate encryption algorithm (default: '
+              'none).')
         print('      --key-encryption <algorithm>   Key encryption algorithm (default: PBES2).')
         print('      --append                       Append into an existing PKCS #12 file.')
         print('      --no-trust-flags               Do not include trust flags')
@@ -967,7 +973,7 @@ class CertFixCLI(pki.cli.CLI):
         super(CertFixCLI, self).__init__(
             'fix', 'Fix expired system certificate(s).')
 
-    def print_help(self):  # flake8: noqa
+    def print_help(self):
         print('Usage: pki-server cert-fix [OPTIONS]')
         # CertID:  subsystem, sslserver, kra_storage, kra_transport, ca_ocsp_signing,
         # ca_audit_signing, kra_audit_signing
@@ -977,7 +983,8 @@ class CertFixCLI(pki.cli.CLI):
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('  -d <NSS database>               NSS database location (default: ~/.dogtag/nssdb)')
         print('  -c <NSS DB password>            NSS database password')
-        print('  -C <path>                       Input file containing the password for the NSS database.')
+        print('  -C <path>                       Input file containing the password for the NSS '
+              'database.')
         print('  -n <nickname>                   Client certificate nickname')
         print('  -v, --verbose                   Run in verbose mode.')
         print('      --debug                     Run in debug mode.')

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -68,7 +68,7 @@ class HTTPConnectorCLI(pki.cli.CLI):
             connector.attrib.pop(name)
 
     @staticmethod
-    def print_connector(connector):  # flake8: noqa
+    def print_connector(connector):
 
         HTTPConnectorCLI.print_param(connector, 'name', 'Connector ID')
         HTTPConnectorCLI.print_param(connector, 'scheme', 'Scheme')
@@ -77,8 +77,10 @@ class HTTPConnectorCLI(pki.cli.CLI):
 
         HTTPConnectorCLI.print_param(connector, 'sslImplementationName', 'SSL Implementation')
 
-        HTTPConnectorCLI.print_param(connector, 'sslVersionRangeStream', 'SSL Version Range Stream')
-        HTTPConnectorCLI.print_param(connector, 'sslVersionRangeDatagram', 'SSL Version Range Datagram')
+        HTTPConnectorCLI.print_param(connector, 'sslVersionRangeStream',
+                                     'SSL Version Range Stream')
+        HTTPConnectorCLI.print_param(connector, 'sslVersionRangeDatagram',
+                                     'SSL Version Range Datagram')
         HTTPConnectorCLI.print_param(connector, 'sslRangeCiphers', 'SSL Range Ciphers')
 
         HTTPConnectorCLI.print_param(connector, 'certdbDir', 'NSS Database Directory')
@@ -330,7 +332,8 @@ class HTTPConnectorModCLI(pki.cli.CLI):
         connector = connectors[name]
 
         HTTPConnectorCLI.set_param(connector, 'certdbDir', nss_database_dir)
-        HTTPConnectorCLI.set_param(connector, 'passwordClass', 'org.apache.tomcat.util.net.jss.PlainPasswordFile')
+        HTTPConnectorCLI.set_param(connector, 'passwordClass',
+                                   'org.apache.tomcat.util.net.jss.PlainPasswordFile')
         HTTPConnectorCLI.set_param(connector, 'passwordFile', nss_password_file)
         HTTPConnectorCLI.set_param(connector, 'serverCertNickFile', server_cert_nickname_file)
 
@@ -364,7 +367,8 @@ class HTTPConnectorModCLI(pki.cli.CLI):
             HTTPConnectorCLI.set_param(connector, 'keystorePassFile', keystore_password_file)
             HTTPConnectorCLI.set_param(connector, 'keyAlias', 'sslserver')
 
-            HTTPConnectorCLI.set_param(connector, 'trustManagerClassName', 'org.dogtagpki.tomcat.PKITrustManager')
+            HTTPConnectorCLI.set_param(connector, 'trustManagerClassName',
+                                       'org.dogtagpki.tomcat.PKITrustManager')
 
         else:
             raise Exception('Invalid connector type: %s' % connector_type)

--- a/base/server/python/pki/server/cli/instance.py
+++ b/base/server/python/pki/server/cli/instance.py
@@ -70,13 +70,15 @@ class InstanceCertExportCLI(pki.cli.CLI):
         super(InstanceCertExportCLI, self).__init__(
             'export', 'Export system certificates')
 
-    def print_help(self):  # flake8: noqa
+    def print_help(self):
         print('Usage: pki-server instance-cert-export [OPTIONS] [nicknames...]')
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
-        print('      --pkcs12-file <path>           Output file to store the exported certificate and key in PKCS #12 format.')
+        print('      --pkcs12-file <path>           Output file to store the exported certificate '
+              'and key in PKCS #12 format.')
         print('      --pkcs12-password <password>   Password for the PKCS #12 file.')
-        print('      --pkcs12-password-file <path>  Input file containing the password for the PKCS #12 file.')
+        print('      --pkcs12-password-file <path>  Input file containing the password for the '
+              'PKCS #12 file.')
         print('      --append                       Append into an existing PKCS #12 file.')
         print('      --no-trust-flags               Do not include trust flags')
         print('      --no-key                       Do not include private key')
@@ -624,7 +626,8 @@ class InstanceExternalCertAddCLI(pki.cli.CLI):
         print('Usage: pki-server instance-externalcert-add [OPTIONS]')
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
-        print('      --cert-file <path>             Input file containing the external certificate or certificate chain.')
+        print('      --cert-file <path>             Input file containing the external certificate'
+              ' or certificate chain.')
         print('      --trust-args <trust-args>      Trust args (default \",,\").')
         print('      --nickname <nickname>          Nickname to be used.')
         print('      --token <token_name>           Token (default: internal).')
@@ -636,7 +639,7 @@ class InstanceExternalCertAddCLI(pki.cli.CLI):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=',
-                'cert-file=', 'trust-args=', 'nickname=','token=',
+                'cert-file=', 'trust-args=', 'nickname=', 'token=',
                 'verbose', 'help'])
 
         except getopt.GetoptError as e:
@@ -745,7 +748,7 @@ class InstanceExternalCertDeleteCLI(pki.cli.CLI):
     def execute(self, argv):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'nickname=','token=',
+                'instance=', 'nickname=', 'token=',
                 'verbose', 'help'])
 
         except getopt.GetoptError as e:

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -564,15 +564,19 @@ class SubsystemCertExportCLI(pki.cli.CLI):
         super(SubsystemCertExportCLI, self).__init__(
             'export', 'Export subsystem certificate')
 
-    def print_help(self):  # flake8: noqa
+    def print_help(self):
         print('Usage: pki-server subsystem-cert-export [OPTIONS] <subsystem ID> [cert ID]')
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
-        print('      --cert-file <path>             Output file to store the exported certificate in PEM format.')
-        print('      --csr-file <path>              Output file to store the exported CSR in PEM format.')
-        print('      --pkcs12-file <path>           Output file to store the exported certificate and key in PKCS #12 format.')
+        print('      --cert-file <path>             Output file to store the exported certificate '
+              'in PEM format.')
+        print('      --csr-file <path>              Output file to store the exported CSR in PEM '
+              'format.')
+        print('      --pkcs12-file <path>           Output file to store the exported certificate '
+              'and key in PKCS #12 format.')
         print('      --pkcs12-password <password>   Password for the PKCS #12 file.')
-        print('      --pkcs12-password-file <path>  Input file containing the password for the PKCS #12 file.')
+        print('      --pkcs12-password-file <path>  Input file containing the password for the '
+              'PKCS #12 file.')
         print('      --append                       Append into an existing PKCS #12 file.')
         print('      --no-trust-flags               Do not include trust flags')
         print('      --no-key                       Do not include private key')
@@ -839,7 +843,8 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
 
             if data:
                 if self.verbose:
-                    print('Removing old %s certificate from database.' % subsystem_cert['nickname'])
+                    print('Removing old %s certificate from database.'
+                          % subsystem_cert['nickname'])
                 nssdb.remove_cert(nickname=subsystem_cert['nickname'])
             if self.verbose:
                 print('Adding new %s certificate into database.' % subsystem_cert['nickname'])


### PR DESCRIPTION
Since 3.6.0 flake8 respects '# flake8: noqa' processor rule if
it is only on a line by itself.

http://flake8.pycqa.org/en/latest/release-notes/3.6.0.html?highlight=noqa

Additionally this fixes simple Python style errors found here.

Fixes: https://pagure.io/dogtagpki/issue/3090