### PR TITLE
Change pylint logic to run against all individual python files

### DIFF
--- a/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
@@ -89,8 +89,8 @@ class DogtagCertsConfigCheck(CSPlugin):
                         token=cert['token'],
                         output_format='base64'
                     )
-                except Exception as e:
-                    logger.debug('Unable to load cert from NSSDB: %s' % str(e))
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug('Unable to load cert from NSSDB: %s', str(e))
                     yield Result(self, constants.ERROR,
                                  key=cert_id,
                                  nssdbDir=self.instance.nssdb_dir,

--- a/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
@@ -13,6 +13,7 @@ from pki.server.instance import PKIInstance
 
 class CSPlugin(Plugin):
     def __init__(self, registry):
+        # pylint: disable=redefined-outer-name
         super(CSPlugin, self).__init__(registry)
         # TODO: Support custom instance names
         self.instance = PKIInstance('pki-tomcat')

--- a/base/server/healthcheck/setup.py
+++ b/base/server/healthcheck/setup.py
@@ -32,6 +32,6 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     python_requires='!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-    setup_requires=['pytest-runner',],
-    tests_require=['pytest',],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
 )

--- a/pki.spec
+++ b/pki.spec
@@ -239,6 +239,13 @@ BuildRequires:    go-md2man
 BuildRequires:    golang-github-cpuguy83-md2man
 %endif
 
+# pki-healthcheck depends on the following library
+%if 0%{?rhel}
+BuildRequires:         ipa-healthcheck-core
+%else
+BuildRequires:         freeipa-healthcheck-core
+%endif
+
 # PKICertImport depends on certutil and openssl
 BuildRequires:    nss-tools
 BuildRequires:    openssl

--- a/tools/pylint-build-scan.py
+++ b/tools/pylint-build-scan.py
@@ -39,7 +39,6 @@ FILENAMES = [
     os.path.abspath(__file__),
     os.path.abspath("base/server/healthcheck/setup.py")
 ]
-UPGRADE_SCRIPT = re.compile('^[0-9]+-.*')
 PYTHON_SCRIPT = re.compile('\\S+\\.py$')
 
 
@@ -67,13 +66,6 @@ def rpm_env(args):
     }
     return env
 
-
-def find_upgrades(root):
-    """Find upgrade scripts"""
-    for dirpath, _, filenames in os.walk(root):
-        for filename in filenames:
-            if UPGRADE_SCRIPT.match(filename):
-                yield os.path.join(dirpath, filename)
 
 def find_pki_python_files(root):
     """Find all python files in PKI project"""
@@ -122,6 +114,8 @@ def main():
 
     # Populate all the python files that needs to be linted
     FILENAMES.extend(find_pki_python_files(env['sitepackages']))
+    FILENAMES.extend(find_pki_python_files('{sharepki}/upgrade'.format(**env)))
+    FILENAMES.extend(find_pki_python_files('{sharepki}/server/upgrade'.format(**env)))
 
     pylint = [
         'pylint' if sys.version_info.major == 2 else 'pylint-3',
@@ -129,8 +123,6 @@ def main():
     ]
     pylint.extend(extra_args)
     pylint.extend(FILENAMES)
-    pylint.extend(find_upgrades('{sharepki}/upgrade'.format(**env)))
-    pylint.extend(find_upgrades('{sharepki}/server/upgrade'.format(**env)))
     if args.verbose:
         pprint.pprint(pylint)
 


### PR DESCRIPTION
The previous logic was to run pylint on the directory. As a result, few of
the python files were left untested.

This patch improves the logic to list and test individual python files. This
will also help to automatically include any new python files added to the project in future

As shown below, the number of statement analysed: **21274** vs **21354**

## Before this patch
````
$ python tools/pylint-build-scan.py rpm --prefix  /home/dmoluguw/build/pki/BUILDROOT/pki-10.8.0-0.5.fc31.x86_64/


Report
======
21274 statements analysed.

Statistics by type
------------------

+---------+-------+-----------+-----------+------------+---------+
|type     |number |old number |difference |%documented |%badname |
+=========+=======+===========+===========+============+=========+
|module   |131    |137        |-6.00      |NC          |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|class    |361    |364        |-3.00      |NC          |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|method   |1476   |1479       |-3.00      |NC          |1.36     |
+---------+-------+-----------+-----------+------------+---------+
|function |83     |86         |-3.00      |NC          |7.23     |
+---------+-------+-----------+-----------+------------+---------+



External dependencies
---------------------
::

    cryptography 
      \-hazmat 
      | \-backends (pki.server.deployment.scriptlets.configuration)
      | \-primitives 
      |   \-asymmetric 
      |   | \-padding (pki.crypto)
      |   \-ciphers (pki.crypto)
      |   | \-algorithms (pki.crypto)
      |   | \-modes (pki.crypto)
      |   \-keywrap (pki.crypto)
      |   \-padding (pki.crypto)
      \-x509 (pki.server.deployment.scriptlets.configuration)
        \-oid (pki.server.deployment.scriptlets.configuration)
    ldap (pki.server.deployment.pkiparser)
      \-filter (pki.server)
      \-modlist (pki.server.cli.kra)
    ldif (pki.server.cli.kra)
    lxml 
      \-etree (01-AddTPSExternalRegISEtokenParams)
    nss 
      \-nss (pki.crypto)
    pki (pki.server.deployment.pkihelper)
      \-account (pki.server.deployment.pkiparser)
      \-cert (pki.server.cli.cert)
      \-cli (pki.server.cli.subsystem)
      | \-password (pki.cli.main)
      | \-pkcs12 (pki.cli.main)
      \-client (pki.server.deployment.pkiparser)
      \-crypto (pki.key)
      \-encoder (pki.server.deployment.scriptlets.configuration)
      \-info (pki.kra)
      \-key (pki.kra)
      \-keyring (pki.server)
      \-nssdb (pki.server.deployment.pkihelper)
      \-pkcs12 (pki.server.deployment.scriptlets.security_databases)
      \-profile (pki.cert)
      \-server (pki.server.deployment.scriptlets.configuration)
      | \-cli (pki.server.pkiserver)
      | | \-audit (pki.server.cli.kra)
      | | \-config (pki.server.cli.kra)
      | | \-db (pki.server.cli.kra)
      | \-deployment 
      | | \-pkiconfig (pki.server.deployment.pkihelper)
      | | \-pkilogging (pki.server.deployment.pkiparser)
      | | \-pkimanifest (pki.server.deployment.pkihelper)
      | | \-pkimessages (pki.server.deployment.pkihelper)
      | | \-pkiparser (pki.server.deployment.pkihelper)
      | | \-pkiscriptlet (pki.server.deployment.scriptlets.configuration)
      | \-instance (pki.server.deployment.scriptlets.configuration)
      | \-upgrade (01-AddTPSExternalRegISEtokenParams)
      \-system (pki.server.deployment.scriptlets.configuration)
      \-systemcert (pki.kra)
      \-upgrade (01-AddJniJarDir)
      \-util (pki.server.deployment.pkihelper)
    requests (pki.server.deployment.pkihelper)
    selinux (pki.server.deployment.pkihelper)
    seobject (pki.server.deployment.pkihelper)
    six (pki.server.deployment.pkiparser)
    urllib3 
      \-exceptions (pki.client)



Raw metrics
-----------

+----------+-------+------+---------+-----------+
|type      |number |%     |previous |difference |
+==========+=======+======+=========+===========+
|code      |25477  |59.94 |25609    |-132.00    |
+----------+-------+------+---------+-----------+
|docstring |3927   |9.24  |3949     |-22.00     |
+----------+-------+------+---------+-----------+
|comment   |4241   |9.98  |4280     |-39.00     |
+----------+-------+------+---------+-----------+
|empty     |8862   |20.85 |8902     |-40.00     |
+----------+-------+------+---------+-----------+



Duplication
-----------

+-------------------------+------+---------+-----------+
|                         |now   |previous |difference |
+=========================+======+=========+===========+
|nb duplicated lines      |0     |0        |=          |
+-------------------------+------+---------+-----------+
|percent duplicated lines |0.000 |0.000    |=          |
+-------------------------+------+---------+-----------+



Messages by category
--------------------

+-----------+-------+---------+-----------+
|type       |number |previous |difference |
+===========+=======+=========+===========+
|convention |0      |0        |=          |
+-----------+-------+---------+-----------+
|refactor   |0      |0        |=          |
+-----------+-------+---------+-----------+
|warning    |0      |0        |=          |
+-----------+-------+---------+-----------+
|error      |0      |0        |=          |
+-----------+-------+---------+-----------+




--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

````

## After this patch

````
$ python tools/pylint-build-scan.py rpm --prefix  /home/dmoluguw/build/pki/BUILDROOT/pki-10.8.0-0.5.fc31.x86_64/


Report
======
21354 statements analysed.

Statistics by type
------------------

+---------+-------+-----------+-----------+------------+---------+
|type     |number |old number |difference |%documented |%badname |
+=========+=======+===========+===========+============+=========+
|module   |137    |131        |+6.00      |NC          |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|class    |364    |361        |+3.00      |NC          |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|method   |1479   |1476       |+3.00      |NC          |1.35     |
+---------+-------+-----------+-----------+------------+---------+
|function |86     |83         |+3.00      |NC          |6.98     |
+---------+-------+-----------+-----------+------------+---------+



External dependencies
---------------------
::

    cryptography 
      \-hazmat 
      | \-backends (pki.server.deployment.scriptlets.configuration)
      | \-primitives 
      |   \-asymmetric 
      |   | \-padding (pki.crypto)
      |   \-ciphers (pki.crypto)
      |   | \-algorithms (pki.crypto)
      |   | \-modes (pki.crypto)
      |   \-keywrap (pki.crypto)
      |   \-padding (pki.crypto)
      \-x509 (pki.server.deployment.scriptlets.configuration)
        \-oid (pki.server.deployment.scriptlets.configuration)
    ldap (pki.server.deployment.pkiparser)
      \-filter (pki.server)
      \-modlist (pki.server.cli.kra)
    ldif (pki.server.cli.kra)
    lxml 
      \-etree (01-AddTPSExternalRegISEtokenParams)
    nss 
      \-nss (pki.crypto)
    pki (pki.server.deployment.pkihelper)
      \-account (pki.server.deployment.pkiparser)
      \-cert (pki.server.cli.cert)
      \-cli (pki.server.cli.subsystem)
      | \-password (pki.cli.main)
      | \-pkcs12 (pki.cli.main)
      \-client (pki.server.deployment.pkiparser)
      \-crypto (pki.key)
      \-encoder (pki.server.deployment.scriptlets.configuration)
      \-info (pki.kra)
      \-key (pki.kra)
      \-keyring (pki.server)
      \-nssdb (pki.server.deployment.pkihelper)
      \-pkcs12 (pki.server.deployment.scriptlets.security_databases)
      \-profile (pki.cert)
      \-server (03-FixRegistryFile)
      | \-cli (pki.server.pkiserver)
      | | \-audit (pki.server.cli.kra)
      | | \-config (pki.server.cli.kra)
      | | \-db (pki.server.cli.kra)
      | \-deployment 
      | | \-pkiconfig (pki.server.deployment.pkihelper)
      | | \-pkilogging (pki.server.deployment.pkiparser)
      | | \-pkimanifest (pki.server.deployment.pkihelper)
      | | \-pkimessages (pki.server.deployment.pkihelper)
      | | \-pkiparser (pki.server.deployment.pkihelper)
      | | \-pkiscriptlet (pki.server.deployment.scriptlets.configuration)
      | \-healthcheck 
      | | \-meta 
      | |   \-plugin (meta.csconfig)
      | \-instance (pki.server.deployment.scriptlets.configuration)
      | \-upgrade (01-AddTPSExternalRegISEtokenParams)
      \-system (pki.server.deployment.scriptlets.configuration)
      \-systemcert (pki.kra)
      \-upgrade (pki.server.deployment.pkiparser)
      \-util (pki.server.deployment.pkihelper)
    requests (pki.server.deployment.pkihelper)
    selinux (pki.server.deployment.pkihelper)
    seobject (pki.server.deployment.pkihelper)
    six (pki.server.deployment.pkiparser)
    urllib3 
      \-exceptions (pki.client)



Raw metrics
-----------

+----------+-------+------+---------+-----------+
|type      |number |%     |previous |difference |
+==========+=======+======+=========+===========+
|code      |25609  |59.92 |25477    |+132.00    |
+----------+-------+------+---------+-----------+
|docstring |3949   |9.24  |3927     |+22.00     |
+----------+-------+------+---------+-----------+
|comment   |4280   |10.01 |4241     |+39.00     |
+----------+-------+------+---------+-----------+
|empty     |8902   |20.83 |8862     |+40.00     |
+----------+-------+------+---------+-----------+



Duplication
-----------

+-------------------------+------+---------+-----------+
|                         |now   |previous |difference |
+=========================+======+=========+===========+
|nb duplicated lines      |0     |0        |=          |
+-------------------------+------+---------+-----------+
|percent duplicated lines |0.000 |0.000    |=          |
+-------------------------+------+---------+-----------+



Messages by category
--------------------

+-----------+-------+---------+-----------+
|type       |number |previous |difference |
+===========+=======+=========+===========+
|convention |0      |0        |=          |
+-----------+-------+---------+-----------+
|refactor   |0      |0        |=          |
+-----------+-------+---------+-----------+
|warning    |0      |0        |=          |
+-----------+-------+---------+-----------+
|error      |0      |0        |=          |
+-----------+-------+---------+-----------+




--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
````



Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>