### PR TITLE
Fix 'pkidestroy --force' to pickup correct instance name

### DIFF
--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -263,11 +263,17 @@ class PKIConfigParser:
             )
         return dbtype
 
-    def init_config(self):
+    def init_config(self, pki_instance_name=None):
         self.deployer.nss_db_type = self.get_nss_db_type()
         java_home = self._getenv('JAVA_HOME').strip()
 
-        default_instance_name = 'pki-tomcat'
+        # Check if a instance name is provided before assigning a default
+        # instance_name
+        if pki_instance_name:
+            default_instance_name = pki_instance_name
+        else:
+            default_instance_name = 'pki-tomcat'
+
         default_http_port = '8080'
         default_https_port = '8443'
 

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -351,6 +351,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         logger.info('Removing NSS database')
 
+        # Remove NSS DB when uninstalling the last subsystem
+        #
+        # NOTE: We check for 0 subsystems to exist at this point as
+        # /var/lib/pki/<instance>/<subsystem> dir should
+        # be removed as part of subsystem_layout scriptlet
         if len(deployer.instance.tomcat_instance_subsystems()) == 0:
 
             if deployer.directory.exists(deployer.mdict['pki_client_dir']):

--- a/base/server/python/pki/server/deployment/scriptlets/selinux_setup.py
+++ b/base/server/python/pki/server/deployment/scriptlets/selinux_setup.py
@@ -55,7 +55,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
     # Helper function to check if a given `context_value` exists in the given
     # set of `records`. This method can process both port contexts and file contexts
-    def is_exist(self, records, context_value):
+    def context_exists(self, records, context_value):
         for keys in records.keys():
             for key in keys:
                 if str(key) == context_value:
@@ -178,9 +178,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                         fcon = seobject.fcontextRecords(trans)
                         file_records = fcon.get_all()
 
-                        if self.is_exist(file_records,
-                                         deployer.mdict['pki_instance_path'] +
-                                         self.suffix):
+                        if self.context_exists(file_records,
+                                               deployer.mdict['pki_instance_path'] +
+                                               self.suffix):
                             logger.info(
                                 "deleting selinux fcontext \"%s\"",
                                 deployer.mdict['pki_instance_path'] + self.suffix)
@@ -188,9 +188,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                                 deployer.mdict['pki_instance_path'] +
                                 self.suffix, "")
 
-                        if self.is_exist(file_records,
-                                         deployer.mdict['pki_instance_log_path'] +
-                                         self.suffix):
+                        if self.context_exists(file_records,
+                                               deployer.mdict['pki_instance_log_path'] +
+                                               self.suffix):
                             logger.info(
                                 "deleting selinux fcontext \"%s\"",
                                 deployer.mdict['pki_instance_log_path'] +
@@ -199,9 +199,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                                 deployer.mdict['pki_instance_log_path'] +
                                 self.suffix, "")
 
-                        if self.is_exist(file_records,
-                                         deployer.mdict['pki_instance_configuration_path'] +
-                                         self.suffix):
+                        if self.context_exists(file_records,
+                                               deployer.mdict['pki_instance_configuration_path'] +
+                                               self.suffix):
                             logger.info(
                                 "deleting selinux fcontext \"%s\"",
                                 deployer.mdict['pki_instance_configuration_path'] +
@@ -210,9 +210,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                                 deployer.mdict['pki_instance_configuration_path'] +
                                 self.suffix, "")
 
-                        if self.is_exist(file_records,
-                                         deployer.mdict['pki_server_database_path'] +
-                                         self.suffix):
+                        if self.context_exists(file_records,
+                                               deployer.mdict['pki_server_database_path'] +
+                                               self.suffix):
                             logger.info(
                                 "deleting selinux fcontext \"%s\"",
                                 deployer.mdict['pki_server_database_path'] + self.suffix)
@@ -223,7 +223,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                         port_records = seobject.portRecords(trans)
                         port_record_values = port_records.get_all()
                         for port in ports:
-                            if self.is_exist(port_record_values, port):
+                            if self.context_exists(port_record_values, port):
                                 logger.info("deleting selinux port %s", port)
                                 port_records.delete(port, "tcp")
 

--- a/base/server/python/pki/server/deployment/scriptlets/selinux_setup.py
+++ b/base/server/python/pki/server/deployment/scriptlets/selinux_setup.py
@@ -53,6 +53,15 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         selinux.restorecon(mdict['pki_instance_log_path'], True)
         selinux.restorecon(mdict['pki_instance_configuration_path'], True)
 
+    # Helper function to check if a given `context_value` exists in the given
+    # set of `records`. This method can process both port contexts and file contexts
+    def is_exist(self, records, context_value):
+        for keys in records.keys():
+            for key in keys:
+                if str(key) == context_value:
+                    return True
+        return False
+
     def spawn(self, deployer):
 
         if config.str2bool(deployer.mdict['pki_skip_installation']):
@@ -154,57 +163,80 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 config.PKI_DEPLOYMENT_DEFAULT_TOMCAT_INSTANCE_NAME):
             return
 
-        # remove SELinux contexts when removing the last subsystem
-        if len(deployer.instance.tomcat_instance_subsystems()) == 0 and \
-                deployer.mdict['pki_instance_name'] != \
-                config.PKI_DEPLOYMENT_DEFAULT_TOMCAT_INSTANCE_NAME:
-
-            context_to_delete = ['pki_instance_path', 'pki_instance_log_path',
-                                 'pki_instance_configuration_path', 'pki_server_database_path',
-                                 'ports']
-
-            # Delete SELinux contexts
-            for context in context_to_delete:
-
-                # A maximum of 10 tries to delete 1 SELinux context
-                max_tries = 10
-
-                for counter in range(1, max_tries):
-
+        # A maximum of 10 tries to delete the SELinux contexts
+        max_tries = 10
+        for counter in range(1, max_tries):
+            try:
+                # remove SELinux contexts when removing the last subsystem
+                if len(deployer.instance.tomcat_instance_subsystems()) == 0:
                     trans = seobject.semanageRecords("targeted")
-                    try:
-                        trans.start()
-                        # If a port context is specified
-                        if context == 'ports':
-                            port_records = seobject.portRecords(trans)
-                            for port in ports:
+                    trans.start()
+
+                    if deployer.mdict['pki_instance_name'] != \
+                            config.PKI_DEPLOYMENT_DEFAULT_TOMCAT_INSTANCE_NAME:
+
+                        fcon = seobject.fcontextRecords(trans)
+                        file_records = fcon.get_all()
+
+                        if self.is_exist(file_records,
+                                         deployer.mdict['pki_instance_path'] +
+                                         self.suffix):
+                            logger.info(
+                                "deleting selinux fcontext \"%s\"",
+                                deployer.mdict['pki_instance_path'] + self.suffix)
+                            fcon.delete(
+                                deployer.mdict['pki_instance_path'] +
+                                self.suffix, "")
+
+                        if self.is_exist(file_records,
+                                         deployer.mdict['pki_instance_log_path'] +
+                                         self.suffix):
+                            logger.info(
+                                "deleting selinux fcontext \"%s\"",
+                                deployer.mdict['pki_instance_log_path'] +
+                                self.suffix)
+                            fcon.delete(
+                                deployer.mdict['pki_instance_log_path'] +
+                                self.suffix, "")
+
+                        if self.is_exist(file_records,
+                                         deployer.mdict['pki_instance_configuration_path'] +
+                                         self.suffix):
+                            logger.info(
+                                "deleting selinux fcontext \"%s\"",
+                                deployer.mdict['pki_instance_configuration_path'] +
+                                self.suffix)
+                            fcon.delete(
+                                deployer.mdict['pki_instance_configuration_path'] +
+                                self.suffix, "")
+
+                        if self.is_exist(file_records,
+                                         deployer.mdict['pki_server_database_path'] +
+                                         self.suffix):
+                            logger.info(
+                                "deleting selinux fcontext \"%s\"",
+                                deployer.mdict['pki_server_database_path'] + self.suffix)
+                            fcon.delete(
+                                deployer.mdict['pki_server_database_path'] +
+                                self.suffix, "")
+
+                        port_records = seobject.portRecords(trans)
+                        port_record_values = port_records.get_all()
+                        for port in ports:
+                            if self.is_exist(port_record_values, port):
                                 logger.info("deleting selinux port %s", port)
                                 port_records.delete(port, "tcp")
 
-                        # Else it's a file context
-                        else:
-                            fcon = seobject.fcontextRecords(trans)
-
-                            logger.info(
-                                "deleting selinux fcontext \"%s\"",
-                                deployer.mdict[context] + self.suffix)
-                            fcon.delete(
-                                deployer.mdict[context] + self.suffix, "")
-                        break
-                    except ValueError as e:
-                        error_message = str(e)
-                        logger.error(error_message)
-                        if error_message.strip() == \
-                                "Could not start semanage transaction":
-                            if counter >= max_tries:
-                                raise
-                            time.sleep(5)
-                            logger.debug("Retrying to remove selinux context ...")
-                        else:
-                            # If it is a forced destroy, there won't be any se contexts to destroy
-                            if deployer.mdict['pki_force_destroy']:
-                                break
-                            else:
-                                raise
-                    finally:
-                        trans.finish()
+                    trans.finish()
+                break
+            except ValueError as e:
+                error_message = str(e)
+                logger.error(error_message)
+                if error_message.strip() == \
+                        "Could not start semanage transaction":
+                    if counter >= max_tries:
+                        raise
+                    time.sleep(5)
+                    logger.debug("Retrying to remove selinux context ...")
+                else:
+                    raise

--- a/base/server/python/pki/server/pkidestroy.py
+++ b/base/server/python/pki/server/pkidestroy.py
@@ -213,7 +213,7 @@ def main(argv):
         config.user_deployment_cfg = None
 
     parser.validate()
-    parser.init_config()
+    parser.init_config(pki_instance_name=config.pki_deployed_instance_name)
 
     # Enable 'pkidestroy' logging.
     config.pki_log_dir = config.PKI_DEPLOYMENT_LOG_ROOT


### PR DESCRIPTION
- When `pkidestroy --force` was executed with a non-existant non-default
  instance, it should not pickup `pki-tomcat` as the default instance.

- The master dictionary was incorrectly being setup; First, the  instance_name gets
  loaded from default.cfg and later gets overwritten with entries from the user's deployment
  config file. When using the force option, the user's config file is absent and the default
  instance name was getting assigned

- A small reformat of destroy() in selinux_setup to handle the force clean
  up of an instance

Fixes: BZ#1698084

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`