### PR TITLE
Using JSSImplementation for Tomcat 8.5

### DIFF
--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -116,6 +116,7 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
         print('      --scheme <scheme>                     Scheme.')
         print('      --secure <true|false>                 Secure.')
         print('      --sslEnabled <true|false>             SSL enabled.')
+        print('      --sslImpl <class>                     SSL implementation.')
         print('      --sslProtocol <protocol>              SSL protocol.')
         print('      --certVerification <verification>     Certificate verification.')
         print('      --trustManager <class>                Trust Manager.')
@@ -129,7 +130,8 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
         try:
             opts, args = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=',
-                'port=', 'protocol=', 'scheme=', 'secure=', 'sslEnabled=',
+                'port=', 'protocol=', 'scheme=',
+                'secure=', 'sslEnabled=', 'sslImpl=',
                 'sslProtocol=', 'certVerification=', 'trustManager=',
                 'verbose', 'debug', 'help'])
 
@@ -144,6 +146,7 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
         scheme = None
         secure = None
         sslEnabled = None
+        sslImpl = None
         sslProtocol = None
         certVerification = None
         trustManager = None
@@ -166,6 +169,9 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
 
             elif o == '--sslEnabled':
                 sslEnabled = a
+
+            elif o == '--sslImpl':
+                sslImpl = a
 
             elif o == '--sslProtocol':
                 sslProtocol = a
@@ -222,6 +228,7 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
         HTTPConnectorCLI.set_param(connector, 'scheme', scheme)
         HTTPConnectorCLI.set_param(connector, 'secure', secure)
         HTTPConnectorCLI.set_param(connector, 'SSLEnabled', sslEnabled)
+        HTTPConnectorCLI.set_param(connector, 'sslImplementationName', sslImpl)
 
         sslhost = server_config.create_sslhost(connector)
 

--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -460,6 +460,7 @@ class MigrateCLI(pki.cli.CLI):
             if connector.get('secure') != 'true':
                 continue
 
+            connector.set('sslImplementationName', 'org.dogtagpki.tomcat.JSSImplementation')
             connector.attrib.pop('sslProtocol', None)
             connector.attrib.pop('clientAuth', None)
             connector.attrib.pop('keystoreType', None)
@@ -475,7 +476,7 @@ class MigrateCLI(pki.cli.CLI):
 
             sslHostConfig.set('sslProtocol', 'SSL')
             sslHostConfig.set('certificateVerification', 'optional')
-            sslHostConfig.set('trustManagerClassName', 'org.dogtagpki.tomcat.PKITrustManager')
+            sslHostConfig.attrib.pop('trustManagerClassName', None)
 
             certificates = sslHostConfig.findall('Certificate')
             if len(certificates) > 0:

--- a/base/server/tomcat-8.5/conf/server.xml
+++ b/base/server/tomcat-8.5/conf/server.xml
@@ -152,6 +152,7 @@ Tomcat Port         = [TOMCAT_SERVER_PORT] (for shutdown)
                port="[PKI_SECURE_PORT]"
                protocol="org.dogtagpki.tomcat.Http11NioProtocol"
                SSLEnabled="true"
+               sslImplementationName="org.dogtagpki.tomcat.JSSImplementation"
                scheme="https"
                secure="true"
                connectionTimeout="80000"
@@ -179,8 +180,7 @@ Tomcat Port         = [TOMCAT_SERVER_PORT] (for shutdown)
                certdbDir="[PKI_INSTANCE_PATH]/alias">
 
         <SSLHostConfig sslProtocol="SSL"
-                       certificateVerification="optional"
-                       trustManagerClassName="org.dogtagpki.tomcat.PKITrustManager">
+                       certificateVerification="optional">
             <Certificate certificateKeystoreType="pkcs11"
                          certificateKeystoreProvider="Mozilla-JSS"
                          certificateKeyAlias="sslserver"/>

--- a/docs/installation/Installing_Basic_PKI_Server.md
+++ b/docs/installation/Installing_Basic_PKI_Server.md
@@ -33,6 +33,7 @@ $ pki-server http-connector-add -i tomcat@pki Secure \
     --scheme https \
     --secure true \
     --sslEnabled true \
+    --sslImpl org.dogtagpki.tomcat.JSSImplementation \
     --sslProtocol SSL
 ```
 

--- a/pki.spec
+++ b/pki.spec
@@ -309,8 +309,8 @@ BuildRequires:    jpackage-utils >= 0:1.7.5-10
 BuildRequires:    jss >= 4.4.0-11
 BuildRequires:    tomcatjss >= 7.2.1-4
 %else
-BuildRequires:    jss >= 4.5.2-3
-BuildRequires:    tomcatjss >= 7.3.6
+BuildRequires:    jss >= 4.5.3
+BuildRequires:    tomcatjss >= 7.4.0
 %endif
 BuildRequires:    systemd-units
 
@@ -426,7 +426,7 @@ Requires:         jpackage-utils >= 0:1.7.5-10
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:         jss >= 4.4.0-11
 %else
-Requires:         jss >= 4.5.2-3
+Requires:         jss >= 4.5.3
 %endif
 Requires:         nss >= 3.38.0
 
@@ -549,7 +549,7 @@ Requires:         jpackage-utils >= 0:1.7.5-10
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:         jss >= 4.4.0-11
 %else
-Requires:         jss >= 4.5.2-3
+Requires:         jss >= 4.5.3
 %endif
 Requires:         ldapjdk >= 4.20
 Requires:         pki-base = %{version}-%{release}
@@ -674,7 +674,7 @@ Requires(pre):    shadow-utils
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:         tomcatjss >= 7.2.1-4
 %else
-Requires:         tomcatjss >= 7.3.6
+Requires:         tomcatjss >= 7.4.0
 %endif
 
 # https://pagure.io/freeipa/issue/7742

--- a/travis/global_variables
+++ b/travis/global_variables
@@ -3,5 +3,5 @@ BUILDDIR=/tmp/workdir
 SCRIPTDIR=${BUILDDIR}/pki/travis
 LOGS=${TRAVIS_BUILD_DIR}/logs.txt
 BASE_IMAGE=fedora:${BASE_IMAGE_VERSION}
-COPR_REPO=@pki/10.6
+COPR_REPO=@pki/10.7
 test_set="test_caacl_plugin.py test_caacl_profile_enforcement.py test_cert_plugin.py test_certprofile_plugin.py test_ca_plugin.py test_vault_plugin.py"


### PR DESCRIPTION
The installation code for Tomcat 8.5 has been modified to
use JSSImplementation which provides JSSKeyManager and
JSSTrustManager instead of PKITrustManager.

The JSS and Tomcat JSS dependencies in pki.spec have been
updated accordingly.

This PR depends on PR #177.