### PR TITLE
Adding optional Rawhide tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,17 @@ script:
       docker exec -i ${CONTAINER} ${SCRIPTDIR}/ds-remove.sh
     fi
 
+matrix:
+  fast_finish: true
+  include:
+    - stage: rawhide
+      env: BASE_IMAGE_VERSION=rawhide TASK="PKI"
+    - env: BASE_IMAGE_VERSION=rawhide TASK="IPA"
+  allow_failures:
+    - stage: rawhide
+      env: BASE_IMAGE_VERSION=rawhide TASK="PKI"
+    - env: BASE_IMAGE_VERSION=rawhide TASK="IPA"
+
 after_script:
   - cat ${LOGS}
   - docker kill ${CONTAINER}

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,12 @@ matrix:
     - stage: rawhide
       env: BASE_IMAGE_VERSION=rawhide TASK="PKI"
     - env: BASE_IMAGE_VERSION=rawhide TASK="IPA"
+    # This is a dummy job to mark the build as finished, without waiting for rawhide jobs
+    - env: DUMMY_JOB=FOR_FAST_FINISH
+      before_install: true
+      install: true
+      script: true
+      after_script: true
   allow_failures:
     - stage: rawhide
       env: BASE_IMAGE_VERSION=rawhide TASK="PKI"


### PR DESCRIPTION
This patch adds optional rawhide jobs to the Travis build matrix to pickup the errors as quickly as possible in the release process.

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`