### PR TITLE
Update Offline Cert Renewal Document

### DIFF
--- a/docs/admin/Offline_System_Certificate_Renewal.md
+++ b/docs/admin/Offline_System_Certificate_Renewal.md
@@ -17,7 +17,7 @@ This tool's behavior is different in an **IPA environment** and **standalone PKI
 
 #### Assumptions:
 
-- Valid CA certificate [WIP to remove this assumption]
+- Valid CA certificate
 - `cert-fix` must be run as `root`
 - `LDAPI` must be configured, with `root` autobinding to `cn=Directory Manager` or other account with privileges on `o=ipaca` subtree, including password reset privileges
 - The password of the specified agent account will be reset. If needed, it can be changed back afterwards (manually; successful execution of `cert-fix` proves that the operator has privileges to do this)
@@ -39,7 +39,7 @@ If you need to fix only a **specific system certificates**, use the `--cert <Cer
 
 #### Assumptions:
 
-- Valid CA certificate [WIP to remove this assumption]
+- Valid CA certificate
 - TLS configured Directory Server
 - If Dogtag was configured to use TLS certificate authentication to bind to LDAP, a Valid DS service certificate
 
@@ -99,7 +99,7 @@ It is recommended to run the following steps to ensure that `CS.cfg` and NSS dat
 
 ### System Certificate Renewal
 
-1. If you have a **valid admin cert** and a LDAP/LDAPS Directory server configuration, renew required system certs using PKI tool. For **`sslserver`** cert provide the `serial number` from the **original SSL server cert** to avoid placing request for unintended cert.
+1. If you have a **valid admin cert**, renew required system certs using PKI tool. For **`sslserver`** cert provide the `serial number` from the **original SSL server cert** to avoid placing request for unintended cert.
     ````
     # pki-server cert-create --renew \
     -n <admin cert nickname> \
@@ -108,16 +108,6 @@ It is recommended to run the following steps to ensure that `CS.cfg` and NSS dat
     <cert ID> \
     --serial <serial number>
     ````
-    **OR**
-
-    If your **admin cert is expired** and TLS/SSL is configured for LDAP [WORK IN PROGRESS]:
-
-    ````
-    # pki-server cert-create --renew \
-    --agent-uid <admin username>
-    ````
-
-    ***NOTE:*** This results in resetting the LDAP password
 
     **OR**
 

--- a/docs/admin/Offline_System_Certificate_Renewal.md
+++ b/docs/admin/Offline_System_Certificate_Renewal.md
@@ -17,14 +17,20 @@ This tool's behavior is different in an **IPA environment** and **standalone PKI
 
 ### IPA Environment (Uses LDAPI)
 
+#### Reason for using LDAPI mechanism:
+
+This tool was designed with a mindset of "one-stop solution" for sysadmins to bring up a PKI server that failed
+due to expired system certificates. In an IPA environment, LDAPI is used for the following reasons:
+
+- DS certificate may be expired
+- We need to set/reset password for some accounts using `ldappasswd` which need confidentiality. Therefore we cannot use LDAPS/STARTTLS
+
 #### Assumptions:
 
 - Valid CA certificate
 - `cert-fix` must be run as `root`
-- `LDAPI` must be configured, with `root` autobinding to `cn=Directory Manager` or other account with privileges on `o=ipaca` subtree, including password reset privileges
 - The password of the specified agent account will be reset. If needed, it can be changed back afterwards (manually; successful execution of `cert-fix` proves that the operator has privileges to do this)
 - The password of the `pkidbuser` account will be reset
-- LDAPI (ldappasswd) and need to be root
 
 #### Usage:
 
@@ -87,6 +93,9 @@ This tool's behavior is different in an **IPA environment** and **standalone PKI
 - Valid CA certificate
 - TLS configured Directory Server
 - If Dogtag was configured to use TLS certificate authentication to bind to LDAP, a Valid DS service certificate
+- `cert-fix` must be run as `root`
+- The password of the specified agent account will be reset. If needed, it can be changed back afterwards (manually; successful execution of `cert-fix` proves that the operator has privileges to do this)
+- The password of the `pkidbuser` account will be reset
 
 #### Usage:
 
@@ -102,8 +111,9 @@ For all available options, you can type:
 
 ## Manual Renewal Process
 
-**NOTE:** The steps listed here are for a *PKI standalone environment*. For the *IPA Environment*, the steps are very complicated and it's
-suggested to use the [automated process](#ipa-environment-uses-ldapi)
+**NOTE:** The steps listed here are for a *PKI standalone environment*. For the *IPA Environment*, it's suggested to use
+the **IPA specific `ipa-cert-fix` tool** to simplify the process. It uses [`pki-server cert-fix`](#ipa-environment-uses-ldapi)
+behind the scenes.
 
 ### Initialization
 

--- a/docs/admin/Offline_System_Certificate_Renewal.md
+++ b/docs/admin/Offline_System_Certificate_Renewal.md
@@ -101,6 +101,10 @@ For all available options, you can type:
     $ pki-server cert-fix --help
 
 ## Manual Renewal Process
+
+**NOTE:** The steps listed here are for a *PKI standalone environment*. For the *IPA Environment*, the steps are very complicated and it's
+suggested to use the [automated process](#ipa-environment-uses-ldapi)
+
 ### Initialization
 
 It is recommended to run the following steps to ensure that `CS.cfg` and NSS database are synchronized and that the server can operate without any issues.
@@ -128,33 +132,6 @@ It is recommended to run the following steps to ensure that `CS.cfg` and NSS dat
 
 There are 2 different scenarios based on value of `internaldb.ldapauth.authtype` in your target subsystems' CS.cfg:
 
-#### IPA Environment (Uses LDAPI)
-1. Update corresponding CS.cfg key-values as follows:
-
-    ````
-    internaldb.ldapauth.authtype=BasicAuth
-    internaldb.ldapconn.port=389
-    internaldb.ldapconn.secureConn=false
-    internaldb.ldapauth.bindDN=uid=pkidbuser,ou=people,<internaldb.basedn>
-    ````
-2. Set a LDAP password using `ldappasswd` (Use `%2F` instead of a `/` in file path):
-    ````
-    # ldappasswd -H ldapi://%2Fvar%2Frun%2Fslapd-REALM.socket -Y EXTERNAL -s <LDAP pasword> uid=pkidbuser,ou=people,<internaldb.basedn>
-    ````
-
-3. Set the agent password (requires a secure connection to LDAP)
-    ````
-    # ldappasswd -H ldapi://%2Fvar%2Frun%2Fslapd-REALM.socket -Y EXTERNAL -s <agent password> uid=<agent UID>,ou=people,<internaldb.basedn>
-    ````
-    **NOTE:** If your `<LDAP host URL>` starts with `ldap://`, add `-ZZ` flag to the above command
-
-4. Set the LDAP password in `password.conf`:
-    ````
-    # echo <LDAP password> >> /etc/pki/pki-tomcat/password.conf
-    ````
-
-#### PKI Standalone Environment (Uses LDAPS)
-
 1. Update corresponding CS.cfg key-values as follows:
 
     ````
@@ -170,7 +147,7 @@ There are 2 different scenarios based on value of `internaldb.ldapauth.authtype`
 
 3. Set the LDAP password in `password.conf`:
     ````
-    # echo <LDAP password> >> /etc/pki/pki-tomcat/password.conf
+    # echo internaldb=<LDAP password> >> /etc/pki/pki-tomcat/password.conf
     ````
 
 ### Bringing up the PKI server


### PR DESCRIPTION
Recently, we made some major modifications to the offline cert renewal system. The corresponding docs have been updated.

This patch includes doc update for PRs: #182 #199 

I have the following test-matrix which I'll update as i do testing. These tests are based on a layman reading this doc

|                | Manual | Automated | 
|---------------|------------|----------|
| **PKI standalone** | :heavy_check_mark:       |  :heavy_check_mark:      |  
| **IPA**            | N/A  | :heavy_check_mark:  |  

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`