### PR TITLE
Fix Bug 1809273 - CRL generation performs an unindexed search.

### DIFF
--- a/base/ca/shared/conf/crlcaissuer.ldif
+++ b/base/ca/shared/conf/crlcaissuer.ldif
@@ -1,0 +1,15 @@
+dn: cn=allRevokedCertsByIssuer-{instanceId}, cn={database}, cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: vlvSearch
+cn: allRevokedCertsByIssuer-{instanceId}
+vlvBase: ou=certificateRepository,ou=ca,{rootSuffix}
+vlvScope: 1
+vlvFilter: (&(certStatus=REVOKED)(|(!(issuerName=*))(issuerName={caIssuerDN}))) 
+
+dn: cn=allRevokedCertsByIssuer-{instanceId}Index, cn=allRevokedCerts-{instanceId}, cn={database}, cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: vlvIndex
+cn: allRevokedCertsByIssuer-{instanceId}Index
+vlvSort: serialno
+vlvEnabled: 0
+vlvUses: 0

--- a/base/ca/shared/conf/crlcaissuertasks.ldif
+++ b/base/ca/shared/conf/crlcaissuertasks.ldif
@@ -1,0 +1,7 @@
+dn: cn=index1160589779, cn=index, cn=tasks, cn=config
+objectclass: top
+objectclass: extensibleObject
+cn: index1160589779
+ttl: 10
+nsinstance: {database}
+nsindexVLVAttribute: allRevokedCertsByIssuer-{instanceId}

--- a/base/server/python/pki/server/cli/db.py
+++ b/base/server/python/pki/server/cli/db.py
@@ -806,6 +806,19 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
         print('Usage: pki-server %s-db-upgrade [OPTIONS]' % self.parent.parent.name)
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        if self.parent.parent.name == "ca":
+            print('      --action <action>              update-vlv-indexes or:')
+            print('                                         fix-missing-issuer-names')
+            print('                                         (default: fix-missing-issuer-names)')
+            print('      --issuer_dn <Issuer DN>        CA signing cert issuer dn')
+            print('                                         required only for update-vlv-indexes')
+            print('      --vlv-file <VLV File>          LDIF file with desired vlv indexes')
+            print('                                         required only for update-vlv-indexes')
+            print('      --vlv-tasks-file <VLV Tasks>   LDIF file with desired vlv tasks')
+            print('                                         required only for update-vlv-indexes')
+        else:
+            print('      --action <action>              fix-missing-issuer-names')
+            print('                                         (default: fix-missing-issuer-names)')
         print('      --as-current-user              Run as current user.')
         print('  -v, --verbose                      Run in verbose mode.')
         print('      --debug                        Run in debug mode.')
@@ -816,7 +829,8 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=',
-                'as-current-user',
+                'as-current-user', "action=", "issuer-dn=",
+                'vlv-file=', 'vlv-tasks-file=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -831,6 +845,7 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
         cmd = [subsystem_name + '-db-upgrade']
 
         for o, a in opts:
+            logging.info('opt %s', o)
             if o in ('-i', '--instance'):
                 instance_name = a
 
@@ -848,6 +863,20 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
             elif o == '--help':
                 self.print_help()
                 sys.exit()
+
+            elif o == '--issuer-dn':
+                logging.info('--issuer-dn')
+                cmd.extend(['--issuer-dn', a])
+
+            elif o == '--action':
+                logging.info('--action')
+                cmd.extend(['--action', a])
+
+            elif o == '--vlv-file':
+                cmd.extend(['--vlv-file', a])
+
+            elif o == '--vlv-tasks-file':
+                cmd.extend(['--vlv-tasks-file', a])
 
             else:
                 logging.error('Invalid option: %s', o)
@@ -868,5 +897,4 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
             logging.error('No %s subsystem in instance %s.',
                           subsystem_name.upper(), instance_name)
             sys.exit(1)
-
         subsystem.run(cmd, as_current_user=as_current_user)

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -802,6 +802,12 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             setup_db_manager=setup_db_manager,
             setup_vlv_indexes=setup_vlv_indexes)
 
+        update_crl_vlv_indexes = (subsystem.type == 'CA')
+        if update_crl_vlv_indexes:
+            subsystem.update_database(
+                issuer_dn=deployer.mdict['pki_ca_signing_subject_dn'],
+                update_crl_vlv_indexes=update_crl_vlv_indexes)
+
         # Start/Restart this Tomcat PKI Process
         # Optionally prepare to enable a java debugger
         # (e. g. - 'eclipse'):

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -888,6 +888,29 @@ class PKISubsystem(object):
 
         self.run(cmd, as_current_user=as_current_user)
 
+    def update_database(
+            self,
+            issuer_dn,
+            update_crl_vlv_indexes=False,
+            as_current_user=False):
+
+        if self.name != 'ca':
+            return
+        cmd = [self.name + '-db-upgrade']
+        if update_crl_vlv_indexes:
+            cmd.extend(['--action', 'update-vlv-indexes'])
+            cmd.extend(['--vlv-file', 'crlcaissuer.ldif'])
+            cmd.extend(['--vlv-tasks-file', 'crlcaissuertasks.ldif'])
+            cmd.extend(['--issuer-dn', issuer_dn])
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd, as_current_user=as_current_user)
+
     def empty_database(self, force=False, as_current_user=False):
 
         cmd = [self.name + '-db-empty']

--- a/base/server/src/org/dogtagpki/server/cli/CADBUpgradeCLI.java
+++ b/base/server/src/org/dogtagpki/server/cli/CADBUpgradeCLI.java
@@ -18,17 +18,25 @@
 
 package org.dogtagpki.server.cli;
 
+import java.security.cert.CertificateException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.lang.StringUtils;
 import org.dogtagpki.cli.CLI;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.netscape.certsrv.base.EBaseException;
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
 import com.netscape.cmscore.ldapconn.LdapBoundConnection;
 
 import netscape.ldap.LDAPAttribute;
 import netscape.ldap.LDAPAttributeSet;
 import netscape.ldap.LDAPEntry;
+import netscape.ldap.LDAPException;
 import netscape.ldap.LDAPModification;
 import netscape.ldap.LDAPSearchResults;
 import netscape.ldap.LDAPv3;
@@ -44,12 +52,67 @@ public class CADBUpgradeCLI extends SubsystemDBUpgradeCLI {
         super("upgrade", "Upgrade CA database", parent);
     }
 
-    public void upgrade(LDAPConfig ldapConfig, LdapBoundConnection conn) throws Exception {
+    public void createOptions() {
+
+        Option action = new Option(null, "action", true, "Desired CA database upgrade action");
+        action.setArgName("action");
+        options.addOption(action);
+
+
+        Option issuerDn = new Option(null, "issuer-dn", true, "Optional CA issuer DN");
+        issuerDn.setArgName("issuer-dn");
+        options.addOption(issuerDn);
+
+        Option vlvFile = new Option(null,"vlv-file",true, "Vlv file to update vlv indexes");
+        vlvFile.setArgName("vlv-file");
+        options.addOption(vlvFile);
+
+        Option vlvTasksFile = new Option(null,"vlv-tasks-file",true, "Vlv tasks file to update vlv indexes");
+        vlvTasksFile.setArgName("vlv-tasks-file");
+        options.addOption(vlvTasksFile);
+
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+        this.cmd = cmd;
+        super.execute(cmd);
+    }
+
+    public void upgrade(String instanceId, LDAPConfig ldapConfig, LdapBoundConnection conn) throws Exception {
+
+        if (cmd.hasOption("action")) {
+            String caIssuerDn = null;
+            String actionVal = cmd.getOptionValue("action");
+            logger.info("Attempting to execute a specific action: " + actionVal);
+
+            if (cmd.hasOption("issuer-dn")) {
+                caIssuerDn = cmd.getOptionValue("issuer-dn");
+            }
+
+            if ("update-vlv-indexes".equals(actionVal)) {
+                updateVlvIndexes(instanceId, caIssuerDn, ldapConfig, conn);
+                return;
+            } else if ("fix-missing-issuer-names".equals(actionVal)) {
+                fixMissingIssuerNames(ldapConfig, conn);
+                return;
+            } else {
+                logger.info("Invalid action requested: " + actionVal);
+                return;
+            }
+        }
+
+        //Take default action which is to upgrade the db with missing issuerNames
+        fixMissingIssuerNames(ldapConfig, conn);
+    }
+
+    private void fixMissingIssuerNames(LDAPConfig ldapConfig, LdapBoundConnection conn)
+            throws EBaseException, LDAPException, CertificateException {
 
         logger.info("Searching certificates records with missing issuerName");
 
         String baseDN = ldapConfig.getBaseDN();
         String certRepoDN = "ou=certificateRepository,ou=ca," + baseDN;
+
 
         LDAPSearchResults results = conn.search(
                 certRepoDN,
@@ -79,4 +142,41 @@ public class CADBUpgradeCLI extends SubsystemDBUpgradeCLI {
             conn.modify(entry.getDN(), mods);
         }
     }
+
+    private void updateVlvIndexes(String instanceId, String caIssuerDn, LDAPConfig ldapConfig, LdapBoundConnection conn)
+            throws Exception {
+
+        String actionVal = cmd.getOptionValue("action");
+
+        if (StringUtils.isEmpty(actionVal)) {
+            logger.info("Invalid number of args for updateVlvIndexes");
+            return;
+        }
+
+        if (!cmd.hasOption("vlv-file")) {
+            logger.info("Command must have a value for argument vlv-file");
+            return;
+        }
+
+        if (StringUtils.isEmpty(caIssuerDn)) {
+            logger.info("Command must have a value for argument issuerDN ");
+            return;
+        }
+
+        String vlvName = cmd.getOptionValue("vlv-file");
+        String vlvTasksName = cmd.getOptionValue("vlv-tasks-file");
+
+        if (StringUtils.isEmpty(vlvName) || StringUtils.isEmpty(vlvTasksName)) {
+            logger.info("Command must include vlv-fle and vlv-tasks-file arguments");
+            return;
+        }
+
+        LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, instanceId, caIssuerDn, ldapConfig);
+
+        ldapConfigurator.createAdditionalVLVIndexes("ca", vlvName);
+        ldapConfigurator.rebuildAdditionalVLVIndexes("ca", vlvTasksName);
+
+    }
+
+    private CommandLine cmd = null;
 }

--- a/base/server/src/org/dogtagpki/server/cli/SubsystemDBUpgradeCLI.java
+++ b/base/server/src/org/dogtagpki/server/cli/SubsystemDBUpgradeCLI.java
@@ -117,7 +117,7 @@ public class SubsystemDBUpgradeCLI extends CommandCLI {
         LdapBoundConnection conn = new LdapBoundConnection(socketFactory, connInfo, authInfo);
 
         try {
-            upgrade(ldapConfig, conn);
+            upgrade(instanceId, ldapConfig, conn);
 
         } finally {
             conn.disconnect();
@@ -126,6 +126,6 @@ public class SubsystemDBUpgradeCLI extends CommandCLI {
         System.out.println(parent.parent.name.toUpperCase() + " database upgraded");
     }
 
-    public void upgrade(LDAPConfig ldapConfig, LdapBoundConnection conn) throws Exception {
+    public void upgrade(String instanceId,LDAPConfig ldapConfig, LdapBoundConnection conn) throws Exception {
     }
 }


### PR DESCRIPTION
Implemented with a modification to a CLI command, also calls this command from pkispawn to take care of new instances:

Example use of standalone command:

Which will work if the indexes in question have not been created already.

pki-server ca-db-upgrade --verbose --action update-vlv-indexes --vlv-file crlcaissuer.ldif --vlv-tasks-file crlcaissuertasks.ldif  --issuer-dn "CN=CA Signing Certificate,OU=pki-tomcat,O=localhost.localdomain Security Domain"