### PR TITLE
PKI healthcheck docs

### DIFF
--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -162,6 +162,7 @@ add_custom_command(
     COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man8/pki-server-upgrade.8.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man8/pki-server-upgrade.8
     COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man8/pkidestroy.8.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man8/pkidestroy.8
     COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man8/pkispawn.8.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man8/pkispawn.8
+    COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man8/pki-healthcheck.8.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man8/pki-healthcheck.8
 )
 
 # Customize default tomcat.conf.

--- a/docs/admin/PKI_Health_Check_Tool.md
+++ b/docs/admin/PKI_Health_Check_Tool.md
@@ -10,17 +10,17 @@ The purpose of the healthcheck tool is to find and report error conditions that 
 
 ### Dependencies
 
-The pki-healthcheck tool will depend on `freeipa-healthcheck-core` package for the base framework, which is built along with `freeipa-healthcheck`. This is done to ensure that `pki-healthcheck` can integrate smoothly with the `freeipa-healthcheck` since FreeIPA project depends on PKI for CA/KRA backened.
+The pki-healthcheck tool depends on `freeipa-healthcheck-core` package for the base framework, which is built along with `freeipa-healthcheck`. This is done to ensure that `pki-healthcheck` can integrate smoothly with the `freeipa-healthcheck` since FreeIPA project depends on PKI for CA/KRA backened.
 
 You can read more on the base framework [here](https://www.freeipa.org/page/V4/Healthcheck)
 
 ### Delivery
 
-The Health Check tool requires privileged access and runs on a PKI server and so, it will be delivered via the `pki-server` package.
+PKI Health Check tool will be delivered via the `pki-server` package.
 
-In future, this tool can be delivered via PyPi.
+In the future, this tool can be delivered via PyPi.
 
-### Severity
+### Test Severity Status
 
 Severity of a problem is defined as:
 
@@ -28,12 +28,14 @@ Severity of a problem is defined as:
 |-------|----------|------------|
 | 0 | Success | The check executed and found no issue |
 | 1 | Critical | Something is terribly wrong (e.g. a service is not started, certificates are expired, etc). |
-| 2 | Error | Something is wrong but your IPA master is probably still working (e.g. replication conflict) |
+| 2 | Error | Something is wrong but your PKI server is probably still working (e.g. clone conflict) |
 | 3 | Warning | Not an issue yet, but may be (e.g. expiring certificate soon) |
 
 ### Checks Included
 
 1. System certificate sync between CS.cfg and NSS database
+
+(More checks will be added in the future)
 
 ### Configuration
 
@@ -52,13 +54,11 @@ It is difficult to simulate some issues and so, unit tests will use [unittest.mo
 
 ## How to use
 
-Healthcheck executes a series of plugins to collect its information. Each plugin, referred to later as a source, is organized around a specific theme (system certificates, file system permissions and ownership, clones, etc.). A source is a collection of tests, refered to as checks, that should test one small piece of IPA. The purpose is so that when developing and running the tests, one can control which are executed.
+Healthcheck executes a series of plugins to collect its information. Each plugin, referred to later as a source, is organized around a specific theme (system certificates, file system permissions and ownership, clones, etc.). A source is a collection of tests, refered to as checks, that should test one small piece of PKI.
 
-The report will consist of a message describing what was run and the status. If the status is not successful it may include additional information for the administrator to use to correct the issue (e.g. a file has the wrong permissions, expected X and got Y).
+The report will consist of a message describing what was run and the status. If the status is not successful, the message may include additional information, which can be used by the admin to correct the issue (e.g. a file has the wrong permissions, expected X and got Y).
 
 ### Manual Execution
-
-The `pki-healthcheck` command will exit with a returncode of 0, even if any checks discovered issues with the PKI installation. A non-zero returncode means that `pki-healthcheck` failed in a non-recoverable way.
 
 To run it manually, execute:
 
@@ -85,7 +85,9 @@ The default output looks like:
         }
     }
 
-For all available options, you can execute the tool with `--help` option or read the `pki-healthcheck (8)` man page.
+The `pki-healthcheck` command will exit with a returncode of 0, even if any checks discovered issues with the PKI installation. A non-zero returncode means that `pki-healthcheck` tool failed in a non-recoverable way.
+
+For all available options, you can execute the tool with `--help` or read the `pki-healthcheck (8)` man page.
 
 ### Repairing Issues
 

--- a/docs/admin/PKI_Health_Check_Tool.md
+++ b/docs/admin/PKI_Health_Check_Tool.md
@@ -1,0 +1,94 @@
+# PKI Health Check Tool
+
+## Overview
+
+Dogtag provides no way to do introspection to discover possible issues. A framework is needed to assist with the identification, diagnosis and potentially repair of problems. This has the benefit of increasing confidence in a PKI installation and reducing costs associated with addressing issues.
+
+The purpose of the healthcheck tool is to find and report error conditions that may impact the PKI environment. Automated repair would be possible in some limited cases.
+
+## Design
+
+### Dependencies
+
+The pki-healthcheck tool will depend on `freeipa-healthcheck-core` package for the base framework, which is built along with `freeipa-healthcheck`. This is done to ensure that `pki-healthcheck` can integrate smoothly with the `freeipa-healthcheck` since FreeIPA project depends on PKI for CA/KRA backened.
+
+You can read more on the base framework [here](https://www.freeipa.org/page/V4/Healthcheck)
+
+### Delivery
+
+The Health Check tool requires privileged access and runs on a PKI server and so, it will be delivered via the `pki-server` package.
+
+In future, this tool can be delivered via PyPi.
+
+### Severity
+
+Severity of a problem is defined as:
+
+| Value | Severity | Definition |
+|-------|----------|------------|
+| 0 | Success | The check executed and found no issue |
+| 1 | Critical | Something is terribly wrong (e.g. a service is not started, certificates are expired, etc). |
+| 2 | Error | Something is wrong but your IPA master is probably still working (e.g. replication conflict) |
+| 3 | Warning | Not an issue yet, but may be (e.g. expiring certificate soon) |
+
+### Checks Included
+
+1. System certificate sync between CS.cfg and NSS database
+
+### Configuration
+
+The `pki-healthcheck` tool will store its configuration in `/etc/pki/healthcheck.conf`. It will be an ini-style config file. The format is
+
+    [global]
+    plugin_timeout=300
+
+### Limitations
+
+Due to [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1789991) in the base framework, currently the healthcheck can only be executed on a system with **single** pki instance named **pki-tomcat**
+
+### Testing
+
+It is difficult to simulate some issues and so, unit tests will use [unittest.mock](https://docs.python.org/3/library/unittest.mock.html) library to run some unittests.
+
+## How to use
+
+Healthcheck executes a series of plugins to collect its information. Each plugin, referred to later as a source, is organized around a specific theme (system certificates, file system permissions and ownership, clones, etc.). A source is a collection of tests, refered to as checks, that should test one small piece of IPA. The purpose is so that when developing and running the tests, one can control which are executed.
+
+The report will consist of a message describing what was run and the status. If the status is not successful it may include additional information for the administrator to use to correct the issue (e.g. a file has the wrong permissions, expected X and got Y).
+
+### Manual Execution
+
+The `pki-healthcheck` command will exit with a returncode of 0, even if any checks discovered issues with the PKI installation. A non-zero returncode means that `pki-healthcheck` failed in a non-recoverable way.
+
+To run it manually, execute:
+
+    # pki-healthcheck
+
+A specific check can be execuated as well:
+
+    #  pki-healthcheck --source pki.server.healthcheck.meta.csconfig --check DogtagCertsConfigCheck
+
+Output will be a list of sources and checks executed along with the status displayed in JSON format. It does not log to a file by default. `--output-file` can be used to write the JSON output to a file.
+
+The default output looks like:
+
+    {
+        "source": "pki.server.healthcheck.meta.csconfig",
+        "check": "DogtagCertsConfigCheck",
+        "result": "SUCCESS",
+        "uuid": "067ea8ab-e780-42a9-ae03-ae40869a242d",
+        "when": "20200117190214Z",
+        "duration": "0.194885",
+        "kw": {
+            "key": "ca_signing",
+            "configfile": "/var/lib/pki/pki-tomcat/ca/conf/CS.cfg"
+        }
+    }
+
+For all available options, you can execute the tool with `--help` option or read the `pki-healthcheck (8)` man page.
+
+### Repairing Issues
+
+Repairing an issue involves the administrator making the suggested changes to their system.
+
+`pki-healthcheck` will make some recommendations but it is up to a human to apply them.

--- a/docs/manuals/man8/pki-healthcheck.8.md
+++ b/docs/manuals/man8/pki-healthcheck.8.md
@@ -1,0 +1,118 @@
+# pki-healthcheck 8 "January 16, 2020" PKI "pki-healthcheck CLI"
+
+## NAME
+
+pki-healthcheck - Command-Line Interface to check health of a PKI installation
+
+## SYNOPSIS
+
+**pki-healthcheck** [*CLI-options*]
+
+## DESCRIPTION
+
+A PKI installation is a complex setup and identifying real or potential issues can be difficult and require a lot of analysis. This tool aims to reduce the burden by attempting to identify issues in advance so that they can be corrected, ideally before the issue becomes critical.
+
+### ORGANIZATION
+
+The areas of the system to check are logically grouped together. This grouping is called a source. A source consists of one or more checks.
+
+A check is as atomic as possible to limit the scope and complexity and provide a yes/no answer on whether that particular configuration is correct.
+
+Each check will return a result, either a result of WARNING, ERROR, CRITICAL or SUCCESS. Returning SUCCESS tells you that the check was done and was deemed correct. This should help track when the last time  something  was examined.
+
+Upon  failure,  the  output  will include the source and check that detected the failure along with a message and name/value pairs indicating the problem. If a check can't make a final determination, it throws WARNING so that it can be examined.
+
+## OPTIONS
+
+### COMMANDS
+
+**--list-sources**  
+    Display a list of the available sources and the checks associated with those sources.
+
+### OPTIONAL ARGUMENTS
+
+**--source**=*SOURCE*  
+    Execute one or more checks within this given source.
+
+**--check**=*CHECK*  
+    Execute this particular check within a source. A *source* must be supplied as well with this option.
+
+**--output-type**=*TYPE*  
+    Set the output type. Defaults to JSON.
+
+**--failures-only**  
+    Exclude SUCCESS results on output.
+
+**--severity**=*SEVERITY*  
+    Only report errors in the requested severity of SUCCESS, WARNING, ERROR or CRITICAL. This can be provided multiple times to search on multiple levels.
+
+**--debug**  
+    Generate additional debugging output.
+
+### JSON OUTPUT
+
+The output is displayed as a list of result messages for each check executed in JSON format. This could be input for a monitoring system.
+
+**--output-file**=*FILENAME*  
+    Write the output to this filename rather than stdout.
+
+**--indent**=*INDENT*  
+    Pretty-print the JSON with this indention level. This can make the output more human-readable.
+
+### HUMAN-READABLE OUTPUT
+
+The results are displayed in a more human-readable format.
+
+**--input-file**=*FILENAME*  
+    Take as input a JSON results output and convert it to a more human-readable form.
+
+## EXIT STATUS
+
+0 if all checks were successful
+
+1 if any one check failed or the command failed to execute properly
+
+## FILES
+
+/etc/pki/healthcheck.conf
+
+## NOTES
+
+### CHECKS INCLUDED
+
+**Certificate sync between CS.cfg and NSS database**  
+Checks whether the system certificates in CS.cfg and NSS database are the same
+
+## BUGS
+
+**pki-healthcheck** tool can operate only on a *single instance* PKI installation with the instance name as *pki-tomcat*
+
+## EXAMPLES
+
+Execute healthcheck with the default JSON output:  
+**pki-healthcheck**
+
+Execute healthcheck with a prettier JSON output:  
+**pki-healthcheck --indent 2**
+
+Execute healthcheck and only display errors:  
+**pki-healthcheck --failures-only**
+
+Execute healthcheck and display results in human-readable format:  
+**pki-healthcheck --output-format human**
+
+Execute healthcheck and write results to a file:  
+**pki-healthcheck --output-file /var/log/pki/healthcheck/results.json**
+
+Display in the previous report in a human-readable format:  
+**pki-healthcheck --output-format human --input-file /var/log/pki/healthcheck/results.json**
+
+## AUTHORS
+
+Dinesh Prasanth M K \<dmoluguw@redhat.com>
+
+## COPYRIGHT
+
+Copyright (c) 2020 Red Hat, Inc.
+This is licensed under the GNU General Public License, version 2 (GPLv2).
+A copy of this license is  available  at <http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.

--- a/docs/manuals/man8/pki-healthcheck.8.md
+++ b/docs/manuals/man8/pki-healthcheck.8.md
@@ -10,17 +10,17 @@ pki-healthcheck - Command-Line Interface to check health of a PKI installation
 
 ## DESCRIPTION
 
-A PKI installation is a complex setup and identifying real or potential issues can be difficult and require a lot of analysis. This tool aims to reduce the burden by attempting to identify issues in advance so that they can be corrected, ideally before the issue becomes critical.
+A PKI installation can be complex, therefore identifying real or potential issues can be difficult and require a lot of analysis. This tool aims to reduce the burden by attempting to identify issues in advance so that they can be corrected, ideally before the issue becomes critical.
 
 ### ORGANIZATION
 
 The areas of the system to check are logically grouped together. This grouping is called a source. A source consists of one or more checks.
 
-A check is as atomic as possible to limit the scope and complexity and provide a yes/no answer on whether that particular configuration is correct.
+A check is as atomic as possible to limit the scope and complexity.
 
-Each check will return a result, either a result of WARNING, ERROR, CRITICAL or SUCCESS. Returning SUCCESS tells you that the check was done and was deemed correct. This should help track when the last time  something  was examined.
+Each check will return a result, either a result of WARNING, ERROR, CRITICAL or SUCCESS. Returning SUCCESS tells you that the check was done and was deemed correct.
 
-Upon  failure,  the  output  will include the source and check that detected the failure along with a message and name/value pairs indicating the problem. If a check can't make a final determination, it throws WARNING so that it can be examined.
+Upon  failure,  the  output  will include name of the source and name of the check that detected the failure along with a message and name/value pairs indicating the problem. If a check can't make a final determination, it throws WARNING so that it can be examined.
 
 ## OPTIONS
 
@@ -37,7 +37,7 @@ Upon  failure,  the  output  will include the source and check that detected the
 **--check**=*CHECK*  
     Execute this particular check within a source. A *source* must be supplied as well with this option.
 
-**--output-type**=*TYPE*  
+**--output-type**=*[json|human]*  
     Set the output type. Defaults to JSON.
 
 **--failures-only**  

--- a/pki.spec
+++ b/pki.spec
@@ -1143,6 +1143,7 @@ fi
 %{_mandir}/man8/pki-server-ocsp.8.gz
 %{_mandir}/man8/pki-server-tks.8.gz
 %{_mandir}/man8/pki-server-tps.8.gz
+%{_mandir}/man8/pki-healthcheck.8.gz
 %{_datadir}/pki/setup/
 %{_datadir}/pki/server/
 %{_datadir}/pki/acme/


### PR DESCRIPTION
This patch adds the documentation (both `man` page and upstream doc) for
the PKI health check tool that was merged as part of #301 

The man page will be autogenerated at buildtime and will reside in the `pki-server`
package.