### PR TITLE
bug1706521 CA - SubjectAltNameExtInput does not display text fields t…

### DIFF
--- a/base/server/src/com/netscape/cms/profile/input/SubjectAltNameExtInput.java
+++ b/base/server/src/com/netscape/cms/profile/input/SubjectAltNameExtInput.java
@@ -124,11 +124,11 @@ public class SubjectAltNameExtInput extends EnrollInput {
      * parameter by name.
      */
     public IDescriptor getValueDescriptor(Locale locale, String name) {
-       if (name.equals(VAL_SAN_REQ_TYPE)) {
+       if (name.startsWith(VAL_SAN_REQ_TYPE)) {
             return new Descriptor(IDescriptor.STRING, null,
                     null,
                     CMS.getUserMessage(locale, "CMS_PROFILE_REQ_SAN_TYPE"));
-        } else if (name.equals(VAL_SAN_REQ_PATTERN)) {
+        } else if (name.startsWith(VAL_SAN_REQ_PATTERN)) {
             return new Descriptor(IDescriptor.STRING, null,
                     null,
                     CMS.getUserMessage(locale, "CMS_PROFILE_REQ_SAN_PATTERN"));


### PR DESCRIPTION
…o the enrollment page

This patch is proposed by RHCS_Maint.  With this patch, the SANs text fields
now will show up on the profile display at EE enrollment UI.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1706521