### PR TITLE
Explicitly select Mozilla JSS provider

### DIFF
--- a/base/ca/src/com/netscape/ca/CAService.java
+++ b/base/ca/src/com/netscape/ca/CAService.java
@@ -1161,12 +1161,12 @@ public class CAService implements ICAService, IService {
         byte[] signature_type = new byte[] {0}; // certificate_timestamp(0)
         byte[] entry_type = new byte[] {0, 1}; // LogEntryType: precert_entry(1)
         byte google_pub[] = CryptoUtil.base64Decode(GoogleTestTube_Pub);
-        PublicKey google_pubKey = KeyFactory.getInstance("RSA").generatePublic(
+        PublicKey google_pubKey = KeyFactory.getInstance("RSA", "Mozilla-JSS").generatePublic(
                 new X509EncodedKeySpec(google_pub));
         /*
         byte[] key_id = null;
         try {
-            MessageDigest SHA256Digest = MessageDigest.getInstance("SHA256");
+            MessageDigest SHA256Digest = MessageDigest.getInstance("SHA256", "Mozilla-JSS");
 
             key_id = SHA256Digest.digest(google_pubKey.getEncoded());
         } catch (NoSuchAlgorithmException ex) {
@@ -1178,7 +1178,7 @@ public class CAService implements ICAService, IService {
         byte[] issuer_key = cacert.getPublicKey().getEncoded();
         byte[] issuer_key_hash = null;
         try {
-            MessageDigest SHA256Digest = MessageDigest.getInstance("SHA256");
+            MessageDigest SHA256Digest = MessageDigest.getInstance("SHA256", "Mozilla-JSS");
 
             issuer_key_hash = SHA256Digest.digest(issuer_key);
         } catch (NoSuchAlgorithmException ex) {
@@ -2055,7 +2055,7 @@ class serviceCheckChallenge implements IServant {
         mService = service;
         mCA = mService.getCA();
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
             logger.warn(CMS.getLogMessage("OPERATION_ERROR", e.toString()), e);
         }

--- a/base/ca/src/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/com/netscape/ca/CertificateAuthority.java
@@ -2382,7 +2382,7 @@ public class CertificateAuthority
         MessageDigest md = null;
 
         try {
-            md = MessageDigest.getInstance("SHA1");
+            md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
             return null;
         }
@@ -2612,7 +2612,7 @@ public class CertificateAuthority
         String digestName = cid.getDigestName();
         if (digestName != null) {
             try {
-                MessageDigest md = MessageDigest.getInstance(digestName);
+                MessageDigest md = MessageDigest.getInstance(digestName, "Mozilla-JSS");
                 nameHash = md.digest(mName.getEncoded());
             } catch (NoSuchAlgorithmException | IOException e) {
             }

--- a/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -323,7 +323,7 @@ public class CRSEnrollment extends HttpServlet {
         OID_SERIALNUMBER = X500NameAttrMap.getDefault().getOid("SERIALNUMBER");
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
         }
 
@@ -1700,7 +1700,7 @@ public class CRSEnrollment extends HttpServlet {
 
         for (int i = 0; i < hashes.length; i++) {
             try {
-                md = MessageDigest.getInstance(hashes[i]);
+                md = MessageDigest.getInstance(hashes[i], "Mozilla-JSS");
                 md.update(p10.getCertRequestInfo());
                 fingerprints.put(hashes[i], md.digest());
             } catch (NoSuchAlgorithmException nsa) {
@@ -1853,7 +1853,7 @@ public class CRSEnrollment extends HttpServlet {
             byte[] ed = crsResp.makeEnvelopedData(0);
 
             // 7. Make Digest of SignedData Content
-            MessageDigest md = MessageDigest.getInstance(mHashAlgorithm);
+            MessageDigest md = MessageDigest.getInstance(mHashAlgorithm, "Mozilla-JSS");
             msgdigest = md.digest(ed);
 
             crsResp.setMsgDigest(msgdigest);

--- a/base/common/src/com/netscape/certsrv/key/KeyClient.java
+++ b/base/common/src/com/netscape/certsrv/key/KeyClient.java
@@ -449,7 +449,7 @@ public class KeyClient extends Client {
             // TODO(alee) This assumes RSA for now
 
             byte[] pubKeyBytes = Utils.base64decode(data.getPublicKey());
-            PublicKey pubKey = KeyFactory.getInstance("RSA").generatePublic(
+            PublicKey pubKey = KeyFactory.getInstance("RSA", "Mozilla-JSS").generatePublic(
                     new X509EncodedKeySpec(pubKeyBytes));
 
             bytes = crypto.unwrapAsymmetricKeyWithSessionKey(

--- a/base/java-tools/src/com/netscape/cmstools/CMCEnroll.java
+++ b/base/java-tools/src/com/netscape/cmstools/CMCEnroll.java
@@ -187,7 +187,7 @@ public class CMCEnroll {
             byte[] dig;
 
             try {
-                MessageDigest SHA1Digest = MessageDigest.getInstance("SHA1");
+                MessageDigest SHA1Digest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
                 dig = SHA1Digest.digest(salt.getBytes());
             } catch (NoSuchAlgorithmException ex) {
@@ -207,7 +207,7 @@ public class CMCEnroll {
             byte[] transId;
 
             try {
-                MessageDigest MD5Digest = MessageDigest.getInstance("MD5");
+                MessageDigest MD5Digest = MessageDigest.getInstance("MD5", "Mozilla-JSS");
 
                 transId = MD5Digest.digest(pkcs.getSubjectPublicKeyInfo().getKey());
             } catch (Exception ex) {
@@ -238,7 +238,7 @@ public class CMCEnroll {
             byte[] digest = null;
 
             try {
-                SHADigest = MessageDigest.getInstance("SHA1");
+                SHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
                 digestAlg = DigestAlgorithm.SHA1;
 
                 ByteArrayOutputStream ostream = new ByteArrayOutputStream();

--- a/base/java-tools/src/com/netscape/cmstools/CMCRequest.java
+++ b/base/java-tools/src/com/netscape/cmstools/CMCRequest.java
@@ -338,7 +338,7 @@ public class CMCRequest {
 
             byte[] digest = null;
             try {
-                SHADigest = MessageDigest.getInstance("SHA256");
+                SHADigest = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
                 digestAlg = DigestAlgorithm.SHA256;
 
                 ByteArrayOutputStream ostream = new ByteArrayOutputStream();
@@ -1066,7 +1066,7 @@ public class CMCRequest {
             toBeDigested = sharedSecret + ident;
         }
         try {
-            MessageDigest hash = MessageDigest.getInstance(hashAlgString);
+            MessageDigest hash = MessageDigest.getInstance(hashAlgString, "Mozilla-JSS");
             key = hash.digest(toBeDigested.getBytes());
         } catch (NoSuchAlgorithmException ex) {
             System.out.println(method + "No such algorithm!");
@@ -1121,7 +1121,7 @@ public class CMCRequest {
         byte[] key = null;
         byte[] finalDigest = null;
         try {
-            MessageDigest SHA1Digest = MessageDigest.getInstance("SHA1");
+            MessageDigest SHA1Digest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
             key = SHA1Digest.digest(sharedSecret.getBytes());
         } catch (NoSuchAlgorithmException ex) {
             System.out.println("CMCRequest::addIdentityProofAttr() - "
@@ -1276,7 +1276,7 @@ public class CMCRequest {
             byte[] rdigest = null;
             DigestAlgorithm digestAlg1 = null;
             try {
-                rSHADigest = MessageDigest.getInstance("SHA1");
+                rSHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
                 digestAlg1 = DigestAlgorithm.SHA1;
 
                 ByteArrayOutputStream ostream = new ByteArrayOutputStream();
@@ -1382,7 +1382,7 @@ public class CMCRequest {
         String salt = "lala123" + date.toString();
         if (id == null || id.equals("")) {
             try {
-                MessageDigest MD5Digest = MessageDigest.getInstance("MD5");
+                MessageDigest MD5Digest = MessageDigest.getInstance("MD5", "Mozilla-JSS");
                 if (format.equals("crmf")) {
                     CertRequest certreq = certReqMsg.getCertReq();
                     CertTemplate certTemplate = certreq.getCertTemplate();
@@ -1428,7 +1428,7 @@ public class CMCRequest {
             String salt = "lala123" + date.toString();
 
             try {
-                MessageDigest SHA256Digest = MessageDigest.getInstance("SHA256");
+                MessageDigest SHA256Digest = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
 
                 dig = SHA256Digest.digest(salt.getBytes());
             } catch (NoSuchAlgorithmException ex) {
@@ -1545,7 +1545,7 @@ public class CMCRequest {
 
         // (2) compute key from sharedSecret + identity
         try {
-            MessageDigest hash = MessageDigest.getInstance(keyGenAlgString);
+            MessageDigest hash = MessageDigest.getInstance(keyGenAlgString, "Mozilla-JSS");
             key = hash.digest(toBeDigested.getBytes());
         } catch (NoSuchAlgorithmException ex) {
             System.out.println(method + "No such algorithm!");
@@ -1871,7 +1871,7 @@ public class CMCRequest {
 
             // now verify the witness
             try {
-                MessageDigest hash = MessageDigest.getInstance(CryptoUtil.getNameFromHashAlgorithm(witnessAlgID));
+                MessageDigest hash = MessageDigest.getInstance(CryptoUtil.getNameFromHashAlgorithm(witnessAlgID), "Mozilla-JSS");
                 byte[] digest = hash.digest(challenge);
                 boolean witnessChecked = Arrays.equals(digest, witness.toByteArray());
                 CryptoUtil.obscureBytes(digest,"random");

--- a/base/java-tools/src/com/netscape/cmstools/CMCRevoke.java
+++ b/base/java-tools/src/com/netscape/cmstools/CMCRevoke.java
@@ -343,7 +343,7 @@ public class CMCRevoke {
             byte[] dig;
 
             try {
-                MessageDigest SHA2Digest = MessageDigest.getInstance("SHA256");
+                MessageDigest SHA2Digest = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
 
                 dig = SHA2Digest.digest(salt.getBytes());
             } catch (NoSuchAlgorithmException ex) {
@@ -399,7 +399,7 @@ public class CMCRevoke {
             byte[] digest = null;
 
             try {
-                SHADigest = MessageDigest.getInstance("SHA256");
+                SHADigest = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
                 digestAlg = DigestAlgorithm.SHA256;
 
                 ByteArrayOutputStream ostream = new ByteArrayOutputStream();

--- a/base/java-tools/src/com/netscape/cmstools/CRMFPopClient.java
+++ b/base/java-tools/src/com/netscape/cmstools/CRMFPopClient.java
@@ -746,7 +746,7 @@ public class CRMFPopClient {
     public OCTET_STRING createIDPOPLinkWitness() throws Exception {
 
         String secretValue = "testing";
-        MessageDigest digest1 = MessageDigest.getInstance("SHA1");
+        MessageDigest digest1 = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
         byte[] key1 = digest1.digest(secretValue.getBytes());
 
         /* Example of adding the POP link witness control to CRMF */

--- a/base/java-tools/src/com/netscape/cmstools/PKCS10Client.java
+++ b/base/java-tools/src/com/netscape/cmstools/PKCS10Client.java
@@ -264,7 +264,7 @@ public class PKCS10Client {
             String secretValue = "testing";
             byte[] key1 = null;
             byte[] finalDigest = null;
-            MessageDigest SHA1Digest = MessageDigest.getInstance("SHA1");
+            MessageDigest SHA1Digest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
             key1 = SHA1Digest.digest(secretValue.getBytes());
 
             // seed

--- a/base/kra/src/com/netscape/kra/RecoveryService.java
+++ b/base/kra/src/com/netscape/kra/RecoveryService.java
@@ -766,7 +766,7 @@ public class RecoveryService implements IService {
             byte certDer[] = cert.getEncoded();
 
             // XXX - should use JSS
-            MessageDigest md = MessageDigest.getInstance("SHA");
+            MessageDigest md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
             md.update(certDer);
             return md.digest();

--- a/base/ocsp/src/com/netscape/ocsp/OCSPAuthority.java
+++ b/base/ocsp/src/com/netscape/ocsp/OCSPAuthority.java
@@ -231,7 +231,7 @@ public class OCSPAuthority implements IOCSPAuthority, IOCSPService, ISubsystem, 
         MessageDigest md = null;
 
         try {
-            md = MessageDigest.getInstance("SHA1");
+            md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
             return null;
         }

--- a/base/server/src/com/netscape/cms/authentication/CMCAuth.java
+++ b/base/server/src/com/netscape/cms/authentication/CMCAuth.java
@@ -812,7 +812,7 @@ public class CMCAuth implements IAuthManager, IExtendedPluginInfo,
                         DigestAlgorithm.fromOID(dai.getOID()).toString();
 
                 MessageDigest md =
-                        MessageDigest.getInstance(name);
+                        MessageDigest.getInstance(name, "Mozilla-JSS");
 
                 byte[] digest = md.digest(content.toByteArray());
 
@@ -829,7 +829,7 @@ public class CMCAuth implements IAuthManager, IExtendedPluginInfo,
                 byte[] digest = digs.get(name);
 
                 if (digest == null) {
-                    MessageDigest md = MessageDigest.getInstance(name);
+                    MessageDigest md = MessageDigest.getInstance(name, "Mozilla-JSS");
                     ByteArrayOutputStream ostream = new ByteArrayOutputStream();
 
                     pkiData.encode(ostream);

--- a/base/server/src/com/netscape/cms/authentication/CMCUserSignedAuth.java
+++ b/base/server/src/com/netscape/cms/authentication/CMCUserSignedAuth.java
@@ -984,7 +984,7 @@ public class CMCUserSignedAuth implements IAuthManager, IExtendedPluginInfo,
                 AlgorithmIdentifier dai = (AlgorithmIdentifier) dais.elementAt(i);
                 String name = DigestAlgorithm.fromOID(dai.getOID()).toString();
 
-                MessageDigest md = MessageDigest.getInstance(name);
+                MessageDigest md = MessageDigest.getInstance(name, "Mozilla-JSS");
 
                 byte[] digest = md.digest(content.toByteArray());
 
@@ -1002,7 +1002,7 @@ public class CMCUserSignedAuth implements IAuthManager, IExtendedPluginInfo,
                 byte[] digest = digs.get(name);
 
                 if (digest == null) {
-                    MessageDigest md = MessageDigest.getInstance(name);
+                    MessageDigest md = MessageDigest.getInstance(name, "Mozilla-JSS");
                     ByteArrayOutputStream ostream = new ByteArrayOutputStream();
 
                     pkiData.encode(ostream);

--- a/base/server/src/com/netscape/cms/authentication/HashAuthentication.java
+++ b/base/server/src/com/netscape/cms/authentication/HashAuthentication.java
@@ -94,7 +94,7 @@ public class HashAuthentication implements IAuthManager, IExtendedPluginInfo {
         mHosts = new HashAuthData();
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
             throw new EAuthException(CMS.getUserMessage("CMS_AUTHENTICATION_INTERNAL_ERROR", e.getMessage()));
         }

--- a/base/server/src/com/netscape/cms/authentication/UidPwdPinDirAuthentication.java
+++ b/base/server/src/com/netscape/cms/authentication/UidPwdPinDirAuthentication.java
@@ -176,9 +176,9 @@ public class UidPwdPinDirAuthentication extends DirBasedAuthentication
         }
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
-            mMD5Digest = MessageDigest.getInstance("MD5");
-            mSHA256Digest = MessageDigest.getInstance("SHA256");
+            mSHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
+            mMD5Digest = MessageDigest.getInstance("MD5", "Mozilla-JSS");
+            mSHA256Digest = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
             throw new EAuthException(CMS.getUserMessage("CMS_AUTHENTICATION_INTERNAL_ERROR", e.getMessage()));
         }

--- a/base/server/src/com/netscape/cms/ocsp/DefStore.java
+++ b/base/server/src/com/netscape/cms/ocsp/DefStore.java
@@ -462,7 +462,7 @@ public class DefStore implements IDefStore, IExtendedPluginInfo {
                     throw e;
                 }
 
-                MessageDigest md = MessageDigest.getInstance(cid.getDigestName());
+                MessageDigest md = MessageDigest.getInstance(cid.getDigestName(), "Mozilla-JSS");
                 X509Key key = (X509Key) cert.getPublicKey();
                 byte digest[] = md.digest(key.getKey());
 

--- a/base/server/src/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/server/src/com/netscape/cms/ocsp/LDAPStore.java
@@ -486,7 +486,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
 
         while (caCerts.hasMoreElements()) {
             X509CertImpl caCert = caCerts.nextElement();
-            MessageDigest md = MessageDigest.getInstance(cid.getDigestName());
+            MessageDigest md = MessageDigest.getInstance(cid.getDigestName(), "Mozilla-JSS");
             X509Key key = (X509Key) caCert.getPublicKey();
 
             if (key == null) {

--- a/base/server/src/com/netscape/cms/profile/common/EnrollProfile.java
+++ b/base/server/src/com/netscape/cms/profile/common/EnrollProfile.java
@@ -610,7 +610,7 @@ public abstract class EnrollProfile extends Profile {
                 logger.debug(method + "now compute and set witness");
                 String hashName = CryptoUtil.getDefaultHashAlgName();
                 logger.debug(method + "hashName is " + hashName);
-                MessageDigest hash = MessageDigest.getInstance(hashName);
+                MessageDigest hash = MessageDigest.getInstance(hashName, "Mozilla-JSS");
                 byte[] witness = hash.digest(challenge);
                 req.setExtData("pop_witness", witness);
 
@@ -1370,7 +1370,7 @@ public abstract class EnrollProfile extends Profile {
                 return null;
             }
 
-            MessageDigest digest = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
+            MessageDigest digest = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName(), "Mozilla-JSS");
             if (digest == null) {
                 msg = method + "digest null after decryptUsingSymmetricKey returned";
                 logger.warn(msg);
@@ -1466,7 +1466,7 @@ public abstract class EnrollProfile extends Profile {
         byte[] verifyBytes = null;
         try {
             DigestAlgorithm keyGenAlgID = DigestAlgorithm.fromOID(keyGenAlg.getOID());
-            MessageDigest keyGenMDAlg = MessageDigest.getInstance(keyGenAlgID.toString());
+            MessageDigest keyGenMDAlg = MessageDigest.getInstance(keyGenAlgID.toString(), "Mozilla-JSS");
 
             HMACAlgorithm macAlgID = HMACAlgorithm.fromOID(macAlg.getOID());
             MessageDigest macMDAlg = MessageDigest
@@ -1708,7 +1708,7 @@ public abstract class EnrollProfile extends Profile {
     private boolean verifyDigest(byte[] sharedSecret, byte[] text, byte[] bv) {
         MessageDigest hashAlg;
         try {
-            hashAlg = MessageDigest.getInstance("SHA1");
+            hashAlg = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException ex) {
             logger.warn("EnrollProfile:verifyDigest: " + ex.getMessage(), ex);
             return false;
@@ -1885,7 +1885,7 @@ public abstract class EnrollProfile extends Profile {
                     ASN1Util.encode(vals.elementAt(0))));
 
             DigestAlgorithm hashAlgID = DigestAlgorithm.fromOID(idV2val.getHashAlgID().getOID());
-            MessageDigest hashAlg = MessageDigest.getInstance(hashAlgID.toString());
+            MessageDigest hashAlg = MessageDigest.getInstance(hashAlgID.toString(), "Mozilla-JSS");
 
             HMACAlgorithm macAlgId = HMACAlgorithm.fromOID(idV2val.getMacAlgId().getOID());
             MessageDigest macAlg = MessageDigest

--- a/base/server/src/com/netscape/cms/profile/input/FileSigningInput.java
+++ b/base/server/src/com/netscape/cms/profile/input/FileSigningInput.java
@@ -114,7 +114,7 @@ public class FileSigningInput extends EnrollInput {
             is.close();
 
             // calculate digest
-            MessageDigest digester = MessageDigest.getInstance("SHA256");
+            MessageDigest digester = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
             byte digest[] = digester.digest(data);
             request.setExtData(DIGEST, toHexString(digest));
         } catch (Exception e) {

--- a/base/server/src/com/netscape/cms/servlet/base/CMSServlet.java
+++ b/base/server/src/com/netscape/cms/servlet/base/CMSServlet.java
@@ -369,7 +369,7 @@ public abstract class CMSServlet extends HttpServlet {
         }
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
             logger.error(CMS.getLogMessage("CMSGW_ERR_CONF_TEMP_PARAMS", e.toString()), e);
             throw new ServletException(e);

--- a/base/server/src/com/netscape/cms/servlet/common/CMCOutputTemplate.java
+++ b/base/server/src/com/netscape/cms/servlet/common/CMCOutputTemplate.java
@@ -633,7 +633,7 @@ public class CMCOutputTemplate {
             MessageDigest msgDigest = null;
             byte[] digest = null;
 
-            msgDigest = MessageDigest.getInstance(digestAlg.toString());
+            msgDigest = MessageDigest.getInstance(digestAlg.toString(), "Mozilla-JSS");
 
             ByteArrayOutputStream ostream = new ByteArrayOutputStream();
 
@@ -929,7 +929,7 @@ public class CMCOutputTemplate {
                 String salt = "lala123" + date.toString();
                 byte[] dig;
                 try {
-                    MessageDigest SHA2Digest = MessageDigest.getInstance("SHA256");
+                    MessageDigest SHA2Digest = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
                     dig = SHA2Digest.digest(salt.getBytes());
                 } catch (NoSuchAlgorithmException ex) {
                     dig = salt.getBytes();
@@ -1513,7 +1513,7 @@ public class CMCOutputTemplate {
             for (int i = 0; i < numDig; i++) {
                 AlgorithmIdentifier dai = (AlgorithmIdentifier) dias.elementAt(i);
                 String name = DigestAlgorithm.fromOID(dai.getOID()).toString();
-                MessageDigest md = MessageDigest.getInstance(name);
+                MessageDigest md = MessageDigest.getInstance(name, "Mozilla-JSS");
                 byte[] digest = md.digest(content.toByteArray());
                 digs.put(name, digest);
             }
@@ -1525,7 +1525,7 @@ public class CMCOutputTemplate {
                 String name = si.getDigestAlgorithm().toString();
                 byte[] digest = digs.get(name);
                 if (digest == null) {
-                    MessageDigest md = MessageDigest.getInstance(name);
+                    MessageDigest md = MessageDigest.getInstance(name, "Mozilla-JSS");
                     ByteArrayOutputStream ostream = new ByteArrayOutputStream();
                     revRequest.encode(ostream);
                     digest = md.digest(ostream.toByteArray());

--- a/base/server/src/com/netscape/cms/servlet/common/GenPendingTemplateFiller.java
+++ b/base/server/src/com/netscape/cms/servlet/common/GenPendingTemplateFiller.java
@@ -160,7 +160,7 @@ public class GenPendingTemplateFiller implements ICMSTemplateFiller {
                 byte[] dig;
 
                 try {
-                    MessageDigest SHA2Digest = MessageDigest.getInstance("SHA256");
+                    MessageDigest SHA2Digest = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
 
                     dig = SHA2Digest.digest(salt.getBytes());
                 } catch (NoSuchAlgorithmException ex) {
@@ -220,7 +220,7 @@ public class GenPendingTemplateFiller implements ICMSTemplateFiller {
                     byte[] digest = null;
 
                     try {
-                        SHADigest = MessageDigest.getInstance("SHA256");
+                        SHADigest = MessageDigest.getInstance("SHA-256", "Mozilla-JSS");
                         digestAlg = DigestAlgorithm.SHA256;
 
                         ByteArrayOutputStream ostream = new ByteArrayOutputStream();

--- a/base/server/src/com/netscape/cms/servlet/processors/CMCProcessor.java
+++ b/base/server/src/com/netscape/cms/servlet/processors/CMCProcessor.java
@@ -212,7 +212,7 @@ public class CMCProcessor extends PKIProcessor {
                         DigestAlgorithm.fromOID(dai.getOID()).toString();
 
                 MessageDigest md =
-                        MessageDigest.getInstance(name);
+                        MessageDigest.getInstance(name, "Mozilla-JSS");
 
                 byte[] digest = md.digest(content.toByteArray());
 
@@ -231,7 +231,7 @@ public class CMCProcessor extends PKIProcessor {
                 byte[] digest = digs.get(name);
 
                 if (digest == null) {
-                    MessageDigest md = MessageDigest.getInstance(name);
+                    MessageDigest md = MessageDigest.getInstance(name, "Mozilla-JSS");
                     ByteArrayOutputStream ostream = new ByteArrayOutputStream();
 
                     pkiData.encode(ostream);
@@ -296,7 +296,7 @@ public class CMCProcessor extends PKIProcessor {
                         X509Key subjectKeyInfo =
                                 (X509Key) ((CertificateX509Key) certInfoArray[j].get(X509CertInfo.KEY))
                                         .get(CertificateX509Key.KEY);
-                        MessageDigest md = MessageDigest.getInstance("SHA-1");
+                        MessageDigest md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
                         md.update(subjectKeyInfo.getEncoded());
                         byte[] skib = md.digest();

--- a/base/server/src/com/netscape/cms/servlet/request/CheckRequest.java
+++ b/base/server/src/com/netscape/cms/servlet/request/CheckRequest.java
@@ -456,7 +456,7 @@ public class CheckRequest extends CMSServlet {
                                         byte[] dig;
 
                                         try {
-                                            MessageDigest SHA1Digest = MessageDigest.getInstance("SHA1");
+                                            MessageDigest SHA1Digest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
                                             dig = SHA1Digest.digest(salt.getBytes());
                                         } catch (NoSuchAlgorithmException ex) {
@@ -515,7 +515,7 @@ public class CheckRequest extends CMSServlet {
                                         byte[] digest = null;
 
                                         try {
-                                            SHADigest = MessageDigest.getInstance("SHA1");
+                                            SHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
                                             digestAlg = DigestAlgorithm.SHA1;
                                             ByteArrayOutputStream ostream = new ByteArrayOutputStream();
 

--- a/base/server/src/com/netscape/cmscore/authentication/ChallengePhraseAuthentication.java
+++ b/base/server/src/com/netscape/cmscore/authentication/ChallengePhraseAuthentication.java
@@ -112,7 +112,7 @@ public class ChallengePhraseAuthentication implements IAuthManager {
         mConfig = config;
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
         } catch (NoSuchAlgorithmException e) {
             throw new EAuthException(CMS.getUserMessage("CMS_AUTHENTICATION_INTERNAL_ERROR", e.getMessage()), e);

--- a/base/server/src/com/netscape/cmscore/cert/CertUtils.java
+++ b/base/server/src/com/netscape/cmscore/cert/CertUtils.java
@@ -818,7 +818,7 @@ public class CertUtils {
     public static String getFingerPrint(Certificate cert)
             throws CertificateEncodingException, NoSuchAlgorithmException {
         byte certDer[] = cert.getEncoded();
-        MessageDigest md = MessageDigest.getInstance("MD5");
+        MessageDigest md = MessageDigest.getInstance("MD5", "Mozilla-JSS");
 
         md.update(certDer);
         byte digestedCert[] = md.digest();
@@ -856,7 +856,7 @@ public class CertUtils {
         PrettyPrintFormat pp = new PrettyPrintFormat(":");
 
         for (int i = 0; i < hashes.length; i++) {
-            MessageDigest md = MessageDigest.getInstance(hashes[i]);
+            MessageDigest md = MessageDigest.getInstance(hashes[i], "Mozilla-JSS");
 
             md.update(certDer);
             certFingerprints += "    " + hashes[i] + ":" +
@@ -893,7 +893,7 @@ public class CertUtils {
         PrettyPrintFormat pp = new PrettyPrintFormat(":");
 
         for (int i = 0; i < hashes.length; i++) {
-            MessageDigest md = MessageDigest.getInstance(hashes[i]);
+            MessageDigest md = MessageDigest.getInstance(hashes[i], "Mozilla-JSS");
 
             md.update(certDer);
             certFingerprints.append(hashes[i] + ":\n" +

--- a/base/server/src/com/netscape/cmscore/util/PFXUtils.java
+++ b/base/server/src/com/netscape/cmscore/util/PFXUtils.java
@@ -124,7 +124,7 @@ public class PFXUtils {
             throws EBaseException {
         try {
             byte certDer[] = cert.getEncoded();
-            MessageDigest md = MessageDigest.getInstance("SHA");
+            MessageDigest md = MessageDigest.getInstance("SHA", "Mozilla-JSS");
 
             md.update(certDer);
             return md.digest();

--- a/base/server/src/org/dogtagpki/legacy/server/policy/APolicyRule.java
+++ b/base/server/src/org/dogtagpki/legacy/server/policy/APolicyRule.java
@@ -245,7 +245,7 @@ public abstract class APolicyRule implements IPolicyRule {
 
     public static KeyIdentifier createKeyIdentifier(X509Key key)
             throws NoSuchAlgorithmException, InvalidKeyException {
-        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        MessageDigest md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
         md.update(key.getEncoded());
         return new KeyIdentifier(md.digest());
@@ -322,7 +322,7 @@ public abstract class APolicyRule implements IPolicyRule {
             }
             byte[] rawKey = key.getKey();
 
-            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            MessageDigest md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
             md.update(rawKey);
             keyId = new KeyIdentifier(md.digest());

--- a/base/server/src/org/dogtagpki/legacy/server/policy/extensions/SubjectKeyIdentifierExt.java
+++ b/base/server/src/org/dogtagpki/legacy/server/policy/extensions/SubjectKeyIdentifierExt.java
@@ -313,7 +313,7 @@ public class SubjectKeyIdentifierExt extends APolicyRule
         }
         try {
             byte[] octetString = new byte[8];
-            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            MessageDigest md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
             md.update(key.getKey());
             byte[] hash = md.digest();

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
@@ -3749,7 +3749,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
 
         java.security.MessageDigest mozillaDigest;
         try {
-            mozillaDigest = java.security.MessageDigest.getInstance(alg);
+            mozillaDigest = java.security.MessageDigest.getInstance(alg, "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
             throw new TPSException("TPSEnrollProcessor.makeKeyIDFromPublicKeyInfo: " + e,
                     TPSStatus.STATUS_ERROR_MAC_ENROLL_PDU);

--- a/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -1539,7 +1539,7 @@ public class CryptoUtil {
             alg = "SHA-1";
         }
         try {
-            MessageDigest md = MessageDigest.getInstance(alg);
+            MessageDigest md = MessageDigest.getInstance(alg, "Mozilla-JSS");
 
             md.update(rawKey);
             byte[] hash = md.digest();

--- a/base/util/src/com/netscape/cmsutil/ocsp/OCSPProcessor.java
+++ b/base/util/src/com/netscape/cmsutil/ocsp/OCSPProcessor.java
@@ -98,7 +98,7 @@ public class OCSPProcessor {
     public OCSPRequest createRequest(X500Name issuerName, X509Key issuerKey, BigInteger serialNumber)
             throws Exception {
 
-        MessageDigest md = MessageDigest.getInstance("SHA");
+        MessageDigest md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
         // calculate hashes
         byte issuerNameHash[] = md.digest(issuerName.getEncoded());

--- a/base/util/src/com/netscape/cmsutil/radius/RequestAuthenticator.java
+++ b/base/util/src/com/netscape/cmsutil/radius/RequestAuthenticator.java
@@ -31,7 +31,7 @@ public class RequestAuthenticator extends Authenticator {
 
         rand.nextBytes(authenticator);
 
-        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        MessageDigest md5 = MessageDigest.getInstance("MD5", "Mozilla-JSS");
 
         md5.update(authenticator);
         md5.update(secret.getBytes());

--- a/base/util/src/com/netscape/cmsutil/radius/UserPasswordAttribute.java
+++ b/base/util/src/com/netscape/cmsutil/radius/UserPasswordAttribute.java
@@ -41,7 +41,7 @@ public class UserPasswordAttribute extends Attribute {
         MessageDigest md5 = null;
 
         try {
-            md5 = MessageDigest.getInstance("MD5");
+            md5 = MessageDigest.getInstance("MD5", "Mozilla-JSS");
         } catch (NoSuchAlgorithmException e) {
             throw new IOException(e.getMessage());
         }

--- a/tests/dogtag/shared/java/ca/ca_ee_ocspRequest.java
+++ b/tests/dogtag/shared/java/ca/ca_ee_ocspRequest.java
@@ -62,7 +62,7 @@ public class ca_ee_ocspRequest
                 {
                         CryptoManager manager = CryptoManager.getInstance();
                         cert = manager.findCertByNickname(ca_cert_nickname);
-                        MessageDigest md = MessageDigest.getInstance("SHA");
+                        MessageDigest md = MessageDigest.getInstance("SHA-1", "Mozilla-JSS");
 
                         // calculate issuer key hash
                         X509CertImpl x509Cert = new X509CertImpl(cert.getEncoded());


### PR DESCRIPTION
When using the Java provider API, explicitly select the Mozilla JSS
provider. This prevents using a non-FIPS-validated provider if JSS is
not the default, and also protects us from other providers clobbering
the default.

@edewata I think this was something we talked about adding sometime in the past. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`