### PR TITLE
Fixed CLI option handling

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/kra/KRAKeyGenerateCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/kra/KRAKeyGenerateCLI.java
@@ -31,7 +31,6 @@ public class KRAKeyGenerateCLI extends CommandCLI {
         Option option = new Option(null, "key-algorithm", true,
                 "Algorithm to be used to create a key.\nValid values: AES, DES, DES3, RC2, RC4, DESede, RSA, DSA");
         option.setArgName("algorithm");
-        option.setRequired(true);
         options.addOption(option);
 
         option = new Option(
@@ -72,6 +71,10 @@ public class KRAKeyGenerateCLI extends CommandCLI {
         String keySize = cmd.getOptionValue("key-size");
         String realm = cmd.getOptionValue("realm");
 
+        if (keyAlgorithm == null) {
+            throw new Exception("Missing key algorithm");
+        }
+
         if (keySize == null) {
             switch (keyAlgorithm) {
             case KeyRequestResource.DES3_ALGORITHM:
@@ -98,6 +101,7 @@ public class KRAKeyGenerateCLI extends CommandCLI {
         } catch (NumberFormatException e) {
             throw new Exception("Key size must be an integer.", e);
         }
+
         List<String> usages = null;
         String givenUsages = cmd.getOptionValue("usages");
         if (givenUsages != null) {
@@ -128,6 +132,7 @@ public class KRAKeyGenerateCLI extends CommandCLI {
         default:
             throw new Exception("Algorithm not supported.");
         }
+
         MainCLI.printMessage("Key generation request info");
         KRAKeyCLI.printKeyRequestInfo(response.getRequestInfo());
     }

--- a/base/java-tools/src/com/netscape/cmstools/kra/KRAKeyModifyCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/kra/KRAKeyModifyCLI.java
@@ -44,7 +44,6 @@ public class KRAKeyModifyCLI extends CommandCLI {
 
     public void createOptions() {
         Option option = new Option(null, "status", true, "Status of the key.\nValid values: active, inactive");
-        option.setRequired(true);
         option.setArgName("status");
         options.addOption(option);
     }
@@ -58,6 +57,10 @@ public class KRAKeyModifyCLI extends CommandCLI {
         }
 
         String status = cmd.getOptionValue("status");
+
+        if (status == null) {
+            throw new Exception("Missing key status");
+        }
 
         KeyId keyId = new KeyId(cmdArgs[0]);
 

--- a/base/java-tools/src/com/netscape/cmstools/kra/KRAKeyRequestReviewCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/kra/KRAKeyRequestReviewCLI.java
@@ -28,7 +28,6 @@ public class KRAKeyRequestReviewCLI extends CommandCLI {
         Option option = new Option(null, "action", true,
                 "Action to be performed on the request.\nValid values: approve, reject, cancel.");
         option.setArgName("Action to perform");
-        option.setRequired(true);
         options.addOption(option);
     }
 
@@ -48,6 +47,11 @@ public class KRAKeyRequestReviewCLI extends CommandCLI {
         KeyClient keyClient = keyCLI.getKeyClient();
 
         String action = cmd.getOptionValue("action");
+
+        if (action == null) {
+            throw new Exception("Missing action");
+        }
+
         switch (action.toLowerCase()) {
         case "approve":
             keyClient.approveRequest(reqId);

--- a/base/java-tools/src/com/netscape/cmstools/system/TPSConnectorShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/TPSConnectorShowCLI.java
@@ -46,7 +46,6 @@ public class TPSConnectorShowCLI extends CommandCLI {
     public void createOptions() {
         Option option = new Option(null, "host", true, "TPS host");
         option.setArgName("host");
-        option.setRequired(true);
         options.addOption(option);
 
         option = new Option(null, "port", true, "TPS port");
@@ -64,6 +63,10 @@ public class TPSConnectorShowCLI extends CommandCLI {
 
         String tpsHost = cmd.getOptionValue("host");
         String tpsPort = cmd.getOptionValue("port", "443");
+
+        if (tpsHost == null) {
+            throw new Exception("Missing TPS hostname");
+        }
 
         TPSConnectorClient tpsConnectorClient = tpsConnectorCLI.getTPSConnectorClient();
         TPSConnectorData data = tpsConnectorClient.getConnector(tpsHost, tpsPort);

--- a/base/java-tools/src/com/netscape/cmstools/tps/authenticator/AuthenticatorAddCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tps/authenticator/AuthenticatorAddCLI.java
@@ -52,7 +52,6 @@ public class AuthenticatorAddCLI extends CommandCLI {
     public void createOptions() {
         Option option = new Option(null, "input", true, "Input file containing authenticator properties.");
         option.setArgName("file");
-        option.setRequired(true);
         options.addOption(option);
     }
 
@@ -65,6 +64,10 @@ public class AuthenticatorAddCLI extends CommandCLI {
         }
 
         String input = cmd.getOptionValue("input");
+
+        if (input == null) {
+            throw new Exception("Missing input file");
+        }
 
         AuthenticatorData authenticatorData;
 

--- a/base/java-tools/src/com/netscape/cmstools/tps/config/ConfigModifyCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tps/config/ConfigModifyCLI.java
@@ -53,7 +53,6 @@ public class ConfigModifyCLI extends CommandCLI {
     public void createOptions() {
         Option option = new Option(null, "input", true, "Input file containing general properties.");
         option.setArgName("file");
-        option.setRequired(true);
         options.addOption(option);
 
         option = new Option(null, "output", true, "Output file to store general properties.");
@@ -71,6 +70,10 @@ public class ConfigModifyCLI extends CommandCLI {
 
         String input = cmd.getOptionValue("input");
         String output = cmd.getOptionValue("output");
+
+        if (input == null) {
+            throw new Exception("Missing input file");
+        }
 
         ConfigData configData;
 

--- a/base/java-tools/src/com/netscape/cmstools/tps/connector/ConnectorAddCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tps/connector/ConnectorAddCLI.java
@@ -52,7 +52,6 @@ public class ConnectorAddCLI extends CommandCLI {
     public void createOptions() {
         Option option = new Option(null, "input", true, "Input file containing connector properties.");
         option.setArgName("file");
-        option.setRequired(true);
         options.addOption(option);
     }
 
@@ -65,6 +64,10 @@ public class ConnectorAddCLI extends CommandCLI {
         }
 
         String input = cmd.getOptionValue("input");
+
+        if (input == null) {
+            throw new Exception("Missing input file");
+        }
 
         ConnectorData connectorData;
 

--- a/base/java-tools/src/com/netscape/cmstools/tps/profile/ProfileAddCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tps/profile/ProfileAddCLI.java
@@ -52,7 +52,6 @@ public class ProfileAddCLI extends CommandCLI {
     public void createOptions() {
         Option option = new Option(null, "input", true, "Input file containing profile properties.");
         option.setArgName("file");
-        option.setRequired(true);
         options.addOption(option);
     }
 
@@ -65,6 +64,10 @@ public class ProfileAddCLI extends CommandCLI {
         }
 
         String input = cmd.getOptionValue("input");
+
+        if (input == null) {
+            throw new Exception("Missing input file");
+        }
 
         ProfileData profileData;
 

--- a/base/java-tools/src/com/netscape/cmstools/tps/profile/ProfileMappingAddCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tps/profile/ProfileMappingAddCLI.java
@@ -52,7 +52,6 @@ public class ProfileMappingAddCLI extends CommandCLI {
     public void createOptions() {
         Option option = new Option(null, "input", true, "Input file containing profile mapping properties.");
         option.setArgName("file");
-        option.setRequired(true);
         options.addOption(option);
     }
 
@@ -65,6 +64,10 @@ public class ProfileMappingAddCLI extends CommandCLI {
         }
 
         String input = cmd.getOptionValue("input");
+
+        if (input == null) {
+            throw new Exception("Missing input file");
+        }
 
         ProfileMappingData profileMappingData;
 

--- a/base/java-tools/src/com/netscape/cmstools/user/UserAddCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/user/UserAddCLI.java
@@ -47,7 +47,6 @@ public class UserAddCLI extends CommandCLI {
     public void createOptions() {
         Option option = new Option(null, "fullName", true, "Full name");
         option.setArgName("fullName");
-        option.setRequired(true);
         options.addOption(option);
 
         option = new Option(null, "email", true, "Email");
@@ -80,10 +79,15 @@ public class UserAddCLI extends CommandCLI {
         }
 
         String userID = cmdArgs[0];
+        String fullName = cmd.getOptionValue("fullName");
+
+        if (fullName == null) {
+            throw new Exception("Missing full name");
+        }
 
         UserData userData = new UserData();
         userData.setUserID(userID);
-        userData.setFullName(cmd.getOptionValue("fullName"));
+        userData.setFullName(fullName);
         userData.setEmail(cmd.getOptionValue("email"));
         userData.setPassword(cmd.getOptionValue("password"));
         userData.setPhone(cmd.getOptionValue("phone"));


### PR DESCRIPTION
Previously some mandatory CLI options such as --status were defined
using Option.setRequired(true) so these options had to be specified
in all cases, including when displaying the help message using the
--help option. This behavior made it difficult to use the command.

The code has been modified to parse all options without using
Option.setRequired(true). Instead, the code will check the option
value if it's required and generate an exception if it's missing.
This way the --help option can be used to display the help message
without specifying the mandatory options.

https://bugzilla.redhat.com/show_bug.cgi?id=1777032