### PR TITLE
Moved deployment log files

### DIFF
--- a/base/common/python/pki/__init__.py
+++ b/base/common/python/pki/__init__.py
@@ -55,36 +55,6 @@ CERT_FOOTER = "-----END CERTIFICATE-----"
 PUNCTUATIONS = '!#*+,-./:;^_|~'
 GEN_PASS_CHARSET = string.digits + string.ascii_lowercase + string.ascii_uppercase + PUNCTUATIONS
 
-# Map from X.509 attribute OID to short name.
-# Source: https://github.com/freeipa/freeipa/blob/master/ipapython/dn.py
-ATTR_NAME_BY_OID = {
-    cryptography.x509.oid.NameOID.COMMON_NAME: 'CN',
-    cryptography.x509.oid.NameOID.COUNTRY_NAME: 'C',
-    cryptography.x509.oid.NameOID.LOCALITY_NAME: 'L',
-    cryptography.x509.oid.NameOID.STATE_OR_PROVINCE_NAME: 'ST',
-    cryptography.x509.oid.NameOID.ORGANIZATION_NAME: 'O',
-    cryptography.x509.oid.NameOID.ORGANIZATIONAL_UNIT_NAME: 'OU',
-    cryptography.x509.oid.NameOID.SERIAL_NUMBER: 'serialNumber',
-    cryptography.x509.oid.NameOID.SURNAME: 'SN',
-    cryptography.x509.oid.NameOID.GIVEN_NAME: 'givenName',
-    cryptography.x509.oid.NameOID.TITLE: 'title',
-    cryptography.x509.oid.NameOID.GENERATION_QUALIFIER: 'generationQualifier',
-    cryptography.x509.oid.NameOID.DN_QUALIFIER: 'dnQualifier',
-    cryptography.x509.oid.NameOID.PSEUDONYM: 'pseudonym',
-    cryptography.x509.oid.NameOID.DOMAIN_COMPONENT: 'DC',
-    cryptography.x509.oid.NameOID.EMAIL_ADDRESS: 'E',
-    cryptography.x509.oid.NameOID.JURISDICTION_COUNTRY_NAME:
-        'incorporationCountry',
-    cryptography.x509.oid.NameOID.JURISDICTION_LOCALITY_NAME:
-        'incorporationLocality',
-    cryptography.x509.oid.NameOID.JURISDICTION_STATE_OR_PROVINCE_NAME:
-        'incorporationState',
-    cryptography.x509.oid.NameOID.BUSINESS_CATEGORY: 'businessCategory',
-    cryptography.x509.ObjectIdentifier('2.5.4.9'): 'STREET',
-    cryptography.x509.ObjectIdentifier('2.5.4.17'): 'postalCode',
-    cryptography.x509.ObjectIdentifier('0.9.2342.19200300.100.1.1'): 'UID',
-}
-
 # Retry-able connection errors, see https://github.com/dogtagpki/pki/issues/3091
 RETRYABLE_EXCEPTIONS = (
     requests.exceptions.ConnectionError,  # connection failed
@@ -92,34 +62,6 @@ RETRYABLE_EXCEPTIONS = (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def convert_x509_name_to_dn(name):
-    """
-    Convert X.509 Name into NSS-style DN string.
-
-    See also:
-    - https://cryptography.io/en/latest/x509/reference/#cryptography.x509.Name
-    - https://cryptography.io/en/latest/x509/reference/#cryptography.x509.NameAttribute
-    - https://cryptography.io/en/latest/x509/reference/#cryptography.x509.ObjectIdentifier
-
-    :param name: X.509 Name
-    :type name: cryptography.x509.Name
-    :returns: str -- DN string.
-    """
-    dn = None
-
-    for attr in name:
-        oid = attr.oid
-        attr_name = ATTR_NAME_BY_OID.get(oid, oid.dotted_string)
-        rdn = '%s=%s' % (attr_name, attr.value)
-
-        if dn:
-            dn = rdn + ',' + dn
-        else:
-            dn = rdn
-
-    return dn
 
 
 def specification_version():

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1339,8 +1339,9 @@ class NSSDatabase(object):
 
         cert['serial_number'] = cert_obj.serial_number
 
-        cert['issuer'] = pki.convert_x509_name_to_dn(cert_obj.issuer)
-        cert['subject'] = pki.convert_x509_name_to_dn(cert_obj.subject)
+        # https://cryptography.io/en/latest/x509/reference.html#cryptography.x509.Name.rfc4514_string
+        cert['issuer'] = cert_obj.issuer.rfc4514_string()
+        cert['subject'] = cert_obj.subject.rfc4514_string()
 
         cert['not_before'] = self.convert_time_to_millis(cert_obj.not_valid_before)
         cert['not_after'] = self.convert_time_to_millis(cert_obj.not_valid_after)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -447,7 +447,7 @@ class PKIDeployer:
         logger.info('Adding subsystem cert into pkidbuser')
         subsystem.add_user_cert('pkidbuser', cert_data=cert_data, cert_format='PEM')
 
-        logger.info('Linking pkidbuser to subsystem cert')
+        logger.info('Linking pkidbuser to subsystem cert: %s', subject)
         subsystem.modify_user('pkidbuser', add_see_also=subject)
 
         logger.info('Finding other users linked to subsystem cert')


### PR DESCRIPTION
Previously the deployment log files were created at:
- pkispawn: /var/log/pki/pki-&lt;subsystem&gt;-spawn.&lt;timestamp&gt;.log
- pkidestroy: /var/log/pki/pki-&lt;subsystem&gt;-destroy.&lt;timestamp&gt;.log

Since the path of the log files did not contain the instance name,
it was difficult to find the log file for a particular deployment.

To address the issue, the deployment log files are now created at:
- pkispawn: /var/log/pki/&lt;instance&gt;/&lt;subsystem&gt;/install.log
- pkidestroy: /var/log/pki/&lt;instance&gt;/&lt;subsystem&gt;/uninstall.log

https://pagure.io/dogtagpki/issue/512

Updated man page:
https://github.com/edewata/pki/blob/install/docs/manuals/man8/pkispawn.8.md