### PR TITLE
Support AES for LWCA key replication

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/authority/AuthorityKeyExportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/authority/AuthorityKeyExportCLI.java
@@ -28,6 +28,9 @@ public class AuthorityKeyExportCLI extends CLI {
 
     public AuthorityCLI authorityCLI;
 
+    private OBJECT_IDENTIFIER DES_EDE3_CBC_OID =
+        new OBJECT_IDENTIFIER("1.2.840.113549.3.7");
+
     public AuthorityKeyExportCLI(AuthorityCLI authorityCLI) {
         super("key-export", "Export wrapped CA signing key", authorityCLI);
         this.authorityCLI = authorityCLI;
@@ -45,10 +48,18 @@ public class AuthorityKeyExportCLI extends CLI {
         option = new Option(null, "target-nickname", true, "Nickname of target key");
         option.setArgName("nickname");
         options.addOption(option);
+
+        option = new Option(null, "algorithm", true, "Symmetric encryption algorithm");
+        option.setArgName("OID");
+        options.addOption(option);
     }
 
     public void printHelp() {
-        formatter.printHelp(getFullName() + "--wrap-nickname NICKNAME --target-nickname NICKNAME -o FILENAME", options);
+        formatter.printHelp(
+            getFullName()
+                + "--wrap-nickname NICKNAME --target-nickname NICKNAME -o FILENAME"
+                + "[--algorithm OID]",
+            options);
     }
 
     public void execute(String[] args) throws Exception {
@@ -75,6 +86,14 @@ public class AuthorityKeyExportCLI extends CLI {
             throw new Exception("No target key nickname specified.");
         }
 
+        // Old servers only support DES and do not specify
+        // the algorithm to use, so default to DES.
+        OBJECT_IDENTIFIER algOid = DES_EDE3_CBC_OID;
+        String algOidString = cmd.getOptionValue("algorithm");
+        if (algOidString != null) {
+            algOid = new OBJECT_IDENTIFIER(algOidString);
+        }
+
         CryptoManager cm = CryptoManager.getInstance();
         X509Certificate wrapCert = cm.findCertByNickname(wrapNick);
         X509Certificate targetCert = cm.findCertByNickname(targetNick);
@@ -83,17 +102,24 @@ public class AuthorityKeyExportCLI extends CLI {
         PrivateKey toBeWrapped = cm.findPrivKeyByCert(targetCert);
         CryptoToken token = cm.getInternalKeyStorageToken();
 
-        byte iv[] = { 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1 };
-        IVParameterSpec ivps = new IVParameterSpec(iv);
+        AlgorithmIdentifier aid = null;
+        WrappingParams params = null;
 
-        WrappingParams params = new WrappingParams(
+        if (algOid.equals(DES_EDE3_CBC_OID)) {
+            byte iv[] = { 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1 };
+            IVParameterSpec ivps = new IVParameterSpec(iv);
+
+            params = new WrappingParams(
                 SymmetricKey.DES3, KeyGenAlgorithm.DES3, 168,
                 KeyWrapAlgorithm.RSA, EncryptionAlgorithm.DES3_CBC_PAD,
                 KeyWrapAlgorithm.DES3_CBC_PAD, ivps, ivps);
 
-        AlgorithmIdentifier aid = new AlgorithmIdentifier(
-                new OBJECT_IDENTIFIER("1.2.840.113549.3.7"),
-                new OCTET_STRING(ivps.getIV()));
+            aid = new AlgorithmIdentifier(algOid, new OCTET_STRING(ivps.getIV()));
+        }
+
+        else {
+            throw new Exception("Unsupported algorithm: " + algOid.toString());
+        }
 
         byte[] data = CryptoUtil.createEncodedPKIArchiveOptions(
                 token,

--- a/base/java-tools/src/com/netscape/cmstools/authority/AuthorityKeyExportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/authority/AuthorityKeyExportCLI.java
@@ -30,6 +30,8 @@ public class AuthorityKeyExportCLI extends CLI {
 
     private OBJECT_IDENTIFIER DES_EDE3_CBC_OID =
         new OBJECT_IDENTIFIER("1.2.840.113549.3.7");
+    private OBJECT_IDENTIFIER AES_128_CBC_OID =
+        new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.1.2");
 
     public AuthorityKeyExportCLI(AuthorityCLI authorityCLI) {
         super("key-export", "Export wrapped CA signing key", authorityCLI);
@@ -114,6 +116,19 @@ public class AuthorityKeyExportCLI extends CLI {
                 SymmetricKey.DES3, KeyGenAlgorithm.DES3, 168,
                 KeyWrapAlgorithm.RSA, encAlg,
                 KeyWrapAlgorithm.DES3_CBC_PAD, ivps, ivps);
+
+            aid = new AlgorithmIdentifier(algOid, new OCTET_STRING(iv));
+        }
+
+        else if (algOid.equals(AES_128_CBC_OID)) {
+            EncryptionAlgorithm encAlg = EncryptionAlgorithm.AES_CBC_PAD;
+            byte iv[] = CryptoUtil.getNonceData(encAlg.getIVLength());
+            IVParameterSpec ivps = new IVParameterSpec(iv);
+
+            params = new WrappingParams(
+                SymmetricKey.AES, KeyGenAlgorithm.AES, 128,
+                KeyWrapAlgorithm.RSA, encAlg,
+                KeyWrapAlgorithm.AES_CBC_PAD, ivps, ivps);
 
             aid = new AlgorithmIdentifier(algOid, new OCTET_STRING(iv));
         }

--- a/base/java-tools/src/com/netscape/cmstools/authority/AuthorityKeyExportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/authority/AuthorityKeyExportCLI.java
@@ -106,15 +106,16 @@ public class AuthorityKeyExportCLI extends CLI {
         WrappingParams params = null;
 
         if (algOid.equals(DES_EDE3_CBC_OID)) {
-            byte iv[] = { 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1 };
+            EncryptionAlgorithm encAlg = EncryptionAlgorithm.DES3_CBC_PAD;
+            byte iv[] = CryptoUtil.getNonceData(encAlg.getIVLength());
             IVParameterSpec ivps = new IVParameterSpec(iv);
 
             params = new WrappingParams(
                 SymmetricKey.DES3, KeyGenAlgorithm.DES3, 168,
-                KeyWrapAlgorithm.RSA, EncryptionAlgorithm.DES3_CBC_PAD,
+                KeyWrapAlgorithm.RSA, encAlg,
                 KeyWrapAlgorithm.DES3_CBC_PAD, ivps, ivps);
 
-            aid = new AlgorithmIdentifier(algOid, new OCTET_STRING(ivps.getIV()));
+            aid = new AlgorithmIdentifier(algOid, new OCTET_STRING(iv));
         }
 
         else {


### PR DESCRIPTION
These commits add support for AES128-CBC in LWCA key replication.

Tickets:

- https://pagure.io/dogtagpki/issue/2666
- https://pagure.io/dogtagpki/issue/2777

```
Changes:

73b7dc039 (Fraser Tweedale, 37 minutes ago)
   ca-authority-key-export: support AES

   Add support for exporting wrapped private keys using AES128-CBC as the
   symmetric algorithm.

   Fixes: https://pagure.io/dogtagpki/issue/2666

0d79504e1 (Fraser Tweedale, 2 hours ago)
   ca-authority-key-export: use random IV

   Part of: https://pagure.io/dogtagpki/issue/2666

3f8225693 (Fraser Tweedale, 2 hours ago)
   ca-authority-key-export: add --algorithm option

   We need to support AES key export, but also require backwards compatibility
   with existing servers that can only import DES-EDE3-CBC.  So as a first
   step, teach the ca-authority-key-export command the --algorithm option,
   which defaults to 1.2.840.113549.3.7
   (DES-EDE3-CBC).  AES support will be added in a subsequent commit.

   Part of: https://pagure.io/dogtagpki/issue/2666

61ed1dfa7 (Fraser Tweedale, 2 hours ago)
   importPKIArchiveOptions: support AES

   CryptoUtil.importPKIArchiveOptions() is used for Lightweight CA
   (LWCA) key import.  Update it to support AES-encrypted keys.  DES import
   remains supported for backwards compatibility.

   Fixes: https://pagure.io/dogtagpki/issue/2777
```