### PR TITLE
Fixed TPSTokendb.tdbFindTokenRecordsByUID() [PKI 10.5]

### DIFF
--- a/base/server/cmscore/src/com/netscape/cmscore/dbs/LDAPDatabase.java
+++ b/base/server/cmscore/src/com/netscape/cmscore/dbs/LDAPDatabase.java
@@ -108,12 +108,22 @@ public abstract class LDAPDatabase<E extends IDBObj> extends Database<E> {
         // if no attributes specified, don't change filter
         if (attributes == null || attributes.isEmpty()) return;
 
-        // wrap current filter with attribute matching filter
-        sb.insert(0, "(&");
+        // count filter components
+        int components = 0;
+        if (sb.length() > 0) components++; // count original filter
+        components += attributes.size(); // count attribute filters
+
+        // concatenate the original filter and attribute filters:
+        // <original filter>(<attribute>=<value>)...(<attribute>=<value>)
         for (Map.Entry<String, String> entry : attributes.entrySet()) {
             sb.append("(" + entry.getKey() + "=" + LDAPUtil.escapeFilter(entry.getValue()) + ")");
         }
-        sb.append(")");
+
+        // if there are multiple filter components, join with AND operator
+        if (components > 1) {
+            sb.insert(0, "(&");
+            sb.append(")");
+        }
     }
 
     @Override
@@ -121,13 +131,20 @@ public abstract class LDAPDatabase<E extends IDBObj> extends Database<E> {
         return findRecords(keyword, null);
     }
 
+    /**
+     * Search for LDAP records with the specified keyword and attributes.
+     * The keyword parameter will be used to search with wildcards on certain attributes.
+     * The attributes parameter will be used to find exact matches of the specified attributes.
+     */
     public Collection<E> findRecords(String keyword, Map<String, String> attributes) throws Exception {
 
         CMS.debug("LDAPDatabase: findRecords()");
 
         try (IDBSSession session = dbSubsystem.createSession()) {
             Collection<E> list = new ArrayList<E>();
+
             String ldapFilter = createFilter(keyword, attributes);
+
             CMS.debug("LDAPDatabase: searching " + baseDN + " with filter " + ldapFilter);
             IDBSearchResults results = session.search(baseDN, ldapFilter);
 

--- a/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.dogtagpki.server.tps.cms.CARemoteRequestHandler;
@@ -141,17 +142,20 @@ public class TPSTokendb {
      */
     public ArrayList<TokenRecord> tdbFindTokenRecordsByUID(String uid)
             throws Exception {
+
+        // search for tokens with (tokenUserID=<owner UID>)
+        Map<String, String> attributes = new LinkedHashMap<>();
+        attributes.put("tokenUserID", uid);
+
+        Iterator<TokenRecord> records = tps.tokenDatabase.findRecords(null, attributes).iterator();
+
         ArrayList<TokenRecord> tokenRecords = new ArrayList<TokenRecord>();
-        String filter = uid;
-        Iterator<TokenRecord> records = null;
-        records = tps.tokenDatabase.findRecords(filter).iterator();
+        while (records.hasNext()) {
+            TokenRecord tokenRecord = records.next();
+            tokenRecords.add(tokenRecord);
+        }
 
-       while (records.hasNext()) {
-           TokenRecord tokenRecord = records.next();
-           tokenRecords.add(tokenRecord);
-       }
-
-       return tokenRecords;
+        return tokenRecords;
     }
 
     public void tdbHasActiveToken(String userid)

--- a/base/tps/src/org/dogtagpki/server/tps/dbs/TokenDatabase.java
+++ b/base/tps/src/org/dogtagpki/server/tps/dbs/TokenDatabase.java
@@ -60,6 +60,7 @@ public class TokenDatabase extends LDAPDatabase<TokenRecord> {
         StringBuilder sb = new StringBuilder();
 
         if (keyword != null) {
+            // if keyword is specified, generate filter with wildcards
             keyword = LDAPUtil.escapeFilter(keyword);
             sb.append("(|(id=*" + keyword + "*)(userID=*" + keyword + "*))");
         }


### PR DESCRIPTION
The TPSTokendb.tdbFindTokenRecordsByUID() has been modified such
that it uses (tokenUserID=<UIID>) filter to find tokens with exact
owner UID instead of filter with wildcards.

https://bugzilla.redhat.com/show_bug.cgi?id=1520258