### PR TITLE
CryptoUtil.getKeywrapAlgorithmFromOID: Fix DES-EDE3-CBC selection

### DIFF
--- a/base/kra/src/com/netscape/kra/SecurityDataProcessor.java
+++ b/base/kra/src/com/netscape/kra/SecurityDataProcessor.java
@@ -208,6 +208,8 @@ public class SecurityDataProcessor {
                             KeyRequestService.SYMKEY_TYPES.get(algorithm),
                             strength);
                 } catch (Exception e) {
+                    CMS.debug("Can't decrypt symmetric key:");
+                    CMS.debug(e);
                     throw new EBaseException("Can't decrypt symmetric key.", e);
                 }
             }
@@ -222,6 +224,8 @@ public class SecurityDataProcessor {
                         secdata,
                         null);
             } catch (Exception e) {
+                CMS.debug("Can't decrypt passphrase.");
+                CMS.debug(e);
                 throw new EBaseException("Can't decrypt passphrase.", e);
             }
 

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -2878,7 +2878,7 @@ public class CryptoUtil {
         if (oid.equals(KeyWrapAlgorithm.DES_CBC_PAD_OID))
             return KeyWrapAlgorithm.DES3_CBC_PAD;
 
-        throw new NoSuchAlgorithmException();
+        throw new NoSuchAlgorithmException(wrapOID);
     }
 
 }

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -2875,7 +2875,7 @@ public class CryptoUtil {
         if (oid.equals(KeyWrapAlgorithm.AES_KEY_WRAP_OID))
             return KeyWrapAlgorithm.AES_CBC_PAD;
 
-        if (oid.equals(KeyWrapAlgorithm.DES_CBC_PAD_OID))
+        if (oid.equals(KeyWrapAlgorithm.DES3_CBC_PAD_OID))
             return KeyWrapAlgorithm.DES3_CBC_PAD;
 
         throw new NoSuchAlgorithmException(wrapOID);

--- a/base/util/src/netscape/security/util/WrappingParams.java
+++ b/base/util/src/netscape/security/util/WrappingParams.java
@@ -67,7 +67,7 @@ public class WrappingParams {
             // New clients set this correctly.
             // We'll assume the old DES3 wrapping here.
             encrypt = EncryptionAlgorithm.DES_CBC_PAD;
-        } else if (encryptOID.equals(KeyWrapAlgorithm.DES_CBC_PAD_OID.toString())) {
+        } else if (encryptOID.equals(KeyWrapAlgorithm.DES3_CBC_PAD_OID.toString())) {
             encrypt = EncryptionAlgorithm.DES3_CBC_PAD;
         } else if (encryptOID.equals(KeyWrapAlgorithm.AES_CBC_PAD_OID.toString())) {
             encrypt = EncryptionAlgorithm.AES_128_CBC_PAD;


### PR DESCRIPTION
Commit dbd2d9b587f46b8af2f78b73d62715c1fd3344fc contained the edit:

```
-        if (oid.equals(KW_DES_CBC_PAD))
+        if (oid.equals(KeyWrapAlgorithm.DES_CBC_PAD_OID))
```

KW_DES_CBC_PAD was 1.2.840.113549.3.7 (DES-EDE3-CBC; this definition was
removed in the same commit). But KeyWrapAlgorithm.DES_CBC_PAD_OID is
1.3.14.3.2.7.  This is a behaviour change that breaks KRA archival
(possibly recovery too).

Test equality to KeyWrapAlgorithm.DES3_CBC_PAD_OID to restore the correct
behaviour.  Also fix a similar error in WrappingParams.java.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1709585