### PR TITLE
Temporarily disable PKI COPR repo for SSLEngine

### DIFF
--- a/travis/pki-init.sh
+++ b/travis/pki-init.sh
@@ -42,7 +42,7 @@ then
 fi
 
 # Enable pki related COPR repo
-dnf copr enable -y ${COPR_REPO}
+# dnf copr enable -y ${COPR_REPO}
 
 # update, container might be outdated
 dnf update -y --best --allowerasing


### PR DESCRIPTION
Having a `SSLContext` implementation is confusing Tomcat, resulting in PKI
CI failing. Temporarily disable PKI's COPR repo, preventing a newer JSS
from being pulled in.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`