### PR TITLE
[10.6] cert-fix enhancements

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1632,6 +1632,14 @@ class PKIInstance(object):
                 raise PKIServerException('No subsystem can be loaded for %s in '
                                          'instance %s.' % (cert_id, self.name))
 
+    @property
+    def cert_folder(self):
+        return os.path.join(pki.CONF_DIR, self.name, 'certs')
+
+    def cert_file(self, cert_id):
+        """Compute name of certificate under instance cert folder."""
+        return os.path.join(self.cert_folder, cert_id + '.crt')
+
     def nssdb_import_cert(self, cert_id, cert_file=None):
         """
         Add cert from cert_file to NSS db with appropriate trust flags
@@ -1663,11 +1671,9 @@ class PKIInstance(object):
         nssdb = self.open_nssdb()
 
         try:
-            cert_folder = os.path.join(pki.CONF_DIR, self.name, 'certs')
-
             # If cert_file is not provided, load the cert from /etc/pki/certs/<cert_id>.crt
             if not cert_file:
-                cert_file = os.path.join(cert_folder, cert_id + '.crt')
+                cert_file = self.cert_file(cert_id)
 
             if not os.path.isfile(cert_file):
                 raise PKIServerException('%s does not exist.' % cert_file)
@@ -1754,14 +1760,13 @@ class PKIInstance(object):
         nssdb = self.open_nssdb()
         tmpdir = tempfile.mkdtemp()
         try:
-            cert_folder = os.path.join(pki.CONF_DIR, self.name, 'certs')
-            if not os.path.exists(cert_folder):
-                os.makedirs(cert_folder)
+            if not os.path.exists(self.cert_folder):
+                os.makedirs(self.cert_folder)
 
             if output:
                 new_cert_file = output
             else:
-                new_cert_file = os.path.join(cert_folder, cert_id + '.crt')
+                new_cert_file = self.cert_file(cert_id)
 
             subsystem_name, cert_tag = PKIServer.split_cert_id(cert_id)
 

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1045,6 +1045,30 @@ class PKISubsystem(object):
             raise PKIServerException('Failed to generate CA-signed temp SSL '
                                      'certificate. RC: %d' % rc)
 
+    def get_db_config(self):
+        """Return DB configuration as dict."""
+        shortkeys = [
+            'ldapconn.host', 'ldapconn.port', 'ldapconn.secureConn',
+            'ldapauth.authtype', 'ldapauth.bindDN', 'ldapauth.bindPWPrompt',
+            'ldapauth.clientCertNickname', 'database', 'basedn',
+            'multipleSuffix.enable', 'maxConns', 'minConns',
+        ]
+        db_keys = ['internaldb.{}'.format(x) for x in shortkeys]
+        return {k: v for k, v in self.config.items() if k in db_keys}
+
+    def set_db_config(self, new_config):
+        """Write the dict of DB configuration to subsystem config.
+
+        Right now this does not perform sanity checks; it just calls
+        ``update`` on the config dict.  Fields that are ``None`` will
+        overwrite the existing key.  So if you do not want to reset a
+        field, ensure the key is absent.
+
+        Likewise, extraneous fields will be set into the main config.
+
+        """
+        self.config.update(new_config)
+
 
 class CASubsystem(PKISubsystem):
 

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -40,6 +40,8 @@ import six
 from lxml import etree
 
 import pki
+import pki.account
+import pki.cert
 import pki.client as client
 import pki.nssdb
 import pki.util
@@ -97,8 +99,19 @@ class PKIServer(object):
         return subsystem_name, cert_tag
 
     @staticmethod
-    def setup_authentication(client_nssdb_pass, client_nssdb_pass_file, client_cert,
-                             client_nssdb, tmpdir, subsystem_name):
+    def setup_password_authentication(username, password, subsystem_name='ca'):
+        """Return a PKIConnection, logged in using username and password."""
+        connection = client.PKIConnection(
+            'https', os.environ['HOSTNAME'], '8443', subsystem_name)
+        connection.authenticate(username, password)
+        account_client = pki.account.AccountClient(connection)
+        account_client.login()
+        return connection
+
+    @staticmethod
+    def setup_cert_authentication(
+            client_nssdb_pass, client_nssdb_pass_file, client_cert,
+            client_nssdb, tmpdir, subsystem_name):
         """
         Utility method to set up a secure authenticated connection with a
         subsystem of PKI Server through PKI client
@@ -1729,14 +1742,21 @@ class PKIInstance(object):
         updated_cert = self.nssdb_import_cert(cert_id, cert_file)
         self.cert_update_config(cert_id, updated_cert)
 
-    def cert_create(self, cert_id, client_cert=None, client_nssdb=None, client_nssdb_pass=None,
-                    client_nssdb_pass_file=None, serial=None, temp_cert=False, renew=False,
-                    output=None):
+    def cert_create(
+            self, cert_id,
+            username=None, password=None,
+            client_cert=None, client_nssdb=None,
+            client_nssdb_pass=None, client_nssdb_pass_file=None,
+            serial=None, temp_cert=False, renew=False, output=None):
         """
         Create a new cert for the cert_id provided
 
         :param cert_id: New cert's ID
         :type cert_id: str
+        :param username: Username (must also supply password)
+        :type username: str
+        :param password: Password (must also supply username)
+        :type password: str
         :param client_cert: Client cert nickname
         :type client_cert: str
         :param client_nssdb: Path to nssdb
@@ -1756,6 +1776,11 @@ class PKIInstance(object):
         :return: None
         :rtype: None
         :raises PKIServerException
+
+        Either supply both username and password, or supply
+        client_nssdb and client_cert and
+        (client_nssdb_pass or client_nssdb_pass_file).
+
         """
         nssdb = self.open_nssdb()
         tmpdir = tempfile.mkdtemp()
@@ -1794,21 +1819,23 @@ class PKIInstance(object):
                     # TODO: Support rekey
                     raise PKIServerException('Rekey is not supported yet.')
 
-                if not client_cert:
-                    raise PKIServerException('Client cert nick name required.')
-
-                if not client_nssdb_pass and not client_nssdb_pass_file:
-                    raise PKIServerException('NSS db password required.')
-
                 logger.info('Trying to setup a secure connection to CA subsystem.')
-                connection = PKIServer.setup_authentication(
-                    client_nssdb_pass=client_nssdb_pass,
-                    client_cert=client_cert,
-                    client_nssdb_pass_file=client_nssdb_pass_file,
-                    client_nssdb=client_nssdb,
-                    tmpdir=tmpdir,
-                    subsystem_name='ca'
-                )
+                if username and password:
+                    connection = PKIServer.setup_password_authentication(
+                        username, password, subsystem_name='ca')
+                else:
+                    if not client_cert:
+                        raise PKIServerException('Client cert nick name required.')
+                    if not client_nssdb_pass and not client_nssdb_pass_file:
+                        raise PKIServerException('NSS db password required.')
+                    connection = PKIServer.setup_cert_authentication(
+                        client_nssdb_pass=client_nssdb_pass,
+                        client_cert=client_cert,
+                        client_nssdb_pass_file=client_nssdb_pass_file,
+                        client_nssdb=client_nssdb,
+                        tmpdir=tmpdir,
+                        subsystem_name='ca'
+                    )
                 logger.info('Secure connection with CA is established.')
 
                 logger.info('Placing cert creation request for serial: %s', serial)

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1272,11 +1272,7 @@ class PKIInstance(object):
                     self.group = m.group(1)
                     self.gid = grp.getgrnam(self.group).gr_gid
 
-        # load passwords
-        self.passwords.clear()
-        if os.path.exists(self.password_conf):
-            logger.info('Loading password config: %s', self.password_conf)
-            pki.util.load_properties(self.password_conf, self.passwords)
+        self.load_passwords()
 
         self.load_external_certs(self.external_certs_conf)
 
@@ -1447,6 +1443,19 @@ class PKIInstance(object):
 
             finally:
                 shutil.rmtree(tmpdir)
+
+    def load_passwords(self):
+
+        self.passwords.clear()
+
+        if os.path.exists(self.password_conf):
+            logger.info('Loading password config: %s', self.password_conf)
+            pki.util.load_properties(self.password_conf, self.passwords)
+
+    def store_passwords(self):
+
+        pki.util.store_properties(self.password_conf, self.passwords)
+        pki.util.chown(self.password_conf, self.uid, self.gid)
 
     def get_server_config(self):
         server_config = ServerConfiguration(self.server_xml)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -996,6 +996,7 @@ class CertFixCLI(pki.cli.CLI):
         # ca.cert.list=signing,ocsp_signing,sslserver,subsystem,audit_signing
         print()
         print('      --cert <Cert ID>            Fix specified system cert (default: all certs).')
+        print('      --extra-cert <Serial>       Also renew cert with given serial number.')
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('  -v, --verbose                   Run in verbose mode.')
         print('      --debug                     Run in debug mode.')
@@ -1007,7 +1008,7 @@ class CertFixCLI(pki.cli.CLI):
 
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'cert=',
+                'instance=', 'cert=', 'extra-cert=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -1018,6 +1019,7 @@ class CertFixCLI(pki.cli.CLI):
         instance_name = 'pki-tomcat'
         all_certs = True
         fix_certs = []
+        extra_certs = []
 
         for o, a in opts:
             if o in ('-i', '--instance'):
@@ -1026,6 +1028,15 @@ class CertFixCLI(pki.cli.CLI):
             elif o == '--cert':
                 all_certs = False
                 fix_certs.append(a)
+
+            elif o == '--extra-cert':
+                try:
+                    int(a)
+                except ValueError:
+                    logger.error('--extra-cert requires serial number as integer')
+                    sys.exit(1)
+                all_certs = False
+                extra_certs.append(a)
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -1073,7 +1084,8 @@ class CertFixCLI(pki.cli.CLI):
 
                     fix_certs.append(cert['id'])
 
-        logger.info('Fixing the following certs: %s', fix_certs)
+        logger.info('Fixing the following system certs: %s', fix_certs)
+        logger.info('Renewing the following additional certs: %s', extra_certs)
 
         # 2. Stop the server, if it's up
         logger.info('Stopping the instance to proceed with system cert renewal')
@@ -1152,6 +1164,17 @@ class CertFixCLI(pki.cli.CLI):
                         instance.cert_create(
                             cert_id=cert_id, renew=True,
                             username='admin', password=admin_pass)
+                    for serial in extra_certs:
+                        output = instance.cert_file('{}-renewed'.format(serial))
+                        logger.info(
+                            'Requesting new cert for %s; writing to %s',
+                            serial, output)
+                        try:
+                            instance.cert_create(
+                                serial=serial, renew=True, output=output,
+                                username='admin', password=admin_pass)
+                        except pki.PKIException as e:
+                            logger.error("Failed to renew certificate %s: %s", serial, e)
 
                 # 8. Delete existing certs and then import the renewed system cert(s)
                 for cert_id in fix_certs:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -31,6 +31,7 @@ import os
 import random
 import subprocess
 import sys
+import time
 
 import pki.cert
 import pki.cli
@@ -1198,6 +1199,8 @@ def start_stop(instance):
     """Start the server, run the block, and guarantee stop afterwards."""
     logger.info('Starting the instance')
     instance.start()
+    logger.info('Sleeping for 10 seconds to allow server time to start...')
+    time.sleep(10)
     try:
         yield
     finally:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -22,6 +22,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from contextlib import contextmanager
 import datetime
 import getopt
 import getpass
@@ -1122,65 +1123,49 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
-            # Convert set to list
-            target_subsys = list(target_subsys)
+            with suppress_selftest(target_subsys):
 
-            for subsystem in target_subsys:
-                subsystem.set_startup_test_criticality(False)
-                subsystem.save()
+                # 4. Bring up the server using a temp SSL cert if the sslcert is expired
+                if 'sslserver' in fix_certs:
+                    # 4a. Create temp SSL cert
+                    logger.info('Creating a temporary sslserver cert')
+                    instance.cert_create(cert_id='sslserver', temp_cert=True)
 
-            logger.info('Selftests disabled for subsystems: %s', ', '.join(
-                str(x.name) for x in target_subsys))
+                    # 4b. Delete the existing SSL Cert
+                    logger.debug('Removing sslserver cert from instance')
+                    instance.cert_del('sslserver')
 
-            # 4. Bring up the server using a temp SSL cert if the sslcert is expired
-            if 'sslserver' in fix_certs:
-                # 4a. Create temp SSL cert
-                logger.debug('Creating a temp sslserver cert')
-                instance.cert_create(cert_id='sslserver', temp_cert=True)
+                    # 4d. Import the temp sslcert into the instance
+                    logger.debug('Importing temp sslserver cert')
+                    instance.cert_import('sslserver')
 
-                # 4b. Delete the existing SSL Cert
-                logger.debug('Removing sslserver cert from instance')
-                instance.cert_del('sslserver')
+                # 5. Bring up the server temporarily
+                logger.debug('Starting the instance with temp sslserver cert')
+                instance.start()
 
-                # 4d. Import the temp sslcert into the instance
-                logger.debug('Importing temp sslserver cert')
-                instance.cert_import('sslserver')
+                # 6. Place renewal request for all certs in fix_certs
+                for cert_id in fix_certs:
+                    logger.debug('Creating new cert for %s', cert_id)
+                    instance.cert_create(cert_id=cert_id,
+                                         client_cert=client_cert,
+                                         client_nssdb=client_nssdb,
+                                         client_nssdb_pass=client_nssdb_pass,
+                                         client_nssdb_pass_file=client_nssdb_pass_file,
+                                         renew=True)
 
-            # 5. Bring up the server temporarily
-            logger.debug('Starting the instance with temp sslserver cert')
-            instance.start()
+                # 7. Stop the server
+                logger.debug('Stopping the instance')
+                instance.stop()
 
-            # 6. Place renewal request for all certs in fix_certs
-            for cert_id in fix_certs:
-                logger.debug('Creating new cert for %s', cert_id)
-                instance.cert_create(cert_id=cert_id,
-                                     client_cert=client_cert,
-                                     client_nssdb=client_nssdb,
-                                     client_nssdb_pass=client_nssdb_pass,
-                                     client_nssdb_pass_file=client_nssdb_pass_file,
-                                     renew=True)
+                # 8. Delete existing certs and then import the renewed system cert(s)
+                for cert_id in fix_certs:
+                    # Delete the existing cert from the instance
+                    logger.debug('Removing old %s cert from instance %s', cert_id, instance_name)
+                    instance.cert_del(cert_id)
 
-            # 7. Stop the server
-            logger.debug('Stopping the instance')
-            instance.stop()
-
-            # 8. Delete existing certs and then import the renewed system cert(s)
-            for cert_id in fix_certs:
-                # Delete the existing cert from the instance
-                logger.debug('Removing old %s cert from instance %s', cert_id, instance_name)
-                instance.cert_del(cert_id)
-
-                # Import this new cert into the instance
-                logger.debug('Importing new %s cert into instance %s', cert_id, instance_name)
-                instance.cert_import(cert_id)
-
-            # 9. Enable self tests for the subsystems disabled earlier
-            for subsystem in target_subsys:
-                subsystem.set_startup_test_criticality(True)
-                subsystem.save()
-
-            logger.info('Selftests enabled for subsystems: %s', ', '.join(
-                str(x.name) for x in target_subsys))
+                    # Import this new cert into the instance
+                    logger.debug('Importing new %s cert into instance %s', cert_id, instance_name)
+                    instance.cert_import(cert_id)
 
             # 10. Bring up the server
             logger.info('Starting the instance with renewed certs')
@@ -1189,3 +1174,23 @@ class CertFixCLI(pki.cli.CLI):
         except server.PKIServerException as e:
             logger.error(str(e))
             sys.exit(1)
+
+
+@contextmanager
+def suppress_selftest(subsystems):
+    """Suppress selftests in the given subsystems."""
+    for subsystem in subsystems:
+        subsystem.set_startup_test_criticality(False)
+        subsystem.save()
+    logger.info(
+        'Selftests disabled for subsystems: %s',
+        ', '.join(str(x.name) for x in subsystems))
+    try:
+        yield
+    finally:
+        for subsystem in subsystems:
+            subsystem.set_startup_test_criticality(True)
+            subsystem.save()
+        logger.info(
+            'Selftests enabled for subsystems: %s',
+            ', '.join(str(x.name) for x in subsystems))

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1392,6 +1392,8 @@ def ldap_conn_args(ldap_url, use_ldapi, dm_pass_file):
     else:
         if ldap_url:
             args.extend(['-H', ldap_url])
+            if not ldap_url.startswith('ldaps'):
+                args.append('-ZZ')  # require STARTTLS
         args.extend(['-D', 'cn=Directory Manager', '-y', dm_pass_file])
     return args
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1105,21 +1105,6 @@ class CertFixCLI(pki.cli.CLI):
         dbuser_dn = 'uid=pkidbuser,ou=people,{}'.format(basedn)
         agent_dn = 'uid={},ou=people,{}'.format(agent_uid, basedn)
 
-        # Prompt for DM password
-        dm_pass = getpass.getpass(prompt='Enter Directory Manager password: ')
-        try:
-            subprocess.check_output([
-                'ldapsearch', '-D', 'cn=Directory Manager', '-w', dm_pass,
-                '-s', 'base', '-b', basedn, '1.1',
-            ])
-        except subprocess.CalledProcessError:
-            logger.error("Failed to verify Directory Manager password.")
-            sys.exit(1)
-
-        logger.info('Resetting password for %s', agent_dn)
-        agent_pass = gen_random_password()
-        ldappasswd(dm_pass, agent_dn, agent_pass)
-
         # 3. Find the subsystem and disable Self-tests
         try:
             # Placeholder used to hold subsystems whose selftest have been turned off
@@ -1148,8 +1133,30 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
-            with ldap_password_authn(instance, target_subsys, dbuser_dn, dm_pass), \
+            # Prompt for DM password
+            dm_pass = getpass.getpass(prompt='Enter Directory Manager password: ')
+
+            # Generate new password for agent account
+            agent_pass = gen_random_password()
+
+            with write_temp_file(dm_pass.encode('utf8')) as dm_pass_file, \
+                    write_temp_file(agent_pass.encode('utf8')) as agent_pass_file, \
+                    ldap_password_authn(instance, target_subsys, dbuser_dn, dm_pass_file), \
                     suppress_selftest(target_subsys):
+
+                # Verify DM password
+                try:
+                    subprocess.check_output([
+                        'ldapsearch', '-D', 'cn=Directory Manager', '-y', dm_pass_file,
+                        '-s', 'base', '-b', basedn, '1.1',
+                    ])
+                except subprocess.CalledProcessError:
+                    logger.error("Failed to verify Directory Manager password.")
+                    sys.exit(1)
+
+                # Reset agent password
+                logger.info('Resetting password for %s', agent_dn)
+                ldappasswd(dm_pass_file, agent_dn, agent_pass_file)
 
                 # 4. Bring up the server using a temp SSL cert if the sslcert is expired
                 if 'sslserver' in fix_certs:
@@ -1198,8 +1205,7 @@ class CertFixCLI(pki.cli.CLI):
                 # TLS auth, add the cert to pkidbuser entry
                 if dbuser_dn and 'subsystem' in fix_certs:
                     logger.info('Importing new subsystem cert into %s', dbuser_dn)
-                    with NamedTemporaryFile(mode='w+b') as ldif_file, \
-                            NamedTemporaryFile(mode='w+b') as der_file:
+                    with NamedTemporaryFile(mode='w+b') as der_file:
                         # convert subsystem cert to DER
                         subprocess.check_call([
                             'openssl', 'x509',
@@ -1208,21 +1214,17 @@ class CertFixCLI(pki.cli.CLI):
                             '-out', der_file.name,
                         ])
 
-                        # write LDIF
-                        ldif_file.write(
-                            self.PKIDBUSER_LDIF_TEMPLATE.format(
-                                dn=dbuser_dn, der_file=der_file.name)
-                            .encode('utf-8')
-                        )
-                        ldif_file.flush()
-                        os.fsync(ldif_file.fileno())
-
-                        # ldapmodify
-                        subprocess.check_call([
-                            'ldapmodify',
-                            '-D', 'cn=Directory Manager', '-w', dm_pass,
-                            '-f', ldif_file.name,
-                        ])
+                        with write_temp_file(
+                            self.PKIDBUSER_LDIF_TEMPLATE
+                                .format(dn=dbuser_dn, der_file=der_file.name)
+                                .encode('utf-8')
+                        ) as ldif_file:
+                            # ldapmodify
+                            subprocess.check_call([
+                                'ldapmodify',
+                                '-D', 'cn=Directory Manager', '-y', dm_pass_file,
+                                '-f', ldif_file,
+                            ])
 
             # 10. Bring up the server
             logger.info('Starting the instance with renewed certs')
@@ -1268,7 +1270,7 @@ def start_stop(instance):
 
 
 @contextmanager
-def ldap_password_authn(instance, subsystems, bind_dn, dm_pass):
+def ldap_password_authn(instance, subsystems, bind_dn, dm_pass_file):
     """LDAP password authentication context.
 
     This context manager switches the server to password
@@ -1322,7 +1324,8 @@ def ldap_password_authn(instance, subsystems, bind_dn, dm_pass):
             # _now_ we can perform ldappasswd
             if not ldappasswd_performed:
                 logger.info('Setting pkidbuser password via ldappasswd')
-                ldappasswd(dm_pass, bind_dn, password)
+                with write_temp_file(password.encode('utf8')) as pwdfile:
+                    ldappasswd(dm_pass_file, bind_dn, pwdfile)
                 ldappasswd_performed = True
 
         elif authtype == 'BasicAuth':
@@ -1348,7 +1351,7 @@ def ldap_password_authn(instance, subsystems, bind_dn, dm_pass):
             instance.store_passwords()
 
 
-def ldappasswd(dm_pass, user_dn, password):
+def ldappasswd(dm_pass_file, user_dn, pass_file):
     """
     Run ldappasswd as Directory Manager.
 
@@ -1357,8 +1360,8 @@ def ldappasswd(dm_pass, user_dn, password):
     """
     subprocess.check_call([
         'ldappasswd',
-        '-D', 'cn=Directory Manager', '-w', dm_pass,
-        '-s', password,
+        '-D', 'cn=Directory Manager', '-y', dm_pass_file,
+        '-T', pass_file,
         user_dn,
     ])
 
@@ -1367,3 +1370,13 @@ def gen_random_password():
     rnd = random.SystemRandom()
     xs = "abcdefghijklmnopqrstuvwxyz0123456789"
     return ''.join(rnd.choice(xs) for i in range(32))
+
+
+@contextmanager
+def write_temp_file(data):
+    """Create a temporary file, write data to it, yield the filename."""
+    with NamedTemporaryFile() as f:
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())
+        yield f.name

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1145,6 +1145,9 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
+            if len(extra_certs) > 0:
+                target_subsys.add(ca_subsystem)
+
             # Generate new password for agent account
             agent_pass = gen_random_password()
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1139,23 +1139,17 @@ class CertFixCLI(pki.cli.CLI):
                     logger.debug('Importing temp sslserver cert')
                     instance.cert_import('sslserver')
 
-                # 5. Bring up the server temporarily
-                logger.debug('Starting the instance with temp sslserver cert')
-                instance.start()
-
-                # 6. Place renewal request for all certs in fix_certs
-                for cert_id in fix_certs:
-                    logger.debug('Creating new cert for %s', cert_id)
-                    instance.cert_create(cert_id=cert_id,
-                                         client_cert=client_cert,
-                                         client_nssdb=client_nssdb,
-                                         client_nssdb_pass=client_nssdb_pass,
-                                         client_nssdb_pass_file=client_nssdb_pass_file,
-                                         renew=True)
-
-                # 7. Stop the server
-                logger.debug('Stopping the instance')
-                instance.stop()
+                with start_stop(instance):
+                    # Place renewal request for all certs in fix_certs
+                    for cert_id in fix_certs:
+                        logger.info('Requesting new cert for %s', cert_id)
+                        instance.cert_create(
+                            cert_id=cert_id,
+                            client_cert=client_cert,
+                            client_nssdb=client_nssdb,
+                            client_nssdb_pass=client_nssdb_pass,
+                            client_nssdb_pass_file=client_nssdb_pass_file,
+                            renew=True)
 
                 # 8. Delete existing certs and then import the renewed system cert(s)
                 for cert_id in fix_certs:
@@ -1194,3 +1188,15 @@ def suppress_selftest(subsystems):
         logger.info(
             'Selftests enabled for subsystems: %s',
             ', '.join(str(x.name) for x in subsystems))
+
+
+@contextmanager
+def start_stop(instance):
+    """Start the server, run the block, and guarantee stop afterwards."""
+    logger.info('Starting the instance')
+    instance.start()
+    try:
+        yield
+    finally:
+        logger.info('Stopping the instance')
+        instance.stop()

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1107,15 +1107,25 @@ class CertFixCLI(pki.cli.CLI):
         logger.info('Fixing the following system certs: %s', fix_certs)
         logger.info('Renewing the following additional certs: %s', extra_certs)
 
-        # 2. Stop the server, if it's up
-        logger.info('Stopping the instance to proceed with system cert renewal')
-        instance.stop()
-
         # Get the CA subsystem and find out Base DN.
         ca_subsystem = instance.get_subsystem('ca')
         basedn = ca_subsystem.get_db_config()['internaldb.basedn']
         dbuser_dn = 'uid=pkidbuser,ou=people,{}'.format(basedn)
         agent_dn = 'uid={},ou=people,{}'.format(agent_uid, basedn)
+
+        # Verify LDAP connection
+        try:
+            subprocess.check_output([
+                'ldapsearch', '-H', ldap_url, '-Y', 'EXTERNAL',
+                '-s', 'base', '-b', basedn, '1.1',
+            ])
+        except subprocess.CalledProcessError:
+            logger.error("Failed to connect to LDAP at %s", ldap_url)
+            sys.exit(1)
+
+        # 2. Stop the server, if it's up
+        logger.info('Stopping the instance to proceed with system cert renewal')
+        instance.stop()
 
         # 3. Find the subsystem and disable Self-tests
         try:
@@ -1154,17 +1164,6 @@ class CertFixCLI(pki.cli.CLI):
             with write_temp_file(agent_pass.encode('utf8')) as agent_pass_file, \
                     ldap_password_authn(instance, target_subsys, dbuser_dn, ldap_url), \
                     suppress_selftest(target_subsys):
-
-                # Verify LDAP connection
-                try:
-                    subprocess.check_output([
-                        'ldapsearch', '-H', ldap_url, '-Y', 'EXTERNAL',
-                        '-s', 'base', '-b', basedn, '1.1',
-                    ])
-                except subprocess.CalledProcessError:
-                    logger.error("Failed to connect to LDAP at %s", ldap_url)
-                    sys.exit(1)
-
                 # Reset agent password
                 logger.info('Resetting password for %s', agent_dn)
                 ldappasswd(ldap_url, agent_dn, agent_pass_file)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1004,7 +1004,7 @@ class CertFixCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        logging.basicConfig(format='%(levelname)s: %(message)s')
+        logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
@@ -1040,7 +1040,6 @@ class CertFixCLI(pki.cli.CLI):
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
-                logging.getLogger().setLevel(logging.INFO)
 
             elif o == '--debug':
                 self.set_verbose(True)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -997,6 +997,7 @@ class CertFixCLI(pki.cli.CLI):
         print()
         print('      --cert <Cert ID>            Fix specified system cert (default: all certs).')
         print('      --extra-cert <Serial>       Also renew cert with given serial number.')
+        print('      --agent-uid <String>        UID of Dogtag agent user')
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('  -v, --verbose                   Run in verbose mode.')
         print('      --debug                     Run in debug mode.')
@@ -1008,7 +1009,7 @@ class CertFixCLI(pki.cli.CLI):
 
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'cert=', 'extra-cert=',
+                'instance=', 'cert=', 'extra-cert=', 'agent-uid=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -1020,6 +1021,7 @@ class CertFixCLI(pki.cli.CLI):
         all_certs = True
         fix_certs = []
         extra_certs = []
+        agent_uid = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
@@ -1037,6 +1039,9 @@ class CertFixCLI(pki.cli.CLI):
                     sys.exit(1)
                 all_certs = False
                 extra_certs.append(a)
+
+            elif o == '--agent-uid':
+                agent_uid = a
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -1059,6 +1064,10 @@ class CertFixCLI(pki.cli.CLI):
 
         if not instance.is_valid():
             logger.error('Invalid instance %s.', instance_name)
+            sys.exit(1)
+
+        if not agent_uid:
+            logger.error('Must specify --agent-uid')
             sys.exit(1)
 
         instance.load()
@@ -1094,7 +1103,7 @@ class CertFixCLI(pki.cli.CLI):
         ca_subsystem = instance.get_subsystem('ca')
         basedn = ca_subsystem.get_db_config()['internaldb.basedn']
         dbuser_dn = 'uid=pkidbuser,ou=people,{}'.format(basedn)
-        admin_dn = 'uid=admin,ou=people,{}'.format(basedn)
+        agent_dn = 'uid={},ou=people,{}'.format(agent_uid, basedn)
 
         # Prompt for DM password
         dm_pass = getpass.getpass(prompt='Enter Directory Manager password: ')
@@ -1107,9 +1116,9 @@ class CertFixCLI(pki.cli.CLI):
             logger.error("Failed to verify Directory Manager password.")
             sys.exit(1)
 
-        logger.info('Resetting PKI admin account password.')
-        admin_pass = gen_random_password()
-        ldappasswd(dm_pass, admin_dn, admin_pass)
+        logger.info('Resetting password for %s', agent_dn)
+        agent_pass = gen_random_password()
+        ldappasswd(dm_pass, agent_dn, agent_pass)
 
         # 3. Find the subsystem and disable Self-tests
         try:
@@ -1162,7 +1171,7 @@ class CertFixCLI(pki.cli.CLI):
                         logger.info('Requesting new cert for %s', cert_id)
                         instance.cert_create(
                             cert_id=cert_id, renew=True,
-                            username='admin', password=admin_pass)
+                            username=agent_uid, password=agent_pass)
                     for serial in extra_certs:
                         output = instance.cert_file('{}-renewed'.format(serial))
                         logger.info(
@@ -1171,7 +1180,7 @@ class CertFixCLI(pki.cli.CLI):
                         try:
                             instance.cert_create(
                                 serial=serial, renew=True, output=output,
-                                username='admin', password=admin_pass)
+                                username=agent_uid, password=agent_pass)
                         except pki.PKIException as e:
                             logger.error("Failed to renew certificate %s: %s", serial, e)
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -551,8 +551,12 @@ class CertCreateCLI(pki.cli.CLI):
         instance.load()
 
         try:
-            instance.cert_create(cert_id, client_cert, client_nssdb, client_nssdb_password,
-                                 client_nssdb_pass_file, serial, temp_cert, renew, output)
+            instance.cert_create(
+                cert_id=cert_id,
+                client_cert=client_cert, client_nssdb=client_nssdb,
+                client_nssdb_pass=client_nssdb_password,
+                client_nssdb_pass_file=client_nssdb_pass_file,
+                serial=serial, temp_cert=temp_cert, renew=renew, output=output)
 
         except server.PKIServerException as e:
             logger.error(str(e))

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -34,6 +34,8 @@ import sys
 from tempfile import NamedTemporaryFile
 import time
 
+from six.moves.urllib.parse import quote  # pylint: disable=F0401,E0611
+
 import pki.cert
 import pki.cli
 import pki.nssdb
@@ -998,6 +1000,7 @@ class CertFixCLI(pki.cli.CLI):
         print('      --cert <Cert ID>            Fix specified system cert (default: all certs).')
         print('      --extra-cert <Serial>       Also renew cert with given serial number.')
         print('      --agent-uid <String>        UID of Dogtag agent user')
+        print('      --ldapi-socket <Path>       Path to DS LDAPI socket')
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('  -v, --verbose                   Run in verbose mode.')
         print('      --debug                     Run in debug mode.')
@@ -1010,7 +1013,8 @@ class CertFixCLI(pki.cli.CLI):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=', 'cert=', 'extra-cert=', 'agent-uid=',
-                'verbose', 'debug', 'help'])
+                'ldapi-socket=', 'verbose', 'debug', 'help',
+            ])
 
         except getopt.GetoptError as e:
             logger.error(e)
@@ -1022,6 +1026,7 @@ class CertFixCLI(pki.cli.CLI):
         fix_certs = []
         extra_certs = []
         agent_uid = None
+        ldap_url = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
@@ -1042,6 +1047,9 @@ class CertFixCLI(pki.cli.CLI):
 
             elif o == '--agent-uid':
                 agent_uid = a
+
+            elif o == '--ldapi-socket':
+                ldap_url = 'ldapi://{}'.format(quote(a, safe=''))
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -1068,6 +1076,10 @@ class CertFixCLI(pki.cli.CLI):
 
         if not agent_uid:
             logger.error('Must specify --agent-uid')
+            sys.exit(1)
+
+        if not ldap_url:
+            logger.error('Must specify --ldapi-socket')
             sys.exit(1)
 
         instance.load()
@@ -1133,30 +1145,26 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
-            # Prompt for DM password
-            dm_pass = getpass.getpass(prompt='Enter Directory Manager password: ')
-
             # Generate new password for agent account
             agent_pass = gen_random_password()
 
-            with write_temp_file(dm_pass.encode('utf8')) as dm_pass_file, \
-                    write_temp_file(agent_pass.encode('utf8')) as agent_pass_file, \
-                    ldap_password_authn(instance, target_subsys, dbuser_dn, dm_pass_file), \
+            with write_temp_file(agent_pass.encode('utf8')) as agent_pass_file, \
+                    ldap_password_authn(instance, target_subsys, dbuser_dn, ldap_url), \
                     suppress_selftest(target_subsys):
 
-                # Verify DM password
+                # Verify LDAP connection
                 try:
                     subprocess.check_output([
-                        'ldapsearch', '-D', 'cn=Directory Manager', '-y', dm_pass_file,
+                        'ldapsearch', '-H', ldap_url, '-Y', 'EXTERNAL',
                         '-s', 'base', '-b', basedn, '1.1',
                     ])
                 except subprocess.CalledProcessError:
-                    logger.error("Failed to verify Directory Manager password.")
+                    logger.error("Failed to connect to LDAP at %s", ldap_url)
                     sys.exit(1)
 
                 # Reset agent password
                 logger.info('Resetting password for %s', agent_dn)
-                ldappasswd(dm_pass_file, agent_dn, agent_pass_file)
+                ldappasswd(ldap_url, agent_dn, agent_pass_file)
 
                 # 4. Bring up the server using a temp SSL cert if the sslcert is expired
                 if 'sslserver' in fix_certs:
@@ -1221,8 +1229,7 @@ class CertFixCLI(pki.cli.CLI):
                         ) as ldif_file:
                             # ldapmodify
                             subprocess.check_call([
-                                'ldapmodify',
-                                '-D', 'cn=Directory Manager', '-y', dm_pass_file,
+                                'ldapmodify', '-H', ldap_url, '-Y', 'EXTERNAL',
                                 '-f', ldif_file,
                             ])
 
@@ -1270,7 +1277,7 @@ def start_stop(instance):
 
 
 @contextmanager
-def ldap_password_authn(instance, subsystems, bind_dn, dm_pass_file):
+def ldap_password_authn(instance, subsystems, bind_dn, ldap_url):
     """LDAP password authentication context.
 
     This context manager switches the server to password
@@ -1325,7 +1332,7 @@ def ldap_password_authn(instance, subsystems, bind_dn, dm_pass_file):
             if not ldappasswd_performed:
                 logger.info('Setting pkidbuser password via ldappasswd')
                 with write_temp_file(password.encode('utf8')) as pwdfile:
-                    ldappasswd(dm_pass_file, bind_dn, pwdfile)
+                    ldappasswd(ldap_url, bind_dn, pwdfile)
                 ldappasswd_performed = True
 
         elif authtype == 'BasicAuth':
@@ -1351,7 +1358,7 @@ def ldap_password_authn(instance, subsystems, bind_dn, dm_pass_file):
             instance.store_passwords()
 
 
-def ldappasswd(dm_pass_file, user_dn, pass_file):
+def ldappasswd(ldap_url, user_dn, pass_file):
     """
     Run ldappasswd as Directory Manager.
 
@@ -1359,10 +1366,8 @@ def ldappasswd(dm_pass_file, user_dn, pass_file):
 
     """
     subprocess.check_call([
-        'ldappasswd',
-        '-D', 'cn=Directory Manager', '-y', dm_pass_file,
-        '-T', pass_file,
-        user_dn,
+        'ldappasswd', '-H', ldap_url, '-Y', 'EXTERNAL',
+        '-T', pass_file, user_dn,
     ])
 
 


### PR DESCRIPTION
This is a rebase of the cert-fix enhancements branch onto the 10.6
branch.  There was one trivial conflict, and one trivial additional
commit which adds a missing feature:

    c7f0e46b4 (Fraser Tweedale, 67 minutes ago)
       PKIInstance: add store_passwords method

Log (reverse):

```
c88df3f38 (Fraser Tweedale, 22 hours ago)
   cert-fix: default log verbosity to INFO

   Operators need to see a bit more about what's going on.  Default the log /
   output verbosity to INFO.

   Part of: https://pagure.io/dogtagpki/issue/2776

795987560 (Fraser Tweedale, 25 hours ago)
   cert-fix: support renewing additional certs by serial

   In a broader operational context, it may be necessary to renew more than
   just the Dogtag system certificates, e.g. expired DS service certificate or
   agent certificates.  Teach cert-fix the
   `--extra-cert' option which specifies serial numbers of additional 
   certificates to renew.

   Part of: https://pagure.io/dogtagpki/issue/2776

3a15e30aa (Fraser Tweedale, 2 days ago)
   PKIInstance.cert_create: support renewal by serial only

   PKIInstance.cert_create() currently requires the "cert_id" argument, which
   refers to a system certificate (e.g. "sslserver",
   "ca_ocsp_signing", etc).

   The cert-fix tool may need to renew other expired certificates, too, in
   order to bring a deployment back to a fully functional state
   (e.g. LDAP TLS service certificate, agent certificate).  To support this
   use case, update cert_create() to accept a serial number to be renewed,
   _without_ requiring cert_id.

   Part of: https://pagure.io/dogtagpki/issue/2776

fd6b1f51a (Fraser Tweedale, 2 days ago)
   cert-fix: use admin password authentication

   If the agent/admin certificate is expired, cert-fix will fail. Avoid this
   issue by using password authentication to submit the renewal requests.

   We don't know the current admin account password (and the user might not
   know it either), so we have to reset it.  This will be a caveat of
   cert-fix.  But because the user does know the Directory Manager password,
   they can reset the admin account password afterwards.

   Part of: https://pagure.io/dogtagpki/issue/2776

64d5cf84b (Fraser Tweedale, 2 days ago)
   cert-fix: prompt only once for DM password

   cert-fix now performs several operations that require the Directory Manager
   password.  Currently each operation prompts for the password.  Modify the
   code so that the administrator only has to enter it once.

   Part of: https://pagure.io/dogtagpki/issue/2776

87556c517 (Fraser Tweedale, 2 days ago)
   cert-fix: extract password gen and ldappasswd routines

   cert-fix will be modified to use admin/agent password authentication 
   instead of certificate authentication.  As a preliminary step, extract the
   ldappasswd and password generation logic subroutines, which will also be
   needed to set the admin/agent account password.

   Part of: https://pagure.io/dogtagpki/issue/2776

025b62a0f (Fraser Tweedale, 2 days ago)
   PKIInstance.cert_create: support password authentication

   The cert-fix tool currently needs a valid agent certificate, but this is
   not a good assumption - it could be expired.  Update the cert_create()
   method to support password authentication.

   Part of: https://pagure.io/dogtagpki/issue/2776

ad51212a0 (Fraser Tweedale, 3 days ago)
   cert-fix: add subsystem cert to pkidbuser entry

   Update cert-fix to import the subsystem certificate into the pkidbuser
   entry, if it was renewed and the instance uses LDAP TLS client
   authentication.

   Part of: https://pagure.io/dogtagpki/issue/2776

2b5c480f6 (Fraser Tweedale, 3 days ago)
   PKIInstance: add 'cert_folder' and 'cert_file' methods

   The cert_folder and locations of certificates under that folder are useful
   to know from outside the PKIInstance class.  In particular the cert-fix
   tool will need these data.  Extract the computation of the folder path to a
   property, and the computation of certificate file paths to a method.

   Part of: https://pagure.io/dogtagpki/issue/2776

39851756f (Fraser Tweedale, 3 days ago)
   cert-fix: sleep after starting server

   If the server does not start quickly enough, cert-fix sends requests to the
   server before it is ready to handle them, causing failure.

   A proper solution is to poll the server until the status resource indicates
   that it is ready.  But for now, the quick workaround is to sleep for a
   little while.

   Part of: https://pagure.io/dogtagpki/issue/2776

7b719ee17 (Fraser Tweedale, 4 days ago)
   cert-fix: use LDAP password authentication

   If the LDAP service certificate is expired and Dogtag is using a secure
   connection to LDAP, connecting to the database will fail. Likewise, if the
   subsystem certificate is expired and LDAP client cert authentication is
   configured (the default), then LDAP authentication will fail.  To avoid
   these issues, the cert-fix tool has to reconfigure subsystems to use
   password authentication on a non-TLS connection.

   Add a context manager that performs this reconfiguration, and restores
   original configuration on exit.  Update cert-fix to use this context
   manager.

   If targeted subsystems are using TLS certificate authentication, then a
   random password for pkidbuser will be generated, written to password.conf,
   and set for the user via the 'ldappasswd' command. This requires the
   Directory Manager credential.

   If targeted subsystems are already using password authentication, they are
   only reconfigured to use port 389 and no TLS/STARTTLS. ldappasswd is not
   invoked and the Directory Manager credential is not required.

   Part of: https://pagure.io/dogtagpki/issue/2776

4981edc2a (Fraser Tweedale, 4 days ago)
   PKISubsystem: add methods to read/write database config

   The offline certificate renewal system needs to be able to adjust database
   configuration, and restore it afterwards.  As a step towards this, add
   PKISubsystem methods 'get_db_config' and
   'set_db_config'.

   Part of: https://pagure.io/dogtagpki/issue/2776

3c9473f2f (Fraser Tweedale, 4 days ago)
   cert-fix: ensure server stopped before restoring config

   Use a context manager to ensure, even in presense of exception, that the
   server gets stopped before configuration (CS.cfg) gets restored.

   Part of: https://pagure.io/dogtagpki/issue/2776

47705ad02 (Fraser Tweedale, 4 days ago)
   cert-fix: use context manager to disable/enable selftest

   To ensure self-test criticality is reinstated even when cert-fix fails due
   to exception, use a context manager.  This change also improves readability
   a bit.

   Also promote the "creating temporary sslserver cert" message from DEBUG to
   INFO.

   Part of: https://pagure.io/dogtagpki/issue/2776

c7f0e46b4 (Fraser Tweedale, 67 minutes ago)
   PKIInstance: add store_passwords method

   Manual partial backport of 768e5bc05b92e4b773c6184a2357ea29079b5772, which
   is needed by cert-fix.

   Part of: https://pagure.io/dogtagpki/issue/2776
```