### PR TITLE
Backport of cert-fix

### DIFF
--- a/base/common/python/pki/cli/pkcs12.py
+++ b/base/common/python/pki/cli/pkcs12.py
@@ -224,7 +224,8 @@ class PKCS12ImportCLI(pki.cli.CLI):
                     cert_id = cert_info['id']
                     nickname = cert_info['nickname']
 
-                    cert = nssdb.get_cert(nickname)
+                    cert = nssdb.get_cert(
+                        nickname=nickname)
 
                     if cert:
                         if not overwrite:

--- a/base/common/python/pki/cli/pkcs12.py
+++ b/base/common/python/pki/cli/pkcs12.py
@@ -268,7 +268,10 @@ class PKCS12ImportCLI(pki.cli.CLI):
                     if main_cli.verbose:
                         print('Importing %s' % nickname)
 
-                    nssdb.add_cert(nickname, cert_file, trust_flags)
+                    nssdb.add_cert(
+                        nickname=nickname,
+                        cert_file=cert_file,
+                        trust_attributes=trust_flags)
 
             finally:
                 shutil.rmtree(tmpdir)

--- a/base/common/python/pki/cli/pkcs12.py
+++ b/base/common/python/pki/cli/pkcs12.py
@@ -232,7 +232,8 @@ class PKCS12ImportCLI(pki.cli.CLI):
                             print('WARNING: cert %s already exists' % nickname)
                             continue
 
-                        nssdb.remove_cert(nickname)
+                        nssdb.remove_cert(
+                            nickname=nickname)
 
                     if 'trust_flags' in cert_info:
                         trust_flags = cert_info['trust_flags']

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -74,6 +74,25 @@ class PKIServer(object):
         return instances
 
     @staticmethod
+    def split_cert_id(cert_id):
+        """
+        Utility method to return cert_tag and corresponding subsystem details from cert_id
+
+        :param cert_id: Cert ID
+        :type cert_id: str
+        :returns: (subsystem_name, cert_tag)
+        :rtype: (str, str)
+        """
+        if cert_id == 'sslserver' or cert_id == 'subsystem':
+            subsystem_name = None
+            cert_tag = cert_id
+        else:
+            parts = cert_id.split('_', 1)
+            subsystem_name = parts[0]
+            cert_tag = parts[1]
+        return subsystem_name, cert_tag
+
+    @staticmethod
     def load_audit_events(filename):
         '''
         This method loads audit event info from audit-events.properties
@@ -1272,11 +1291,9 @@ class PKIDatabaseConnection(object):
         self.temp_dir = tempfile.mkdtemp()
 
         if self.nssdb_dir:
-
             ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, self.nssdb_dir)
 
         if self.client_cert_nickname:
-
             password_file = os.path.join(self.temp_dir, 'password.txt')
             with open(password_file, 'w') as f:
                 f.write(self.nssdb_password)
@@ -1302,7 +1319,6 @@ class PKIServerException(pki.PKIException):
 
     def __init__(self, message, exception=None,
                  instance=None, subsystem=None):
-
         pki.PKIException.__init__(self, message, exception)
 
         self.instance = instance

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -881,73 +881,6 @@ class PKISubsystem(object):
                 target_tests[testID] = critical
         self.set_startup_tests(target_tests)
 
-    def nssdb_import_cert(self, cert_tag, cert_file=None):
-        """
-        Add cert from cert_file to NSS db with appropriate trust flags
-
-        :param cert_tag: Cert Tag
-        :type cert_tag: str
-        :param cert_file: Cert file to be imported into NSS db
-        :type cert_file: str
-        :return: New cert data loaded into nssdb
-        :rtype: dict
-        :raises PKIServerException
-        """
-        # audit and CA signing cert require special flags set in NSSDB
-        trust_attributes = None
-        if self.name == 'ca' and cert_tag == 'signing':
-            trust_attributes = 'CT,C,C'
-        elif cert_tag == 'audit_signing':
-            trust_attributes = ',,P'
-
-        nssdb = self.instance.open_nssdb()
-
-        try:
-            cert_folder = os.path.join(pki.CONF_DIR, self.instance.name, 'certs')
-
-            # If cert_file is not provided, load the cert from /etc/pki/certs/<cert_id>.crt
-            if not cert_file:
-                cert_file = os.path.join(cert_folder,
-                                         self.name + '_' + cert_tag + '.crt')
-
-            if not os.path.isfile(cert_file):
-                raise PKIServerException('%s does not exist.' % cert_file)
-
-            cert = self.get_subsystem_cert(cert_tag)
-
-            logger.debug('Checking existing %s certificate in NSS database'
-                         ' for subsystem: %s, instance: %s',
-                         cert_tag, self.name, self.instance.name)
-
-            if nssdb.get_cert(
-                    nickname=cert['nickname'],
-                    token=cert['token']):
-                raise PKIServerException('Certificate already exists: %s in'
-                                         'subsystem %s' % (cert_tag, self.name))
-
-            logger.debug('Importing new %s certificate into NSS database'
-                         ' for subsys %s, instance %s',
-                         cert_tag, self.name, self.instance.name)
-            nssdb.add_cert(
-                nickname=cert['nickname'],
-                token=cert['token'],
-                cert_file=cert_file,
-                trust_attributes=trust_attributes)
-
-            logger.info('Updating CS.cfg with the new certificate')
-            data = nssdb.get_cert(
-                nickname=cert['nickname'],
-                token=cert['token'],
-                output_format='base64')
-
-            # Store the cert data retrieved from NSS db
-            cert['data'] = data
-
-            return cert
-
-        finally:
-            nssdb.close()
-
     def setup_temp_renewal(self, tmpdir, cert_tag):
         """
         Retrieve CA's cert, Subject Key Identifier (SKI aka AKI) and CSR for
@@ -1468,7 +1401,9 @@ class PKIInstance(object):
         Delete a cert from NSS db
 
         :param cert_id: Cert ID
+        :type cert_id: str
         :param remove_key: Remove associate private key
+        :type remove_key: bool
         """
 
         subsystem_name, cert_tag = PKIServer.split_cert_id(cert_id)
@@ -1526,6 +1461,97 @@ class PKIInstance(object):
             else:
                 raise PKIServerException('No subsystem can be loaded for %s in '
                                          'instance %s.' % (cert_id, self.name))
+
+    def nssdb_import_cert(self, cert_id, cert_file=None):
+        """
+        Add cert from cert_file to NSS db with appropriate trust flags
+
+        :param cert_id: Cert ID
+        :type cert_id: str
+        :param cert_file: Cert file to be imported into NSS db
+        :type cert_file: str
+        :return: New cert data loaded into nssdb
+        :rtype: dict
+
+        :raises PKIServerException
+        """
+
+        subsystem_name, cert_tag = PKIServer.split_cert_id(cert_id)
+
+        if not subsystem_name:
+            subsystem_name = self.subsystems[0].name
+
+        subsystem = self.get_subsystem(subsystem_name)
+
+        # audit and CA signing cert require special flags set in NSSDB
+        trust_attributes = None
+        if subsystem_name == 'ca' and cert_tag == 'signing':
+            trust_attributes = 'CT,C,C'
+        elif cert_tag == 'audit_signing':
+            trust_attributes = ',,P'
+
+        nssdb = self.open_nssdb()
+
+        try:
+            cert_folder = os.path.join(pki.CONF_DIR, self.name, 'certs')
+
+            # If cert_file is not provided, load the cert from /etc/pki/certs/<cert_id>.crt
+            if not cert_file:
+                cert_file = os.path.join(cert_folder, cert_id + '.crt')
+
+            if not os.path.isfile(cert_file):
+                raise PKIServerException('%s does not exist.' % cert_file)
+
+            cert = subsystem.get_subsystem_cert(cert_tag)
+
+            logger.debug('Checking existing %s certificate in NSS database'
+                         ' for subsystem: %s, instance: %s',
+                         cert_tag, subsystem_name, self.name)
+
+            if nssdb.get_cert(
+                    nickname=cert['nickname'],
+                    token=cert['token']):
+                raise PKIServerException('Certificate already exists: %s in'
+                                         'subsystem %s' % (cert_tag, self.name))
+
+            logger.debug('Importing new %s certificate into NSS database'
+                         ' for subsys %s, instance %s',
+                         cert_tag, subsystem_name, self.name)
+
+            nssdb.add_cert(
+                nickname=cert['nickname'],
+                token=cert['token'],
+                cert_file=cert_file,
+                trust_attributes=trust_attributes)
+
+            logger.info('Updating CS.cfg with the new certificate')
+            data = nssdb.get_cert(
+                nickname=cert['nickname'],
+                token=cert['token'],
+                output_format='base64')
+
+            # Store the cert data retrieved from NSS db
+            cert['data'] = data
+
+            return cert
+
+        finally:
+            nssdb.close()
+
+    def cert_import(self, cert_id, cert_file=None):
+        """
+        Import cert from cert_file into NSS db with appropriate trust flags and update
+        all corresponding subsystem's CS.cfg
+
+        :param cert_id: Cert ID
+        :type cert_id: str
+        :param cert_file: Cert file to be imported into NSS db
+        :type cert_file: str
+        :return: None
+        :rtype: None
+        """
+        updated_cert = self.nssdb_import_cert(cert_id, cert_file)
+        self.cert_update_config(cert_id, updated_cert)
 
     def cert_create(self, cert_id, client_cert=None, client_nssdb=None, client_nssdb_pass=None,
                     client_nssdb_pass_file=None, serial=None, temp_cert=False, renew=False,

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -94,19 +94,20 @@ class PKIServer(object):
         return subsystem_name, cert_tag
 
     @staticmethod
-    def setup_authentication(c_nssdb_pass, c_nssdb_pass_file, c_cert,
-                             c_nssdb, tmpdir, subsystem_name):
+    def setup_authentication(client_nssdb_pass, client_nssdb_pass_file, client_cert,
+                             client_nssdb, tmpdir, subsystem_name):
         """
         Utility method to set up a secure authenticated connection with a
         subsystem of PKI Server through PKI client
-        :param c_nssdb_pass: Client NSS db plain password
-        :type c_nssdb_pass: str
-        :param c_nssdb_pass_file: File containing client NSS db password
-        :type c_nssdb_pass_file: str
-        :param c_cert: Client Cert nick name
-        :type c_cert: str
-        :param c_nssdb: Client NSS db path
-        :type c_nssdb: str
+
+        :param client_nssdb_pass: Client NSS db plain password
+        :type client_nssdb_pass: str
+        :param client_nssdb_pass_file: File containing client NSS db password
+        :type client_nssdb_pass_file: str
+        :param client_cert: Client Cert nick name
+        :type client_cert: str
+        :param client_nssdb: Client NSS db path
+        :type client_nssdb: str
         :param tmpdir: Absolute path of temp dir to store p12 and pem files
         :type tmpdir: str
         :param subsystem_name: Name of the subsystem
@@ -116,7 +117,7 @@ class PKIServer(object):
         temp_auth_p12 = os.path.join(tmpdir, 'auth.p12')
         temp_auth_cert = os.path.join(tmpdir, 'auth.pem')
 
-        if not c_cert:
+        if not client_cert:
             raise PKIServerException('Client cert nickname is required.')
 
         # Create a PKIConnection object that stores the details of subsystem.
@@ -129,8 +130,8 @@ class PKIServer(object):
         cmd_generate_pk12 = [
             'pk12util',
             '-o', temp_auth_p12,
-            '-n', c_cert,
-            '-d', c_nssdb
+            '-n', client_cert,
+            '-d', client_nssdb
         ]
 
         # The pem file used for authentication. Created from a p12 file using the
@@ -145,16 +146,16 @@ class PKIServer(object):
 
         ]
 
-        if c_nssdb_pass_file:
+        if client_nssdb_pass_file:
             # Use the same password file for the generated pk12 file
-            cmd_generate_pk12.extend(['-k', c_nssdb_pass_file,
-                                      '-w', c_nssdb_pass_file])
-            cmd_generate_pem.extend(['-passin', 'file:' + c_nssdb_pass_file])
+            cmd_generate_pk12.extend(['-k', client_nssdb_pass_file,
+                                      '-w', client_nssdb_pass_file])
+            cmd_generate_pem.extend(['-passin', 'file:' + client_nssdb_pass_file])
         else:
             # Use the same password for the generated pk12 file
-            cmd_generate_pk12.extend(['-K', c_nssdb_pass,
-                                      '-W', c_nssdb_pass])
-            cmd_generate_pem.extend(['-passin', 'pass:' + c_nssdb_pass])
+            cmd_generate_pk12.extend(['-K', client_nssdb_pass,
+                                      '-W', client_nssdb_pass])
+            cmd_generate_pem.extend(['-passin', 'pass:' + client_nssdb_pass])
 
         # Generate temp_auth_p12 file
         res_pk12 = subprocess.check_output(cmd_generate_pk12,
@@ -171,6 +172,58 @@ class PKIServer(object):
         connection.set_authentication_cert(temp_auth_cert)
 
         return connection
+
+    @staticmethod
+    def renew_certificate(connection, output, serial):
+        """
+        Renew cert associated with the provided serial
+        :param connection: Secure authenticated connection to PKI Server
+        :type connection: PKIConnection
+        :param output: Location of the new cert file to be written to
+        :type output: str
+        :param serial: Serial number of the cert to be renewed
+        :type serial: str
+        :return: None
+        :rtype: None
+        """
+
+        # Instantiate the CertClient
+        cert_client = pki.cert.CertClient(connection)
+
+        inputs = dict()
+        inputs['serial_num'] = serial
+
+        # request: CertRequestInfo object for request generated.
+        # cert: CertData object for certificate generated (if any)
+        ret = cert_client.enroll_cert(inputs=inputs, profile_id='caManualRenewal')
+
+        request_data = ret[0].request
+        cert_data = ret[0].cert
+
+        logger.info('Request ID: %s', request_data.request_id)
+        logger.info('Request Status: %s', request_data.request_status)
+        logger.debug('request_data: %s', request_data)
+        logger.debug('cert_data: %s', cert_data)
+
+        if not cert_data:
+            raise PKIServerException('Unable to renew system '
+                                     'certificate for serial: %s' % serial)
+
+        # store cert_id for usage later
+        cert_serial_number = cert_data.serial_number
+        if not cert_serial_number:
+            raise PKIServerException('Unable to retrieve serial number of '
+                                     'renewed certificate.')
+
+        logger.info('Serial Number: %s', cert_serial_number)
+        logger.info('Issuer: %s', cert_data.issuer_dn)
+        logger.info('Subject: %s', cert_data.subject_dn)
+        logger.debug('Pretty Print:')
+        logger.debug(cert_data.pretty_repr)
+
+        new_cert_data = cert_client.get_cert(cert_serial_number=cert_serial_number)
+        with open(output, 'w') as f:
+            f.write(new_cert_data.encoded)
 
     @staticmethod
     def load_audit_events(filename):
@@ -721,6 +774,7 @@ class PKISubsystem(object):
 
         # get the list of audit events from audit-events.properties
 
+        properties = {}
         tmpdir = tempfile.mkdtemp()
 
         try:
@@ -1462,6 +1516,97 @@ class PKIInstance(object):
             else:
                 raise PKIServerException('No subsystem can be loaded for %s in '
                                          'instance %s.' % (cert_id, self.name))
+
+    def cert_create(self, cert_id, client_cert=None, client_nssdb=None, client_nssdb_pass=None,
+                    client_nssdb_pass_file=None, serial=None, temp_cert=False, renew=False,
+                    output=None):
+        """
+        Create a new cert for the subsystem provided
+
+        :param cert_id: New cert's ID
+        :type cert_id: str
+        :param client_cert: Client cert nickname
+        :type client_cert: str
+        :param client_nssdb: Path to nssdb
+        :type client_nssdb: str
+        :param client_nssdb_pass: Password to the nssdb
+        :type client_nssdb_pass: str
+        :param client_nssdb_pass_file: File containing nssdb's password
+        :type client_nssdb_pass_file: str
+        :param serial: Serial number to be assigned to new cert
+        :type serial: str
+        :param temp_cert: Whether new cert is a temporary cert
+        :type temp_cert: bool
+        :param renew: Whether to place a renewal request to ca
+        :type renew: bool
+        :param output: Path to which new cert needs to be written to
+        :type output: str
+        :return: None
+        :rtype: None
+        :raises PKIServerException
+        """
+        nssdb = self.open_nssdb()
+        tmpdir = tempfile.mkdtemp()
+        try:
+            cert_folder = os.path.join(pki.CONF_DIR, self.name, 'certs')
+            if not os.path.exists(cert_folder):
+                os.makedirs(cert_folder)
+
+            if output:
+                new_cert_file = output
+            else:
+                new_cert_file = os.path.join(cert_folder, cert_id + '.crt')
+
+            subsystem_name, cert_tag = PKIServer.split_cert_id(cert_id)
+
+            if not subsystem_name:
+                subsystem_name = self.subsystems[0].name
+
+            subsystem = self.get_subsystem(subsystem_name)
+
+            if not serial:
+                # If admin doesn't provide a serial number, set the serial to
+                # the same serial number available in the nssdb
+                serial = subsystem.get_subsystem_cert(cert_tag)["serial_number"]
+
+            if temp_cert:
+                logger.info('Trying to create a new temp cert for %s.', cert_id)
+
+                # Create Temp Cert and write it to new_cert_file
+                subsystem.temp_cert_create(nssdb, tmpdir, cert_tag, serial, new_cert_file)
+
+                logger.info('Temp cert for %s is available at %s.', cert_id, new_cert_file)
+
+            else:
+                # Create permanent certificate
+                if not renew:
+                    # TODO: Support rekey
+                    raise PKIServerException('Rekey is not supported yet.')
+
+                if not client_cert:
+                    raise PKIServerException('Client cert nick name required.')
+
+                if not client_nssdb_pass and not client_nssdb_pass_file:
+                    raise PKIServerException('NSS db password required.')
+
+                logger.info('Trying to setup a secure connection to CA subsystem.')
+                connection = PKIServer.setup_authentication(
+                    client_nssdb_pass=client_nssdb_pass,
+                    client_cert=client_cert,
+                    client_nssdb_pass_file=client_nssdb_pass_file,
+                    client_nssdb=client_nssdb,
+                    tmpdir=tmpdir,
+                    subsystem_name='ca'
+                )
+                logger.info('Secure connection with CA is established.')
+
+                logger.info('Placing cert creation request for serial: %s', serial)
+                PKIServer.renew_certificate(connection, new_cert_file, serial)
+                logger.info('New cert is available at: %s', new_cert_file)
+
+        finally:
+            nssdb.close()
+            shutil.rmtree(tmpdir)
 
 
 class PKIDatabaseConnection(object):

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -881,24 +881,6 @@ class PKISubsystem(object):
                 target_tests[testID] = critical
         self.set_startup_tests(target_tests)
 
-    def cert_del(self, cert_tag, remove_key=False):
-        """
-        Delete a cert from NSS db
-        :param cert_tag: Cert Tag
-        :param remove_key: Remove associate private key
-        """
-        cert = self.get_subsystem_cert(cert_tag)
-        nssdb = self.instance.open_nssdb()
-        try:
-            logger.debug('Removing %s certificate from NSS database for '
-                         'subsystem %s instance %s', cert_tag, self.name, self.instance)
-            nssdb.remove_cert(
-                nickname=cert['nickname'],
-                token=cert['token'],
-                remove_key=remove_key)
-        finally:
-            nssdb.close()
-
     def nssdb_import_cert(self, cert_tag, cert_file=None):
         """
         Add cert from cert_file to NSS db with appropriate trust flags
@@ -1480,6 +1462,34 @@ class PKIInstance(object):
         if self.type == 9:
             return "Dogtag 9 " + self.name
         return self.name
+
+    def cert_del(self, cert_id, remove_key=False):
+        """
+        Delete a cert from NSS db
+
+        :param cert_id: Cert ID
+        :param remove_key: Remove associate private key
+        """
+
+        subsystem_name, cert_tag = PKIServer.split_cert_id(cert_id)
+
+        if not subsystem_name:
+            subsystem_name = self.subsystems[0].name
+
+        subsystem = self.get_subsystem(subsystem_name)
+
+        cert = subsystem.get_subsystem_cert(cert_tag)
+        nssdb = self.open_nssdb()
+
+        try:
+            logger.debug('Removing %s certificate from NSS database from '
+                         'subsystem %s in instance %s', cert_tag, subsystem.name, self.name)
+            nssdb.remove_cert(
+                nickname=cert['nickname'],
+                token=cert['token'],
+                remove_key=remove_key)
+        finally:
+            nssdb.close()
 
     def cert_update_config(self, cert_id, cert):
         """

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -233,6 +233,8 @@ class PKISubsystem(object):
 
     def create_subsystem_cert_object(self, cert_id):
 
+        logger.info('Getting %s cert info for %s', cert_id, self.name)
+
         nickname = self.config.get('%s.%s.nickname' % (self.name, cert_id))
         token = self.config.get('%s.%s.tokenname' % (self.name, cert_id))
 

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1557,7 +1557,7 @@ class PKIInstance(object):
                     client_nssdb_pass_file=None, serial=None, temp_cert=False, renew=False,
                     output=None):
         """
-        Create a new cert for the subsystem provided
+        Create a new cert for the cert_id provided
 
         :param cert_id: New cert's ID
         :type cert_id: str

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -520,25 +520,9 @@ class CertImportCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
-
-        # If cert ID is instance specific, get it from first subsystem
-        if not subsystem_name:
-            subsystem_name = instance.subsystems[0].name
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error(
-                'No %s subsystem in instance %s.',
-                subsystem_name, instance_name)
-            sys.exit(1)
-
         try:
-            # Load the cert into NSS db
-            cert = subsystem.nssdb_import_cert(cert_tag, cert_file)
-            # Update the CS.cfg file for (all) corresponding subsystems
-            instance.cert_update_config(cert_id, cert)
+            # Load the cert into NSS db and update all corresponding subsystem's CS.cfg
+            instance.cert_import(cert_id, cert_file)
 
         except server.PKIServerException as e:
             logger.error(str(e))

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -813,19 +813,5 @@ class CertRemoveCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
-
-        # If cert ID is instance specific, get it from first subsystem
-        if not subsystem_name:
-            subsystem_name = instance.subsystems[0].name
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error(
-                'No %s subsystem in instance %s.',
-                subsystem_name, instance_name)
-            sys.exit(1)
-
         logger.info('Removing %s certificate from NSS database', cert_id)
-        subsystem.cert_del(cert_tag=cert_tag, remove_key=remove_key)
+        instance.cert_del(cert_id=cert_id, remove_key=remove_key)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -404,7 +404,8 @@ class CertCreateCLI(pki.cli.CLI):
                 create_temp_cert = True
 
             elif o == '--serial':
-                serial = a
+                # string containing the dec or hex value for the identifier
+                serial = str(int(a, 0))
 
             elif o == '--output':
                 output = a

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -97,7 +97,7 @@ class CertFindCLI(pki.cli.CLI):
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('      --show-all                  Show all attributes.')
         print('  -v, --verbose                   Run in verbose mode.')
-        print('      --debug                     Show debug messages.')
+        print('      --debug                     Run in debug mode.')
         print('      --help                      Show help message.')
         print()
 
@@ -111,7 +111,7 @@ class CertFindCLI(pki.cli.CLI):
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
-            print('ERROR: ' + str(e))
+            logger.error(e)
             self.print_help()
             sys.exit(1)
 
@@ -139,14 +139,14 @@ class CertFindCLI(pki.cli.CLI):
                 sys.exit()
 
             else:
-                print('ERROR: unknown option ' + o)
+                logger.error('option %s not recognized', o)
                 self.print_help()
                 sys.exit(1)
 
         instance = server.PKIInstance(instance_name)
 
         if not instance.is_valid():
-            print('ERROR: Invalid instance %s.' % instance_name)
+            logger.error('Invalid instance %s.', instance_name)
             sys.exit(1)
 
         instance.load()

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -250,17 +250,21 @@ class CertUpdateCLI(pki.cli.CLI):
         subsystem_name = None
         cert_tag = cert_id
 
-        if cert_id != 'sslserver' and cert_id != 'subsystem':
-            # To avoid ambiguity where cert ID can contain more than 1 _, we limit to one split
-            temp_cert_identify = cert_id.split('_', 1)
-            subsystem_name = temp_cert_identify[0]
-            cert_tag = temp_cert_identify[1]
+        if cert_id == 'sslserver' or cert_id == 'subsystem':
+            subsystem_name = None
+            cert_tag = cert_id
+
+        else:
+            parts = cert_id.split('_', 1)
+            subsystem_name = parts[0]
+            cert_tag = parts[1]
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
             subsystem_name = instance.subsystems[0].name
 
         subsystem = instance.get_subsystem(subsystem_name)
+
         if not subsystem:
             logger.error(
                 'No %s subsystem in instance %s.',
@@ -452,11 +456,14 @@ class CertCreateCLI(pki.cli.CLI):
         subsystem_name = None
         cert_tag = cert_id
 
-        if cert_id != 'sslserver' and cert_id != 'subsystem':
-            # To avoid ambiguity where cert ID can contain more than 1 _, we limit to one split
-            temp_cert_identify = cert_id.split('_', 1)
-            subsystem_name = temp_cert_identify[0]
-            cert_tag = temp_cert_identify[1]
+        if cert_id == 'sslserver' or cert_id == 'subsystem':
+            subsystem_name = None
+            cert_tag = cert_id
+
+        else:
+            parts = cert_id.split('_', 1)
+            subsystem_name = parts[0]
+            cert_tag = parts[1]
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -863,13 +870,14 @@ class CertImportCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name = None
-        cert_tag = cert_id
-        if cert_id != 'sslserver' and cert_id != 'subsystem':
-            # To avoid ambiguity where cert ID can contain more than 1 _, we limit to one split
-            temp_cert_identify = cert_id.split('_', 1)
-            subsystem_name = temp_cert_identify[0]
-            cert_tag = temp_cert_identify[1]
+        if cert_id == 'sslserver' or cert_id == 'subsystem':
+            subsystem_name = None
+            cert_tag = cert_id
+
+        else:
+            parts = cert_id.split('_', 1)
+            subsystem_name = parts[0]
+            cert_tag = parts[1]
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1052,11 +1060,14 @@ class CertExportCLI(pki.cli.CLI):
         subsystem_name = None
         cert_tag = cert_id
 
-        if cert_id != 'sslserver' and cert_id != 'subsystem':
-            # To avoid ambiguity where cert ID can contain more than 1 _, we limit to one split
-            temp_cert_identify = cert_id.split('_', 1)
-            subsystem_name = temp_cert_identify[0]
-            cert_tag = temp_cert_identify[1]
+        if cert_id == 'sslserver' or cert_id == 'subsystem':
+            subsystem_name = None
+            cert_tag = cert_id
+
+        else:
+            parts = cert_id.split('_', 1)
+            subsystem_name = parts[0]
+            cert_tag = parts[1]
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -87,24 +87,6 @@ class CertCLI(pki.cli.CLI):
     def convert_millis_to_date(millis):
         return datetime.datetime.fromtimestamp(millis / 1000.0).strftime("%a %b %d %H:%M:%S %Y")
 
-    @staticmethod
-    def split_cert_id(cert_id):
-        """
-        Return cert_tag and corresponding subsystem details from cert_id
-        :param cert_id: Cert ID
-        :type cert_id: str
-        :returns: (subsystem_name, cert_tag)
-        :rtype: (str, str)
-        """
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
-        return subsystem_name, cert_tag
-
 
 class CertFindCLI(pki.cli.CLI):
     def __init__(self):
@@ -266,7 +248,7 @@ class CertUpdateCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -872,7 +854,7 @@ class CertImportCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1012,7 +994,7 @@ class CertExportCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1165,7 +1147,7 @@ class CertRemoveCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
+        subsystem_name, cert_tag = server.PKIServer.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1,5 +1,6 @@
 # Authors:
 #     Dinesh Prasanth M K <dmoluguw@redhat.com>
+#     Endi S. Dewata <edewata@redhat.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -85,6 +86,24 @@ class CertCLI(pki.cli.CLI):
     @staticmethod
     def convert_millis_to_date(millis):
         return datetime.datetime.fromtimestamp(millis / 1000.0).strftime("%a %b %d %H:%M:%S %Y")
+
+    @staticmethod
+    def split_cert_id(cert_id):
+        """
+        Return cert_tag and corresponding subsystem details from cert_id
+        :param cert_id: Cert ID
+        :type cert_id: str
+        :returns: (subsystem_name, cert_tag)
+        :rtype: (str, str)
+        """
+        if cert_id == 'sslserver' or cert_id == 'subsystem':
+            subsystem_name = None
+            cert_tag = cert_id
+        else:
+            parts = cert_id.split('_', 1)
+            subsystem_name = parts[0]
+            cert_tag = parts[1]
+        return subsystem_name, cert_tag
 
 
 class CertFindCLI(pki.cli.CLI):
@@ -247,17 +266,7 @@ class CertUpdateCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name = None
-        cert_tag = cert_id
-
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -470,8 +479,8 @@ class CertCreateCLI(pki.cli.CLI):
         if not subsystem_name:
             subsystem_name = instance.subsystems[0].name
 
-        # Get the subsystem - Eg: ca, kra, tps, tks
         subsystem = instance.get_subsystem(subsystem_name)
+
         if not subsystem:
             logger.error(
                 'No %s subsystem in instance %s.',
@@ -871,20 +880,12 @@ class CertImportCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
             subsystem_name = instance.subsystems[0].name
 
-        # Get the subsystem - Eg: ca, kra, tps, tks
         subsystem = instance.get_subsystem(subsystem_name)
 
         if not subsystem:
@@ -1066,17 +1067,7 @@ class CertExportCLI(pki.cli.CLI):
 
         instance.load()
 
-        subsystem_name = None
-        cert_tag = cert_id
-
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1229,14 +1220,7 @@ class CertRemoveCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
+        subsystem_name, cert_tag = CertCLI.split_cert_id(cert_id)
 
         # If cert ID is instance specific, get it from first subsystem
         if not subsystem_name:
@@ -1250,17 +1234,5 @@ class CertRemoveCLI(pki.cli.CLI):
                 subsystem_name, instance_name)
             sys.exit(1)
 
-        cert = subsystem.get_subsystem_cert(cert_tag)
-
-        nssdb = instance.open_nssdb()
-
-        try:
-            logger.info('Removing %s certificate from NSS database', cert_id)
-
-            nssdb.remove_cert(
-                nickname=cert['nickname'],
-                token=cert['token'],
-                remove_key=remove_key)
-
-        finally:
-            nssdb.close()
+        logger.info('Removing %s certificate from NSS database', cert_id)
+        subsystem.cert_del(cert_tag=cert_tag, remove_key=remove_key)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -909,11 +909,15 @@ class CertImportCLI(pki.cli.CLI):
 
             nssdb.add_cert(
                 nickname=cert['nickname'],
+                token=cert['token'],
                 cert_file=cert_file)
 
             logger.info('Updating CS.cfg with the new certificate')
 
-            data = nssdb.get_cert(nickname=cert['nickname'], output_format='base64')
+            data = nssdb.get_cert(
+                nickname=cert['nickname'],
+                token=cert['token'],
+                output_format='base64')
             cert['data'] = data
 
             if cert_id == 'sslserver' or cert_id == 'subsystem':

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -148,33 +148,33 @@ class CertFindCLI(pki.cli.CLI):
             sys.exit(1)
 
         instance.load()
+
+        first = True
         results = []
 
         for subsystem in instance.subsystems:
 
             # Retrieve the subsystem's system certificate
-            sub_system_certs = subsystem.find_system_certs()
+            certs = subsystem.find_system_certs()
 
             # Iterate on all subsystem's system certificate to prepend subsystem name to the ID
-            for subsystem_cert in sub_system_certs:
+            for cert in certs:
 
-                if subsystem_cert['id'] != 'sslserver' and subsystem_cert['id'] != 'subsystem':
-                    subsystem_cert['id'] = subsystem.name + '_' + subsystem_cert['id']
+                if cert['id'] != 'sslserver' and cert['id'] != 'subsystem':
+                    cert['id'] = subsystem.name + '_' + cert['id']
 
                 # Append only unique certificates to other subsystem certificate list
-                if subsystem_cert not in results:
-                    results.append(subsystem_cert)
+                if cert['id'] in results:
+                    continue
 
-        self.print_message('%s entries matched' % len(results))
+                results.append(cert['id'])
 
-        first = True
-        for cert in results:
-            if first:
-                first = False
-            else:
-                print()
+                if first:
+                    first = False
+                else:
+                    print()
 
-            CertCLI.print_system_cert(cert, show_all)
+                CertCLI.print_system_cert(cert, show_all)
 
 
 class CertUpdateCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -32,7 +32,6 @@ import sys
 import pki.cert
 import pki.cli
 import pki.nssdb
-
 import pki.server as server
 
 logger = logging.getLogger(__name__)
@@ -48,6 +47,7 @@ class CertCLI(pki.cli.CLI):
         self.add_module(CertImportCLI())
         self.add_module(CertExportCLI())
         self.add_module(CertRemoveCLI())
+        self.add_module(CertFixCLI())
 
     @staticmethod
     def print_system_cert(cert, show_all=False):
@@ -799,3 +799,211 @@ class CertRemoveCLI(pki.cli.CLI):
 
         logger.info('Removing %s certificate from NSS database', cert_id)
         instance.cert_del(cert_id=cert_id, remove_key=remove_key)
+
+
+class CertFixCLI(pki.cli.CLI):
+    def __init__(self):
+        super(CertFixCLI, self).__init__(
+            'fix', 'Fix expired system certificate(s).')
+
+    def print_help(self):  # flake8: noqa
+        print('Usage: pki-server cert-fix [OPTIONS]')
+        # CertID:  subsystem, sslserver, kra_storage, kra_transport, ca_ocsp_signing,
+        # ca_audit_signing, kra_audit_signing
+        # ca.cert.list=signing,ocsp_signing,sslserver,subsystem,audit_signing
+        print()
+        print('      --cert <Cert ID>            Fix specified system cert (default: all certs).')
+        print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
+        print('  -d <NSS database>               NSS database location (default: ~/.dogtag/nssdb)')
+        print('  -c <NSS DB password>            NSS database password')
+        print('  -C <path>                       Input file containing the password for the NSS database.')
+        print('  -n <nickname>                   Client certificate nickname')
+        print('  -v, --verbose                   Run in verbose mode.')
+        print('      --debug                     Run in debug mode.')
+        print('      --help                      Show help message.')
+        print()
+
+    def execute(self, argv):
+        logging.basicConfig(format='%(levelname)s: %(message)s')
+
+        try:
+            opts, _ = getopt.gnu_getopt(argv, 'i:d:c:C:n:v', [
+                'instance=', 'cert=',
+                'verbose', 'debug', 'help'])
+
+        except getopt.GetoptError as e:
+            logger.error(e)
+            self.print_help()
+            sys.exit(1)
+
+        instance_name = 'pki-tomcat'
+        all_certs = True
+        client_nssdb = os.getenv('HOME') + '/.dogtag/nssdb'
+        client_nssdb_pass = None
+        client_nssdb_pass_file = None
+        client_cert = None
+        fix_certs = []
+
+        for o, a in opts:
+            if o in ('-i', '--instance'):
+                instance_name = a
+
+            elif o == '--cert':
+                all_certs = False
+                fix_certs.append(a)
+
+            elif o == '-d':
+                client_nssdb = a
+
+            elif o == '-c':
+                client_nssdb_pass = a
+
+            elif o == '-C':
+                client_nssdb_pass_file = a
+
+            elif o == '-n':
+                client_cert = a
+
+            elif o in ('-v', '--verbose'):
+                self.set_verbose(True)
+                logging.getLogger().setLevel(logging.INFO)
+
+            elif o == '--debug':
+                self.set_verbose(True)
+                self.set_debug(True)
+                logging.getLogger().setLevel(logging.DEBUG)
+
+            elif o == '--help':
+                self.print_help()
+                sys.exit()
+
+            else:
+                logger.error('option %s not recognized', o)
+                self.print_help()
+                sys.exit(1)
+
+        if not client_cert:
+            logger.error('Client nick name is required.')
+            self.print_help()
+            sys.exit(1)
+
+        if not client_nssdb_pass and not client_nssdb_pass_file:
+            logger.error('Client NSS db password is required.')
+            self.print_help()
+            sys.exit(1)
+
+        instance = server.PKIInstance(instance_name)
+
+        if not instance.is_valid():
+            logger.error('Invalid instance %s.', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        # 1. Make a list of certs to fix OR use the list provided through CLI options
+        if all_certs:
+            # TODO: Identify only certs that are EXPIRED or ALMOST EXPIRED
+            for subsystem in instance.subsystems:
+                # Retrieve the subsystem's system certificate
+                certs = subsystem.find_system_certs()
+
+                # Iterate on all subsystem's system certificate to prepend
+                # subsystem name to the ID
+                for cert in certs:
+                    if cert['id'] != 'sslserver' and cert['id'] != 'subsystem':
+                        cert['id'] = subsystem.name + '_' + cert['id']
+
+                    # Append only unique certificates to other subsystem certificate list
+                    # ca_signing isn't supported yet
+                    if cert['id'] in fix_certs or cert['id'] == 'ca_signing':
+                        continue
+
+                    fix_certs.append(cert['id'])
+
+        logger.info('Fixing the following certs: %s', fix_certs)
+
+        # 2. Stop the server, if it's up
+        instance.stop()
+
+        # 3. Find the subsystem and disable Self-tests
+        try:
+            # Placeholder used to hold subsystems whose selftest have been turned off
+            # Note: This is initialized as a set to avoid duplicates
+            # Example of duplicates:
+            # fix_certs = [ca_ocsp_signing, ca_audit_signing] -> will add 'ca' entry twice
+            target_subsys = set()
+
+            if 'sslserver' in fix_certs or 'subsystem' in fix_certs:
+                # If the cert is either sslserver/subsystem, disable selftest for all
+                # subsystems since all subsystems use these 2 certs.
+                target_subsys = set(instance.subsystems)
+
+            else:
+                for cert_id in fix_certs:
+                    # Since we already filtered sslserver/subsystem, we can be quite sure
+                    # that this split will definitely be of form: <subsys>_<cert_tag>
+                    subsystem_name = cert_id.split('_', 1)[0]
+                    subsystem = instance.get_subsystem(subsystem_name)
+
+                    # If the subsystem is wrong, stop the process
+                    if not subsystem:
+                        logger.error('No %s subsystem in instance %s.',
+                                     subsystem_name, instance_name)
+                        sys.exit(1)
+
+                    target_subsys.add(subsystem)
+
+            # Convert set to list
+            target_subsys = list(target_subsys)
+
+            for subsystem in target_subsys:
+                subsystem.set_startup_test_criticality(False)
+                subsystem.save()
+
+            logger.info('Selftests disabled for subsystems: %s', ', '.join(
+                str(x.name) for x in target_subsys))
+
+            # 4. Bring up the server using a temp SSL cert if the sslcert is expired
+            if 'sslserver' in fix_certs:
+                # 4a. Create temp SSL cert
+                instance.cert_create(cert_id='sslserver', temp_cert=True)
+
+                # 4b. Delete the existing SSL Cert
+                instance.cert_del('sslserver')
+
+                # 4d. Import the temp sslcert into the instance
+                instance.cert_import('sslserver')
+
+            # 5. Bring up the server temporarily
+            instance.start()
+
+            # 6. Place renewal request for all certs in fix_certs
+            for cert_id in fix_certs:
+                instance.cert_create(cert_id=cert_id,
+                                     client_cert=client_cert,
+                                     client_nssdb=client_nssdb,
+                                     client_nssdb_pass=client_nssdb_pass,
+                                     client_nssdb_pass_file=client_nssdb_pass_file,
+                                     renew=True)
+
+            # 7. Stop the server
+            instance.stop()
+
+            # 8. Delete existing certs and then import the renewed system cert(s)
+            for cert_id in fix_certs:
+                # Delete the existing cert from the instance
+                instance.cert_del(cert_id)
+
+                # Import this new cert into the instance
+                instance.cert_import(cert_id)
+
+            # 9. Enable self tests for the subsystems disabled earlier
+            for subsystem in target_subsys:
+                subsystem.set_startup_test_criticality(True)
+
+            # 10. Bring up the server
+            instance.start()
+
+        except server.PKIServerException as e:
+            logger.error(str(e))
+            sys.exit(1)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -893,6 +893,13 @@ class CertImportCLI(pki.cli.CLI):
                 subsystem_name, instance_name)
             sys.exit(1)
 
+        # audit and CA certs require special flags set in NSSDB
+        trust_attributes = None
+        if cert_id == 'ca_signing':
+            trust_attributes = 'CT,C,C'
+        elif cert_tag == 'audit_signing':
+            trust_attributes = ',,P'
+
         nssdb = instance.open_nssdb()
 
         try:
@@ -920,7 +927,8 @@ class CertImportCLI(pki.cli.CLI):
             nssdb.add_cert(
                 nickname=cert['nickname'],
                 token=cert['token'],
-                cert_file=cert_file)
+                cert_file=cert_file,
+                trust_attributes=trust_attributes)
 
             logger.info('Updating CS.cfg with the new certificate')
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -852,7 +852,9 @@ class CertImportCLI(pki.cli.CLI):
 
             if self.verbose:
                 print('Adding new %s certificate into NSS database.' % cert_id)
-            nssdb.add_cert(nickname=cert['nickname'], cert_file=cert_file)
+            nssdb.add_cert(
+                nickname=cert['nickname'],
+                cert_file=cert_file)
 
             # Update CS.cfg with the new certificate
             if self.verbose:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -55,7 +55,10 @@ class CertCLI(pki.cli.CLI):
     def print_system_cert(cert, show_all=False):
         print('  Cert ID: %s' % cert['id'])
         print('  Nickname: %s' % cert['nickname'])
-        print('  Token: %s' % cert['token'])
+
+        token = cert.get('token')
+        if token:
+            print('  Token: %s' % token)
 
         serial_number = cert.get('serial_number')
         if serial_number:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -791,7 +791,7 @@ class CertImportCLI(pki.cli.CLI):
         super(CertImportCLI, self).__init__(
             'import', 'Import system certificate.')
 
-    def usage(self):
+    def print_help(self):
         print('Usage: pki-server cert-import [OPTIONS] <Cert ID>')
         # CertID:  subsystem, sslserver, kra_storage, kra_transport, ca_ocsp_signing,
         # ca_audit_signing, kra_audit_signing
@@ -800,7 +800,7 @@ class CertImportCLI(pki.cli.CLI):
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('      --input <file>              Provide input file name.')
         print('  -v, --verbose                   Run in verbose mode.')
-        print('      --debug                     Show debug messages.')
+        print('      --debug                     Run in debug mode.')
         print('      --help                      Show help message.')
         print()
 
@@ -814,8 +814,8 @@ class CertImportCLI(pki.cli.CLI):
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
-            print('ERROR: ' + str(e))
-            self.usage()
+            logger.error(e)
+            self.print_help()
             sys.exit(1)
 
         instance_name = 'pki-tomcat'
@@ -838,17 +838,17 @@ class CertImportCLI(pki.cli.CLI):
                 logging.getLogger().setLevel(logging.DEBUG)
 
             elif o == '--help':
-                self.usage()
+                self.print_help()
                 sys.exit()
 
             else:
-                self.print_message('ERROR: unknown option ' + o)
-                self.usage()
+                logger.error('option %s not recognized', o)
+                self.print_help()
                 sys.exit(1)
 
         if len(args) < 1:
-            print('ERROR: missing cert ID')
-            self.usage()
+            logger.error('Missing cert ID.')
+            self.print_help()
             sys.exit(1)
 
         cert_id = args[0]
@@ -856,7 +856,7 @@ class CertImportCLI(pki.cli.CLI):
         instance = server.PKIInstance(instance_name)
 
         if not instance.is_valid():
-            print('ERROR: Invalid instance %s.' % instance_name)
+            logger.error('Invalid instance %s.', instance_name)
             sys.exit(1)
 
         # Load the instance. Default: pki-tomcat
@@ -878,8 +878,9 @@ class CertImportCLI(pki.cli.CLI):
         subsystem = instance.get_subsystem(subsystem_name)
 
         if not subsystem:
-            print('ERROR: No %s subsystem in instance.'
-                  '%s.' % (subsystem_name, instance_name))
+            logger.error(
+                'No %s subsystem in instance %s.',
+                subsystem_name, instance_name)
             sys.exit(1)
 
         nssdb = instance.open_nssdb()
@@ -890,8 +891,8 @@ class CertImportCLI(pki.cli.CLI):
                 cert_file = os.path.join(cert_folder, cert_id + '.crt')
 
             if not os.path.isfile(cert_file):
-                print('ERROR: No %s such file.' % cert_file)
-                self.usage()
+                logger.error('No %s such file.', cert_file)
+                self.print_help()
                 sys.exit(1)
 
             cert = subsystem.get_subsystem_cert(cert_tag)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -27,9 +27,7 @@ import getopt
 import getpass
 import logging
 import os
-import shutil
 import sys
-import tempfile
 
 import pki.cert
 import pki.cli
@@ -358,22 +356,21 @@ class CertCreateCLI(pki.cli.CLI):
             sys.exit(1)
 
         instance_name = 'pki-tomcat'
-        create_temp_cert = False
+        temp_cert = False
         serial = None
-        client_nssdb_location = os.getenv('HOME') + '/.dogtag/nssdb'
+        client_nssdb = os.getenv('HOME') + '/.dogtag/nssdb'
         client_nssdb_password = None
         client_nssdb_pass_file = None
         client_cert = None
         output = None
         renew = False
-        connection = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
                 instance_name = a
 
             elif o == '-d':
-                client_nssdb_location = a
+                client_nssdb = a
 
             elif o == '-c':
                 client_nssdb_password = a
@@ -385,7 +382,7 @@ class CertCreateCLI(pki.cli.CLI):
                 client_cert = a
 
             elif o == '--temp':
-                create_temp_cert = True
+                temp_cert = True
 
             elif o == '--serial':
                 # string containing the dec or hex value for the identifier
@@ -420,7 +417,7 @@ class CertCreateCLI(pki.cli.CLI):
             self.print_help()
             sys.exit(1)
 
-        if not create_temp_cert:
+        if not temp_cert:
             # For permanent certificate, password of NSS db is required.
             if not client_nssdb_password and not client_nssdb_pass_file:
                 logger.error('NSS database password is required.')
@@ -438,210 +435,13 @@ class CertCreateCLI(pki.cli.CLI):
         # Load the instance. Default: pki-tomcat
         instance.load()
 
-        subsystem_name = None
-        cert_tag = cert_id
-
-        if cert_id == 'sslserver' or cert_id == 'subsystem':
-            subsystem_name = None
-            cert_tag = cert_id
-
-        else:
-            parts = cert_id.split('_', 1)
-            subsystem_name = parts[0]
-            cert_tag = parts[1]
-
-        # If cert ID is instance specific, get it from first subsystem
-        if not subsystem_name:
-            subsystem_name = instance.subsystems[0].name
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error(
-                'No %s subsystem in instance %s.',
-                subsystem_name, instance_name)
-            sys.exit(1)
-
-        nssdb = instance.open_nssdb()
-        tmpdir = tempfile.mkdtemp()
         try:
-            cert_folder = os.path.join(pki.CONF_DIR, instance_name, 'certs')
-            if not os.path.exists(cert_folder):
-                os.makedirs(cert_folder)
-            new_cert_file = os.path.join(cert_folder, cert_id + '.crt')
+            instance.cert_create(cert_id, client_cert, client_nssdb, client_nssdb_password,
+                                 client_nssdb_pass_file, serial, temp_cert, renew, output)
 
-            if output:
-                new_cert_file = output
-
-            if create_temp_cert:
-                if not serial:
-                    # If admin doesn't provide a serial number, find the highest in NSS db
-                    # and add 1 to it
-                    serial = 0
-                    for sub in instance.subsystems:
-                        for n_cert in sub.find_system_certs():
-                            if int(n_cert['serial_number']) > serial:
-                                serial = int(n_cert['serial_number'])
-
-                    # Add 1 and then rewrap it as a string
-                    serial = str(serial + 1)
-
-            else:
-                # Create permanent certificate
-                if not renew:
-                    # Fixme: Support rekey
-                    raise Exception('Rekey is not supported yet.')
-
-                # Create a secure connection to CA
-                connection = server.PKIServer.setup_authentication(
-                    c_nssdb_pass=client_nssdb_password,
-                    c_cert=client_cert,
-                    c_nssdb_pass_file=client_nssdb_pass_file,
-                    c_nssdb=client_nssdb_location,
-                    tmpdir=tmpdir,
-                    subsystem_name='ca')
-
-            if cert_tag == 'sslserver':
-                self.create_ssl_cert(subsystem=subsystem,
-                                     is_temp_cert=create_temp_cert,
-                                     new_cert_file=new_cert_file, nssdb=nssdb, serial=serial,
-                                     tmpdir=tmpdir, connection=connection)
-
-            elif cert_tag == 'subsystem':
-                self.create_subsystem_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                           subsystem=subsystem, new_cert_file=new_cert_file,
-                                           connection=connection)
-
-            elif cert_id in ['ca_ocsp_signing', 'ocsp_signing']:
-                self.create_ocsp_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                      subsystem=subsystem, new_cert_file=new_cert_file,
-                                      connection=connection)
-
-            elif cert_tag == 'audit_signing':
-                self.create_audit_cert(is_temp_cert=create_temp_cert, serial=serial,
-                                       subsystem=subsystem, new_cert_file=new_cert_file,
-                                       connection=connection)
-
-            else:
-                # renewal not yet supported
-                raise Exception('Renewal for %s not yet supported.' % cert_id)
-
-        finally:
-            nssdb.close()
-            shutil.rmtree(tmpdir)
-
-    def renew_system_certificate(self, connection,
-                                 output, serial):
-
-        # Instantiate the CertClient
-        cert_client = pki.cert.CertClient(connection)
-
-        inputs = dict()
-        inputs['serial_num'] = serial
-
-        # request: CertRequestInfo object for request generated.
-        # cert: CertData object for certificate generated (if any)
-        ret = cert_client.enroll_cert(inputs=inputs, profile_id='caManualRenewal')
-
-        request_data = ret[0].request
-        cert_data = ret[0].cert
-
-        logger.info('Request ID: %s', request_data.request_id)
-        logger.info('Request Status: %s', request_data.request_status)
-
-        if not cert_data:
-            raise Exception('Unable to renew system certificate for serial: %s' % serial)
-
-        # store cert_id for usage later
-        cert_id = cert_data.serial_number
-        if not cert_id:
-            raise Exception('Unable to retrieve serial number of renewed certificate.')
-
-        logger.info('Serial Number: %s', cert_id)
-        logger.info('Issuer: %s', cert_data.issuer_dn)
-        logger.info('Subject: %s', cert_data.subject_dn)
-        logger.info('Pretty Print:')
-        logger.info(cert_data.pretty_repr)
-
-        new_cert_data = cert_client.get_cert(cert_serial_number=cert_id)
-        with open(output, 'w') as f:
-            f.write(new_cert_data.encoded)
-
-    # NOTE: The following method will be removed in subsequent patches
-    def create_ssl_cert(self, subsystem, serial, is_temp_cert, tmpdir,
-                        new_cert_file, nssdb, connection):
-
-        logger.info('Creating SSL server certificate.')
-
-        if is_temp_cert:
-            subsystem.temp_cert_create(nssdb, tmpdir, 'sslserver', serial, new_cert_file)
-
-        else:
-
-            logger.info('Renewing SSL certificate')
-
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('sslserver')["serial_number"]
-
-            logger.info('Serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    # NOTE: The following method will be removed in subsequent patches
-    def create_ocsp_cert(self, subsystem, is_temp_cert, new_cert_file, serial, connection):
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for OCSP is not supported.')
-
-        else:
-            cert_tag = 'ocsp_signing'
-            if subsystem.name is 'ocsp':
-                cert_tag = 'signing'
-
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert(cert_tag)["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    # NOTE: The following method will be removed in subsequent patches
-    def create_subsystem_cert(self, subsystem, is_temp_cert, new_cert_file, serial,
-                              connection):
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for subsystem is not supported.')
-
-        else:
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('subsystem')["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
-
-    # NOTE: The following method will be removed in subsequent patches
-    def create_audit_cert(self, subsystem, is_temp_cert, new_cert_file, serial, connection):
-
-        logger.info('Creating audit certificate')
-
-        if is_temp_cert:
-            raise Exception('Temp certificate for audit signing is not supported.')
-        else:
-            if not serial:
-                # If serial number is not provided, get Serial Number from NSS db
-                serial = subsystem.get_subsystem_cert('audit_signing')["serial_number"]
-
-            logger.info('Renewing for certificate with serial number: %s', serial)
-
-            self.renew_system_certificate(connection=connection,
-                                          output=new_cert_file, serial=serial)
+        except server.PKIServerException as e:
+            logger.error(str(e))
+            sys.exit(1)
 
 
 class CertImportCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -897,8 +897,17 @@ class CertImportCLI(pki.cli.CLI):
             cert = subsystem.get_subsystem_cert(cert_tag)
 
             logger.info('Removing old %s certificate from NSS database', cert_id)
-
-            nssdb.remove_cert(cert['nickname'])
+            try:
+                nssdb.remove_cert(
+                    nickname=cert['nickname'],
+                    token=cert['token'])
+            except subprocess.CalledProcessError as e:
+                # if the cert is missing, certutil will return 255, ignore it
+                if e.returncode != 255:
+                    raise e
+                logger.warning(
+                    'Unable to remove old %s certificate from NSS database (rc: %d)',
+                    cert_id, e.returncode)
 
             logger.info('Importing new %s certificate into NSS database', cert_id)
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -898,18 +898,13 @@ class CertImportCLI(pki.cli.CLI):
 
             cert = subsystem.get_subsystem_cert(cert_tag)
 
-            logger.info('Removing old %s certificate from NSS database', cert_id)
-            try:
-                nssdb.remove_cert(
+            logger.info('Checking existing %s certificate in NSS database', cert_id)
+
+            if nssdb.get_cert(
                     nickname=cert['nickname'],
-                    token=cert['token'])
-            except subprocess.CalledProcessError as e:
-                # if the cert is missing, certutil will return 255, ignore it
-                if e.returncode != 255:
-                    raise e
-                logger.warning(
-                    'Unable to remove old %s certificate from NSS database (rc: %d)',
-                    cert_id, e.returncode)
+                    token=cert['token']):
+                logger.error('Certificate already exists: %s', cert_id)
+                sys.exit(1)
 
             logger.info('Importing new %s certificate into NSS database', cert_id)
 

--- a/base/server/python/pki/server/cli/instance.py
+++ b/base/server/python/pki/server/cli/instance.py
@@ -714,7 +714,9 @@ class InstanceExternalCertAddCLI(pki.cli.CLI):
             password=password,
             token=token)
         _chain, nicks = certdb.import_cert_chain(
-            nickname, cert_file, trust_attributes=trust_args)
+            nickname=nickname,
+            cert_chain_file=cert_file,
+            trust_attributes=trust_args)
         return nicks
 
     def update_instance_config(self, instance, nicks, token):

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -4078,7 +4078,8 @@ class ConfigClient:
         config.pki_log.info("loading %s certificate", nickname,
                             extra=config.PKI_INDENTATION_LEVEL_2)
 
-        cert.cert = nssdb.get_cert(nickname)
+        cert.cert = nssdb.get_cert(
+            nickname=nickname)
 
     def set_system_certs(self, nssdb, data):
         systemCerts = []  # nopep8
@@ -4354,7 +4355,7 @@ class ConfigClient:
 
             try:
                 data.adminCert = client_nssdb.get_cert(
-                    self.mdict['pki_admin_nickname'])
+                    nickname=self.mdict['pki_admin_nickname'])
                 if data.adminCert:  # already imported, return
                     return
 

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -85,7 +85,12 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         return (key_type, key_size, curve, hash_alg)
 
-    def generate_csr(self, deployer, nssdb, subsystem, tag, csr_path,
+    def generate_csr(self,
+                     deployer,
+                     nssdb,
+                     subsystem,
+                     tag,
+                     csr_path,
                      basic_constraints_ext=None,
                      key_usage_ext=None,
                      extended_key_usage_ext=None,
@@ -97,6 +102,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             "generating %s CSR in %s", cert_id, csr_path,
             extra=config.PKI_INDENTATION_LEVEL_2)
 
+        cert = subsystem.get_subsystem_cert(tag)
+        token = pki.nssdb.normalize_token(cert['token'])
+
         subject_dn = deployer.mdict['pki_%s_subject_dn' % cert_id]
 
         (key_type, key_size, curve, hash_alg) = self.get_key_params(
@@ -105,6 +113,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         nssdb.create_request(
             subject_dn=subject_dn,
             request_file=csr_path,
+            token=token,
             key_type=key_type,
             key_size=key_size,
             curve=curve,
@@ -158,7 +167,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             generic_exts = [generic_ext]
 
         self.generate_csr(
-            deployer, nssdb, subsystem, 'signing', csr_path,
+            deployer,
+            nssdb,
+            subsystem,
+            'signing',
+            csr_path,
             basic_constraints_ext=basic_constraints_ext,
             key_usage_ext=key_usage_ext,
             generic_exts=generic_exts
@@ -938,7 +951,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 remove_key = False
             else:
                 remove_key = True
-            nssdb.remove_cert(nickname, remove_key=remove_key)
+            nssdb.remove_cert(nickname=nickname,
+                              remove_key=remove_key)
 
         finally:
             nssdb.close()

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -960,7 +960,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             with open(cert_file, 'w') as f:
                 f.write(pem_cert)
 
-            nssdb.add_cert(nickname, cert_file)
+            nssdb.add_cert(
+                nickname=nickname,
+                cert_file=cert_file)
 
         finally:
             nssdb.close()

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -794,7 +794,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         cert_id = self.get_cert_id(subsystem, tag)
         nickname = deployer.mdict['pki_%s_nickname' % cert_id]
-        cert_data = nssdb.get_cert(nickname)
+        cert_data = nssdb.get_cert(
+            nickname=nickname)
 
         if not cert_data:
             return
@@ -836,7 +837,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 "checking existing SSL server cert: %s", nickname,
                 extra=config.PKI_INDENTATION_LEVEL_2)
 
-            pem_cert = nssdb.get_cert(nickname)
+            pem_cert = nssdb.get_cert(
+                nickname=nickname)
 
             if pem_cert:
                 cert = x509.load_pem_x509_certificate(pem_cert, default_backend())


### PR DESCRIPTION
## How was the list of commits prepared?
Since the `cert-fix` exists in cert.py, I compared the history of `DOGTAG_10_5_BRANCH` with `master`. The list was then made from the point where `DOGTAG_10_5_BRANCH` was left behind

## How to review this PR
1. Refer table below for any major merge conflicts
2. The commits in the table refer to the commits in this PR
3. The original commit ID have been included in the individual commit's description
4. Conflict resolution is also included in the commit's description

| Commit | Commit Desc | Review Required| Reviewed |
|--------|------------|-------------|-----|
| ce9f8c4cb1aed1a739fade7bf75c556b81888a4c | Added param to override default token in NSSDatabase.  | Yes | <ul><li>[ ] Done</li></ul>  |
|a03a547c8f4c883760598be94dbdc284b1a1a0b9| Added logging for pki-server cert-find | No |
|36ef994dcd666ae1f462433d167531bf3ff99aec| Refactored pki-server cert-find | Yes | <ul><li>[ ] Done</li></ul> |
|35e9421857191eaef21705d3e34a86debd3d219a| Added logger for pki-server cert-create | No | |
|8871b33f9458eed28ff1a935c616e0522202abbf | Added logger for pki-server cert-import | No | |
|bb0bf50e742ee44ae6d00f19b2f994d90337262a | Added logger for pki-server cert-update | No | |
|197763a86c072ee78937454aeeb912637b62b81c | Refactored NSSDatabase.get_cert() | Yes |<ul><li>[ ] Done</li></ul> |
|b278e6632710a9155e2fe7dd35b624a9793b1556 | Updated logging in pki-server cert-create | No | |
|b1c4d9ebf4945022e4a8ca9f1078a5b1678b3cd1|Refactored NSSDatabase.remove_cert()| Yes | <ul><li>[ ] Done</li></ul> |
|eb3ec4c9df5c849d029070679df1f6b1343934bb|Updated logging in pki-server cert-import|No| |
|e84e186103dc4e96c4426faead57c3b9cb8b5334|Updated logging in pki-server cert-find|No| |
|080dc498ad570b63bbf0a014ad509141d1ad0647|Added pki-server cert-del|No| |
|2c04b8662d225f4117d3694e0761d642ce3fb595|Fixed pki-server cert-import|No| |
|bfb887d7bf72f60809210b58c1015f4e849efd1f| Cleaned up pki-server cert commands  | Yes | <ul><li>[ ] Done</li></ul> |
|1da5c0029c75452451fcd6fbd501e46b92913b47|cert-create --serial option takes both hex and int|No||
|824cfa7a1a1acbfb70f3606613930d63714417ce|Fix trust flags for audit and ca signing cert|No||
|9e93741292192917acb0a9274e49bc73c7837a98|Refactoring `cert-del` module and generalizing split of `cert_id` field (#66)|Yes |<ul><li>[ ] Done</li></ul> |
|3e4c086dc015181c1ef08d926e2aff5b72db4448|Refactor `cert-import` and `cert-update` module (#67)|No||
|6ad5133324664487a04b11127bb8d77578a8884d|Refactoring `split_cert_id` for code reusability (#71)|Yes|<ul><li>[ ] Done</li></ul> |
|bc7fbe9d0311678338f4c9130cddd19db028efba|Refactoring `temp cert creation` (#72)|Yes|<ul><li>[ ] Done</li></ul> |
|824721b9a479967a202ec87fde162f475c27eab5| Refactoring of `setup_authentication` (#73)|Yes| <ul><li>[ ] Done</li></ul> |
|020c68a55959d86c686a712d5ba42de0b1970b5c|Fixed pki-server cert-* output|No| |
|2b89b557f6dc628d6ea5bd52ed98feaf3629f73f|Refactoring `cert_create` module to accommodate `cert-fix` (#96)| Yes|<ul><li>[ ] Done</li></ul> |
|0b7bc3d778c63a1e682e28da5f9e2bce36efc42e|Refactoring cert_del method to PKI Instance (#101)|No||
|879d1438a51ff6e193c39910ecc29a944b5f790b|Refactoring cert-import module (#102)|No| |
|b455ffdf15d469c3e34acc33771a814febc74502|Adding `cert-fix` module for automated Offline Cert Renewal Tool (#98)|No | |
|0c8b4ec37631e9778ab54720898a9eae88296992|Minor bug fix in cert-fix module|No | |
|a36b5bbf5506be342ce493a4851a7db8416935f2|Refactoring `seltest` module (#64)|No | |