### PR TITLE
bump jss min version to 4.6.0

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -313,7 +313,7 @@ BuildRequires:    jpackage-utils >= 0:1.7.5-10
 BuildRequires:    jss >= 4.4.0-11
 BuildRequires:    tomcatjss >= 7.2.1-4
 %else
-BuildRequires:    jss >= 4.5.3
+BuildRequires:    jss >= 4.6.0
 BuildRequires:    tomcatjss >= 7.4.0
 %endif
 BuildRequires:    systemd-units
@@ -438,7 +438,7 @@ Requires:         jpackage-utils >= 0:1.7.5-10
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:         jss >= 4.4.0-11
 %else
-Requires:         jss >= 4.5.3
+Requires:         jss >= 4.6.0
 %endif
 Requires:         nss >= 3.38.0
 
@@ -560,7 +560,7 @@ Requires:         jpackage-utils >= 0:1.7.5-10
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:         jss >= 4.4.0-11
 %else
-Requires:         jss >= 4.5.3
+Requires:         jss >= 4.6.0
 %endif
 Requires:         ldapjdk >= 4.21.0
 Requires:         pki-base = %{version}


### PR DESCRIPTION
f520f28a83d2253b8eb69a309ac705e96defdf0d introduced a dependency on
jss 4.6.0, but the min bound was not bumped.