### PR TITLE
Include new ecj.jar path in pki.policy

### DIFF
--- a/base/server/share/conf/pki.policy
+++ b/base/server/share/conf/pki.policy
@@ -32,6 +32,10 @@ grant codeBase "file:/usr/share/java/ecj.jar" {
         permission java.security.AllPermission;
 };
 
+grant codeBase "file:/usr/share/java/ecj/ecj.jar" {
+        permission java.security.AllPermission;
+};
+
 grant codeBase "file:/usr/share/java/eclipse/-" {
         permission java.security.AllPermission;
 };


### PR DESCRIPTION
Resolves: [rhbz#1755634](https://bugzilla.redhat.com/show_bug.cgi?id=1755634)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

-----

Fraser's comment got me thinking; if it isn't a vararg problem, what is it? Reading the stack trace closely, it isn't that varargs aren't allowed -- it is that the permission to _read_ the property isn't allowed. Why? Because the JAR has changed paths on Fedora. :-)