### PR TITLE
getPasswordStore(): extract to IPasswordStore

### DIFF
--- a/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
@@ -186,33 +186,14 @@ public class CMSEngine {
         return instanceDir;
     }
 
-    public static IPasswordStore getPasswordStore(String id, PropConfigStore cs)
-            throws EBaseException {
-        String pwdClass = null;
-        String pwdPath = null;
-
-        if (NuxwdogUtil.startedByNuxwdog()) {
-            pwdClass = NuxwdogPasswordStore.class.getName();
-            // note: pwdPath is expected to be null in this case
-        } else {
-            pwdClass = cs.getString("passwordClass");
-            pwdPath = cs.getString("passwordFile", null);
-        }
-
-        try {
-            IPasswordStore ps = (IPasswordStore) Class.forName(pwdClass).newInstance();
-            ps.init(pwdPath);
-            ps.setId(id);
-            return ps;
-        } catch (Exception e) {
-            logger.error("Cannot get password store: " + e);
-            throw new EBaseException(e);
-        }
-    }
-
     public synchronized IPasswordStore getPasswordStore() throws EBaseException {
         if (mPasswordStore == null) {
-            mPasswordStore = getPasswordStore(instanceId, mConfig);
+            try {
+                mPasswordStore =
+                    IPasswordStore.getPasswordStore(instanceId, mConfig.getProperties());
+            } catch (Exception e) {
+                throw new EBaseException("Failed to initialise password store", e);
+            }
         }
         return mPasswordStore;
     }

--- a/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
@@ -98,6 +98,7 @@ import com.netscape.cmscore.util.Debug;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 import com.netscape.cmsutil.password.IPasswordStore;
 import com.netscape.cmsutil.password.NuxwdogPasswordStore;
+import com.netscape.cmsutil.util.NuxwdogUtil;
 
 import netscape.ldap.LDAPConnection;
 import netscape.ldap.LDAPException;
@@ -185,20 +186,12 @@ public class CMSEngine {
         return instanceDir;
     }
 
-    public static boolean startedByNuxwdog() {
-        String wdPipeName = System.getenv("WD_PIPE_NAME");
-        if (StringUtils.isNotEmpty(wdPipeName)) {
-            return true;
-        }
-        return false;
-    }
-
     public static IPasswordStore getPasswordStore(String id, PropConfigStore cs)
             throws EBaseException {
         String pwdClass = null;
         String pwdPath = null;
 
-        if (startedByNuxwdog()) {
+        if (NuxwdogUtil.startedByNuxwdog()) {
             pwdClass = NuxwdogPasswordStore.class.getName();
             // note: pwdPath is expected to be null in this case
         } else {
@@ -1195,7 +1188,7 @@ public class CMSEngine {
             cmds = new String[3];
             cmds[0] = "/usr/bin/systemctl";
             cmds[1] = cmd;
-            if (startedByNuxwdog()) {
+            if (NuxwdogUtil.startedByNuxwdog()) {
                 cmds[2] = "pki-tomcatd-nuxwdog@" + instanceId + ".service";
             } else {
                 cmds[2] = "pki-tomcatd@" + instanceId + ".service";

--- a/base/server/tomcat/src/com/netscape/cms/tomcat/NuxwdogPasswordStore.java
+++ b/base/server/tomcat/src/com/netscape/cms/tomcat/NuxwdogPasswordStore.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang.StringUtils;
 
 import com.netscape.cmsutil.crypto.CryptoUtil;
 import com.netscape.cmsutil.util.Keyring;
+import com.netscape.cmsutil.util.NuxwdogUtil;
 
 public class NuxwdogPasswordStore implements org.apache.tomcat.util.net.jss.IPasswordStore {
 
@@ -26,7 +27,7 @@ public class NuxwdogPasswordStore implements org.apache.tomcat.util.net.jss.IPas
 
     @Override
     public void init(String confFile) throws IOException {
-        if (!startedByNuxwdog()) {
+        if (!NuxwdogUtil.startedByNuxwdog()) {
             throw new IOException("process not started by nuxwdog");
         }
 
@@ -37,16 +38,6 @@ public class NuxwdogPasswordStore implements org.apache.tomcat.util.net.jss.IPas
         }
 
         pwCache = new Hashtable<String, String>();
-    }
-
-    private boolean startedByNuxwdog() {
-        // confirm that process was started by nuxwdog
-        String wdPipeName = System.getenv("WD_PIPE_NAME");
-        if (StringUtils.isNotEmpty(wdPipeName)) {
-            return true;
-        }
-        return false;
-
     }
 
     /**

--- a/base/util/src/com/netscape/cmsutil/password/IPasswordStore.java
+++ b/base/util/src/com/netscape/cmsutil/password/IPasswordStore.java
@@ -19,8 +19,48 @@ package com.netscape.cmsutil.password;
 
 import java.io.IOException;
 import java.util.Enumeration;
+import java.util.Map;
+
+import com.netscape.cmsutil.util.NuxwdogUtil;
 
 public interface IPasswordStore {
+
+    /** Construct a password store.
+     *
+     * If the process was started by Nuxwdog return a NuxwdogPasswordStore.
+     * Otherwise the class name is read from the "passwordClass" key in the
+     * map, an instance is constructed, its init() method is called with the
+     * value of the "passwordFile" key in the map, and the instance is
+     * returned.
+     */
+    public static IPasswordStore getPasswordStore(String id, Map<String, String> kv)
+            throws RuntimeException {
+        String pwdClass = null;
+        String pwdPath = null;
+
+        if (NuxwdogUtil.startedByNuxwdog()) {
+            pwdClass = NuxwdogPasswordStore.class.getName();
+            // note: pwdPath is expected to be null in this case
+        } else {
+            pwdClass = kv.get("passwordClass");
+            if (pwdClass == null) {
+                throw new RuntimeException(
+                    "IPasswordStore.getPasswordStore: passwordClass not defined");
+            }
+
+            pwdPath = kv.get("passwordFile");
+        }
+
+        try {
+            IPasswordStore ps = (IPasswordStore) Class.forName(pwdClass).newInstance();
+            ps.init(pwdPath);
+            ps.setId(id);
+            return ps;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to construct or initialise password store", e);
+        }
+    }
+
     public void init(String pwdPath) throws IOException;
 
     public String getPassword(String tag, int iteration);

--- a/base/util/src/com/netscape/cmsutil/password/NuxwdogPasswordStore.java
+++ b/base/util/src/com/netscape/cmsutil/password/NuxwdogPasswordStore.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang.StringUtils;
 
 import com.netscape.cmsutil.crypto.CryptoUtil;
 import com.netscape.cmsutil.util.Keyring;
+import com.netscape.cmsutil.util.NuxwdogUtil;
 
 public class NuxwdogPasswordStore implements IPasswordStore {
 
@@ -26,7 +27,7 @@ public class NuxwdogPasswordStore implements IPasswordStore {
 
     @Override
     public void init(String confFile) throws IOException {
-        if (!startedByNuxwdog()) {
+        if (!NuxwdogUtil.startedByNuxwdog()) {
             throw new IOException("process not started by nuxwdog");
         }
 
@@ -37,16 +38,6 @@ public class NuxwdogPasswordStore implements IPasswordStore {
         }
 
         pwCache = new Hashtable<String, String>();
-    }
-
-    private boolean startedByNuxwdog() {
-        // confirm that process was started by nuxwdog
-        String wdPipeName = System.getenv("WD_PIPE_NAME");
-        if (StringUtils.isNotEmpty(wdPipeName)) {
-            return true;
-        }
-        return false;
-
     }
 
     /**

--- a/base/util/src/com/netscape/cmsutil/util/NuxwdogUtil.java
+++ b/base/util/src/com/netscape/cmsutil/util/NuxwdogUtil.java
@@ -1,0 +1,33 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2020 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package com.netscape.cmsutil.util;
+
+import org.apache.commons.lang.StringUtils;
+
+public class NuxwdogUtil {
+
+    public static boolean startedByNuxwdog() {
+        String wdPipeName = System.getenv("WD_PIPE_NAME");
+        if (StringUtils.isNotEmpty(wdPipeName)) {
+            return true;
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
Refactors in response to @edewata's review feedback in
https://github.com/dogtagpki/pki/pull/334#discussion_r385438719.

Changes:

```
767ce3540 (Fraser Tweedale, 18 minutes ago)
   getPasswordStore(): extract to IPasswordStore

   The ACME LDAP database driver needs an IPasswordStore.  But we don't want
   to depend on CMSEngine, where getPasswordStore() is defined.

   So extract getPasswordStore() to a static method on the IPasswordStore
   interface.  (Static methods on interfaces are supported since Java 8). 
   This requires one small change: cmsutil does not depend on on cmscore so
   the config store must be passed as a Map<String, String> instead of a
   PropConfigStore.

457067f8a (Fraser Tweedale, 20 minutes ago)
   startedByNuxwdog(): extract common code to class

   Several classes have duplicated the startedByNuxwdog subroutine. Extract it
   to a utility class.
```