### PR TITLE
Bug fix for Nuxwdog

### DIFF
--- a/base/server/scripts/pki-server-nuxwdog
+++ b/base/server/scripts/pki-server-nuxwdog
@@ -122,3 +122,7 @@ for tag in sorted(iter(tags)):
     key_name = instance_name + '/' + tag
 
     keyring.put_password(key_name=key_name, password=entered_pass)
+
+# 4. Put this script to sleep in background to keep the keyring fd open until main program starts
+# due to systemd bug #1668954
+subprocess.Popen(['/usr/bin/sleep', '10'])

--- a/pki.spec
+++ b/pki.spec
@@ -609,6 +609,8 @@ Requires:         pki-symkey >= %{version}-%{release}
 Requires:         pki-base-java >= %{version}-%{release}
 Requires:         pki-tools >= %{version}-%{release}
 
+Requires:         keyutils
+
 %if 0%{?rhel} && 0%{?rhel} <= 7
 # no policycoreutils-python-utils
 %else


### PR DESCRIPTION
- systemd doesn't keep the keys pinned between `ExecStartPre` and `ExecStart`.
  As a result, PKI server sees an empty keyring when it starts. (Bug #1668954)

- This PR includes a fix to keep a fd open until the PKI server starts. This will
  keep a process running for `User=<pkiuser>` and so the keyring won't be dropped. 
  As per conv with @dhowells, this PR reduces the probability of keyring getting unpinned.
  This is **not a final solution**. 

**Notes/Risks with this PR:**
when you run `systemctl status pki-server-nuxwdog@pki-tomcat`, there is a warning thrown:

```
Jan 24 22:29:52 <host> systemd[1]: pki-tomcatd-nuxwdog@pki-tomcat.service: Found left-over process 18396 (sleep) in control group while starting unit. Ignoring.
Jan 24 22:29:52 <host> systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
```
The interesting thing to note is that, there is a [RFE](https://github.com/systemd/systemd/issues/8630) filed to clean up left-over processes. The RFE is originally filed for **residual process from a previous service start**. However, i'm unsure about the effects on **left-over processes from a single service**.

**UPDATE:** Another [RFE](https://github.com/systemd/systemd/issues/7864) is to allow **intended processes** to run in the background.



Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>