### PR TITLE
Add support for non-default ports in Offline Cert renewal tool

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -584,10 +584,10 @@ class PKIServer(object):
         return subsystem_name, cert_tag
 
     @staticmethod
-    def setup_password_authentication(username, password, subsystem_name='ca'):
+    def setup_password_authentication(username, password, subsystem_name='ca', secure_port='8443'):
         """Return a PKIConnection, logged in using username and password."""
         connection = client.PKIConnection(
-            'https', os.environ['HOSTNAME'], '8443', subsystem_name)
+            'https', os.environ['HOSTNAME'], secure_port, subsystem_name)
         connection.authenticate(username, password)
         account_client = pki.account.AccountClient(connection)
         account_client.login()
@@ -596,7 +596,7 @@ class PKIServer(object):
     @staticmethod
     def setup_cert_authentication(
             client_nssdb_pass, client_nssdb_pass_file, client_cert,
-            client_nssdb, tmpdir, subsystem_name):
+            client_nssdb, tmpdir, subsystem_name, secure_port='8443'):
         """
         Utility method to set up a secure authenticated connection with a
         subsystem of PKI Server through PKI client
@@ -613,6 +613,8 @@ class PKIServer(object):
         :type tmpdir: str
         :param subsystem_name: Name of the subsystem
         :type subsystem_name: str
+        :param secure_port: Secure Port Number
+        :type secure_port: str
         :return: Authenticated secure connection to PKI server
         """
         temp_auth_p12 = os.path.join(tmpdir, 'auth.p12')
@@ -622,7 +624,7 @@ class PKIServer(object):
             raise PKIServerException('Client cert nickname is required.')
 
         # Create a PKIConnection object that stores the details of subsystem.
-        connection = client.PKIConnection('https', os.environ['HOSTNAME'], '8443',
+        connection = client.PKIConnection('https', os.environ['HOSTNAME'], secure_port,
                                           subsystem_name)
 
         # Create a p12 file using
@@ -1424,7 +1426,8 @@ class PKIInstance(PKIServer):
             username=None, password=None,
             client_cert=None, client_nssdb=None,
             client_nssdb_pass=None, client_nssdb_pass_file=None,
-            serial=None, temp_cert=False, renew=False, output=None):
+            serial=None, temp_cert=False, renew=False, output=None,
+            secure_port='8443'):
         """
         Create a new cert for the cert_id provided
 
@@ -1453,6 +1456,8 @@ class PKIInstance(PKIServer):
         :type renew: bool
         :param output: Path to which new cert needs to be written to
         :type output: str
+        :param secure_port: Secure port number in case of renewing a certificate
+        :type secure_port: str
         :return: None
         :rtype: None
         :raises PKIServerException
@@ -1511,7 +1516,7 @@ class PKIInstance(PKIServer):
                 logger.info('Trying to setup a secure connection to CA subsystem.')
                 if username and password:
                     connection = PKIServer.setup_password_authentication(
-                        username, password, subsystem_name='ca')
+                        username, password, subsystem_name='ca', secure_port=secure_port)
                 else:
                     if not client_cert:
                         raise PKIServerException('Client cert nick name required.')
@@ -1523,7 +1528,8 @@ class PKIInstance(PKIServer):
                         client_nssdb_pass_file=client_nssdb_pass_file,
                         client_nssdb=client_nssdb,
                         tmpdir=tmpdir,
-                        subsystem_name='ca'
+                        subsystem_name='ca',
+                        secure_port=secure_port
                     )
                 logger.info('Secure connection with CA is established.')
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -436,6 +436,7 @@ class CertCreateCLI(pki.cli.CLI):
         # ca.cert.list=signing,ocsp_signing,sslserver,subsystem,audit_signing
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
+        print('  -p, --port <port number>        Secure port number (default: 8443).')
         print('  -d <database>                   Security database location '
               '(default: ~/.dogtag/nssdb)')
         print('  -c <NSS DB password>            NSS database password')
@@ -460,9 +461,9 @@ class CertCreateCLI(pki.cli.CLI):
     def execute(self, argv):
 
         try:
-            opts, args = getopt.gnu_getopt(argv, 'i:d:c:C:n:u:w:W:v', [
+            opts, args = getopt.gnu_getopt(argv, 'i:d:c:C:n:u:w:W:p:v', [
                 'instance=', 'temp', 'serial=',
-                'output=', 'renew',
+                'output=', 'renew', 'port=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -482,6 +483,7 @@ class CertCreateCLI(pki.cli.CLI):
         agent_username = None
         agent_password = None
         agent_password_file = None
+        port = '8443'
 
         for o, a in opts:
             if o in ('-i', '--instance'):
@@ -532,6 +534,9 @@ class CertCreateCLI(pki.cli.CLI):
                     logger.error('-W cannot be used with -w')
                     sys.exit(1)
                 agent_password_file = a
+
+            elif o in ('-p', '--port'):
+                port = a
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -586,7 +591,7 @@ class CertCreateCLI(pki.cli.CLI):
                 client_nssdb_pass=client_nssdb_password,
                 client_nssdb_pass_file=client_nssdb_pass_file,
                 serial=serial, temp_cert=temp_cert, renew=renew, output=output,
-                username=agent_username, password=agent_password)
+                username=agent_username, password=agent_password, secure_port=port)
 
         except server.PKIServerException as e:
             logger.error(str(e))
@@ -1025,6 +1030,7 @@ class CertFixCLI(pki.cli.CLI):
         print('      --ldapi-socket <Path>       Path to DS LDAPI socket')
         print('      --ldap-url <URL>            LDAP URL (mutually exclusive to --ldapi-socket)')
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
+        print('  -p, --port <port number>        Secure port number (default: 8443).')
         print('  -v, --verbose                   Run in verbose mode.')
         print('      --debug                     Run in debug mode.')
         print('      --help                      Show help message.')
@@ -1034,9 +1040,9 @@ class CertFixCLI(pki.cli.CLI):
         logging.getLogger().setLevel(logging.INFO)
 
         try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
+            opts, _ = getopt.gnu_getopt(argv, 'i:p:v', [
                 'instance=', 'cert=', 'extra-cert=', 'agent-uid=',
-                'ldapi-socket=', 'ldap-url=', 'verbose', 'debug', 'help',
+                'ldapi-socket=', 'ldap-url=', 'port=', 'verbose', 'debug', 'help',
             ])
 
         except getopt.GetoptError as e:
@@ -1051,6 +1057,7 @@ class CertFixCLI(pki.cli.CLI):
         agent_uid = None
         ldap_url = None
         use_ldapi = False
+        port = '8443'
 
         for o, a in opts:
             if o in ('-i', '--instance'):
@@ -1084,6 +1091,9 @@ class CertFixCLI(pki.cli.CLI):
                     logger.error('--ldap-url cannot be used with --ldapi-socket')
                     sys.exit(1)
                 ldap_url = a
+
+            elif o in ('-p', '--port'):
+                port = a
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -1227,7 +1237,7 @@ class CertFixCLI(pki.cli.CLI):
                         logger.info('Requesting new cert for %s', cert_id)
                         instance.cert_create(
                             cert_id=cert_id, renew=True,
-                            username=agent_uid, password=agent_pass)
+                            username=agent_uid, password=agent_pass, secure_port=port)
                     for serial in extra_certs:
                         output = instance.cert_file('{}-renewed'.format(serial))
                         logger.info(
@@ -1236,7 +1246,7 @@ class CertFixCLI(pki.cli.CLI):
                         try:
                             instance.cert_create(
                                 serial=serial, renew=True, output=output,
-                                username=agent_uid, password=agent_pass)
+                                username=agent_uid, password=agent_pass, secure_port=port)
                         except pki.PKIException as e:
                             logger.error("Failed to renew certificate %s: %s", serial, e)
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -537,6 +537,13 @@ class CertCreateCLI(pki.cli.CLI):
 
             elif o in ('-p', '--port'):
                 port = a
+                try:
+                    n = int(port)
+                    if n < 1 or n > 65535:
+                        raise ValueError
+                except ValueError:
+                    logger.error('-p, --port requires a valid port number as integer')
+                    sys.exit(1)
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)
@@ -1094,6 +1101,13 @@ class CertFixCLI(pki.cli.CLI):
 
             elif o in ('-p', '--port'):
                 port = a
+                try:
+                    n = int(port)
+                    if n < 1 or n > 65535:
+                        raise ValueError
+                except ValueError:
+                    logger.error('-p, --port requires a valid port number as integer')
+                    sys.exit(1)
 
             elif o in ('-v', '--verbose'):
                 self.set_verbose(True)


### PR DESCRIPTION
This patch adds an option to be utilized in a
non-standard environment (ie) allows custom secure ports
to be specified during offline cert renewal process.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1679480

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>