### PR TITLE
Move changes to fix nightly test

### DIFF
--- a/travis/ipa-test.sh
+++ b/travis/ipa-test.sh
@@ -45,6 +45,14 @@ exit_handler() {
 # Print the version of installed components
 rpm -qa tomcat* pki-* freeipa-* nss* 389-ds* jss*| sort
 
+# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1727378
+# TODO: remove after the fix is available
+ds_version=`rpm -q 389-ds-base`
+if [[ $ds_version =~ 389-ds-base-1.4.0.24-1.fc29 ]]
+then
+    dnf downgrade -y 389-ds-base
+fi
+
 # Disable IPV6
 sysctl net.ipv6.conf.lo.disable_ipv6=0
 

--- a/travis/pki-init.sh
+++ b/travis/pki-init.sh
@@ -47,11 +47,3 @@ dnf copr enable -y ${COPR_REPO}
 
 # update, container might be outdated
 dnf update -y --best --allowerasing
-
-# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1727378
-# TODO: remove after the fix is available
-ds_version=`rpm -q 389-ds-base`
-if [[ $ds_version =~ 389-ds-base-1.4.0.24-1.fc29 ]]
-then
-    dnf downgrade -y 389-ds-base
-fi


### PR DESCRIPTION
- Since the PKI's nightly job runs IPA sanity tests, this patch
  moves the content of PR#226 to the ipa related scripts.

- We don't need the workaround for standalone PKI environment

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>