### PR TITLE
[trivial] ca-authority-del: fix usage string

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/authority/AuthorityRemoveCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/authority/AuthorityRemoveCLI.java
@@ -22,7 +22,7 @@ public class AuthorityRemoveCLI extends CLI {
     }
 
     public void printHelp() {
-        formatter.printHelp(getFullName() + " <dn>", options);
+        formatter.printHelp(getFullName() + " <ID>", options);
     }
 
     public void execute(String[] args) throws Exception {


### PR DESCRIPTION
The usage string for `pki ca-authority-del' mentions "DN", but the
argument is actually an authority ID.  Fix the string.