### PR TITLE
Updated Ansible requirement

### DIFF
--- a/tests/dogtag/pytest-ansible/requirements.txt
+++ b/tests/dogtag/pytest-ansible/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.7.0
+ansible>=2.7.8
 pytest-ansible==2.0.2
 pytest-ansible-playbook
 pytest-logger


### PR DESCRIPTION
The minimum version for Ansible has been updated due to the following issue:
https://nvd.nist.gov/vuln/detail/CVE-2019-3828