### PR TITLE
Use JSS-provided CSPRNG for token generation

### DIFF
--- a/base/acme/src/org/dogtagpki/acme/ACME.java
+++ b/base/acme/src/org/dogtagpki/acme/ACME.java
@@ -5,12 +5,31 @@
 //
 package org.dogtagpki.acme;
 
+import java.security.SecureRandom;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import org.apache.commons.lang.RandomStringUtils;
+
 /**
  * @author Endi S. Dewata
+ * @author Alexander M. Scheel
  */
 public class ACME {
     public final static DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+    public static SecureRandom csprng;
+
+    public static String randomAlphanumeric(int length) {
+        if (csprng == null) {
+            try {
+                csprng = SecureRandom.getInstance("pkcs11prng", "Mozilla-JSS");
+            } catch (Exception e) {
+                throw new RuntimeException("Must initialize JSS before calling ACME: " + e.getMessage(), e);
+            }
+        }
+
+        /* Wrap RandomStringUtils.random instead of calling randomAlphanumeric
+         * so that we control choice of RNG. */
+        return RandomStringUtils.random(length, 0, 0, true, true, null, csprng);
+    }
 }

--- a/base/acme/src/org/dogtagpki/acme/server/ACMENewOrderService.java
+++ b/base/acme/src/org/dogtagpki/acme/server/ACMENewOrderService.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.dogtagpki.acme.ACME;
 import org.dogtagpki.acme.ACMEAccount;
 import org.dogtagpki.acme.ACMEAuthorization;
 import org.dogtagpki.acme.ACMEHeader;
@@ -69,9 +69,7 @@ public class ACMENewOrderService {
 
             logger.info("Identifier " + identifier.getType() + ": " + identifier.getValue());
 
-            // TODO: find better way to generate authorization ID
-
-            String authzID = RandomStringUtils.randomAlphanumeric(10);
+            String authzID = ACME.randomAlphanumeric(10);
             logger.info("- authorization ID: " + authzID);
 
             ACMEAuthorization authorization = new ACMEAuthorization();
@@ -85,9 +83,7 @@ public class ACMENewOrderService {
             authzURLs.add(authzURI);
         }
 
-        // TODO: find better way to generate order ID
-
-        String orderID = RandomStringUtils.randomAlphanumeric(10);
+        String orderID = ACME.randomAlphanumeric(10);
         logger.info("Order ID: " + orderID);
 
         ACMEOrder order = new ACMEOrder();

--- a/base/acme/src/org/dogtagpki/acme/validator/ACMEValidator.java
+++ b/base/acme/src/org/dogtagpki/acme/validator/ACMEValidator.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.dogtagpki.acme.ACME;
 import org.dogtagpki.acme.ACMEAuthorization;
 import org.dogtagpki.acme.ACMEChallenge;
 import org.dogtagpki.acme.ACMEError;
@@ -69,9 +69,7 @@ public abstract class ACMEValidator {
             String authzID,
             String token) throws Exception {
 
-        // TODO: find better way to generate challenge ID
-
-        String challengeID = RandomStringUtils.randomAlphanumeric(10);
+        String challengeID = ACME.randomAlphanumeric(10);
         logger.info("Creating " + name + " challenge: " + challengeID);
 
         URI challengeURI = uriInfo.getBaseUriBuilder().path("chall").path(challengeID).build();


### PR DESCRIPTION
`RandomStringUtils.randomAlphanumeric` isn't guaranteed to choose numbers
from a cryptographically secure random source. The default `Random(...)`
instance in Java isn't likely to be a CSPRNG either. Use
`RandomStringUtils.random(...)` with a JSS-provided CSPRNG instead.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`