### PR TITLE
[master] cert-fix enhancements

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1556,6 +1556,30 @@ class PKISubsystem(object):
             raise PKIServerException('Failed to generate CA-signed temp SSL '
                                      'certificate. RC: %d' % rc)
 
+    def get_db_config(self):
+        """Return DB configuration as dict."""
+        shortkeys = [
+            'ldapconn.host', 'ldapconn.port', 'ldapconn.secureConn',
+            'ldapauth.authtype', 'ldapauth.bindDN', 'ldapauth.bindPWPrompt',
+            'ldapauth.clientCertNickname', 'database', 'basedn',
+            'multipleSuffix.enable', 'maxConns', 'minConns',
+        ]
+        db_keys = ['internaldb.{}'.format(x) for x in shortkeys]
+        return {k: v for k, v in self.config.items() if k in db_keys}
+
+    def set_db_config(self, new_config):
+        """Write the dict of DB configuration to subsystem config.
+
+        Right now this does not perform sanity checks; it just calls
+        ``update`` on the config dict.  Fields that are ``None`` will
+        overwrite the existing key.  So if you do not want to reset a
+        field, ensure the key is absent.
+
+        Likewise, extraneous fields will be set into the main config.
+
+        """
+        self.config.update(new_config)
+
 
 class CASubsystem(PKISubsystem):
 

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -2281,7 +2281,7 @@ class PKIInstance(PKIServer):
         self.cert_update_config(cert_id, updated_cert)
 
     def cert_create(
-            self, cert_id,
+            self, cert_id=None,
             username=None, password=None,
             client_cert=None, client_nssdb=None,
             client_nssdb_pass=None, client_nssdb_pass_file=None,
@@ -2303,7 +2303,10 @@ class PKIInstance(PKIServer):
         :type client_nssdb_pass: str
         :param client_nssdb_pass_file: File containing nssdb's password
         :type client_nssdb_pass_file: str
-        :param serial: Serial number to be assigned to new cert
+        :param serial: Serial number of the cert to be renewed.  If creating
+                       a temporary certificate (temp_cert == True), the serial
+                       number will be reused.  If not supplied, the cert_id is
+                       used to look it up.
         :type serial: str
         :param temp_cert: Whether new cert is a temporary cert
         :type temp_cert: bool
@@ -2322,28 +2325,37 @@ class PKIInstance(PKIServer):
         """
         nssdb = self.open_nssdb()
         tmpdir = tempfile.mkdtemp()
+        subsystem = None  # used for system certs
+
         try:
+            if cert_id:
+                new_cert_file = output if output else self.cert_file(cert_id)
+
+                subsystem_name, cert_tag = PKIServer.split_cert_id(cert_id)
+                if not subsystem_name:
+                    subsystem_name = self.subsystems[0].name
+                subsystem = self.get_subsystem(subsystem_name)
+
+                if serial is None:
+                    # If admin doesn't provide a serial number, set the serial to
+                    # the same serial number available in the nssdb
+                    serial = subsystem.get_subsystem_cert(cert_tag)["serial_number"]
+
+            else:
+                if serial is None:
+                    raise PKIServerException("Must provide either 'cert_id' or 'serial'")
+                if output is None:
+                    raise PKIServerException("Must provide 'output' when renewing by serial")
+                if temp_cert:
+                    raise PKIServerException("'temp_cert' must be used with 'cert_id'")
+                new_cert_file = output
+
             if not os.path.exists(self.cert_folder):
                 os.makedirs(self.cert_folder)
 
-            if output:
-                new_cert_file = output
-            else:
-                new_cert_file = self.cert_file(cert_id)
-
-            subsystem_name, cert_tag = PKIServer.split_cert_id(cert_id)
-
-            if not subsystem_name:
-                subsystem_name = self.subsystems[0].name
-
-            subsystem = self.get_subsystem(subsystem_name)
-
-            if not serial:
-                # If admin doesn't provide a serial number, set the serial to
-                # the same serial number available in the nssdb
-                serial = subsystem.get_subsystem_cert(cert_tag)["serial_number"]
-
             if temp_cert:
+                assert subsystem is not None  # temp_cert only supported with cert_id
+
                 logger.info('Trying to create a new temp cert for %s.', cert_id)
 
                 # Create Temp Cert and write it to new_cert_file

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -2170,6 +2170,14 @@ class PKIInstance(PKIServer):
                 raise PKIServerException('No subsystem can be loaded for %s in '
                                          'instance %s.' % (cert_id, self.name))
 
+    @property
+    def cert_folder(self):
+        return os.path.join(pki.CONF_DIR, self.name, 'certs')
+
+    def cert_file(self, cert_id):
+        """Compute name of certificate under instance cert folder."""
+        return os.path.join(self.cert_folder, cert_id + '.crt')
+
     def nssdb_import_cert(self, cert_id, cert_file=None):
         """
         Add cert from cert_file to NSS db with appropriate trust flags
@@ -2201,11 +2209,9 @@ class PKIInstance(PKIServer):
         nssdb = self.open_nssdb()
 
         try:
-            cert_folder = os.path.join(pki.CONF_DIR, self.name, 'certs')
-
             # If cert_file is not provided, load the cert from /etc/pki/certs/<cert_id>.crt
             if not cert_file:
-                cert_file = os.path.join(cert_folder, cert_id + '.crt')
+                cert_file = self.cert_file(cert_id)
 
             if not os.path.isfile(cert_file):
                 raise PKIServerException('%s does not exist.' % cert_file)
@@ -2292,14 +2298,13 @@ class PKIInstance(PKIServer):
         nssdb = self.open_nssdb()
         tmpdir = tempfile.mkdtemp()
         try:
-            cert_folder = os.path.join(pki.CONF_DIR, self.name, 'certs')
-            if not os.path.exists(cert_folder):
-                os.makedirs(cert_folder)
+            if not os.path.exists(self.cert_folder):
+                os.makedirs(self.cert_folder)
 
             if output:
                 new_cert_file = output
             else:
-                new_cert_file = os.path.join(cert_folder, cert_id + '.crt')
+                new_cert_file = self.cert_file(cert_id)
 
             subsystem_name, cert_tag = PKIServer.split_cert_id(cert_id)
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -990,6 +990,7 @@ class CertFixCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
+        logging.getLogger().setLevel(logging.INFO)
 
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
@@ -1025,7 +1026,6 @@ class CertFixCLI(pki.cli.CLI):
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
-                logging.getLogger().setLevel(logging.INFO)
 
             elif o == '--debug':
                 self.set_verbose(True)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1095,6 +1095,22 @@ class CertFixCLI(pki.cli.CLI):
         logger.info('Stopping the instance to proceed with system cert renewal')
         instance.stop()
 
+        # Get the CA subsystem and find out Base DN.
+        ca_subsystem = instance.get_subsystem('ca')
+        basedn = ca_subsystem.get_db_config()['internaldb.basedn']
+        dbuser_dn = 'uid=pkidbuser,ou=people,{}'.format(basedn)
+
+        # Prompt for DM password
+        dm_pass = getpass.getpass(prompt='Enter Directory Manager password: ')
+        try:
+            subprocess.check_output([
+                'ldapsearch', '-D', 'cn=Directory Manager', '-w', dm_pass,
+                '-s', 'base', '-b', basedn, '1.1',
+            ])
+        except subprocess.CalledProcessError:
+            logger.error("Failed to verify Directory Manager password.")
+            sys.exit(1)
+
         # 3. Find the subsystem and disable Self-tests
         try:
             # Placeholder used to hold subsystems whose selftest have been turned off
@@ -1123,7 +1139,7 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
-            with ldap_password_authn(instance, target_subsys) as dbuser_dn, \
+            with ldap_password_authn(instance, target_subsys, dbuser_dn, dm_pass), \
                     suppress_selftest(target_subsys):
 
                 # 4. Bring up the server using a temp SSL cert if the sslcert is expired
@@ -1188,7 +1204,7 @@ class CertFixCLI(pki.cli.CLI):
                         # ldapmodify
                         subprocess.check_call([
                             'ldapmodify',
-                            '-D', 'cn=Directory Manager', '-W',
+                            '-D', 'cn=Directory Manager', '-w', dm_pass,
                             '-f', ldif_file.name,
                         ])
 
@@ -1236,7 +1252,7 @@ def start_stop(instance):
 
 
 @contextmanager
-def ldap_password_authn(instance, subsystems):
+def ldap_password_authn(instance, subsystems, bind_dn, dm_pass):
     """LDAP password authentication context.
 
     This context manager switches the server to password
@@ -1272,13 +1288,8 @@ def ldap_password_authn(instance, subsystems):
     else:
         generated_password = False
 
-    # we don't know the Base DN until we see the config,
-    # so defer performing ldappasswd...
+    # We don't perform ldappasswd unless we need to (and only once).
     ldappasswd_performed = False
-
-    # Set this if Dogtag is using TLS cert auth to LDAP, and yield
-    # it so that the new subsystem cert can be added to the entry.
-    bind_dn = None
 
     for subsystem in subsystems:
         cfg = subsystem.get_db_config()
@@ -1290,16 +1301,12 @@ def ldap_password_authn(instance, subsystems):
             cfg['internaldb.ldapauth.authtype'] = 'BasicAuth'
             cfg['internaldb.ldapconn.port'] = '389'
             cfg['internaldb.ldapconn.secureConn'] = 'false'
-            bind_dn = \
-                'uid=pkidbuser,ou=people,{}'.format(cfg['internaldb.basedn'])
             cfg['internaldb.ldapauth.bindDN'] = bind_dn
 
             # _now_ we can perform ldappasswd
             if not ldappasswd_performed:
                 logger.info('Setting pkidbuser password via ldappasswd')
-                subprocess.check_call([
-                    'echo', "Enter Directory Manager password."])
-                ldappasswd(bind_dn, password)
+                ldappasswd(dm_pass, bind_dn, password)
                 ldappasswd_performed = True
 
         elif authtype == 'BasicAuth':
@@ -1311,7 +1318,7 @@ def ldap_password_authn(instance, subsystems):
         subsystem.save()
 
     try:
-        yield bind_dn
+        yield
 
     finally:
         logger.info('Restoring previous LDAP configuration')
@@ -1325,7 +1332,7 @@ def ldap_password_authn(instance, subsystems):
             instance.store_passwords()
 
 
-def ldappasswd(user_dn, password):
+def ldappasswd(dm_pass, user_dn, password):
     """
     Run ldappasswd as Directory Manager.
 
@@ -1334,7 +1341,7 @@ def ldappasswd(user_dn, password):
     """
     subprocess.check_call([
         'ldappasswd',
-        '-D', 'cn=Directory Manager', '-W',
+        '-D', 'cn=Directory Manager', '-w', dm_pass,
         '-s', password,
         user_dn,
     ])

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -34,6 +34,8 @@ import sys
 from tempfile import NamedTemporaryFile
 import time
 
+from six.moves.urllib.parse import quote  # pylint: disable=F0401,E0611
+
 import pki.cert
 import pki.cli
 import pki.nssdb
@@ -984,6 +986,7 @@ class CertFixCLI(pki.cli.CLI):
         print('      --cert <Cert ID>            Fix specified system cert (default: all certs).')
         print('      --extra-cert <Serial>       Also renew cert with given serial number.')
         print('      --agent-uid <String>        UID of Dogtag agent user')
+        print('      --ldapi-socket <Path>       Path to DS LDAPI socket')
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('  -v, --verbose                   Run in verbose mode.')
         print('      --debug                     Run in debug mode.')
@@ -996,7 +999,8 @@ class CertFixCLI(pki.cli.CLI):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=', 'cert=', 'extra-cert=', 'agent-uid=',
-                'verbose', 'debug', 'help'])
+                'ldapi-socket=', 'verbose', 'debug', 'help',
+            ])
 
         except getopt.GetoptError as e:
             logger.error(e)
@@ -1008,6 +1012,7 @@ class CertFixCLI(pki.cli.CLI):
         fix_certs = []
         extra_certs = []
         agent_uid = None
+        ldap_url = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
@@ -1028,6 +1033,9 @@ class CertFixCLI(pki.cli.CLI):
 
             elif o == '--agent-uid':
                 agent_uid = a
+
+            elif o == '--ldapi-socket':
+                ldap_url = 'ldapi://{}'.format(quote(a, safe=''))
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -1054,6 +1062,10 @@ class CertFixCLI(pki.cli.CLI):
 
         if not agent_uid:
             logger.error('Must specify --agent-uid')
+            sys.exit(1)
+
+        if not ldap_url:
+            logger.error('Must specify --ldapi-socket')
             sys.exit(1)
 
         instance.load()
@@ -1119,30 +1131,26 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
-            # Prompt for DM password
-            dm_pass = getpass.getpass(prompt='Enter Directory Manager password: ')
-
             # Generate new password for agent account
             agent_pass = gen_random_password()
 
-            with write_temp_file(dm_pass.encode('utf8')) as dm_pass_file, \
-                    write_temp_file(agent_pass.encode('utf8')) as agent_pass_file, \
-                    ldap_password_authn(instance, target_subsys, dbuser_dn, dm_pass_file), \
+            with write_temp_file(agent_pass.encode('utf8')) as agent_pass_file, \
+                    ldap_password_authn(instance, target_subsys, dbuser_dn, ldap_url), \
                     suppress_selftest(target_subsys):
 
-                # Verify DM password
+                # Verify LDAP connection
                 try:
                     subprocess.check_output([
-                        'ldapsearch', '-D', 'cn=Directory Manager', '-y', dm_pass_file,
+                        'ldapsearch', '-H', ldap_url, '-Y', 'EXTERNAL',
                         '-s', 'base', '-b', basedn, '1.1',
                     ])
                 except subprocess.CalledProcessError:
-                    logger.error("Failed to verify Directory Manager password.")
+                    logger.error("Failed to connect to LDAP at %s", ldap_url)
                     sys.exit(1)
 
                 # Reset agent password
                 logger.info('Resetting password for %s', agent_dn)
-                ldappasswd(dm_pass_file, agent_dn, agent_pass_file)
+                ldappasswd(ldap_url, agent_dn, agent_pass_file)
 
                 # 4. Bring up the server using a temp SSL cert if the sslcert is expired
                 if 'sslserver' in fix_certs:
@@ -1207,8 +1215,7 @@ class CertFixCLI(pki.cli.CLI):
                         ) as ldif_file:
                             # ldapmodify
                             subprocess.check_call([
-                                'ldapmodify',
-                                '-D', 'cn=Directory Manager', '-y', dm_pass_file,
+                                'ldapmodify', '-H', ldap_url, '-Y', 'EXTERNAL',
                                 '-f', ldif_file,
                             ])
 
@@ -1256,7 +1263,7 @@ def start_stop(instance):
 
 
 @contextmanager
-def ldap_password_authn(instance, subsystems, bind_dn, dm_pass_file):
+def ldap_password_authn(instance, subsystems, bind_dn, ldap_url):
     """LDAP password authentication context.
 
     This context manager switches the server to password
@@ -1311,7 +1318,7 @@ def ldap_password_authn(instance, subsystems, bind_dn, dm_pass_file):
             if not ldappasswd_performed:
                 logger.info('Setting pkidbuser password via ldappasswd')
                 with write_temp_file(password.encode('utf8')) as pwdfile:
-                    ldappasswd(dm_pass_file, bind_dn, pwdfile)
+                    ldappasswd(ldap_url, bind_dn, pwdfile)
                 ldappasswd_performed = True
 
         elif authtype == 'BasicAuth':
@@ -1337,7 +1344,7 @@ def ldap_password_authn(instance, subsystems, bind_dn, dm_pass_file):
             instance.store_passwords()
 
 
-def ldappasswd(dm_pass_file, user_dn, pass_file):
+def ldappasswd(ldap_url, user_dn, pass_file):
     """
     Run ldappasswd as Directory Manager.
 
@@ -1345,10 +1352,8 @@ def ldappasswd(dm_pass_file, user_dn, pass_file):
 
     """
     subprocess.check_call([
-        'ldappasswd',
-        '-D', 'cn=Directory Manager', '-y', dm_pass_file,
-        '-T', pass_file,
-        user_dn,
+        'ldappasswd', '-H', ldap_url, '-Y', 'EXTERNAL',
+        '-T', pass_file, user_dn,
     ])
 
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1265,9 +1265,7 @@ def ldap_password_authn(instance, subsystems):
         password = instance.passwords['internaldb']
     except KeyError:
         # generate a new password and write it to file
-        rnd = random.SystemRandom()
-        xs = "abcdefghijklmnopqrstuvwxyz0123456789"
-        password = ''.join(rnd.choice(xs) for i in range(32))
+        password = gen_random_password()
         instance.passwords['internaldb'] = password
         instance.store_passwords()
         generated_password = True
@@ -1301,12 +1299,7 @@ def ldap_password_authn(instance, subsystems):
                 logger.info('Setting pkidbuser password via ldappasswd')
                 subprocess.check_call([
                     'echo', "Enter Directory Manager password."])
-                subprocess.check_call([
-                    'ldappasswd',
-                    '-D', 'cn=Directory Manager', '-W',
-                    '-s', password,
-                    bind_dn,
-                ])
+                ldappasswd(bind_dn, password)
                 ldappasswd_performed = True
 
         elif authtype == 'BasicAuth':
@@ -1330,3 +1323,24 @@ def ldap_password_authn(instance, subsystems):
         if generated_password:
             del instance.passwords['internaldb']
             instance.store_passwords()
+
+
+def ldappasswd(user_dn, password):
+    """
+    Run ldappasswd as Directory Manager.
+
+    Raise CalledProcessError on error.
+
+    """
+    subprocess.check_call([
+        'ldappasswd',
+        '-D', 'cn=Directory Manager', '-W',
+        '-s', password,
+        user_dn,
+    ])
+
+
+def gen_random_password():
+    rnd = random.SystemRandom()
+    xs = "abcdefghijklmnopqrstuvwxyz0123456789"
+    return ''.join(rnd.choice(xs) for i in range(32))

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -31,6 +31,7 @@ import os
 import random
 import subprocess
 import sys
+import time
 
 import pki.cert
 import pki.cli
@@ -1183,6 +1184,8 @@ def start_stop(instance):
     """Start the server, run the block, and guarantee stop afterwards."""
     logger.info('Starting the instance')
     instance.start()
+    logger.info('Sleeping for 10 seconds to allow server time to start...')
+    time.sleep(10)
     try:
         yield
     finally:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -983,11 +983,6 @@ class CertFixCLI(pki.cli.CLI):
         print()
         print('      --cert <Cert ID>            Fix specified system cert (default: all certs).')
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
-        print('  -d <NSS database>               NSS database location (default: ~/.dogtag/nssdb)')
-        print('  -c <NSS DB password>            NSS database password')
-        print('  -C <path>                       Input file containing the password for the NSS '
-              'database.')
-        print('  -n <nickname>                   Client certificate nickname')
         print('  -v, --verbose                   Run in verbose mode.')
         print('      --debug                     Run in debug mode.')
         print('      --help                      Show help message.')
@@ -996,7 +991,7 @@ class CertFixCLI(pki.cli.CLI):
     def execute(self, argv):
 
         try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:d:c:C:n:v', [
+            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=', 'cert=',
                 'verbose', 'debug', 'help'])
 
@@ -1007,10 +1002,6 @@ class CertFixCLI(pki.cli.CLI):
 
         instance_name = 'pki-tomcat'
         all_certs = True
-        client_nssdb = os.getenv('HOME') + '/.dogtag/nssdb'
-        client_nssdb_pass = None
-        client_nssdb_pass_file = None
-        client_cert = None
         fix_certs = []
 
         for o, a in opts:
@@ -1020,18 +1011,6 @@ class CertFixCLI(pki.cli.CLI):
             elif o == '--cert':
                 all_certs = False
                 fix_certs.append(a)
-
-            elif o == '-d':
-                client_nssdb = a
-
-            elif o == '-c':
-                client_nssdb_pass = a
-
-            elif o == '-C':
-                client_nssdb_pass_file = a
-
-            elif o == '-n':
-                client_cert = a
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -1050,16 +1029,6 @@ class CertFixCLI(pki.cli.CLI):
                 logger.error('option %s not recognized', o)
                 self.print_help()
                 sys.exit(1)
-
-        if not client_cert:
-            logger.error('Client nick name is required.')
-            self.print_help()
-            sys.exit(1)
-
-        if not client_nssdb_pass and not client_nssdb_pass_file:
-            logger.error('Client NSS db password is required.')
-            self.print_help()
-            sys.exit(1)
 
         instance = server.PKIInstance(instance_name)
 
@@ -1099,6 +1068,7 @@ class CertFixCLI(pki.cli.CLI):
         ca_subsystem = instance.get_subsystem('ca')
         basedn = ca_subsystem.get_db_config()['internaldb.basedn']
         dbuser_dn = 'uid=pkidbuser,ou=people,{}'.format(basedn)
+        admin_dn = 'uid=admin,ou=people,{}'.format(basedn)
 
         # Prompt for DM password
         dm_pass = getpass.getpass(prompt='Enter Directory Manager password: ')
@@ -1110,6 +1080,10 @@ class CertFixCLI(pki.cli.CLI):
         except subprocess.CalledProcessError:
             logger.error("Failed to verify Directory Manager password.")
             sys.exit(1)
+
+        logger.info('Resetting PKI admin account password.')
+        admin_pass = gen_random_password()
+        ldappasswd(dm_pass, admin_dn, admin_pass)
 
         # 3. Find the subsystem and disable Self-tests
         try:
@@ -1161,12 +1135,8 @@ class CertFixCLI(pki.cli.CLI):
                     for cert_id in fix_certs:
                         logger.info('Requesting new cert for %s', cert_id)
                         instance.cert_create(
-                            cert_id=cert_id,
-                            client_cert=client_cert,
-                            client_nssdb=client_nssdb,
-                            client_nssdb_pass=client_nssdb_pass,
-                            client_nssdb_pass_file=client_nssdb_pass_file,
-                            renew=True)
+                            cert_id=cert_id, renew=True,
+                            username='admin', password=admin_pass)
 
                 # 8. Delete existing certs and then import the renewed system cert(s)
                 for cert_id in fix_certs:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1378,6 +1378,8 @@ def ldap_conn_args(ldap_url, use_ldapi, dm_pass_file):
     else:
         if ldap_url:
             args.extend(['-H', ldap_url])
+            if not ldap_url.startswith('ldaps'):
+                args.append('-ZZ')  # require STARTTLS
         args.extend(['-D', 'cn=Directory Manager', '-y', dm_pass_file])
     return args
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -987,6 +987,7 @@ class CertFixCLI(pki.cli.CLI):
         print('      --extra-cert <Serial>       Also renew cert with given serial number.')
         print('      --agent-uid <String>        UID of Dogtag agent user')
         print('      --ldapi-socket <Path>       Path to DS LDAPI socket')
+        print('      --ldap-url <URL>            LDAP URL (mutually exclusive to --ldapi-socket)')
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('  -v, --verbose                   Run in verbose mode.')
         print('      --debug                     Run in debug mode.')
@@ -999,7 +1000,7 @@ class CertFixCLI(pki.cli.CLI):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=', 'cert=', 'extra-cert=', 'agent-uid=',
-                'ldapi-socket=', 'verbose', 'debug', 'help',
+                'ldapi-socket=', 'ldap-url=', 'verbose', 'debug', 'help',
             ])
 
         except getopt.GetoptError as e:
@@ -1013,6 +1014,7 @@ class CertFixCLI(pki.cli.CLI):
         extra_certs = []
         agent_uid = None
         ldap_url = None
+        use_ldapi = False
 
         for o, a in opts:
             if o in ('-i', '--instance'):
@@ -1035,7 +1037,17 @@ class CertFixCLI(pki.cli.CLI):
                 agent_uid = a
 
             elif o == '--ldapi-socket':
+                if ldap_url is not None:
+                    logger.error('--ldapi-socket cannot be used with --ldap-url')
+                    sys.exit(1)
+                use_ldapi = True
                 ldap_url = 'ldapi://{}'.format(quote(a, safe=''))
+
+            elif o == '--ldap-url':
+                if use_ldapi:
+                    logger.error('--ldap-url cannot be used with --ldapi-socket')
+                    sys.exit(1)
+                ldap_url = a
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -1062,10 +1074,6 @@ class CertFixCLI(pki.cli.CLI):
 
         if not agent_uid:
             logger.error('Must specify --agent-uid')
-            sys.exit(1)
-
-        if not ldap_url:
-            logger.error('Must specify --ldapi-socket')
             sys.exit(1)
 
         instance.load()
@@ -1099,15 +1107,10 @@ class CertFixCLI(pki.cli.CLI):
         dbuser_dn = 'uid=pkidbuser,ou=people,{}'.format(basedn)
         agent_dn = 'uid={},ou=people,{}'.format(agent_uid, basedn)
 
-        # Verify LDAP connection
-        try:
-            subprocess.check_output([
-                'ldapsearch', '-H', ldap_url, '-Y', 'EXTERNAL',
-                '-s', 'base', '-b', basedn, '1.1',
-            ])
-        except subprocess.CalledProcessError:
-            logger.error("Failed to connect to LDAP at %s", ldap_url)
-            sys.exit(1)
+        dm_pass = ''
+        if not use_ldapi:
+            # Prompt for DM password
+            dm_pass = getpass.getpass(prompt='Enter Directory Manager password: ')
 
         # 2. Stop the server, if it's up
         logger.info('Stopping the instance to proceed with system cert renewal')
@@ -1148,11 +1151,25 @@ class CertFixCLI(pki.cli.CLI):
             agent_pass = gen_random_password()
 
             with write_temp_file(agent_pass.encode('utf8')) as agent_pass_file, \
-                    ldap_password_authn(instance, target_subsys, dbuser_dn, ldap_url), \
+                    write_temp_file(dm_pass.encode('utf8')) as dm_pass_file, \
+                    ldap_password_authn(
+                        instance, target_subsys, dbuser_dn,
+                        ldap_url, use_ldapi, dm_pass_file), \
                     suppress_selftest(target_subsys):
+
+                # Verify LDAP connection and DM password
+                cmd = ['ldapsearch'] + \
+                    ldap_conn_args(ldap_url, use_ldapi, dm_pass_file) + \
+                    ['-s', 'base', '-b', basedn, '1.1']
+                try:
+                    subprocess.check_output(cmd)
+                except subprocess.CalledProcessError:
+                    logger.error("Failed to connect/authenticate to LDAP at '%s'", ldap_url)
+                    sys.exit(1)
+
                 # Reset agent password
                 logger.info('Resetting password for %s', agent_dn)
-                ldappasswd(ldap_url, agent_dn, agent_pass_file)
+                ldappasswd(ldap_url, use_ldapi, dm_pass_file, agent_dn, agent_pass_file)
 
                 # 4. Bring up the server using a temp SSL cert if the sslcert is expired
                 if 'sslserver' in fix_certs:
@@ -1216,10 +1233,10 @@ class CertFixCLI(pki.cli.CLI):
                                 .encode('utf-8')
                         ) as ldif_file:
                             # ldapmodify
-                            subprocess.check_call([
-                                'ldapmodify', '-H', ldap_url, '-Y', 'EXTERNAL',
-                                '-f', ldif_file,
-                            ])
+                            cmd = ['ldapmodify'] + \
+                                ldap_conn_args(ldap_url, use_ldapi, dm_pass_file) + \
+                                ['-f', ldif_file]
+                            subprocess.check_call(cmd)
 
             # 10. Bring up the server
             logger.info('Starting the instance with renewed certs')
@@ -1265,7 +1282,8 @@ def start_stop(instance):
 
 
 @contextmanager
-def ldap_password_authn(instance, subsystems, bind_dn, ldap_url):
+def ldap_password_authn(
+        instance, subsystems, bind_dn, ldap_url, use_ldapi, dm_pass_file):
     """LDAP password authentication context.
 
     This context manager switches the server to password
@@ -1320,7 +1338,7 @@ def ldap_password_authn(instance, subsystems, bind_dn, ldap_url):
             if not ldappasswd_performed:
                 logger.info('Setting pkidbuser password via ldappasswd')
                 with write_temp_file(password.encode('utf8')) as pwdfile:
-                    ldappasswd(ldap_url, bind_dn, pwdfile)
+                    ldappasswd(ldap_url, use_ldapi, dm_pass_file, bind_dn, pwdfile)
                 ldappasswd_performed = True
 
         elif authtype == 'BasicAuth':
@@ -1346,17 +1364,35 @@ def ldap_password_authn(instance, subsystems, bind_dn, ldap_url):
             instance.store_passwords()
 
 
-def ldappasswd(ldap_url, user_dn, pass_file):
+def ldap_conn_args(ldap_url, use_ldapi, dm_pass_file):
+    """Set ldap connection arguments for user with ldapsearch/ldapmodify/etc.
+
+    If use_ldapi is True, then ldap_url is assumed be to an ldapi URL.
+    If use_ldapi is False, then dm_pass_file is assumed to be the path to
+    a file containing the DM passphrase, and ldap_url may be empty.
+
+    """
+    args = []
+    if use_ldapi:
+        args.extend(['-H', ldap_url, '-Y', 'EXTERNAL'])
+    else:
+        if ldap_url:
+            args.extend(['-H', ldap_url])
+        args.extend(['-D', 'cn=Directory Manager', '-y', dm_pass_file])
+    return args
+
+
+def ldappasswd(ldap_url, use_ldapi, dm_pass_file, user_dn, pass_file):
     """
     Run ldappasswd as Directory Manager.
 
     Raise CalledProcessError on error.
 
     """
-    subprocess.check_call([
-        'ldappasswd', '-H', ldap_url, '-Y', 'EXTERNAL',
-        '-T', pass_file, user_dn,
-    ])
+    cmd = ['ldappasswd'] + \
+        ldap_conn_args(ldap_url, use_ldapi, dm_pass_file) + \
+        ['-T', pass_file, user_dn]
+    subprocess.check_call(cmd)
 
 
 def gen_random_password():

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -28,6 +28,8 @@ import getopt
 import getpass
 import logging
 import os
+import random
+import subprocess
 import sys
 
 import pki.cert
@@ -1108,7 +1110,8 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
-            with suppress_selftest(target_subsys):
+            with ldap_password_authn(instance, target_subsys), \
+                    suppress_selftest(target_subsys):
 
                 # 4. Bring up the server using a temp SSL cert if the sslcert is expired
                 if 'sslserver' in fix_certs:
@@ -1185,3 +1188,90 @@ def start_stop(instance):
     finally:
         logger.info('Stopping the instance')
         instance.stop()
+
+
+@contextmanager
+def ldap_password_authn(instance, subsystems):
+    """LDAP password authentication context.
+
+    This context manager switches the server to password
+    authentication, runs the block, then restores the original
+    subsystem configuration.
+
+    Specifically:
+
+    - if we are already using BasicAuth, force port 389 and no TLS/STARTTLS
+      but leave everything else alone.
+
+    - if using TLS client cert auth, switch to BasicAuth, using pkidbuser
+      account, and using a randomly generated password.  The DM credential
+      is required to set that password.
+
+    """
+    logger.info('Configuring LDAP password authentication')
+    orig = {}
+    try:
+        password = instance.passwords['internaldb']
+    except KeyError:
+        # generate a new password and write it to file
+        rnd = random.SystemRandom()
+        xs = "abcdefghijklmnopqrstuvwxyz0123456789"
+        password = ''.join(rnd.choice(xs) for i in range(32))
+        instance.passwords['internaldb'] = password
+        instance.store_passwords()
+        generated_password = True
+    else:
+        generated_password = False
+
+    # we don't know the Base DN until we see the config,
+    # so defer performing ldappasswd...
+    ldappasswd_performed = False
+
+    for subsystem in subsystems:
+        cfg = subsystem.get_db_config()
+        orig[subsystem] = cfg.copy()  # copy because dict is mutable
+
+        authtype = cfg['internaldb.ldapauth.authtype']
+        if authtype == 'SslClientAuth':
+            # switch to BasicAuth
+            cfg['internaldb.ldapauth.authtype'] = 'BasicAuth'
+            cfg['internaldb.ldapconn.port'] = '389'
+            cfg['internaldb.ldapconn.secureConn'] = 'false'
+            bind_dn = \
+                'uid=pkidbuser,ou=people,{}'.format(cfg['internaldb.basedn'])
+            cfg['internaldb.ldapauth.bindDN'] = bind_dn
+
+            # _now_ we can perform ldappasswd
+            if not ldappasswd_performed:
+                logger.info('Setting pkidbuser password via ldappasswd')
+                subprocess.check_call([
+                    'echo', "Enter Directory Manager password."])
+                subprocess.check_call([
+                    'ldappasswd',
+                    '-D', 'cn=Directory Manager', '-W',
+                    '-s', password,
+                    bind_dn,
+                ])
+                ldappasswd_performed = True
+
+        elif authtype == 'BasicAuth':
+            # force port 389, no TLS / STARTTLS.  Leave other settings alone.
+            cfg['internaldb.ldapconn.port'] = '389'
+            cfg['internaldb.ldapconn.secureConn'] = 'false'
+
+        subsystem.set_db_config(cfg)
+        subsystem.save()
+
+    try:
+        yield
+
+    finally:
+        logger.info('Restoring previous LDAP configuration')
+
+        for subsystem, cfg in orig.items():
+            subsystem.set_db_config(cfg)
+            subsystem.save()
+
+        if generated_password:
+            del instance.passwords['internaldb']
+            instance.store_passwords()

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -543,8 +543,12 @@ class CertCreateCLI(pki.cli.CLI):
         instance.load()
 
         try:
-            instance.cert_create(cert_id, client_cert, client_nssdb, client_nssdb_password,
-                                 client_nssdb_pass_file, serial, temp_cert, renew, output)
+            instance.cert_create(
+                cert_id=cert_id,
+                client_cert=client_cert, client_nssdb=client_nssdb,
+                client_nssdb_pass=client_nssdb_password,
+                client_nssdb_pass_file=client_nssdb_pass_file,
+                serial=serial, temp_cert=temp_cert, renew=renew, output=output)
 
         except server.PKIServerException as e:
             logger.error(str(e))

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1131,6 +1131,9 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
+            if len(extra_certs) > 0:
+                target_subsys.add(ca_subsystem)
+
             # Generate new password for agent account
             agent_pass = gen_random_password()
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1124,23 +1124,17 @@ class CertFixCLI(pki.cli.CLI):
                     logger.debug('Importing temp sslserver cert')
                     instance.cert_import('sslserver')
 
-                # 5. Bring up the server temporarily
-                logger.debug('Starting the instance with temp sslserver cert')
-                instance.start()
-
-                # 6. Place renewal request for all certs in fix_certs
-                for cert_id in fix_certs:
-                    logger.debug('Creating new cert for %s', cert_id)
-                    instance.cert_create(cert_id=cert_id,
-                                         client_cert=client_cert,
-                                         client_nssdb=client_nssdb,
-                                         client_nssdb_pass=client_nssdb_pass,
-                                         client_nssdb_pass_file=client_nssdb_pass_file,
-                                         renew=True)
-
-                # 7. Stop the server
-                logger.debug('Stopping the instance')
-                instance.stop()
+                with start_stop(instance):
+                    # Place renewal request for all certs in fix_certs
+                    for cert_id in fix_certs:
+                        logger.info('Requesting new cert for %s', cert_id)
+                        instance.cert_create(
+                            cert_id=cert_id,
+                            client_cert=client_cert,
+                            client_nssdb=client_nssdb,
+                            client_nssdb_pass=client_nssdb_pass,
+                            client_nssdb_pass_file=client_nssdb_pass_file,
+                            renew=True)
 
                 # 8. Delete existing certs and then import the renewed system cert(s)
                 for cert_id in fix_certs:
@@ -1179,3 +1173,15 @@ def suppress_selftest(subsystems):
         logger.info(
             'Selftests enabled for subsystems: %s',
             ', '.join(str(x.name) for x in subsystems))
+
+
+@contextmanager
+def start_stop(instance):
+    """Start the server, run the block, and guarantee stop afterwards."""
+    logger.info('Starting the instance')
+    instance.start()
+    try:
+        yield
+    finally:
+        logger.info('Stopping the instance')
+        instance.stop()

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -22,6 +22,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from contextlib import contextmanager
 import datetime
 import getopt
 import getpass
@@ -1107,65 +1108,49 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
-            # Convert set to list
-            target_subsys = list(target_subsys)
+            with suppress_selftest(target_subsys):
 
-            for subsystem in target_subsys:
-                subsystem.set_startup_test_criticality(False)
-                subsystem.save()
+                # 4. Bring up the server using a temp SSL cert if the sslcert is expired
+                if 'sslserver' in fix_certs:
+                    # 4a. Create temp SSL cert
+                    logger.info('Creating a temporary sslserver cert')
+                    instance.cert_create(cert_id='sslserver', temp_cert=True)
 
-            logger.info('Selftests disabled for subsystems: %s', ', '.join(
-                str(x.name) for x in target_subsys))
+                    # 4b. Delete the existing SSL Cert
+                    logger.debug('Removing sslserver cert from instance')
+                    instance.cert_del('sslserver')
 
-            # 4. Bring up the server using a temp SSL cert if the sslcert is expired
-            if 'sslserver' in fix_certs:
-                # 4a. Create temp SSL cert
-                logger.debug('Creating a temp sslserver cert')
-                instance.cert_create(cert_id='sslserver', temp_cert=True)
+                    # 4d. Import the temp sslcert into the instance
+                    logger.debug('Importing temp sslserver cert')
+                    instance.cert_import('sslserver')
 
-                # 4b. Delete the existing SSL Cert
-                logger.debug('Removing sslserver cert from instance')
-                instance.cert_del('sslserver')
+                # 5. Bring up the server temporarily
+                logger.debug('Starting the instance with temp sslserver cert')
+                instance.start()
 
-                # 4d. Import the temp sslcert into the instance
-                logger.debug('Importing temp sslserver cert')
-                instance.cert_import('sslserver')
+                # 6. Place renewal request for all certs in fix_certs
+                for cert_id in fix_certs:
+                    logger.debug('Creating new cert for %s', cert_id)
+                    instance.cert_create(cert_id=cert_id,
+                                         client_cert=client_cert,
+                                         client_nssdb=client_nssdb,
+                                         client_nssdb_pass=client_nssdb_pass,
+                                         client_nssdb_pass_file=client_nssdb_pass_file,
+                                         renew=True)
 
-            # 5. Bring up the server temporarily
-            logger.debug('Starting the instance with temp sslserver cert')
-            instance.start()
+                # 7. Stop the server
+                logger.debug('Stopping the instance')
+                instance.stop()
 
-            # 6. Place renewal request for all certs in fix_certs
-            for cert_id in fix_certs:
-                logger.debug('Creating new cert for %s', cert_id)
-                instance.cert_create(cert_id=cert_id,
-                                     client_cert=client_cert,
-                                     client_nssdb=client_nssdb,
-                                     client_nssdb_pass=client_nssdb_pass,
-                                     client_nssdb_pass_file=client_nssdb_pass_file,
-                                     renew=True)
+                # 8. Delete existing certs and then import the renewed system cert(s)
+                for cert_id in fix_certs:
+                    # Delete the existing cert from the instance
+                    logger.debug('Removing old %s cert from instance %s', cert_id, instance_name)
+                    instance.cert_del(cert_id)
 
-            # 7. Stop the server
-            logger.debug('Stopping the instance')
-            instance.stop()
-
-            # 8. Delete existing certs and then import the renewed system cert(s)
-            for cert_id in fix_certs:
-                # Delete the existing cert from the instance
-                logger.debug('Removing old %s cert from instance %s', cert_id, instance_name)
-                instance.cert_del(cert_id)
-
-                # Import this new cert into the instance
-                logger.debug('Importing new %s cert into instance %s', cert_id, instance_name)
-                instance.cert_import(cert_id)
-
-            # 9. Enable self tests for the subsystems disabled earlier
-            for subsystem in target_subsys:
-                subsystem.set_startup_test_criticality(True)
-                subsystem.save()
-
-            logger.info('Selftests enabled for subsystems: %s', ', '.join(
-                str(x.name) for x in target_subsys))
+                    # Import this new cert into the instance
+                    logger.debug('Importing new %s cert into instance %s', cert_id, instance_name)
+                    instance.cert_import(cert_id)
 
             # 10. Bring up the server
             logger.info('Starting the instance with renewed certs')
@@ -1174,3 +1159,23 @@ class CertFixCLI(pki.cli.CLI):
         except server.PKIServerException as e:
             logger.error(str(e))
             sys.exit(1)
+
+
+@contextmanager
+def suppress_selftest(subsystems):
+    """Suppress selftests in the given subsystems."""
+    for subsystem in subsystems:
+        subsystem.set_startup_test_criticality(False)
+        subsystem.save()
+    logger.info(
+        'Selftests disabled for subsystems: %s',
+        ', '.join(str(x.name) for x in subsystems))
+    try:
+        yield
+    finally:
+        for subsystem in subsystems:
+            subsystem.set_startup_test_criticality(True)
+            subsystem.save()
+        logger.info(
+            'Selftests enabled for subsystems: %s',
+            ', '.join(str(x.name) for x in subsystems))

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -31,6 +31,7 @@ import os
 import random
 import subprocess
 import sys
+from tempfile import NamedTemporaryFile
 import time
 
 import pki.cert
@@ -963,6 +964,13 @@ class CertFixCLI(pki.cli.CLI):
         super(CertFixCLI, self).__init__(
             'fix', 'Fix expired system certificate(s).')
 
+    PKIDBUSER_LDIF_TEMPLATE = (
+        "dn: {dn}\n"
+        "changetype: modify\n"
+        "add: userCertificate\n"
+        "userCertificate:< file://{der_file}\n"
+    )
+
     def print_help(self):
         print('Usage: pki-server cert-fix [OPTIONS]')
         # CertID:  subsystem, sslserver, kra_storage, kra_transport, ca_ocsp_signing,
@@ -1111,7 +1119,7 @@ class CertFixCLI(pki.cli.CLI):
 
                     target_subsys.add(subsystem)
 
-            with ldap_password_authn(instance, target_subsys), \
+            with ldap_password_authn(instance, target_subsys) as dbuser_dn, \
                     suppress_selftest(target_subsys):
 
                 # 4. Bring up the server using a temp SSL cert if the sslcert is expired
@@ -1149,6 +1157,36 @@ class CertFixCLI(pki.cli.CLI):
                     # Import this new cert into the instance
                     logger.debug('Importing new %s cert into instance %s', cert_id, instance_name)
                     instance.cert_import(cert_id)
+
+                # If subsystem cert was renewed and server was using
+                # TLS auth, add the cert to pkidbuser entry
+                if dbuser_dn and 'subsystem' in fix_certs:
+                    logger.info('Importing new subsystem cert into %s', dbuser_dn)
+                    with NamedTemporaryFile(mode='w+b') as ldif_file, \
+                            NamedTemporaryFile(mode='w+b') as der_file:
+                        # convert subsystem cert to DER
+                        subprocess.check_call([
+                            'openssl', 'x509',
+                            '-inform', 'PEM', '-outform', 'DER',
+                            '-in', instance.cert_file('subsystem'),
+                            '-out', der_file.name,
+                        ])
+
+                        # write LDIF
+                        ldif_file.write(
+                            self.PKIDBUSER_LDIF_TEMPLATE.format(
+                                dn=dbuser_dn, der_file=der_file.name)
+                            .encode('utf-8')
+                        )
+                        ldif_file.flush()
+                        os.fsync(ldif_file.fileno())
+
+                        # ldapmodify
+                        subprocess.check_call([
+                            'ldapmodify',
+                            '-D', 'cn=Directory Manager', '-W',
+                            '-f', ldif_file.name,
+                        ])
 
             # 10. Bring up the server
             logger.info('Starting the instance with renewed certs')
@@ -1210,6 +1248,12 @@ def ldap_password_authn(instance, subsystems):
       account, and using a randomly generated password.  The DM credential
       is required to set that password.
 
+    This context manager yields the pkidbuser DN, so that the new
+    subsystem certificate (if it was one of the renewal targets) can
+    be added to the entry.  It is only yielded if the server was
+    already using TLS client cert authn, otherwise the yielded value
+    is ``None``.
+
     """
     logger.info('Configuring LDAP password authentication')
     orig = {}
@@ -1229,6 +1273,10 @@ def ldap_password_authn(instance, subsystems):
     # we don't know the Base DN until we see the config,
     # so defer performing ldappasswd...
     ldappasswd_performed = False
+
+    # Set this if Dogtag is using TLS cert auth to LDAP, and yield
+    # it so that the new subsystem cert can be added to the entry.
+    bind_dn = None
 
     for subsystem in subsystems:
         cfg = subsystem.get_db_config()
@@ -1266,7 +1314,7 @@ def ldap_password_authn(instance, subsystems):
         subsystem.save()
 
     try:
-        yield
+        yield bind_dn
 
     finally:
         logger.info('Restoring previous LDAP configuration')


### PR DESCRIPTION
See also #181 which is for 10.6 branch.

```
Changes:

68c56104c (Fraser Tweedale, 22 hours ago)
   cert-fix: default log verbosity to INFO

   Operators need to see a bit more about what's going on.  Default the log /
   output verbosity to INFO.

   Part of: https://pagure.io/dogtagpki/issue/2776

53ae4d421 (Fraser Tweedale, 25 hours ago)
   cert-fix: support renewing additional certs by serial

   In a broader operational context, it may be necessary to renew more than
   just the Dogtag system certificates, e.g. expired DS service certificate or
   agent certificates.  Teach cert-fix the
   `--extra-cert' option which specifies serial numbers of additional 
   certificates to renew.

   Part of: https://pagure.io/dogtagpki/issue/2776

228faf1c0 (Fraser Tweedale, 2 days ago)
   PKIInstance.cert_create: support renewal by serial only

   PKIInstance.cert_create() currently requires the "cert_id" argument, which
   refers to a system certificate (e.g. "sslserver",
   "ca_ocsp_signing", etc).

   The cert-fix tool may need to renew other expired certificates, too, in
   order to bring a deployment back to a fully functional state
   (e.g. LDAP TLS service certificate, agent certificate).  To support this
   use case, update cert_create() to accept a serial number to be renewed,
   _without_ requiring cert_id.

   Part of: https://pagure.io/dogtagpki/issue/2776

73d22908e (Fraser Tweedale, 2 days ago)
   cert-fix: use admin password authentication

   If the agent/admin certificate is expired, cert-fix will fail. Avoid this
   issue by using password authentication to submit the renewal requests.

   We don't know the current admin account password (and the user might not
   know it either), so we have to reset it.  This will be a caveat of
   cert-fix.  But because the user does know the Directory Manager password,
   they can reset the admin account password afterwards.

   Part of: https://pagure.io/dogtagpki/issue/2776

d2ebb109c (Fraser Tweedale, 2 days ago)
   cert-fix: prompt only once for DM password

   cert-fix now performs several operations that require the Directory Manager
   password.  Currently each operation prompts for the password.  Modify the
   code so that the administrator only has to enter it once.

   Part of: https://pagure.io/dogtagpki/issue/2776

dfcb01a40 (Fraser Tweedale, 2 days ago)
   cert-fix: extract password gen and ldappasswd routines

   cert-fix will be modified to use admin/agent password authentication 
   instead of certificate authentication.  As a preliminary step, extract the
   ldappasswd and password generation logic subroutines, which will also be
   needed to set the admin/agent account password.

   Part of: https://pagure.io/dogtagpki/issue/2776

bd6f71013 (Fraser Tweedale, 2 days ago)
   PKIInstance.cert_create: support password authentication

   The cert-fix tool currently needs a valid agent certificate, but this is
   not a good assumption - it could be expired.  Update the cert_create()
   method to support password authentication.

   Part of: https://pagure.io/dogtagpki/issue/2776

27c70fa6f (Fraser Tweedale, 3 days ago)
   cert-fix: add subsystem cert to pkidbuser entry

   Update cert-fix to import the subsystem certificate into the pkidbuser
   entry, if it was renewed and the instance uses LDAP TLS client
   authentication.

   Part of: https://pagure.io/dogtagpki/issue/2776

a90fc9b39 (Fraser Tweedale, 3 days ago)
   PKIInstance: add 'cert_folder' and 'cert_file' methods

   The cert_folder and locations of certificates under that folder are useful
   to know from outside the PKIInstance class.  In particular the cert-fix
   tool will need these data.  Extract the computation of the folder path to a
   property, and the computation of certificate file paths to a method.

   Part of: https://pagure.io/dogtagpki/issue/2776

c8d57ed1a (Fraser Tweedale, 3 days ago)
   cert-fix: sleep after starting server

   If the server does not start quickly enough, cert-fix sends requests to the
   server before it is ready to handle them, causing failure.

   A proper solution is to poll the server until the status resource indicates
   that it is ready.  But for now, the quick workaround is to sleep for a
   little while.

   Part of: https://pagure.io/dogtagpki/issue/2776

2317f5b9d (Fraser Tweedale, 4 days ago)
   cert-fix: use LDAP password authentication

   If the LDAP service certificate is expired and Dogtag is using a secure
   connection to LDAP, connecting to the database will fail. Likewise, if the
   subsystem certificate is expired and LDAP client cert authentication is
   configured (the default), then LDAP authentication will fail.  To avoid
   these issues, the cert-fix tool has to reconfigure subsystems to use
   password authentication on a non-TLS connection.

   Add a context manager that performs this reconfiguration, and restores
   original configuration on exit.  Update cert-fix to use this context
   manager.

   If targeted subsystems are using TLS certificate authentication, then a
   random password for pkidbuser will be generated, written to password.conf,
   and set for the user via the 'ldappasswd' command. This requires the
   Directory Manager credential.

   If targeted subsystems are already using password authentication, they are
   only reconfigured to use port 389 and no TLS/STARTTLS. ldappasswd is not
   invoked and the Directory Manager credential is not required.

   Part of: https://pagure.io/dogtagpki/issue/2776

14d112732 (Fraser Tweedale, 4 days ago)
   PKISubsystem: add methods to read/write database config

   The offline certificate renewal system needs to be able to adjust database
   configuration, and restore it afterwards.  As a step towards this, add
   PKISubsystem methods 'get_db_config' and
   'set_db_config'.

   Part of: https://pagure.io/dogtagpki/issue/2776

bfe541452 (Fraser Tweedale, 4 days ago)
   cert-fix: ensure server stopped before restoring config

   Use a context manager to ensure, even in presense of exception, that the
   server gets stopped before configuration (CS.cfg) gets restored.

   Part of: https://pagure.io/dogtagpki/issue/2776

8036cdd4f (Fraser Tweedale, 4 days ago)
   cert-fix: use context manager to disable/enable selftest

   To ensure self-test criticality is reinstated even when cert-fix fails due
   to exception, use a context manager.  This change also improves readability
   a bit.

   Also promote the "creating temporary sslserver cert" message from DEBUG to
   INFO.

   Part of: https://pagure.io/dogtagpki/issue/2776
```