### PR TITLE
install: fix token normalisation

### DIFF
--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -666,8 +666,9 @@ class PKIConfigParser:
         if not token:
             token = self.mdict.get('pki_token_name')
 
-        # normalize token name
-        token = pki.nssdb.normalize_token(token)
+        # DO NOT normalise the token name here, to avoid re-interpreting
+        # the internal token as the default token.  The token name must
+        # be conveyed to the Java SystemConfigService as-is.
 
         # update cert token
         self.mdict[name] = token


### PR DESCRIPTION
17677ae4d2cda456b64ec67e2b25ba63f4a58a70 changed pkispawn to treat
blank token name as the default token name (as specified in the
pkispawn config, or the internal token if not specified).  As part
of this change, the token normalisation routine was updated to
replace "internal" will null.  But this introduced a regression
under the following scenario:

- default token is NOT the internal token (e.g. HSM); and
- some certificate is to use the internal token (e.g. Server-Cert)

In this case, the internal token is normalised to null, and later
re-interpreted to mean the default token.

Do not normalise internal token names to null in the Python side of
pkispawn.  This ensures that any token name that has been specified
is transmitted to the Java configuration service as-is.  Null tokens
are still interpreted as the default token on the Java side.

Fixes: https://pagure.io/dogtagpki/issue/3093