### PR TITLE
Fix interactive DS configuration

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -146,6 +146,9 @@ class PKIDeployer:
         self.tps_connector = util.TPSConnector(self)
         self.config_client = util.ConfigClient(self)
 
+        self.ds_init()
+
+    def ds_init(self):
         ds_hostname = self.mdict['pki_ds_hostname']
 
         if config.str2bool(self.mdict['pki_ds_secure_connection']):
@@ -212,6 +215,9 @@ class PKIDeployer:
         self.manifest_db.append(record)
 
     def ds_connect(self):
+        if not self.ds_url:
+            logger.info('ds_connect called without corresponding call to ds_init')
+            self.ds_init()
 
         logger.info('Connecting to LDAP server at %s', self.ds_url)
 

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -66,6 +66,7 @@ def interrupt_handler(event, frame):
 
 def verify_ds_configuration():
     try:
+        deployer.ds_init()
         deployer.ds_connect()
         deployer.ds_bind()
         deployer.ds_search()
@@ -336,6 +337,10 @@ def main(argv):
 
                 except ldap.LDAPError as e:
                     parser.print_text('ERROR: ' + e.args[0]['desc'])
+
+                    # Force deployer to re-initialize the DS connection string
+                    # next time, as we're in interactive mode here.
+                    deployer.ds_url = None
                     continue
 
                 parser.read_text('Base DN',


### PR DESCRIPTION
In f218c64bec0ccfe754a42bdcd46c7c2cfc09bc77, `PKIDeployer` configuration
was refactored. This included placing most of the DS specific init logic
into a separate `PKIDeployer.init()` call. However, this wasn't issued
until much later in the PKI Spawn process. During interactive
installations, the user would be prompted for DS connection information,
which would subsequently be verified. However, since `PKIDeployer.init()`
hadn't yet been called, `ds_url` was `None`, resulting in a connection
failure:

    Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/pki/server/pkispawn.py", line 69, in verify_ds_configuration
        deployer.ds_connect()
      File "/usr/lib/python3.6/site-packages/pki/server/deployment/__init__.py", line 214, in ds_connect
        self.ds_connection = ldap.initialize(self.ds_url)
      File "/usr/lib64/python3.6/site-packages/ldap/functions.py", line 85, in initialize
        return LDAPObject(uri,trace_level,trace_file,trace_stack_limit,bytes_mode)
      File "/usr/lib64/python3.6/site-packages/ldap/ldapobject.py", line 104, in __init__
        self._l = ldap.functions._ldap_function_call(ldap._ldap_module_lock,_ldap.initialize,uri)
      File "/usr/lib64/python3.6/site-packages/ldap/functions.py", line 55, in _ldap_function_call
        result = func(*args,**kwargs)
    TypeError: initialize() argument 1 must be str, not None

Move DS configuration out of `init()` and into `ds_init()`; make
`ds_connect()` call `ds_init()` when `ds_url` is `None`, and call `ds_init()` from
`init()`. PKI Spawn has been updated to call `ds_init()` when necessary, and
also to reset `ds_url` to `None` when validation fails, forcing `ds_init()` to
be called again.

Resolves: [`rh-bz#1795215`](https://bugzilla.redhat.com/show_bug.cgi?id=1795215)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`