### PR TITLE
CI improvements

### DIFF
--- a/travis/pki-build.sh
+++ b/travis/pki-build.sh
@@ -1,33 +1,52 @@
 #!/bin/bash
 set -e
 
-BUILDLOG=/tmp/pki-build.log
+BUILDLOG=/tmp/pki-build.txt
 
-function compose {
-    sudo -u ${BUILDUSER} -- ${BUILDDIR}/pki/build.sh --work-dir=${BUILDDIR}/packages --with-timestamp --with-commit-id "$@"
+build() {
+
+    echo "Installing PKI build dependencies"
+    dnf builddep -y --allowerasing --spec ${BUILDDIR}/pki/pki.spec
+
+    echo "Building PKI packages"
+    sudo -u ${BUILDUSER} -- ${BUILDDIR}/pki/build.sh \
+        --work-dir=${BUILDDIR}/packages \
+        --with-timestamp \
+        --with-commit-id "$@" \
+         2>&1 | tee $BUILDLOG
+    echo "Build complete"
 }
 
-function upload {
+exit_handler() {
+
+    if [ $? -eq 0 ]
+    then
+        # build succeeded, do not upload build log
+        return
+    fi
+
+    echo "Build failed"
+
     if test -f $BUILDLOG; then
-        curl -k -w "\n" --upload-file $BUILDLOG https://transfer.sh/pki-build.txt >> ${BUILDDIR}/pki/logs.txt || true
+
+        # display the last 1000 lines for troubleshooting
+        tail -n 1000 $BUILDLOG
+
+        echo "Uploading build log"
+        curl -k -w "\n" --upload-file $BUILDLOG https://transfer.sh/pki-build.txt \
+            >> ${BUILDDIR}/pki/logs.txt || true
         cat ${BUILDDIR}/pki/logs.txt
     fi
 }
 
-echo "Installing PKI build dependencies"
-
-dnf builddep -y --allowerasing --spec ${BUILDDIR}/pki/pki.spec
-
-echo "Building PKI packages"
-
 if test "${TRAVIS}" != "true"; then
-    compose
+    build
 
 else
-    # Always invoke upload() while exiting the script
-    trap "upload" EXIT
+    # Always invoke exit_handler() while exiting the script
+    trap "exit_handler" EXIT
 
     # If IPA task is run, we just need to build base, server, ca and kra packages
     [[ $TASK == 'IPA' ]] && args="$@ --with-pkgs=base,server,ca,kra" || args="$@"
-    compose $args >> $BUILDLOG 2>&1
+    build $args
 fi


### PR DESCRIPTION
To improve CI reliability, reduce execution time, and conserve
resources, the build and test logs will be uploaded to transfer.sh
only on failures.