### PR TITLE
Cleaned up TPS build scripts

### DIFF
--- a/base/tps-client/CMakeLists.txt
+++ b/base/tps-client/CMakeLists.txt
@@ -42,31 +42,6 @@ add_subdirectory(tools)
 # install files
 add_subdirectory(setup)
 
-# install systemd scripts
-install(
-    FILES
-        lib/systemd/system/pki-tpsd.target
-        lib/systemd/system/pki-tpsd@.service
-    DESTINATION
-        ${SYSTEMD_LIB_INSTALL_DIR}
-    PERMISSIONS
-        OWNER_WRITE OWNER_READ
-        GROUP_READ
-        WORLD_READ
-)
-
-# install init script
-install(
-    FILES
-        etc/init.d/pki-tpsd
-    DESTINATION
-        ${SYSCONF_INSTALL_DIR}/rc.d/init.d
-    PERMISSIONS
-        OWNER_EXECUTE OWNER_WRITE OWNER_READ
-        GROUP_EXECUTE GROUP_READ
-        WORLD_EXECUTE WORLD_READ
-)
-
 install(
     FILES
         applets/1.3.44724DDE.ijc
@@ -78,54 +53,9 @@ install(
 
 install(
     DIRECTORY
-        apache/cgi-bin
-    DESTINATION
-        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}
-)
-
-install(
-    DIRECTORY
         apache/conf
     DESTINATION
         ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}
-)
-
-install(
-    DIRECTORY
-        apache/docroot
-    DESTINATION
-        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}
-)
-
-install(
-    DIRECTORY
-        lib
-    DESTINATION
-        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}
-)
-
-install(
-    FILES
-        scripts/nss_pcache
-    DESTINATION
-        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}/scripts
-    PERMISSIONS
-        OWNER_EXECUTE OWNER_WRITE OWNER_READ
-        GROUP_EXECUTE GROUP_READ
-        WORLD_EXECUTE WORLD_READ
-)
-
-install(
-    FILES
-        scripts/addAgents.ldif
-        scripts/addIndexes.ldif
-        scripts/addTokens.ldif
-        scripts/addVLVIndexes.ldif
-        scripts/database.ldif
-        scripts/schemaMods.ldif
-        scripts/vlvtasks.ldif
-    DESTINATION
-        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}/scripts
 )
 
 # install empty directories

--- a/base/tps-client/src/authentication/CMakeLists.txt
+++ b/base/tps-client/src/authentication/CMakeLists.txt
@@ -43,9 +43,3 @@ set_target_properties(${LDAPAUTH_SHARED_LIBRARY}
         OUTPUT_NAME
             ldapauth
 )
-
-install(
-    TARGETS
-        ${LDAPAUTH_SHARED_LIBRARY}
-    LIBRARY DESTINATION ${LIB_INSTALL_DIR}/tps
-)

--- a/base/tps-client/src/modules/tokendb/CMakeLists.txt
+++ b/base/tps-client/src/modules/tokendb/CMakeLists.txt
@@ -38,10 +38,3 @@ set_target_properties(${TOKENDB_MODULE}
             mod_tokendb
         PREFIX ""
 )
-
-install(
-    TARGETS
-        ${TOKENDB_MODULE}
-    DESTINATION
-        ${LIB_INSTALL_DIR}/httpd/modules
-)

--- a/base/tps-client/src/modules/tps/CMakeLists.txt
+++ b/base/tps-client/src/modules/tps/CMakeLists.txt
@@ -42,10 +42,3 @@ set_target_properties(${TPS_MODULE}
             mod_tps
         PREFIX ""
 )
-
-install(
-    TARGETS
-        ${TPS_MODULE}
-    DESTINATION
-        ${LIB_INSTALL_DIR}/httpd/modules
-)

--- a/base/tps-client/tools/raclient/CMakeLists.txt
+++ b/base/tps-client/tools/raclient/CMakeLists.txt
@@ -36,12 +36,3 @@ install(
     LIBRARY DESTINATION ${LIB_INSTALL_DIR}/tps
     ARCHIVE DESTINATION ${LIB_INSTALL_DIR}/tps
 )
-
-install(
-    FILES
-        enroll.tps
-        format.tps
-        reset_pin.tps
-    DESTINATION
-        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/tps/samples
-)

--- a/base/tps/CMakeLists.txt
+++ b/base/tps/CMakeLists.txt
@@ -48,17 +48,6 @@ install(
 )
 
 install(
-    FILES
-        shared/applets/listappletdates
-    DESTINATION
-        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}/shared/applets
-    PERMISSIONS
-        OWNER_EXECUTE OWNER_WRITE OWNER_READ
-        GROUP_EXECUTE GROUP_READ
-        WORLD_EXECUTE WORLD_READ
-)
-
-install(
     DIRECTORY
         ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/
     DESTINATION


### PR DESCRIPTION
Previously the TPS build scripts generated some artifacts in the
buildroot that were not included in the RPM package so rpmbuild
would generate warnings about those files.

To avoid the warnings the TPS build scripts have been modified
to no longer install those files into the buildroot.

In the future the unused sources should be removed from the
source repository.