### PR TITLE
Added ACME certificate revocation

### DIFF
--- a/base/acme/conf/database/postgresql/statements.conf
+++ b/base/acme/conf/database/postgresql/statements.conf
@@ -100,6 +100,14 @@ FROM \
 WHERE \
     o."id" = oa."order_id" AND oa."authz_id" = ? AND o."status" = ?
 
+getOrderByCertificate=\
+SELECT \
+    "id", "account_id", "status", "expires", "not_before", "not_after", \
+FROM \
+    "orders" \
+WHERE \
+    "cert_id" = ?
+
 addOrder=\
 INSERT INTO \
     "orders" ("id", "account_id", "status", "expires", "not_before", "not_after", "cert_id") \

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
@@ -47,6 +47,24 @@ public abstract class ACMEDatabase {
             String authzID,
             String status)
         throws Exception;
+
+    /**
+     * This method returns the order record that created the certificate.
+     * The order record may be purged by the server at some point, so this
+     * record is not guaranteed to be available for all certificates.
+     *
+     * A certificate has at most one order record that corresponds to it.
+     * Only valid orders will have a certificate associated to them. If an
+     * order fails during processing, no certificates will be issued for it.
+     * If a certificate is renewed, a new order will be created which will
+     * then have a new certificate.
+     *
+     * @param certID The ID of the certificate.
+     * @return The order record corresponding to the provided certificate.
+     * @throws Exception
+     */
+    public abstract ACMEOrder getOrderByCertificate(String certID) throws Exception;
+
     public abstract void addOrder(ACMEOrder order) throws Exception;
     public abstract void updateOrder(ACMEOrder order) throws Exception;
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
@@ -79,6 +79,18 @@ public class InMemoryDatabase extends ACMEDatabase {
         return l;
     }
 
+    public ACMEOrder getOrderByCertificate(String certID) throws Exception {
+        for (ACMEOrder order : orders.values()) {
+            if (certID.equals(order.getCertID())) {
+                // order found
+                return order;
+            }
+        }
+
+        // no order found
+        return null;
+    }
+
     public void addOrder(ACMEOrder order) throws Exception {
         orders.put(order.getID(), order);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/PostgreSQLDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/PostgreSQLDatabase.java
@@ -413,6 +413,50 @@ public class PostgreSQLDatabase extends ACMEDatabase {
         return orders;
     }
 
+    public ACMEOrder getOrderByCertificate(String certID) throws Exception {
+
+        logger.info("Getting order for certificate " + certID);
+
+        String sql = statements.getProperty("getOrderByCertificate");
+        logger.info("SQL: " + sql);
+
+        ACMEOrder order = new ACMEOrder();
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, certID);
+
+            try (ResultSet rs = ps.executeQuery()) {
+
+                if (!rs.next()) {
+                    // no order found
+                    return null;
+                }
+
+                // order found
+
+                order.setID(rs.getString("id"));
+                order.setAccountID(rs.getString("account_id"));
+                order.setStatus(rs.getString("status"));
+
+                Timestamp expires = rs.getTimestamp("expires");
+                order.setExpirationTime(new Date(expires.getTime()));
+
+                Timestamp notBefore = rs.getTimestamp("not_before");
+                order.setNotBeforeTime(notBefore == null ? null : new Date(notBefore.getTime()));
+
+                Timestamp notAfter = rs.getTimestamp("not_after");
+                order.setNotAfterTime(notAfter == null ? null : new Date(notAfter.getTime()));
+
+                order.setCertID(certID);
+            }
+        }
+
+        getOrderIdentifiers(order);
+        getOrderAuthorizations(order);
+
+        return order;
+    }
+
     public void getOrderIdentifiers(ACMEOrder order) throws Exception {
 
         String orderID = order.getID();

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
@@ -36,6 +36,7 @@ public class ACMEApplication extends Application {
         classes.add(ACMEOrderService.class);
         classes.add(ACMECertificateService.class);
         classes.add(ACMEAccountService.class);
+        classes.add(ACMERevokeCertificateService.class);
     }
 
     public Set<Class<?>> getClasses() {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDirectoryService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDirectoryService.java
@@ -49,6 +49,9 @@ public class ACMEDirectoryService {
         URI newOrderURL = uriInfo.getBaseUriBuilder().path("new-order").build();
         directory.setNewOrder(newOrderURL);
 
+        URI revokeCertURL = uriInfo.getBaseUriBuilder().path("revoke-cert").build();
+        directory.setRevokeCert(revokeCertURL);
+
         logger.info("Directory:\n" + directory);
 
         ResponseBuilder builder = Response.ok();

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERevokeCertificateService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERevokeCertificateService.java
@@ -1,0 +1,110 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.net.URI;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.dogtagpki.acme.ACMEAccount;
+import org.dogtagpki.acme.ACMEHeader;
+import org.dogtagpki.acme.ACMENonce;
+import org.dogtagpki.acme.ACMERevocation;
+import org.dogtagpki.acme.JWK;
+import org.dogtagpki.acme.JWS;
+import org.dogtagpki.acme.backend.ACMEBackend;
+
+/**
+ * @author Endi S. Dewata
+ */
+@Path("revoke-cert")
+public class ACMERevokeCertificateService {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMERevokeCertificateService.class);
+
+    @Context
+    UriInfo uriInfo;
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response revokeCert(JWS jws) throws Exception {
+
+        logger.info("Revoking certificate");
+
+        String protectedHeader = new String(jws.getProtectedHeaderAsBytes(), "UTF-8");
+        logger.info("Header: " + protectedHeader);
+        ACMEHeader header = ACMEHeader.fromJSON(protectedHeader);
+
+        ACMEEngine engine = ACMEEngine.getInstance();
+        engine.validateNonce(header.getNonce());
+
+        String payload = new String(jws.getPayloadAsBytes(), "UTF-8");
+        logger.info("Payload: " + payload);
+
+        ACMERevocation revocation = ACMERevocation.fromJSON(payload);
+        URI kid = header.getKid();
+        JWK jwk = header.getJwk();
+
+        // RFC 8555 Section 6.2: Request Authentication
+        //
+        // The "jwk" and "kid" fields are mutually exclusive.  Servers MUST
+        // reject requests that contain both.
+        //
+        // For newAccount requests, and for revokeCert requests authenticated by
+        // a certificate key, there MUST be a "jwk" field.  This field MUST
+        // contain the public key corresponding to the private key used to sign
+        // the JWS.
+        //
+        // For all other requests, the request is signed using an existing
+        // account, and there MUST be a "kid" field.  This field MUST contain
+        // the account URL received by POSTing to the newAccount resource.
+
+        if (kid != null && jwk == null) {
+
+            String kidPath = kid.getPath();
+            String accountID = kidPath.substring(kidPath.lastIndexOf('/') + 1);
+            logger.info("Account ID: " + accountID);
+
+            // validate that the revocation request was signed with the account key
+            ACMEAccount account = engine.getAccount(accountID);
+            engine.validateJWS(jws, header.getAlg(), account.getJWK());
+
+            // validate that the account is authorized to revoke the cert
+            engine.validateRevocation(account, revocation);
+
+        } else if (kid == null && jwk != null) {
+            // validate that the revocation request was signed
+            // with the key of the cert being revoked
+            engine.validateJWS(jws, header.getAlg(), jwk);
+
+        } else {
+            // TODO: generate proper exception
+            throw new Exception("Invalid revocation request");
+        }
+
+        ACMEBackend backend = engine.getBackend();
+        backend.revokeCert(revocation);
+
+        logger.info("Certificate revoked");
+
+        ResponseBuilder builder = Response.ok();
+
+        ACMENonce nonce = engine.createNonce();
+        builder.header("Replay-Nonce", nonce.getValue());
+
+        URI directoryURL = uriInfo.getBaseUriBuilder().path("directory").build();
+        builder.link(directoryURL, "index");
+
+        return builder.build();
+    }
+}

--- a/docs/user/Using_ACME_Responder.md
+++ b/docs/user/Using_ACME_Responder.md
@@ -20,28 +20,56 @@ so the examples below are executed over insecure HTTP connections.
 
 ## Certificate Enrollment
 
+The PKI ACME responder supports certificate enrollment using certbot.
+The certificate enrollment can be done with either of the following domain validations:
+* HTTP-01
+* DNS-01
+
+When enrolling a certificate, certbot will try to create an ACME account on the responder,
+unless an account was already created previously.
+
+If a new account is required, enter an email address when asked by certbot
+(or specify a `-m <email address>` parameter) and also accept the terms of service
+(or specify a `--agree-tos` parameter).
+
 ### Certificate enrollment with HTTP-01
 
-To request a certificate with automatic http-01 validation, execute the following command:
+To enroll a certificate with automatic HTTP-01 validation, execute the following command:
 
 ```
 $ certbot certonly --standalone \
     --server http://$HOSTNAME:8080/acme/directory \
-    -d $HOSTNAME \
-    --preferred-challenges http \
-    -m user@example.com
+    -d server.example.com \
+    --preferred-challenges http
 ```
 
-### Certificate enrollment with DNS-01
-
-To request a certificate with manual dns-01 validation, execute the following command:
+To enroll a certificate with manual HTTP-01 validation, execute the following command:
 
 ```
 $ certbot certonly --manual \
     --server http://$HOSTNAME:8080/acme/directory \
     -d server.example.com \
-    --preferred-challenges dns \
-    -m user@example.com
+    --preferred-challenges http
+```
+
+Configure the challenge response on a web server as instructed by certbot,
+then check with the following command:
+
+```
+$ curl http://server.example.com/.well-known/acme-challenge/<token>
+```
+
+Once the challenge response is configured properly, complete the enrollment using certbot.
+
+### Certificate enrollment with DNS-01
+
+To enroll a certificate with manual DNS-01 validation, execute the following command:
+
+```
+$ certbot certonly --manual \
+    --server http://$HOSTNAME:8080/acme/directory \
+    -d server.example.com \
+    --preferred-challenges dns
 ```
 
 Create a TXT record in the DNS server as instructed by certbot.
@@ -53,16 +81,35 @@ $ dig _acme-challenge.server.example.com TXT
 
 Once the TXT record is propagated properly, complete the enrollment using certbot.
 
+## Certificate Revocation
+
+To revoke a certificate owned by the ACME account:
+
+```
+$ certbot revoke \
+    --server http://$HOSTNAME:8080/acme/directory \
+    --cert-path /etc/letsencrypt/live/server.example.com/cert.pem
+```
+
+To revoke a certificate associated with a private key:
+
+```
+$ certbot revoke \
+    --server http://$HOSTNAME:8080/acme/directory \
+    --cert-path /etc/letsencrypt/live/server.example.com/cert.pem \
+    --key-path /etc/letsencrypt/live/server.example.com/privkey.pem
+```
+
 ## Account Management
 
 ### Creating an account
 
-To create an ACME account:
+To create an ACME account without certificate enrollment:
 
 ```
 $ certbot register \
     --server http://$HOSTNAME:8080/acme/directory \
-    -m user@example.com \
+    -m <email address> \
     --agree-tos
 ```
 
@@ -73,7 +120,7 @@ To update an ACME account:
 ```
 $ certbot update_account \
     --server http://$HOSTNAME:8080/acme/directory \
-    -m user@example.com
+    -m <new email address>
 ```
 
 ### Deactivating an account
@@ -86,4 +133,5 @@ $ certbot unregister --server http://$HOSTNAME:8080/acme/directory
 
 ## See Also
 
+* [certbot](https://certbot.eff.org)
 * [Installing ACME Responder](../installation/Installing_ACME_Responder.md)


### PR DESCRIPTION
The PR is adding the support for revoking a certificate through ACME.

Updated doc:
https://github.com/edewata/pki/blob/acme-dev/docs/user/Using_ACME_Responder.md

This PR may need to be updated if #334 is merged first.