### PR TITLE
Renamed ACME backend to issuer

### DIFF
--- a/base/acme/conf/backend.json
+++ b/base/acme/conf/backend.json
@@ -1,3 +1,0 @@
-{
-    "class": "org.dogtagpki.acme.backend.ACMEBackend"
-}

--- a/base/acme/conf/issuer.json
+++ b/base/acme/conf/issuer.json
@@ -1,0 +1,3 @@
+{
+    "class": "org.dogtagpki.acme.issuer.ACMEIssuer"
+}

--- a/base/acme/conf/issuer/pki/issuer.json
+++ b/base/acme/conf/issuer/pki/issuer.json
@@ -1,5 +1,5 @@
 {
-    "class": "org.dogtagpki.acme.backend.PKIBackend",
+    "class": "org.dogtagpki.acme.issuer.PKIIssuer",
     "parameters": {
         "url": "https://localhost:8443",
         "profile": "acmeServerCert",

--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/ACMEIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/ACMEIssuer.java
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-package org.dogtagpki.acme.backend;
+package org.dogtagpki.acme.issuer;
 
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
@@ -15,15 +15,15 @@ import org.dogtagpki.acme.ACMERevocation;
 /**
  * @author Endi S. Dewata
  */
-public class ACMEBackend {
+public class ACMEIssuer {
 
-    protected ACMEBackendConfig config;
+    protected ACMEIssuerConfig config;
 
-    public ACMEBackendConfig getConfig() {
+    public ACMEIssuerConfig getConfig() {
         return config;
     }
 
-    public void setConfig(ACMEBackendConfig config) {
+    public void setConfig(ACMEIssuerConfig config) {
         this.config = config;
     }
 
@@ -37,7 +37,7 @@ public class ACMEBackend {
      * This method generates a unique ID for a certificate.
      *
      * By default this method will return the base64-encoded serial number
-     * of the certificate. This method may be overridden to generate a backend-
+     * of the certificate. This method may be overridden to generate a issuer-
      * specific unique ID for the certificate.
      *
      * @param cert Certificate.

--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/ACMEIssuerConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/ACMEIssuerConfig.java
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-package org.dogtagpki.acme.backend;
+package org.dogtagpki.acme.issuer;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class ACMEBackendConfig {
+public class ACMEIssuerConfig {
 
     @JsonProperty("class")
     private String className;
@@ -66,9 +66,9 @@ public class ACMEBackendConfig {
         return mapper.writeValueAsString(this);
     }
 
-    public static ACMEBackendConfig fromJSON(String json) throws Exception {
+    public static ACMEIssuerConfig fromJSON(String json) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, ACMEBackendConfig.class);
+        return mapper.readValue(json, ACMEIssuerConfig.class);
     }
 
     public String toString() {

--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-package org.dogtagpki.acme.backend;
+package org.dogtagpki.acme.issuer;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -40,9 +40,9 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
 /**
  * @author Endi S. Dewata
  */
-public class PKIBackend extends ACMEBackend {
+public class PKIIssuer extends ACMEIssuer {
 
-    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIBackend.class);
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIIssuer.class);
 
     private ClientConfig clientConfig = new ClientConfig();
     private String profile;
@@ -59,7 +59,7 @@ public class PKIBackend extends ACMEBackend {
 
     public void init() throws Exception {
 
-        logger.info("Initializing PKI backend");
+        logger.info("Initializing PKI issuer");
 
         String url = config.getParameter("url");
         logger.info("- URL: " + url);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMECertificateService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMECertificateService.java
@@ -18,7 +18,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.dogtagpki.acme.ACMENonce;
-import org.dogtagpki.acme.backend.ACMEBackend;
+import org.dogtagpki.acme.issuer.ACMEIssuer;
 
 /**
  * @author Endi S. Dewata
@@ -48,8 +48,8 @@ public class ACMECertificateService {
         logger.info("Retrieving certificate " + certID);
 
         ACMEEngine engine = ACMEEngine.getInstance();
-        ACMEBackend backend = engine.getBackend();
-        String certChain = backend.getCertificateChain(certID);
+        ACMEIssuer issuer = engine.getIssuer();
+        String certChain = issuer.getCertificateChain(certID);
 
         ResponseBuilder builder = Response.ok();
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
@@ -22,7 +22,7 @@ import org.dogtagpki.acme.ACMEHeader;
 import org.dogtagpki.acme.ACMENonce;
 import org.dogtagpki.acme.ACMEOrder;
 import org.dogtagpki.acme.JWS;
-import org.dogtagpki.acme.backend.ACMEBackend;
+import org.dogtagpki.acme.issuer.ACMEIssuer;
 
 /**
  * @author Endi S. Dewata
@@ -75,8 +75,8 @@ public class ACMEFinalizeOrderService {
         logger.info("CSR: " + csr);
         engine.validateCSR(account, order, csr);
 
-        ACMEBackend backend = engine.getBackend();
-        String certID = backend.issueCertificate(csr);
+        ACMEIssuer issuer = engine.getIssuer();
+        String certID = issuer.issueCertificate(csr);
         logger.info("Certificate issued: " + certID);
 
         order.setStatus("valid");

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERevokeCertificateService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERevokeCertificateService.java
@@ -22,7 +22,7 @@ import org.dogtagpki.acme.ACMENonce;
 import org.dogtagpki.acme.ACMERevocation;
 import org.dogtagpki.acme.JWK;
 import org.dogtagpki.acme.JWS;
-import org.dogtagpki.acme.backend.ACMEBackend;
+import org.dogtagpki.acme.issuer.ACMEIssuer;
 
 /**
  * @author Endi S. Dewata
@@ -92,8 +92,8 @@ public class ACMERevokeCertificateService {
             throw new Exception("Invalid revocation request");
         }
 
-        ACMEBackend backend = engine.getBackend();
-        backend.revokeCert(revocation);
+        ACMEIssuer issuer = engine.getIssuer();
+        issuer.revokeCert(revocation);
 
         logger.info("Certificate revoked");
 

--- a/docs/installation/Installing_ACME_Responder.md
+++ b/docs/installation/Installing_ACME_Responder.md
@@ -64,7 +64,7 @@ The command will create the initial configuration files in /etc/pki/pki-tomcat/a
 
 See also [pki-server-acme(8)](../manuals/man8/pki-server-acme.8.md).
 
-## Configuring ACME Responder Database
+## Configuring ACME Database
 
 The database configuration for the ACME responder is located at /etc/pki/pki-tomcat/acme/database.json.
 
@@ -87,23 +87,23 @@ Currently there are no parameters to configure for in-memory database.
 
 See also [Configuring ACME Responder](https://www.dogtagpki.org/wiki/Configuring_ACME_Responder).
 
-## Configuring ACME Responder Backend
+## Configuring ACME Issuer
 
-The backend configuration for the ACME responder is located at /etc/pki/pki-tomcat/acme/backend.json.
+The issuer configuration for the ACME responder is located at /etc/pki/pki-tomcat/acme/issuer.json.
 
-To use the CA subsystem as the backend for the ACME responder,
+To use the CA subsystem as the issuer for the ACME responder,
 copy the sample configuration with the following command:
 
 ```
-$ cp /usr/share/pki/acme/conf/backend/pki/backend.json \
-    /etc/pki/pki-tomcat/acme/backend.json
+$ cp /usr/share/pki/acme/conf/issuer/pki/issuer.json \
+    /etc/pki/pki-tomcat/acme/issuer.json
 ```
 
 Alternatively, edit the file as follows:
 
 ```
 {
-    "class": "org.dogtagpki.acme.backend.PKIBackend",
+    "class": "org.dogtagpki.acme.issuer.PKIIssuer",
     "parameters": {
         "url": "https://localhost:8443",
         "profile": "acmeServerCert",


### PR DESCRIPTION
The term "backend" is too generic and might be confused with "database backend" so it has been replaced with "issuer". The code, config files, and docs have been updated accordingly.

The term "issuer" was selected since that is the term used in [cert-manager](https://cert-manager.io/docs/concepts/issuer/) and [openshift-acme](https://github.com/tnozicka/openshift-acme/blob/master/deploy/single-namespace/issuer-letsencrypt-staging.yaml), but if you have other suggestions please let me know.