### PR TITLE
Removed release number from Requires tags

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -370,21 +370,21 @@ Summary:          %{brand} PKI Package
 
 # Make certain that this 'meta' package requires the latest version(s)
 # of ALL PKI theme packages
-Requires:         %{vendor}-pki-server-theme = %{version}-%{release}
-Requires:         %{vendor}-pki-console-theme = %{version}-%{release}
+Requires:         %{vendor}-pki-server-theme = %{version}
+Requires:         %{vendor}-pki-console-theme = %{version}
 
 # Make certain that this 'meta' package requires the latest version(s)
 # of ALL PKI core packages
-Requires:         pki-ca = %{version}-%{release}
-Requires:         pki-kra = %{version}-%{release}
-Requires:         pki-ocsp = %{version}-%{release}
-Requires:         pki-tks = %{version}-%{release}
-Requires:         pki-tps = %{version}-%{release}
+Requires:         pki-ca = %{version}
+Requires:         pki-kra = %{version}
+Requires:         pki-ocsp = %{version}
+Requires:         pki-tks = %{version}
+Requires:         pki-tps = %{version}
 
 # Make certain that this 'meta' package requires the latest version(s)
 # of PKI console
-Requires:         pki-console = %{version}-%{release}
-Requires:         pki-javadoc = %{version}-%{release}
+Requires:         pki-console = %{version}
+Requires:         pki-javadoc = %{version}
 
 # Make certain that this 'meta' package requires the latest version(s)
 # of ALL PKI clients
@@ -431,10 +431,10 @@ Requires:         jss >= 4.5.3
 Requires:         nss >= 3.38.0
 
 # Ensure we end up with a useful installation
-Conflicts:        pki-symkey < %{version}-%{release}
-Conflicts:        pki-javadoc < %{version}-%{release}
-Conflicts:        pki-server-theme < %{version}-%{release}
-Conflicts:        pki-console-theme < %{version}-%{release}
+Conflicts:        pki-symkey < %{version}
+Conflicts:        pki-javadoc < %{version}
+Conflicts:        pki-server-theme < %{version}
+Conflicts:        pki-console-theme < %{version}
 
 %description -n   pki-symkey
 The PKI Symmetric Key Java Package supplies various native
@@ -449,18 +449,18 @@ BuildArch:        noarch
 
 Requires:         nss >= 3.36.1
 %if 0%{?with_python3_default}
-Requires:         python3-pki = %{version}-%{release}
-Requires(post):   python3-pki = %{version}-%{release}
+Requires:         python3-pki = %{version}
+Requires(post):   python3-pki = %{version}
 %else
-Requires:         python2-pki = %{version}-%{release}
-Requires(post):   python2-pki = %{version}-%{release}
+Requires:         python2-pki = %{version}
+Requires(post):   python2-pki = %{version}
 %endif  # with_python3_default
 
 # Ensure we end up with a useful installation
-Conflicts:        pki-symkey < %{version}-%{release}
-Conflicts:        pki-javadoc < %{version}-%{release}
-Conflicts:        pki-server-theme < %{version}-%{release}
-Conflicts:        pki-console-theme < %{version}-%{release}
+Conflicts:        pki-symkey < %{version}
+Conflicts:        pki-javadoc < %{version}
+Conflicts:        pki-server-theme < %{version}
+Conflicts:        pki-console-theme < %{version}
 
 %description -n   pki-base
 The PKI Base Package contains the common and client libraries and utilities
@@ -475,12 +475,12 @@ Summary:          PKI Python 2 Package
 BuildArch:        noarch
 
 Obsoletes:        pki-base-python2 < %{version}
-Provides:         pki-base-python2 = %{version}-%{release}
+Provides:         pki-base-python2 = %{version}
 %if 0%{?fedora}
 %{?python_provide:%python_provide python2-pki}
 %endif
 
-Requires:         pki-base = %{version}-%{release}
+Requires:         pki-base = %{version}
 Requires:         python2-cryptography
 %if 0%{?rhel} && 0%{?rhel} <= 7 || 0%{?fedora} && 0%{?fedora} <= 27
 Requires:         python-nss
@@ -506,12 +506,12 @@ Summary:          PKI Python 3 Package
 BuildArch:        noarch
 
 Obsoletes:        pki-base-python3 < %{version}
-Provides:         pki-base-python3 = %{version}-%{release}
+Provides:         pki-base-python3 = %{version}
 %if 0%{?fedora}
 %{?python_provide:%python_provide python3-pki}
 %endif
 
-Requires:         pki-base = %{version}-%{release}
+Requires:         pki-base = %{version}
 Requires:         python3-cryptography
 Requires:         python3-lxml
 Requires:         python3-nss
@@ -552,7 +552,7 @@ Requires:         jss >= 4.4.0-11
 Requires:         jss >= 4.5.3
 %endif
 Requires:         ldapjdk >= 4.20
-Requires:         pki-base = %{version}-%{release}
+Requires:         pki-base = %{version}
 
 %if 0%{?rhel} && 0%{?rhel} <= 7
 # 'resteasy-base' is a subset of the complete set of
@@ -589,7 +589,7 @@ Summary:          PKI Tools Package
 
 Requires:         openldap-clients
 Requires:         nss-tools >= 3.36.1
-Requires:         pki-base-java = %{version}-%{release}
+Requires:         pki-base-java = %{version}
 
 %description -n   pki-tools
 This package contains PKI executables that can be used to help make
@@ -616,8 +616,8 @@ Requires:         openssl >= 1.0.2k-11
 %else
 Requires:         openssl
 %endif
-Requires:         pki-symkey = %{version}-%{release}
-Requires:         pki-tools = %{version}-%{release}
+Requires:         pki-symkey = %{version}
+Requires:         pki-tools = %{version}
 
 Requires:         keyutils
 
@@ -700,7 +700,7 @@ following PKI subsystems:
 Summary:          PKI CA Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Requires:         pki-server = %{version}
 Requires(post):   systemd-units
 Requires(preun):  systemd-units
 Requires(postun): systemd-units
@@ -724,7 +724,7 @@ where it obtains its own signing certificate from a public CA.
 Summary:          PKI KRA Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Requires:         pki-server = %{version}
 Requires(post):   systemd-units
 Requires(preun):  systemd-units
 Requires(postun): systemd-units
@@ -754,7 +754,7 @@ since such archival would undermine non-repudiation properties of signing keys.
 Summary:          PKI OCSP Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Requires:         pki-server = %{version}
 Requires(post):   systemd-units
 Requires(preun):  systemd-units
 Requires(postun): systemd-units
@@ -791,7 +791,7 @@ whenever they are issued or updated.
 Summary:          PKI TKS Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Requires:         pki-server = %{version}
 Requires(post):   systemd-units
 Requires(preun):  systemd-units
 Requires(postun): systemd-units
@@ -821,7 +821,7 @@ behind the firewall with restricted access.
 
 Summary:          PKI TPS Package
 
-Requires:         pki-server = %{version}-%{release}
+Requires:         pki-server = %{version}
 Requires(post):   systemd-units
 Requires(preun):  systemd-units
 Requires(postun): systemd-units
@@ -863,10 +863,10 @@ Summary:          PKI Javadoc Package
 BuildArch:        noarch
 
 # Ensure we end up with a useful installation
-Conflicts:        pki-base < %{version}-%{release}
-Conflicts:        pki-symkey < %{version}-%{release}
-Conflicts:        pki-server-theme < %{version}-%{release}
-Conflicts:        pki-console-theme < %{version}-%{release}
+Conflicts:        pki-base < %{version}
+Conflicts:        pki-symkey < %{version}
+Conflicts:        pki-server-theme < %{version}
+Conflicts:        pki-console-theme < %{version}
 
 %description -n   pki-javadoc
 This package contains PKI API documentation.
@@ -884,8 +884,8 @@ BuildArch:        noarch
 BuildRequires:    idm-console-framework >= 1.2.0
 
 Requires:         idm-console-framework >= 1.2.0
-Requires:         pki-base-java = %{version}-%{release}
-Requires:         pki-console-theme = %{version}-%{release}
+Requires:         pki-base-java = %{version}
+Requires:         pki-console-theme = %{version}
 
 %description -n   pki-console
 The PKI Console is a Java application used to administer PKI server.
@@ -900,13 +900,13 @@ The PKI Console is a Java application used to administer PKI server.
 Summary:          %{brand} PKI Server Theme Package
 BuildArch:        noarch
 
-Provides:         pki-server-theme = %{version}-%{release}
+Provides:         pki-server-theme = %{version}
 
 # Ensure we end up with a useful installation
-Conflicts:        pki-base < %{version}-%{release}
-Conflicts:        pki-symkey < %{version}-%{release}
-Conflicts:        pki-console-theme < %{version}-%{release}
-Conflicts:        pki-javadoc < %{version}-%{release}
+Conflicts:        pki-base < %{version}
+Conflicts:        pki-symkey < %{version}
+Conflicts:        pki-console-theme < %{version}
+Conflicts:        pki-javadoc < %{version}
 
 %description -n   %{vendor}-pki-server-theme
 This PKI Server Theme Package contains
@@ -919,13 +919,13 @@ This PKI Server Theme Package contains
 Summary:          %{brand} PKI Console Theme Package
 BuildArch:        noarch
 
-Provides:         pki-console-theme = %{version}-%{release}
+Provides:         pki-console-theme = %{version}
 
 # Ensure we end up with a useful installation
-Conflicts:        pki-base < %{version}-%{release}
-Conflicts:        pki-symkey < %{version}-%{release}
-Conflicts:        pki-server-theme < %{version}-%{release}
-Conflicts:        pki-javadoc < %{version}-%{release}
+Conflicts:        pki-base < %{version}
+Conflicts:        pki-symkey < %{version}
+Conflicts:        pki-server-theme < %{version}
+Conflicts:        pki-javadoc < %{version}
 
 %description -n   %{vendor}-pki-console-theme
 This PKI Console Theme Package contains


### PR DESCRIPTION
This is a proposal. If you have other ideas please let me know.

This patch removes the release numbers from all Requires tags
since they will not work if the packages are built in different modules.

Here's an example:
* pki-server-10.6.9-2.module+el8+2728+a4ad6bba
* pki-tps-10.6.9-2.module+el8+2876+2bd8167f

The pki-tps installation will fail since the pki-server will not provide
the required dependency due to mismatching release number:

```
Requires: pki-server = %{version}-%{release}
```
I think in general we should define dependencies without release
numbers, but if necessary it's possible to temporarily add a
specific release number as follows:

```
Requires: pki-server = %{version}-2
```
Once the packages are rebased (e.g. to 10.6.10) the temporary
release number should be removed.
