### PR TITLE
Added enabled by default info

### DIFF
--- a/base/server/cmsbundle/src/audit-events.properties
+++ b/base/server/cmsbundle/src/audit-events.properties
@@ -1,6 +1,7 @@
 ####################### SIGNED AUDIT EVENTS #############################
-# This file defines signed audit events which are required by CIMC PP.
-# Please consult cfu before adding/deleting/modifying the events.
+# This file defines signed audit events where many of them are required
+# to meet security standards. Please consult cfu before adding, deleting,
+# or modifying the events.
 #
 # WARNING: The comments are incrementally being transformed into parsable
 # document. Please use the following format when updating the comments.
@@ -8,6 +9,7 @@
 #   Event: <event type>
 #   Description: <event description>
 #   Applicable subsystems: <comma-separated list of subsystems>
+#   Enabled by default: <Yes|No>
 #   Fields:
 #   - <field name>: <field description>
 #
@@ -25,18 +27,21 @@
 # Event: AUDIT_LOG_STARTUP
 # - used at audit function startup
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_AUDIT_LOG_STARTUP_2=<type=AUDIT_LOG_STARTUP>:[AuditEvent=AUDIT_LOG_STARTUP][SubjectID={0}][Outcome={1}] audit function startup
 #
 # Event: AUDIT_LOG_SHUTDOWN
 # - used at audit function shutdown
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_AUDIT_LOG_SHUTDOWN_2=<type=AUDIT_LOG_SHUTDOWN>:[AuditEvent=AUDIT_LOG_SHUTDOWN][SubjectID={0}][Outcome={1}] audit function shutdown
 #
 # Event: CIMC_CERT_VERIFICATION
 # - used for verifying CIMC system certificates
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: No
 # - CertNickName is the cert nickname
 #
 LOGGING_SIGNED_AUDIT_CIMC_CERT_VERIFICATION_3=<type=CIMC_CERT_VERIFICATION>:[AuditEvent=CIMC_CERT_VERIFICATION][SubjectID={0}][Outcome={1}][CertNickName={2}] CIMC certificate verification
@@ -45,6 +50,7 @@ LOGGING_SIGNED_AUDIT_CIMC_CERT_VERIFICATION_3=<type=CIMC_CERT_VERIFICATION>:[Aud
 # - used when user assumes a role (in current CS that's when one accesses a
 #     role port)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # Role must be be one of the valid roles, by default: "Administrators",
 #     "Certificate Manager Agents", and "Auditors"
 #     note that customized role names can be used once configured
@@ -53,7 +59,8 @@ LOGGING_SIGNED_AUDIT_ROLE_ASSUME=<type=ROLE_ASSUME>:[AuditEvent=ROLE_ASSUME]{0} 
 #
 # Event: CONFIG_CERT_POLICY
 # - used when configuring certificate policy constraints and extensions
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: No
 # ParamNameValPairs must be a name;;value pair
 # (where name and value are separated by the delimiter ;;)
 # separated by + (if more than one name;;value pair) of config params changed
@@ -64,7 +71,8 @@ LOGGING_SIGNED_AUDIT_CONFIG_CERT_POLICY_3=<type=CONFIG_CERT_POLICY>:[AuditEvent=
 # - used when configuring certificate profile
 #    (general settings and certificate profile)
 #    (extensions and constraints policies are to be obsoleted but do it anyway)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -74,7 +82,8 @@ LOGGING_SIGNED_AUDIT_CONFIG_CERT_PROFILE_3=<type=CONFIG_CERT_PROFILE>:[AuditEven
 # Event: CONFIG_CRL_PROFILE
 # - used when configuring  CRL profile
 #    (extensions, frequency, CRL format)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -84,7 +93,8 @@ LOGGING_SIGNED_AUDIT_CONFIG_CRL_PROFILE_3=<type=CONFIG_CRL_PROFILE>:[AuditEvent=
 # Event: CONFIG_OCSP_PROFILE
 # - used when configuring OCSP profile
 #    (everything under Online Certificate Status Manager)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: OCSP
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -94,6 +104,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_OCSP_PROFILE_3=<type=CONFIG_OCSP_PROFILE>:[AuditEven
 # Event: CONFIG_AUTH
 # - used when configuring authentication
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -105,6 +116,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_AUTH_3=<type=CONFIG_AUTH>:[AuditEvent=CONFIG_AUTH][S
 # - used when configuring role information (anything under users/groups)
 #       add/remove/edit a role, etc)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -114,6 +126,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_ROLE=<type=CONFIG_ROLE>:[AuditEvent=CONFIG_ROLE]{0} 
 # Event: CONFIG_ACL
 # - used when configuring ACL information
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -123,6 +136,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_ACL_3=<type=CONFIG_ACL>:[AuditEvent=CONFIG_ACL][Subj
 # Event: CONFIG_SIGNED_AUDIT
 # - used when configuring signedAudit
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -132,6 +146,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_SIGNED_AUDIT=<type=CONFIG_SIGNED_AUDIT>:[AuditEvent=
 # Event: CONFIG_ENCRYPTION
 # - used when configuring encryption (cert settings and SSL cipher preferences)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -146,6 +161,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_ENCRYPTION_3=<type=CONFIG_ENCRYPTION>:[AuditEvent=CO
 #         certificate database (Although CrossCertificatePairs are stored
 #         within internaldb, audit them as well)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -155,7 +171,8 @@ LOGGING_SIGNED_AUDIT_CONFIG_TRUSTED_PUBLIC_KEY=<type=CONFIG_TRUSTED_PUBLIC_KEY>:
 # Event: CONFIG_DRM
 # - used when configuring DRM
 #     (Key recovery scheme, change of any secret component)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: KRA
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -166,6 +183,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_DRM_3=<type=CONFIG_DRM>:[AuditEvent=CONFIG_DRM][Subj
 # Event: SELFTESTS_EXECUTION
 # - used when self tests are run
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_SELFTESTS_EXECUTION_2=<type=SELFTESTS_EXECUTION>:[AuditEvent=SELFTESTS_EXECUTION][SubjectID={0}][Outcome={1}] self tests execution (see selftests.log for details)
 #
@@ -174,6 +192,7 @@ LOGGING_SIGNED_AUDIT_SELFTESTS_EXECUTION_2=<type=SELFTESTS_EXECUTION>:[AuditEven
 #    but in case authz gets compromised.  Make sure it is written
 #    AFTER the log expiration happens)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: No
 # LogFile must be the complete name (including the path) of the
 #    signedAudit log that is attempted to be deleted
 #
@@ -185,6 +204,7 @@ LOGGING_SIGNED_AUDIT_LOG_DELETE_3=<type=AUDIT_LOG_DELETE>:[AuditEvent=AUDIT_LOG_
 #    change is attempted (authz should not allow, but make sure it's
 #    written after the attempt)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # LogType must be "System", "Transaction", or "SignedAudit"
 # toLogFile must be the name (including any path changes) that the user is
 #    attempting to change to
@@ -195,6 +215,7 @@ LOGGING_SIGNED_AUDIT_LOG_PATH_CHANGE_4=<type=LOG_PATH_CHANGE>:[AuditEvent=LOG_PA
 # - used when log expiration time change is attempted (authz should not
 #    allow, but make sure it's written after the attempt)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: No
 # LogType must be "System", "Transaction", or "SignedAudit"
 # ExpirationTime must be the amount of time (in seconds) that is
 #    attempted to be changed to
@@ -206,6 +227,7 @@ LOGGING_SIGNED_AUDIT_LOG_PATH_CHANGE_4=<type=LOG_PATH_CHANGE>:[AuditEvent=LOG_PA
 # - used when server-side key generation request is made
 #    This is for tokenkeys
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # EntityID must be the representation of the subject that will be on the certificate when issued
 #
 LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_REQUEST=<type=SERVER_SIDE_KEYGEN_REQUEST>:[AuditEvent=SERVER_SIDE_KEYGEN_REQUEST]{0} server-side key generation request
@@ -214,6 +236,7 @@ LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_REQUEST=<type=SERVER_SIDE_KEYGEN_REQUEST
 # - used when server-side key generation request has been processed.
 #    This is for tokenkeys
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # EntityID must be the representation of the subject that will be on the certificate when issued
 # PubKey must be the base-64 encoded public key associated with
 #    the private key to be archived
@@ -223,6 +246,7 @@ LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_REQUEST_PROCESSED=<type=SERVER_SIDE_KEYG
 # Event: KEY_RECOVERY_REQUEST
 # - used when key recovery request is made
 # Applicable subsystems: CA, OCSP, TKS, TPS, TPS
+# Enabled by default: No
 # RecoveryID must be the recovery request ID
 # PubKey must be the base-64 encoded public key associated with
 #    the private key to be recovered
@@ -232,7 +256,8 @@ LOGGING_SIGNED_AUDIT_KEY_RECOVERY_REQUEST_4=<type=KEY_RECOVERY_REQUEST>:[AuditEv
 # Event: KEY_RECOVERY_AGENT_LOGIN
 # - used when DRM agents login as recovery agents to approve
 #       key recovery requests
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: KRA
+# Enabled by default: Yes
 # RecoveryID must be the recovery request ID
 # RecoveryAgent must be the recovery agent the DRM agent is
 #       logging in with
@@ -244,28 +269,33 @@ LOGGING_SIGNED_AUDIT_KEY_RECOVERY_AGENT_LOGIN_4=<type=KEY_RECOVERY_AGENT_LOGIN>:
 #   (like when CA certificate requests are generated -
 #      e.g. CA certificate change over, renewal with new key, etc.)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # PubKey must be the base-64 encoded public key material
 #
 LOGGING_SIGNED_AUDIT_KEY_GEN_ASYMMETRIC_3=<type=KEY_GEN_ASYMMETRIC>:[AuditEvent=KEY_GEN_ASYMMETRIC][SubjectID={0}][Outcome={1}][PubKey={2}] asymmetric key generation
 #
 # Event: CERT_SIGNING_INFO
 # Applicable subsystems: CA
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_CERT_SIGNING_INFO=<type=CERT_SIGNING_INFO>:[AuditEvent=CERT_SIGNING_INFO]{0} certificate signing info
 #
 # Event: OCSP_SIGNING_INFO
-# Applicable subsystems: CA
+# Applicable subsystems: CA, OCSP
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_OCSP_SIGNING_INFO=<type=OCSP_SIGNING_INFO>:[AuditEvent=OCSP_SIGNING_INFO]{0} OCSP signing info
 #
 # Event: CRL_SIGNING_INFO
 # Applicable subsystems: CA
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_CRL_SIGNING_INFO=<type=CRL_SIGNING_INFO>:[AuditEvent=CRL_SIGNING_INFO]{0} CRL signing info
 #
 # Event: NON_PROFILE_CERT_REQUEST
 # - used when a non-profile certificate request is made (before approval process)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: No
 # SubjectID must be the UID of user that triggered this event
 #        (if CMC enrollment requests signed by an agent, SubjectID should
 #        be that of the agent), while
@@ -279,6 +309,7 @@ LOGGING_SIGNED_AUDIT_NON_PROFILE_CERT_REQUEST_5=<type=NON_PROFILE_CERT_REQUEST>:
 # Event: CMC_REQUEST_RECEIVED
 # - used when a CMC request is received.
 # Applicable subsystems: CA
+# Enabled by default: Yes
 # SubjectID must be the UID of user that triggered this event
 #        (if CMC requests is signed by an agent, SubjectID should
 #        be that of the agent)
@@ -289,13 +320,15 @@ LOGGING_SIGNED_AUDIT_CMC_REQUEST_RECEIVED_3=<type=CMC_REQUEST_RECEIVED>:[AuditEv
 # Event: CMC_RESPONSE_SENT
 # - used when a CMC response is sent
 # Applicable subsystems: CA
+# Enabled by default: Yes
 # SubjectID must be the UID of user that triggered this event
 #
 LOGGING_SIGNED_AUDIT_CMC_RESPONSE_SENT_3=<type=CMC_RESPONSE_SENT>:[AuditEvent=CMC_RESPONSE_SENT][SubjectID={0}][Outcome={1}][CMCResponse={2}] CMC response sent
 #
 # Event: PROFILE_CERT_REQUEST
 # - used when a profile certificate request is made (before approval process)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # SubjectID must be the UID of user that triggered this event
 #        (if CMC enrollment requests signed by an agent, SubjectID should
 #        be that of the agent), while
@@ -308,7 +341,8 @@ LOGGING_SIGNED_AUDIT_PROFILE_CERT_REQUEST_5=<type=PROFILE_CERT_REQUEST>:[AuditEv
 #
 # Event: CERT_REQUEST_PROCESSED
 # - used when certificate request has just been through the approval process
-# Applicable subsystems: CA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # SubjectID must be the UID of the agent who approves, rejects, or cancels
 #        the certificate request
 # ReqID must be the request ID
@@ -322,7 +356,8 @@ LOGGING_SIGNED_AUDIT_CERT_REQUEST_PROCESSED=<type=CERT_REQUEST_PROCESSED>:[Audit
 # Event: CERT_STATUS_CHANGE_REQUEST
 # - used when a certificate status change request (e.g. revocation)
 #        is made (before approval process)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # ReqID must be the request ID
 # CertSerialNum must be the serial number (in hex) of the certificate to be revoked
 # RequestType must be "revoke", "on-hold", "off-hold"
@@ -332,7 +367,8 @@ LOGGING_SIGNED_AUDIT_CERT_STATUS_CHANGE_REQUEST=<type=CERT_STATUS_CHANGE_REQUEST
 # Event: CERT_STATUS_CHANGE_REQUEST_PROCESSED
 # - used when certificate status is changed (revoked, expired, on-hold,
 #        off-hold)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # SubjectID must be the UID of the agent that processed the request
 # ReqID must be the request ID
 # RequestType must be "revoke", "on-hold", "off-hold"
@@ -355,6 +391,7 @@ LOGGING_SIGNED_AUDIT_CERT_STATUS_CHANGE_REQUEST_PROCESSED=<type=CERT_STATUS_CHAN
 # Event: AUTHZ with [Outcome=Success]
 # - used when authorization is successful
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # Outcome must be success for this event
 # aclResource must be the ACL resource ID as defined in ACL resource list
 # Op must be one of the operations as defined with the ACL statement
@@ -365,6 +402,7 @@ LOGGING_SIGNED_AUDIT_AUTHZ_SUCCESS=<type=AUTHZ>:[AuditEvent=AUTHZ]{0} authorizat
 # Event: AUTHZ with [Outcome=Failure]
 # - used when authorization has failed
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # Outcome must be failure for this event
 # aclResource must be the ACL resource ID as defined in ACL resource list
 # Op must be one of the operations as defined with the ACL statement
@@ -376,6 +414,7 @@ LOGGING_SIGNED_AUDIT_AUTHZ_FAIL=<type=AUTHZ>:[AuditEvent=AUTHZ]{0} authorization
 # - used when inter-CIMC_Boundary data transfer is successful
 #   (this is used when data does not need to be captured)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: No
 # ProtectionMethod must be one of the following: "SSL", or "unknown"
 # ReqType must be the request type
 # ReqID must be the request ID
@@ -387,6 +426,7 @@ LOGGING_SIGNED_AUDIT_INTER_BOUNDARY_SUCCESS_5=<type=INTER_BOUNDARY>:[AuditEvent=
 #    only webserver env can pick up the SSL violation;
 #    CS authMgr can pick up certificate mis-match, so this event is used)
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # Outcome should always be "failure" in this event
 #   (obviously, if authentication failed, you won't have a valid SubjectID, so
 #       in this case, SubjectID should be $Unidentified$)
@@ -399,6 +439,7 @@ LOGGING_SIGNED_AUDIT_AUTH_FAIL=<type=AUTH>:[AuditEvent=AUTH]{0} authentication f
 # Event: AUTH with [Outcome=Success]
 # - used when authentication succeeded
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # Outcome should always be "success" in this event
 # AuthMgr must be the authentication manager instance name that did
 #   this authentication
@@ -408,7 +449,8 @@ LOGGING_SIGNED_AUDIT_AUTH_SUCCESS=<type=AUTH>:[AuditEvent=AUTH]{0} authenticatio
 # Event: CERT_PROFILE_APPROVAL
 # - used when an agent approves/disapproves a certificate profile set by the
 #     administrator for automatic approval
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # ProfileID must be one of the profiles defined by the administrator
 #           and to be approved by an agent
 # Op must be "approve" or "disapprove"
@@ -417,13 +459,15 @@ LOGGING_SIGNED_AUDIT_CERT_PROFILE_APPROVAL_4=<type=CERT_PROFILE_APPROVAL>:[Audit
 #
 # Event: PROOF_OF_POSSESSION
 # - used for proof of possession during certificate enrollment processing
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_PROOF_OF_POSSESSION_3=<type=PROOF_OF_POSSESSION>:[AuditEvent=PROOF_OF_POSSESSION][SubjectID={0}][Outcome={1}][Info={2}] proof of possession
 #
 # Event: CMC_PROOF_OF_IDENTIFICATION
 # - used for proof of identification during CMC request processing
 # Applicable subsystems: CA
+# Enabled by default: No
 # - In case of success, "SubjectID" is the actual identified identification;
 # - In case of failure, "SubjectID" is the attempted identification
 #
@@ -432,12 +476,14 @@ LOGGING_SIGNED_AUDIT_CMC_PROOF_OF_IDENTIFICATION_3=<type=CMC_PROOF_OF_IDENTIFICA
 # Event: CMC_ID_POP_LINK_WITNESS
 # - used for identification and POP linking verification during CMC request processing
 # Applicable subsystems: CA
+# Enabled by default: No
 #
 LOGGING_SIGNED_AUDIT_CMC_ID_POP_LINK_WITNESS_3=<type=CMC_ID_POP_LINK_WITNESS>:[AuditEvent=CMC_ID_POP_LINK_WITNESS][SubjectID={0}][Outcome={1}][Info={2}] Identification Proof of Possession linking witness verification
 #
 # Event: SCHEDULE_CRL_GENERATION
 # - used when CRL generation is scheduled
 # Applicable subsystems: CA
+# Enabled by default: No
 # Outcome is "success" when CRL generation is scheduled successfully, "failure" otherwise
 #
 LOGGING_SIGNED_AUDIT_SCHEDULE_CRL_GENERATION=<type=SCHEDULE_CRL_GENERATION>:[AuditEvent=SCHEDULE_CRL_GENERATION]{0} schedule for CRL generation
@@ -445,6 +491,7 @@ LOGGING_SIGNED_AUDIT_SCHEDULE_CRL_GENERATION=<type=SCHEDULE_CRL_GENERATION>:[Aud
 # Event: DELTA_CRL_GENERATION
 # - used when delta CRL generation is complete
 # Applicable subsystems: CA
+# Enabled by default: Yes
 # Outcome is "success" when delta CRL is generated successfully, "failure" otherwise
 #
 LOGGING_SIGNED_AUDIT_DELTA_CRL_GENERATION=<type=DELTA_CRL_GENERATION>:[AuditEvent=DELTA_CRL_GENERATION]{0} Delta CRL generation
@@ -452,6 +499,7 @@ LOGGING_SIGNED_AUDIT_DELTA_CRL_GENERATION=<type=DELTA_CRL_GENERATION>:[AuditEven
 # Event: DELTA_CRL_PUBLISHING
 # - used when delta CRL publishing is complete
 # Applicable subsystems: CA
+# Enabled by default: No
 # Outcome is "success" when delta CRL is publishing successfully, "failure" otherwise
 #
 LOGGING_SIGNED_AUDIT_DELTA_CRL_PUBLISHING=<type=DELTA_CRL_PUBLISHING>:[AuditEvent=DELTA_CRL_PUBLISHING]{0} Delta CRL publishing
@@ -459,6 +507,7 @@ LOGGING_SIGNED_AUDIT_DELTA_CRL_PUBLISHING=<type=DELTA_CRL_PUBLISHING>:[AuditEven
 # Event: FULL_CRL_GENERATION
 # - used when full CRL generation is complete
 # Applicable subsystems: CA
+# Enabled by default: Yes
 # Outcome is "success" when full CRL is generated successfully, "failure" otherwise
 #
 LOGGING_SIGNED_AUDIT_FULL_CRL_GENERATION=<type=FULL_CRL_GENERATION>:[AuditEvent=FULL_CRL_GENERATION]{0} Full CRL generation
@@ -466,13 +515,15 @@ LOGGING_SIGNED_AUDIT_FULL_CRL_GENERATION=<type=FULL_CRL_GENERATION>:[AuditEvent=
 # Event: FULL_CRL_PUBLISHING
 # - used when full  CRL publishing is complete
 # Applicable subsystems: CA
+# Enabled by default: No
 # Outcome is "success" when full CRL is publishing successfully, "failure" otherwise
 #
 LOGGING_SIGNED_AUDIT_FULL_CRL_PUBLISHING=<type=FULL_CRL_PUBLISHING>:[AuditEvent=FULL_CRL_PUBLISHING]{0} Full CRL publishing
 #
 # Event: CRL_RETRIEVAL
 # - used when CRLs are retrieved by the OCSP Responder
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: OCSP
+# Enabled by default: No
 # Outcome is "success" when CRL is retrieved successfully, "failure" otherwise
 # CRLnum is the CRL number that identifies the CRL
 #
@@ -480,13 +531,15 @@ LOGGING_SIGNED_AUDIT_CRL_RETRIEVAL_3=<type=CRL_RETRIEVAL>:[AuditEvent=CRL_RETRIE
 #
 # Event: CRL_VALIDATION
 # - used when CRL is retrieved and validation process occurs
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: OCSP
+# Enabled by default: No
 #
 LOGGING_SIGNED_AUDIT_CRL_VALIDATION_2=<type=CRL_VALIDATION>:[AuditEvent=CRL_VALIDATION][SubjectID={0}][Outcome={1}] CRL validation
 #
 # Event: OCSP_ADD_CA_REQUEST
 # - used when a CA is attempted to be added to the OCSP Responder
 # Applicable subsystems: OCSP
+# Enabled by default: No
 # Outcome is "success" as the request is made
 # CA must be the base-64 encoded PKCS7 certificate (or chain)
 #
@@ -495,6 +548,7 @@ LOGGING_SIGNED_AUDIT_OCSP_ADD_CA_REQUEST=<type=OCSP_ADD_CA_REQUEST>:[AuditEvent=
 # Event: OCSP_ADD_CA_REQUEST_PROCESSED
 # - used when an add CA request to the OCSP Responder is processed
 # Applicable subsystems: OCSP
+# Enabled by default: Yes
 # Outcome is "success" when CA is added successfully, "failure" otherwise
 # CASubjectDN is the subject DN of the leaf CA cert in the chain
 #
@@ -503,6 +557,7 @@ LOGGING_SIGNED_AUDIT_OCSP_ADD_CA_REQUEST_PROCESSED=<type=OCSP_ADD_CA_REQUEST_PRO
 # Event: OCSP_REMOVE_CA_REQUEST
 # - used when a CA is attempted to be removed from the OCSP Responder
 # Applicable subsystems: OCSP
+# Enabled by default: No
 # Outcome is "success" as the request is made
 # CA must be the DN id of the CA
 LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST=<type=OCSP_REMOVE_CA_REQUEST>:[AuditEvent=OCSP_REMOVE_CA_REQUEST]{0} request to remove a CA from OCSP Responder
@@ -510,6 +565,7 @@ LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST=<type=OCSP_REMOVE_CA_REQUEST>:[Audit
 # Event: OCSP_REMOVE_CA_REQUEST_PROCESSED with [Outcome=Success]
 # - used when a remove CA request to the OCSP Responder is processed successfully
 # Applicable subsystems: OCSP
+# Enabled by default: Yes
 # Outcome is "success" when CA is removed successfully, "failure" otherwise
 # CASubjectDN is the subject DN of the leaf CA cert in the chain
 #
@@ -518,6 +574,7 @@ LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST_PROCESSED_SUCCESS=<type=OCSP_REMOVE_
 # Event: OCSP_REMOVE_CA_REQUEST_PROCESSED with [Outcome=Failure]
 # - used when a remove CA request to the OCSP Responder is processed and failed
 # Applicable subsystems: OCSP
+# Enabled by default: Yes
 # Outcome is  "failure"
 # CASubjectDN is  DN ID of the CA
 #
@@ -526,6 +583,7 @@ LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST_PROCESSED_FAILURE=<type=OCSP_REMOVE_
 # Event: OCSP_GENERATION
 # - used when an OCSP response generated is complete
 # Applicable subsystems: CA, OCSP
+# Enabled by default: Yes
 # Outcome is "success" when OCSP response is generated successfully, "failure" otherwise
 #
 LOGGING_SIGNED_AUDIT_OCSP_GENERATION=<type=OCSP_GENERATION>:[AuditEvent=OCSP_GENERATION]{0} OCSP response generation
@@ -533,6 +591,7 @@ LOGGING_SIGNED_AUDIT_OCSP_GENERATION=<type=OCSP_GENERATION>:[AuditEvent=OCSP_GEN
 # Event: RANDOM_GENERATION
 # - used when a random number generation is complete
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # Info:
 # - Caller is PKI code that calls the random number generator
 # - Size is size of random number in bytes
@@ -542,7 +601,8 @@ LOGGING_SIGNED_AUDIT_RANDOM_GENERATION=<type=RANDOM_GENERATION>:[AuditEvent=RAND
 # Event: CMC_SIGNED_REQUEST_SIG_VERIFY
 # - used when agent signed CMC certificate requests or revocation requests
 #   are submitted and signature is verified
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # ReqType must be the request type (enrollment, or revocation)
 # CertSubject must be the certificate subject name of the certificate request
 # SignerInfo must be a unique String representation for the signer
@@ -553,6 +613,7 @@ LOGGING_SIGNED_AUDIT_CMC_SIGNED_REQUEST_SIG_VERIFY=<type=CMC_SIGNED_REQUEST_SIG_
 # - used when CMC (user-signed or self-signed) certificate requests or revocation requests
 #   are submitted and signature is verified
 # Applicable subsystems: CA
+# Enabled by default: Yes
 # ReqType must be the request type (enrollment, or revocation)
 # CertSubject must be the certificate subject name of the certificate request
 # CMCSignerInfo must be a unique String representation for the CMC request signer
@@ -562,14 +623,16 @@ LOGGING_SIGNED_AUDIT_CMC_USER_SIGNED_REQUEST_SIG_VERIFY_FAILURE=<type=CMC_USER_S
 #
 # Event: COMPUTE_RANDOM_DATA_REQUEST
 # - used for TPS to TKS to get random challenge data
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # AgentID must be the trusted agent id used to make the request
 #
 LOGGING_SIGNED_AUDIT_COMPUTE_RANDOM_DATA_REQUEST_2=<type=COMPUTE_RANDOM_DATA_REQUEST>:[AuditEvent=COMPUTE_RANDOM_DATA_REQUEST][Outcome={0}][AgentID={1}] TKS Compute random data request
 #
 # Event: COMPUTE_RANDOM_DATA_REQUEST_PROCESSED with [Outcome=Success]
 # - used for TPS to TKS to get random challenge data
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # Outcome is SUCCESS or FAILURE
 # Status is 0 for no error.
 # AgentID must be the trusted agent id used to make the request
@@ -577,7 +640,8 @@ LOGGING_SIGNED_AUDIT_COMPUTE_RANDOM_DATA_REQUEST_PROCESSED_SUCCESS=<type=COMPUTE
 #
 # Event: COMPUTE_RANDOM_DATA_REQUEST_PROCESSED with [Outcome=Failure]
 # - used for TPS to TKS to get random challenge data
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # Outcome is SUCCESS or FAILURE
 # Status is 0 for no error.
 # Error gives the error message
@@ -587,7 +651,8 @@ LOGGING_SIGNED_AUDIT_COMPUTE_RANDOM_DATA_REQUEST_PROCESSED_FAILURE=<type=COMPUTE
 #
 # Event: COMPUTE_SESSION_KEY_REQUEST
 # - used for TPS to TKS to get a sessoin key for secure channel setup
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token establishing the secure channel
 # AgentID must be the trusted agent id used to make the request
 ## AC: KDF SPEC CHANGE - Need to log both the KDD and CUID, not just the
@@ -600,7 +665,8 @@ LOGGING_SIGNED_AUDIT_COMPUTE_SESSION_KEY_REQUEST_4=<type=COMPUTE_SESSION_KEY_REQ
 #
 # Event: COMPUTE_SESSION_KEY_REQUEST_PROCESSED with [Outcome=Success]
 # - request for TPS to TKS to get a sessoin key for secure channel processed
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token establishing the secure channel
 # AgentID must be the trusted agent id used to make the request
 # Outcome is SUCCESS or FAILURE
@@ -626,7 +692,8 @@ LOGGING_SIGNED_AUDIT_COMPUTE_SESSION_KEY_REQUEST_PROCESSED_SUCCESS=<type=COMPUTE
 #
 # Event: COMPUTE_SESSION_KEY_REQUEST_PROCESSED with [Outcome=Failure]
 # - request for TPS to TKS to get a sessoin key for secure channel processed
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token establishing the secure channel
 # Outcome is SUCCESS or FAILURE
 # Status is error code or 0 for no error.
@@ -651,7 +718,8 @@ LOGGING_SIGNED_AUDIT_COMPUTE_SESSION_KEY_REQUEST_PROCESSED_FAILURE=<type=COMPUTE
 #
 # Event: DIVERSIFY_KEY_REQUEST
 # - request for TPS to TKS to do key change over
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token requesting key change over
 # AgentID must be the trusted agent id used to make the request
 # status is 0 for success, non-zero for various errors
@@ -666,7 +734,8 @@ LOGGING_SIGNED_AUDIT_DIVERSIFY_KEY_REQUEST_6=<type=DIVERSIFY_KEY_REQUEST>:[Audit
 #
 # Event: DIVERSIFY_KEY_REQUEST_PROCESSED with [Outcome=Success]
 # - request for TPS to TKS to do key change over request processed
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token requesting key change over
 # AgentID must be the trusted agent id used to make the request
 # Outcome is SUCCESS or FAILURE
@@ -688,7 +757,8 @@ LOGGING_SIGNED_AUDIT_DIVERSIFY_KEY_REQUEST_PROCESSED_SUCCESS=<type=DIVERSIFY_KEY
 #
 # Event: DIVERSIFY_KEY_REQUEST_PROCESSED with [Outcome=Failure]
 # - request for TPS to TKS to do key change over request processed
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token requesting key change over
 # AgentID must be the trusted agent id used to make the request
 # Outcome is SUCCESS or FAILURE
@@ -712,7 +782,8 @@ LOGGING_SIGNED_AUDIT_DIVERSIFY_KEY_REQUEST_PROCESSED_FAILURE=<type=DIVERSIFY_KEY
 # Event: ENCRYPT_DATA_REQUEST
 # - request from TPS to TKS to encrypt data
 #        (or generate random data and encrypt)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token requesting encrypt data
 # AgentID must be the trusted agent id used to make the request
 # status is 0 for success, non-zero for various errors
@@ -729,7 +800,8 @@ LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_5=<type=ENCRYPT_DATA_REQUEST>:[AuditEv
 # Event: ENCRYPT_DATA_REQUEST_PROCESSED with [Outcome=Success]
 # - request from TPS to TKS to encrypt data
 #        (or generate random data and encrypt)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token requesting encrypt data
 # AgentID must be the trusted agent id used to make the request
 # Outcome is SUCCESS or FAILURE
@@ -752,7 +824,8 @@ LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS=<type=ENCRYPT_DATA_R
 # Event: ENCRYPT_DATA_REQUEST_PROCESSED with [Outcome=Failure]
 # - request from TPS to TKS to encrypt data
 #        (or generate random data and encrypt)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Applicable subsystems: TKS, TPS
+# Enabled by default: No
 # SubjectID must be the CUID of the token requesting encrypt data
 # AgentID must be the trusted agent id used to make the request
 # Outocme is SUCCESS or FAILURE
@@ -776,7 +849,8 @@ LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_FAILURE=<type=ENCRYPT_DATA_R
 # Event: SECURITY_DOMAIN_UPDATE
 # - used when updating contents of security domain
 #       (add/remove a subsystem)
-# Applicable subsystems: CA, TPS
+# Applicable subsystems: CA
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -787,6 +861,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DOMAIN_UPDATE_1=<type=SECURITY_DOMAIN_UPDATE>:[Aud
 # - used when configuring serial number ranges
 #      (when requesting a serial number range when cloning, for example)
 # Applicable subsystems: CA, KRA, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -797,6 +872,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_SERIAL_NUMBER_1=<type=CONFIG_SERIAL_NUMBER>:[AuditEv
 # - used when user security data archive request is processed
 #    this is when DRM receives and processed the request
 # Applicable subsystems: KRA
+# Enabled by default: Yes
 # ArchivalRequestID is the requestID provided by the CA through the connector
 #    It is used to track the request through from CA to KRA.
 # RequestId is the KRA archival request ID
@@ -808,6 +884,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_ARCHIVAL_REQUEST_PROCESSED=<type=SECURITY_DAT
 # Event: SECURITY_DATA_ARCHIVAL_REQUEST
 # - used when security data recovery request is made
 # Applicable subsystems: CA, KRA
+# Enabled by default: Yes
 # ArchivalRequestID is the requestID provided by the CA through the connector
 #    It is used to track the request through from CA to KRA.
 # RequestId is the KRA archival request ID
@@ -819,6 +896,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_ARCHIVAL_REQUEST=<type=SECURITY_DATA_ARCHIVAL
 # Event: SECURITY_DATA_RECOVERY_REQUEST_PROCESSED
 # - used when security data recovery request is processed
 # Applicable subsystems: KRA
+# Enabled by default: Yes
 # RecoveryID must be the recovery request ID
 # KeyID is the ID of the security data being requested to be recovered
 # RecoveryAgents are the UIDs of the recovery agents approving this request
@@ -828,6 +906,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST_PROCESSED=<type=SECURITY_DAT
 # Event: SECURITY_DATA_RECOVERY_REQUEST
 # - used when security data recovery request is made
 # Applicable subsystems: KRA
+# Enabled by default: Yes
 # RecoveryID must be the recovery request ID
 # DataID is the ID of the security data to be recovered
 #
@@ -837,6 +916,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST=<type=SECURITY_DATA_RECOVERY
 # - used when DRM agents login as recovery agents to change
 #   the state of key recovery requests
 # Applicable subsystems: KRA
+# Enabled by default: Yes
 # RecoveryID must be the recovery request ID
 # Operation is the operation performed (approve, reject, cancel etc.)
 #
@@ -846,6 +926,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST_STATE_CHANGE=<type=SECURITY_
 # - used when user attempts to retrieve key after the recovery request
 #   has been approved.
 # Applicable subsystems: KRA
+# Enabled by default: No
 # RecoveryID must be the recovery request ID
 # KeyID is the key being retrieved
 # Info is the failure reason if the export fails.
@@ -856,6 +937,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_EXPORT_KEY=<type=SECURITY_DATA_EXPORT_KEY>:[A
 # Event: SECURITY_DATA_INFO
 # - used when user attempts to get metadata information about a key
 # Applicable subsystems: KRA
+# Enabled by default: No
 # RecoveryID must be the recovery request ID
 # KeyID is the key being retrieved
 # Info is the failure reason if the export fails.
@@ -866,6 +948,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_INFO=<type=SECURITY_DATA_INFO>:[AuditEvent=SE
 # Event: KEY_STATUS_CHANGE
 # - used when modify key status is executed
 # Applicable subsystems: KRA
+# Enabled by default: No
 # keyID must be an existing key id in the database
 # oldStatus is the old status to change from
 # newStatus is the new status to change to
@@ -876,6 +959,7 @@ LOGGING_SIGNED_AUDIT_KEY_STATUS_CHANGE=<type=KEY_STATUS_CHANGE>:[AuditEvent=KEY_
 # - used when symmetric key generation request is processed
 #    this is when DRM receives and processes the request
 # Applicable subsystems: KRA
+# Enabled by default: Yes
 # Client ID must be the user supplied client ID associated with
 #    the symmetric key to be generated and archived
 #
@@ -884,6 +968,7 @@ LOGGING_SIGNED_AUDIT_SYMKEY_GEN_REQUEST_PROCESSED=<type=SYMKEY_GENERATION_REQUES
 # Event: SYMKEY_GENERATION_REQUEST
 # - used when symmetric key generation request is made
 # Applicable subsystems: KRA
+# Enabled by default: Yes
 # ClientKeyID is the ID of the symmetirc key to be generated and archived
 #
 LOGGING_SIGNED_AUDIT_SYMKEY_GENERATION_REQUEST=<type=SYMKEY_GENERATION_REQUEST>:[AuditEvent=SYMKEY_GENERATION_REQUEST]{0} symkey generation request made
@@ -891,6 +976,7 @@ LOGGING_SIGNED_AUDIT_SYMKEY_GENERATION_REQUEST=<type=SYMKEY_GENERATION_REQUEST>:
 # Event: ASYMKEY_GENERATION_REQUEST
 # - used when asymmetric key generation request is made
 # Applicable subsystems: KRA
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_ASYMKEY_GENERATION_REQUEST=<type=ASYMKEY_GENERATION_REQUEST>:[AuditEvent=ASYMKEY_GENERATION_REQUEST]{0} Asymkey generation request made
 #
@@ -898,12 +984,14 @@ LOGGING_SIGNED_AUDIT_ASYMKEY_GENERATION_REQUEST=<type=ASYMKEY_GENERATION_REQUEST
 # - used when a request to generate asymmetric keys received by the DRM
 #   is processed.
 # Applicable subsystems: KRA
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_ASYMKEY_GEN_REQUEST_PROCESSED=<type=ASYMKEY_GENERATION_REQUEST_PROCESSED>:[AuditEvent=ASYMKEY_GENERATION_REQUEST_PROCESSED]{0} Asymkey generation request processed
 #
 # Event: TOKEN_CERT_ENROLLMENT
 # - used for TPS when token certificate enrollment request is made
 # Applicable subsystems: TPS
+# Enabled by default: No
 # - Info is normally used to store more info in case of failure
 #
 LOGGING_SIGNED_AUDIT_TOKEN_CERT_ENROLLMENT_9=<type=TOKEN_CERT_ENROLLMENT>:[AuditEvent=TOKEN_CERT_ENROLLMENT][IP={0}][SubjectID={1}][CUID={2}][Outcome={3}][tokenType={4}][KeyVersion={5}][Serial={6}][CA_ID={7}][Info={8}] token certificate enrollment request made
@@ -911,6 +999,7 @@ LOGGING_SIGNED_AUDIT_TOKEN_CERT_ENROLLMENT_9=<type=TOKEN_CERT_ENROLLMENT>:[Audit
 # Event: TOKEN_CERT_RENEWAL
 # - used for TPS when token certificate renewal request is made
 # Applicable subsystems: TPS
+# Enabled by default: No
 # - Info is normally used to store more info in case of failure
 #
 LOGGING_SIGNED_AUDIT_TOKEN_CERT_RENEWAL_9=<type=TOKEN_CERT_RENEWAL>:[AuditEvent=TOKEN_CERT_RENEWAL][IP={0}][SubjectID={1}][CUID={2}][Outcome={3}][tokenType={4}][KeyVersion={5}][Serial={6}][CA_ID={7}][Info={8}] token certificate renewal request made
@@ -919,17 +1008,21 @@ LOGGING_SIGNED_AUDIT_TOKEN_CERT_RENEWAL_9=<type=TOKEN_CERT_RENEWAL>:[AuditEvent=
 # - used for TPS when token certificate retrieval request is made;
 #   usually used during recovery, along with LOGGING_SIGNED_AUDIT_TOKEN_KEY_RECOVERY
 # Applicable subsystems: TPS
+# Enabled by default: No
 #
 LOGGING_SIGNED_AUDIT_TOKEN_CERT_RETRIEVAL_9=<type=TOKEN_CERT_RETRIEVAL>:[AuditEvent=TOKEN_CERT_RETRIEVAL][IP={0}][SubjectID={1}][CUID={2}][Outcome={3}][tokenType={4}][KeyVersion={5}][Serial={6}][CA_ID={7}][Info={8}] token certificate retrieval request made
 #
 # Event: TOKEN_KEY_RECOVERY
 # - used for TPS when token certificate key recovery request is made
 # Applicable subsystems: TPS
+# Enabled by default: No
 #
 LOGGING_SIGNED_AUDIT_TOKEN_KEY_RECOVERY_10=<type=TOKEN_KEY_RECOVERY>:[AuditEvent=TOKEN_KEY_RECOVERY][IP={0}][SubjectID={1}][CUID={2}][Outcome={3}][tokenType={4}][KeyVersion={5}][Serial={6}][CA_ID={7}][KRA_ID={8}][Info={9}] token certificate/key recovery request made
 #
 # Event: TOKEN_CERT_STATUS_CHANGE_REQUEST
 # - used when a token certificate status change request (e.g. revocation) is made
+# Applicable subsystems: TPS
+# Enabled by default: No
 # CUID must be the last token that the certificate was associated with
 # CertSerialNum must be the serial number (in decimal) of the certificate to be revoked
 # RequestType must be "revoke", "on-hold", "off-hold"
@@ -938,18 +1031,22 @@ LOGGING_SIGNED_AUDIT_TOKEN_CERT_STATUS_CHANGE_REQUEST_10=<type=TOKEN_CERT_STATUS
 #
 # Event: TOKEN_PIN_RESET with [Outcome=Success]
 # - used when token pin reset request succeeded
+# Applicable subsystems: TPS
+# Enabled by default: No
 #
 LOGGING_SIGNED_AUDIT_TOKEN_PIN_RESET_SUCCESS=<type=TOKEN_PIN_RESET>:[AuditEvent=TOKEN_PIN_RESET]{0} token op pin reset success
 #
 # Event: TOKEN_PIN_RESET with [Outcome=Failure]
 # - used when token pin reset request failed
 # Applicable subsystems: TPS
+# Enabled by default: No
 #
 LOGGING_SIGNED_AUDIT_TOKEN_PIN_RESET_FAILURE=<type=TOKEN_PIN_RESET>:[AuditEvent=TOKEN_PIN_RESET]{0} token op pin reset failure
 #
 # Event: TOKEN_OP_REQUEST
 # - used when token processor op request is made
 # Applicable subsystems: TPS
+# Enabled by default: No
 # - OP can be "format", "enroll", or "pinReset"
 #
 LOGGING_SIGNED_AUDIT_TOKEN_OP_REQUEST_6=<type=TOKEN_OP_REQUEST>:[AuditEvent=TOKEN_OP_REQUEST][IP={0}][CUID={1}][MSN={2}][Outcome={3}][OP={4}][AppletVersion={5}] token processor op request made
@@ -957,36 +1054,42 @@ LOGGING_SIGNED_AUDIT_TOKEN_OP_REQUEST_6=<type=TOKEN_OP_REQUEST>:[AuditEvent=TOKE
 # Event: TOKEN_FORMAT with [Outcome=Success]
 # - used when token format op succeeded
 # Applicable subsystems: TPS
+# Enabled by default: No
 #
 LOGGING_SIGNED_AUDIT_TOKEN_FORMAT_SUCCESS=<type=TOKEN_FORMAT>:[AuditEvent=TOKEN_FORMAT]{0} token op format success
 #
 # Event: TOKEN_FORMAT with [Outcome=Failure]
 # - used when token format op failed
 # Applicable subsystems: TPS
+# Enabled by default: No
 #
 LOGGING_SIGNED_AUDIT_TOKEN_FORMAT_FAILURE=<type=TOKEN_FORMAT>:[AuditEvent=TOKEN_FORMAT]{0} token op format failure
 #
 # Event: TOKEN_APPLET_UPGRADE with [Outcome=Success]
 # - used when token apple upgrade succeeded
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_TOKEN_APPLET_UPGRADE_SUCCESS=<type=TOKEN_APPLET_UPGRADE>:[AuditEvent=TOKEN_APPLET_UPGRADE]{0} token applet upgrade success
 #
 # Event: TOKEN_APPLET_UPGRADE with [Outcome=Failure]
 # - used when token apple upgrade failed
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_TOKEN_APPLET_UPGRADE_FAILURE=<type=TOKEN_APPLET_UPGRADE>:[AuditEvent=TOKEN_APPLET_UPGRADE]{0} token applet upgrade failure
 #
 # Event: TOKEN_KEY_CHANGEOVER_REQUIRED
 # - used when token key changeover is required
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_TOKEN_KEY_CHANGEOVER_REQUIRED_10=<type=TOKEN_KEY_CHANGEOVER_REQUIRED>:[AuditEvent=TOKEN_KEY_CHANGEOVER_REQUIRED][IP={0}][SubjectID={1}][CUID={2}][MSN={3}][Outcome={4}][tokenType={5}][AppletVersion={6}][oldKeyVersion={7}][newKeyVersion={8}][Info={9}] token key changeover required
 #
 # Event: TOKEN_KEY_CHANGEOVER with [Outcome=Success]
 # - used when token key changeover succeeded
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 # - Info usually is unused for success
 #
 LOGGING_SIGNED_AUDIT_TOKEN_KEY_CHANGEOVER_SUCCESS=<type=TOKEN_KEY_CHANGEOVER>:[AuditEvent=TOKEN_KEY_CHANGEOVER]{0} token key changeover success
@@ -994,6 +1097,7 @@ LOGGING_SIGNED_AUDIT_TOKEN_KEY_CHANGEOVER_SUCCESS=<type=TOKEN_KEY_CHANGEOVER>:[A
 # Event: TOKEN_KEY_CHANGEOVER with [Outcome=Failure]
 # - used when token key changeover failed
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 # - Info is used for storing more info in case of failure
 #
 LOGGING_SIGNED_AUDIT_TOKEN_KEY_CHANGEOVER_FAILURE=<type=TOKEN_KEY_CHANGEOVER>:[AuditEvent=TOKEN_KEY_CHANGEOVER]{0} token key changeover failure
@@ -1001,6 +1105,7 @@ LOGGING_SIGNED_AUDIT_TOKEN_KEY_CHANGEOVER_FAILURE=<type=TOKEN_KEY_CHANGEOVER>:[A
 # Event: TOKEN_AUTH with [Outcome=Failure]
 # - used when authentication failed
 # Applicable subsystems: TPS
+# Enabled by default: No
 # Outcome should always be "failure" in this event
 #   (obviously, if authentication failed, you won't have a valid SubjectID, so
 #       in this case, AttemptedID is recorded)
@@ -1012,6 +1117,7 @@ LOGGING_SIGNED_AUDIT_TOKEN_AUTH_FAILURE=<type=TOKEN_AUTH>:[AuditEvent=TOKEN_AUTH
 # Event: TOKEN_AUTH with [Outcome=Success]
 # - used when authentication succeeded
 # Applicable subsystems: TPS
+# Enabled by default: No
 # Outcome should always be "success" in this event
 # AuthMgr must be the authentication manager instance name that did
 #   this authentication
@@ -1021,6 +1127,7 @@ LOGGING_SIGNED_AUDIT_TOKEN_AUTH_SUCCESS=<type=TOKEN_AUTH>:[AuditEvent=TOKEN_AUTH
 # Event: CONFIG_TOKEN_GENERAL
 # - used when doing general TPS configuration
 # Applicable subsystems: TPS
+# Enabled by default: No
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -1032,6 +1139,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_GENERAL_5=<type=CONFIG_TOKEN_GENERAL>:[AuditEv
 # Event: CONFIG_TOKEN_PROFILE
 # - used when configuring token profile
 # Applicable subsystems: TPS
+# Enabled by default: No
 # Service can be any of the methods offered
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
@@ -1044,6 +1152,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_PROFILE_6=<type=CONFIG_TOKEN_PROFILE>:[AuditEv
 # Event: CONFIG_TOKEN_MAPPING_RESOLVER
 # - used when configuring token mapping resolver
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -1055,6 +1164,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_MAPPING_RESOLVER_6=<type=CONFIG_TOKEN_MAPPING_
 # Event: CONFIG_TOKEN_AUTHENTICATOR
 # - used when configuring token authenticators
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 # Service can be any of the methods offered
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
@@ -1067,6 +1177,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_AUTHENTICATOR_6=<type=CONFIG_TOKEN_AUTHENTICAT
 # Event: CONFIG_TOKEN_CONNECTOR
 # - used when configuring token connectors
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 # Service can be any of the methods offered
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
@@ -1079,6 +1190,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_CONNECTOR_6=<type=CONFIG_TOKEN_CONNECTOR>:[Aud
 # Event: CONFIG_TOKEN_RECORD
 # - used when information in token record changed
 # Applicable subsystems: TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -1090,6 +1202,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_RECORD_6=<type=CONFIG_TOKEN_RECORD>:[AuditEven
 # Event: TOKEN_STATE_CHANGE
 # - used when token state changed
 # Applicable subsystems: TPS
+# Enabled by default: No
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -1101,6 +1214,7 @@ LOGGING_SIGNED_AUDIT_TOKEN_STATE_CHANGE_8=<type=TOKEN_STATE_CHANGE>:[AuditEvent=
 # Event: AUTHORITY_CONFIG
 # - used when configuring lightweight authorities
 # Applicable subsystems: CA
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -1110,6 +1224,7 @@ LOGGING_SIGNED_AUDIT_AUTHORITY_CONFIG_3=<type=AUTHORITY_CONFIG>:[AuditEvent=AUTH
 # Event: ACCESS_SESSION_ESTABLISH with [Outcome=Failure]
 # - used when access session failed to establish
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -1120,6 +1235,7 @@ LOGGING_SIGNED_AUDIT_ACCESS_SESSION_ESTABLISH_FAILURE=\
 # Event: ACCESS_SESSION_ESTABLISH with [Outcome=Success]
 # - used when access session was established successfully
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -1130,6 +1246,7 @@ LOGGING_SIGNED_AUDIT_ACCESS_SESSION_ESTABLISH_SUCCESS=\
 # Event: ACCESS_SESSION_TERMINATED
 # - used when access session was terminated
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)
 #    separated by + (if more than one name;;value pair) of config params changed
@@ -1139,7 +1256,8 @@ LOGGING_SIGNED_AUDIT_ACCESS_SESSION_TERMINATED=\
 #
 # Event: CLIENT_ACCESS_SESSION_ESTABLISH with [Outcome=Failure]
 # access session failed to establish when Certificate System acts as client
-# Applicable subsystems: CA, KRA, OCSP, TKS
+# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_ESTABLISH_FAILURE=\
 <type=CLIENT_ACCESS_SESSION_ESTABLISH>:[AuditEvent=CLIENT_ACCESS_SESSION_ESTABLISH]{0} access session failed to establish when Certificate System acts as client
@@ -1147,14 +1265,16 @@ LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_ESTABLISH_FAILURE=\
 # Event: CLIENT_ACCESS_SESSION_ESTABLISH with [Outcome=Success]
 # - used when access session was established successfully when
 #   Certificate System acts as client
-# Applicable subsystems: CA, KRA, OCSP, TKS
+# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_ESTABLISH_SUCCESS=\
 <type=CLIENT_ACCESS_SESSION_ESTABLISH>:[AuditEvent=CLIENT_ACCESS_SESSION_ESTABLISH]{0} access session establish successfully when Certificate System acts as client
 #
 # Event: CLIENT_ACCESS_SESSION_TERMINATED
 # - used when access session was terminated when Certificate System acts as client
-# Applicable subsystems: CA, KRA, OCSP, TKS
+# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 #
 LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_TERMINATED=\
 <type=CLIENT_ACCESS_SESSION_TERMINATED>:[AuditEvent=CLIENT_ACCESS_SESSION_TERMINATED]{0} access session terminated when Certificate System acts as client
@@ -1164,6 +1284,8 @@ LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_TERMINATED=\
 #
 # Event: AUDIT_LOG_SIGNING
 # - used when a signature on the audit log is generated (same as "flush" time)
+# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
 # SubjectID is predefined to be "$System$" because this operation
 #   associates with no user
 # sig must be the base-64 encoded signature of the buffer just flushed

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -75,6 +75,10 @@ class PKIServer(object):
 
     @staticmethod
     def load_audit_events(filename):
+        '''
+        This method loads audit event info from audit-events.properties
+        and return it as a map of objects.
+        '''
 
         logger.info('Loading %s', filename)
 
@@ -85,6 +89,8 @@ class PKIServer(object):
 
         event_pattern = re.compile(r'# Event: (\S+)')
         subsystems_pattern = re.compile(r'# Applicable subsystems: (.*)')
+        enabled_pattern = re.compile(r'# Enabled by default: (.*)')
+
         event = None
 
         for line in lines:
@@ -94,10 +100,15 @@ class PKIServer(object):
             event_match = event_pattern.match(line)
             if event_match:
 
-                event = event_match.group(1)
-                logger.info('Found event %s', event)
+                name = event_match.group(1)
+                logger.info('Found event %s', name)
 
-                events[event] = []
+                event = {}
+                event['name'] = name
+                event['subsystems'] = []
+                event['enabled_by_default'] = False
+
+                events[name] = event
                 continue
 
             subsystems_match = subsystems_pattern.match(line)
@@ -107,14 +118,25 @@ class PKIServer(object):
                 logger.info('Found subsystems %s', subsystems)
 
                 subsystems = subsystems.replace(' ', '').split(',')
-                event_subsystems = events.get(event)
-                event_subsystems.extend(subsystems)
+                event['subsystems'] = subsystems
+
+            enabled_match = enabled_pattern.match(line)
+            if enabled_match:
+
+                enabled = enabled_match.group(1)
+                logger.info('Found enabled by default %s', enabled)
+
+                if enabled == 'Yes':
+                    event['enabled_by_default'] = True
+                else:
+                    event['enabled_by_default'] = False
 
         logger.info('Events:')
 
-        for event in events:
-            subsystems = events[event]
-            logger.info('- %s: %s', event, subsystems)
+        for name, event in events.items():
+            logger.info('- %s', name)
+            logger.info('  Applicable subsystems: %s', event['subsystems'])
+            logger.info('  Enabled by default: %s', event['enabled_by_default'])
 
         return events
 
@@ -477,8 +499,7 @@ class PKISubsystem(object):
         if not event_name:
             raise ValueError("Please specify the Event name")
 
-        names = self.get_audit_events()
-        if event_name not in names:
+        if event_name not in self.get_audit_events():
             raise PKIServerException('Invalid audit event: %s' % event_name)
 
         value = self.config['log.instance.SignedAudit.events']
@@ -498,8 +519,7 @@ class PKISubsystem(object):
         if not event_name:
             raise ValueError("Please specify the Event name")
 
-        names = self.get_audit_events()
-        if event_name not in names:
+        if event_name not in self.get_audit_events():
             raise PKIServerException('Invalid audit event: %s' % event_name)
 
         name = 'log.instance.SignedAudit.filters.%s' % event_name
@@ -514,8 +534,7 @@ class PKISubsystem(object):
         if not event_name:
             raise ValueError("Please specify the Event name")
 
-        names = self.get_audit_events()
-        if event_name not in names:
+        if event_name not in self.get_audit_events():
             raise PKIServerException('Invalid audit event: %s' % event_name)
 
         value = self.config['log.instance.SignedAudit.events']
@@ -530,43 +549,55 @@ class PKISubsystem(object):
 
         return True
 
-    def find_audit_event_configs(self, enabled=None):
+    def find_audit_event_configs(self, enabled=None, enabled_by_default=None):
+        '''
+        This method returns current audit configuration based on the specified
+        filters.
+        '''
 
-        events = []
+        events = self.get_audit_events()
+        enabled_events = set(self.get_enabled_audit_events())
 
-        # get enabled events
-        enabled_event_names = self.get_enabled_audit_events()
+        # apply "enabled_by_default" filter
+        if enabled_by_default is None:
+            # return all events
+            names = set(events.keys())
 
+        else:
+            # return events enabled by default
+            names = set()
+            for name, event in events.items():
+                if enabled_by_default is event['enabled_by_default']:
+                    names.add(name)
+
+        # apply "enabled" filter
         if enabled is None:
-            # get all events
-            names = self.get_audit_events()
+            # return all events
+            pass
 
         elif enabled:  # enabled == True
-            # get enabled events
-            names = enabled_event_names
+            # return currently enabled events
+            names = names.intersection(enabled_events)
 
         else:  # enabled == False
-            # get all events
-            all_event_names = self.get_audit_events()
+            # return currently disabled events
+            names = names.difference(enabled_events)
 
-            # get disabled events by subtracting enabled events from all events
-            names = sorted(set(all_event_names) - set(enabled_event_names))
+        results = []
 
         # get event properties
-        for name in names:
+        for name in sorted(names):
             event = {}
             event['name'] = name
-            event['enabled'] = name in enabled_event_names
+            event['enabled'] = name in enabled_events
             event['filter'] = self.config.get('log.instance.SignedAudit.filters.%s' % name)
-            events.append(event)
+            results.append(event)
 
-        return events
+        return results
 
     def get_audit_event_config(self, name):
 
-        names = self.get_audit_events()
-
-        if name not in names:
+        if name not in self.get_audit_events():
             raise PKIServerException('Invalid audit event: %s' % name)
 
         enabled_event_names = self.get_enabled_audit_events()
@@ -579,8 +610,12 @@ class PKISubsystem(object):
         return event
 
     def get_audit_events(self):
+        '''
+        This method returns audit events applicable to this subsystem
+        as a map of objects.
+        '''
 
-        # get the full list of audit events from audit-events.properties
+        # get the list of audit events from audit-events.properties
 
         tmpdir = tempfile.mkdtemp()
 
@@ -611,19 +646,16 @@ class PKISubsystem(object):
         finally:
             shutil.rmtree(tmpdir)
 
-        # get audit events for the subsystem
-        results = set()
+        # get audit events for this subsystem
+        results = {}
         subsystem = self.name.upper()
 
-        for event, subsystems in events.items():
+        for name, event in events.items():
+            if subsystem in event['subsystems']:
+                logger.info('Returning %s', name)
+                results[name] = event
 
-            if subsystem not in subsystems:
-                continue
-
-            logger.info('Returning %s', event)
-            results.add(event)
-
-        return sorted(results)
+        return results
 
     def get_enabled_audit_events(self):
 

--- a/base/server/python/pki/server/cli/audit.py
+++ b/base/server/python/pki/server/cli/audit.py
@@ -315,10 +315,16 @@ class AuditEventFindCLI(pki.cli.CLI):
     def print_help(self):
         print('Usage: pki-server %s-audit-event-find [OPTIONS]' % self.parent.parent.name)
         print()
-        print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
-        print('      --enabled <True|False>         Show enabled/disabled events only.')
-        print('  -v, --verbose                      Run in verbose mode.')
-        print('      --help                         Show help message.')
+        print('  -i, --instance <instance ID>       '
+              '  Instance ID (default: pki-tomcat).')
+        print('      --enabled <True|False>         '
+              '  Show events currently enabled/disabled only.')
+        print('      --enabledByDefault <True|False>'
+              '  Show events enabled/disabled by default only.')
+        print('  -v, --verbose                      '
+              '  Run in verbose mode.')
+        print('      --help                         '
+              '  Show help message.')
         print()
 
     def execute(self, argv):
@@ -326,7 +332,7 @@ class AuditEventFindCLI(pki.cli.CLI):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=',
-                'enabled=',
+                'enabled=', 'enabledByDefault=',
                 'verbose', 'help'])
 
         except getopt.GetoptError as e:
@@ -336,6 +342,7 @@ class AuditEventFindCLI(pki.cli.CLI):
 
         instance_name = 'pki-tomcat'
         enabled = None
+        enabled_by_default = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
@@ -343,6 +350,9 @@ class AuditEventFindCLI(pki.cli.CLI):
 
             elif o == '--enabled':
                 enabled = a == 'True'
+
+            elif o == '--enabledByDefault':
+                enabled_by_default = a == 'True'
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -370,7 +380,7 @@ class AuditEventFindCLI(pki.cli.CLI):
                   % (subsystem_name.upper(), instance_name))
             sys.exit(1)
 
-        events = subsystem.find_audit_event_configs(enabled)
+        events = subsystem.find_audit_event_configs(enabled, enabled_by_default)
 
         self.print_message('%s entries matched' % len(events))
 


### PR DESCRIPTION
The audit-events.properties has been modified to include the
"Enabled by default" fields.

The pki-server <subsystem>-audit-event-find has been modified
to provide an option to show the events enabled by default
based on the information in audit-events.properties.

https://pagure.io/dogtagpki/issue/2686
