### PR TITLE
Bug 1709585 PKI (test support) for PKCS#11standard AES KeyWrap for HS…

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/CRMFPopClient.java
+++ b/base/java-tools/src/com/netscape/cmstools/CRMFPopClient.java
@@ -316,7 +316,7 @@ public class CRMFPopClient {
 
         String curve = cmd.getOptionValue("c", "nistp256");
         boolean sslECDH = Boolean.parseBoolean(cmd.getOptionValue("x", "false"));
-        boolean temporary = Boolean.parseBoolean(cmd.getOptionValue("t", "true"));
+        boolean temporary = Boolean.parseBoolean(cmd.getOptionValue("t", (algorithm.equals("rsa"))? "false":"true"));
         int sensitive = Integer.parseInt(cmd.getOptionValue("s", "-1"));
         int extractable = Integer.parseInt(cmd.getOptionValue("e", "-1"));
 
@@ -363,11 +363,6 @@ public class CRMFPopClient {
         if (algorithm.equals("rsa")) {
             if (cmd.hasOption("c")) {
                 printError("Illegal parameter for RSA: -c");
-                System.exit(1);
-            }
-
-            if (cmd.hasOption("t")) {
-                printError("Illegal parameter for RSA: -t");
                 System.exit(1);
             }
 
@@ -472,7 +467,7 @@ public class CRMFPopClient {
             if (verbose) System.out.println("Generating key pair");
             KeyPair keyPair;
             if (algorithm.equals("rsa")) {
-                keyPair = CryptoUtil.generateRSAKeyPair(token, keySize);
+                keyPair = CryptoUtil.generateRSAKeyPair(token, keySize, temporary);
             } else if (algorithm.equals("ec")) {
                 keyPair = client.generateECCKeyPair(token, curve, sslECDH, temporary, sensitive, extractable);
 
@@ -727,6 +722,11 @@ public class CRMFPopClient {
             return new WrappingParams(
                 SymmetricKey.AES, KeyGenAlgorithm.AES, 128,
                 KeyWrapAlgorithm.RSA, EncryptionAlgorithm.AES_128_CBC_PAD,
+                kwAlg, ivps, ivps);
+        } else if (kwAlg == KeyWrapAlgorithm.AES_KEY_WRAP) {
+            return new WrappingParams(
+                SymmetricKey.AES, KeyGenAlgorithm.AES, 128,
+                KeyWrapAlgorithm.RSA, EncryptionAlgorithm.AES_128_CBC,
                 kwAlg, ivps, ivps);
         } else if (kwAlg == KeyWrapAlgorithm.DES3_CBC_PAD) {
             return new WrappingParams(

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -573,7 +573,15 @@ public class CryptoUtil {
     }
 
     public static KeyPair generateRSAKeyPair(CryptoToken token, int keysize) throws Exception {
+        return generateRSAKeyPair(token, keysize, false);
+    }
+
+    public static KeyPair generateRSAKeyPair(CryptoToken token, int keysize, boolean temporary) throws Exception {
         KeyPairGenerator kg = token.getKeyPairGenerator(KeyPairAlgorithm.RSA);
+
+        if (temporary == true)
+            kg.temporaryPairs(true);
+
         kg.initialize(keysize);
         return kg.genKeyPair();
     }
@@ -2905,6 +2913,7 @@ public class CryptoUtil {
             pk = wrapper.unwrapPrivate(wrappedData,
                     keyType, pubKey);
         }
+System.out.println("CryptoUtil: unwrap: unwrap succeeded!");
         return pk;
     }
 
@@ -3065,10 +3074,6 @@ public class CryptoUtil {
         throw new NoSuchAlgorithmException();
     }
 
-    public static final OBJECT_IDENTIFIER KW_AES_KEY_WRAP_PAD = new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.1.8");
-    public static final OBJECT_IDENTIFIER KW_AES_CBC_PAD = new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.1.2");
-    public static final OBJECT_IDENTIFIER KW_DES_CBC_PAD = new OBJECT_IDENTIFIER("1.2.840.113549.3.7");
-
     /*
      * Useful method to map KeyWrap algorithms to an OID.
      * This is not yet defined within JSS, although it will be valuable to do
@@ -3081,27 +3086,33 @@ public class CryptoUtil {
      */
     public static OBJECT_IDENTIFIER getOID(KeyWrapAlgorithm kwAlg) throws NoSuchAlgorithmException {
         String name = kwAlg.toString();
+
+        if (name.equals(KeyWrapAlgorithm.AES_KEY_WRAP.toString()))
+            return KeyWrapAlgorithm.AES_KEY_WRAP_OID;
         if (name.equals(KeyWrapAlgorithm.AES_KEY_WRAP_PAD.toString()))
-            return KW_AES_KEY_WRAP_PAD;
+            return KeyWrapAlgorithm.AES_KEY_WRAP_PAD_OID;
         if (name.equals(KeyWrapAlgorithm.AES_CBC_PAD.toString()))
-            return KW_AES_CBC_PAD;
+            return KeyWrapAlgorithm.AES_CBC_PAD_OID;
         if (name.equals(KeyWrapAlgorithm.DES3_CBC_PAD.toString()))
-            return KW_DES_CBC_PAD;
+            return KeyWrapAlgorithm.DES_CBC_PAD_OID;
         if (name.equals(KeyWrapAlgorithm.DES_CBC_PAD.toString()))
-            return KW_DES_CBC_PAD;
+            return KeyWrapAlgorithm.DES_CBC_PAD_OID;
 
         throw new NoSuchAlgorithmException();
     }
 
     public static KeyWrapAlgorithm getKeyWrapAlgorithmFromOID(String wrapOID) throws NoSuchAlgorithmException {
         OBJECT_IDENTIFIER oid = new OBJECT_IDENTIFIER(wrapOID);
-        if (oid.equals(KW_AES_KEY_WRAP_PAD))
+        if (oid.equals(KeyWrapAlgorithm.AES_KEY_WRAP_PAD_OID))
             return KeyWrapAlgorithm.AES_KEY_WRAP_PAD;
 
-        if (oid.equals(KW_AES_CBC_PAD))
+        if (oid.equals(KeyWrapAlgorithm.AES_KEY_WRAP_OID))
+            return KeyWrapAlgorithm.AES_KEY_WRAP;
+
+        if (oid.equals(KeyWrapAlgorithm.AES_CBC_PAD_OID))
             return KeyWrapAlgorithm.AES_CBC_PAD;
 
-        if (oid.equals(KW_DES_CBC_PAD))
+        if (oid.equals(KeyWrapAlgorithm.DES_CBC_PAD_OID))
             return KeyWrapAlgorithm.DES3_CBC_PAD;
 
         throw new NoSuchAlgorithmException();

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -2913,7 +2913,6 @@ public class CryptoUtil {
             pk = wrapper.unwrapPrivate(wrappedData,
                     keyType, pubKey);
         }
-System.out.println("CryptoUtil: unwrap: unwrap succeeded!");
         return pk;
     }
 

--- a/base/util/src/netscape/security/util/WrappingParams.java
+++ b/base/util/src/netscape/security/util/WrappingParams.java
@@ -67,9 +67,9 @@ public class WrappingParams {
             // New clients set this correctly.
             // We'll assume the old DES3 wrapping here.
             encrypt = EncryptionAlgorithm.DES_CBC_PAD;
-        } else if (encryptOID.equals(CryptoUtil.KW_DES_CBC_PAD.toString())) {
+        } else if (encryptOID.equals(KeyWrapAlgorithm.DES_CBC_PAD_OID.toString())) {
             encrypt = EncryptionAlgorithm.DES3_CBC_PAD;
-        } else if (encryptOID.equals(CryptoUtil.KW_AES_CBC_PAD.toString())) {
+        } else if (encryptOID.equals(KeyWrapAlgorithm.AES_CBC_PAD_OID.toString())) {
             encrypt = EncryptionAlgorithm.AES_128_CBC_PAD;
         } else {
             encrypt = EncryptionAlgorithm.fromOID(new OBJECT_IDENTIFIER(encryptOID));


### PR DESCRIPTION
…M support

This patch adds test support to
Bug 1709551 - JSS: add PKCS#11standard AES KeyWrap for HSM support

specifically on the ability for CRMFPopClient to generate temporary RSA keys
 so that they can be extractable on HSM, as currently PSS is not yet supported
by PKI so can't rely on KRA to test the feature.
Also for the same reason, until Thales HSM SW 12.60 is available,
tests are only limited to
1. not break existing functionality for CKM_NSS_AES_KEY_WRAP_PAD on nss
2. have the expected result to be documented in https://bugzilla.redhat.com/show_bug.cgi?id=1709585

Also, relevant OIDs in CryptoUtil are changed to referce the JSS definitions
in KeyWrapAlgorithm instead, with the addition of AES_KEY_WRAP_OID.
(This results in a dependency)

See https://bugzilla.redhat.com/show_bug.cgi?id=1709551 for more detail.

https://bugzilla.redhat.com/show_bug.cgi?id=1709585