### PR TITLE
[CI] Update CI matrix in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ services:
 cache: pip
 
 env:
-  - IMAGE=fedora:29 TASK="PKI"
-  - IMAGE=fedora:29 TASK="IPA"
   - IMAGE=fedora:30 TASK="PKI"
   - IMAGE=fedora:30 TASK="IPA"
+  - IMAGE=fedora:31 TASK="PKI"
+  - IMAGE=fedora:31 TASK="IPA"
 
 before_install:
   - set -a && source travis/global_variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   - IMAGE=fedora:30 TASK="PKI"
   - IMAGE=fedora:30 TASK="IPA"
   - IMAGE=fedora:31 TASK="PKI"
-  - IMAGE=fedora:31 TASK="IPA"
 
 before_install:
   - set -a && source travis/global_variables
@@ -56,6 +55,9 @@ matrix:
     - stage: rawhide
       env: IMAGE=fedora:rawhide TASK="PKI"
     - env: IMAGE=fedora:rawhide TASK="IPA"
+    # NOTE: Fedora 31 canoot run IPA test suite
+    # due to upstream issue: https://pagure.io/freeipa/issue/7989
+    - env: IMAGE=fedora:31 TASK="IPA"
     # This is a dummy job to mark the build as finished, without waiting for rawhide jobs
     - env: DUMMY_JOB=FOR_FAST_FINISH
       before_install: true
@@ -66,6 +68,7 @@ matrix:
     - stage: rawhide
       env: IMAGE=fedora:rawhide TASK="PKI"
     - env: IMAGE=fedora:rawhide TASK="IPA"
+    - env: IMAGE=fedora:31 TASK="IPA"
 
 after_script:
   - cat ${LOGS}

--- a/travis/ipa-init.sh
+++ b/travis/ipa-init.sh
@@ -22,7 +22,12 @@
 set -e
 
 # Enable IPA COPR repo
-dnf copr enable -y @freeipa/freeipa-4-7
+# NOTE: IPA does not build for F30
+. /etc/os-release
+if [[ `echo "$VERSION_ID"` -ge 31 ]]
+then
+    dnf copr enable -y @freeipa/freeipa-master-nightly
+fi
 
 # Install latest IPA from official fedora/updates repository
 dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad python3-ipatests --best --allowerasing

--- a/travis/ipa-init.sh
+++ b/travis/ipa-init.sh
@@ -21,13 +21,8 @@
 #
 set -e
 
-# Enable IPA COPR repo
-# NOTE: IPA does not build for F30
-. /etc/os-release
-if [[ `echo "$VERSION_ID"` -ge 31 ]]
-then
-    dnf copr enable -y @freeipa/freeipa-master-nightly
-fi
+# Enable IPA's nightly COPR repo
+dnf copr enable -y @freeipa/freeipa-master-nightly
 
 # Install latest IPA from official fedora/updates repository
 dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad python3-ipatests --best --allowerasing


### PR DESCRIPTION
Remove EOL release and add latest

**Blocker:** Currently blocked until the PR gets merged in freeipa: https://github.com/freeipa/freeipa/pull/3783

**Update:** Since the blocker is pending review, this patch moves running IPA tests on F31, from "Mandatory" tests to "Optional" tests
 
`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`