### PR TITLE
Removed unsupported capture_output in subprocess.run()

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -355,7 +355,8 @@ class PKIDeployer:
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))
-        result = subprocess.run(cmd, capture_output=True, check=False)
+        # TODO: Replace stdout/stderr with capture_output in Python 3.7.
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
 
         if result.returncode == 0:
             return json.loads(result.stdout.decode())
@@ -383,7 +384,8 @@ class PKIDeployer:
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))
-        result = subprocess.run(cmd, capture_output=True, check=False)
+        # TODO: Replace stdout/stderr with capture_output in Python 3.7.
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
 
         if result.returncode == 0:
             return json.loads(result.stdout.decode())
@@ -405,7 +407,8 @@ class PKIDeployer:
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))
-        result = subprocess.run(cmd, capture_output=True, check=False)
+        # TODO: Replace stdout/stderr with capture_output in Python 3.7.
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
 
         if result.returncode == 0:
             return json.loads(result.stdout.decode())
@@ -428,7 +431,8 @@ class PKIDeployer:
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))
-        result = subprocess.run(cmd, capture_output=True, check=False)
+        # TODO: Replace stdout/stderr with capture_output in Python 3.7.
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
 
         if result.returncode == 0:
             return json.loads(result.stdout.decode())
@@ -451,7 +455,8 @@ class PKIDeployer:
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))
-        result = subprocess.run(cmd, capture_output=True, check=False)
+        # TODO: Replace stdout/stderr with capture_output in Python 3.7.
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
 
         if result.returncode == 0:
             return json.loads(result.stdout.decode())

--- a/pki.spec
+++ b/pki.spec
@@ -198,7 +198,7 @@ BuildRequires:    python3-flake8 >= 2.5.4
 BuildRequires:    python3-pyflakes >= 1.2.3
 %endif
 
-BuildRequires:    python3
+BuildRequires:    python3 >= 3.5
 BuildRequires:    python3-devel
 BuildRequires:    python3-cryptography
 BuildRequires:    python3-lxml
@@ -382,6 +382,7 @@ Provides:         pki-base-python3 = %{version}
 %endif
 
 Requires:         pki-base = %{version}
+Requires:         python3 >= 3.5
 Requires:         python3-cryptography
 Requires:         python3-lxml
 Requires:         python3-nss


### PR DESCRIPTION
The PKI Python library uses subprocess.run() which is available
since Python 3.5. However, the capture_output parameter is only
available since Python 3.7. Since some platforms do not have it
yet it has been changed to set the stdout and stderr parameters
to PIPE instead.

The pki.spec file has also been updated to require Python 3.5.