### PR TITLE
Fix pkidaemon status when nuxwdog is enabled

### DIFF
--- a/base/server/scripts/operations
+++ b/base/server/scripts/operations
@@ -716,7 +716,18 @@ display_configuration_information()
 
 display_instance_status_systemd()
 {
+    # source the instance specific variables
+    . /etc/sysconfig/${PKI_INSTANCE_NAME}
+
+    echo "Instance ${PKI_INSTANCE_NAME} is configured to use nuxwdog: ${USE_NUXWDOG}"
     echo -n "Status for ${PKI_INSTANCE_NAME}: "
+
+    # find the systemd target to query status
+    PKI_SYSTEMD_TARGET="pki-${pki_instance_type}d"
+    if [ "$USE_NUXWDOG" = true ] ; then
+        PKI_SYSTEMD_TARGET="${PKI_SYSTEMD_TARGET}-nuxwdog"
+    fi
+
     systemctl status "$PKI_SYSTEMD_TARGET@$PKI_INSTANCE_NAME.service" > /dev/null 2>&1
     rv=$?
 

--- a/base/server/scripts/pkidaemon
+++ b/base/server/scripts/pkidaemon
@@ -29,7 +29,6 @@ pki_instance_id="$2"
 
 PKI_REGISTRY="/etc/sysconfig/pki/${pki_instance_type}"
 PKI_TYPE="${pki_instance_type}"
-PKI_SYSTEMD_TARGET="pki-${pki_instance_type}d"
 
 # Source the PKI function library
 . /usr/share/pki/scripts/operations


### PR DESCRIPTION
- Target the right systemd file, based on whether nuxwdog is enabled.
- Add status of nuxwdog configuration to the pkidaemon output

Resolves: [BZ#1487418](https://bugzilla.redhat.com/show_bug.cgi?id=1487418)

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`