### PR TITLE
Convert multiline script to use literal style scalar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ install:
   - docker exec -i ${CONTAINER} ${SCRIPTDIR}/pki-install.sh
   
 script:
-  - >
+  - |
+    set -e
     if [ $TASK = "IPA" ]; then
       docker exec -i ${CONTAINER} ${SCRIPTDIR}/ipa-test.sh
     else

--- a/travis/builder-init.sh
+++ b/travis/builder-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 #
 # Authors:
 #     Dinesh Prasanth M K <dmoluguw@redhat.com>
@@ -19,7 +19,6 @@
 # Copyright (C) 2018 Red Hat, Inc.
 # All rights reserved.
 #
-set -e
 
 docker pull ${IMAGE}
 

--- a/travis/ca-create.sh
+++ b/travis/ca-create.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkispawn -v -f ${BUILDDIR}/pki/travis/pki.cfg -s CA

--- a/travis/ca-remove.sh
+++ b/travis/ca-remove.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkidestroy -i pkitest -s CA

--- a/travis/ds-create.sh
+++ b/travis/ds-create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 setup-ds.pl \
     --silent \

--- a/travis/ds-remove.sh
+++ b/travis/ds-remove.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 remove-ds.pl -f -i slapd-pkitest

--- a/travis/ipa-init.sh
+++ b/travis/ipa-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 #
 # Authors:
 #     Dinesh Prasanth M K <dmoluguw@redhat.com>
@@ -19,7 +19,6 @@
 # Copyright (C) 2018 Red Hat, Inc.
 # All rights reserved.
 #
-set -e
 
 # Enable IPA's nightly COPR repo
 dnf copr enable -y @freeipa/freeipa-master-nightly

--- a/travis/ipa-test.sh
+++ b/travis/ipa-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eEx
 #
 # Authors:
 #     Dinesh Prasanth M K <dmoluguw@redhat.com>
@@ -19,7 +19,6 @@
 # Copyright (C) 2017 Red Hat, Inc.
 # All rights reserved.
 #
-set -eE
 
 TEST_LOG=/tmp/ipa-test.txt
 LOGS_TAR_NAME="var_log.tar"

--- a/travis/kra-create.sh
+++ b/travis/kra-create.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkispawn -v -f ${BUILDDIR}/pki/travis/pki.cfg -s KRA

--- a/travis/kra-remove.sh
+++ b/travis/kra-remove.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkidestroy -v -i pkitest -s KRA

--- a/travis/ocsp-create.sh
+++ b/travis/ocsp-create.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkispawn -v -f ${BUILDDIR}/pki/travis/pki.cfg -s OCSP

--- a/travis/ocsp-remove.sh
+++ b/travis/ocsp-remove.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkidestroy -v -i pkitest -s OCSP

--- a/travis/pki-build.sh
+++ b/travis/pki-build.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/bash -ex
 
 BUILDLOG=/tmp/pki-build.txt
 

--- a/travis/pki-init.sh
+++ b/travis/pki-init.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/bash -ex
 
 . /etc/os-release
 

--- a/travis/pki-install.sh
+++ b/travis/pki-install.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e
+#!/bin/bash -ex
+
 PACKAGES=`find ${BUILDDIR}/packages/RPMS/ -name '*.rpm' -and -not -name '*debuginfo*'`
 
 # To list all packages that are available. Useful for debug purposes

--- a/travis/tks-create.sh
+++ b/travis/tks-create.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkispawn -v -f ${BUILDDIR}/pki/travis/pki.cfg -s TKS

--- a/travis/tks-remove.sh
+++ b/travis/tks-remove.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkidestroy -v -i pkitest -s TKS

--- a/travis/tps-create.sh
+++ b/travis/tps-create.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkispawn -v -f ${BUILDDIR}/pki/travis/pki.cfg -s TPS

--- a/travis/tps-remove.sh
+++ b/travis/tps-remove.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 pkidestroy -v -i pkitest -s TPS


### PR DESCRIPTION
The literal style scalar `|` preserve newlines while
folded scalar `>` replaces newlines with space. As a
result unintended exit codes can occur

````
-e  Exit immediately if a command exits with a non-zero status.
-x  Print commands and their arguments as they are executed.
````

### Example test run
Travis Failed job: https://travis-ci.org/SilleBille/pki/jobs/655149806


`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`