### PR TITLE
Add warning about CVE-2020-1938

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -240,6 +240,11 @@ pki_subsystem_registry_link=%(pki_subsystem_path)s/registry
 ##               are MUTUALLY EXCLUSIVE entities!!!                          ##
 ###############################################################################
 [Tomcat]
+# Note: see Tomcat CVE 2020-1938. It is strongly recommended to leave
+# pki_ajp_host as localhost. If trying to use AJP over a reverse proxy from
+# another host, manually edit server.xml to specify a shared secret or
+# tunnel it over a secure network. Refer to the Tomcat documentation for more
+# information about secure Tomcat configuration.
 pki_ajp_host=localhost
 pki_ajp_port=8009
 pki_server_pkcs12_path=


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

I figured this wouldn't hurt. Hopefully it clarifies that AJP adapter should be used carefully, if at all. 

In the future, I think we should move to a HTTPS based reverse-proxy for IdM. However, I fear that should use mutual client auth (between Apache httpd and Tomcat), which'd require more work to set up, and be another certificate to manage (unless we give it an insane lifetime). 

But that's a discussion for another time. 