### PR TITLE
Enable TLS 1.3 post handshake auth

### DIFF
--- a/base/native-tools/src/bulkissuance/bulkissuance.c
+++ b/base/native-tools/src/bulkissuance/bulkissuance.c
@@ -604,6 +604,17 @@ client_main(
         }
         errExit("SSL_OptionSet SSL_SECURITY");
     }
+#ifdef SSL_ENABLE_POST_HANDSHAKE_AUTH
+    rv = SSL_OptionSet(model_sock,
+                       SSL_ENABLE_POST_HANDSHAKE_AUTH, PR_TRUE);
+    if (rv < 0) {
+        if( model_sock != NULL ) {
+            PR_Close( model_sock );
+            model_sock = NULL;
+        }
+        errExit("SSL_OptionSet SSL_ENABLE_POST_HANDSHAKE_AUTH");
+    }
+#endif
 
     SSL_SetURL(model_sock, hostName);
 

--- a/base/native-tools/src/revoker/revoker.c
+++ b/base/native-tools/src/revoker/revoker.c
@@ -586,6 +586,17 @@ client_main(
         }
         errExit("SSL_OptionSet SSL_SECURITY");
     }
+#ifdef SSL_ENABLE_POST_HANDSHAKE_AUTH
+    rv = SSL_OptionSet(model_sock,
+                       SSL_ENABLE_POST_HANDSHAKE_AUTH, PR_TRUE);
+    if (rv < 0) {
+        if( model_sock != NULL ) {
+            PR_Close( model_sock );
+            model_sock = NULL;
+        }
+        errExit("SSL_OptionSet SSL_ENABLE_POST_HANDSHAKE_AUTH");
+    }
+#endif
 
     SSL_SetURL(model_sock, hostName);
 

--- a/base/native-tools/src/sslget/sslget.c
+++ b/base/native-tools/src/sslget/sslget.c
@@ -717,6 +717,10 @@ client_main(
             /* do SSL configuration. */
 
             rv = SSL_OptionSet(model_sock, SSL_SECURITY, 1);
+#ifdef SSL_ENABLE_POST_HANDSHAKE_AUTH
+            SSL_OptionSet(model_sock,
+                          SSL_ENABLE_POST_HANDSHAKE_AUTH, PR_TRUE);
+#endif
 
             if (rv < 0) {
                 if( model_sock != NULL ) {

--- a/base/tps-client/src/httpClient/engine.cpp
+++ b/base/tps-client/src/httpClient/engine.cpp
@@ -612,6 +612,12 @@ PRFileDesc * Engine::_doConnect(PRNetAddr *addr, PRBool SSLOn,
         if ( SECSuccess == rv ) {
 			rv = SSL_OptionSet(sock, SSL_ENABLE_TLS, PR_TRUE);
 		}
+#ifdef SSL_ENABLE_POST_HANDSHAKE_AUTH
+        if ( SECSuccess == rv ) {
+            rv = SSL_OptionSet(sock,
+                               SSL_ENABLE_POST_HANDSHAKE_AUTH, PR_TRUE);
+        }
+#endif
         if ( SECSuccess != rv ) {
             error = PORT_GetError();
             if( sock != NULL ) {


### PR DESCRIPTION
TLS 1.3 no longer supports renegotiations. Clients must announce support for
post handshake authentication to support conditional authentication with
client certs.

The fix is required to make Dogtag work with FreeIPA and TLS 1.3 enabled
Apache HTTPd proxy.

Change-Id: I07da8779e233f6e77526df30e29da575676ac0e9