### PR TITLE
acme: add LDAP indices

### DIFF
--- a/base/ca/shared/conf/index.ldif
+++ b/base/ca/shared/conf/index.ldif
@@ -205,3 +205,53 @@ nsindexType: pres
 nsindexType: sub
 nsSystemindex: false
 cn: extension
+
+dn: cn=acmeExpires,cn=index,cn={database},cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeExpires
+
+dn: cn=acmeAccountId,cn=index,cn={database},cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeAccountId
+
+dn: cn=acmeStatus,cn=index,cn={database},cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeStatus
+
+dn: cn=acmeAuthorizationId,cn=index,cn={database},cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeAuthorizationId
+
+dn: cn=acmeIdentifier,cn=index,cn={database},cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeIdentifier
+
+dn: cn=acmeCertificateId,cn=index,cn={database},cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeCertificateId
+
+dn: cn=acmeAuthorizationWildcard,cn=index,cn={database},cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: pres
+nsindexType: eq
+nsSystemindex: false
+cn: acmeAuthorizationWildcard

--- a/base/ca/shared/conf/indextasks.ldif
+++ b/base/ca/shared/conf/indextasks.ldif
@@ -30,3 +30,10 @@ nsIndexAttribute: issuername:eq,pres,sub
 nsIndexAttribute: requestsourceid:eq,pres,sub
 nsIndexAttribute: revInfo:eq,pres,sub
 nsIndexAttribute: extension:eq,pres,sub
+nsIndexAttribute: acmeExpires:eq
+nsIndexAttribute: acmeAccountId:eq
+nsIndexAttribute: acmeStatus:eq
+nsIndexAttribute: acmeAuthorizationId:eq
+nsIndexAttribute: acmeIdentifier:eq
+nsIndexAttribute: acmeCertificateId:eq
+nsIndexAttribute: acmeAuthorizationWildcard:eq,pres


### PR DESCRIPTION
Add database indices for efficient searches.  The 'eq' index type is
sufficient for range queries, i.e. for the 'acmeExpires' attribute.
VLV indicies are not required.