### PR TITLE
Add support for running PKI under GDB

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -261,11 +261,11 @@ class PKIServer(object):
         logger.debug('Command: %s', ' '.join(cmd))
         subprocess.check_call(cmd)
 
-    def run(self, command='start', jdb=False, as_current_user=False):
-        p = self.execute(command, jdb=jdb, as_current_user=as_current_user)
+    def run(self, command='start', jdb=False, as_current_user=False, gdb=False):
+        p = self.execute(command, jdb=jdb, as_current_user=as_current_user, gdb=gdb)
         p.wait()
 
-    def execute(self, command, jdb=False, as_current_user=False):
+    def execute(self, command, jdb=False, as_current_user=False, gdb=False):
 
         logger.debug('Environment variables:')
         for name in self.config:
@@ -293,6 +293,9 @@ class PKIServer(object):
         ]
 
         cmd = prefix
+        if gdb:
+            cmd.extend(['gdb', '--args'])
+
         if jdb:
             cmd.extend(['jdb'])
         else:

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -670,7 +670,8 @@ class RunCLI(pki.cli.CLI):
         print('Usage: pki-server run [OPTIONS] [<instance ID>]')
         print()
         print('      --as-current-user         Run as current user.')
-        print('      --jdb                     Run with Java Debugger.')
+        print('      --gdb                     Run under the GNU Debugger.')
+        print('      --jdb                     Run under the Java Debugger.')
         print('  -v, --verbose                 Run in verbose mode.')
         print('      --debug                   Run in debug mode.')
         print('      --help                    Show help message.')
@@ -691,10 +692,14 @@ class RunCLI(pki.cli.CLI):
         instance_name = 'pki-tomcat'
         as_current_user = False
         jdb = False
+        gdb = False
 
         for o, _ in opts:
             if o == '--as-current-user':
                 as_current_user = True
+
+            elif o == '--gdb':
+                gdb = True
 
             elif o == '--jdb':
                 jdb = True
@@ -726,7 +731,7 @@ class RunCLI(pki.cli.CLI):
         instance.load()
 
         try:
-            instance.run(jdb=jdb, as_current_user=as_current_user)
+            instance.run(gdb=gdb, jdb=jdb, as_current_user=as_current_user)
 
         except KeyboardInterrupt:
             logging.debug('Server stopped')

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -181,7 +181,7 @@ class PKIInstance(pki.server.PKIServer):
     def unit_file(self):
         return PKIInstance.TARGET_WANTS + '/%s.service' % self.service_name
 
-    def execute(self, command, jdb=False, as_current_user=False):
+    def execute(self, command, jdb=False, as_current_user=False, gdb=False):
 
         if command == 'start':
 
@@ -213,7 +213,9 @@ class PKIInstance(pki.server.PKIServer):
 
             subprocess.run(cmd, env=self.config, check=True)
 
-        return super(PKIInstance, self).execute(command, jdb=jdb, as_current_user=as_current_user)
+        return super(PKIInstance, self).execute(command, jdb=jdb,
+                                                as_current_user=as_current_user,
+                                                gdb=gdb)
 
     def create(self, force=False):
 


### PR DESCRIPTION
Sometimes it is necessary to debug the PKI instance under GDB,
especially when the issue is in the native layer, e.g., in the
JSS<->NSS mapping. Add the --gdb flag for running the PKI server
under gdb.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`