### PR TITLE
Fixed TPSTokendb.tdbFindTokenRecordsByUID()

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.dogtagpki.server.tps.cms.CARemoteRequestHandler;
@@ -143,17 +144,20 @@ public class TPSTokendb {
      */
     public ArrayList<TokenRecord> tdbFindTokenRecordsByUID(String uid)
             throws Exception {
+
+        // search for tokens with (tokenUserID=<owner UID>)
+        Map<String, String> attributes = new LinkedHashMap<>();
+        attributes.put("tokenUserID", uid);
+
+        Iterator<TokenRecord> records = tps.tokenDatabase.findRecords(null, attributes).iterator();
+
         ArrayList<TokenRecord> tokenRecords = new ArrayList<TokenRecord>();
-        String filter = uid;
-        Iterator<TokenRecord> records = null;
-        records = tps.tokenDatabase.findRecords(filter).iterator();
+        while (records.hasNext()) {
+            TokenRecord tokenRecord = records.next();
+            tokenRecords.add(tokenRecord);
+        }
 
-       while (records.hasNext()) {
-           TokenRecord tokenRecord = records.next();
-           tokenRecords.add(tokenRecord);
-       }
-
-       return tokenRecords;
+        return tokenRecords;
     }
 
     public void tdbHasActiveToken(String userid)

--- a/base/tps/src/org/dogtagpki/server/tps/dbs/TokenDatabase.java
+++ b/base/tps/src/org/dogtagpki/server/tps/dbs/TokenDatabase.java
@@ -60,6 +60,7 @@ public class TokenDatabase extends LDAPDatabase<TokenRecord> {
         StringBuilder sb = new StringBuilder();
 
         if (keyword != null) {
+            // if keyword is specified, generate filter with wildcards
             keyword = LDAPUtil.escapeFilter(keyword);
             sb.append("(|(id=*" + keyword + "*)(userID=*" + keyword + "*))");
         }


### PR DESCRIPTION
The TPSTokendb.tdbFindTokenRecordsByUID() has been modified such
that it uses (tokenUserID=<UIID>) filter to find tokens with exact
owner UID instead of filter with wildcards.

https://bugzilla.redhat.com/show_bug.cgi?id=1520258