### PR TITLE
Remove non-breaking space from pki-server-nuxwdog

### DIFF
--- a/base/server/sbin/pki-server-nuxwdog
+++ b/base/server/sbin/pki-server-nuxwdog
@@ -43,7 +43,7 @@ chown ${TOMCAT_USER}: ${nux_fname}
 
 echo "ExeFile ${JAVA_HOME}/bin/java" > $nux_fname
 echo "ExeArgs ${JAVA_HOME}/bin/java ${JAVACMD_OPTS} ${FLAGS} -classpath ${CLASSPATH} ${OPTIONS} ${MAIN_CLASS} start" >> $nux_fname
-echo "TmpDir ${CATALINA_BASE}/logs/pids" >> $nux_fname
+echo "TmpDir ${CATALINA_BASE}/logs/pids" >> $nux_fname
 echo "ChildSecurity 1" >> $nux_fname
 echo "ExeOut ${CATALINA_BASE}/logs/catalina.out" >> $nux_fname
 echo "ExeErr ${CATALINA_BASE}/logs/catalina.out" >> $nux_fname


### PR DESCRIPTION
In `pki-server-nuxwdog`, we had a non-breaking space at the end of a
quoted string, causing the resulting directory to end with a
non-breaking space.

This results in paths with incorrect names:

    /var/log/pki/$INSTANCE/pids /

instead of

    /var/log/pki/$INSTANCE/pids/

Resolves: [rhbz#1774282](https://bugzilla.redhat.com/show_bug.cgi?id=1774282)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`