### PR TITLE
Remove space from AlgorithmId.toString()

### DIFF
--- a/base/util/src/netscape/security/x509/AlgorithmId.java
+++ b/base/util/src/netscape/security/x509/AlgorithmId.java
@@ -627,7 +627,11 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * Returns a string describing the algorithm and its parameters.
      */
     public String toString() {
-        return (algName() + " " + paramsToString());
+        if (params == null) {
+            return algName();
+        }
+
+        return algName() + " " + paramsToString();
     }
 
     /**


### PR DESCRIPTION
Remove space from `AlgorithmId.toString()`
    
In commit 53de751485b04fe2a1555228342ed642c9a9e347, a fix for this issue
was introduced, making the caller trim whitespace. Instead, we should
fix the `toString()` function.
    
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`