### PR TITLE
ACMEEngine: check (!= null) when shutting down

### DIFF
--- a/base/acme/src/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/org/dogtagpki/acme/server/ACMEEngine.java
@@ -197,7 +197,8 @@ public class ACMEEngine implements ServletContextListener {
     }
 
     public void shutdownDatabase() throws Exception {
-        database.close();
+        if (database != null)
+            database.close();
     }
 
     public void loadValidatorsConfig(String filename) throws Exception {
@@ -271,7 +272,8 @@ public class ACMEEngine implements ServletContextListener {
     }
 
     public void shutdownBackend() throws Exception {
-        backend.close();
+        if (backend != null)
+            backend.close();
     }
 
     public void contextInitialized(ServletContextEvent event) {


### PR DESCRIPTION
After ACME engine startup failure, the shutdown methods are invoked.
But due to the errors, the backend and/or database may not have been
initialised, and a NullPointerException occurs.  This adds extra
backtrace noise the log/journal.  Add a (!= null) check to avoid
this.