### PR TITLE
Added option to install with Maven dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,3 +152,10 @@ endif ()
 if (NOT "${THEME}" STREQUAL "")
     add_subdirectory(themes)
 endif ()
+
+install(
+    FILES
+        pom.xml
+    DESTINATION
+        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}
+)

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -312,6 +312,7 @@ class CreateCLI(pki.cli.CLI):
     def print_help(self):
         print('Usage: pki-server create [OPTIONS] [<instance ID>]')
         print()
+        print('      --with-maven-deps         Install Maven dependencies.')
         print('      --force                   Force creation.')
         print('  -v, --verbose                 Run in verbose mode.')
         print('      --debug                   Run in debug mode.')
@@ -322,7 +323,7 @@ class CreateCLI(pki.cli.CLI):
 
         try:
             opts, args = getopt.gnu_getopt(argv, 'v', [
-                'force',
+                'with-maven-deps', 'force',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -331,10 +332,14 @@ class CreateCLI(pki.cli.CLI):
             sys.exit(1)
 
         instance_name = 'pki-tomcat'
+        with_maven_deps = False
         force = False
 
         for o, _ in opts:
-            if o == '--force':
+            if o == '--with-maven-deps':
+                with_maven_deps = True
+
+            elif o == '--force':
                 force = True
 
             elif o in ('-v', '--verbose'):
@@ -363,7 +368,8 @@ class CreateCLI(pki.cli.CLI):
 
         logging.info('Creating instance: %s', instance_name)
 
-        instance.create(force)
+        instance.with_maven_deps = with_maven_deps
+        instance.create(force=force)
 
 
 class RemoveCLI(pki.cli.CLI):
@@ -426,7 +432,7 @@ class RemoveCLI(pki.cli.CLI):
         logging.info('Removing instance: %s', instance_name)
 
         instance.stop()
-        instance.remove(force)
+        instance.remove(force=force)
 
 
 class StatusCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -65,6 +65,8 @@ class PKIDeployer:
         self.parser = None
         self.nss_db_type = None
 
+        self.with_maven_deps = False
+
         # Set installation time
         ticks = time.time()
         self.install_time = time.asctime(time.localtime(ticks))

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -148,6 +148,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 "localhost",
                 "pki.xml"))
 
+        instance.with_maven_deps = deployer.with_maven_deps
         instance.create_libs()
 
         deployer.directory.create(deployer.mdict['pki_tomcat_tmpdir_path'])

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -109,6 +109,12 @@ def main(argv):
         action='store_true',
         help='enforce strict hostname/FQDN checks')
 
+    parser.optional.add_argument(
+        '--with-maven-deps',
+        dest='with_maven_deps',
+        action='store_true',
+        help='Install Maven dependencies')
+
     args = parser.process_command_line_arguments()
 
     config.default_deployment_cfg = \
@@ -533,6 +539,9 @@ def main(argv):
     # Process the various "scriptlets" to create the specified PKI subsystem.
     pki_subsystem_scriptlets = parser.mdict['spawn_scriplets'].split()
     deployer.init(parser)
+
+    logger.info('Installing Maven dependencies: %s', args.with_maven_deps)
+    deployer.with_maven_deps = args.with_maven_deps
 
     try:
         for scriptlet_name in pki_subsystem_scriptlets:

--- a/pki.spec
+++ b/pki.spec
@@ -1316,6 +1316,7 @@ fi
 %doc %{_datadir}/doc/pki-base/html
 %dir %{_datadir}/pki
 %{_datadir}/pki/VERSION
+%{_datadir}/pki/pom.xml
 %dir %{_datadir}/pki/etc
 %{_datadir}/pki/etc/pki.conf
 %{_datadir}/pki/etc/logging.properties


### PR DESCRIPTION
The pkispawn and pki-server create commands have been modified
to provide a --with-maven-deps option to create the PKI server
instance with Maven dependencies.