### PR TITLE
Restored pki CLI error messages

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -662,24 +662,24 @@ public class MainCLI extends CLI {
     public static void handleException(Throwable t) {
 
         if (logger.isInfoEnabled()) {
-            logger.error(t.getMessage(), t);
+            t.printStackTrace(System.err);
 
         } else if (t.getClass() == Exception.class) {
             // display a generic error
-            logger.error(t.getMessage());
+            System.err.println("ERROR: " + t.getMessage());
 
         } else if (t instanceof UnrecognizedOptionException) {
             // display only the error message
-            logger.error(t.getMessage());
+            System.err.println(t.getMessage());
 
         } else if (t instanceof ProcessingException) {
             // display the cause of the exception
             t = t.getCause();
-            logger.error(t.getClass().getSimpleName() + ": " + t.getMessage());
+            System.err.println(t.getClass().getSimpleName() + ": " + t.getMessage());
 
         } else {
             // display the actual Exception
-            logger.error(t.getClass().getSimpleName() + ": " + t.getMessage());
+            System.err.println(t.getClass().getSimpleName() + ": " + t.getMessage());
         }
     }
 
@@ -691,7 +691,7 @@ public class MainCLI extends CLI {
         } catch (CLIException e) {
             String message = e.getMessage();
             if (message != null) {
-                logger.error(message);
+                System.err.println("ERROR: " + message);
             }
             System.exit(e.getCode());
 


### PR DESCRIPTION
The pki CLI has been modified to match the error messages
in PKI 10.7:
https://github.com/dogtagpki/pki/blob/v10.7/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java#L676-L716

The exception is that the **Error:** will now become **ERROR:**.

A COPR build for Fedora is available here:
https://copr.fedorainfracloud.org/coprs/edewata/pki/build/1124766/

https://bugzilla.redhat.com/show_bug.cgi?id=1778953