### PR TITLE
[10.5] handle inflated numSubordinates

### DIFF
--- a/base/common/src/com/netscape/certsrv/util/AsyncLoader.java
+++ b/base/common/src/com/netscape/certsrv/util/AsyncLoader.java
@@ -18,6 +18,8 @@
 
 package com.netscape.certsrv.util;
 
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -33,28 +35,54 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class AsyncLoader {
     private CountDownLatch producerInitialised = new CountDownLatch(1);
-    private ReentrantLock loadingLock = new ReentrantLock();
+    private GoAwayLock loadingLock = new GoAwayLock();
     private Integer numItems = null;
     private int numItemsLoaded = 0;
+    private boolean loading = true;
+    private int timeoutSeconds = 0;
+    private Timer timer = new Timer("AsyncLoader watchdog");
+    private TimerTask watchdog = null;
+
+    /** Create an AsyncLoader with the specified timeout.
+     *
+     * If timeoutSeconds > 0, startLoading() will start a timer
+     * that will forcibly unlock the loader after the specified
+     * timeout.
+     */
+    public AsyncLoader(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
 
     /**
-     * Acquire the lock as a producer.
+     * Acquire the lock as a producer and reset
+     * progress-tracking variables.
      */
     public void startLoading() {
+        loadingLock.lock();
+        loading = true;
         numItems = null;
         numItemsLoaded = 0;
-        loadingLock.lock();
         producerInitialised.countDown();
+        if (timeoutSeconds > 0) {
+            if (watchdog != null)
+                watchdog.cancel();
+            watchdog = new AsyncLoaderWatchdog();
+            timer.schedule(watchdog, timeoutSeconds * 1000);
+        }
     }
 
     /**
      * Increment the number of items loaded by 1.  If the number
      * of items is known and that many items have been loaded,
      * unlock the loader.
+     *
+     * If the loader is not currently loading, does nothing.
      */
     public void increment() {
-        numItemsLoaded += 1;
-        checkLoadDone();
+        if (loading) {
+            numItemsLoaded += 1;
+            checkLoadDone();
+        }
     }
 
     /**
@@ -69,18 +97,77 @@ public class AsyncLoader {
 
     private void checkLoadDone() {
         if (numItems != null && numItemsLoaded >= numItems) {
+            watchdog.cancel();
+            loading = false;
             while (loadingLock.isHeldByCurrentThread())
                 loadingLock.unlock();
         }
     }
 
+    /**
+     * Wait upon the consumer to finish loading items.
+     *
+     * @throws InterruptedException if the thread is interrupted
+     * while waiting for the loading lock.  This can happen due
+     * to timeout.
+     */
     public void awaitLoadDone() throws InterruptedException {
         /* A consumer may await upon the Loader immediately after
          * starting the producer.  To ensure that the producer
-         * has time to acquire the lock, we use a CountDownLatch.
+         * has time to acquire the lock, we use a CountDownLatch
+         * that only the producer can release (in 'startLoading').
          */
-        producerInitialised.await();
-        loadingLock.lock();
-        loadingLock.unlock();
+        if (loading) {
+            producerInitialised.await();
+            loadingLock.lockInterruptibly();
+            loadingLock.unlock();
+        }
+    }
+
+    /** Forcibly unlock this AsyncLoader.
+     *
+     * There's no way we can safely interrupt the producer to
+     * release the loadingLock.  So here's what we do.
+     *
+     * - Interrupt all threads that are waiting on the lock.
+     * - Set loading = false so that future call to awaitLoadDone()
+     *   return immediately.
+     *
+     * Upon subseqent re-loads (e.g. due to loss and reesablishment
+     * of LDAP persistent search), the producer thread will call
+     * startLoading() again, which will increment the producer's
+     * hold count.  That's OK because when the unlock condition is
+     * met, checkLoadDone() will call loadingLock.unlock() as many
+     * times as needed to effect the unlock.
+     *
+     * This method DOES NOT interrupt threads waiting on the
+     * producerInitialised CountDownLatch.  The producer MUST call
+     * startLoading() which will acquire the loading lock then
+     * release the CountDownLatch.
+     */
+    private void forceUnlock() {
+        loading = false;
+        loadingLock.interruptWaitingThreads();
+    }
+
+    /** Subclass of ReentrantLock that can tell waiting threads
+     * to go away (by interrupting them).  Awaiters must use
+     * lockInterruptibly() to acquire the lock.
+     *
+     * This needed to be a subclass of ReentrantLock because
+     * ReentrantLock.getQueuedThreads() has visibility 'protected'.
+     */
+    private static class GoAwayLock extends ReentrantLock {
+        public void interruptWaitingThreads() {
+            for (Thread thread : getQueuedThreads()) {
+                thread.interrupt();
+            }
+        }
+    }
+
+    private class AsyncLoaderWatchdog extends TimerTask {
+        public void run() {
+            forceUnlock();
+        }
     }
 }

--- a/base/server/cmscore/src/com/netscape/cmscore/profile/LDAPProfileSubsystem.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/profile/LDAPProfileSubsystem.java
@@ -58,7 +58,9 @@ public class LDAPProfileSubsystem
         extends AbstractProfileSubsystem
         implements IProfileSubsystem, Runnable {
 
-    private String dn;
+    private String profileContainerDNString;
+    private DN profileContainerDN;
+
     private ILdapConnFactory dbFactory;
 
     private boolean stopped = false;
@@ -73,7 +75,7 @@ public class LDAPProfileSubsystem
     /* Set of nsUniqueIds of deleted entries */
     private TreeSet<String> deletedNsUniqueIds;
 
-    private AsyncLoader loader = new AsyncLoader();
+    private AsyncLoader loader = new AsyncLoader(10 /*10s timeout*/);
 
     /**
      * Initializes this subsystem with the given configuration
@@ -112,7 +114,8 @@ public class LDAPProfileSubsystem
 
         // read profile id, implementation, and its configuration files
         String basedn = cs.getString("internaldb.basedn");
-        dn = "ou=certificateProfiles,ou=ca," + basedn;
+        profileContainerDNString = "ou=certificateProfiles,ou=ca," + basedn;
+        profileContainerDN = new DN(profileContainerDNString);
 
         monitor = new Thread(this, "profileChangeMonitor");
         monitor.start();
@@ -121,6 +124,8 @@ public class LDAPProfileSubsystem
         } catch (InterruptedException e) {
             CMS.debug("LDAPProfileSubsystem: caught InterruptedException "
                     + "while waiting for initial load of profiles.");
+            CMS.debug("You may have replication conflict entries or "
+                    + "extraneous data under " + profileContainerDNString);
         }
         CMS.debug("LDAPProfileSubsystem: finished init");
     }
@@ -294,12 +299,10 @@ public class LDAPProfileSubsystem
     }
 
     private synchronized void handleMODDN(DN oldDN, LDAPEntry entry) {
-        DN profilesDN = new DN(dn);
-
-        if (oldDN.isDescendantOf(profilesDN))
+        if (oldDN.isDescendantOf(profileContainerDN))
             forgetProfile(oldDN.explodeDN(true)[0]);
 
-        if ((new DN(entry.getDN())).isDescendantOf(profilesDN))
+        if ((new DN(entry.getDN())).isDescendantOf(profileContainerDN))
             readProfile(entry);
     }
 
@@ -384,12 +387,14 @@ public class LDAPProfileSubsystem
         if (id == null) {
             throw new EProfileException("CMS_PROFILE_ID_NOT_FOUND");
         }
-        return "cn=" + id + "," + dn;
+        return "cn=" + id + "," + profileContainerDNString;
     }
 
     private void ensureProfilesOU(LDAPConnection conn) throws LDAPException {
         try {
-            conn.search(dn, LDAPConnection.SCOPE_BASE, "(objectclass=*)", null, false);
+            conn.search(
+                profileContainerDNString, LDAPConnection.SCOPE_BASE,
+                "(objectclass=*)", null, false);
         } catch (LDAPException e) {
             if (e.getLDAPResultCode() == LDAPException.NO_SUCH_OBJECT) {
                 CMS.debug("Adding LDAP certificate profiles container");
@@ -398,7 +403,7 @@ public class LDAPProfileSubsystem
                     new LDAPAttribute("ou", "certificateProfiles")
                 };
                 LDAPAttributeSet attrSet = new LDAPAttributeSet(attrs);
-                LDAPEntry entry = new LDAPEntry(dn, attrSet);
+                LDAPEntry entry = new LDAPEntry(profileContainerDNString, attrSet);
                 conn.add(entry);
             }
         }
@@ -426,8 +431,8 @@ public class LDAPProfileSubsystem
                 cons.setServerTimeLimit(0 /* seconds */);
                 String[] attrs = {"*", "entryUSN", "nsUniqueId", "numSubordinates"};
                 LDAPSearchResults results = conn.search(
-                    dn, LDAPConnection.SCOPE_SUB, "(objectclass=*)",
-                    attrs, false, cons);
+                    profileContainerDNString, LDAPConnection.SCOPE_SUB,
+                    "(objectclass=*)", attrs, false, cons);
 
                 /* Wait until the last possible moment before taking
                  * the load lock and dropping all profiles, so that
@@ -443,15 +448,43 @@ public class LDAPProfileSubsystem
 
                 while (!stopped && results.hasMoreElements()) {
                     LDAPEntry entry = results.next();
+                    DN entryDN = new DN(entry.getDN());
 
-                    String[] objectClasses =
-                        entry.getAttribute("objectClass").getStringValueArray();
-                    if (Arrays.asList(objectClasses).contains("organizationalUnit")) {
+                    if (entryDN.countRDNs() == profileContainerDN.countRDNs()) {
+                        /* This is the profile container.  Read numSubordinates to get
+                         * the expected number of profiles entries to read.
+                         *
+                         * numSubordinates is not reliable; it may be too high
+                         * due to objects we cannot see (e.g. replication conflict
+                         * entries).  In that case AsyncLoader has a watchdog
+                         * timer to interrupt waiting threads.
+                         */
                         loader.setNumItems(new Integer(
                             entry.getAttribute("numSubordinates")
                                 .getStringValueArray()[0]));
                         continue;
                     }
+
+                    if (entryDN.countRDNs() > profileContainerDN.countRDNs() + 1) {
+                        /* This entry is unexpectedly deep.  We ignore it.
+                         * numSubordinates only counts immediate subordinates
+                         * (https://tools.ietf.org/html/draft-boreham-numsubordinates-01)
+                         * so don't increment() the AsyncLoader.
+                         */
+                        continue;
+                    }
+
+                    /* This entry is at the expected depth.  Is it a certProfile? */
+                    String[] objectClasses =
+                        entry.getAttribute("objectClass").getStringValueArray();
+                    if (!Arrays.asList(objectClasses).contains("certProfile")) {
+                        /* It is not a certProfile; ignore it.  But it does
+                         * contribute to numSubordinates so increment the loader. */
+                        loader.increment();
+                        continue;
+                    }
+
+                    /* We have a profile.  Process it. */
 
                     LDAPEntryChangeControl changeControl = (LDAPEntryChangeControl)
                         LDAPUtil.getControl(


### PR DESCRIPTION
Backport of https://github.com/dogtagpki/pki/pull/188 to 10.5.  There were some
trivial conflicts related to change of logging system (`CMS.debug` ->
`logger.(debug|warn)`) and `import` reordering.