### PR TITLE
Modified HttpClient.java to pick token details correctly if admin/age…

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/HttpClient.java
+++ b/base/java-tools/src/com/netscape/cmstools/HttpClient.java
@@ -144,16 +144,15 @@ public class HttpClient {
                     }
                     certname.append(nickname);
                     System.out.println("Certificate Nickname:" + " " + certname);
-
+                    String certnick = certname.toString();
                     X509Certificate cert =
-                        cm.findCertByNickname(certname.toString());
+                        cm.findCertByNickname(certnick);
 
                     if (cert == null)
                         System.out.println("client cert is null");
                     else
                         System.out.println("client cert is not null");
                     sslSocket.setUseClientMode(true);
-                    String certnick = certname.toString();
                     sslSocket.setClientCertNickname(certnick);
                 }
 

--- a/base/java-tools/src/com/netscape/cmstools/HttpClient.java
+++ b/base/java-tools/src/com/netscape/cmstools/HttpClient.java
@@ -143,6 +143,7 @@ public class HttpClient {
                         certname.append(":");
                     }
                     certname.append(nickname);
+                    System.out.println("Certificate Nickname:" + " " + certname);
 
                     X509Certificate cert =
                         cm.findCertByNickname(certname.toString());
@@ -152,7 +153,8 @@ public class HttpClient {
                     else
                         System.out.println("client cert is not null");
                     sslSocket.setUseClientMode(true);
-                    sslSocket.setClientCertNickname(nickname);
+                    String certnick = certname.toString();
+                    sslSocket.setClientCertNickname(certnick);
                 }
 
                 sslSocket.forceHandshake();


### PR DESCRIPTION
…nt certificates reside in HSM

Signed-off-by: gkapoor <gkapoor@redhat.com>

**Problem:**
This fix basically get us rid of exception if admin/agent cert is in HSM or any external token.
This will fix exception --

<error snip>
java.lang.RuntimeException: org.mozilla.jss.crypto.ObjectNotFoundException: Certificate not found: subsystemCert cert-rhel77
    at org.mozilla.jss.ssl.SocketBase.setClientCertNickname(SocketBase.java:410)
    at org.mozilla.jss.ssl.SSLSocket.setClientCertNickname(SSLSocket.java:1283)
    at com.netscape.cmstools.HttpClient.send(HttpClient.java:155)
    at com.netscape.cmstools.HttpClient.main(HttpClient.java:395)
Caused by: org.mozilla.jss.crypto.ObjectNotFoundException: Certificate not found: subsystemCert cert-rhel77
    at org.mozilla.jss.CryptoManager.findCertByNicknameNative(Native Method)
    at org.mozilla.jss.CryptoManager.findCertByNickname(CryptoManager.java:1309)
    at org.mozilla.jss.ssl.SocketBase.setClientCertNickname(SocketBase.java:403)
    ... 3 more

</error snip>

Christina..could you please review it. I don't have a ticket for this fix. Please have a look.
With the fix ,I have performed a basic sanity test for HSM and Internal.

Below is the test report:

**Test Case 1: Token :Internal** 

- HttpClient http.cfg.internal 

Total number of bytes read = 1438
after SSLSocket created, thread token is NSS FIPS 140-2 User Private Key
Certificate Nickname: subsystemCert cert-pki-tomcat
client cert is not null
handshake happened
writing to socket
Total number of bytes read = 2647
The response in binary format is stored in cmc.role_crmf.resp

- CMCResponse -i cmc.role_crmf.resp
Certificates: 
    Certificate: 
        Data: 
            Version:  v3
            Serial Number: 0xB
            Signature Algorithm: SHA256withRSA - 1.2.840.113549.1.1.11
            Issuer: CN=CA Signing Certificate,OU=pki-tomcat,O=idmqe.lab.eng.bos.redhat.com Security Domain
            Validity: 
                Not Before: Saturday, June 22, 2019 4:15:12 PM EDT America/New_York
                Not  After: Thursday, December 19, 2019 4:15:12 PM EST America/New_York
            Subject: UID=user2,OU=People,DC=example,DC=org
            ...........
    Certificate: 
        Data: 
            Version:  v3
            Serial Number: 0x1
            Signature Algorithm: SHA256withRSA - 1.2.840.113549.1.1.11
            Issuer: CN=CA Signing Certificate,OU=pki-tomcat,O=idmqe.lab.eng.bos.redhat.com Security Domain
            Validity: 
                Not Before: Friday, June 21, 2019 1:45:35 PM EDT America/New_York
                Not  After: Tuesday, June 21, 2039 1:45:35 PM EDT America/New_York
            Subject: CN=CA Signing Certificate,OU=pki-tomcat,O=idmqe.lab.eng.bos.redhat.com Security Domain
            ..................................
Number of controls is 1
Control #0: CMCStatusInfoV2
   OID: {1 3 6 1 5 5 7 7 25}
   BodyList: 1 
   Status: SUCCESS
CMC Full Response.
=================================================

**Test case 2: With HSM Token :**

- HttpClient http.cfg 

Total number of bytes read = 1428
after SSLSocket created, thread token is NHSM6000-OCS
Certificate Nickname: NHSM6000-OCS:subsystemCert cert-rhel77_ca_gkapoor1
client cert is not null
handshake happened
writing to socket
Total number of bytes read = 2535
...................
The response in binary format is stored in cmc.role_crmf.resp


- CMCResponse -i cmc.role_crmf.resp
Certificates: 
    Certificate: 
        Data: 
            Version:  v3
            Serial Number: 0xFCA64BB
            Signature Algorithm: SHA256withRSA - 1.2.840.113549.1.1.11
            Issuer: CN=CA Signing Certificate,OU=rhel77_ca_gkapoor1,O=Example-rhcs10-CA
            Validity: 
                Not Before: Saturday, June 22, 2019 4:40:45 PM EDT America/New_York
                Not  After: Thursday, December 19, 2019 4:40:45 PM EST America/New_York
            Subject: UID=user1a,OU=People,DC=example,DC=org
            ........................
    Certificate: 
        Data: 
            Version:  v3
            Serial Number: 0x7561F89
            Signature Algorithm: SHA256withRSA - 1.2.840.113549.1.1.11
            Issuer: CN=CA Signing Certificate,OU=rhel77_ca_gkapoor1,O=Example-rhcs10-CA
            Validity: 
                Not Before: Friday, June 21, 2019 7:33:28 AM EDT America/New_York
                Not  After: Tuesday, June 21, 2039 7:33:28 AM EDT America/New_York
            Subject: CN=CA Signing Certificate,OU=rhel77_ca_gkapoor1,O=Example-rhcs10-CA
            ......................................

Number of controls is 1
Control #0: CMCStatusInfoV2
   OID: {1 3 6 1 5 5 7 7 25}
   BodyList: 1 
   Status: SUCCESS
CMC Full Response.
