### PR TITLE
Minor fix to appease ipa install. The code in question was getting

### DIFF
--- a/base/server/cms/src/com/netscape/cms/profile/def/SigningAlgDefault.java
+++ b/base/server/cms/src/com/netscape/cms/profile/def/SigningAlgDefault.java
@@ -119,9 +119,14 @@ public class SigningAlgDefault extends EnrollDefault {
         }
         if (name.equals(VAL_ALGORITHM)) {
             try {
+                String newValue = value;
+                if(newValue != null) {
+                    newValue = newValue.trim();
+                }
+                CMS.debug("SigningAlgDefault: setValue value: " + newValue);
                 info.set(X509CertInfo.ALGORITHM_ID,
                         new CertificateAlgorithmId(
-                                AlgorithmId.get(value)));
+                                AlgorithmId.get(newValue)));
             } catch (Exception e) {
                 CMS.debug("SigningAlgDefault: setValue " + e.toString());
                 throw new EPropertyException(CMS.getUserMessage(


### PR DESCRIPTION
an algorithmId name with trailing whitespace, which was not recognized.