### PR TITLE
Build PKI in %build, not %install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
 project(pki)
 
 # Required cmake version
-cmake_minimum_required(VERSION 2.6.0)
+cmake_minimum_required(VERSION 3.0.0)
 
 # global needed variables
 set(APPLICATION_NAME ${PROJECT_NAME})
+
+# Skip recompiling when already compiled
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
 
 # Suppress install messages
 set(CMAKE_INSTALL_MESSAGE NEVER)

--- a/pki.spec
+++ b/pki.spec
@@ -834,12 +834,6 @@ cd build
     -DTHEME=%{?with_theme:%{vendor_id}} \
     ..
 
-################################################################################
-%install
-################################################################################
-
-cd build
-
 # Do not use _smp_mflags to preserve build order
 %{__make} \
     VERBOSE=%{?_verbose} \
@@ -847,7 +841,21 @@ cd build
     DESTDIR=%{buildroot} \
     INSTALL="install -p" \
     --no-print-directory \
-    all install
+    all
+
+################################################################################
+%install
+################################################################################
+
+cd build
+
+%{__make} \
+    VERBOSE=%{?_verbose} \
+    CMAKE_NO_VERBOSE=1 \
+    DESTDIR=%{buildroot} \
+    INSTALL="install -p" \
+    --no-print-directory \
+    install
 
 %if %{with_test}
 ctest --output-on-failure


### PR DESCRIPTION
We build PKI in the `%install` section of the RPM Spec file currently; we
should move the build to the `%build` section so tooling works correctly.

Resolves: [`rh-bz#1792252`](https://bugzilla.redhat.com/show_bug.cgi?id=1792252)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`


I'm opening this PR to begin a discussion: this **does not work**.

In particular, while the build is successful, if you check the logs, it builds PKI **twice**!

To me this indicates a fundamental problem with the CMake build scripts: Make has no way of detecting if something needs to get rebuilt and so it does.

But I also don't know how this project's CMake scripts are set up or where to begin fixing this.

Endi, do you have any thoughts? 