### PR TITLE
acme: fix revocation checks when account did not issue certificate

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -785,16 +785,14 @@ public class ACMEEngine implements ServletContextListener {
             logger.info("Order ID: " + order.getID());
 
             // check order ownership
-            if (!order.getAccountID().equals(account.getID())) {
-                // TODO: generate proper exception
-                throw new Exception("Account did not issue the certificate");
+            if (order.getAccountID().equals(account.getID())) {
+                // No need to check order status since it's guaranteed to be valid.
+                // No need to check order expiration since it's irrelevant for revocation.
+                logger.info("Account issued the certificate; revocation OK");
+                return;
+            } else {
+                logger.info("Account did not issue the certificate");
             }
-
-            // No need to check order status since it's guaranteed to be valid.
-            // No need to check order expiration since it's irrelevant for revocation.
-
-            logger.info("Account issued the certificate");
-            return;
         }
 
         // Case 2: validate using authorization records (if available)


### PR DESCRIPTION
ACME provides three ways to revoke a certificate:

- proof of possession of private key

- ACME account issued the certificate to be revoked

- ACME account holds authorizations for all identifiers on the
  certificate to be revoked

We recently implemented the third case, but we never reach that code
because an exception is thrown immediately if the current account
did not issue the certificate to be revoked.  Fix the code by not
throwing an exception and instead fall through to the code for the
third case.