### PR TITLE
[10.5] Fix cloning failured caused by range depletion

### DIFF
--- a/base/ca/src/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/com/netscape/ca/CertificateAuthority.java
@@ -1077,7 +1077,7 @@ public class CertificateAuthority
     public String getStartSerial() {
         try {
             BigInteger serial =
-                    mCertRepot.getTheSerialNumber();
+                    mCertRepot.peekNextSerialNumber();
 
             if (serial == null)
                 return "";

--- a/base/common/src/com/netscape/certsrv/dbs/repository/IRepository.java
+++ b/base/common/src/com/netscape/certsrv/dbs/repository/IRepository.java
@@ -50,7 +50,7 @@ public interface IRepository {
      * @return serial number
      * @exception EBaseException failed to retrieve next serial number
      */
-    public BigInteger getTheSerialNumber() throws EBaseException;
+    public BigInteger peekNextSerialNumber() throws EBaseException;
 
     /**
      * Set the maximum serial number.

--- a/base/server/cms/src/com/netscape/cms/servlet/csadmin/UpdateNumberRange.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/csadmin/UpdateNumberRange.java
@@ -187,7 +187,7 @@ public class UpdateNumberRange extends CMSServlet {
             BigInteger decrement = new BigInteger(decrementStr, radix);
             beginNum = endNum.subtract(decrement).add(oneNum);
 
-            if (beginNum.compareTo(repo.getTheSerialNumber()) < 0) {
+            if (beginNum.compareTo(repo.peekNextSerialNumber()) < 0) {
                 String nextEndNumStr = cs.getString(nextEndConfig, "");
                 BigInteger endNum2 = new BigInteger(nextEndNumStr, radix);
                 CMS.debug("Transferring from the end of on-deck range");

--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
@@ -346,7 +346,7 @@ public abstract class Repository implements IRepository {
      * Returns null if the next number exceeds the current range and
      * there is not a next range.
      */
-    public BigInteger getTheSerialNumber() throws EBaseException {
+    public BigInteger peekNextSerialNumber() throws EBaseException {
 
         CMS.debug("Repository:In getTheSerialNumber ");
         if (mLastSerialNo == null)

--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
@@ -298,6 +298,25 @@ public abstract class Repository implements IRepository {
         BigInteger theSerialNo = null;
         theSerialNo = getLastSerialNumberInRange(mMinSerialNo, mMaxSerialNo);
 
+        if (theSerialNo == null) {
+            // This arises when range has been depleted by servicing
+            // UpdateNumberRange requests for clones.  Attempt to
+            // move to next range.
+            CMS.debug(
+                "Repository: failed to get last serial number in range "
+                + mMinSerialNo + ".." + mMaxSerialNo);
+
+            if (hasNextRange()) {
+                CMS.debug("Repository: switching to next range.");
+                switchToNextRange();
+                CMS.debug("Repository: new range: " + mMinSerialNo + ".." + mMaxSerialNo);
+                // try again with updated range
+                theSerialNo = getLastSerialNumberInRange(mMinSerialNo, mMaxSerialNo);
+            } else {
+                CMS.debug("Repository: next range not available.");
+            }
+        }
+
         if (theSerialNo != null) {
 
             mLastSerialNo = new BigInteger(theSerialNo.toString());

--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/Repository.java
@@ -185,7 +185,7 @@ public abstract class Repository implements IRepository {
      * @param serial maximum number
      * @exception EBaseException failed to set maximum serial number
      */
-    public void setMaxSerial(String serial) throws EBaseException {
+    public synchronized void setMaxSerial(String serial) throws EBaseException {
         BigInteger maxSerial = null;
         CMS.debug("Repository:setMaxSerial " + serial);
 
@@ -211,7 +211,7 @@ public abstract class Repository implements IRepository {
      * @param serial maximum number in next range
      * @exception EBaseException failed to set maximum serial number in next range
      */
-    public void setNextMaxSerial(String serial) throws EBaseException {
+    public synchronized void setNextMaxSerial(String serial) throws EBaseException {
         BigInteger maxSerial = null;
         CMS.debug("Repository:setNextMaxSerial " + serial);
 
@@ -346,7 +346,7 @@ public abstract class Repository implements IRepository {
      * Returns null if the next number exceeds the current range and
      * there is not a next range.
      */
-    public BigInteger peekNextSerialNumber() throws EBaseException {
+    public synchronized BigInteger peekNextSerialNumber() throws EBaseException {
 
         CMS.debug("Repository:In getTheSerialNumber ");
         if (mLastSerialNo == null)


### PR DESCRIPTION
Backport of https://github.com/dogtagpki/pki/pull/40

# Tickets

-   https://pagure.io/dogtagpki/issue/3055
-   https://pagure.io/freeipa/issue/7654

This issue addresses several problems related to range management that can cause cloning failure and startup failure.

# How to reproduce

1.  Install a master (called A).

2.  Install a clone from A (called B).

3.  Install a clone from B (called C).

4.  Install another clone from B (called D). Cloning fails due to NullPointerException on B while servicing UpdateNumberRange request.

5.  Further observe that B fails to restart due to an error initialising the range cache:

```
2018-09-03 15:12:16 [localhost-startStop-1] SEVERE: Unable to start CMS engine: Error in obtaining the last serial number in the repository!
Error in obtaining the last serial number in the repository!
        at com.netscape.cmscore.dbs.Repository.initCache(Repository.java:308)
        at com.netscape.cmscore.dbs.Repository.checkRanges(Repository.java:498)
        at com.netscape.cmscore.apps.CMSEngine.startup(CMSEngine.java:1309)
```

# Fix description

The fix consists of a number of parts (addressed in separate commits).

1.  A method to peek at the next serial number (without comsuming it) returned null when the current number range was depleted (even when a next range was available). This was the cause of the NPE resulting in cloning failure. This method was updated to return a number from the next range (if available).

2.  Range cache initialisation was updated to switch to the next range (if available) when the current range is exhausted. This avoids the startup issue after the range has been exhausted.

3.  A number of potential concurrency issues were addressed through use of synchronized.



```
eb08940f1 (Fraser Tweedale, 1 year ago)
   Add missing synchronisation for range management

   Several methods in Repository (and CertificateRepository) need 
   synchronisation on the intrisic lock.  Make these methods synchronised.

   Also take the lock in UpdateNumberRange so that no serial numbers can be
   handed out in other threads between peekNextSerialNumber() and
   set(Next)?MaxSerial().  Without this synchronisation, it is possible that
   the master instance will use some of the serial numbers it transfers to the
   clone.

   Fixes: https://pagure.io/dogtagpki/issue/3055

09d377695 (Fraser Tweedale, 1 year ago)
   checkRange: small refactor and add commentary

   Add some commentary about the behaviour and proper usage of 
   Repository.checkRange().  Also perform a small refactor, avoiding a
   redundant stringify and parse.

   Part of: https://pagure.io/dogtagpki/issue/3055

542599c70 (Fraser Tweedale, 1 year ago)
   rename method getTheSerialNumber -> peekNextSerialNumber

   Rename Repository.getTheSerialNumber -> peekNextSerialNumber to more 
   accurately reflect what it does: peek at the next serial number without
   actually consuming it.

   Part of: https://pagure.io/dogtagpki/issue/3055

6cb927363 (Fraser Tweedale, 1 year ago)
   Repository: handle depleted range in initCache()

   Repository.initCache() does not handle the case where the current range has
   been fully depleted, but the switch to the next range has not occurred yet.
    This situation arises when the range has been fully depleted by servicing
   UpdateNumberRange requests for clones.

   Detect this situation and handle it by switching to the next range
   (when available).

   Part of: https://pagure.io/dogtagpki/issue/3055

83bb622f3 (Fraser Tweedale, 1 year ago)
   getTheSerialNumber: only return null if next range not available

   When cloning, if the master's current number range has been depleted due to
   a previous UpdateNumberRange request, Repository.getTheSerialNumber()
   returns null because the next serial number is out of the current range,
   but the next range has not been activated yet.  NullPointerException
   ensues.

   Update getTheSerialNumber() to return the next serial number even when it
   exceeds the current number range, as long as there is a next range.  If
   there is no next range, return null (as before).  It is assumed that the
   next range is non-empty

   Also do a couple of drive-by method extractions to improve readability.

   Part of: https://pagure.io/dogtagpki/issue/3055
```