### PR TITLE
[acme] configuration: enable/disable ACME service

### DIFF
--- a/base/acme/conf/configsources.conf
+++ b/base/acme/conf/configsources.conf
@@ -1,0 +1,15 @@
+# ACME engine configuration
+#
+# This file is /optional/.  It allows specifying an alternative
+# sources of ACME engine configuration.
+
+# Specify the ACMEEngineConfigSource subclass to use.
+# If not specified, defaults to ACMEEngineConfigDefaultSource.
+engine.class=org.dogtagpki.acme.server.ACMEEngineConfigFileSource
+
+# Further parameters provide the configuration for the class
+# specified above.  As such, they are class-specific.
+
+# The 'filename' parameter tells the ACMEEngineConfigFileSource
+# where to read the engine configuration from.
+engine.filename=/etc/pki/pki-tomcat/acme/engine.conf

--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -1,0 +1,6 @@
+# Parameters read by ACMEEngineConfigFileSource, i.e. these are
+# expected to be in the file pointed to by the 'filename' directive
+# above.
+#
+# Whether to enable the ACME service:
+enabled=1

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
@@ -37,6 +37,8 @@ public class ACMEApplication extends Application {
         classes.add(ACMECertificateService.class);
         classes.add(ACMEAccountService.class);
         classes.add(ACMERevokeCertificateService.class);
+
+        singletons.add(new ACMERequestFilter());
     }
 
     public Set<Class<?>> getClasses() {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -94,6 +94,8 @@ public class ACMEEngine implements ServletContextListener {
     private ACMEIssuerConfig issuerConfig;
     private ACMEIssuer issuer;
 
+    private boolean enabled = true;
+
     public static ACMEEngine getInstance() {
         return INSTANCE;
     }
@@ -160,6 +162,36 @@ public class ACMEEngine implements ServletContextListener {
 
     public void setIssuer(ACMEIssuer issuer) {
         this.issuer = issuer;
+    }
+
+    /**
+     * Whether the whole ACME service is enabled or not.
+     */
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    private void setEnabled(boolean b) {
+        this.enabled = b;
+    }
+
+    public void loadEngineConfig(String filename) throws Exception {
+        logger.info("Loading ACME engine config " + filename);
+        File f = new File(filename);
+        if (f.exists()) {
+            Properties props = new Properties();
+            try (FileReader reader = new FileReader(f)) {
+                props.load(reader);
+            }
+
+            // set whether ACME service is enabled
+            String s = props.getProperty("enabled");
+            if ("0".equals(s) || "false".equalsIgnoreCase(s)) {
+                this.enabled = false;
+                logger.info("ACME service is DISABLED by configuration");
+            }
+
+        } // else proceed with default config systems and settings
     }
 
     public void loadMetadata(String filename) throws Exception {
@@ -314,6 +346,8 @@ public class ACMEEngine implements ServletContextListener {
         logger.info("ACME configuration directory: " + acmeConfDir);
 
         try {
+            loadEngineConfig(acmeConfDir + File.separator + "engine.conf");
+
             loadMetadata(acmeConfDir + File.separator + "metadata.conf");
 
             loadDatabaseConfig(acmeConfDir + File.separator + "database.conf");

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfigDefaultSource.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfigDefaultSource.java
@@ -1,0 +1,22 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.util.function.Consumer;
+import java.util.Properties;
+
+/**
+ * Default values for ACME engine configuration.
+ *
+ * No updates are ever performed.
+ */
+class ACMEEngineConfigDefaultSource extends ACMEEngineConfigSource {
+    Consumer<Boolean> setEnabled;
+
+    public void init(Properties _cfg, Consumer<Boolean> setEnabled) {
+        setEnabled.accept(true);
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfigFileSource.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfigFileSource.java
@@ -1,0 +1,112 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.function.Consumer;
+
+/**
+ * Monitor the file for configuration changes.
+ */
+class ACMEEngineConfigFileSource
+        extends ACMEEngineConfigSource
+        implements Runnable {
+
+    static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEEngine.class);
+
+    String filename;
+    Thread monitorThread = null;
+
+    public void init(
+            Properties cfg,
+            Consumer<Boolean> setEnabled)
+            throws Exception {
+        init(setEnabled);
+
+        filename = cfg.getProperty("engine.filename");
+        if (null == filename) {
+            throw new IllegalArgumentException("'engine.filename' parameter must not be null");
+        }
+
+        // initial load
+        loadFile();
+
+        // start file monitor thread
+        monitorThread = new Thread(this, "ACMEEngineConfigFileSource");
+        monitorThread.start();
+    }
+
+    void loadFile() throws IOException {
+        File f = new File(filename);
+        if (f.exists()) {
+            Properties props = new Properties();
+            try (FileReader reader = new FileReader(f)) {
+                props.load(reader);
+            }
+
+            // set whether ACME service is enabled
+            String s = props.getProperty("enabled");
+            setEnabled.accept(!("0".equals(s) || "false".equalsIgnoreCase(s)));
+        } else {
+            setEnabled.accept(true); // enabled by default
+        }
+    }
+
+    public void run() {
+
+        final Path path = FileSystems.getDefault().getPath(filename);
+
+        try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
+            // You can only watch a directory, not a file.  So we must
+            // watch the parent dir and check the event is for the file.
+            path.getParent().register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+            while (true) {
+                WatchKey wk = watchService.take();
+                for (WatchEvent<?> event : wk.pollEvents()) {
+                    if (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY) {
+                        if (((Path) event.context()).endsWith(path.getFileName())) {
+                            loadFile();
+                        }
+                    }
+                }
+
+                if (!wk.reset()) {
+                    // watch key could not be reset; break loop
+                    break;
+                }
+            }
+        } catch (InterruptedException e) {
+            // probably due to shutdown()
+            logger.info("ACMEEngineConfigSource: file monitoring interrupted");
+        } catch (Throwable e) {
+            logger.error(
+                "ACMEEngineConfigFileSource: caught exception while monitoring file",
+                e
+            );
+        }
+        logger.info("ACMEConfigFileSource: watch thread exiting");
+        monitorThread = null;
+
+    }
+
+    @Override
+    public void shutdown() {
+        if (monitorThread != null) {
+            logger.info("ACMEEngineConfigSource.shutdown(): interrupting monitor thread");
+            monitorThread.interrupt();
+            monitorThread = null;
+        }
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfigSource.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfigSource.java
@@ -1,0 +1,37 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.util.function.Consumer;
+import java.util.Properties;
+
+/**
+ * Source of ACME engine configuration.
+ *
+ * This class allows for dynamic (re)configuration of the ACME service.
+ *
+ * Sinks configuration values to the setBlah methods when the configuration
+ * is first read, and when changes to those values are detected.
+ */
+abstract class ACMEEngineConfigSource {
+    Consumer<Boolean> setEnabled;
+
+    public abstract void init(
+        Properties cfg,
+        Consumer<Boolean> setEnabled)
+        throws Exception;
+
+    void init(Consumer<Boolean> setEnabled) {
+        this.setEnabled = setEnabled;
+    }
+
+    /**
+     * Shut down the engine config source.  Subclasses that e.g. create
+     * background threads should override this.
+     */
+    public void shutdown() {
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERequestFilter.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERequestFilter.java
@@ -1,0 +1,31 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import javax.ws.rs.ServiceUnavailableException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Fraser Tweedale
+ */
+@Provider
+@PreMatching  // run filter before JAX-RS request matching
+public class ACMERequestFilter implements ContainerRequestFilter {
+
+    public static org.slf4j.Logger logger =
+        org.slf4j.LoggerFactory.getLogger(ACMERequestFilter.class);
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        ACMEEngine engine = ACMEEngine.getInstance();
+        if (!engine.isEnabled()) {
+            throw new ServiceUnavailableException("ACME service is disabled");
+        }
+    }
+}


### PR DESCRIPTION
Add a config knob to disable and enable the ACME service entirely.  (This is
needed for FreeIPA use case).  Also add interfaces for dynamically updating
this configuration, and a file-watching implementation (LDAP - also for FreeIPA
use case - will come later).