### PR TITLE
 Updated certificate request review process

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestActionCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestActionCLI.java
@@ -1,0 +1,123 @@
+package com.netscape.cmstools.ca;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.ca.CACertClient;
+import com.netscape.certsrv.cert.CertRequestInfo;
+import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class CACertRequestActionCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CACertRequestActionCLI.class);
+
+    CACertRequestCLI certRequestCLI;
+
+    public CACertRequestActionCLI(
+            String name,
+            String description,
+            CACertRequestCLI certRequestCLI) {
+        super(name, description, certRequestCLI);
+        this.certRequestCLI = certRequestCLI;
+    }
+
+    @Override
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " <Request ID> [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "input-file", true, "Input file containing certificate request.");
+        option.setArgName("filename");
+        options.addOption(option);
+
+        options.addOption(null, "force", false, "Force");
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing certificate request ID");
+        }
+
+        RequestId requestId;
+        try {
+            requestId = new RequestId(cmdArgs[0]);
+        } catch (NumberFormatException e) {
+            throw new Exception("Invalid certificate request ID: " + cmdArgs[0], e);
+        }
+
+        String filename = cmd.getOptionValue("input-file");
+        boolean force = cmd.hasOption("force");
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        logger.info("Retrieving certificate request " + requestId);
+        CACertClient certClient = certRequestCLI.getCertClient();
+        CertReviewResponse reviewInfo = certClient.reviewRequest(requestId);
+
+        // save new nonce
+        String nonce = reviewInfo.getNonce();
+        logger.info("Nonce: " + nonce);
+
+        if (filename == null) {
+
+            // if input file not provided, ask for confirmation (unless forced)
+            // before performing the action on the request
+
+            if (!force) {
+
+                CACertRequestCLI.printCertReviewResponse(reviewInfo);
+
+                System.out.println();
+                System.out.print("Are you sure (y/N)? ");
+                System.out.flush();
+
+                BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+                String confirmation = reader.readLine().trim();
+
+                if (!confirmation.equalsIgnoreCase("y")) {
+                    return;
+                }
+            }
+
+        } else {
+
+            // if input file provided, load updated request from file
+
+            logger.info("Loading certificate request from " + filename);
+            String xml = new String(Files.readAllBytes(Paths.get(filename)));
+            reviewInfo = CertReviewResponse.fromXML(xml);
+
+            if (!requestId.equals(reviewInfo.getRequestId())) {
+                throw new Exception("Incorrect certificate request in " + filename);
+            }
+
+            // replace old nonce with the new one
+            reviewInfo.setNonce(nonce);
+        }
+
+        performAction(certClient, requestId, reviewInfo);
+
+        CertRequestInfo certRequest = certClient.getRequest(requestId);
+        CACertRequestCLI.printCertRequestInfo(certRequest);
+    }
+
+    public void performAction(
+            CACertClient certClient,
+            RequestId requestId,
+            CertReviewResponse reviewInfo) {
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestApproveCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestApproveCLI.java
@@ -1,0 +1,22 @@
+package com.netscape.cmstools.ca;
+
+import com.netscape.certsrv.ca.CACertClient;
+import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class CACertRequestApproveCLI extends CACertRequestActionCLI {
+
+    public CACertRequestApproveCLI(CACertRequestCLI certRequestCLI) {
+        super("approve", "Approve certificate request", certRequestCLI);
+    }
+
+    public void performAction(
+            CACertClient certClient,
+            RequestId requestId,
+            CertReviewResponse reviewInfo) {
+
+        certClient.approveRequest(requestId, reviewInfo);
+        MainCLI.printMessage("Approved certificate request " + requestId);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestAssignCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestAssignCLI.java
@@ -1,0 +1,22 @@
+package com.netscape.cmstools.ca;
+
+import com.netscape.certsrv.ca.CACertClient;
+import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class CACertRequestAssignCLI extends CACertRequestActionCLI {
+
+    public CACertRequestAssignCLI(CACertRequestCLI certRequestCLI) {
+        super("assign", "Assign certificate request", certRequestCLI);
+    }
+
+    public void performAction(
+            CACertClient certClient,
+            RequestId requestId,
+            CertReviewResponse reviewInfo) {
+
+        certClient.assignRequest(requestId, reviewInfo);
+        MainCLI.printMessage("Assigned certificate request " + requestId);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestCLI.java
@@ -18,6 +18,7 @@
 
 package com.netscape.cmstools.ca;
 
+import org.apache.commons.lang.StringUtils;
 import org.dogtagpki.cli.CLI;
 
 import com.netscape.certsrv.ca.CACertClient;
@@ -25,6 +26,8 @@ import com.netscape.certsrv.cert.CertRequestInfo;
 import com.netscape.certsrv.cert.CertRequestInfos;
 import com.netscape.certsrv.cert.CertReviewResponse;
 import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.profile.ProfileAttribute;
+import com.netscape.certsrv.profile.ProfileInput;
 import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmstools.cli.SubsystemCLI;
 
@@ -44,6 +47,13 @@ public class CACertRequestCLI extends CLI {
         addModule(new CACertRequestShowCLI(this));
         addModule(new CACertRequestSubmitCLI(this));
         addModule(new CACertRequestReviewCLI(this));
+        addModule(new CACertRequestApproveCLI(this));
+        addModule(new CACertRequestRejectCLI(this));
+        addModule(new CACertRequestCancelCLI(this));
+        addModule(new CACertRequestUpdateCLI(this));
+        addModule(new CACertRequestValidateCLI(this));
+        addModule(new CACertRequestAssignCLI(this));
+        addModule(new CACertRequestUnassignCLI(this));
 
         addModule(new CACertRequestProfileFindCLI(this));
         addModule(new CACertRequestProfileShowCLI(this));
@@ -113,9 +123,32 @@ public class CACertRequestCLI extends CLI {
     }
 
     public static void printCertReviewResponse(CertReviewResponse response) {
+
         System.out.println("  Request ID: " + response.getRequestId());
         System.out.println("  Profile: " + response.getProfileName());
         System.out.println("  Type: " + response.getRequestType());
         System.out.println("  Status: " + response.getRequestStatus());
+
+        for (ProfileInput input : response.getInputs()) {
+
+            System.out.println();
+            System.out.println("  " + input.getName() + ":");
+            boolean inputProvided = false;
+
+            for (ProfileAttribute attribute : input.getAttributes()) {
+
+                String name = attribute.getName();
+                String value = attribute.getValue().trim();
+
+                if (!StringUtils.isEmpty(value)) {
+                    System.out.println("    " + name + ": " + value);
+                    inputProvided = true;
+                }
+            }
+
+            if (!inputProvided) {
+                System.out.println("    none");
+            }
+        }
     }
 }

--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestCancelCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestCancelCLI.java
@@ -1,0 +1,22 @@
+package com.netscape.cmstools.ca;
+
+import com.netscape.certsrv.ca.CACertClient;
+import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class CACertRequestCancelCLI extends CACertRequestActionCLI {
+
+    public CACertRequestCancelCLI(CACertRequestCLI certRequestCLI) {
+        super("cancel", "Cancel certificate request", certRequestCLI);
+    }
+
+    public void performAction(
+            CACertClient certClient,
+            RequestId requestId,
+            CertReviewResponse reviewInfo) {
+
+        certClient.cancelRequest(requestId, reviewInfo);
+        MainCLI.printMessage("Canceled certificate request " + requestId);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestRejectCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestRejectCLI.java
@@ -1,0 +1,22 @@
+package com.netscape.cmstools.ca;
+
+import com.netscape.certsrv.ca.CACertClient;
+import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class CACertRequestRejectCLI extends CACertRequestActionCLI {
+
+    public CACertRequestRejectCLI(CACertRequestCLI certRequestCLI) {
+        super("reject", "Reject certificate request", certRequestCLI);
+    }
+
+    public void performAction(
+            CACertClient certClient,
+            RequestId requestId,
+            CertReviewResponse reviewInfo) {
+
+        certClient.rejectRequest(requestId, reviewInfo);
+        MainCLI.printMessage("Rejected certificate request " + requestId);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestUnassignCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestUnassignCLI.java
@@ -1,0 +1,22 @@
+package com.netscape.cmstools.ca;
+
+import com.netscape.certsrv.ca.CACertClient;
+import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class CACertRequestUnassignCLI extends CACertRequestActionCLI {
+
+    public CACertRequestUnassignCLI(CACertRequestCLI certRequestCLI) {
+        super("unassign", "Unassign certificate request", certRequestCLI);
+    }
+
+    public void performAction(
+            CACertClient certClient,
+            RequestId requestId,
+            CertReviewResponse reviewInfo) {
+
+        certClient.unassignRequest(requestId, reviewInfo);
+        MainCLI.printMessage("Unassigned certificate request " + requestId);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestUpdateCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestUpdateCLI.java
@@ -1,0 +1,22 @@
+package com.netscape.cmstools.ca;
+
+import com.netscape.certsrv.ca.CACertClient;
+import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class CACertRequestUpdateCLI extends CACertRequestActionCLI {
+
+    public CACertRequestUpdateCLI(CACertRequestCLI certRequestCLI) {
+        super("update", "Update certificate request", certRequestCLI);
+    }
+
+    public void performAction(
+            CACertClient certClient,
+            RequestId requestId,
+            CertReviewResponse reviewInfo) {
+
+        certClient.updateRequest(requestId, reviewInfo);
+        MainCLI.printMessage("Updated certificate request " + requestId);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestValidateCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/ca/CACertRequestValidateCLI.java
@@ -1,0 +1,22 @@
+package com.netscape.cmstools.ca;
+
+import com.netscape.certsrv.ca.CACertClient;
+import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class CACertRequestValidateCLI extends CACertRequestActionCLI {
+
+    public CACertRequestValidateCLI(CACertRequestCLI certRequestCLI) {
+        super("validate", "Validate certificate request", certRequestCLI);
+    }
+
+    public void performAction(
+            CACertClient certClient,
+            RequestId requestId,
+            CertReviewResponse reviewInfo) {
+
+        certClient.validateRequest(requestId, reviewInfo);
+        MainCLI.printMessage("Validated certificate request " + requestId);
+    }
+}


### PR DESCRIPTION
This patch introduces new certificate request review processes
which should be easier to use and automate.

The following command will display a summary of the request,
then ask the user to enter an action:
```
$ pki ca-cert-request-review <request ID>
```
The following command will display a summary of the request,
then ask the user to confirm the specified action:
```
$ pki ca-cert-request-<action> <request ID>
```
The following command will execute the specified action on
the request without asking for confirmation:
```
$ pki ca-cert-request-<action> <request ID> --force
```
The following commands will store the complete request into
a file allowing a more detailed review, then perform the
specified action based on the updated request in the file:
```
$ pki ca-cert-request-review <request ID> --output-file <file>
$ pki ca-cert-request-<action> <request ID> --input-file <file>
```
The old processes are still available, but they have been
deprecated and may be removed in the future.

https://www.dogtagpki.org/wiki/PKI_10.8_PKI_CLI_Changes