### PR TITLE
Patch ECAdminCertProfile upgrade script

### DIFF
--- a/base/server/upgrade/10.8.2/01-FixECAdminCertProfile.py
+++ b/base/server/upgrade/10.8.2/01-FixECAdminCertProfile.py
@@ -28,30 +28,28 @@ class FixECAdminCertProfile(pki.server.upgrade.PKIServerUpgradeScriptlet):
         self.backup(subsystem.cs_conf)
 
         path = subsystem.config.get('profile.caECAdminCert.config')
-        logger.info('Current path: %s', path)
-
         if path is None:
-            # The attribute is missing. Patch the missing attribute
-            logger.info('profile.caECAdminCert.config missing in CS.cfg')
+            # Add missing path
+            logger.info('Missing profile.caECAdminCert.config')
 
-            path = "{0}/profiles/{1}/caAdminCert.cfg".format(
+            path = "{0}/profiles/{1}/caECAdminCert.cfg".format(
                 subsystem.base_dir, subsystem.name)
 
-            subsystem.config['profile.caECAdminCert.class_id'] = 'caEnrollImpl'
-            subsystem.config['profile.caECAdminCert.config'] = path
+        else:
+            # Fix existing path
+            logger.info("Fixing profile.caECAdminCert.config")
+            dirname = os.path.dirname(path)
+            path = os.path.join(dirname, 'caECAdminCert.cfg')
 
-            logger.info('Patched path: %s', path)
-
-            # check if caECAdminCert is part of profile.list
-            profile_list = subsystem.config['profile.list'].split(',')
-            if 'caECAdminCert' not in profile_list:
-                profile_list.append('caECAdminCert')
-                subsystem.config['profile.list'] = ','.join(profile_list)
-
-        dirname = os.path.dirname(path)
-
-        path = os.path.join(dirname, 'caECAdminCert.cfg')
         logger.info('New path: %s', path)
-
         subsystem.config['profile.caECAdminCert.config'] = path
+
+        subsystem.config['profile.caECAdminCert.class_id'] = 'caEnrollImpl'
+
+        # check if caECAdminCert is part of profile.list
+        profile_list = subsystem.config['profile.list'].split(',')
+        if 'caECAdminCert' not in profile_list:
+            profile_list.append('caECAdminCert')
+            subsystem.config['profile.list'] = ','.join(profile_list)
+
         subsystem.save()

--- a/base/server/upgrade/10.8.2/01-FixECAdminCertProfile.py
+++ b/base/server/upgrade/10.8.2/01-FixECAdminCertProfile.py
@@ -30,6 +30,24 @@ class FixECAdminCertProfile(pki.server.upgrade.PKIServerUpgradeScriptlet):
         path = subsystem.config.get('profile.caECAdminCert.config')
         logger.info('Current path: %s', path)
 
+        if path is None:
+            # The attribute is missing. Patch the missing attribute
+            logger.info('profile.caECAdminCert.config missing in CS.cfg')
+
+            path = "{0}/profiles/{1}/caAdminCert.cfg".format(
+                subsystem.base_dir, subsystem.name)
+
+            subsystem.config['profile.caECAdminCert.class_id'] = 'caEnrollImpl'
+            subsystem.config['profile.caECAdminCert.config'] = path
+
+            logger.info('Patched path: %s', path)
+
+            # check if caECAdminCert is part of profile.list
+            profile_list = subsystem.config['profile.list'].split(',')
+            if 'caECAdminCert' not in profile_list:
+                profile_list.append('caECAdminCert')
+                subsystem.config['profile.list'] = ','.join(profile_list)
+
         dirname = os.path.dirname(path)
 
         path = os.path.join(dirname, 'caECAdminCert.cfg')


### PR DESCRIPTION
The caECAdminCert profile was added 2 years ago but was never patched
to be added to the CS.cfg. Hence, when a user tries to upgrade, the path
did not exist and so, the upgrade failed. This patch adds the missing
attribute to ensure smooth upgradation process

Resolves: BZ#1814242
Upstream: https://pagure.io/dogtagpki/issue/3168

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`

## Test Execution

````
 # pki-server upgrade --debug

~snip~
Upgrading from version 10.8.2 to 10.8.3:
1. Fix EC admin certificate profile (Yes/No) [Y]: 
INFO: Loading instance: pki-tomcat
INFO: Loading global Tomcat config: /etc/tomcat/tomcat.conf
INFO: Loading PKI Tomcat config: /usr/share/pki/etc/tomcat.conf
INFO: Loading instance Tomcat config: /etc/pki/pki-tomcat/tomcat.conf
INFO: Loading password config: /etc/pki/pki-tomcat/password.conf
INFO: Loading instance registry: /etc/sysconfig/pki/tomcat/pki-tomcat/pki-tomcat
INFO: Loading subsystem: ca
INFO: Loading subsystem config: /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
INFO: Upgrading pki-tomcat instance
INFO: Loading subsystem: ca
INFO: Loading subsystem config: /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
INFO: Upgrading ca subsystem
INFO: Upgrading pki-tomcat/ca subsystem
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki/pki-tomcat
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki/pki-tomcat/ca
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki/pki-tomcat/ca/conf
INFO: Saving /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
DEBUG: Command: cp /var/lib/pki/pki-tomcat/ca/conf/CS.cfg /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki/pki-tomcat/ca/conf/CS.cfg
INFO: Current path: None
INFO: profile.caECAdminCert.config missing in CS.cfg
INFO: Patched path: /var/lib/pki/pki-tomcat/ca/profiles/ca/caAdminCert.cfg
INFO: New path: /var/lib/pki/pki-tomcat/ca/profiles/ca/caECAdminCert.cfg
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki/pki-tomcat/ca/conf
WARNING: Directory already exists: /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki/pki-tomcat/ca/conf
INFO: Saving /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
DEBUG: Command: cp /var/lib/pki/pki-tomcat/ca/conf/CS.cfg /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki/pki-tomcat/ca/conf/CS.cfg
WARNING: File already exists: /var/log/pki/server/upgrade/10.8.2/1/oldfiles/var/lib/pki/pki-tomcat/ca/conf/CS.cfg
INFO: Upgrading pki-tomcat instance
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/etc
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/etc/pki
DEBUG: Command: mkdir /var/log/pki/server/upgrade/10.8.2/1/oldfiles/etc/pki/pki-tomcat
INFO: Saving /etc/pki/pki-tomcat/tomcat.conf
DEBUG: Command: cp /etc/pki/pki-tomcat/tomcat.conf /var/log/pki/server/upgrade/10.8.2/1/oldfiles/etc/pki/pki-tomcat/tomcat.conf

~snip~
````