### PR TITLE
Fix interactive installation for subsystems other than CA

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -253,11 +253,6 @@ class PKIDeployer:
             port=sd_port,
             trust_env=False)
 
-        sd_user = self.mdict['pki_security_domain_user']
-        sd_password = self.mdict['pki_security_domain_password']
-
-        self.sd_connection.authenticate(sd_user, sd_password)
-
         return self.sd_connection
 
     def get_domain_info(self):
@@ -275,6 +270,12 @@ class PKIDeployer:
         return self.domain_info
 
     def sd_login(self):
+
+        sd_user = self.mdict['pki_security_domain_user']
+        sd_password = self.mdict['pki_security_domain_password']
+
+        self.sd_connection.authenticate(sd_user, sd_password)
+
         account = pki.account.AccountClient(self.sd_connection, subsystem='ca')
         account.login()
 


### PR DESCRIPTION
When doing an interactive installation, the pkispawn script tries
to connect to Security Domain via `sd_connect` and attaches user
credentials. At this point, the user has not been prompted for any
credentials. So, the authentication happens with empty strings. As
a result the interactive installation fails.

This was not observed in non-interactive installation because all the info
is provided via cfg file and is available in the dictionary at the time
of execution.

This patch moves the authentication logic from `sd_connect()`
to `sd_login()` (ie) authenticate before trying to log in

The bug was introduced in commit: 08ea62892a894553d8ceae200618c6fa8d7f0585

Resolves: [BZ#1795215](https://bugzilla.redhat.com/show_bug.cgi?id=1795215)

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`