### PR TITLE
Deprecated subsystem and use_root_uri params in PKIConnection

### DIFF
--- a/base/common/python/pki/account.py
+++ b/base/common/python/pki/account.py
@@ -35,7 +35,7 @@ class AccountClient:
        * call logout() to invalidate the session.
     """
 
-    def __init__(self, connection):
+    def __init__(self, connection, subsystem=None):
         """
         Creates an AccountClient for the connection.
 
@@ -48,6 +48,14 @@ class AccountClient:
 
         self.login_url = '/rest/account/login'
         self.logout_url = '/rest/account/logout'
+
+        if connection.subsystem is None:
+
+            if subsystem is None:
+                raise Exception('Missing subsystem for AccountClient')
+
+            self.login_url = '/' + subsystem + self.login_url
+            self.logout_url = '/' + subsystem + self.logout_url
 
     @pki.handle_exceptions()
     def login(self):

--- a/base/common/python/pki/authority.py
+++ b/base/common/python/pki/authority.py
@@ -341,7 +341,7 @@ def issue_cert_using_authority(cert_client, authority_id):
 
 def main():
     # Create a PKIConnection object that stores the details of the CA.
-    connection = client.PKIConnection('https', 'localhost', '8453', 'ca')
+    connection = client.PKIConnection('https', 'localhost', '8453')
 
     # The pem file used for authentication. Created from a p12 file using the
     # command -

--- a/base/common/python/pki/authority.py
+++ b/base/common/python/pki/authority.py
@@ -133,6 +133,9 @@ class AuthorityClient(object):
 
         self.ca_url = '/rest/authorities'
 
+        if connection.subsystem is None:
+            self.ca_url = '/ca' + self.ca_url
+
     @pki.handle_exceptions()
     def get_ca(self, aid):
         """ Return a AuthorityData object for a subordinate CA. """

--- a/base/common/python/pki/cert.py
+++ b/base/common/python/pki/cert.py
@@ -628,6 +628,12 @@ class CertClient(object):
         self.cert_requests_url = '/rest/certrequests'
         self.agent_cert_requests_url = '/rest/agent/certrequests'
 
+        if connection.subsystem is None:
+            self.cert_url = '/ca' + self.cert_url
+            self.agent_cert_url = '/ca' + self.agent_cert_url
+            self.cert_requests_url = '/ca' + self.cert_requests_url
+            self.agent_cert_requests_url = '/ca' + self.agent_cert_requests_url
+
         self.headers = {'Content-type': 'application/json',
                         'Accept': 'application/json'}
 

--- a/base/common/python/pki/cert.py
+++ b/base/common/python/pki/cert.py
@@ -1070,7 +1070,7 @@ encoder.NOTYPES['ProfileParameter'] = profile.ProfileParameter
 
 def main():
     # Create a PKIConnection object that stores the details of the CA.
-    connection = client.PKIConnection('https', 'localhost', '8443', 'ca')
+    connection = client.PKIConnection('https', 'localhost', '8443')
 
     # The pem file used for authentication. Created from a p12 file using the
     # command -

--- a/base/common/python/pki/client.py
+++ b/base/common/python/pki/client.py
@@ -22,6 +22,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import functools
+import inspect
+import logging
 import warnings
 
 import requests
@@ -29,6 +31,8 @@ try:
     from requests.packages.urllib3.exceptions import InsecureRequestWarning
 except ImportError:
     from urllib3.exceptions import InsecureRequestWarning
+
+logger = logging.getLogger(__name__)
 
 
 def catch_insecure_warning(func):
@@ -54,7 +58,7 @@ class PKIConnection:
     """
 
     def __init__(self, protocol='http', hostname='localhost', port='8080',
-                 subsystem='ca', accept='application/json',
+                 subsystem=None, accept='application/json',
                  trust_env=None, verify=False):
         """
         Set the parameters for a python-requests based connection to a
@@ -65,7 +69,8 @@ class PKIConnection:
         :type hostname: str
         :param port: port of server
         :type port: str
-        :param subsystem: ca, kra, ocsp, tks or tps
+        :param subsystem: Subsystem name: ca, kra, ocsp, tks, tps.
+           DEPRECATED: https://www.dogtagpki.org/wiki/PKI_10.8_Python_Changes
         :type subsystem: str
         :param accept: value of accept header.  Supported values are usually
            'application/json' or 'application/xml'
@@ -85,11 +90,20 @@ class PKIConnection:
         self.subsystem = subsystem
 
         self.rootURI = self.protocol + '://' + self.hostname + ':' + self.port
-        self.serverURI = self.rootURI + '/' + self.subsystem
+
+        if subsystem is not None:
+            logger.warning(
+                '%s:%s: The subsystem in PKIConnection.__init__() has been deprecated '
+                '(https://www.dogtagpki.org/wiki/PKI_10.8_Python_Changes).',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)
+            self.serverURI = self.rootURI + '/' + subsystem
+        else:
+            self.serverURI = self.rootURI
 
         self.session = requests.Session()
         self.session.trust_env = trust_env
         self.session.verify = verify
+
         if accept:
             self.session.headers.update({'Accept': accept})
 
@@ -151,6 +165,10 @@ class PKIConnection:
             successful, or returns an error code.
         """
         if use_root_uri:
+            logger.warning(
+                '%s:%s: The use_root_uri in PKIConnection.get() has been deprecated '
+                '(https://www.dogtagpki.org/wiki/PKI_10.8_Python_Changes).',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)
             target_path = self.rootURI + path
         else:
             target_path = self.serverURI + path
@@ -186,6 +204,10 @@ class PKIConnection:
             successful, or returns an error code.
         """
         if use_root_uri:
+            logger.warning(
+                '%s:%s: The use_root_uri in PKIConnection.post() has been deprecated '
+                '(https://www.dogtagpki.org/wiki/PKI_10.8_Python_Changes).',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)
             target_path = self.rootURI + path
         else:
             target_path = self.serverURI + path
@@ -216,6 +238,10 @@ class PKIConnection:
             successful, or returns an error code.
         """
         if use_root_uri:
+            logger.warning(
+                '%s:%s: The use_root_uri in PKIConnection.put() has been deprecated '
+                '(https://www.dogtagpki.org/wiki/PKI_10.8_Python_Changes).',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)
             target_path = self.rootURI + path
         else:
             target_path = self.serverURI + path
@@ -240,6 +266,10 @@ class PKIConnection:
             successful, or returns an error code.
         """
         if use_root_uri:
+            logger.warning(
+                '%s:%s: The use_root_uri in PKIConnection.delete() has been deprecated '
+                '(https://www.dogtagpki.org/wiki/PKI_10.8_Python_Changes).',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)
             target_path = self.rootURI + path
         else:
             target_path = self.serverURI + path

--- a/base/common/python/pki/feature.py
+++ b/base/common/python/pki/feature.py
@@ -114,6 +114,9 @@ class FeatureClient(object):
 
         self.feature_url = '/rest/config/features'
 
+        if connection.subsystem is None:
+            self.feature_url = '/ca' + self.feature_url
+
         self.headers = {'Content-type': 'application/json',
                         'Accept': 'application/json'}
 

--- a/base/common/python/pki/feature.py
+++ b/base/common/python/pki/feature.py
@@ -145,7 +145,7 @@ encoder.NOTYPES['Feature'] = Feature
 
 def main():
     # Create a PKIConnection object that stores the details of the CA.
-    connection = client.PKIConnection('https', 'localhost', '8453', 'ca')
+    connection = client.PKIConnection('https', 'localhost', '8453')
 
     # Instantiate the FeatureClient
     feature_client = FeatureClient(connection)

--- a/base/common/python/pki/info.py
+++ b/base/common/python/pki/info.py
@@ -110,7 +110,7 @@ class InfoClient(object):
 
         headers = {'Content-type': 'application/json',
                    'Accept': 'application/json'}
-        r = self.connection.get(self.info_url, headers, use_root_uri=True)
+        r = self.connection.get(self.info_url, headers)
         return Info.from_json(r.json())
 
     @pki.handle_exceptions()

--- a/base/common/python/pki/key.py
+++ b/base/common/python/pki/key.py
@@ -474,6 +474,10 @@ class KeyClient(object):
         self.key_url = '/rest/agent/keys'
         self.key_requests_url = '/rest/agent/keyrequests'
 
+        if connection.subsystem is None:
+            self.key_url = '/kra' + self.key_url
+            self.key_requests_url = '/kra' + self.key_requests_url
+
         self.headers = {'Content-type': 'application/json',
                         'Accept': 'application/json'}
 

--- a/base/common/python/pki/profile.py
+++ b/base/common/python/pki/profile.py
@@ -998,7 +998,7 @@ class ProfileClient(object):
         self.headers = {'Content-type': 'application/json',
                         'Accept': 'application/json'}
 
-        self.account_client = account.AccountClient(connection)
+        self.account_client = account.AccountClient(connection, subsystem='ca')
 
     def _get(self, url, query_params=None, payload=None):
         self.account_client.login()
@@ -1163,7 +1163,7 @@ class ProfileClient(object):
 
 def main():
     # Initialize a PKIConnection object for the CA
-    connection = client.PKIConnection('https', 'localhost', '8443', 'ca')
+    connection = client.PKIConnection('https', 'localhost', '8443')
 
     # The pem file used for authentication. Created from a p12 file using the
     # command -

--- a/base/common/python/pki/profile.py
+++ b/base/common/python/pki/profile.py
@@ -992,6 +992,9 @@ class ProfileClient(object):
 
         self.profiles_url = '/rest/profiles'
 
+        if connection.subsystem is None:
+            self.profiles_url = '/ca' + self.profiles_url
+
         self.headers = {'Content-type': 'application/json',
                         'Accept': 'application/json'}
 

--- a/base/common/python/pki/system.py
+++ b/base/common/python/pki/system.py
@@ -181,6 +181,10 @@ class SecurityDomainClient(object):
         self.domain_info_url = '/rest/securityDomain/domainInfo'
         self.domain_xml_url = '/admin/ca/getDomainXML'
 
+        if connection.subsystem is None:
+            self.domain_info_url = '/ca' + self.domain_info_url
+            self.domain_xml_url = '/ca' + self.domain_xml_url
+
     def get_security_domain_info(self):
         """
         Contact the security domain CA specified in the connection object
@@ -291,7 +295,8 @@ class SystemConfigClient(object):
     the PKIConnection object used when constructing this object.
     """
 
-    def __init__(self, connection):
+    def __init__(self, connection, subsystem=None):
+
         self.connection = connection
 
         self.configure_url = '/rest/installer/configure'
@@ -302,6 +307,20 @@ class SystemConfigClient(object):
         self.setup_security_domain_url = '/rest/installer/setupSecurityDomain'
         self.setup_db_user_url = '/rest/installer/setupDatabaseUser'
         self.finalize_config_url = '/rest/installer/finalizeConfiguration'
+
+        if connection.subsystem is None:
+
+            if subsystem is None:
+                raise Exception('Missing subsystem for SystemConfigClient')
+
+            self.configure_url = '/' + subsystem + self.configure_url
+            self.setup_database_url = '/' + subsystem + self.setup_database_url
+            self.setup_cert_url = '/' + subsystem + self.setup_cert_url
+            self.setup_admin_url = '/' + subsystem + self.setup_admin_url
+            self.backup_keys_url = '/' + subsystem + self.backup_keys_url
+            self.setup_security_domain_url = '/' + subsystem + self.setup_security_domain_url
+            self.setup_db_user_url = '/' + subsystem + self.setup_db_user_url
+            self.finalize_config_url = '/' + subsystem + self.finalize_config_url
 
     def configure(self, request):
         """
@@ -440,10 +459,18 @@ class SystemStatusClient(object):
     Client used to check the status of a Dogtag subsystem.
     """
 
-    def __init__(self, connection):
+    def __init__(self, connection, subsystem=None):
+
         self.connection = connection
 
-        self.get_status_url = '/admin/%s/getStatus' % connection.subsystem
+        if connection.subsystem is not None:
+            self.get_status_url = '/admin/%s/getStatus' % connection.subsystem
+
+        elif subsystem is not None:
+            self.get_status_url = '/%s/admin/%s/getStatus' % (subsystem, subsystem)
+
+        else:
+            raise Exception('Missing subsystem for SystemStatusClient')
 
     def get_status(self, timeout=None):
         """

--- a/base/common/python/pki/systemcert.py
+++ b/base/common/python/pki/systemcert.py
@@ -43,6 +43,9 @@ class SystemCertClient(object):
 
         self.cert_url = '/rest/config/cert'
 
+        if connection.subsystem is None:
+            self.cert_url = '/ca' + self.cert_url
+
         self.headers = {'Content-type': 'application/json',
                         'Accept': 'application/json'}
 

--- a/base/kra/functional/drmtest.py
+++ b/base/kra/functional/drmtest.py
@@ -94,7 +94,7 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     """ test code execution """
 
     # set up the connection to the DRM, including authentication credentials
-    connection = PKIConnection(protocol, hostname, port, 'kra')
+    connection = PKIConnection(protocol, hostname, port)
     connection.set_authentication_cert(client_cert)
 
     # create kraclient

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -719,10 +719,9 @@ class PKIServer(object):
     @staticmethod
     def setup_password_authentication(username, password, subsystem_name='ca', secure_port='8443'):
         """Return a PKIConnection, logged in using username and password."""
-        connection = client.PKIConnection(
-            'https', os.environ['HOSTNAME'], secure_port, subsystem_name)
+        connection = client.PKIConnection('https', os.environ['HOSTNAME'], secure_port)
         connection.authenticate(username, password)
-        account_client = pki.account.AccountClient(connection)
+        account_client = pki.account.AccountClient(connection, subsystem=subsystem_name)
         account_client.login()
         return connection
 

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -587,7 +587,6 @@ class PKIConfigParser:
             protocol='https',
             hostname=self.mdict['pki_security_domain_hostname'],
             port=self.mdict['pki_security_domain_https_port'],
-            subsystem='ca',
             trust_env=False)
 
     def sd_get_info(self):
@@ -605,7 +604,7 @@ class PKIConfigParser:
             self.mdict['pki_security_domain_user'],
             self.mdict['pki_security_domain_password'])
 
-        account = pki.account.AccountClient(self.sd_connection)
+        account = pki.account.AccountClient(self.sd_connection, subsystem='ca')
         try:
             account.login()
             account.logout()
@@ -650,9 +649,8 @@ class PKIConfigParser:
             protocol=parse.scheme,
             hostname=parse.hostname,
             port=str(parse.port),
-            subsystem=system_type,
             trust_env=False)
-        client = pki.system.SystemStatusClient(conn)
+        client = pki.system.SystemStatusClient(conn, subsystem=system_type)
         response = client.get_status()
         root = ET.fromstring(response)
         return root.findtext("Status")

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -704,10 +704,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             protocol='https',
             hostname=deployer.mdict['pki_hostname'],
             port=deployer.mdict['pki_https_port'],
-            subsystem=deployer.mdict['pki_subsystem_type'],
             trust_env=False)
 
-        client = pki.system.SystemConfigClient(connection)
+        client = pki.system.SystemConfigClient(
+            connection,
+            subsystem=deployer.mdict['pki_subsystem_type'])
 
         logger.info('Configuring %s subsystem', subsystem.type)
         request = deployer.config_client.create_config_request()

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -388,11 +388,10 @@ class PKISubsystem(object):
             protocol=protocol,
             hostname=socket.getfqdn(),
             port=port,
-            subsystem=self.name,
             accept='application/xml',
             trust_env=False)
 
-        client = pki.system.SystemStatusClient(connection)
+        client = pki.system.SystemStatusClient(connection, subsystem=self.name)
         response = client.get_status(timeout=timeout)
 
         root = ET.fromstring(response)


### PR DESCRIPTION
The subsystem and use_root_uri params in PKIConnection have been
deprecated such that the object can be used with all subsystems.
    
https://www.dogtagpki.org/wiki/PKI_10.8_Python_Changes
