### PR TITLE
Disallow 'pkidbuser' in cert-fix

### DIFF
--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1134,6 +1134,10 @@ class CertFixCLI(pki.cli.CLI):
             logging.error('Must specify --agent-uid')
             sys.exit(1)
 
+        if agent_uid == "pkidbuser":
+            logging.error('\'pkidbuser\' cannot be used.')
+            sys.exit(1)
+
         instance.load()
 
         # 1. Make a list of certs to fix OR use the list provided through CLI options


### PR DESCRIPTION
`cert-fix` command when run with `--agent-uid pkidbuser` renders
the system in an unstable state. This patch disallows specifying
`pkidbuser` as the agent uid

Resolves: BZ1729215

Thanks @geetikakay  for reporting this and @frasertweedale for the idea :+1: 

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`