### PR TITLE
Added pki-server run

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -471,10 +471,10 @@ class PKIServer(object):
 
         self.config.clear()
 
-        if os.path.exists(self.service_conf):
+        if os.path.exists(self.tomcat_conf):
 
-            logger.info('Loading service config: %s', self.service_conf)
-            pki.util.load_properties(self.service_conf, self.config)
+            logger.info('Loading Tomcat config: %s', self.tomcat_conf)
+            pki.util.load_properties(self.tomcat_conf, self.config)
 
             # strip quotes
             for name, value in self.config.items():


### PR DESCRIPTION
A new pki-server run command has been added to run PKI server
in the foreground instead of in the background as systemd service.

By default the server will run as the same user used in the systemd
service, but the command provides an option to run the server as
the current user.

This functionality is needed to run PKI server in container:
https://www.dogtagpki.org/wiki/PKI_ACME_Container