### PR TITLE
Refactored ACMEBackend

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/backend/ACMEBackend.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/backend/ACMEBackend.java
@@ -6,7 +6,10 @@
 package org.dogtagpki.acme.backend;
 
 import java.math.BigInteger;
+import java.security.cert.X509Certificate;
 
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.NotImplementedException;
 import org.dogtagpki.acme.ACMERevocation;
 
 /**
@@ -30,14 +33,52 @@ public class ACMEBackend {
     public void close() throws Exception {
     }
 
-    public BigInteger issueCertificate(String csr) throws Exception {
-        return null;
+    /**
+     * This method generates a unique ID for a certificate.
+     *
+     * By default this method will return the base64-encoded serial number
+     * of the certificate. This method may be overridden to generate a backend-
+     * specific unique ID for the certificate.
+     *
+     * @param cert Certificate.
+     * @return Unique ID for the certificate.
+     * @throws Exception
+     */
+    public String getCertificateID(X509Certificate cert) throws Exception {
+        BigInteger serialNumber = cert.getSerialNumber();
+        return Base64.encodeBase64URLSafeString(serialNumber.toByteArray());
+    }
+
+    /**
+     * This method generates a certificate using the provided certificate signing request,
+     * then returns the new certificate.
+     *
+     * @param csr Certificate signing request.
+     * @return Certificate.
+     * @throws Exception
+     */
+    public X509Certificate generateCertificate(String csr) throws Exception {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * This method generates a certificate using the provided certificate signing request,
+     * then returns a unique ID for the new certificate.
+     *
+     * @param csr Certificate signing request.
+     * @return Unique ID for the new certificate.
+     * @throws Exception
+     */
+    public String issueCertificate(String csr) throws Exception {
+        X509Certificate cert = generateCertificate(csr);
+        return getCertificateID(cert);
     }
 
     public String getCertificateChain(String certID) throws Exception {
-        return null;
+        throw new NotImplementedException();
     }
 
     public void revokeCert(ACMERevocation revocation) throws Exception {
+        throw new NotImplementedException();
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/backend/PKIBackend.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/backend/PKIBackend.java
@@ -87,7 +87,7 @@ public class PKIBackend extends ACMEBackend {
         caClient = new CAClient(pkiClient);
     }
 
-    public BigInteger issueCertificate(String csr) throws Exception {
+    public String issueCertificate(String csr) throws Exception {
 
         logger.info("Issuing certificate");
 
@@ -136,7 +136,9 @@ public class PKIBackend extends ACMEBackend {
         logger.info("Serial number: " + info.getCertId().toHexString());
 
         CertId id = info.getCertId();
-        return id.toBigInteger();
+        BigInteger serialNumber = id.toBigInteger();
+
+        return Base64.encodeBase64URLSafeString(serialNumber.toByteArray());
     }
 
     public String getCertificateChain(String certID) throws Exception {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
@@ -5,7 +5,6 @@
 //
 package org.dogtagpki.acme.server;
 
-import java.math.BigInteger;
 import java.net.URI;
 
 import javax.ws.rs.POST;
@@ -18,7 +17,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.codec.binary.Base64;
 import org.dogtagpki.acme.ACMEAccount;
 import org.dogtagpki.acme.ACMEHeader;
 import org.dogtagpki.acme.ACMENonce;
@@ -78,9 +76,7 @@ public class ACMEFinalizeOrderService {
         engine.validateCSR(account, order, csr);
 
         ACMEBackend backend = engine.getBackend();
-        BigInteger serialNumber = backend.issueCertificate(csr);
-        String certID = Base64.encodeBase64URLSafeString(serialNumber.toByteArray());
-
+        String certID = backend.issueCertificate(csr);
         logger.info("Certificate issued: " + certID);
 
         order.setStatus("valid");


### PR DESCRIPTION
Some ACME backends might support only one cert authority, so
the serial number of the certs will be unique. However, some
other backends might support multiple cert authorities so the
serial number by itself might not be unique. The ACMEBackend
needs to be able to generate backend-specific unique ID for
the certs if necessary.

Some ACME backends use two-step cert enrollment: issuance and
retrieval. These steps match the ACME protocol. However, some
other backends use only one-step enrollment. In that case the
server will need to store the issued cert in ACME database for
a later retrieval.

To support the above requirements, the code has been modified
as follows:

- The ACMEBackend.getCertificateID() has been added to create
  a unique ID for a cert. By default it will generate a unique
  ID based on the serial number. A subclass can override this
  method to generate a backend-specific unique ID.

- The ACMEBackend.generateCertificate() has been added to
  generate a certificate in one step. By default this method
  is not implemented. A subclass can override this method to
  implement backend-specific one-step enrollment.

- The ACMEBackend.issueCertificate() has been modified to
  return a cert unique ID instead of the serial number. By
  default this method will call generateCertificate(), then
  call getCertificateID(). A subclass can override this method
  to implement a backend-specific cert issuance.

The ACMEBackend.getCertificateChain() has not been modififed,
but a subclass can override this method either to retrieve the
cert from ACME database (for one-step enrollment) or from the
ACME backend (for two-step enrollment).