### PR TITLE
Added pki kra-cert-transport commands

### DIFF
--- a/base/common/src/org/dogtagpki/cli/CLI.java
+++ b/base/common/src/org/dogtagpki/cli/CLI.java
@@ -212,7 +212,7 @@ public class CLI {
     public void printHelp() {
 
         int leftPadding = 1;
-        int rightPadding = 25;
+        int rightPadding = 35;
 
         System.out.println("Commands:");
 
@@ -339,7 +339,9 @@ public class CLI {
             System.arraycopy(args, 1, moduleArgs, 0, args.length-1);
         }
 
-        // Add "--help" option to all command modules
+        // Add default options to all command modules
+        module.options.addOption("v", "verbose", false, "Run in verbose mode");
+        module.options.addOption(null, "debug", false, "Run in debug mode");
         module.options.addOption(null, "help", false, "Show help options");
 
         module.execute(moduleArgs);

--- a/base/java-tools/src/com/netscape/cmstools/kra/KRACLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/kra/KRACLI.java
@@ -40,6 +40,7 @@ public class KRACLI extends SubsystemCLI {
         super("kra", "KRA management commands", parent);
 
         addModule(new AuditCLI(this));
+        addModule(new KRACertCLI(this));
         addModule(new GroupCLI(this));
         addModule(new KRAKeyCLI(this));
         addModule(new SelfTestCLI(this));

--- a/base/java-tools/src/com/netscape/cmstools/kra/KRACertCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/kra/KRACertCLI.java
@@ -1,0 +1,38 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2019 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.kra;
+
+import org.dogtagpki.cli.CLI;
+
+import com.netscape.certsrv.kra.KRAClient;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class KRACertCLI extends CLI {
+
+    public KRAClient kraClient;
+
+    public KRACertCLI(CLI parent) {
+        super("cert", "KRA certificate management commands", parent);
+
+        addModule(new KRACertTransportExportCLI(this));
+        addModule(new KRACertTransportShowCLI(this));
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/kra/KRACertTransportExportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/kra/KRACertTransportExportCLI.java
@@ -1,0 +1,116 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2019 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.kra;
+
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.util.logging.PKILogger;
+import org.mozilla.jss.netscape.security.util.Cert;
+
+import com.netscape.certsrv.cert.CertData;
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.system.SystemCertClient;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class KRACertTransportExportCLI extends CLI {
+
+    public KRACertCLI certCLI;
+
+    public KRACertTransportExportCLI(KRACertCLI certCLI) {
+        super("transport-export", "Export transport certificate", certCLI);
+        this.certCLI = certCLI;
+
+        createOptions();
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "output-format", true, "Output format: PEM (default), DER");
+        option.setArgName("format");
+        options.addOption(option);
+
+        option = new Option(null, "output-file", true, "Output file");
+        option.setArgName("file");
+        options.addOption(option);
+    }
+
+    public void execute(String[] args) throws Exception {
+
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            printHelp();
+            return;
+        }
+
+        if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(PKILogger.Level.INFO);
+
+        } else if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+        }
+
+        PKIClient client = getClient();
+        SystemCertClient certClient = new SystemCertClient(client, "kra");
+        CertData certData = certClient.getTransportCert();
+
+        String outputFormat = cmd.getOptionValue("output-format");
+
+        String cert = null;
+        byte[] bytes = null;
+
+        if (outputFormat == null || "PEM".equals(outputFormat.toUpperCase())) {
+            cert = certData.getEncoded();
+
+        } else if ("DER".equals(outputFormat.toUpperCase())) {
+            bytes = Cert.parseCertificate(certData.getEncoded());
+
+        } else {
+            throw new Exception("Unsupported format: " + outputFormat);
+        }
+
+        String outputFile = cmd.getOptionValue("output-file");
+
+        if (outputFile != null) {
+            try (PrintStream out = new PrintStream(new FileOutputStream(outputFile))) {
+                if (cert != null) {
+                    out.println(cert);
+                } else {
+                    out.write(bytes);
+                }
+            }
+
+        } else {
+            if (cert != null) {
+                System.out.println(cert);
+            } else {
+                System.out.write(bytes);
+            }
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/kra/KRACertTransportShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/kra/KRACertTransportShowCLI.java
@@ -1,0 +1,71 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2019 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmstools.kra;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.util.logging.PKILogger;
+
+import com.netscape.certsrv.cert.CertData;
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.system.SystemCertClient;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class KRACertTransportShowCLI extends CLI {
+
+    public KRACertCLI certCLI;
+
+    public KRACertTransportShowCLI(KRACertCLI certCLI) {
+        super("transport-show", "Show transport certificate", certCLI);
+        this.certCLI = certCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void execute(String[] args) throws Exception {
+
+        CommandLine cmd = parser.parse(options, args);
+
+        if (cmd.hasOption("help")) {
+            printHelp();
+            return;
+        }
+
+        if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(PKILogger.Level.INFO);
+
+        } else if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+        }
+
+        PKIClient client = getClient();
+        SystemCertClient certClient = new SystemCertClient(client, "kra");
+        CertData certData = certClient.getTransportCert();
+
+        System.out.println("  Serial Number: " + certData.getSerialNumber().toHexString());
+        System.out.println("  Subject DN: " + certData.getSubjectDN());
+        System.out.println("  Issuer DN: " + certData.getIssuerDN());
+        System.out.println("  Not Valid Before: " + certData.getNotBefore());
+        System.out.println("  Not Valid After: " + certData.getNotAfter());
+    }
+}


### PR DESCRIPTION
New PKI commands have been added to display and retrieve KRA's
transport certificate.