### PR TITLE
Bug 1671586 adjustment patch to original bug for event division and c…

### DIFF
--- a/base/server/cmsbundle/src/audit-events.properties
+++ b/base/server/cmsbundle/src/audit-events.properties
@@ -21,7 +21,7 @@
 # Common fields:
 # - Outcome: "Success" or "Failure"
 # - SubjectID: The UID of the user responsible for the operation
-#     "$System$" if system-initiated operation (e.g. log signing).
+#     "$System$" or "SYSTEM" if system-initiated operation (e.g. log signing).
 #
 #########################################################################
 # Default Signed Audit Events
@@ -61,38 +61,12 @@ LOGGING_SIGNED_AUDIT_ACCESS_SESSION_ESTABLISH_SUCCESS=\
 # - ClientIP: Client IP address.
 # - ServerIP: Server IP address.
 # - SubjectID: Client certificate subject DN.
+# - Info: The TLS Alert received from NSS
 # - Outcome: Success
-# - Info: Termination reason.
+# - Info: The TLS Alert received from NSS
 #
 LOGGING_SIGNED_AUDIT_ACCESS_SESSION_TERMINATED=\
 <type=ACCESS_SESSION_TERMINATED>:[AuditEvent=ACCESS_SESSION_TERMINATED]{0} access session terminated
-#
-# Event: ASYMKEY_GENERATION_REQUEST
-# Description: This event is used when asymmetric key generation request is made.
-# Applicable subsystems: KRA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - GenerationRequestID:
-# - ClientKeyID:
-#
-LOGGING_SIGNED_AUDIT_ASYMKEY_GENERATION_REQUEST=<type=ASYMKEY_GENERATION_REQUEST>:[AuditEvent=ASYMKEY_GENERATION_REQUEST]{0} Asymkey generation request made
-#
-# Event: ASYMKEY_GENERATION_REQUEST_PROCESSED
-# Description: This event is used when a request to generate asymmetric keys received by the DRM
-#   is processed.
-# Applicable subsystems: KRA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - GenerationRequestID:
-# - ClientKeyID:
-# - KeyID:
-# - FailureReason:
-#
-LOGGING_SIGNED_AUDIT_ASYMKEY_GEN_REQUEST_PROCESSED=<type=ASYMKEY_GENERATION_REQUEST_PROCESSED>:[AuditEvent=ASYMKEY_GENERATION_REQUEST_PROCESSED]{0} Asymkey generation request processed
 #
 # Event: AUDIT_LOG_SIGNING
 # Description: This event is used when a signature on the audit log is generated (same as "flush" time).
@@ -111,7 +85,7 @@ LOGGING_SIGNED_AUDIT_AUDIT_LOG_SIGNING_3=[AuditEvent=AUDIT_LOG_SIGNING][SubjectI
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: $System$
 # - Outcome:
 #
 LOGGING_SIGNED_AUDIT_AUDIT_LOG_STARTUP_2=<type=AUDIT_LOG_STARTUP>:[AuditEvent=AUDIT_LOG_STARTUP][SubjectID={0}][Outcome={1}] audit function startup
@@ -138,32 +112,19 @@ LOGGING_SIGNED_AUDIT_AUTH_FAIL=<type=AUTH>:[AuditEvent=AUTH]{0} authentication f
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of user who has been authenticated
 # - Outcome: Success
 # - AuthMgr: The authentication manager instance name that did
 #     this authentication.
 #
 LOGGING_SIGNED_AUDIT_AUTH_SUCCESS=<type=AUTH>:[AuditEvent=AUTH]{0} authentication success
 #
-# Event: AUTHORITY_CONFIG
-# Description: This event is used when configuring lightweight authorities.
-# Applicable subsystems: CA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - ParamNameValPairs: A name-value pair
-#     (where name and value are separated by the delimiter ;;)
-#     separated by + (if more than one name-value pair) of config params changed.
-#
-LOGGING_SIGNED_AUDIT_AUTHORITY_CONFIG_3=<type=AUTHORITY_CONFIG>:[AuditEvent=AUTHORITY_CONFIG][SubjectID={0}][Outcome={1}][ParamNameValPairs={2}] lightweight authority configuration change
-#
 # Event: AUTHZ with [Outcome=Failure]
 # Description: This event is used when authorization has failed.
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of user who has failed to be authorized for an action
 # - Outcome: Failure
 # - aclResource: The ACL resource ID as defined in ACL resource list.
 # - Op: One of the operations as defined with the ACL statement
@@ -177,7 +138,7 @@ LOGGING_SIGNED_AUDIT_AUTHZ_FAIL=<type=AUTHZ>:[AuditEvent=AUTHZ]{0} authorization
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of user who has been authorized for an action
 # - Outcome: Success
 # - aclResource: The ACL resource ID as defined in ACL resource list.
 # - Op: One of the operations as defined with the ACL statement
@@ -191,7 +152,7 @@ LOGGING_SIGNED_AUDIT_AUTHZ_SUCCESS=<type=AUTHZ>:[AuditEvent=AUTHZ]{0} authorizat
 # Applicable subsystems: CA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of the CA agent who approved the certificate enrollment profile
 # - Outcome:
 # - ProfileID: One of the profiles defined by the administrator
 #     and to be approved by an agent.
@@ -221,10 +182,10 @@ LOGGING_SIGNED_AUDIT_CERT_REQUEST_PROCESSED=<type=CERT_REQUEST_PROCESSED>:[Audit
 # Applicable subsystems: CA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: $System$
 # - Outcome: Success
-# - SKI:
-# - AuthorityID:
+# - SKI: Subject Key Identifier of the certificate signing certificate
+# - AuthorityID: (applicable only to lightweight CA)
 #
 LOGGING_SIGNED_AUDIT_CERT_SIGNING_INFO=<type=CERT_SIGNING_INFO>:[AuditEvent=CERT_SIGNING_INFO]{0} certificate signing info
 #
@@ -234,7 +195,7 @@ LOGGING_SIGNED_AUDIT_CERT_SIGNING_INFO=<type=CERT_SIGNING_INFO>:[AuditEvent=CERT
 # Applicable subsystems: CA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of uer who performed the action
 # - Outcome:
 # - ReqID: The request ID.
 # - CertSerialNum: The serial number (in hex) of the certificate to be revoked.
@@ -277,7 +238,7 @@ LOGGING_SIGNED_AUDIT_CERT_STATUS_CHANGE_REQUEST_PROCESSED=<type=CERT_STATUS_CHAN
 # - ClientHost: Client hostname.
 # - ServerHost: Server hostname.
 # - ServerPort: Server port.
-# - SubjectID:
+# - SubjectID: SYSTEM
 # - Outcome: Failure
 # - Info:
 #
@@ -293,7 +254,7 @@ LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_ESTABLISH_FAILURE=\
 # - ClientHost: Client hostname.
 # - ServerHost: Server hostname.
 # - ServerPort: Server port.
-# - SubjectID:
+# - SubjectID: SYSTEM
 # - Outcome: Success
 #
 LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_ESTABLISH_SUCCESS=\
@@ -307,9 +268,9 @@ LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_ESTABLISH_SUCCESS=\
 # - ClientHost: Client hostname.
 # - ServerHost: Server hostname.
 # - ServerPort: Server port.
-# - SubjectID:
+# - SubjectID: SYSTEM
 # - Outcome: Success
-# - Info:
+# - Info: The TLS Alert received from NSS
 #
 LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_TERMINATED=\
 <type=CLIENT_ACCESS_SESSION_TERMINATED>:[AuditEvent=CLIENT_ACCESS_SESSION_TERMINATED]{0} access session terminated when Certificate System acts as client
@@ -324,7 +285,7 @@ LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_TERMINATED=\
 #     be that of the agent.
 #     In case of an unsigned request, it would bear $Unidentified$.
 # - Outcome:
-# - CMCRequest:
+# - CMCRequest: Base64 encoding of the CMC request received
 #
 LOGGING_SIGNED_AUDIT_CMC_REQUEST_RECEIVED_3=<type=CMC_REQUEST_RECEIVED>:[AuditEvent=CMC_REQUEST_RECEIVED][SubjectID={0}][Outcome={1}][CMCRequest={2}] CMC request received
 #
@@ -335,7 +296,7 @@ LOGGING_SIGNED_AUDIT_CMC_REQUEST_RECEIVED_3=<type=CMC_REQUEST_RECEIVED>:[AuditEv
 # Fields:
 # - SubjectID: The UID of user that triggered this event.
 # - Outcome:
-# - CMCResponse:
+# - CMCResponse: Base64 encoding of the CMC response sent
 #
 LOGGING_SIGNED_AUDIT_CMC_RESPONSE_SENT_3=<type=CMC_RESPONSE_SENT>:[AuditEvent=CMC_RESPONSE_SENT][SubjectID={0}][Outcome={1}][CMCResponse={2}] CMC response sent
 #
@@ -345,7 +306,7 @@ LOGGING_SIGNED_AUDIT_CMC_RESPONSE_SENT_3=<type=CMC_RESPONSE_SENT>:[AuditEvent=CM
 # Applicable subsystems: CA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: the user who signed the CMC request (success case)
 # - Outcome:
 # - ReqType: The request type (enrollment, or revocation).
 # - CertSubject: The certificate subject name of the certificate request.
@@ -359,7 +320,7 @@ LOGGING_SIGNED_AUDIT_CMC_SIGNED_REQUEST_SIG_VERIFY=<type=CMC_SIGNED_REQUEST_SIG_
 # Applicable subsystems: CA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: the user who signed the CMC request (success case)
 # - Outcome:
 # - ReqType: The request type (enrollment, or revocation).
 # - CertSubject: The certificate subject name of the certificate request.
@@ -374,7 +335,7 @@ LOGGING_SIGNED_AUDIT_CMC_USER_SIGNED_REQUEST_SIG_VERIFY_SUCCESS=<type=CMC_USER_S
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
@@ -387,7 +348,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_ACL_3=<type=CONFIG_ACL>:[AuditEvent=CONFIG_ACL][Subj
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
@@ -402,7 +363,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_AUTH_3=<type=CONFIG_AUTH>:[AuditEvent=CONFIG_AUTH][S
 # Applicable subsystems: CA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
@@ -416,7 +377,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_CERT_PROFILE_3=<type=CONFIG_CERT_PROFILE>:[AuditEven
 # Applicable subsystems: CA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
@@ -425,12 +386,12 @@ LOGGING_SIGNED_AUDIT_CONFIG_CERT_PROFILE_3=<type=CONFIG_CERT_PROFILE>:[AuditEven
 LOGGING_SIGNED_AUDIT_CONFIG_CRL_PROFILE_3=<type=CONFIG_CRL_PROFILE>:[AuditEvent=CONFIG_CRL_PROFILE][SubjectID={0}][Outcome={1}][ParamNameValPairs={2}] CRL profile configuration parameter(s) change
 #
 # Event: CONFIG_DRM
-# Description: This event is used when configuring DRM.
+# Description: This event is used when configuring KRA.
 #   This includes key recovery scheme, change of any secret component.
 # Applicable subsystems: KRA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs A name-value pair
 #     (where name and value are separated by the delimiter ;;)
@@ -439,26 +400,13 @@ LOGGING_SIGNED_AUDIT_CONFIG_CRL_PROFILE_3=<type=CONFIG_CRL_PROFILE>:[AuditEvent=
 #
 LOGGING_SIGNED_AUDIT_CONFIG_DRM_3=<type=CONFIG_DRM>:[AuditEvent=CONFIG_DRM][SubjectID={0}][Outcome={1}][ParamNameValPairs={2}] DRM configuration parameter(s) change
 #
-# Event: CONFIG_ENCRYPTION
-# Description: This event is used when configuring encryption (cert settings and SSL cipher preferences).
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - ParamNameValPairs: A name-value pair
-#     (where name and value are separated by the delimiter ;;)
-#     separated by + (if more than one name-value pair) of config params changed.
-#
-LOGGING_SIGNED_AUDIT_CONFIG_ENCRYPTION_3=<type=CONFIG_ENCRYPTION>:[AuditEvent=CONFIG_ENCRYPTION][SubjectID={0}][Outcome={1}][ParamNameValPairs={2}] encryption configuration parameter(s) change
-#
 # Event: CONFIG_OCSP_PROFILE
 # Description: This event is used when configuring OCSP profile
 #   (everything under Online Certificate Status Manager).
 # Applicable subsystems: OCSP
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
@@ -472,7 +420,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_OCSP_PROFILE_3=<type=CONFIG_OCSP_PROFILE>:[AuditEven
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
@@ -486,7 +434,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_ROLE=<type=CONFIG_ROLE>:[AuditEvent=CONFIG_ROLE]{0} 
 # Applicable subsystems: CA, KRA
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
@@ -499,13 +447,244 @@ LOGGING_SIGNED_AUDIT_CONFIG_SERIAL_NUMBER_1=<type=CONFIG_SERIAL_NUMBER>:[AuditEv
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: id of administrator who performed the action
 # - Outcome:
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
 #     separated by + (if more than one name-value pair) of config params changed.
 #
 LOGGING_SIGNED_AUDIT_CONFIG_SIGNED_AUDIT=<type=CONFIG_SIGNED_AUDIT>:[AuditEvent=CONFIG_SIGNED_AUDIT]{0} signed audit configuration parameter(s) change
+#
+# Event: CONFIG_TRUSTED_PUBLIC_KEY
+# Description: This event is used when:
+#   1. "Manage Certificate" is used to edit the trustness of certificates
+#      and deletion of certificates
+#   2. "Certificate Setup Wizard" is used to import CA certificates into the
+#      certificate database (Although CrossCertificatePairs are stored
+#      within internaldb, audit them as well)
+# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: ID of administrator who performed this configuration
+# - Outcome:
+# - ParamNameValPairs: A name-value pair
+#     (where name and value are separated by the delimiter ;;)
+#     separated by + (if more than one name-value pair) of config params changed.
+#
+LOGGING_SIGNED_AUDIT_CONFIG_TRUSTED_PUBLIC_KEY=<type=CONFIG_TRUSTED_PUBLIC_KEY>:[AuditEvent=CONFIG_TRUSTED_PUBLIC_KEY]{0} certificate database configuration
+#
+# Event: CRL_SIGNING_INFO
+# Description: This event indicates which key is used to sign CRLs.
+# Applicable subsystems: CA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: $System$
+# - Outcome:
+# - SKI: Subject Key Identifier of the CRL signing certificate
+#
+LOGGING_SIGNED_AUDIT_CRL_SIGNING_INFO=<type=CRL_SIGNING_INFO>:[AuditEvent=CRL_SIGNING_INFO]{0} CRL signing info
+#
+# Event: DELTA_CRL_GENERATION
+# Description: This event is used when delta CRL generation is complete.
+# Applicable subsystems: CA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: $Unidentified$
+# - Outcome: "Success" when delta CRL is generated successfully, "Failure" otherwise.
+# - CRLnum: The CRL number that identifies the CRL
+# - Info:
+# - FailureReason:
+#
+LOGGING_SIGNED_AUDIT_DELTA_CRL_GENERATION=<type=DELTA_CRL_GENERATION>:[AuditEvent=DELTA_CRL_GENERATION]{0} Delta CRL generation
+#
+# Event: FULL_CRL_GENERATION
+# Description: This event is used when full CRL generation is complete.
+# Applicable subsystems: CA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: $System$
+# - Outcome: "Success" when full CRL is generated successfully, "Failure" otherwise.
+# - CRLnum: The CRL number that identifies the CRL
+# - Info:
+# - FailureReason:
+#
+LOGGING_SIGNED_AUDIT_FULL_CRL_GENERATION=<type=FULL_CRL_GENERATION>:[AuditEvent=FULL_CRL_GENERATION]{0} Full CRL generation
+#
+# Event: PROFILE_CERT_REQUEST
+# Description: This event is used when a profile certificate request is made (before approval process).
+# Applicable subsystems: CA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: The UID of user that triggered this event.
+#     If CMC enrollment requests signed by an agent, SubjectID should
+#     be that of the agent.
+# - Outcome:
+# - CertSubject: The certificate subject name of the certificate request.
+# - ReqID: The certificate request ID.
+# - ProfileID: One of the certificate profiles defined by the
+#     administrator.
+#
+LOGGING_SIGNED_AUDIT_PROFILE_CERT_REQUEST_5=<type=PROFILE_CERT_REQUEST>:[AuditEvent=PROFILE_CERT_REQUEST][SubjectID={0}][Outcome={1}][ReqID={2}][ProfileID={3}][CertSubject={4}] certificate request made with certificate profiles
+#
+# Event: PROOF_OF_POSSESSION
+# Description: This event is used for proof of possession during certificate enrollment processing.
+# Applicable subsystems: CA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: id that represents the authenticated user
+# - Outcome:
+# - Info: some information on when/how it occurred
+#
+LOGGING_SIGNED_AUDIT_PROOF_OF_POSSESSION_3=<type=PROOF_OF_POSSESSION>:[AuditEvent=PROOF_OF_POSSESSION][SubjectID={0}][Outcome={1}][Info={2}] proof of possession
+#
+# Event: OCSP_ADD_CA_REQUEST_PROCESSED
+# Description: This event is used when an add CA request to the OCSP Responder is processed.
+# Applicable subsystems: OCSP
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: OCSP administrator user id
+# - Outcome: "Success" when CA is added successfully, "Failure" otherwise.
+# - CASubjectDN: The subject DN of the leaf CA cert in the chain.
+#
+LOGGING_SIGNED_AUDIT_OCSP_ADD_CA_REQUEST_PROCESSED=<type=OCSP_ADD_CA_REQUEST_PROCESSED>:[AuditEvent=OCSP_ADD_CA_REQUEST_PROCESSED]{0} Add CA for OCSP Responder
+#
+# Event: OCSP_GENERATION
+# Description: This event is used when an OCSP response generated is complete.
+# Applicable subsystems: CA, OCSP
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: $NonRoleUser$
+# - Outcome: "Success" when OCSP response is generated successfully, "Failure" otherwise.
+# - FailureReason:
+#
+LOGGING_SIGNED_AUDIT_OCSP_GENERATION=<type=OCSP_GENERATION>:[AuditEvent=OCSP_GENERATION]{0} OCSP response generation
+#
+# Event: OCSP_REMOVE_CA_REQUEST_PROCESSED with [Outcome=Failure]
+# Description: This event is used when a remove CA request to the OCSP Responder is processed and failed.
+# Applicable subsystems: OCSP
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: OCSP administrator user id
+# - Outcome: Failure
+# - CASubjectDN: The subject DN of the leaf CA certificate in the chain.
+#
+LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST_PROCESSED_FAILURE=<type=OCSP_REMOVE_CA_REQUEST_PROCESSED>:[AuditEvent=OCSP_REMOVE_CA_REQUEST_PROCESSED]{0} Remove CA for OCSP Responder has failed
+#
+# Event: OCSP_REMOVE_CA_REQUEST_PROCESSED with [Outcome=Success]
+# Description: This event is used when a remove CA request to the OCSP Responder is processed successfully.
+# Applicable subsystems: OCSP
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: OCSP administrator user id
+# - Outcome: "Success" when CA is removed successfully, "Failure" otherwise.
+# - CASubjectDN: The subject DN of the leaf CA certificate in the chain.
+#
+LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST_PROCESSED_SUCCESS=<type=OCSP_REMOVE_CA_REQUEST_PROCESSED>:[AuditEvent=OCSP_REMOVE_CA_REQUEST_PROCESSED]{0} Remove CA for OCSP Responder is successful
+#
+# Event: OCSP_SIGNING_INFO
+# Description: This event indicates which key is used to sign OCSP responses.
+# Applicable subsystems: CA, OCSP
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: $System$
+# - Outcome:
+# - SKI: Subject Key Identifier of the OCSP signing certificate
+# - AuthorityID: (applicable only to lightweight CA)
+#
+LOGGING_SIGNED_AUDIT_OCSP_SIGNING_INFO=<type=OCSP_SIGNING_INFO>:[AuditEvent=OCSP_SIGNING_INFO]{0} OCSP signing info
+#
+# Event: ROLE_ASSUME
+# Description: This event is used when a user assumes a role.
+# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
+# Fields:
+# - SubjectID:
+# - Outcome:
+# - Role: One of the valid roles:
+#     "Administrators", "Certificate Manager Agents", or "Auditors".
+#     Note that customized role names can be used once configured.
+#
+LOGGING_SIGNED_AUDIT_ROLE_ASSUME=<type=ROLE_ASSUME>:[AuditEvent=ROLE_ASSUME]{0} assume privileged role
+#
+# Event: SECURITY_DOMAIN_UPDATE
+# Description: This event is used when updating contents of security domain
+#   (add/remove a subsystem).
+# Applicable subsystems: CA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: CA administrator user ID
+# - Outcome:
+# - ParamNameValPairs: A name-value pair
+#     (where name and value are separated by the delimiter ;;)
+#     separated by + (if more than one name-value pair) of config params changed.
+#
+LOGGING_SIGNED_AUDIT_SECURITY_DOMAIN_UPDATE_1=<type=SECURITY_DOMAIN_UPDATE>:[AuditEvent=SECURITY_DOMAIN_UPDATE][SubjectID={0}][Outcome={1}][ParamNameValPairs={2}] security domain update
+#
+# Event: SELFTESTS_EXECUTION
+# Description: This event is used when self tests are run.
+# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
+# Fields:
+# - SubjectID: $System$
+# - Outcome:
+#
+LOGGING_SIGNED_AUDIT_SELFTESTS_EXECUTION_2=<type=SELFTESTS_EXECUTION>:[AuditEvent=SELFTESTS_EXECUTION][SubjectID={0}][Outcome={1}] self tests execution (see selftests.log for details)
+#########################################################################
+# Available Signed Audit Events - Enabled by default: Yes
+#########################################################################
+#
+# Event: ASYMKEY_GENERATION_REQUEST
+# Description: This event is used when asymmetric key generation request is made.
+# Applicable subsystems: KRA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID:
+# - Outcome:
+# - GenerationRequestID:
+# - ClientKeyID:
+#
+LOGGING_SIGNED_AUDIT_ASYMKEY_GENERATION_REQUEST=<type=ASYMKEY_GENERATION_REQUEST>:[AuditEvent=ASYMKEY_GENERATION_REQUEST]{0} Asymkey generation request made
+#
+# Event: ASYMKEY_GENERATION_REQUEST_PROCESSED
+# Description: This event is used when a request to generate asymmetric keys received by the KRA
+#   is processed.
+# Applicable subsystems: KRA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID:
+# - Outcome:
+# - GenerationRequestID:
+# - ClientKeyID:
+# - KeyID:
+# - FailureReason:
+#
+LOGGING_SIGNED_AUDIT_ASYMKEY_GEN_REQUEST_PROCESSED=<type=ASYMKEY_GENERATION_REQUEST_PROCESSED>:[AuditEvent=ASYMKEY_GENERATION_REQUEST_PROCESSED]{0} Asymkey generation request processed
+#
+# Event: AUTHORITY_CONFIG
+# Description: This event is used when configuring lightweight authorities.
+# Applicable subsystems: CA
+# Enabled by default: Yes
+# Fields:
+# - SubjectID:
+# - Outcome:
+# - ParamNameValPairs: A name-value pair
+#     (where name and value are separated by the delimiter ;;)
+#     separated by + (if more than one name-value pair) of config params changed.
+#
+LOGGING_SIGNED_AUDIT_AUTHORITY_CONFIG_3=<type=AUTHORITY_CONFIG>:[AuditEvent=AUTHORITY_CONFIG][SubjectID={0}][Outcome={1}][ParamNameValPairs={2}] lightweight authority configuration change
+#
+# Event: CONFIG_ENCRYPTION
+# Description: This event is used when configuring encryption (cert settings and SSL cipher preferences).
+# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
+# Enabled by default: Yes
+# Fields:
+# - SubjectID:
+# - Outcome:
+# - ParamNameValPairs: A name-value pair
+#     (where name and value are separated by the delimiter ;;)
+#     separated by + (if more than one name-value pair) of config params changed.
+#
+LOGGING_SIGNED_AUDIT_CONFIG_ENCRYPTION_3=<type=CONFIG_ENCRYPTION>:[AuditEvent=CONFIG_ENCRYPTION][SubjectID={0}][Outcome={1}][ParamNameValPairs={2}] encryption configuration parameter(s) change
 #
 # Event: CONFIG_TOKEN_AUTHENTICATOR
 # Description: This event is used when configuring token authenticators.
@@ -546,7 +725,7 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_CONNECTOR_6=<type=CONFIG_TOKEN_CONNECTOR>:[Aud
 # Applicable subsystems: TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: TPS administrator id
 # - Outcome:
 # - Service:
 # - MappingResolverID:
@@ -563,10 +742,10 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_MAPPING_RESOLVER_6=<type=CONFIG_TOKEN_MAPPING_
 # Applicable subsystems: TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: TPS administrator id
 # - Outcome:
-# - OP:
-# - TokenID:
+# - OP: operation to add or delete token
+# - TokenID: smart card unique id
 # - ParamNameValPairs: A name-value pair
 #     (where name and value are separated by the delimiter ;;)
 #     separated by + (if more than one name-value pair) of config params changed.
@@ -574,61 +753,6 @@ LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_MAPPING_RESOLVER_6=<type=CONFIG_TOKEN_MAPPING_
 # - Info: in general is used for capturing error info for failed cases
 #
 LOGGING_SIGNED_AUDIT_CONFIG_TOKEN_RECORD_6=<type=CONFIG_TOKEN_RECORD>:[AuditEvent=CONFIG_TOKEN_RECORD][SubjectID={0}][Outcome={1}][OP={2}][TokenID={3}][ParamNameValPairs={4}][Info={5}] token record configuration parameter(s) change
-#
-# Event: CONFIG_TRUSTED_PUBLIC_KEY
-# Description: This event is used when:
-#   1. "Manage Certificate" is used to edit the trustness of certificates
-#      and deletion of certificates
-#   2. "Certificate Setup Wizard" is used to import CA certificates into the
-#      certificate database (Although CrossCertificatePairs are stored
-#      within internaldb, audit them as well)
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - ParamNameValPairs: A name-value pair
-#     (where name and value are separated by the delimiter ;;)
-#     separated by + (if more than one name-value pair) of config params changed.
-#
-LOGGING_SIGNED_AUDIT_CONFIG_TRUSTED_PUBLIC_KEY=<type=CONFIG_TRUSTED_PUBLIC_KEY>:[AuditEvent=CONFIG_TRUSTED_PUBLIC_KEY]{0} certificate database configuration
-#
-# Event: CRL_SIGNING_INFO
-# Description: This event indicates which key is used to sign CRLs.
-# Applicable subsystems: CA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - SKI:
-#
-LOGGING_SIGNED_AUDIT_CRL_SIGNING_INFO=<type=CRL_SIGNING_INFO>:[AuditEvent=CRL_SIGNING_INFO]{0} CRL signing info
-#
-# Event: DELTA_CRL_GENERATION
-# Description: This event is used when delta CRL generation is complete.
-# Applicable subsystems: CA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome: "Success" when delta CRL is generated successfully, "Failure" otherwise.
-# - CRLnum:
-# - Info:
-# - FailureReason:
-#
-LOGGING_SIGNED_AUDIT_DELTA_CRL_GENERATION=<type=DELTA_CRL_GENERATION>:[AuditEvent=DELTA_CRL_GENERATION]{0} Delta CRL generation
-#
-# Event: FULL_CRL_GENERATION
-# Description: This event is used when full CRL generation is complete.
-# Applicable subsystems: CA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome: "Success" when full CRL is generated successfully, "Failure" otherwise.
-# - CRLnum:
-# - Info:
-# - FailureReason:
-#
-LOGGING_SIGNED_AUDIT_FULL_CRL_GENERATION=<type=FULL_CRL_GENERATION>:[AuditEvent=FULL_CRL_GENERATION]{0} Full CRL generation
 #
 # Event: KEY_GEN_ASYMMETRIC
 # Description: This event is used when asymmetric keys are generated
@@ -650,96 +774,13 @@ LOGGING_SIGNED_AUDIT_KEY_GEN_ASYMMETRIC_3=<type=KEY_GEN_ASYMMETRIC>:[AuditEvent=
 # Applicable subsystems: CA, KRA, OCSP, TKS, TPS
 # Enabled by default: Yes
 # Fields:
-# - SubjectID:
+# - SubjectID: administrator user id
 # - Outcome:
 # - LogType: "System", "Transaction", or "SignedAudit"
 # - toLogFile: The name (including any path changes) that the user is
 #     attempting to change to.
 #
 LOGGING_SIGNED_AUDIT_LOG_PATH_CHANGE_4=<type=LOG_PATH_CHANGE>:[AuditEvent=LOG_PATH_CHANGE][SubjectID={0}][Outcome={1}][LogType={2}][toLogFile={3}] log path change attempt
-#
-# Event: PROFILE_CERT_REQUEST
-# Description: This event is used when a profile certificate request is made (before approval process).
-# Applicable subsystems: CA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID: The UID of user that triggered this event.
-#     If CMC enrollment requests signed by an agent, SubjectID should
-#     be that of the agent.
-# - Outcome:
-# - CertSubject: The certificate subject name of the certificate request.
-# - ReqID: The certificate request ID.
-# - ProfileID: One of the certificate profiles defined by the
-#     administrator.
-#
-LOGGING_SIGNED_AUDIT_PROFILE_CERT_REQUEST_5=<type=PROFILE_CERT_REQUEST>:[AuditEvent=PROFILE_CERT_REQUEST][SubjectID={0}][Outcome={1}][ReqID={2}][ProfileID={3}][CertSubject={4}] certificate request made with certificate profiles
-#
-# Event: PROOF_OF_POSSESSION
-# Description: This event is used for proof of possession during certificate enrollment processing.
-# Applicable subsystems: CA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - Info:
-#
-LOGGING_SIGNED_AUDIT_PROOF_OF_POSSESSION_3=<type=PROOF_OF_POSSESSION>:[AuditEvent=PROOF_OF_POSSESSION][SubjectID={0}][Outcome={1}][Info={2}] proof of possession
-#
-# Event: OCSP_ADD_CA_REQUEST_PROCESSED
-# Description: This event is used when an add CA request to the OCSP Responder is processed.
-# Applicable subsystems: OCSP
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome: "Success" when CA is added successfully, "Failure" otherwise.
-# - CASubjectDN: The subject DN of the leaf CA cert in the chain.
-#
-LOGGING_SIGNED_AUDIT_OCSP_ADD_CA_REQUEST_PROCESSED=<type=OCSP_ADD_CA_REQUEST_PROCESSED>:[AuditEvent=OCSP_ADD_CA_REQUEST_PROCESSED]{0} Add CA for OCSP Responder
-#
-# Event: OCSP_GENERATION
-# Description: This event is used when an OCSP response generated is complete.
-# Applicable subsystems: CA, OCSP
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome: "Success" when OCSP response is generated successfully, "Failure" otherwise.
-# - FailureReason:
-#
-LOGGING_SIGNED_AUDIT_OCSP_GENERATION=<type=OCSP_GENERATION>:[AuditEvent=OCSP_GENERATION]{0} OCSP response generation
-#
-# Event: OCSP_REMOVE_CA_REQUEST_PROCESSED with [Outcome=Failure]
-# Description: This event is used when a remove CA request to the OCSP Responder is processed and failed.
-# Applicable subsystems: OCSP
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome: Failure
-# - CASubjectDN: DN ID of the CA.
-#
-LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST_PROCESSED_FAILURE=<type=OCSP_REMOVE_CA_REQUEST_PROCESSED>:[AuditEvent=OCSP_REMOVE_CA_REQUEST_PROCESSED]{0} Remove CA for OCSP Responder has failed
-#
-# Event: OCSP_REMOVE_CA_REQUEST_PROCESSED with [Outcome=Success]
-# Description: This event is used when a remove CA request to the OCSP Responder is processed successfully.
-# Applicable subsystems: OCSP
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome: "Success" when CA is removed successfully, "Failure" otherwise.
-# - CASubjectDN: The subject DN of the leaf CA certificate in the chain.
-#
-LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST_PROCESSED_SUCCESS=<type=OCSP_REMOVE_CA_REQUEST_PROCESSED>:[AuditEvent=OCSP_REMOVE_CA_REQUEST_PROCESSED]{0} Remove CA for OCSP Responder is successful
-#
-# Event: OCSP_SIGNING_INFO
-# Description: This event indicates which key is used to sign OCSP responses.
-# Applicable subsystems: CA, OCSP
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - SKI:
-# - AuthorityID:
-#
-LOGGING_SIGNED_AUDIT_OCSP_SIGNING_INFO=<type=OCSP_SIGNING_INFO>:[AuditEvent=OCSP_SIGNING_INFO]{0} OCSP signing info
 #
 # Event: RANDOM_GENERATION
 # Description: This event is used when a random number generation is complete.
@@ -754,19 +795,6 @@ LOGGING_SIGNED_AUDIT_OCSP_SIGNING_INFO=<type=OCSP_SIGNING_INFO>:[AuditEvent=OCSP
 # - FailureReason:
 #
 LOGGING_SIGNED_AUDIT_RANDOM_GENERATION=<type=RANDOM_GENERATION>:[AuditEvent=RANDOM_GENERATION]{0} Random number generation
-#
-# Event: ROLE_ASSUME
-# Description: This event is used when a user assumes a role.
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - Role: One of the valid roles, by default: "Administrators",
-#     "Certificate Manager Agents", and "Auditors".
-#     Note that customized role names can be used once configured.
-#
-LOGGING_SIGNED_AUDIT_ROLE_ASSUME=<type=ROLE_ASSUME>:[AuditEvent=ROLE_ASSUME]{0} assume privileged role
 #
 # Event: SCHEDULE_CRL_GENERATION
 # Description: This event is used when CRL generation is scheduled.
@@ -797,7 +825,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_ARCHIVAL_REQUEST=<type=SECURITY_DATA_ARCHIVAL
 #
 # Event: SECURITY_DATA_ARCHIVAL_REQUEST_PROCESSED
 # Description: This event is used when user security data archive request is processed.
-#   This is when DRM receives and processed the request.
+#   This is when KRA receives and processed the request.
 # Applicable subsystems: KRA
 # Enabled by default: Yes
 # Fields:
@@ -842,7 +870,7 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST=<type=SECURITY_DATA_RECOVERY
 LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST_PROCESSED=<type=SECURITY_DATA_RECOVERY_REQUEST_PROCESSED>:[AuditEvent=SECURITY_DATA_RECOVERY_REQUEST_PROCESSED]{0} security data recovery request processed
 #
 # Event: SECURITY_DATA_RECOVERY_REQUEST_STATE_CHANGE
-# Description: This event is used when DRM agents login as recovery agents to change
+# Description: This event is used when KRA agents login as recovery agents to change
 #   the state of key recovery requests.
 # Applicable subsystems: KRA
 # Enabled by default: Yes
@@ -853,30 +881,6 @@ LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST_PROCESSED=<type=SECURITY_DAT
 # - Operation: The operation performed (approve, reject, cancel etc.).
 #
 LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST_STATE_CHANGE=<type=SECURITY_DATA_RECOVERY_REQUEST_STATE_CHANGE>:[AuditEvent=SECURITY_DATA_RECOVERY_REQUEST_STATE_CHANGE]{0} security data recovery request state change
-#
-# Event: SECURITY_DOMAIN_UPDATE
-# Description: This event is used when updating contents of security domain
-#   (add/remove a subsystem).
-# Applicable subsystems: CA
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-# - ParamNameValPairs: A name-value pair
-#     (where name and value are separated by the delimiter ;;)
-#     separated by + (if more than one name-value pair) of config params changed.
-#
-LOGGING_SIGNED_AUDIT_SECURITY_DOMAIN_UPDATE_1=<type=SECURITY_DOMAIN_UPDATE>:[AuditEvent=SECURITY_DOMAIN_UPDATE][SubjectID={0}][Outcome={1}][ParamNameValPairs={2}] security domain update
-#
-# Event: SELFTESTS_EXECUTION
-# Description: This event is used when self tests are run.
-# Applicable subsystems: CA, KRA, OCSP, TKS, TPS
-# Enabled by default: Yes
-# Fields:
-# - SubjectID:
-# - Outcome:
-#
-LOGGING_SIGNED_AUDIT_SELFTESTS_EXECUTION_2=<type=SELFTESTS_EXECUTION>:[AuditEvent=SELFTESTS_EXECUTION][SubjectID={0}][Outcome={1}] self tests execution (see selftests.log for details)
 #
 # Event: SERVER_SIDE_KEYGEN_REQUEST
 # Description: This event is used when server-side key generation request is made.
@@ -920,7 +924,7 @@ LOGGING_SIGNED_AUDIT_SYMKEY_GENERATION_REQUEST=<type=SYMKEY_GENERATION_REQUEST>:
 #
 # Event: SYMKEY_GENERATION_REQUEST_PROCESSED
 # Description: This event is used when symmetric key generation request is processed.
-#   This is when DRM receives and processes the request.
+#   This is when KRA receives and processes the request.
 # Applicable subsystems: KRA
 # Enabled by default: Yes
 # Fields:
@@ -1021,9 +1025,9 @@ LOGGING_SIGNED_AUDIT_TOKEN_KEY_CHANGEOVER_SUCCESS=<type=TOKEN_KEY_CHANGEOVER>:[A
 # - Info:
 #
 LOGGING_SIGNED_AUDIT_TOKEN_KEY_CHANGEOVER_REQUIRED_10=<type=TOKEN_KEY_CHANGEOVER_REQUIRED>:[AuditEvent=TOKEN_KEY_CHANGEOVER_REQUIRED][IP={0}][SubjectID={1}][CUID={2}][MSN={3}][Outcome={4}][tokenType={5}][AppletVersion={6}][oldKeyVersion={7}][newKeyVersion={8}][Info={9}] token key changeover required
-#
 #########################################################################
-# Available Signed Audit Events
+# Available Signed Audit Events - Enabled by default: No
+#########################################################################
 #
 # Event: AUDIT_LOG_DELETE
 # Description: This event is used AFTER audit log gets expired.
@@ -1418,7 +1422,7 @@ LOGGING_SIGNED_AUDIT_FULL_CRL_PUBLISHING=<type=FULL_CRL_PUBLISHING>:[AuditEvent=
 LOGGING_SIGNED_AUDIT_INTER_BOUNDARY_SUCCESS_5=<type=INTER_BOUNDARY>:[AuditEvent=INTER_BOUNDARY][SubjectID={0}][Outcome={1}][ProtectionMethod={2}][ReqType={3}][ReqID={4}] inter-CS boundary communication (data exchange) success
 #
 # Event: KEY_RECOVERY_AGENT_LOGIN
-# Description: This event is used when DRM agents login as recovery agents to approve
+# Description: This event is used when KRA agents login as recovery agents to approve
 #   key recovery requests.
 # Applicable subsystems: KRA
 # Enabled by default: No
@@ -1426,7 +1430,7 @@ LOGGING_SIGNED_AUDIT_INTER_BOUNDARY_SUCCESS_5=<type=INTER_BOUNDARY>:[AuditEvent=
 # - SubjectID:
 # - Outcome:
 # - RecoveryID: The recovery request ID.
-# - RecoveryAgent: The recovery agent the DRM agent is
+# - RecoveryAgent: The recovery agent the KRA agent is
 #     logging in with.
 #
 LOGGING_SIGNED_AUDIT_KEY_RECOVERY_AGENT_LOGIN_4=<type=KEY_RECOVERY_AGENT_LOGIN>:[AuditEvent=KEY_RECOVERY_AGENT_LOGIN][SubjectID={0}][Outcome={1}][RecoveryID={2}][RecoveryAgent={3}] key recovery agent login


### PR DESCRIPTION
…omments

This patch
 - Further divides previious "Default Signed Audit Events" into
      "Required Audit Events"
         and
      "Available Audit Events - Enabled by default: Yes"
   and changed the original "Available Signed Audit Events" to
      "Available Audit Events - Enabled by default: No"
 - Filled in missing event description and param description fields
   for each audit event under "Default Signed Audit Events"

Change-Id: I8c8475f59929560c1b7c254366a2d8e04c86d316