### PR TITLE
Installing PKI server with custom NSS databases

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -222,7 +222,7 @@ class NSSDatabase(object):
 
         self.passwords = passwords
 
-    def create(self):
+    def create(self, enable_trust_policy=False):
 
         cmd = [
             'certutil',
@@ -238,7 +238,7 @@ class NSSDatabase(object):
         logger.debug('Command: %s', ' '.join(cmd))
         subprocess.check_call(cmd)
 
-        if not self.module_exists('p11-kit-trust'):
+        if enable_trust_policy and not self.module_exists('p11-kit-trust'):
             self.add_module('p11-kit-trust', '/usr/share/pki/lib/p11-kit-trust.so')
 
     def exists(self):

--- a/base/common/src/org/dogtagpki/nss/NSSDatabase.java
+++ b/base/common/src/org/dogtagpki/nss/NSSDatabase.java
@@ -62,6 +62,10 @@ public class NSSDatabase {
     }
 
     public void create(String password) throws Exception {
+        create(password, false);
+    }
+
+    public void create(String password, boolean enableTrustPolicy) throws Exception {
 
         logger.info("Creating NSS database in " + directory);
 
@@ -104,13 +108,12 @@ public class NSSDatabase {
             if (passwordFile.exists()) passwordFile.delete();
         }
 
-        // Install p11-kit-trust module if it doesn't exist
-        if (!isModuleInstalled("p11-kit-trust")) {
+        if (enableTrustPolicy && !moduleExists("p11-kit-trust")) {
             addModule("p11-kit-trust", "/usr/share/pki/lib/p11-kit-trust.so");
         }
     }
 
-    public boolean isModuleInstalled(String name) throws Exception {
+    public boolean moduleExists(String name) throws Exception {
 
         logger.info("Checking module " + name);
 

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -69,9 +69,15 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if not os.path.isdir(deployer.mdict['pki_server_database_path']):
             instance.makedirs(deployer.mdict['pki_server_database_path'], force=True)
 
-        deployer.certutil.create_security_databases(
-            deployer.mdict['pki_server_database_path'],
+        nssdb = pki.nssdb.NSSDatabase(
+            directory=deployer.mdict['pki_server_database_path'],
             password_file=deployer.mdict['pki_shared_pfile'])
+
+        try:
+            if not nssdb.exists():
+                nssdb.create()
+        finally:
+            nssdb.close()
 
         if not os.path.islink(deployer.mdict['pki_instance_database_link']):
             instance.symlink(
@@ -327,9 +333,15 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         pki.util.makedirs(deployer.mdict['pki_client_database_dir'], force=True)
 
-        deployer.certutil.create_security_databases(
-            deployer.mdict['pki_client_database_dir'],
+        nssdb = pki.nssdb.NSSDatabase(
+            directory=deployer.mdict['pki_client_database_dir'],
             password_file=deployer.mdict['pki_client_password_conf'])
+
+        try:
+            if not nssdb.exists():
+                nssdb.create()
+        finally:
+            nssdb.close()
 
     def update_external_certs_conf(self, external_path, deployer):
         external_certs = pki.server.instance.PKIInstance.read_external_certs(

--- a/docs/installation/Installing_PKI_Server_with_Custom_NSS_Databases.md
+++ b/docs/installation/Installing_PKI_Server_with_Custom_NSS_Databases.md
@@ -1,0 +1,79 @@
+# Installing PKI Server with Custom NSS Databases
+
+## Overview
+
+This page describes the process to create a PKI server with custom NSS databases.
+
+Normally, when installing a PKI subsystem (e.g. CA) some NSS databases will be created by default, for example:
+* server NSS database: /etc/pki/pki-tomcat/alias
+* admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
+
+Under some circumstances the admin may want to use custom NSS databases (e.g. with trust policy).
+In those cases the installation can be done in multiple steps:
+* create a basic PKI server
+* optionally, create a custom NSS database for the server
+* optionally, create a custom NSS database for the admin
+* install PKI subsystem with regular installation procedure
+
+## Creating Basic PKI Server
+
+To create a basic PKI server, execute the following command:
+
+```
+$ pki-server create
+```
+
+This will create a server in /var/lib/pki/pki-tomcat with configuration files in /etc/pki/pki-tomcat.
+
+See also [PKI Server CLI](https://www.dogtagpki.org/wiki/PKI_Server_CLI).
+
+## Creating Custom NSS Database for PKI Server
+
+To create a custom NSS database for the server execute the following commands:
+
+```
+$ pki-server nss-create --password <server password>
+```
+
+To enable trust policy:
+
+```
+$ modutil \
+    -dbdir /etc/pki/pki-tomcat/alias \
+    -add p11-kit-trust \
+    -libfile /usr/share/pki/lib/p11-kit-trust.so
+```
+
+See also [PKI Server NSS CLI](https://www.dogtagpki.org/wiki/PKI_Server_NSS_CLI).
+
+## Creating Custom NSS Database for PKI Administrator
+
+To create a custom NSS database for the admin execute the following commands:
+
+```
+$ pki -d ~/.dogtag/pki-tomcat/ca/alias -c <client password> nss-create
+```
+
+To enable trust policy:
+
+```
+$ modutil \
+    -dbdir ~/.dogtag/pki-tomcat/ca/alias \
+    -add p11-kit-trust \
+    -libfile /usr/share/pki/lib/p11-kit-trust.so
+```
+
+See also [PKI NSS CLI](https://www.dogtagpki.org/wiki/PKI_NSS_CLI).
+
+## Installling PKI Subsystem
+
+To install a PKI subsystem in this server, follow the regular [installation procedure](https://www.dogtagpki.org/wiki/PKI_10_Installation).
+Make sure to use the same NSS database passwords, for example:
+
+```
+[DEFAULT]
+pki_server_database_password=<server password>
+
+[CA]
+pki_client_database_password=<client password>
+```


### PR DESCRIPTION
The installation tool has been modified to use NSSDatabase.create()
to create the server and admin NSS databases with p11-kit-trust
module by default.

A document has been added to describe how to install PKI server
with custom NSS databases.

The document can be viewed [here](https://github.com/edewata/pki/blob/p11-kit-trust/docs/installation/Installing_PKI_Server_with_Custom_NSS_Databases.md).