### PR TITLE
ACMEAuthorizationService: handle empty list of challenges

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAuthorizationService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAuthorizationService.java
@@ -79,7 +79,7 @@ public class ACMEAuthorizationService {
 
         Collection<ACMEChallenge> challenges = authorization.getChallenges();
 
-        if (challenges == null) {
+        if (challenges == null || challenges.size() <= 0) {
             logger.info("Creating new challenges");
             challenges = new ArrayList<>();
 


### PR DESCRIPTION
ACMEAuthorizationService creates challenges for an ACMEAuthorization
if .getChallenges() == null.  But the return type of
ACMEAuthorization.getChallenges is Collection<ACMEChallenge>, so it
is reasonble (and arguably more correct and safer) for the database
implementation that loads the authorisation object to set an empty
list of challenges, if there are no challenges, rather than leaving
it as null.

Indeed, that is what the forthcoming LDAP database implementation
does.  And that has exposed this bug, i.e. that although 'null' is
handled, and empty list is not, resulting in issuance failure (the
order cannot be finalised).

So treat '.size() <= 0' the same as '== null'.