### PR TITLE
AuthorityService.getCert: avoid NPE if CA is not ready

### DIFF
--- a/base/ca/src/org/dogtagpki/server/ca/rest/AuthorityService.java
+++ b/base/ca/src/org/dogtagpki/server/ca/rest/AuthorityService.java
@@ -143,8 +143,13 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
         if (ca == null)
             throw new ResourceNotFoundException("CA \"" + aidString + "\" not found");
 
+        org.mozilla.jss.crypto.X509Certificate cert = ca.getCaX509Cert();
+        if (cert == null)
+            throw new ResourceNotFoundException(
+                "Certificate for CA \"" + aidString + "\" not available");
+
         try {
-            return Response.ok(ca.getCaX509Cert().getEncoded()).build();
+            return Response.ok(cert.getEncoded()).build();
         } catch (CertificateEncodingException e) {
             // this really is a 500 Internal Server Error
             throw new PKIException("Error encoding certificate: " + e);
@@ -170,9 +175,14 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
         if (ca == null)
             throw new ResourceNotFoundException("CA \"" + aidString + "\" not found");
 
+        org.mozilla.jss.netscape.security.x509.CertificateChain chain = ca.getCACertChain();
+        if (chain == null)
+            throw new ResourceNotFoundException(
+                "Certificate chain for CA \"" + aidString + "\" not available");
+
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
-            ca.getCACertChain().encode(out);
+            chain.encode(out);
         } catch (IOException e) {
             throw new PKIException("Error encoding certificate chain: " + e);
         }

--- a/base/server/cms/src/org/dogtagpki/server/rest/PKIExceptionMapper.java
+++ b/base/server/cms/src/org/dogtagpki/server/rest/PKIExceptionMapper.java
@@ -2,6 +2,7 @@ package org.dogtagpki.server.rest;
 
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -17,10 +18,26 @@ public class PKIExceptionMapper implements ExceptionMapper<PKIException> {
 
     public Response toResponse(PKIException exception) {
         // convert PKIException into HTTP response
+
+        // The exception Data can onlybe serialised as XML or JSON,
+        // so coerce the response content type to one of these.
+        // Default to XML, but consider the Accept header.
+        MediaType contentType = MediaType.APPLICATION_XML_TYPE;
+        for (MediaType acceptType : headers.getAcceptableMediaTypes()) {
+            if (acceptType.isCompatible(MediaType.APPLICATION_XML_TYPE)) {
+                contentType = MediaType.APPLICATION_XML_TYPE;
+                break;
+            }
+            if (acceptType.isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
+                contentType = MediaType.APPLICATION_JSON_TYPE;
+                break;
+            }
+        }
+
         return Response
                 .status(exception.getCode())
                 .entity(exception.getData())
-                .type(PKIService.getResponseFormat(headers))
+                .type(contentType)
                 .build();
     }
 }


### PR DESCRIPTION
Fixes: https://pagure.io/dogtagpki/issue/3102

```
785fce0da (Fraser Tweedale, 11 minutes ago)
   PKIExceptionMapper: coerce media type to XML or JSON

   Some resources do not return (upon success) application/json or 
   application/xml.  For example, some resources in AuthorityService can
   return application/pkix-cert, application/x-pem-file or 
   application/pkcs7-mime.  But if a PKIException exception (e.g. 
   ResourceNotFoundException) occurs in such a method, RESTEasy can't turn the
   PKIException.Data entity into the declared media type, and it throws a
   NoMessageBodyWriterFoundFailure, causing a 500 Internal Server Error
   response.

   Update PKIExceptionMapper to always coerce the response Content-Type to
   either application/xml or application/json.  If the Accept header 
   preferences one of these, the preferred media type is used. Otherwise we
   default to application/xml.

   Fixes: https://pagure.io/dogtagpki/issue/3102

142e60d84 (Fraser Tweedale, 12 minutes ago)
   AuthorityService.getCert: avoid NPE if CA is not ready

   If a LWCA is not ready (i.e. key replication and signing unit 
   initialisation has not completed), asking for its certificate results in a
   NullPointerException.  Update AuthorityService.getCert() to raise
   ResourceNotFoundException instead.

   Part of: https://pagure.io/dogtagpki/issue/3102
```