### PR TITLE
Fixed JSS initialization in pki client-cert-import

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/client/ClientCertImportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/client/ClientCertImportCLI.java
@@ -111,6 +111,7 @@ public class ClientCertImportCLI extends CommandCLI {
         }
 
         MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
 
         String nickname = null;
 
@@ -171,9 +172,6 @@ public class ClientCertImportCLI extends CommandCLI {
 
             logger.info("Importing CA certificate from " + caCertPath);
 
-            // initialize JSS
-            mainCLI.init();
-
             if (trustAttributes == null)
                 trustAttributes = "CT,C,C";
 
@@ -187,9 +185,6 @@ public class ClientCertImportCLI extends CommandCLI {
         } else if (pkcs7Path != null) {
 
             logger.info("Importing certificates from " + pkcs7Path);
-
-            // initialize JSS
-            mainCLI.init();
 
             importPKCS7(pkcs7Path, nickname, trustAttributes);
 
@@ -226,9 +221,6 @@ public class ClientCertImportCLI extends CommandCLI {
                     pkcs12PasswordPath);
 
         } else if (importFromCAServer) {
-
-            // late initialization
-            mainCLI.init();
 
             PKIClient client = getClient();
             URI serverURI = mainCLI.config.getServerURL().toURI();


### PR DESCRIPTION
The pki client-cert-import supports importing certificates
from different sources including PEM file, PKCS12 file, and
directly from the server.

When PKI was still using NSS DBM database the command would
initialize JSS only if it was going to use JSS to import the
certificate. If the command would use external tools such as
certutil it would not initialize JSS to prevent conflicts.

There was also a bug that causes the command to miss JSS
initialization when importing a cert from the server by its
serial number.

Since now PKI is using NSS SQL database, the NSS database
can be shared with multiple processes. This patch modifies
the command to initialize JSS in all cases, which will fix
the bug as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1782486