### PR TITLE
Addition to TMS RHCS-maint code merge from 7571dc339ba44c06588764d161…

### DIFF
--- a/base/server/src/com/netscape/cmscore/ldapconn/PKISocketFactory.java
+++ b/base/server/src/com/netscape/cmscore/ldapconn/PKISocketFactory.java
@@ -23,6 +23,8 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.Iterator;
 import java.util.Vector;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.dogtagpki.server.PKIClientSocketListener;
 import org.mozilla.jss.ssl.SSLClientCertificateSelectionCallback;
@@ -54,8 +56,16 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
     private String mClientAuthCertNickname;
     private boolean mClientAuth;
     private boolean keepAlive;
-    private static boolean external = false;
     PKIClientSocketListener sockListener = null;
+
+    /*
+     * Per Bugzilla 1585722, the parameter "external" was introduced
+     * to allow this class to be called by an external application.
+     * Areas specifically guarded by "!external" are
+     * 1. code reaching out to CS.cfg
+     * 2. code writing log messages to server log files
+     */
+    private static boolean external = false;
 
     public PKISocketFactory() {
     }
@@ -89,19 +99,19 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
                 keepAlive = cs.getBoolean("tcp.keepAlive", true);
             } else
                 keepAlive = true;
-            logger.debug("TCP Keep-Alive: " + keepAlive);
+            log("TCP Keep-Alive: " + keepAlive);
             sockListener = new PKIClientSocketListener();
 
         } catch (Exception e) {
             String message = "Unable to read TCP configuration: " + e;
-            logger.error(message, e);
+            log(message, e);
             throw new RuntimeException(message, e);
         }
     }
 
     public SSLSocket makeSSLSocket(String host, int port) throws UnknownHostException, IOException {
         String method = "ldapconn/PKISocketFactory.makeSSLSocket: ";
-        logger.debug(method + "begins");
+        log(method + "begins");
 
         /*
          * let inherit TLS range and cipher settings
@@ -136,7 +146,7 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
 
         if (mClientAuthCertNickname != null) {
             mClientAuth = true;
-            logger.debug("LdapJssSSLSocket: set client auth cert nickname " +
+            log("LdapJssSSLSocket: set client auth cert nickname " +
                     mClientAuthCertNickname);
 
             //We have already established the manual cert selection callback
@@ -161,29 +171,31 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
             s.setKeepAlive(keepAlive);
 
         } catch (Exception e) {
-            // for auditing
-            String localIP = "localhost";
-            try {
-                localIP = InetAddress.getLocalHost().getHostAddress();
-            } catch (UnknownHostException e2) {
-                // default to "localhost";
-            }
-            SignedAuditEvent auditEvent;
-            auditEvent = ClientAccessSessionEstablishEvent.createFailureEvent(
+            if (!external) {
+                // for auditing
+                String localIP = "localhost";
+                try {
+                    localIP = InetAddress.getLocalHost().getHostAddress();
+                } catch (UnknownHostException e2) {
+                    // default to "localhost";
+                }
+                SignedAuditEvent auditEvent;
+                auditEvent = ClientAccessSessionEstablishEvent.createFailureEvent(
                         localIP,
                         host,
                         Integer.toString(port),
                         "SYSTEM",
                         "connect:" +e.toString());
-            signedAuditLogger.log(auditEvent);
+                signedAuditLogger.log(auditEvent);
+            }
 
             String message = "Unable to create socket: " + e;
-            logger.error(message, e);
+            log(message, e);
             if (s != null) {
                 try {
                     s.close();
                 } catch (IOException e1) {
-                    logger.warn("Unable to close socket: " + e1.getMessage(), e1);
+                    log("Unable to close socket: " + e1.getMessage(), e1);
                 }
             }
             throw new LDAPException(message);
@@ -203,6 +215,24 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
     public void log(int level, String msg) {
     }
 
+    private static void log(String msg) {
+        log(msg, null);
+    }
+
+    private static void log(String msg, Exception e) {
+        if(!external && e != null){
+            logger.error(msg, e);
+        } else if (!external) {
+            logger.debug(msg);
+        } else {
+            if(e != null){
+                Logger.getLogger("PKISocketFactory").log(Level.SEVERE, e.getMessage());
+            } else {
+                Logger.getLogger("PKISocketFactory").log(Level.INFO, msg);
+            }
+        }
+    }
+
     static class ClientHandshakeCB implements SSLHandshakeCompletedListener {
         Object sc;
 
@@ -211,7 +241,7 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
         }
 
         public void handshakeCompleted(SSLHandshakeCompletedEvent event) {
-            logger.debug("SSL handshake happened");
+            log("SSL handshake happened");
         }
     }
 
@@ -219,14 +249,14 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
         String desiredCertName = null;
 
         public SSLClientCertificateSelectionCB(String clientAuthCertNickname) {
-            logger.debug("SSLClientCertificateSelectionCB: Setting desired cert nickname to: " + clientAuthCertNickname);
+            log("SSLClientCertificateSelectionCB: Setting desired cert nickname to: " + clientAuthCertNickname);
             desiredCertName = clientAuthCertNickname;
         }
 
         @Override
         public String select(Vector<String> certs) {
 
-            logger.debug("SSLClientCertificatSelectionCB: Entering!");
+            log("SSLClientCertificatSelectionCB: Entering!");
 
             if(desiredCertName == null) {
                 return null;
@@ -238,15 +268,15 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
 
             while(itr.hasNext()){
                 String candidate = itr.next();
-                logger.debug("Candidate cert: " + candidate);
+                log("Candidate cert: " + candidate);
                 if(desiredCertName.equalsIgnoreCase(candidate)) {
                     selection = candidate;
-                    logger.debug("SSLClientCertificateSelectionCB: desired cert found in list: " + desiredCertName);
+                    log("SSLClientCertificateSelectionCB: desired cert found in list: " + desiredCertName);
                     break;
                 }
             }
 
-            logger.debug("SSLClientCertificateSelectionCB: returning: " + selection);
+            log("SSLClientCertificateSelectionCB: returning: " + selection);
             return selection;
 
         }


### PR DESCRIPTION
…749974fe556831

involves:
Bug 1523330 - (addl fix) CC: missing audit event for CS acting as TLS client
Bug 1585722 - TMS - PKISocketFactory – Modify Logging to Allow External Use of class to work like CS8

Fix in 1523330 might have broken 1585722; This patch is to put the audit
call under if (!external) so that external apps calling this class would
not reach the audit code.
In addition, the "external" changes for logging is added (previously omitted
for RHCS-Maint work)

I only tested to be sure that the CA continues to work;  QE will need to
test both again.

https://bugzilla.redhat.com/show_bug.cgi?id=1523330
https://bugzilla.redhat.com/show_bug.cgi?id=1585722