### PR TITLE
acme: fix NPE ACMEEngine.validateCSR()

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -658,7 +658,8 @@ public class ACMEEngine implements ServletContextListener {
 
             if ("dns".equals(type)) {
 
-                if (authz.getWildcard()) {
+                Boolean b = authz.getWildcard();
+                if (null != b && b) {
                     value = "*." + value; // add *. prefix
                 }
 


### PR DESCRIPTION
validateCSR() reads authz.getWildcard() and uses the result in a
condition.  But this routine returns Boolean, and if the result is
null (not set; implying false) then NullPointerException occurs.

Avoid the NPE by first testing != null.