### PR TITLE
Added wildcard support for ACME responder

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
@@ -165,9 +165,21 @@ public class InMemoryDatabase extends ACMEDatabase {
             }
 
             // Compare authorization's identifier against provided identifier
-            // TODO: handle wildcard
 
-            if (!authorization.getIdentifier().equals(identifier)) {
+            ACMEIdentifier authzIdentifier = authorization.getIdentifier();
+            String type = authzIdentifier.getType();
+
+            if ("dns".equals(type) && authorization.getWildcard()) {
+
+                // append *. prefix so the identifiers can be compared
+                String value = "*." + authzIdentifier.getValue();
+
+                authzIdentifier = new ACMEIdentifier();
+                authzIdentifier.setType(type);
+                authzIdentifier.setValue(value);
+            }
+
+            if (!authzIdentifier.equals(identifier)) {
                 logger.info("Authorization " + authorization.getID() + " does not match " + identifier);
                 continue;
             }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
@@ -592,6 +592,9 @@ public class LDAPDatabase extends ACMEDatabase {
     public boolean hasRevocationAuthorization(
             String accountID, Date time, ACMEIdentifier identifier)
             throws Exception {
+
+        // TODO: handle wildcard
+
         List<LDAPEntry> entries = ldapSearch(
             RDN_AUTHORIZATION + "," + basedn,
             "(&(" + ATTR_OBJECTCLASS + "=" + OBJ_AUTHORIZATION

--- a/docs/user/Using_ACME_Responder.md
+++ b/docs/user/Using_ACME_Responder.md
@@ -72,11 +72,20 @@ $ certbot certonly --manual \
     --preferred-challenges dns
 ```
 
+To enroll a wildcard certificate with manual DNS-01 validation, execute the following command:
+
+```
+$ certbot certonly --manual \
+    --server http://$HOSTNAME:8080/acme/directory \
+    -d *.example.com \
+    --preferred-challenges dns
+```
+
 Create a TXT record in the DNS server as instructed by certbot.
 Check the TXT record propagation with the following command:
 
 ```
-$ dig _acme-challenge.server.example.com TXT
+$ dig _acme-challenge.<DNS name> TXT
 ```
 
 Once the TXT record is propagated properly, complete the enrollment using certbot.


### PR DESCRIPTION
The ACME responder has been modified to support wildcards for
enrollment and revocation using in-memory and PostgresSQL
databases. The support for LDAP database will be added later.

Updated doc:
https://github.com/edewata/pki/blob/acme-dev/docs/user/Using_ACME_Responder.md