### PR TITLE
ACME: process all associated pending orders on authz finalisation

### DIFF
--- a/base/acme/conf/database/postgresql/statements.conf
+++ b/base/acme/conf/database/postgresql/statements.conf
@@ -92,13 +92,13 @@ FROM \
 WHERE \
     "order_id" = ?
 
-getOrderByAuthorization=\
+getOrdersByAuthorizationAndStatus=\
 SELECT \
     o."id", o."account_id", o."status", o."expires", o."not_before", o."not_after", o."cert_id" \
 FROM \
     "orders" o, "order_authorizations" oa \
 WHERE \
-    o."id" = oa."order_id" AND oa."authz_id" = ?
+    o."id" = oa."order_id" AND oa."authz_id" = ? AND o."status" = ?
 
 addOrder=\
 INSERT INTO \

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
@@ -5,6 +5,7 @@
 //
 package org.dogtagpki.acme.database;
 
+import java.util.Collection;
 import java.util.Date;
 
 import org.dogtagpki.acme.ACMEAccount;
@@ -42,7 +43,10 @@ public abstract class ACMEDatabase {
     public abstract void updateAccount(ACMEAccount account) throws Exception;
 
     public abstract ACMEOrder getOrder(String orderID) throws Exception;
-    public abstract ACMEOrder getOrderByAuthorization(String authzID) throws Exception;
+    public abstract Collection<ACMEOrder> getOrdersByAuthorizationAndStatus(
+            String authzID,
+            String status)
+        throws Exception;
     public abstract void addOrder(ACMEOrder order) throws Exception;
     public abstract void updateOrder(ACMEOrder order) throws Exception;
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
@@ -5,8 +5,10 @@
 //
 package org.dogtagpki.acme.database;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
+import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.dogtagpki.acme.ACMEAccount;
@@ -57,7 +59,10 @@ public class InMemoryDatabase extends ACMEDatabase {
         return orders.get(orderID);
     }
 
-    public ACMEOrder getOrderByAuthorization(String authzID) throws Exception {
+    public Collection<ACMEOrder> getOrdersByAuthorizationAndStatus(
+            String authzID, String status) throws Exception {
+        Vector<ACMEOrder> l = new Vector<>();
+
         for (ACMEOrder order : orders.values()) {
 
             if (order.getAuthzIDs() == null) {
@@ -65,13 +70,13 @@ public class InMemoryDatabase extends ACMEDatabase {
             }
 
             for (String orderAuthzID : order.getAuthzIDs()) {
-                if (!orderAuthzID.equals(authzID)) continue;
-
-                return order;
+                if (orderAuthzID.equals(authzID) && order.getStatus() == "pending") {
+                    l.add(order);
+                }
             }
         }
 
-        return null;
+        return l;
     }
 
     public void addOrder(ACMEOrder order) throws Exception {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -606,10 +606,13 @@ public class ACMEEngine implements ServletContextListener {
         return order;
     }
 
-    public ACMEOrder getOrderByAuthorization(ACMEAccount account, String authzID) throws Exception {
-        ACMEOrder order = database.getOrderByAuthorization(authzID);
-        validateOrder(account, order);
-        return order;
+    public Collection<ACMEOrder> getOrdersByAuthorizationAndStatus(
+            ACMEAccount account, String authzID, String status)
+            throws Exception {
+        Collection<ACMEOrder> orders = database.getOrdersByAuthorizationAndStatus(authzID, status);
+        // remove orders that are expired or don't match the account ID
+        orders.removeIf(o -> checkOrder(account, o) != CheckOrderResult.OrderAccessOK);
+        return orders;
     }
 
     public void updateOrder(ACMEAccount account, ACMEOrder order) throws Exception {


### PR DESCRIPTION
See discussion: https://github.com/dogtagpki/pki/pull/334#discussion_r385739687

Changes:

```
3c1618f01 (Fraser Tweedale, 12 minutes ago)
   ACME: process all associated pending orders on authz finalisation

   In the ACME data model an authorization may be associated with zero, one or
   multiple orders.  So when finalising an authorization, we should process
   *all* pending orders associated with the completed authorisation, to see if
   those orders are now also complete (i.e. all authorisations have been
   completed).

   To implement this, change the "get order by authz" methods to return a
   Collection of orders, and update the ACMEChallengeService to process all
   returned orders.

d664b9dec (Fraser Tweedale, 15 minutes ago)
   ACMEEngine: extract order checks to method

   ACMEEngine.validateOrder() throws an execption if something is wrong with
   the order (e.g. order does not match account ID, or order is expired).  But
   it is useful to have a variation that does not throw an exception and just
   returns the check result as a value.

   Extract this logic to the 'checkOrder()' method.
```