### PR TITLE
Updated SSL behavior in PKI CLI

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -162,7 +162,7 @@ public class MainCLI extends CLI {
         option.setArgName("uri");
         options.addOption(option);
 
-        option = new Option("P", true, "Protocol (default: http)");
+        option = new Option("P", true, "Protocol (default: https)");
         option.setArgName("protocol");
         options.addOption(option);
 
@@ -170,7 +170,7 @@ public class MainCLI extends CLI {
         option.setArgName("hostname");
         options.addOption(option);
 
-        option = new Option("p", true, "Port (default: 8080)");
+        option = new Option("p", true, "Port (default: 8443)");
         option.setArgName("port");
         options.addOption(option);
 
@@ -335,9 +335,9 @@ public class MainCLI extends CLI {
 
         String url = cmd.getOptionValue("U");
 
-        String protocol = cmd.getOptionValue("P", "http");
+        String protocol = cmd.getOptionValue("P", "https");
         String hostname = cmd.getOptionValue("h", InetAddress.getLocalHost().getCanonicalHostName());
-        String port = cmd.getOptionValue("p", "8080");
+        String port = cmd.getOptionValue("p", "8443");
         String subsystem = cmd.getOptionValue("t");
 
         if (url == null)


### PR DESCRIPTION
The PKI CLI has been modified to use HTTPS over port 8443
by default.

The CLI has also been modified such that when it receives an
untrusted SSL certificate it will ask the user whether to trust
the certificate. If the certificate is trusted, it will be imported
into the client's NSS database and marked as trusted peer.

https://www.dogtagpki.org/wiki/PKI_10.8_PKI_CLI_Changes