### PR TITLE
Fixed TPS installation failure

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSCLI.java
@@ -22,6 +22,8 @@ public class NSSCLI extends CLI {
 
         addModule(new NSSCreateCLI(this));
         addModule(new NSSRemoveCLI(this));
+
+        addModule(new NSSKeyCLI(this));
     }
 
     public String getFullName() {

--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSKeyCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSKeyCLI.java
@@ -1,0 +1,27 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import org.dogtagpki.cli.CLI;
+
+public class NSSKeyCLI extends CLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSKeyCLI.class);
+
+    public NSSCLI nssCLI;
+
+    public NSSKeyCLI(NSSCLI tksCLI) {
+        super("key", "NSS key management commands", tksCLI);
+        this.nssCLI = tksCLI;
+
+        addModule(new NSSKeyExportCLI(this));
+        addModule(new NSSKeyImportCLI(this));
+    }
+
+    public String getFullName() {
+        return parent.getFullName() + "-" + name;
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSKeyExportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSKeyExportCLI.java
@@ -1,0 +1,96 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.util.List;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CommandCLI;
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.crypto.SymmetricKey;
+import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.netscape.security.util.Utils;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+
+import com.netscape.certsrv.key.KeyData;
+import com.netscape.cmstools.cli.MainCLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+public class NSSKeyExportCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSKeyExportCLI.class);
+
+    public NSSKeyCLI nssKeyCLI;
+
+    public NSSKeyExportCLI(NSSKeyCLI nssKeyCLI) {
+        super("export", "Export key from NSS database", nssKeyCLI);
+        this.nssKeyCLI = nssKeyCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <key nickname>", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "output", true, "File to store the exported key");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "wrapper", true, "Nickname of the wrapper certificate");
+        option.setArgName("nickname");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key nickname");
+        }
+
+        String nickname = cmdArgs[0];
+        String outputFile = cmd.getOptionValue("output");
+        String wrapperNickname = cmd.getOptionValue("wrapper");
+
+        if (wrapperNickname == null) {
+            throw new Exception("Missing wrapper certificate nickname");
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        CryptoManager cm = CryptoManager.getInstance();
+        X509Certificate cert = cm.findCertByNickname(wrapperNickname);
+        X509CertImpl certImpl = new X509CertImpl(cert.getEncoded());
+
+        SymmetricKey tempKey = CryptoUtil.createDes3SessionKeyOnInternal();
+
+        List<byte[]> listWrappedKeys = CryptoUtil.exportSharedSecret(nickname, certImpl, tempKey);
+        byte[] wrappedSessionKey = listWrappedKeys.get(0);
+        byte[] wrappedKey = listWrappedKeys.get(1);
+
+        KeyData keyData = new KeyData();
+        keyData.setWrappedPrivateData(Utils.base64encodeSingleLine(wrappedSessionKey));
+        keyData.setAdditionalWrappedPrivateData(Utils.base64encodeSingleLine(wrappedKey));
+
+        logger.info("Wrapped session key: " + keyData.getWrappedPrivateData());
+        logger.info("Wrapped secret key: " + keyData.getAdditionalWrappedPrivateData());
+
+        if (outputFile != null) {
+            try (FileWriter fw = new FileWriter(outputFile);
+                    PrintWriter out = new PrintWriter(fw)) {
+                out.println(keyData.toJSON());
+            }
+
+        } else {
+            System.out.println(keyData.toJSON());
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSKeyImportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSKeyImportCLI.java
@@ -1,0 +1,84 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.io.IOUtils;
+import org.dogtagpki.cli.CommandCLI;
+import org.mozilla.jss.netscape.security.util.Utils;
+
+import com.netscape.certsrv.key.KeyData;
+import com.netscape.cmstools.cli.MainCLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+public class NSSKeyImportCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSKeyImportCLI.class);
+
+    public NSSKeyCLI nssKeyCLI;
+
+    public NSSKeyImportCLI(NSSKeyCLI nssKeyCLI) {
+        super("import", "Import key into NSS database", nssKeyCLI);
+        this.nssKeyCLI = nssKeyCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <key nickname>", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "input", true, "File that contains the key to be imported");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "wrapper", true, "Nickname of the wrapper certificate");
+        option.setArgName("nickname");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key nickname");
+        }
+
+        String nickname = cmdArgs[0];
+        String inputFile = cmd.getOptionValue("input");
+        String wrapperNickname = cmd.getOptionValue("wrapper");
+
+        if (wrapperNickname == null) {
+            throw new Exception("Missing wrapper certificate nickname");
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        byte[] bytes;
+        if (inputFile == null) {
+            // read from standard input
+            bytes = IOUtils.toByteArray(System.in);
+        } else {
+            // read from file
+            bytes = Files.readAllBytes(Paths.get(inputFile));
+        }
+
+        KeyData keyData = KeyData.fromJSON(new String(bytes));
+
+        logger.info("Wrapped session key: " + keyData.getWrappedPrivateData());
+        logger.info("Wrapped secret key: " + keyData.getAdditionalWrappedPrivateData());
+
+        byte[] wrappedSessionKey = Utils.base64decode(keyData.getWrappedPrivateData());
+        byte[] wrappedSecretKey = Utils.base64decode(keyData.getAdditionalWrappedPrivateData());
+
+        CryptoUtil.importSharedSecret(wrappedSessionKey, wrappedSecretKey, wrapperNickname, nickname);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/tks/TKSCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TKSCLI.java
@@ -26,7 +26,6 @@ import com.netscape.cmstools.cli.SubsystemCLI;
 import com.netscape.cmstools.group.GroupCLI;
 import com.netscape.cmstools.logging.AuditCLI;
 import com.netscape.cmstools.selftests.SelfTestCLI;
-import com.netscape.cmstools.system.TPSConnectorCLI;
 import com.netscape.cmstools.user.UserCLI;
 
 /**

--- a/base/java-tools/src/com/netscape/cmstools/tks/TKSCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TKSCLI.java
@@ -42,6 +42,7 @@ public class TKSCLI extends SubsystemCLI {
         addModule(new GroupCLI(this));
         addModule(new SelfTestCLI(this));
         addModule(new TPSConnectorCLI(this));
+        addModule(new TKSKeyCLI(this));
         addModule(new UserCLI(this));
     }
 

--- a/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyCLI.java
@@ -1,0 +1,62 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.tks;
+
+import org.dogtagpki.cli.CLI;
+
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.key.KeyData;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.certsrv.system.TPSConnectorClient;
+
+public class TKSKeyCLI extends CLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TKSKeyCLI.class);
+
+    public TKSCLI tksCLI;
+    public TPSConnectorClient tpsConnectorClient;
+
+    public TKSKeyCLI(TKSCLI tksCLI) {
+        super("key", "Key management commands", tksCLI);
+        this.tksCLI = tksCLI;
+
+        addModule(new TKSKeyCreateCLI(this));
+        addModule(new TKSKeyExportCLI(this));
+        addModule(new TKSKeyRemoveCLI(this));
+        addModule(new TKSKeyReplaceCLI(this));
+        addModule(new TKSKeyShowCLI(this));
+    }
+
+    public String getFullName() {
+        return parent.getFullName() + "-" + name;
+    }
+
+    public TPSConnectorClient getTPSConnectorClient() throws Exception {
+
+        if (tpsConnectorClient != null) return tpsConnectorClient;
+
+        PKIClient client = getClient();
+        tpsConnectorClient = (TPSConnectorClient)parent.getClient("tpsconnector");
+
+        return tpsConnectorClient;
+    }
+
+    public static void printKeyInfo(String id, KeyData data) {
+        System.out.println("  Key ID: " + id);
+
+        String type = data.getType();
+        if (type != null) System.out.println("  Type: " + type);
+
+        String encryptAlgorithmOID = data.getEncryptAlgorithmOID();
+        if (encryptAlgorithmOID != null) System.out.println("  Encrypt Algorithm: " + encryptAlgorithmOID);
+
+        String wrapAlgorithm = data.getWrapAlgorithm();
+        if (wrapAlgorithm != null) System.out.println("  Wrap Algorithm: " + wrapAlgorithm);
+
+        RequestId requestID = data.getRequestID();
+        if (requestID != null) System.out.println("  Request ID: " + requestID);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyCreateCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyCreateCLI.java
@@ -1,0 +1,59 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.tks;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.key.KeyData;
+import com.netscape.certsrv.system.TPSConnectorClient;
+
+public class TKSKeyCreateCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TKSKeyCreateCLI.class);
+
+    public TKSKeyCLI tksKeyCLI;
+
+    public TKSKeyCreateCLI(TKSKeyCLI tksKeyCLI) {
+        super("create", "Create key in TKS", tksKeyCLI);
+        this.tksKeyCLI = tksKeyCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Key ID>", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "output-format", true, "Output format: text (default), json");
+        option.setArgName("format");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key ID");
+        }
+
+        String keyID = cmdArgs[0];
+        String outputFormat = cmd.getOptionValue("output-format", "text");
+
+        PKIClient client = getClient();
+        TPSConnectorClient tpsConnectorClient = tksKeyCLI.getTPSConnectorClient();
+        KeyData keyData = tpsConnectorClient.createSharedSecret(keyID);
+
+        if ("json".equalsIgnoreCase(outputFormat)) {
+            System.out.println(keyData.toJSON());
+
+        } else {
+            TKSKeyCLI.printKeyInfo(keyID, keyData);
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyExportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyExportCLI.java
@@ -1,0 +1,68 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.tks;
+
+import java.io.FileWriter;
+import java.io.PrintWriter;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.key.KeyData;
+import com.netscape.certsrv.system.TPSConnectorClient;
+
+public class TKSKeyExportCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TKSKeyExportCLI.class);
+
+    public TKSKeyCLI tksKeyCLI;
+
+    public TKSKeyExportCLI(TKSKeyCLI tksKeyCLI) {
+        super("export", "Export key from TKS", tksKeyCLI);
+        this.tksKeyCLI = tksKeyCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Key ID>", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "output", true, "File to store the exported key");
+        option.setArgName("path");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key ID");
+        }
+
+        String keyID = cmdArgs[0];
+        String outputFile = cmd.getOptionValue("output");
+
+        PKIClient client = getClient();
+        TPSConnectorClient tpsConnectorClient = tksKeyCLI.getTPSConnectorClient();
+        KeyData keyData = tpsConnectorClient.getSharedSecret(keyID);
+
+        logger.info("Wrapped session key: " + keyData.getWrappedPrivateData());
+        logger.info("Wrapped secret key: " + keyData.getAdditionalWrappedPrivateData());
+
+        if (outputFile != null) {
+            try (FileWriter fw = new FileWriter(outputFile);
+                    PrintWriter out = new PrintWriter(fw)) {
+                out.println(keyData.toJSON());
+            }
+
+        } else {
+            System.out.println(keyData.toJSON());
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyRemoveCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyRemoveCLI.java
@@ -1,0 +1,43 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.tks;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.system.TPSConnectorClient;
+
+public class TKSKeyRemoveCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TKSKeyRemoveCLI.class);
+
+    public TKSKeyCLI tksKeyCLI;
+
+    public TKSKeyRemoveCLI(TKSKeyCLI tksKeyCLI) {
+        super("del", "Remove key from TKS", tksKeyCLI);
+        this.tksKeyCLI = tksKeyCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Key ID>", options);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key ID");
+        }
+
+        String keyID = cmdArgs[0];
+
+        PKIClient client = getClient();
+        TPSConnectorClient tpsConnectorClient = tksKeyCLI.getTPSConnectorClient();
+        tpsConnectorClient.deleteSharedSecret(keyID);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyReplaceCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyReplaceCLI.java
@@ -1,0 +1,59 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.tks;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.key.KeyData;
+import com.netscape.certsrv.system.TPSConnectorClient;
+
+public class TKSKeyReplaceCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TKSKeyReplaceCLI.class);
+
+    public TKSKeyCLI tksKeyCLI;
+
+    public TKSKeyReplaceCLI(TKSKeyCLI tksKeyCLI) {
+        super("replace", "Replace key in TKS", tksKeyCLI);
+        this.tksKeyCLI = tksKeyCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Key ID>", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "output-format", true, "Output format: text (default), json");
+        option.setArgName("format");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key ID");
+        }
+
+        String keyID = cmdArgs[0];
+        String outputFormat = cmd.getOptionValue("output-format", "text");
+
+        PKIClient client = getClient();
+        TPSConnectorClient tpsConnectorClient = tksKeyCLI.getTPSConnectorClient();
+        KeyData keyData = tpsConnectorClient.replaceSharedSecret(keyID);
+
+        if ("json".equalsIgnoreCase(outputFormat)) {
+            System.out.println(keyData.toJSON());
+
+        } else {
+            TKSKeyCLI.printKeyInfo(keyID, keyData);
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TKSKeyShowCLI.java
@@ -1,0 +1,46 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.tks;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.certsrv.key.KeyData;
+import com.netscape.certsrv.system.TPSConnectorClient;
+
+public class TKSKeyShowCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TKSKeyShowCLI.class);
+
+    public TKSKeyCLI tksKeyCLI;
+
+    public TKSKeyShowCLI(TKSKeyCLI tksKeyCLI) {
+        super("show", "Show key in TKS", tksKeyCLI);
+        this.tksKeyCLI = tksKeyCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Key ID>", options);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing key ID");
+        }
+
+        String keyID = cmdArgs[0];
+
+        PKIClient client = getClient();
+        TPSConnectorClient tpsConnectorClient = tksKeyCLI.getTPSConnectorClient();
+        KeyData keyData = tpsConnectorClient.getSharedSecret(keyID);
+
+        TKSKeyCLI.printKeyInfo(keyID, keyData);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorAddCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorAddCLI.java
@@ -22,6 +22,7 @@ import org.apache.commons.cli.Option;
 import org.dogtagpki.cli.CommandCLI;
 
 import com.netscape.certsrv.system.TPSConnectorClient;
+import com.netscape.certsrv.system.TPSConnectorData;
 import com.netscape.cmstools.cli.MainCLI;
 
 /**
@@ -50,6 +51,10 @@ public class TPSConnectorAddCLI extends CommandCLI {
         option = new Option(null, "port", true, "TPS port");
         option.setArgName("port");
         options.addOption(option);
+
+        option = new Option(null, "output-format", true, "Output format: text (default), json");
+        option.setArgName("format");
+        options.addOption(option);
     }
 
     public void execute(CommandLine cmd) throws Exception {
@@ -62,14 +67,20 @@ public class TPSConnectorAddCLI extends CommandCLI {
 
         String tpsHost = cmd.getOptionValue("host");
         String tpsPort = cmd.getOptionValue("port");
+        String outputFormat = cmd.getOptionValue("output-format", "text");
 
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
 
         TPSConnectorClient tpsConnectorClient = tpsConnectorCLI.getTPSConnectorClient();
-        tpsConnectorClient.createConnector(tpsHost, tpsPort);
+        TPSConnectorData data = tpsConnectorClient.createConnector(tpsHost, tpsPort);
 
-        MainCLI.printMessage("Added TPS connector \""+tpsHost + ":" + tpsPort +"\"");
+        if ("json".equalsIgnoreCase(outputFormat)) {
+            System.out.println(data.toJSON());
+
+        } else {
+            MainCLI.printMessage("Added TPS connector \""+tpsHost + ":" + tpsPort +"\"");
+        }
     }
 
 }

--- a/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorAddCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorAddCLI.java
@@ -15,30 +15,26 @@
 // (C) 2013 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package com.netscape.cmstools.system;
-
-import java.util.Collection;
+package com.netscape.cmstools.tks;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.dogtagpki.cli.CommandCLI;
 
 import com.netscape.certsrv.system.TPSConnectorClient;
-import com.netscape.certsrv.system.TPSConnectorCollection;
-import com.netscape.certsrv.system.TPSConnectorData;
 import com.netscape.cmstools.cli.MainCLI;
 
 /**
  * @author Ade Lee
  */
-public class TPSConnectorFindCLI extends CommandCLI {
+public class TPSConnectorAddCLI extends CommandCLI {
 
-    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TPSConnectorFindCLI.class);
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TPSConnectorAddCLI.class);
 
     public TPSConnectorCLI tpsConnectorCLI;
 
-    public TPSConnectorFindCLI(TPSConnectorCLI tpsConnectorCLI) {
-        super("find", "Find TPS connectors on TKS", tpsConnectorCLI);
+    public TPSConnectorAddCLI(TPSConnectorCLI tpsConnectorCLI) {
+        super("add", "Add TPS connector to TKS", tpsConnectorCLI);
         this.tpsConnectorCLI = tpsConnectorCLI;
     }
 
@@ -47,12 +43,12 @@ public class TPSConnectorFindCLI extends CommandCLI {
     }
 
     public void createOptions() {
-        Option option = new Option(null, "start", true, "Page start");
-        option.setArgName("start");
+        Option option = new Option(null, "host", true, "TPS host");
+        option.setArgName("host");
         options.addOption(option);
 
-        option = new Option(null, "size", true, "Page size");
-        option.setArgName("size");
+        option = new Option(null, "port", true, "TPS port");
+        option.setArgName("port");
         options.addOption(option);
     }
 
@@ -64,33 +60,16 @@ public class TPSConnectorFindCLI extends CommandCLI {
             throw new Exception("Too many arguments specified.");
         }
 
-        String s = cmd.getOptionValue("start");
-        Integer start = s == null ? null : Integer.valueOf(s);
-
-        s = cmd.getOptionValue("size");
-        Integer size = s == null ? null : Integer.valueOf(s);
+        String tpsHost = cmd.getOptionValue("host");
+        String tpsPort = cmd.getOptionValue("port");
 
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
 
         TPSConnectorClient tpsConnectorClient = tpsConnectorCLI.getTPSConnectorClient();
-        TPSConnectorCollection result = tpsConnectorClient.findConnectors(null, null, start, size);
+        tpsConnectorClient.createConnector(tpsHost, tpsPort);
 
-        MainCLI.printMessage(result.getTotal() + " entries matched");
-        if (result.getTotal() == 0) return;
-
-        Collection<TPSConnectorData> conns = result.getEntries();
-        boolean first = true;
-        for (TPSConnectorData data: conns) {
-            if (first) {
-                first = false;
-            } else {
-                System.out.println();
-            }
-
-            TPSConnectorCLI.printConnectorInfo(data);
-        }
-
-        MainCLI.printMessage("Number of entries returned " + conns.size());
+        MainCLI.printMessage("Added TPS connector \""+tpsHost + ":" + tpsPort +"\"");
     }
+
 }

--- a/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorCLI.java
@@ -15,7 +15,7 @@
 // (C) 2013 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package com.netscape.cmstools.system;
+package com.netscape.cmstools.tks;
 
 import org.dogtagpki.cli.CLI;
 import org.jboss.resteasy.plugins.providers.atom.Link;
@@ -23,7 +23,6 @@ import org.jboss.resteasy.plugins.providers.atom.Link;
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.system.TPSConnectorClient;
 import com.netscape.certsrv.system.TPSConnectorData;
-import com.netscape.cmstools.tks.TKSCLI;
 
 /**
  * @author Ade Lee
@@ -43,6 +42,7 @@ public class TPSConnectorCLI extends CLI {
         addModule(new TPSConnectorFindCLI(this));
         addModule(new TPSConnectorModCLI(this));
         addModule(new TPSConnectorRemoveCLI(this));
+        addModule(new TPSConnectorShowCLI(this));
     }
 
     public String getFullName() {

--- a/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorModCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorModCLI.java
@@ -1,4 +1,4 @@
-package com.netscape.cmstools.system;
+package com.netscape.cmstools.tks;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;

--- a/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorRemoveCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorRemoveCLI.java
@@ -15,7 +15,7 @@
 // (C) 2013 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package com.netscape.cmstools.system;
+package com.netscape.cmstools.tks;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;

--- a/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorShowCLI.java
@@ -15,7 +15,7 @@
 // (C) 2013 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
-package com.netscape.cmstools.system;
+package com.netscape.cmstools.tks;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;

--- a/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/tks/TPSConnectorShowCLI.java
@@ -51,6 +51,10 @@ public class TPSConnectorShowCLI extends CommandCLI {
         option = new Option(null, "port", true, "TPS port");
         option.setArgName("port");
         options.addOption(option);
+
+        option = new Option(null, "output-format", true, "Output format: text (default), json");
+        option.setArgName("format");
+        options.addOption(option);
     }
 
     public void execute(CommandLine cmd) throws Exception {
@@ -63,6 +67,7 @@ public class TPSConnectorShowCLI extends CommandCLI {
 
         String tpsHost = cmd.getOptionValue("host");
         String tpsPort = cmd.getOptionValue("port", "443");
+        String outputFormat = cmd.getOptionValue("output-format", "text");
 
         if (tpsHost == null) {
             throw new Exception("Missing TPS hostname");
@@ -71,7 +76,12 @@ public class TPSConnectorShowCLI extends CommandCLI {
         TPSConnectorClient tpsConnectorClient = tpsConnectorCLI.getTPSConnectorClient();
         TPSConnectorData data = tpsConnectorClient.getConnector(tpsHost, tpsPort);
 
-        MainCLI.printMessage("TPS Connector \"" + tpsHost + ":" + tpsPort + "\"");
-        TPSConnectorCLI.printConnectorInfo(data);
+        if ("json".equalsIgnoreCase(outputFormat)) {
+            System.out.println(data.toJSON());
+
+        } else {
+            MainCLI.printMessage("TPS Connector \"" + tpsHost + ":" + tpsPort + "\"");
+            TPSConnectorCLI.printConnectorInfo(data);
+        }
     }
 }

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -933,6 +933,10 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         finalize_config_request.installToken = deployer.install_token
         client.finalizeConfiguration(finalize_config_request)
 
+        if subsystem.type == 'TPS':
+            logger.info('Setting up shared secret')
+            deployer.setup_shared_secret(instance, subsystem)
+
         logger.info('%s configuration complete', subsystem.type)
 
         # Create an empty file that designates the fact that although

--- a/base/tks/src/org/dogtagpki/server/tks/rest/TPSConnectorService.java
+++ b/base/tks/src/org/dogtagpki/server/tks/rest/TPSConnectorService.java
@@ -326,8 +326,8 @@ public class TPSConnectorService extends PKIService implements TPSConnectorResou
             byte[] wrappedSharedSecret = listWrappedKeys.get(1);
 
             KeyData keyData = new KeyData();
-            keyData.setWrappedPrivateData(Utils.base64encode(wrappedSessionKey, true));
-            keyData.setAdditionalWrappedPrivateData(Utils.base64encode(wrappedSharedSecret, true));
+            keyData.setWrappedPrivateData(Utils.base64encodeSingleLine(wrappedSessionKey));
+            keyData.setAdditionalWrappedPrivateData(Utils.base64encodeSingleLine(wrappedSharedSecret));
 
             return createOKResponse(keyData);
 
@@ -394,8 +394,8 @@ public class TPSConnectorService extends PKIService implements TPSConnectorResou
             byte[] wrappedSharedSecret = listWrappedKeys.get(1);
 
             KeyData keyData = new KeyData();
-            keyData.setWrappedPrivateData(Utils.base64encode(wrappedSessionKey, true));
-            keyData.setAdditionalWrappedPrivateData(Utils.base64encode(wrappedSharedSecret, true));
+            keyData.setWrappedPrivateData(Utils.base64encodeSingleLine(wrappedSessionKey));
+            keyData.setAdditionalWrappedPrivateData(Utils.base64encodeSingleLine(wrappedSharedSecret));
 
             return createOKResponse(keyData);
 
@@ -476,8 +476,8 @@ public class TPSConnectorService extends PKIService implements TPSConnectorResou
             byte[] wrappedSharedSecret = listWrappedKeys.get(1);
 
             KeyData keyData = new KeyData();
-            keyData.setWrappedPrivateData(Utils.base64encode(wrappedSessionKey, true));
-            keyData.setAdditionalWrappedPrivateData(Utils.base64encode(wrappedSharedSecret, true));
+            keyData.setWrappedPrivateData(Utils.base64encodeSingleLine(wrappedSessionKey));
+            keyData.setAdditionalWrappedPrivateData(Utils.base64encodeSingleLine(wrappedSharedSecret));
 
             return createOKResponse(keyData);
 

--- a/base/tks/src/org/dogtagpki/server/tks/rest/TPSConnectorService.java
+++ b/base/tks/src/org/dogtagpki/server/tks/rest/TPSConnectorService.java
@@ -1,9 +1,7 @@
 package org.dogtagpki.server.tks.rest;
 
-import java.io.CharConversionException;
 import java.net.URI;
 import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -17,11 +15,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jboss.resteasy.plugins.providers.atom.Link;
-import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
-import org.mozilla.jss.crypto.CryptoToken;
-import org.mozilla.jss.crypto.KeyGenAlgorithm;
-import org.mozilla.jss.crypto.KeyGenerator;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
 import org.mozilla.jss.netscape.security.util.Utils;
@@ -314,7 +308,7 @@ public class TPSConnectorService extends PKIService implements TPSConnectorResou
             cs.commit(true);
 
             //Create des3 session sym key to wrap the shared secret.
-            SymmetricKey tempKey = createDes3SessionKeyOnInternal();
+            SymmetricKey tempKey = CryptoUtil.createDes3SessionKeyOnInternal();
 
             if (tempKey == null) {
                 return createNoContentResponse();
@@ -382,7 +376,7 @@ public class TPSConnectorService extends PKIService implements TPSConnectorResou
             CryptoUtil.createSharedSecret(nickname);
 
             //Create des3 session sym key to wrap the shared secret.
-            SymmetricKey tempKey = createDes3SessionKeyOnInternal();
+            SymmetricKey tempKey = CryptoUtil.createDes3SessionKeyOnInternal();
 
             if (tempKey == null) {
                 return createNoContentResponse();
@@ -465,7 +459,7 @@ public class TPSConnectorService extends PKIService implements TPSConnectorResou
             X509Certificate[] certs = user.getX509Certificates();
 
             //Create des3 session sym key to wrap the shared secrt.
-            SymmetricKey tempKey = createDes3SessionKeyOnInternal();
+            SymmetricKey tempKey = CryptoUtil.createDes3SessionKeyOnInternal();
 
             if (tempKey == null) {
                 return createNoContentResponse();
@@ -527,31 +521,5 @@ public class TPSConnectorService extends PKIService implements TPSConnectorResou
         while (sorted.contains(Integer.toString(index)))
             index++;
         return Integer.toString(index);
-    }
-
-    private SymmetricKey createDes3SessionKeyOnInternal() throws EBaseException {
-
-        SymmetricKey tempKey = null;
-        try {
-            CryptoManager cm = CryptoManager.getInstance();
-            CryptoToken token = cm.getInternalKeyStorageToken();
-            KeyGenerator kg = token.getKeyGenerator(KeyGenAlgorithm.DES3);
-
-            SymmetricKey.Usage usages[] = new SymmetricKey.Usage[4];
-            usages[0] = SymmetricKey.Usage.WRAP;
-            usages[1] = SymmetricKey.Usage.UNWRAP;
-            usages[2] = SymmetricKey.Usage.ENCRYPT;
-            usages[3] = SymmetricKey.Usage.DECRYPT;
-
-            kg.setKeyUsages(usages);
-            kg.temporaryKeys(true);
-            tempKey = kg.generate();
-        } catch (NoSuchAlgorithmException | TokenException | IllegalStateException | CharConversionException
-                | NotInitializedException e) {
-            logger.error("TPSConnectorService: Unable to generate temporary session key: " + e.getMessage(), e);
-            throw new EBaseException("Unable to generate temporary session key: " + e.getMessage(), e);
-        }
-
-        return tempKey;
     }
 }

--- a/base/tps/src/org/dogtagpki/server/tps/TPSConfigurator.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSConfigurator.java
@@ -27,23 +27,13 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.dogtagpki.server.tps.installer.TPSInstaller;
-import org.mozilla.jss.netscape.security.util.Utils;
-import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 
-import com.netscape.certsrv.account.AccountClient;
 import com.netscape.certsrv.authentication.EAuthException;
-import com.netscape.certsrv.base.IConfigStore;
 import com.netscape.certsrv.base.PKIException;
-import com.netscape.certsrv.base.ResourceNotFoundException;
-import com.netscape.certsrv.client.ClientConfig;
-import com.netscape.certsrv.client.PKIClient;
-import com.netscape.certsrv.key.KeyData;
 import com.netscape.certsrv.system.AdminSetupRequest;
 import com.netscape.certsrv.system.AdminSetupResponse;
 import com.netscape.certsrv.system.DatabaseSetupRequest;
 import com.netscape.certsrv.system.FinalizeConfigRequest;
-import com.netscape.certsrv.system.TPSConnectorClient;
-import com.netscape.certsrv.system.TPSConnectorData;
 import com.netscape.certsrv.user.UserResource;
 import com.netscape.certsrv.usrgrp.IUser;
 import com.netscape.cms.servlet.csadmin.Configurator;
@@ -303,76 +293,8 @@ public class TPSConfigurator extends Configurator {
 
         String host = cs.getString("service.machineName");
         String port = cs.getString("service.securePort");
-        String dbDir = cs.getInstanceDir() + "/alias";
-        String dbNick = cs.getString("tps.cert.subsystem.nickname");
-
-        String passwordFile = cs.getString("passwordFile");
-        IConfigStore psStore = engine.createFileConfigStore(passwordFile);
-        String dbPass = psStore.getString("internal");
-
-        ClientConfig config = new ClientConfig();
-        config.setServerURL("https://" + tksHost + ":" + tksPort);
-        config.setNSSDatabase(dbDir);
-        config.setNSSPassword(dbPass);
-        config.setCertNickname(dbNick);
-
-        PKIClient client = new PKIClient(config, null);
-
-        // Ignore the "UNTRUSTED_ISSUER" and "CA_CERT_INVALID" validity status
-        // during PKI instance creation since we are using an untrusted temporary CA cert.
-        client.addIgnoredCertStatus(SSLCertificateApprovalCallback.ValidityStatus.UNTRUSTED_ISSUER);
-        client.addIgnoredCertStatus(SSLCertificateApprovalCallback.ValidityStatus.CA_CERT_INVALID);
-
-        AccountClient accountClient = new AccountClient(client, "tks");
-        TPSConnectorClient tpsConnectorClient = new TPSConnectorClient(client, "tks");
-
-        accountClient.login();
-        TPSConnectorData data = null;
-        try {
-            data = tpsConnectorClient.getConnector(host, port);
-        } catch (ResourceNotFoundException e) {
-            // no connector exists
-            data = null;
-        }
-
-        // The connId or data.getID will be the id of the shared secret
-        KeyData keyData = null;
-        if (data == null) {
-            data = tpsConnectorClient.createConnector(host, port);
-            keyData = tpsConnectorClient.createSharedSecret(data.getID());
-        } else {
-            String connId = data.getID();
-            keyData = tpsConnectorClient.getSharedSecret(connId);
-            if (keyData != null) {
-                keyData = tpsConnectorClient.replaceSharedSecret(connId);
-            } else {
-                keyData = tpsConnectorClient.createSharedSecret(connId);
-            }
-        }
-
-        accountClient.logout();
-
-        logger.debug("TPSConfigurator: importKey: " + importKey);
         String nick = "TPS-" + host + "-" + port + " sharedSecret";
 
-        if (importKey) {
-            logger.debug("TPSConfigurator: About to attempt to import shared secret key.");
-            byte[] sessionKeyData = Utils.base64decode(keyData.getWrappedPrivateData());
-            byte[] sharedSecretData = Utils.base64decode(keyData.getAdditionalWrappedPrivateData());
-
-            try {
-                CryptoUtil.importSharedSecret(sessionKeyData, sharedSecretData, dbNick, nick);
-
-            } catch (Exception e) {
-                logger.warn("Failed to automatically import shared secret: " + e.getMessage(), e);
-                logger.warn("Please follow the manual procedure");
-            }
-
-            // this is not needed if we are using a shared database with
-            // the tks.
-        }
-
-        // store the new nick in CS.cfg
         cs.putString("conn.tks1.tksSharedSymKeyName", nick);
         cs.commit(false);
     }

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -57,7 +57,6 @@ import java.util.Vector;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Hex;
@@ -2491,6 +2490,24 @@ public class CryptoUtil {
         CryptoToken token = cm.getInternalKeyStorageToken();
         KeyManager km = new KeyManager(token);
         km.deleteUniqueNamedKey(nickname);
+    }
+
+    public static SymmetricKey createDes3SessionKeyOnInternal() throws Exception {
+
+        CryptoManager cm = CryptoManager.getInstance();
+        CryptoToken token = cm.getInternalKeyStorageToken();
+        KeyGenerator kg = token.getKeyGenerator(KeyGenAlgorithm.DES3);
+
+        SymmetricKey.Usage[] usages = new SymmetricKey.Usage[4];
+        usages[0] = SymmetricKey.Usage.WRAP;
+        usages[1] = SymmetricKey.Usage.UNWRAP;
+        usages[2] = SymmetricKey.Usage.ENCRYPT;
+        usages[3] = SymmetricKey.Usage.DECRYPT;
+
+        kg.setKeyUsages(usages);
+        kg.temporaryKeys(true);
+
+        return kg.generate();
     }
 
     // Return a list of two wrapped keys:


### PR DESCRIPTION
For some reason NSS 3.48 or later was causing a client cert auth problem when configuring the shared secret during TPS installation. That code was originally running inside a REST service on the server being installed. @cipherboy has shown that the same client cert auth worked fine outside of the server, so this PR is moving the code that configures the shared secret into separate CLIs which will run outside of the server to avoid the problem.

This PR has been tested successfully under these scenarios:
* TKS and TPS on a single instance
* TKS and TPS on separate instances (with `pki_import_shared_secret=True`)