### PR TITLE
Added upgrade script for SANToCNDefault

### DIFF
--- a/base/server/upgrade/10.9.0/01-AddSANToCNDefault.py
+++ b/base/server/upgrade/10.9.0/01-AddSANToCNDefault.py
@@ -1,0 +1,41 @@
+# Authors:
+#     Endi S. Dewata <edewata@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from __future__ import absolute_import
+import logging
+
+import pki
+
+logger = logging.getLogger(__name__)
+
+
+class AddSANToCNDefault(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super(AddSANToCNDefault, self).__init__()
+        self.message = 'Add SANToCNDefault policy'
+
+    def upgrade_subsystem(self, instance, subsystem):
+
+        if subsystem.name != 'ca':
+            return
+
+        self.backup(subsystem.registry_conf)
+
+        logger.info('Adding sanToCNDefaultImpl into defaultPolicy.ids')
+        id_list = subsystem.registry.get('defaultPolicy.ids').split(',')
+        if 'sanToCNDefaultImpl' not in id_list:
+            id_list.append('sanToCNDefaultImpl')
+            subsystem.registry['defaultPolicy.ids'] = ','.join(id_list)
+
+        logger.info('Adding defaultPolicy.sanToCNDefaultImpl.name')
+        subsystem.registry['defaultPolicy.sanToCNDefaultImpl.name'] = 'SAN to CN Default'
+
+        logger.info('Adding defaultPolicy.sanToCNDefaultImpl.desc')
+        subsystem.registry['defaultPolicy.sanToCNDefaultImpl.desc'] = 'SAN to CN Default'
+
+        subsystem.save()

--- a/docs/installation/Installing_ACME_Responder.md
+++ b/docs/installation/Installing_ACME_Responder.md
@@ -14,26 +14,6 @@ It assumes that the CA was [installed](Installing_CA.md) with the default instan
 * The API, configuration, or the database may change in the future.
 * There may be no easy upgrade path to the future version.
 
-## Installing SANToCNDefault Policy
-
-The SANToCNDefault is a certificate profile policy which generates
-a default subject DN for the certificate in case the CSR does not provide one.
-The subject DN will be generated from the first DNS name in the the SAN extension.
-
-This policy is needed by the ACME profile, but currently it is not installed by default in the CA,
-so it has to be added manually.
-
-To add the policy, edit /etc/pki/pki-tomcat/ca/registry.cfg as follows:
-
-```
-defaultPolicy.ids=...,sanToCNDefaultImpl
-defaultPolicy.sanToCNDefaultImpl.class=com.netscape.cms.profile.def.SANToCNDefault
-defaultPolicy.sanToCNDefaultImpl.desc=SAN to CN Default
-defaultPolicy.sanToCNDefaultImpl.name=SAN to CN Default
-```
-
-**Note:** Restart the server to enable the policy.
-
 ## Installing ACME Profile
 
 The acmeServerCert.cfg is a sample profile for generating server certificates via ACME responder.


### PR DESCRIPTION
An upgrade script has been added to add SANToCNDefault into
existing registry.cfg. The ACME installation doc has been
updated to no longer require adding SANToCNDefault manually.

https://pagure.io/dogtagpki/issue/3169