### PR TITLE
Bug fix for Nuxwdog (#149)

### DIFF
--- a/base/server/scripts/pki-server-nuxwdog
+++ b/base/server/scripts/pki-server-nuxwdog
@@ -122,3 +122,7 @@ for tag in sorted(iter(tags)):
     key_name = instance_name + '/' + tag
 
     keyring.put_password(key_name=key_name, password=entered_pass)
+
+# 4. Put this script to sleep in background to keep the keyring fd open until main program starts
+# due to systemd bug #1668954
+subprocess.Popen(['/usr/bin/sleep', '10'])

--- a/pki.spec
+++ b/pki.spec
@@ -609,6 +609,8 @@ Requires:         pki-symkey >= %{version}-%{release}
 Requires:         pki-base-java >= %{version}-%{release}
 Requires:         pki-tools >= %{version}-%{release}
 
+Requires:         keyutils
+
 %if 0%{?rhel} && 0%{?rhel} <= 7
 # no policycoreutils-python-utils
 %else


### PR DESCRIPTION
- systemd doesn't keep the keys pinned between ExecStartPre and ExecStart.
  As a result, PKI server sees an empty keyring when it starts. (Bug #1668954)

- This PR includes a fix to keep a fd open until the PKI server starts. This will
  keep a process running for `User=<pkiuser>` and so the keyring won't be dropped.

Backport of #149 

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`