### PR TITLE
Allow page size to influence LDAP query size

### DIFF
--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/DBVirtualList.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/DBVirtualList.java
@@ -28,6 +28,7 @@ import com.netscape.certsrv.dbs.IElementProcessor;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.cms.logging.Logger;
 
+import netscape.ldap.LDAPv2;
 import netscape.ldap.LDAPConnection;
 import netscape.ldap.LDAPControl;
 import netscape.ldap.LDAPEntry;
@@ -436,6 +437,13 @@ public class DBVirtualList<E> implements IDBVirtualList<E> {
             String ldapFilter = mRegistry.getFilter(mFilter);
             String ldapAttrs[] = null;
             LDAPSearchResults result;
+
+            Integer size_limit = (Integer) mConn.getOption(LDAPv2.SIZELIMIT);
+            if (size_limit == 0 ||
+                    (size_limit > 0 && mPageSize != 0 && Math.abs(mPageSize) < size_limit))
+            {
+                mConn.setOption(LDAPv2.SIZELIMIT, Math.abs(mPageSize));
+            }
 
             if (mAttrs != null) {
                 ldapAttrs = mRegistry.getLDAPAttributes(mAttrs);


### PR DESCRIPTION
When performing an LDAP query, we need to take into account the actual
page size of the incoming request. Otherwise, our LDAP query can either
overflow or underflow the request's page size.

This PR was prepared after helping an IRC user with their slow query issues. One problem is that we probably want to limit `mPageSize` to some config-specific maximum value, else we open ourselves up to DOS attacks due to huge `mPageSize` values.

The particular issue in question was solved [in IPA](https://bugzilla.redhat.com/show_bug.cgi?id=1658280) by using a better query, but I think fixing this on the Dogtag side would be nice as well. 


Questions:

 - Do we have an existing configuration value to use here?
 - If we don't, should we set a reasonable default instead (say, 4000-8000 items)?


`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`