### PR TITLE
ExternalProcessKeyRetriever: do not swallow stderr

### DIFF
--- a/base/ca/src/com/netscape/ca/ExternalProcessKeyRetriever.java
+++ b/base/ca/src/com/netscape/ca/ExternalProcessKeyRetriever.java
@@ -60,7 +60,8 @@ public class ExternalProcessKeyRetriever implements KeyRetriever {
             String host = hostPort.split(":")[0];
             command.push(host);
             logger.debug("About to execute command: " + command);
-            ProcessBuilder pb = new ProcessBuilder(command);
+            ProcessBuilder pb = new ProcessBuilder(command)
+                .redirectError(ProcessBuilder.Redirect.INHERIT);
             try {
                 Process p = pb.start();
                 int exitValue = p.waitFor();


### PR DESCRIPTION
ProcessBuilder, by default, redirects stderr to a PIPE.  But because
we do not do anything with stderr; nothing gets logged and nothing
appears in the journal.  This makes it difficult to debug failures
of the subprocess.

Inherit the stderr file descriptor instead of creating a pipe, so
that the subprocess stderr output will appear in the journal.

Related: https://pagure.io/dogtagpki/issue/3102