### PR TITLE
Silence -Wc++11-narrowing warnings

### DIFF
--- a/base/tps-client/src/processor/RA_Enroll_Processor.cpp
+++ b/base/tps-client/src/processor/RA_Enroll_Processor.cpp
@@ -1769,7 +1769,7 @@ bool RA_Enroll_Processor::CheckAndUpgradeSymKeys(
 
 			// Assemble the Buffer with the version information
 			// The second byte is the key offset, which is always 1
-			BYTE nv[2] = { requiredV, 0x01 };
+			BYTE nv[2] = { static_cast<BYTE>(requiredV), 0x01 };
 			Buffer newVersion(nv, 2);
 
 			// GetKeyInfoData will return a buffer which is bytes 11,12 of

--- a/base/tps-client/src/processor/RA_Pin_Reset_Processor.cpp
+++ b/base/tps-client/src/processor/RA_Pin_Reset_Processor.cpp
@@ -406,7 +406,7 @@ TPS_PUBLIC RA_Status RA_Pin_Reset_Processor::Process(RA_Session *session, NameVa
         PR_snprintf((char *)configname, 256, "%s.%s.update.symmetricKeys.requiredVersion", OP_PREFIX, tokenType);
         int v = RA::GetConfigStore()->GetConfigAsInt(configname, 0x00);
         Buffer curKeyInfo = channel->GetKeyInfoData();
-        BYTE nv[2] = { v, 0x01 };
+        BYTE nv[2] = { static_cast<BYTE>(v), 0x01 };
         Buffer newVersion(nv, 2);
         PR_snprintf((char *)configname,  256,"%s.%s.tks.conn", OP_PREFIX, tokenType);
         connid = RA::GetConfigStore()->GetConfigAsString(configname);

--- a/base/tps-client/src/processor/RA_Processor.cpp
+++ b/base/tps-client/src/processor/RA_Processor.cpp
@@ -3234,7 +3234,7 @@ locale),
             PR_snprintf((char *)configname, 256, "%s.%s.update.symmetricKeys.requiredVersion", OP_PREFIX, tokenType);
             int v = RA::GetConfigStore()->GetConfigAsInt(configname, 0x00);
             curKeyInfo = channel->GetKeyInfoData();
-            BYTE nv[2] = { v, 0x01 };
+            BYTE nv[2] = { static_cast<BYTE>(v), 0x01 };
             Buffer newVersion(nv, 2);
             PR_snprintf((char *)configname,  256,"%s.%s.tks.conn", OP_PREFIX, tokenType);
             connid = RA::GetConfigStore()->GetConfigAsString(configname);


### PR DESCRIPTION
Clang treats these as errors by default, so this fixes the build with clang.

Example of one of the warnings:

/builddir/build/BUILD/pki-10.8.3/base/tps-client/src/processor/RA_Processor.cpp:3237:28:
error: non-constant-expression cannot be narrowed from type 'int' to
'BYTE' (aka 'unsigned char') in initializer list [-Wc++11-narrowing]

            BYTE nv[2] = { v, 0x01 };