### PR TITLE
Fix FIPS detection

### DIFF
--- a/base/common/python/pki/__init__.py
+++ b/base/common/python/pki/__init__.py
@@ -233,7 +233,7 @@ class FIPS:
         command = ['sysctl', 'crypto.fips_enabled', '-bn']
 
         with open(os.devnull, 'w') as fnull:
-            output = subprocess.check_output(command, stderr=fnull)
+            output = subprocess.check_output(command, stderr=fnull).decode('utf-8')
 
         if output != '0':
             logger.info('FIPS mode is enabled')


### PR DESCRIPTION
The original FIPS detection code fails on python3:

    $ python3
    Python 3.7.6 (default, Dec 19 2019, 22:52:49)
    >>> '0' == b'0'
    False

This is because bytes and strings are not directly comparable in all
scenarios, so the comparison now returns false. Python3's subprocess
also returns bytes in most scenarios:

> By default, this function will return the data as encoded bytes. The
> actual encoding of the output data may depend on the command being
> invoked, so the decoding to text will often need to be handled at the
> application level.

This results in PKI incorrectly believing that it is in FIPS mode,
when it really isn't.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`