### PR TITLE
Fixed missing SAN extension for CA clone

### DIFF
--- a/base/server/cms/src/com/netscape/cms/servlet/csadmin/CertUtil.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/csadmin/CertUtil.java
@@ -228,34 +228,32 @@ public class CertUtil {
     //              embed a certificate extension into
     //              a PKCS #10 certificate request.
     //
-    public static String buildSANSSLserverURLExtension(IConfigStore config)
+    public static void buildSANSSLserverURLExtension(IConfigStore config, MultivaluedMap<String, String> content)
            throws Exception {
-        String url = "";
-        String entries = "";
 
         CMS.debug("CertUtil: buildSANSSLserverURLExtension() " +
                   "building SAN SSL Server Certificate URL extension . . .");
-        int i = 0;
+
         if (config == null) {
             throw new EBaseException("injectSANextensionIntoRequest: parameter config cannot be null");
         }
+
         String sanHostnames = config.getString("service.sslserver.san");
         String sans[] = StringUtils.split(sanHostnames, ",");
+
+        int i = 0;
         for (String san : sans) {
             CMS.debug("CertUtil: buildSANSSLserverURLExtension() processing " +
                       "SAN hostname: " + san);
             // Add the DNSName for all SANs
-            entries = entries +
-                      "&req_san_pattern_" + i + "=" + san;
+            content.putSingle("req_san_pattern_" + i, san);
             i++;
         }
 
-        url = "&req_san_entries=" + i + entries;
+        content.putSingle("req_san_entries", "" + i);
 
         CMS.debug("CertUtil: buildSANSSLserverURLExtension() " + "placed " +
                   i + " SAN entries into SSL Server Certificate URL.");
-
-        return url;
     }
 
 

--- a/base/server/cms/src/com/netscape/cms/servlet/csadmin/ConfigurationUtils.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/csadmin/ConfigurationUtils.java
@@ -2685,16 +2685,9 @@ public class ConfigurationUtils {
             } catch (Exception ee) {
             }
 
-            String sslserver_extension = "";
-            Boolean injectSAN = config.getBoolean("service.injectSAN", false);
-            CMS.debug("ConfigurationUtils: injectSAN: " + injectSAN);
-
-            if (certTag.equals("sslserver") && injectSAN == true) {
-                sslserver_extension = CertUtil.buildSANSSLserverURLExtension(config);
-            }
-
             MultivaluedMap<String, String> content = new MultivaluedHashMap<String, String>();
             content.putSingle("requestor_name", sysType + "-" + machineName + "-" + securePort);
+
             //Get the correct profile id to send in case it's sslserver type:
             CMS.debug("configRemoteCert: tag: " + certTag + " : setting profileId to: " + profileId);
             String actualProfileId = request.getSystemCertProfileID(certTag, profileId);
@@ -2705,6 +2698,13 @@ public class ConfigurationUtils {
             content.putSingle("cert_request", b64Request);
             content.putSingle("xmlOutput", "true");
             content.putSingle("sessionID", session_id);
+
+            Boolean injectSAN = config.getBoolean("service.injectSAN", false);
+            CMS.debug("ConfigurationUtils: injectSAN: " + injectSAN);
+
+            if (certTag.equals("sslserver") && injectSAN) {
+                CertUtil.buildSANSSLserverURLExtension(config, content);
+            }
 
             cert = CertUtil.createRemoteCert(ca_hostname, ca_port, content, response);
 


### PR DESCRIPTION
The CertUtil.buildSANSSLserverURLExtension() has been modified
to include SAN parameters in the request to generate the SSL
server certificate for CA clone.

https://bugzilla.redhat.com/show_bug.cgi?id=1732637