### PR TITLE
Update KRATool to support netkeyKeyRecovery entries

### DIFF
--- a/base/java-tools/man/man1/KRATool.1
+++ b/base/java-tools/man/man1/KRATool.1
@@ -1,7 +1,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH KRATool 1 "July 18, 2016" "version 10.3" "PKI Key Recovery Authority (KRA) Tool" Dogtag Team
+.TH KRATool 1 "Sep 11, 2019" "version 10.5" "PKI Key Recovery Authority (KRA) Tool" Dogtag Team
 .\" Please adjust this date whenever revising the man page.
 .\"
 .\" Some roff macros, for reference:
@@ -33,6 +33,8 @@ The syntax for rewrapping keys:
 	[-source_pki_security_database_pwdfile </path/to/password_file>]]
 	[-source_kra_naming_context <name> -target_kra_naming_context <name>]
 	[-process_requests_and_key_records_only]
+	[-unwrap_algorithm AES|DES3]
+
 .fi
 .PP
 The syntax for renumbering keys:
@@ -130,6 +132,12 @@ Gives the path and filename to a password file that contains only the password f
 
 This argument is optional when other rewrap parameters are used. If this argument is not used, then the script prompts for the password.
 
+.TP
+.B -unwrap_algorithm <algorithm>
+Specifies the symmetric key algorithm used by source KRA. Available options include \fBDES3\fP and \fBAES\fP
+
+This argument is optional and defaults to \fBDES3\fP if unspecified.
+
 .PP
 The following parameters are optional for renumbering keys:
 
@@ -147,13 +155,14 @@ If \fB-remove_id_offset\fP is used, then do not use the \fB-append_id_offset\fP 
 
 .SH Configuration File (.cfg)
 .PP
-The required configuration file instructs the KRATool how to process attributes in the key archival and key request entries in the LDIF file. There are six types of entries:
+The required configuration file instructs the KRATool how to process attributes in the key archival and key request entries in the LDIF file. There are seven types of entries:
 .IP
 * CA enrollment requests
 * TPS enrollment requests
 * CA key records
 * TPS key records
 * CA and TPS recovery requests (which are treated the same in the KRA)
+* TPS token key recovery requests
 .PP
 Each key and key request has an LDAP entry with attributes that are specific to that kind of record. For example, for a recovery request:
 .IP
@@ -198,7 +207,7 @@ nsUniqueId: b2891805-1dd111b2-a6d7e85f-2c2f0000
 .PP
 Much of that information passes through the script processing unchanged, so it is entered into the new, target KRA just the same. However, some of those attributes can and should be edited, like the Common Name (CN) and DN being changed to match the new KRA instance. The fields which can safely be changed are listed in the configuration file for each type of key entry. (Any attribute not listed is not touched by the tool under any circumstances.)
 .PP
-If a field /fIshould/fP be edited — meaning, the tool can update the record ID number or rename the entry — then the value is set to true in the configuration file. For example, this configuration updates the CN, DN, ID number, last modified date, and associated entry notes for all CA enrollment requests:
+If a field \fIshould\fP be edited — meaning, the tool can update the record ID number or rename the entry — then the value is set to true in the configuration file. For example, this configuration updates the CN, DN, ID number, last modified date, and associated entry notes for all CA enrollment requests:
 .IP
 .nf
 kratool.ldif.caEnrollmentRequest.cn=true
@@ -324,9 +333,9 @@ kratool.ldif.namingContext._037=##    uid                                 ##
 kratool.ldif.namingContext._038=##    uniqueMember                        ##
 kratool.ldif.namingContext._039=##                                        ##
 kratool.ldif.namingContext._040=##  If '-source_naming_context            ##
-kratool.ldif.namingContext._041=##  original source KRA naming context'   ##
+kratool.ldif.namingContext._041=##  <original source KRA naming context>' ##
 kratool.ldif.namingContext._042=##  and '-target_naming_context           ##
-kratool.ldif.namingContext._043=##  renamed target KRA naming context'    ##
+kratool.ldif.namingContext._043=##  <renamed target KRA naming context>'  ##
 kratool.ldif.namingContext._044=##  options are specified, ALWAYS         ##
 kratool.ldif.namingContext._045=##  require 'KRATOOL' to change the       ##
 kratool.ldif.namingContext._046=##  KRA 'naming context' data in ALL of   ##
@@ -355,6 +364,10 @@ kratool.ldif.namingContext._068=##    tpsNetkeyKeygenRequest:             ##
 kratool.ldif.namingContext._069=##                                        ##
 kratool.ldif.namingContext._070=##      dn                                ##
 kratool.ldif.namingContext._071=##                                        ##
+kratool.ldif.namingContext._072=##    tpsNetkeyKeyRecoveryRequest:        ##
+kratool.ldif.namingContext._073=##                                        ##
+kratool.ldif.namingContext._074=##      dn                                ##
+kratool.ldif.namingContext._075=##                                        ##
 kratool.ldif.namingContext._072=############################################
 kratool.ldif.recoveryRequest._000=#####################################
 kratool.ldif.recoveryRequest._001=##  KRA CA / TPS Recovery Request  ##
@@ -401,6 +414,23 @@ kratool.ldif.tpsNetkeyKeygenRequest.extdata.keyRecord=true
 kratool.ldif.tpsNetkeyKeygenRequest.extdata.requestId=true
 kratool.ldif.tpsNetkeyKeygenRequest.extdata.requestNotes=true
 kratool.ldif.tpsNetkeyKeygenRequest.requestId=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._000=########################################
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._001=## KRA TPS Netkey Keyrecovery Request ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._002=########################################
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._003=##                                    ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._004=##  NEVER allow 'KRATOOL' the ability ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._005=##  to change the TPS 'naming context'##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._006=##  data in the following fields:     ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._007=##                                    ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._008=##        extdata-updatedby           ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._009=##                                    ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._010=########################################
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.cn=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.requestId=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.dn=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.dateOfModify=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.extdata.requestId=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.extdata.requestNotes=true
 .if
 
 .SH EXAMPLES
@@ -448,10 +478,10 @@ KRATool -kratool_config_file "/usr/share/pki/java-tools/KRATool.cfg" -source_ldi
 .if
 
 .SH AUTHORS
-Matthew Harmsen <mharmsen@redhat.com>.
+Matthew Harmsen <mharmsen@redhat.com> and Dinesh Prasanth M K <dmoluguw@redhat.com>
 
 .SH COPYRIGHT
-Copyright (c) 2016 Red Hat, Inc. This is licensed under the GNU General Public
+Copyright (c) 2019 Red Hat, Inc. This is licensed under the GNU General Public
 License, version 2 (GPLv2). A copy of this license is available at
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
@@ -157,4 +157,16 @@ kratool.ldif.tpsNetkeyKeygenRequest.extdata.keyRecord=true
 kratool.ldif.tpsNetkeyKeygenRequest.extdata.requestId=true
 kratool.ldif.tpsNetkeyKeygenRequest.extdata.requestNotes=true
 kratool.ldif.tpsNetkeyKeygenRequest.requestId=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._000=########################################
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._001=## KRA TPS Netkey Keyrecovery Request ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._002=########################################
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._003=##                                    ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._004=##  NEVER allow 'KRATOOL' the ability ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._005=##  to change the TPS 'naming context'##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._006=##  data in the following fields:     ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._007=##                                    ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._008=##        extdata-updatedby           ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._009=##                                    ##
+kratool.ldif.tpsNetkeyKeyRecoveryRequest._010=########################################
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.requestId=true
 

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
@@ -174,3 +174,5 @@ kratool.ldif.tpsNetkeyKeyRecoveryRequest._009=##                                
 kratool.ldif.tpsNetkeyKeyRecoveryRequest._010=########################################
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.requestId=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.dn=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.dateOfModify=true
+

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
@@ -172,6 +172,7 @@ kratool.ldif.tpsNetkeyKeyRecoveryRequest._007=##                                
 kratool.ldif.tpsNetkeyKeyRecoveryRequest._008=##        extdata-updatedby           ##
 kratool.ldif.tpsNetkeyKeyRecoveryRequest._009=##                                    ##
 kratool.ldif.tpsNetkeyKeyRecoveryRequest._010=########################################
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.cn=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.requestId=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.dn=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.dateOfModify=true

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
@@ -177,4 +177,5 @@ kratool.ldif.tpsNetkeyKeyRecoveryRequest.requestId=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.dn=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.dateOfModify=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.extdata.requestId=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.extdata.requestNotes=true
 

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
@@ -175,4 +175,5 @@ kratool.ldif.tpsNetkeyKeyRecoveryRequest._010=##################################
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.requestId=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.dn=true
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.dateOfModify=true
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.extdata.requestId=true
 

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.cfg
@@ -111,6 +111,10 @@ kratool.ldif.namingContext._068=##    tpsNetkeyKeygenRequest:             ##
 kratool.ldif.namingContext._069=##                                        ##
 kratool.ldif.namingContext._070=##      dn                                ##
 kratool.ldif.namingContext._071=##                                        ##
+kratool.ldif.namingContext._072=##    tpsNetkeyKeyRecoveryRequest:        ##
+kratool.ldif.namingContext._073=##                                        ##
+kratool.ldif.namingContext._074=##      dn                                ##
+kratool.ldif.namingContext._075=##                                        ##
 kratool.ldif.namingContext._072=############################################
 kratool.ldif.recoveryRequest._000=#####################################
 kratool.ldif.recoveryRequest._001=##  KRA CA / TPS Recovery Request  ##
@@ -169,4 +173,4 @@ kratool.ldif.tpsNetkeyKeyRecoveryRequest._008=##        extdata-updatedby       
 kratool.ldif.tpsNetkeyKeyRecoveryRequest._009=##                                    ##
 kratool.ldif.tpsNetkeyKeyRecoveryRequest._010=########################################
 kratool.ldif.tpsNetkeyKeyRecoveryRequest.requestId=true
-
+kratool.ldif.tpsNetkeyKeyRecoveryRequest.dn=true

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.java
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.java
@@ -699,6 +699,7 @@ public class KRATool {
     private static final String KRATOOL_CFG_RECOVERY = "recoveryRequest";
     private static final String KRATOOL_CFG_TPS_KEY_RECORD = "tpsKeyRecord";
     private static final String KRATOOL_CFG_KEYGEN = "tpsNetkeyKeygenRequest";
+    private static final String KRATOOL_CFG_KEYRECOVERY = "tpsNetkeyKeyRecoveryRequest";
 
     // Constants:  KRATOOL Config File (KRA CA Enrollment Request Fields)
     private static final String KRATOOL_CFG_ENROLLMENT_CN = KRATOOL_CFG_PREFIX
@@ -860,6 +861,12 @@ public class KRATool {
                                       + DOT
                                       + "requestId";
 
+    private static final String KRATOOL_CFG_KEYRECOVERY_REQUEST_ID = KRATOOL_CFG_PREFIX
+                                                                       + DOT
+                                                                       + KRATOOL_CFG_KEYRECOVERY
+                                                                       + DOT
+                                                                       + "requestId";
+
     // Constants:  Target Certificate Information
     private static final String HEADER = "-----BEGIN";
     private static final String TRAILER = "-----END";
@@ -892,6 +899,7 @@ public class KRATool {
     private static final String KRA_LDIF_KEYGEN = "netkeyKeygen";
     private static final String KRA_LDIF_RECOVERY = "recovery";
     private static final String KRA_LDIF_TPS_KEY_RECORD = "TPS";
+    private static final String KRA_LDIF_KEYRECOVERY = "netkeyKeyRecovery";
 
     // Constants:  KRA LDIF Record Messages
     private static final String KRA_LDIF_REWRAP_MESSAGE = "REWRAPPED the '"
@@ -2334,6 +2342,9 @@ public class KRATool {
             } else {
                 output = line;
             }
+        } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
+            output = line;
+            System.out.println("cn: Key Recovery");
         } else if (record_type.equals(KRA_LDIF_RECORD)) {
             // Non-Request / Non-Key Record:
             //     Pass through the original
@@ -2439,6 +2450,9 @@ public class KRATool {
             } else {
                 output = line;
             }
+        } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
+            output = line;
+            System.out.println("Date Of Modify: Key Recovery");
         } else {
             log("ERROR:  Mismatched record field='"
                     + KRA_LDIF_DATE_OF_MODIFY
@@ -2657,6 +2671,9 @@ public class KRATool {
                 } else {
                     output = line;
                 }
+            } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
+                output = line;
+                System.out.println("dn: Key Recovery");
             } else if (record_type.equals(KRA_LDIF_RECORD)) {
                 // Non-Request / Non-Key Record:
                 //     Pass through the original
@@ -2771,6 +2788,9 @@ public class KRATool {
             } else {
                 output = line;
             }
+        } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
+            output = line;
+            System.out.println("extdata-requestid: Key Recovery");
         } else {
             log("ERROR:  Mismatched record field='"
                     + KRA_LDIF_EXTDATA_REQUEST_ID
@@ -3307,6 +3327,9 @@ public class KRATool {
             } else {
                 output = line;
             }
+        } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
+            output = line;
+            System.out.println("extdata-requestnotes: Key Recovery");
         } else {
             log("ERROR:  Mismatched record field='"
                     + KRA_LDIF_EXTDATA_REQUEST_NOTES
@@ -3633,6 +3656,8 @@ public class KRATool {
                     writer.flush();
                     System.out.print(".");
                 }
+            } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
+                System.out.println("create-extdata-requestnotes: Key Recovery");
             }
         }
     }
@@ -3897,6 +3922,15 @@ public class KRATool {
             } else {
                 output = line;
             }
+        } else if ( record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
+            if ( kratoolCfg.get( KRATOOL_CFG_KEYRECOVERY_REQUEST_ID ) ) {
+                    output = compose_numeric_line(KRA_LDIF_REQUEST_ID,
+                                                  SPACE,
+                                                  line,
+                                                  true);
+            } else {
+                    output = line;
+            }
         } else {
             log("ERROR:  Mismatched record field='"
                     + KRA_LDIF_REQUEST_ID
@@ -4115,7 +4149,8 @@ public class KRATool {
                                       ).trim();
                         if (!record_type.equals(KRA_LDIF_ENROLLMENT) &&
                                 !record_type.equals(KRA_LDIF_KEYGEN) &&
-                                !record_type.equals(KRA_LDIF_RECOVERY)) {
+                                !record_type.equals(KRA_LDIF_RECOVERY) &&
+                                !record_type.equals( KRA_LDIF_KEYRECOVERY)) {
                             log("ERROR:  Unknown LDIF record type='"
                                     + record_type
                                     + "'!"
@@ -4398,7 +4433,8 @@ public class KRATool {
                             || name.equals(KRATOOL_CFG_KEYGEN_EXTDATA_KEY_RECORD)
                             || name.equals(KRATOOL_CFG_KEYGEN_EXTDATA_REQUEST_ID)
                             || name.equals(KRATOOL_CFG_KEYGEN_EXTDATA_REQUEST_NOTES)
-                            || name.equals(KRATOOL_CFG_KEYGEN_REQUEST_ID)) {
+                            || name.equals(KRATOOL_CFG_KEYGEN_REQUEST_ID)
+                            || name.equals( KRATOOL_CFG_KEYRECOVERY_REQUEST_ID )) {
                         kratoolCfg.put(name, value);
                         System.out.print(".");
                     }

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.java
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.java
@@ -4496,6 +4496,7 @@ public class KRATool {
                 (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 5)) &&
                 (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 6)) &&
                 (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 7)) &&
+                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 8)) &&
                 (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 9))) {
             System.err.println("ERROR:  Incorrect number of arguments!"
                               + NEWLINE);
@@ -4892,16 +4893,18 @@ public class KRATool {
         }
 
         // Check for the Key Unwrap Algorithm provided by user.
-        // If unprovided, choose DES3 as the default (to maintain consistency with old code)
-        if (keyUnwrapAlgorithmName.equalsIgnoreCase("DES3")) {
-            keyUnwrapAlgorithm = SymmetricKey.DES3;
-        } else if (keyUnwrapAlgorithmName.equalsIgnoreCase("AES")) {
-            keyUnwrapAlgorithm = SymmetricKey.AES;
-        } else {
-            System.err.println("ERROR:  Unsupported key unwrap algorithm '"
-                    + keyUnwrapAlgorithmName + "'"
-                    + NEWLINE);
-            System.exit(1);
+        // If unprovided, DES3 is chosen as the default (to maintain consistency with old code)
+        if (keyUnwrapAlgorithmName != null) {
+            if (keyUnwrapAlgorithmName.equalsIgnoreCase("DES3")) {
+                keyUnwrapAlgorithm = SymmetricKey.DES3;
+            } else if (keyUnwrapAlgorithmName.equalsIgnoreCase("AES")) {
+                keyUnwrapAlgorithm = SymmetricKey.AES;
+            } else {
+                System.err.println("ERROR:  Unsupported key unwrap algorithm '"
+                        + keyUnwrapAlgorithmName + "'"
+                        + NEWLINE);
+                System.exit(1);
+            }
         }
 
         // Check for OPTIONAL "Process Requests and Key Records ONLY" option

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.java
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.java
@@ -3417,8 +3417,166 @@ public class KRATool {
                 output = line;
             }
         } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
-            output = line;
-            System.out.println("extdata-requestnotes: Key Recovery");
+            if( kratoolCfg.get( KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_NOTES ) ) {
+                // write out a revised 'extdata-requestnotes' line
+                if( mRewrapFlag && mAppendIdOffsetFlag ) {
+                    data = input
+                         + SPACE
+                         + LEFT_BRACE
+                         + mDateOfModify
+                         + RIGHT_BRACE
+                         + COLON + SPACE
+                         + KRA_LDIF_REWRAP_MESSAGE
+                         + mPublicKeySize
+                         + KRA_LDIF_RSA_MESSAGE
+                         + mSourcePKISecurityDatabasePwdfileMessage
+                         + SPACE
+                         + PLUS + SPACE
+                         + KRA_LDIF_APPENDED_ID_OFFSET_MESSAGE
+                         + SPACE
+                         + TIC
+                         + mAppendIdOffset.toString()
+                         + TIC
+                         + mKraNamingContextMessage
+                         + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                    // Unformat the data
+                    unformatted_data = stripEOL( data );
+
+                    // Format the unformatted_data
+                    // to match the desired LDIF format
+                    output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                           + SPACE
+                           + format_ldif_data(
+                                 EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                 unformatted_data );
+                } else if( mRewrapFlag && mRemoveIdOffsetFlag ) {
+                    data = input
+                         + SPACE
+                         + LEFT_BRACE
+                         + mDateOfModify
+                         + RIGHT_BRACE
+                         + COLON + SPACE
+                         + KRA_LDIF_REWRAP_MESSAGE
+                         + mPublicKeySize
+                         + KRA_LDIF_RSA_MESSAGE
+                         + mSourcePKISecurityDatabasePwdfileMessage
+                         + SPACE
+                         + PLUS + SPACE
+                         + KRA_LDIF_REMOVED_ID_OFFSET_MESSAGE
+                         + SPACE
+                         + TIC
+                         + mRemoveIdOffset.toString()
+                         + TIC
+                         + mKraNamingContextMessage
+                         + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                    // Unformat the data
+                    unformatted_data = stripEOL( data );
+
+                    // Format the unformatted_data
+                    // to match the desired LDIF format
+                    output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                           + SPACE
+                           + format_ldif_data(
+                                 EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                 unformatted_data );
+                } else if( mRewrapFlag ) {
+                    data = input
+                         + SPACE
+                         + LEFT_BRACE
+                         + mDateOfModify
+                         + RIGHT_BRACE
+                         + COLON + SPACE
+                         + KRA_LDIF_REWRAP_MESSAGE
+                         + mPublicKeySize
+                         + KRA_LDIF_RSA_MESSAGE
+                         + mSourcePKISecurityDatabasePwdfileMessage
+                         + mKraNamingContextMessage
+                         + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                    // Unformat the data
+                    unformatted_data = stripEOL( data );
+
+                    // Format the unformatted_data
+                    // to match the desired LDIF format
+                    output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                           + SPACE
+                           + format_ldif_data(
+                                 EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                 unformatted_data );
+                } else if( mAppendIdOffsetFlag ) {
+                    data = input
+                         + SPACE
+                         + LEFT_BRACE
+                         + mDateOfModify
+                         + RIGHT_BRACE
+                         + COLON + SPACE
+                         + KRA_LDIF_APPENDED_ID_OFFSET_MESSAGE
+                         + SPACE
+                         + TIC
+                         + mAppendIdOffset.toString()
+                         + TIC
+                         + mKraNamingContextMessage
+                         + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                    // Unformat the data
+                    unformatted_data = stripEOL( data );
+
+                    // Format the unformatted_data
+                    // to match the desired LDIF format
+                    output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                           + SPACE
+                           + format_ldif_data(
+                                 EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                 unformatted_data );
+                } else if( mRemoveIdOffsetFlag ) {
+                    data = input
+                         + SPACE
+                         + LEFT_BRACE
+                         + mDateOfModify
+                         + RIGHT_BRACE
+                         + COLON + SPACE
+                         + KRA_LDIF_REMOVED_ID_OFFSET_MESSAGE
+                         + SPACE
+                         + TIC
+                         + mRemoveIdOffset.toString()
+                         + TIC
+                         + mKraNamingContextMessage
+                         + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                    // Unformat the data
+                    unformatted_data = stripEOL( data );
+
+                    // Format the unformatted_data
+                    // to match the desired LDIF format
+                    output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                           + SPACE
+                           + format_ldif_data(
+                                 EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                 unformatted_data );
+                }
+
+                // log this information
+                log( "Changed:"
+                   + NEWLINE
+                   + TIC
+                   + KRA_LDIF_EXTDATA_REQUEST_NOTES
+                   + SPACE
+                   + format_ldif_data(
+                         EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                         input.toString() )
+                   + TIC
+                   + NEWLINE
+                   + "--->"
+                   + NEWLINE
+                   + TIC
+                   + output
+                   + TIC
+                   + NEWLINE, false );
+            } else {
+                output = line;
+            }
         } else {
             log("ERROR:  Mismatched record field='"
                     + KRA_LDIF_EXTDATA_REQUEST_NOTES

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.java
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.java
@@ -885,6 +885,12 @@ public class KRATool {
                                           + DOT
                                           + "extdata.requestId";
 
+    private static final String KRATOOL_CFG_KEYRECOVERY_CN = KRATOOL_CFG_PREFIX
+                          + DOT
+                          + KRATOOL_CFG_KEYRECOVERY
+                          + DOT
+                          + "cn";
+
     // Constants:  Target Certificate Information
     private static final String HEADER = "-----BEGIN";
     private static final String TRAILER = "-----END";
@@ -2361,8 +2367,14 @@ public class KRATool {
                 output = line;
             }
         } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
-            output = line;
-            System.out.println("cn: Key Recovery");
+            if( kratoolCfg.get(KRATOOL_CFG_KEYRECOVERY_CN ) ) {
+                output = compose_numeric_line(KRA_LDIF_CN,
+                    SPACE,
+                    line,
+                    false );
+            } else {
+                output = line;
+            }
         } else if (record_type.equals(KRA_LDIF_RECORD)) {
             // Non-Request / Non-Key Record:
             //     Pass through the original
@@ -4508,7 +4520,8 @@ public class KRATool {
                             || name.equals(KRATOOL_CFG_KEYRECOVERY_REQUEST_ID )
                             || name.equals(KRATOOL_CFG_KEYRECOVERY_DN )
                             || name.equals(KRATOOL_CFG_KEYRECOVERY_DATE_OF_MODIFY)
-                            || name.equals(KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_ID)) {
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_ID)
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_CN)) {
                         kratoolCfg.put(name, value);
                         System.out.print(".");
                     }

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.java
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.java
@@ -891,6 +891,12 @@ public class KRATool {
                           + DOT
                           + "cn";
 
+    private static final String KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_NOTES = KRATOOL_CFG_PREFIX
+                                             + DOT
+                                             + KRATOOL_CFG_KEYRECOVERY
+                                             + DOT
+                                             + "extdata.requestNotes";
+
     // Constants:  Target Certificate Information
     private static final String HEADER = "-----BEGIN";
     private static final String TRAILER = "-----END";
@@ -3739,8 +3745,153 @@ public class KRATool {
                     writer.flush();
                     System.out.print(".");
                 }
-            } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
-                System.out.println("create-extdata-requestnotes: Key Recovery");
+            }
+        } else if (record_type.equals(KRA_LDIF_KEYRECOVERY)) {
+            if( kratoolCfg.get( KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_NOTES ) ) {
+                if(!previous_line.startsWith( KRA_LDIF_EXTDATA_REQUEST_NOTES)) {
+                    // write out the missing 'extdata-requestnotes' line
+                    if( mRewrapFlag && mAppendIdOffsetFlag ) {
+                        data = LEFT_BRACE
+                             + mDateOfModify
+                             + RIGHT_BRACE
+                             + COLON + SPACE
+                             + KRA_LDIF_REWRAP_MESSAGE
+                             + mPublicKeySize
+                             + KRA_LDIF_RSA_MESSAGE
+                             + mSourcePKISecurityDatabasePwdfileMessage
+                             + SPACE
+                             + PLUS + SPACE
+                             + KRA_LDIF_APPENDED_ID_OFFSET_MESSAGE
+                             + SPACE
+                             + TIC
+                             + mAppendIdOffset.toString()
+                             + TIC
+                             + mKraNamingContextMessage
+                             + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                        // Unformat the data
+                        unformatted_data = stripEOL( data );
+
+                        // Format the unformatted_data
+                        // to match the desired LDIF format
+                        output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                               + SPACE
+                               + format_ldif_data(
+                                   EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                   unformatted_data );
+                    } else if( mRewrapFlag && mRemoveIdOffsetFlag ) {
+                        data = LEFT_BRACE
+                             + mDateOfModify
+                             + RIGHT_BRACE
+                             + COLON + SPACE
+                             + KRA_LDIF_REWRAP_MESSAGE
+                             + mPublicKeySize
+                             + KRA_LDIF_RSA_MESSAGE
+                             + mSourcePKISecurityDatabasePwdfileMessage
+                             + SPACE
+                             + PLUS + SPACE
+                             + KRA_LDIF_REMOVED_ID_OFFSET_MESSAGE
+                             + SPACE
+                             + TIC
+                             + mRemoveIdOffset.toString()
+                             + TIC
+                             + mKraNamingContextMessage
+                             + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                        // Unformat the data
+                        unformatted_data = stripEOL( data );
+
+                        // Format the unformatted_data
+                        // to match the desired LDIF format
+                        output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                               + SPACE
+                               + format_ldif_data(
+                                   EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                   unformatted_data );
+                    } else if( mRewrapFlag ) {
+                        data = LEFT_BRACE
+                             + mDateOfModify
+                             + RIGHT_BRACE
+                             + COLON + SPACE
+                             + KRA_LDIF_REWRAP_MESSAGE
+                             + mPublicKeySize
+                             + KRA_LDIF_RSA_MESSAGE
+                             + mSourcePKISecurityDatabasePwdfileMessage
+                             + mKraNamingContextMessage
+                             + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                        // Unformat the data
+                        unformatted_data = stripEOL( data );
+
+                        // Format the unformatted_data
+                        // to match the desired LDIF format
+                        output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                               + SPACE
+                               + format_ldif_data(
+                                   EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                   unformatted_data );
+                    } else if( mAppendIdOffsetFlag ) {
+                        data = LEFT_BRACE
+                             + mDateOfModify
+                             + RIGHT_BRACE
+                             + COLON + SPACE
+                             + KRA_LDIF_APPENDED_ID_OFFSET_MESSAGE
+                             + SPACE
+                             + TIC
+                             + mAppendIdOffset.toString()
+                             + TIC
+                             + mKraNamingContextMessage
+                             + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                        // Unformat the data
+                        unformatted_data = stripEOL( data );
+
+                        // Format the unformatted_data
+                        // to match the desired LDIF format
+                        output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                               + SPACE
+                               + format_ldif_data(
+                                   EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                   unformatted_data );
+                    } else if( mRemoveIdOffsetFlag ) {
+                        data = LEFT_BRACE
+                             + mDateOfModify
+                             + RIGHT_BRACE
+                             + COLON + SPACE
+                             + KRA_LDIF_REMOVED_ID_OFFSET_MESSAGE
+                             + SPACE
+                             + TIC
+                             + mRemoveIdOffset.toString()
+                             + TIC
+                             + mKraNamingContextMessage
+                             + mProcessRequestsAndKeyRecordsOnlyMessage;
+
+                        // Unformat the data
+                        unformatted_data = stripEOL( data );
+
+                        // Format the unformatted_data
+                        // to match the desired LDIF format
+                        output = KRA_LDIF_EXTDATA_REQUEST_NOTES
+                               + SPACE
+                               + format_ldif_data(
+                                   EXTDATA_REQUEST_NOTES_FIRST_LINE_DATA_LENGTH,
+                                   unformatted_data );
+                    }
+
+                    // log this information
+                    log( "Created:"
+                       + NEWLINE
+                       + TIC
+                       + output
+                       + TIC
+                       + NEWLINE, false );
+
+                    // Write out this revised line
+                    // and flush the buffer
+                    writer.write( output + NEWLINE );
+                    writer.flush();
+                    System.out.print( "." );
+                }
             }
         }
     }
@@ -4521,7 +4672,8 @@ public class KRATool {
                             || name.equals(KRATOOL_CFG_KEYRECOVERY_DN )
                             || name.equals(KRATOOL_CFG_KEYRECOVERY_DATE_OF_MODIFY)
                             || name.equals(KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_ID)
-                            || name.equals(KRATOOL_CFG_KEYRECOVERY_CN)) {
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_CN)
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_NOTES) ) {
                         kratoolCfg.put(name, value);
                         System.out.print(".");
                     }

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.java
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.java
@@ -879,6 +879,12 @@ public class KRATool {
                                       + DOT
                                       + "dateOfModify";
 
+    private static final String KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_ID = KRATOOL_CFG_PREFIX
+                                          + DOT
+                                          + KRATOOL_CFG_KEYRECOVERY
+                                          + DOT
+                                          + "extdata.requestId";
+
     // Constants:  Target Certificate Information
     private static final String HEADER = "-----BEGIN";
     private static final String TRAILER = "-----END";
@@ -2848,8 +2854,14 @@ public class KRATool {
                 output = line;
             }
         } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
-            output = line;
-            System.out.println("extdata-requestid: Key Recovery");
+            if( kratoolCfg.get(KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_ID ) ) {
+                output = compose_numeric_line(KRA_LDIF_EXTDATA_REQUEST_ID,
+                        SPACE,
+                        line,
+                        false );
+            } else {
+                output = line;
+            }
         } else {
             log("ERROR:  Mismatched record field='"
                     + KRA_LDIF_EXTDATA_REQUEST_ID
@@ -4495,7 +4507,8 @@ public class KRATool {
                             || name.equals(KRATOOL_CFG_KEYGEN_REQUEST_ID)
                             || name.equals(KRATOOL_CFG_KEYRECOVERY_REQUEST_ID )
                             || name.equals(KRATOOL_CFG_KEYRECOVERY_DN )
-                            || name.equals(KRATOOL_CFG_KEYRECOVERY_DATE_OF_MODIFY)) {
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_DATE_OF_MODIFY)
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_EXTDATA_REQUEST_ID)) {
                         kratoolCfg.put(name, value);
                         System.out.print(".");
                     }

--- a/base/java-tools/src/com/netscape/cmstools/KRATool.java
+++ b/base/java-tools/src/com/netscape/cmstools/KRATool.java
@@ -873,6 +873,12 @@ public class KRATool {
                                       + DOT
                                       + "dn";
 
+    private static final String KRATOOL_CFG_KEYRECOVERY_DATE_OF_MODIFY = KRATOOL_CFG_PREFIX
+                                      + DOT
+                                      + KRATOOL_CFG_KEYRECOVERY
+                                      + DOT
+                                      + "dateOfModify";
+
     // Constants:  Target Certificate Information
     private static final String HEADER = "-----BEGIN";
     private static final String TRAILER = "-----END";
@@ -2457,8 +2463,20 @@ public class KRATool {
                 output = line;
             }
         } else if (record_type.equals( KRA_LDIF_KEYRECOVERY ) ) {
-            output = line;
-            System.out.println("Date Of Modify: Key Recovery");
+            if( kratoolCfg.get( KRATOOL_CFG_KEYRECOVERY_DATE_OF_MODIFY ) ) {
+                output = KRA_LDIF_DATE_OF_MODIFY
+                        + SPACE
+                        + mDateOfModify;
+
+                 log( "Changed '"
+                    + line
+                    + "' to '"
+                    + output
+                    + "'."
+                    + NEWLINE, false );
+            } else {
+                    output = line;
+            }
         } else {
             log("ERROR:  Mismatched record field='"
                     + KRA_LDIF_DATE_OF_MODIFY
@@ -4475,8 +4493,9 @@ public class KRATool {
                             || name.equals(KRATOOL_CFG_KEYGEN_EXTDATA_REQUEST_ID)
                             || name.equals(KRATOOL_CFG_KEYGEN_EXTDATA_REQUEST_NOTES)
                             || name.equals(KRATOOL_CFG_KEYGEN_REQUEST_ID)
-                            || name.equals( KRATOOL_CFG_KEYRECOVERY_REQUEST_ID )
-                            || name.equals( KRATOOL_CFG_KEYRECOVERY_DN )) {
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_REQUEST_ID )
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_DN )
+                            || name.equals(KRATOOL_CFG_KEYRECOVERY_DATE_OF_MODIFY)) {
                         kratoolCfg.put(name, value);
                         System.out.print(".");
                     }


### PR DESCRIPTION
This PR adds support to `KRATool` to process the `netkeyKeyRecovery` entries.

Resolves: [BZ#1445479](https://bugzilla.redhat.com/show_bug.cgi?id=1445479)

~~I'll be adding the man page update as a separate PR.~~ I will also update the upstream wiki while I work on man page

Update 1: [Upstream wiki](https://www.dogtagpki.org/wiki/KRATool)
Update 2: I have updated the man page along with this PR

**NOTE:** I have tried to keep the code changes minimal since this is a stable version.