### PR TITLE
Fix Python error in crypto.import_cert()

### DIFF
--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -26,7 +26,6 @@ import abc
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 
 import nss.nss as nss
@@ -195,7 +194,7 @@ class NSSCryptoProvider(CryptoProvider):
         else:
             content = cert
 
-        if sys.version_info[0] > 2:
+        if type(content) is not six.binary_type:
             content = content.encode()
 
         # certutil -A -d db_dir -n cert_nick -t trust -i cert_file

--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -26,6 +26,7 @@ import abc
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 
 import nss.nss as nss
@@ -193,6 +194,9 @@ class NSSCryptoProvider(CryptoProvider):
             content = cert.encoded
         else:
             content = cert
+
+        if sys.version_info[0] > 2:
+            content = content.encode()
 
         # certutil -A -d db_dir -n cert_nick -t trust -i cert_file
         with tempfile.NamedTemporaryFile() as cert_file:


### PR DESCRIPTION
Patch to fix `import_cert()` method in `crypto.py` to handle
both python2 and python3 based methods

Fixes: https://pagure.io/dogtagpki/issue/3108

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>