### PR TITLE
Additional changes to audit-events.properties

### DIFF
--- a/base/server/cmsbundle/src/audit-events.properties
+++ b/base/server/cmsbundle/src/audit-events.properties
@@ -257,7 +257,7 @@ LOGGING_SIGNED_AUDIT_KEY_RECOVERY_REQUEST_4=<type=KEY_RECOVERY_REQUEST>:[AuditEv
 # - used when DRM agents login as recovery agents to approve
 #       key recovery requests
 # Applicable subsystems: KRA
-# Enabled by default: Yes
+# Enabled by default: No
 # RecoveryID must be the recovery request ID
 # RecoveryAgent must be the recovery agent the DRM agent is
 #       logging in with
@@ -860,7 +860,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DOMAIN_UPDATE_1=<type=SECURITY_DOMAIN_UPDATE>:[Aud
 # Event: CONFIG_SERIAL_NUMBER
 # - used when configuring serial number ranges
 #      (when requesting a serial number range when cloning, for example)
-# Applicable subsystems: CA, KRA, TPS
+# Applicable subsystems: CA, KRA
 # Enabled by default: Yes
 # ParamNameValPairs must be a name;;value pair
 #    (where name and value are separated by the delimiter ;;)


### PR DESCRIPTION
The TPS has been dropped from CONFIG_SERIAL_NUMBER.
The KEY_RECOVERY_AGENT_LOGIN is now disabled by default.

https://pagure.io/dogtagpki/issue/2686