### PR TITLE
Migrate away from deployer.* to pki.util.* in pkidestroy

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/infrastructure_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/infrastructure_layout.py
@@ -25,6 +25,7 @@ import logging
 # PKI Deployment Imports
 from .. import pkiconfig as config
 from .. import pkiscriptlet
+import pki.util
 
 logger = logging.getLogger('infrastructure')
 
@@ -123,7 +124,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         if deployer.mdict['pki_path'] != "/var/lib/pki":
             # remove relocated top-level infrastructure base
-            deployer.directory.delete(deployer.mdict['pki_path'])
+            pki.util.rmtree(deployer.mdict['pki_path'],
+                            deployer.mdict['pki_force_destroy'])
 
         # do NOT remove top-level infrastructure logs
         # since it now stores 'pkispawn'/'pkidestroy' logs
@@ -135,5 +137,6 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             deployer.mdict['pki_configuration_path'] != \
                 config.PKI_DEPLOYMENT_CONFIGURATION_ROOT:
 
-            deployer.directory.delete(
-                deployer.mdict['pki_configuration_path'])
+            pki.util.rmtree(
+                deployer.mdict['pki_configuration_path'],
+                deployer.mdict['pki_force_destroy'])

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -25,6 +25,7 @@ import os
 
 import pki
 import pki.server.instance
+import pki.util
 
 # PKI Deployment Imports
 from .. import pkiconfig as config
@@ -276,28 +277,40 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         logger.info('Removing %s instance', deployer.mdict['pki_instance_name'])
 
         # remove Tomcat instance systemd service link
-        deployer.symlink.delete(deployer.systemd.systemd_link)
+        pki.util.unlink(link=deployer.systemd.systemd_link,
+                        force=deployer.mdict['pki_force_destroy'])
 
         # delete systemd override directories
         if deployer.directory.exists(deployer.systemd.base_override_dir):
-            deployer.directory.delete(deployer.systemd.base_override_dir)
+            pki.util.rmtree(path=deployer.systemd.base_override_dir,
+                            force=deployer.mdict['pki_force_destroy'])
         if deployer.directory.exists(deployer.systemd.nuxwdog_override_dir):
-            deployer.directory.delete(deployer.systemd.nuxwdog_override_dir)
+            pki.util.rmtree(path=deployer.systemd.nuxwdog_override_dir,
+                            force=deployer.mdict['pki_force_destroy'])
+
         deployer.systemd.daemon_reload()
 
         # remove Tomcat instance base
-        deployer.directory.delete(deployer.mdict['pki_instance_path'])
+        pki.util.rmtree(path=deployer.mdict['pki_instance_path'],
+                        force=deployer.mdict['pki_force_destroy'])
 
         # remove Tomcat instance logs only if --remove-logs is specified
         if deployer.mdict['pki_remove_logs']:
-            deployer.directory.delete(deployer.mdict['pki_instance_log_path'])
+            pki.util.rmtree(path=deployer.mdict['pki_instance_log_path'],
+                            force=deployer.mdict['pki_force_destroy'])
 
         # remove Tomcat instance configuration
-        deployer.directory.delete(
-            deployer.mdict['pki_instance_configuration_path'])
+        pki.util.rmtree(
+            path=deployer.mdict['pki_instance_configuration_path'],
+            force=deployer.mdict['pki_force_destroy']
+        )
         # remove PKI 'tomcat.conf' instance file
-        deployer.file.delete(
-            deployer.mdict['pki_target_tomcat_conf_instance_id'])
+        pki.util.remove(
+            path=deployer.mdict['pki_target_tomcat_conf_instance_id'],
+            force=deployer.mdict['pki_force_destroy']
+        )
         # remove Tomcat instance registry
-        deployer.directory.delete(
-            deployer.mdict['pki_instance_registry_path'])
+        pki.util.rmtree(
+            path=deployer.mdict['pki_instance_registry_path'],
+            force=deployer.mdict['pki_force_destroy']
+        )

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -365,10 +365,13 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         if deployer.directory.exists(deployer.mdict['pki_client_dir']):
             logger.info('Removing %s', deployer.mdict['pki_client_dir'])
-            pki.util.rmtree(deployer.mdict['pki_client_dir'])
+            pki.util.rmtree(deployer.mdict['pki_client_dir'],
+                            deployer.mdict['pki_force_destroy'])
 
         logger.info('Removing %s', deployer.mdict['pki_server_database_path'])
-        pki.util.rmtree(deployer.mdict['pki_server_database_path'])
+        pki.util.rmtree(deployer.mdict['pki_server_database_path'],
+                        deployer.mdict['pki_force_destroy'])
 
         logger.info('Removing %s', deployer.mdict['pki_shared_password_conf'])
-        pki.util.remove(deployer.mdict['pki_shared_password_conf'])
+        pki.util.remove(deployer.mdict['pki_shared_password_conf'],
+                        deployer.mdict['pki_force_destroy'])

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -23,6 +23,7 @@ import logging
 
 import pki.server
 import pki.server.instance
+import pki.util
 
 # PKI Deployment Imports
 from .. import pkiconfig as config
@@ -192,23 +193,39 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         # remove instance-based subsystem base
         if deployer.mdict['pki_subsystem'] == "CA":
-            deployer.directory.delete(
-                deployer.mdict['pki_subsystem_emails_path'])
-            deployer.directory.delete(
-                deployer.mdict['pki_subsystem_profiles_path'])
-        deployer.directory.delete(deployer.mdict['pki_subsystem_path'])
+            pki.util.rmtree(
+                path=deployer.mdict['pki_subsystem_emails_path'],
+                force=deployer.mdict['pki_force_destroy']
+            )
+            pki.util.rmtree(
+                path=deployer.mdict['pki_subsystem_profiles_path'],
+                force=deployer.mdict['pki_force_destroy']
+            )
+        pki.util.rmtree(path=deployer.mdict['pki_subsystem_path'],
+                        force=deployer.mdict['pki_force_destroy'])
+
         # remove instance-based subsystem logs only if --remove-logs flag is specified
         if deployer.mdict['pki_remove_logs']:
-            deployer.directory.delete(
-                deployer.mdict['pki_subsystem_signed_audit_log_path'])
-            deployer.directory.delete(
-                deployer.mdict['pki_subsystem_archive_log_path'])
-            deployer.directory.delete(
-                deployer.mdict['pki_subsystem_log_path'])
+            pki.util.rmtree(
+                path=deployer.mdict['pki_subsystem_signed_audit_log_path'],
+                force=deployer.mdict['pki_force_destroy']
+            )
+            pki.util.rmtree(
+                path=deployer.mdict['pki_subsystem_archive_log_path'],
+                force=deployer.mdict['pki_force_destroy']
+            )
+            pki.util.rmtree(
+                path=deployer.mdict['pki_subsystem_log_path'],
+                force=deployer.mdict['pki_force_destroy']
+            )
 
         # remove instance-based subsystem configuration
-        deployer.directory.delete(
-            deployer.mdict['pki_subsystem_configuration_path'])
+        pki.util.rmtree(
+            path=deployer.mdict['pki_subsystem_configuration_path'],
+            force=deployer.mdict['pki_force_destroy']
+        )
         # remove instance-based subsystem registry
-        deployer.directory.delete(
-            deployer.mdict['pki_subsystem_registry_path'])
+        pki.util.rmtree(
+            path=deployer.mdict['pki_subsystem_registry_path'],
+            force=deployer.mdict['pki_force_destroy']
+        )

--- a/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
+++ b/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
@@ -25,6 +25,7 @@ import os
 
 import pki
 import pki.server.instance
+import pki.util
 
 # PKI Deployment Imports
 from .. import pkiconfig as config
@@ -71,9 +72,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         logger.info('Undeploying /%s web application', deployer.mdict['pki_subsystem'].lower())
 
         # Delete <instance>/Catalina/localhost/<subsystem>.xml
-        deployer.file.delete(
-            os.path.join(
+        pki.util.remove(
+            path=os.path.join(
                 deployer.mdict['pki_instance_configuration_path'],
                 "Catalina",
                 "localhost",
-                deployer.mdict['pki_subsystem'].lower() + ".xml"))
+                deployer.mdict['pki_subsystem'].lower() + ".xml"),
+            force=deployer.mdict['pki_force_destroy']
+        )


### PR DESCRIPTION
Since `pki.util.*` is more generic, this patch migrates pkidestroy
deployment scriptlets to use

````
- pki.util.rmtree() instead of deployer.directory.delete()
- pki.util.unline() instead of deployer.{file|symlink}.delete()
````

Question: Do we need to backport this to `v10.8`?

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>