### PR TITLE
Added documentation for default audit events

### DIFF
--- a/docs/admin/Default_CA_Audit_Events.md
+++ b/docs/admin/Default_CA_Audit_Events.md
@@ -1,0 +1,57 @@
+Default CA Audit Events
+=======================
+
+The following audit events are enabled by default in CA subsystem:
+
+| Event                                       | Filter            |
+| ------------------------------------------- | ----------------- |
+| ACCESS_SESSION_ESTABLISH                    |                   |
+| ACCESS_SESSION_TERMINATED                   |                   |
+| AUDIT_LOG_SHUTDOWN                          |                   |
+| AUDIT_LOG_SIGNING                           |                   |
+| AUDIT_LOG_STARTUP                           |                   |
+| AUTH                                        |                   |
+| AUTHORITY_CONFIG                            |                   |
+| AUTHZ                                       |                   |
+| CERT_PROFILE_APPROVAL                       |                   |
+| CERT_REQUEST_PROCESSED                      |                   |
+| CERT_SIGNING_INFO                           |                   |
+| CERT_STATUS_CHANGE_REQUEST                  |                   |
+| CERT_STATUS_CHANGE_REQUEST_PROCESSED        |                   |
+| CLIENT_ACCESS_SESSION_ESTABLISH             |                   |
+| CLIENT_ACCESS_SESSION_TERMINATED            |                   |
+| CMC_REQUEST_RECEIVED                        |                   |
+| CMC_RESPONSE_SENT                           |                   |
+| CMC_SIGNED_REQUEST_SIG_VERIFY               | (Outcome=Failure) |
+| CMC_USER_SIGNED_REQUEST_SIG_VERIFY          | (Outcome=Failure) |
+| CONFIG_ACL                                  |                   |
+| CONFIG_AUTH                                 |                   |
+| CONFIG_CERT_PROFILE                         |                   |
+| CONFIG_CRL_PROFILE                          |                   |
+| CONFIG_ENCRYPTION                           |                   |
+| CONFIG_ROLE                                 |                   |
+| CONFIG_SERIAL_NUMBER                        |                   |
+| CONFIG_SIGNED_AUDIT                         |                   |
+| CONFIG_TRUSTED_PUBLIC_KEY                   |                   |
+| CRL_SIGNING_INFO                            |                   |
+| DELTA_CRL_GENERATION                        | (Outcome=Failure) |
+| FULL_CRL_GENERATION                         | (Outcome=Failure) |
+| KEY_GEN_ASYMMETRIC                          |                   |
+| LOG_PATH_CHANGE                             |                   |
+| OCSP_GENERATION                             | (Outcome=Failure) |
+| OCSP_SIGNING_INFO                           |                   |
+| PROFILE_CERT_REQUEST                        |                   |
+| PROOF_OF_POSSESSION                         |                   |
+| RANDOM_GENERATION                           | (Outcome=Failure) |
+| ROLE_ASSUME                                 |                   |
+| SECURITY_DATA_ARCHIVAL_REQUEST              |                   |
+| SECURITY_DOMAIN_UPDATE                      |                   |
+| SELFTESTS_EXECUTION                         |                   |
+| SERVER_SIDE_KEYGEN_REQUEST                  |                   |
+| SERVER_SIDE_KEYGEN_REQUEST_PROCESSED        |                   |
+
+This information can also be obtained with the following command:
+
+```
+$ pki-server ca-audit-event-find --enabledByDefault True
+```

--- a/docs/admin/Default_KRA_Audit_Events.md
+++ b/docs/admin/Default_KRA_Audit_Events.md
@@ -1,0 +1,46 @@
+Default KRA Audit Events
+========================
+
+The following audit events are enabled by default in KRA subsystem:
+
+| Event                                       | Filter            |
+| ------------------------------------------- | ----------------- |
+| ACCESS_SESSION_ESTABLISH                    |                   |
+| ACCESS_SESSION_TERMINATED                   |                   |
+| ASYMKEY_GENERATION_REQUEST                  | (Outcome=Failure) |
+| ASYMKEY_GENERATION_REQUEST_PROCESSED        | (Outcome=Failure) |
+| AUDIT_LOG_SHUTDOWN                          |                   |
+| AUDIT_LOG_SIGNING                           |                   |
+| AUDIT_LOG_STARTUP                           |                   |
+| AUTH                                        |                   |
+| AUTHZ                                       |                   |
+| CLIENT_ACCESS_SESSION_ESTABLISH             |                   |
+| CLIENT_ACCESS_SESSION_TERMINATED            |                   |
+| CONFIG_ACL                                  |                   |
+| CONFIG_AUTH                                 |                   |
+| CONFIG_DRM                                  |                   |
+| CONFIG_ENCRYPTION                           |                   |
+| CONFIG_ROLE                                 |                   |
+| CONFIG_SERIAL_NUMBER                        |                   |
+| CONFIG_SIGNED_AUDIT                         |                   |
+| CONFIG_TRUSTED_PUBLIC_KEY                   |                   |
+| KEY_GEN_ASYMMETRIC                          |                   |
+| LOG_PATH_CHANGE                             |                   |
+| RANDOM_GENERATION                           | (Outcome=Failure) |
+| ROLE_ASSUME                                 |                   |
+| SECURITY_DATA_ARCHIVAL_REQUEST              | (Outcome=Failure) |
+| SECURITY_DATA_ARCHIVAL_REQUEST_PROCESSED    | (Outcome=Failure) |
+| SECURITY_DATA_RECOVERY_REQUEST              | (Outcome=Failure) |
+| SECURITY_DATA_RECOVERY_REQUEST_PROCESSED    | (Outcome=Failure) |
+| SECURITY_DATA_RECOVERY_REQUEST_STATE_CHANGE | (Outcome=Failure) |
+| SELFTESTS_EXECUTION                         |                   |
+| SERVER_SIDE_KEYGEN_REQUEST                  | (Outcome=Failure) |
+| SERVER_SIDE_KEYGEN_REQUEST_PROCESSED        | (Outcome=Failure) |
+| SYMKEY_GENERATION_REQUEST                   | (Outcome=Failure) |
+| SYMKEY_GENERATION_REQUEST_PROCESSED         | (Outcome=Failure) |
+
+This information can also be obtained with the following command:
+
+```
+$ pki-server kra-audit-event-find --enabledByDefault True
+```

--- a/docs/admin/Default_OCSP_Audit_Events.md
+++ b/docs/admin/Default_OCSP_Audit_Events.md
@@ -1,0 +1,40 @@
+Default OCSP Audit Events
+=========================
+
+The following audit events are enabled by default in OCSP subsystem:
+
+| Event                                       | Filter            |
+| ------------------------------------------- | ----------------- |
+| ACCESS_SESSION_ESTABLISH                    |                   |
+| ACCESS_SESSION_TERMINATED                   |                   |
+| AUDIT_LOG_SHUTDOWN                          |                   |
+| AUDIT_LOG_SIGNING                           |                   |
+| AUDIT_LOG_STARTUP                           |                   |
+| AUTH                                        |                   |
+| AUTHZ                                       |                   |
+| CLIENT_ACCESS_SESSION_ESTABLISH             |                   |
+| CLIENT_ACCESS_SESSION_TERMINATED            |                   |
+| CONFIG_ACL                                  |                   |
+| CONFIG_AUTH                                 |                   |
+| CONFIG_ENCRYPTION                           |                   |
+| CONFIG_OCSP_PROFILE                         |                   |
+| CONFIG_ROLE                                 |                   |
+| CONFIG_SIGNED_AUDIT                         |                   |
+| CONFIG_TRUSTED_PUBLIC_KEY                   |                   |
+| KEY_GEN_ASYMMETRIC                          |                   |
+| LOG_PATH_CHANGE                             |                   |
+| OCSP_ADD_CA_REQUEST_PROCESSED               |                   |
+| OCSP_GENERATION                             |                   |
+| OCSP_REMOVE_CA_REQUEST_PROCESSED            |                   |
+| OCSP_SIGNING_INFO                           |                   |
+| RANDOM_GENERATION                           | (Outcome=Failure) |
+| ROLE_ASSUME                                 |                   |
+| SELFTESTS_EXECUTION                         |                   |
+| SERVER_SIDE_KEYGEN_REQUEST                  |                   |
+| SERVER_SIDE_KEYGEN_REQUEST_PROCESSED        |                   |
+
+This information can also be obtained with the following command:
+
+```
+$ pki-server ocsp-audit-event-find --enabledByDefault True
+```

--- a/docs/admin/Default_TKS_Audit_Events.md
+++ b/docs/admin/Default_TKS_Audit_Events.md
@@ -1,0 +1,35 @@
+Default TKS Audit Events
+========================
+
+The following audit events are enabled by default in TKS subsystem:
+
+| Event                                       | Filter            |
+| ------------------------------------------- | ----------------- |
+| ACCESS_SESSION_ESTABLISH                    |                   |
+| ACCESS_SESSION_TERMINATED                   |                   |
+| AUDIT_LOG_SHUTDOWN                          |                   |
+| AUDIT_LOG_SIGNING                           |                   |
+| AUDIT_LOG_STARTUP                           |                   |
+| AUTH                                        |                   |
+| AUTHZ                                       |                   |
+| CLIENT_ACCESS_SESSION_ESTABLISH             |                   |
+| CLIENT_ACCESS_SESSION_TERMINATED            |                   |
+| CONFIG_ACL                                  |                   |
+| CONFIG_AUTH                                 |                   |
+| CONFIG_ENCRYPTION                           |                   |
+| CONFIG_ROLE                                 |                   |
+| CONFIG_SIGNED_AUDIT                         |                   |
+| CONFIG_TRUSTED_PUBLIC_KEY                   |                   |
+| KEY_GEN_ASYMMETRIC                          |                   |
+| LOG_PATH_CHANGE                             |                   |
+| RANDOM_GENERATION                           | (Outcome=Failure) |
+| ROLE_ASSUME                                 |                   |
+| SELFTESTS_EXECUTION                         |                   |
+| SERVER_SIDE_KEYGEN_REQUEST                  |                   |
+| SERVER_SIDE_KEYGEN_REQUEST_PROCESSED        |                   |
+
+This information can also be obtained with the following command:
+
+```
+$ pki-server tks-audit-event-find --enabledByDefault True
+```

--- a/docs/admin/Default_TPS_Audit_Events.md
+++ b/docs/admin/Default_TPS_Audit_Events.md
@@ -1,0 +1,42 @@
+Default TPS Audit Events
+========================
+
+The following audit events are enabled by default in TPS subsystem:
+
+| Event                                       | Filter            |
+| ------------------------------------------- | ----------------- |
+| ACCESS_SESSION_ESTABLISH                    |                   |
+| ACCESS_SESSION_TERMINATED                   |                   |
+| AUDIT_LOG_SHUTDOWN                          |                   |
+| AUDIT_LOG_SIGNING                           |                   |
+| AUDIT_LOG_STARTUP                           |                   |
+| AUTH                                        |                   |
+| AUTHZ                                       |                   |
+| CLIENT_ACCESS_SESSION_ESTABLISH             |                   |
+| CLIENT_ACCESS_SESSION_TERMINATED            |                   |
+| CONFIG_ACL                                  |                   |
+| CONFIG_AUTH                                 |                   |
+| CONFIG_ENCRYPTION                           |                   |
+| CONFIG_ROLE                                 |                   |
+| CONFIG_SIGNED_AUDIT                         |                   |
+| CONFIG_TOKEN_AUTHENTICATOR                  |                   |
+| CONFIG_TOKEN_CONNECTOR                      |                   |
+| CONFIG_TOKEN_MAPPING_RESOLVER               |                   |
+| CONFIG_TOKEN_RECORD                         |                   |
+| CONFIG_TRUSTED_PUBLIC_KEY                   |                   |
+| KEY_GEN_ASYMMETRIC                          |                   |
+| LOG_PATH_CHANGE                             |                   |
+| RANDOM_GENERATION                           | (Outcome=Failure) |
+| ROLE_ASSUME                                 |                   |
+| SELFTESTS_EXECUTION                         |                   |
+| SERVER_SIDE_KEYGEN_REQUEST                  |                   |
+| SERVER_SIDE_KEYGEN_REQUEST_PROCESSED        |                   |
+| TOKEN_APPLET_UPGRADE                        | (Outcome=Failure) |
+| TOKEN_KEY_CHANGEOVER                        | (Outcome=Failure) |
+| TOKEN_KEY_CHANGEOVER_REQUIRED               |                   |
+
+This information can also be obtained with the following command:
+
+```
+$ pki-server tps-audit-event-find --enabledByDefault True
+```


### PR DESCRIPTION
The documents can be viewed here:

* [Default CA Audit Events](https://github.com/edewata/pki/blob/ticket-2686-v10.5/docs/admin/Default_CA_Audit_Events.md)
* [Default KRA Audit Events](https://github.com/edewata/pki/blob/ticket-2686-v10.5/docs/admin/Default_KRA_Audit_Events.md)
* [Default OCSP Audit Events](https://github.com/edewata/pki/blob/ticket-2686-v10.5/docs/admin/Default_OCSP_Audit_Events.md)
* [Default TKS Audit Events](https://github.com/edewata/pki/blob/ticket-2686-v10.5/docs/admin/Default_TKS_Audit_Events.md)
* [Default TPS Audit Events](https://github.com/edewata/pki/blob/ticket-2686-v10.5/docs/admin/Default_TPS_Audit_Events.md)

https://pagure.io/dogtagpki/issue/2686