### PR TITLE
Updated PKI server library

### DIFF
--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -151,8 +151,6 @@ class MigrateCLI(pki.cli.CLI):
             'pki.xml')
         self.migrate_context_xml(pki_context_xml, tomcat_version)
 
-        self.migrate_tomcat_libraries(instance)
-
     def migrate_server_xml(self, instance, filename, tomcat_version):
         if self.verbose:
             print('Migrating %s' % filename)
@@ -551,29 +549,6 @@ class MigrateCLI(pki.cli.CLI):
             context.append(resources)
 
         resources.set('allowLinking', 'true')
-
-    def migrate_tomcat_libraries(self, instance):
-
-        # remove unnecessary links to Tomcat libraries
-        for filename in os.listdir(instance.lib_dir):
-
-            path = os.path.join(instance.lib_dir, filename)
-
-            if self.verbose:
-                print('Removing %s' % path)
-
-            os.remove(path)
-
-        # slf4j-api.jar
-        source = '/usr/share/pki/server/lib/slf4j-api.jar'
-        dest = os.path.join(instance.lib_dir, 'slf4j-api.jar')
-        self.create_link(instance, source, dest)
-
-        # slf4j-jdk14.jar
-        source = '/usr/share/pki/server/lib/slf4j-jdk14.jar'
-        dest = os.path.join(instance.lib_dir, 'slf4j-jdk14.jar')
-        if os.path.islink(source):
-            self.create_link(instance, source, dest)
 
     def create_link(self, instance, source, dest):
 

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -149,17 +149,12 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 "pki.xml"))
 
         logger.info('Creating %s', deployer.mdict['pki_instance_lib'])
-        deployer.directory.create(deployer.mdict['pki_instance_lib'])
+        # Link /var/lib/pki/<instance>/lib to /usr/share/pki/server/lib
+        deployer.symlink.create(
+            '/usr/share/pki/server/lib',
+            deployer.mdict['pki_instance_lib'])
 
-        for name in os.listdir('/usr/share/pki/server/lib'):
-            deployer.symlink.create(
-                os.path.join(
-                    '/usr/share/pki/server/lib',
-                    name),
-                os.path.join(
-                    deployer.mdict['pki_instance_lib'],
-                    name))
-
+        logger.info('Creating %s', deployer.mdict['pki_tomcat_common_path'])
         # Link /var/lib/pki/<instance>/common to /usr/share/pki/server/common
         deployer.symlink.create(
             '/usr/share/pki/server/common',

--- a/base/server/upgrade/10.7.0/03-FixServerLibrary
+++ b/base/server/upgrade/10.7.0/03-FixServerLibrary
@@ -1,0 +1,54 @@
+# Authors:
+#     Endi S. Dewata <edewata@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+# All rights reserved.
+
+from __future__ import absolute_import
+import os
+import shutil
+
+import pki.server.upgrade
+
+
+class FixServerLibrary(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super(FixServerLibrary, self).__init__()
+        self.message = 'Fix server library'
+
+    def upgrade_instance(self, instance):
+
+        self.replace_with_link(
+            instance,
+            instance.lib_dir,
+            '/usr/share/pki/server/lib')
+
+    def replace_with_link(self, instance, source, target):
+
+        # if source is already a link, skip
+        if os.path.islink(source):
+            return
+
+        self.backup(source)
+
+        if os.path.isdir(source):
+            shutil.rmtree(source)
+        else:
+            os.remove(source)
+
+        # link source to target
+        instance.symlink(target, source)


### PR DESCRIPTION
The deployment scriptlet has been modified to link the server
library folder instead of creating a folder with links to
individual library files.

An upgrade script has been added to make the same changes in
existing instances.

The code that regenerates the links to individual library files
for Tomcat migration is no longer needed and has been removed.