### PR TITLE
Added pki securitydomain-host commands

### DIFF
--- a/base/ca/shared/conf/acl.properties
+++ b/base/ca/shared/conf/acl.properties
@@ -26,6 +26,7 @@ profiles.list = certServer.ee.profiles,list
 profiles.modify = certServer.profile.configuration,modify
 profiles.read = certServer.profile.configuration,read
 securityDomain.read = certServer.securitydomain.domainxml,read
+securityDomain.modify = certServer.securitydomain.domainxml,modify
 selftests.read = certServer.ca.selftests,read
 selftests.execute = certServer.ca.selftests,execute
 users = certServer.ca.users,execute

--- a/base/ca/src/org/dogtagpki/server/ca/rest/CAApplication.java
+++ b/base/ca/src/org/dogtagpki/server/ca/rest/CAApplication.java
@@ -14,6 +14,7 @@ import org.dogtagpki.server.rest.FeatureService;
 import org.dogtagpki.server.rest.GroupService;
 import org.dogtagpki.server.rest.MessageFormatInterceptor;
 import org.dogtagpki.server.rest.PKIExceptionMapper;
+import org.dogtagpki.server.rest.SecurityDomainHostService;
 import org.dogtagpki.server.rest.SecurityDomainService;
 import org.dogtagpki.server.rest.SelfTestService;
 import org.dogtagpki.server.rest.SessionContextInterceptor;
@@ -97,6 +98,7 @@ public class CAApplication extends Application {
             // if it's a new security domain, register the service
             if ("new".equals(select)) {
                 classes.add(SecurityDomainService.class);
+                classes.add(SecurityDomainHostService.class);
             }
         }
 

--- a/base/common/src/com/netscape/certsrv/system/SecurityDomainClient.java
+++ b/base/common/src/com/netscape/certsrv/system/SecurityDomainClient.java
@@ -65,4 +65,9 @@ public class SecurityDomainClient extends Client {
         Response response = securityDomainHostClient.getHost(hostID);
         return client.getEntity(response, SecurityDomainHost.class);
     }
+
+    public void addHost(SecurityDomainHost host) throws Exception {
+        Response response = securityDomainHostClient.addHost(host);
+        client.getEntity(response, Void.class);
+    }
 }

--- a/base/common/src/com/netscape/certsrv/system/SecurityDomainClient.java
+++ b/base/common/src/com/netscape/certsrv/system/SecurityDomainClient.java
@@ -18,7 +18,9 @@
 package com.netscape.certsrv.system;
 
 import java.net.URISyntaxException;
+import java.util.Collection;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 
 import com.netscape.certsrv.client.Client;
@@ -31,6 +33,7 @@ import com.netscape.certsrv.client.PKIClient;
 public class SecurityDomainClient extends Client {
 
     private SecurityDomainResource securityDomainClient;
+    private SecurityDomainHostResource securityDomainHostClient;
 
     public SecurityDomainClient(PKIClient client, String subsystem) throws URISyntaxException {
         super(client, subsystem, "securitydomain");
@@ -39,6 +42,7 @@ public class SecurityDomainClient extends Client {
 
     public void init() throws URISyntaxException {
         securityDomainClient = createProxy(SecurityDomainResource.class);
+        securityDomainHostClient = createProxy(SecurityDomainHostResource.class);
     }
 
     public InstallToken getInstallToken(String hostname, String subsystem) throws Exception {
@@ -49,5 +53,11 @@ public class SecurityDomainClient extends Client {
     public DomainInfo getDomainInfo() throws Exception {
         Response response = securityDomainClient.getDomainInfo();
         return client.getEntity(response, DomainInfo.class);
+    }
+
+    public Collection<SecurityDomainHost> getHosts() throws Exception {
+        Response response = securityDomainHostClient.getHosts();
+        GenericType<Collection<SecurityDomainHost>> type = new GenericType<Collection<SecurityDomainHost>>() {};
+        return client.getEntity(response, type);
     }
 }

--- a/base/common/src/com/netscape/certsrv/system/SecurityDomainClient.java
+++ b/base/common/src/com/netscape/certsrv/system/SecurityDomainClient.java
@@ -60,4 +60,9 @@ public class SecurityDomainClient extends Client {
         GenericType<Collection<SecurityDomainHost>> type = new GenericType<Collection<SecurityDomainHost>>() {};
         return client.getEntity(response, type);
     }
+
+    public SecurityDomainHost getHost(String hostID) throws Exception {
+        Response response = securityDomainHostClient.getHost(hostID);
+        return client.getEntity(response, SecurityDomainHost.class);
+    }
 }

--- a/base/common/src/com/netscape/certsrv/system/SecurityDomainClient.java
+++ b/base/common/src/com/netscape/certsrv/system/SecurityDomainClient.java
@@ -70,4 +70,9 @@ public class SecurityDomainClient extends Client {
         Response response = securityDomainHostClient.addHost(host);
         client.getEntity(response, Void.class);
     }
+
+    public void removeHost(String hostID) throws Exception {
+        Response response = securityDomainHostClient.removeHost(hostID);
+        client.getEntity(response, Void.class);
+    }
 }

--- a/base/common/src/com/netscape/certsrv/system/SecurityDomainHostResource.java
+++ b/base/common/src/com/netscape/certsrv/system/SecurityDomainHostResource.java
@@ -5,6 +5,7 @@
 //
 package com.netscape.certsrv.system;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -29,4 +30,9 @@ public interface SecurityDomainHostResource {
     @PUT
     @ACLMapping("securityDomain.modify")
     public Response addHost(SecurityDomainHost host) throws Exception;
+
+    @DELETE
+    @Path("{hostID}")
+    @ACLMapping("securityDomain.modify")
+    public Response removeHost(@PathParam("hostID") String hostID) throws Exception;
 }

--- a/base/common/src/com/netscape/certsrv/system/SecurityDomainHostResource.java
+++ b/base/common/src/com/netscape/certsrv/system/SecurityDomainHostResource.java
@@ -7,6 +7,7 @@ package com.netscape.certsrv.system;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
 /**
@@ -17,4 +18,8 @@ public interface SecurityDomainHostResource {
 
     @GET
     public Response getHosts() throws Exception;
+
+    @GET
+    @Path("{hostID}")
+    public Response getHost(@PathParam("hostID") String hostID) throws Exception;
 }

--- a/base/common/src/com/netscape/certsrv/system/SecurityDomainHostResource.java
+++ b/base/common/src/com/netscape/certsrv/system/SecurityDomainHostResource.java
@@ -6,9 +6,12 @@
 package com.netscape.certsrv.system;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
+
+import com.netscape.certsrv.acls.ACLMapping;
 
 /**
  * @author Endi S. Dewata
@@ -22,4 +25,8 @@ public interface SecurityDomainHostResource {
     @GET
     @Path("{hostID}")
     public Response getHost(@PathParam("hostID") String hostID) throws Exception;
+
+    @PUT
+    @ACLMapping("securityDomain.modify")
+    public Response addHost(SecurityDomainHost host) throws Exception;
 }

--- a/base/common/src/com/netscape/certsrv/system/SecurityDomainHostResource.java
+++ b/base/common/src/com/netscape/certsrv/system/SecurityDomainHostResource.java
@@ -1,0 +1,20 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.certsrv.system;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Endi S. Dewata
+ */
+@Path("securityDomain/hosts")
+public interface SecurityDomainHostResource {
+
+    @GET
+    public Response getHosts() throws Exception;
+}

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainCLI.java
@@ -41,6 +41,7 @@ public class SecurityDomainCLI extends CLI {
         this.mainCLI = mainCLI;
 
         addModule(new SecurityDomainShowCLI(this));
+        addModule(new SecurityDomainHostCLI(this));
     }
 
     public String getFullName() {

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostAddCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostAddCLI.java
@@ -1,0 +1,83 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.system;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.system.SecurityDomainClient;
+import com.netscape.certsrv.system.SecurityDomainHost;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SecurityDomainHostAddCLI extends CommandCLI {
+
+    public SecurityDomainHostCLI securityDomainHostCLI;
+
+    public SecurityDomainHostAddCLI(SecurityDomainHostCLI securityDomainHostCLI) {
+        super("add", "Add security domain host", securityDomainHostCLI);
+        this.securityDomainHostCLI = securityDomainHostCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Host ID>", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "port", true, "Port (default: 8080)");
+        option.setArgName("port");
+        options.addOption(option);
+
+        option = new Option(null, "securePort", true, "Secure port (default: 8443)");
+        option.setArgName("port");
+        options.addOption(option);
+
+        option = new Option(null, "domainManager", true, "Domain manager (default: FALSE)");
+        option.setArgName("boolean");
+        options.addOption(option);
+
+        option = new Option(null, "clone", true, "Clone (default: FALSE)");
+        option.setArgName("boolean");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing host ID");
+        }
+
+        String hostID = cmdArgs[0];
+
+        SecurityDomainHost host = new SecurityDomainHost();
+        host.setId(hostID);
+
+        String port = cmd.getOptionValue("port", "8080");
+        host.setPort(port);
+
+        String securePort = cmd.getOptionValue("securePort", "8443");
+        host.setSecureEEClientAuthPort(securePort);
+        host.setSecureAdminPort(securePort);
+        host.setSecureAgentPort(securePort);
+
+        String domainManager = cmd.getOptionValue("domainManager", "FALSE");
+        host.setDomainManager(domainManager);
+
+        String clone = cmd.getOptionValue("clone", "FALSE");
+        host.setClone(clone);
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        SecurityDomainClient securityDomainClient = securityDomainHostCLI.getSecurityDomainClient();
+        securityDomainClient.addHost(host);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostCLI.java
@@ -1,0 +1,46 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.system;
+
+import org.dogtagpki.cli.CLI;
+
+import com.netscape.certsrv.system.SecurityDomainClient;
+import com.netscape.certsrv.system.SecurityDomainHost;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SecurityDomainHostCLI extends CLI {
+
+    public SecurityDomainCLI parent;
+
+    public SecurityDomainHostCLI(SecurityDomainCLI parent) {
+        super("host", "Security domain host management commands", parent);
+        this.parent = parent;
+
+        addModule(new SecurityDomainHostFindCLI(this));
+    }
+
+    public SecurityDomainClient getSecurityDomainClient() throws Exception {
+        return parent.getSecurityDomainClient();
+    }
+
+    public static void printSecurityDomainHost(SecurityDomainHost host) {
+
+        System.out.println("  Host ID: " + host.getId());
+        System.out.println("  Hostname: " + host.getHostname());
+        System.out.println("  Port: " + host.getPort());
+        System.out.println("  Secure Port: " + host.getSecurePort());
+
+        if (host.getDomainManager() != null) {
+            System.out.println("  Domain Manager: " + host.getDomainManager());
+        }
+
+        if (host.getClone() != null) {
+            System.out.println("  Clone: " + host.getClone());
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostCLI.java
@@ -23,6 +23,7 @@ public class SecurityDomainHostCLI extends CLI {
 
         addModule(new SecurityDomainHostFindCLI(this));
         addModule(new SecurityDomainHostShowCLI(this));
+        addModule(new SecurityDomainHostAddCLI(this));
     }
 
     public SecurityDomainClient getSecurityDomainClient() throws Exception {

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostCLI.java
@@ -22,6 +22,7 @@ public class SecurityDomainHostCLI extends CLI {
         this.parent = parent;
 
         addModule(new SecurityDomainHostFindCLI(this));
+        addModule(new SecurityDomainHostShowCLI(this));
     }
 
     public SecurityDomainClient getSecurityDomainClient() throws Exception {

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostCLI.java
@@ -24,6 +24,7 @@ public class SecurityDomainHostCLI extends CLI {
         addModule(new SecurityDomainHostFindCLI(this));
         addModule(new SecurityDomainHostShowCLI(this));
         addModule(new SecurityDomainHostAddCLI(this));
+        addModule(new SecurityDomainHostRemoveCLI(this));
     }
 
     public SecurityDomainClient getSecurityDomainClient() throws Exception {

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostFindCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostFindCLI.java
@@ -1,0 +1,53 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.system;
+
+import java.util.Collection;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.system.SecurityDomainClient;
+import com.netscape.certsrv.system.SecurityDomainHost;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SecurityDomainHostFindCLI extends CommandCLI {
+
+    public SecurityDomainHostCLI securityDomainHostCLI;
+
+    public SecurityDomainHostFindCLI(SecurityDomainHostCLI securityDomainHostCLI) {
+        super("find", "Find security domain hosts", securityDomainHostCLI);
+        this.securityDomainHostCLI = securityDomainHostCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        SecurityDomainClient securityDomainClient = securityDomainHostCLI.getSecurityDomainClient();
+        Collection<SecurityDomainHost> hosts = securityDomainClient.getHosts();
+        boolean first = true;
+
+        for (SecurityDomainHost host : hosts) {
+
+            if (first) {
+                first = false;
+            } else {
+                System.out.println();
+            }
+
+            SecurityDomainHostCLI.printSecurityDomainHost(host);
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostRemoveCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostRemoveCLI.java
@@ -1,0 +1,46 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.system;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.system.SecurityDomainClient;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SecurityDomainHostRemoveCLI extends CommandCLI {
+
+    public SecurityDomainHostCLI securityDomainHostCLI;
+
+    public SecurityDomainHostRemoveCLI(SecurityDomainHostCLI securityDomainHostCLI) {
+        super("del", "Remove security domain host", securityDomainHostCLI);
+        this.securityDomainHostCLI = securityDomainHostCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Host ID>", options);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing host ID");
+        }
+
+        String hostID = cmdArgs[0];
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        SecurityDomainClient securityDomainClient = securityDomainHostCLI.getSecurityDomainClient();
+        securityDomainClient.removeHost(hostID);
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostShowCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/system/SecurityDomainHostShowCLI.java
@@ -1,0 +1,49 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.system;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.system.SecurityDomainClient;
+import com.netscape.certsrv.system.SecurityDomainHost;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SecurityDomainHostShowCLI extends CommandCLI {
+
+    public SecurityDomainHostCLI securityDomainHostCLI;
+
+    public SecurityDomainHostShowCLI(SecurityDomainHostCLI securityDomainHostCLI) {
+        super("show", "Show security domain host", securityDomainHostCLI);
+        this.securityDomainHostCLI = securityDomainHostCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <Host ID>", options);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing host ID");
+        }
+
+        String hostID = cmdArgs[0];
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        SecurityDomainClient securityDomainClient = securityDomainHostCLI.getSecurityDomainClient();
+        SecurityDomainHost host = securityDomainClient.getHost(hostID);
+
+        SecurityDomainHostCLI.printSecurityDomainHost(host);
+    }
+}

--- a/base/kra/shared/conf/acl.properties
+++ b/base/kra/shared/conf/acl.properties
@@ -19,6 +19,7 @@ groups = certServer.kra.groups,execute
 keys = certServer.kra.keys,execute
 keyrequests = certServer.kra.keyrequests,execute
 securityDomain.read = certServer.securitydomain.domainxml,read
+securityDomain.modify = certServer.securitydomain.domainxml,modify
 selftests.read = certServer.kra.selftests,read
 selftests.execute = certServer.kra.selftests,execute
 users = certServer.kra.users,execute

--- a/base/kra/src/org/dogtagpki/server/kra/rest/KRAApplication.java
+++ b/base/kra/src/org/dogtagpki/server/kra/rest/KRAApplication.java
@@ -13,6 +13,7 @@ import org.dogtagpki.server.rest.GroupService;
 import org.dogtagpki.server.rest.KRAInfoService;
 import org.dogtagpki.server.rest.MessageFormatInterceptor;
 import org.dogtagpki.server.rest.PKIExceptionMapper;
+import org.dogtagpki.server.rest.SecurityDomainHostService;
 import org.dogtagpki.server.rest.SecurityDomainService;
 import org.dogtagpki.server.rest.SelfTestService;
 import org.dogtagpki.server.rest.SessionContextInterceptor;
@@ -48,6 +49,7 @@ public class KRAApplication extends Application {
             boolean standalone = cs.getBoolean("kra.standalone", false);
             if (standalone) {
                 classes.add(SecurityDomainService.class);
+                classes.add(SecurityDomainHostService.class);
             }
         } catch (EBaseException e) {
             logger.error("KRAApplication: " + e.getMessage(), e);

--- a/base/ocsp/shared/conf/acl.properties
+++ b/base/ocsp/shared/conf/acl.properties
@@ -17,6 +17,7 @@ audit-log.read = certServer.log.content.signedAudit,read
 
 groups = certServer.ocsp.groups,execute
 securityDomain.read = certServer.securitydomain.domainxml,read
+securityDomain.modify = certServer.securitydomain.domainxml,modify
 selftests.read = certServer.ocsp.selftests,read
 selftests.execute = certServer.ocsp.selftests,execute
 users = certServer.ocsp.users,execute

--- a/base/ocsp/src/org/dogtagpki/server/ocsp/rest/OCSPApplication.java
+++ b/base/ocsp/src/org/dogtagpki/server/ocsp/rest/OCSPApplication.java
@@ -12,6 +12,7 @@ import org.dogtagpki.server.rest.AuthMethodInterceptor;
 import org.dogtagpki.server.rest.GroupService;
 import org.dogtagpki.server.rest.MessageFormatInterceptor;
 import org.dogtagpki.server.rest.PKIExceptionMapper;
+import org.dogtagpki.server.rest.SecurityDomainHostService;
 import org.dogtagpki.server.rest.SecurityDomainService;
 import org.dogtagpki.server.rest.SelfTestService;
 import org.dogtagpki.server.rest.SessionContextInterceptor;
@@ -47,6 +48,7 @@ public class OCSPApplication extends Application {
             boolean standalone = cs.getBoolean("ocsp.standalone", false);
             if (standalone) {
                 classes.add(SecurityDomainService.class);
+                classes.add(SecurityDomainHostService.class);
             }
         } catch (EBaseException e) {
             logger.error("OCSPApplication: " + e.getMessage(), e);

--- a/base/server/src/org/dogtagpki/server/rest/SecurityDomainHostService.java
+++ b/base/server/src/org/dogtagpki/server/rest/SecurityDomainHostService.java
@@ -153,4 +153,37 @@ public class SecurityDomainHostService extends PKIService implements SecurityDom
 
         return createNoContentResponse();
     }
+
+    @Override
+    public Response removeHost(String hostID) throws Exception {
+
+        logger.info("SecurityDomainService: Removing security domain host \"" + hostID + "\"");
+
+        // Host ID: <type> <hostname> <port>
+        Pattern pattern = Pattern.compile("^(\\S+) (\\S+) (\\d+)$");
+        Matcher matcher = pattern.matcher(hostID);
+
+        if (!matcher.find()) {
+            throw new BadRequestException("Invalid security domain host: " + hostID);
+        }
+
+        String type = matcher.group(1);
+        logger.debug("SecurityDomainService: type: " + type);
+
+        String hostname = matcher.group(2);
+        logger.debug("SecurityDomainService: hostname: " + hostname);
+
+        String port = matcher.group(3);
+        logger.debug("SecurityDomainService: port: " + port);
+
+        SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+        String status = processor.removeHost(type, hostname, port);
+        logger.debug("SecurityDomainService: status: " + status);
+
+        if (!SecurityDomainProcessor.SUCCESS.equals(status)) {
+            throw new PKIException("Unable to remove security domain host: " + hostID);
+        }
+
+        return createNoContentResponse();
+    }
 }

--- a/base/server/src/org/dogtagpki/server/rest/SecurityDomainHostService.java
+++ b/base/server/src/org/dogtagpki/server/rest/SecurityDomainHostService.java
@@ -7,10 +7,14 @@ package org.dogtagpki.server.rest;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.Response;
 
+import com.netscape.certsrv.base.BadRequestException;
+import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.base.ResourceNotFoundException;
 import com.netscape.certsrv.system.DomainInfo;
 import com.netscape.certsrv.system.SecurityDomainHost;
@@ -74,5 +78,79 @@ public class SecurityDomainHostService extends PKIService implements SecurityDom
         }
 
         throw new ResourceNotFoundException("Security domain host not found: " + hostID);
+    }
+
+    @Override
+    public Response addHost(SecurityDomainHost host) throws Exception {
+
+        String hostID = host.getId();
+        logger.info("SecurityDomainService: Adding security domain host \"" + hostID + "\"");
+
+        // Host ID: <type> <hostname> <port>
+        Pattern pattern = Pattern.compile("^(\\S+) (\\S+) (\\d+)$");
+        Matcher matcher = pattern.matcher(hostID);
+
+        if (!matcher.find()) {
+            throw new BadRequestException("Invalid security domain host: " + hostID);
+        }
+
+        String type = matcher.group(1);
+        logger.debug("SecurityDomainService: type: " + type);
+
+        String hostname = matcher.group(2);
+        logger.debug("SecurityDomainService: hostname: " + hostname);
+
+        String securePort = matcher.group(3);
+        logger.debug("SecurityDomainService: secure port: " + securePort);
+
+        String unsecurePort = host.getPort();
+        logger.debug("SecurityDomainService: unsecure port: " + unsecurePort);
+
+        String eeCAPort = host.getSecureEEClientAuthPort();
+        logger.debug("SecurityDomainService: secure EE port: " + eeCAPort);
+
+        if (!securePort.equals(eeCAPort)) {
+            throw new BadRequestException("Invalid secure (EE) port: " + eeCAPort);
+        }
+
+        String adminSecurePort = host.getSecureAdminPort();
+        logger.debug("SecurityDomainService: secure admin port: " + adminSecurePort);
+
+        if (!securePort.equals(adminSecurePort)) {
+            throw new BadRequestException("Invalid secure (admin) port: " + adminSecurePort);
+        }
+
+        String agentSecurePort = host.getSecureAgentPort();
+        logger.debug("SecurityDomainService: secure agent port: " + agentSecurePort);
+
+        if (!securePort.equals(agentSecurePort)) {
+            throw new BadRequestException("Invalid secure (agent) port: " + agentSecurePort);
+        }
+
+        String domainManager = host.getDomainManager();
+        logger.debug("SecurityDomainService: domain manager: " + domainManager);
+
+        String clone = host.getClone();
+        logger.debug("SecurityDomainService: clone: " + clone);
+
+        SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+        String status = processor.addHost(
+                hostID,
+                type,
+                hostname,
+                securePort,
+                unsecurePort,
+                eeCAPort,
+                adminSecurePort,
+                agentSecurePort,
+                domainManager,
+                clone);
+        logger.debug("SecurityDomainService: status: " + status);
+
+        if (!SecurityDomainProcessor.SUCCESS.equals(status)) {
+            throw new PKIException("Unable to add security domain host: " + hostID);
+        }
+
+        return createNoContentResponse();
     }
 }

--- a/base/server/src/org/dogtagpki/server/rest/SecurityDomainHostService.java
+++ b/base/server/src/org/dogtagpki/server/rest/SecurityDomainHostService.java
@@ -1,0 +1,52 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.ws.rs.core.GenericEntity;
+import javax.ws.rs.core.Response;
+
+import com.netscape.certsrv.system.DomainInfo;
+import com.netscape.certsrv.system.SecurityDomainHost;
+import com.netscape.certsrv.system.SecurityDomainHostResource;
+import com.netscape.certsrv.system.SecurityDomainSubsystem;
+import com.netscape.cms.servlet.base.PKIService;
+import com.netscape.cms.servlet.csadmin.SecurityDomainProcessor;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SecurityDomainHostService extends PKIService implements SecurityDomainHostResource {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SecurityDomainHostService.class);
+
+    @Override
+    public Response getHosts() throws Exception {
+
+        logger.info("SecurityDomainService: Getting all security domain hosts");
+
+        Collection<SecurityDomainHost> hosts = new ArrayList<>();
+
+        SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+
+        DomainInfo domainInfo = processor.getDomainInfo();
+        logger.debug("SecurityDomainService: domain: " + domainInfo.getName());
+
+        for (SecurityDomainSubsystem subsystem : domainInfo.getSubsystems().values()) {
+            for (SecurityDomainHost host : subsystem.getHosts().values()) {
+                logger.debug("SecurityDomainService: - " + host.getId());
+                hosts.add(host);
+            }
+        }
+
+        GenericEntity<Collection<SecurityDomainHost>> entity =
+                new GenericEntity<Collection<SecurityDomainHost>>(hosts) {};
+
+        return createOKResponse(entity);
+    }
+}

--- a/base/server/src/org/dogtagpki/server/rest/SecurityDomainHostService.java
+++ b/base/server/src/org/dogtagpki/server/rest/SecurityDomainHostService.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.Response;
 
+import com.netscape.certsrv.base.ResourceNotFoundException;
 import com.netscape.certsrv.system.DomainInfo;
 import com.netscape.certsrv.system.SecurityDomainHost;
 import com.netscape.certsrv.system.SecurityDomainHostResource;
@@ -48,5 +49,30 @@ public class SecurityDomainHostService extends PKIService implements SecurityDom
                 new GenericEntity<Collection<SecurityDomainHost>>(hosts) {};
 
         return createOKResponse(entity);
+    }
+
+    @Override
+    public Response getHost(String hostID) throws Exception {
+
+        logger.info("SecurityDomainService: Getting security domain host \"" + hostID + "\"");
+
+        SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+
+        DomainInfo domainInfo = processor.getDomainInfo();
+        logger.debug("SecurityDomainService: domain: " + domainInfo.getName());
+
+        for (SecurityDomainSubsystem subsystem : domainInfo.getSubsystems().values()) {
+            for (SecurityDomainHost host : subsystem.getHosts().values()) {
+
+                logger.debug("SecurityDomainService: - " + host.getId());
+
+                if (host.getId().equals(hostID)) {
+                    logger.debug("SecurityDomainService: Found security domain host " + hostID);
+                    return createOKResponse(host);
+                }
+            }
+        }
+
+        throw new ResourceNotFoundException("Security domain host not found: " + hostID);
     }
 }


### PR DESCRIPTION
This PR is adding REST API and CLIs to manage hosts in security domain. Eventually the REST API and CLIs will replace the legacy code and tool currently used in pkispawn and pkidestroy.