### PR TITLE
acme: avoid vacuous revocation authorisation

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -819,6 +819,15 @@ public class ACMEEngine implements ServletContextListener {
         // The identifiers obtained from the certificate may contain wildcards.
         Collection<ACMEIdentifier> identifiers = getCertIdentifiers(cert);
 
+        if (identifiers.isEmpty()) {
+            /* Protect against vacuous authorisation.  If there are no
+             * identifiers, it could be e.g. a user or CA certificate.
+             * Without this check that there are at least /some/ identifiers
+             * to authorise, every account would be vacuously authorised
+             * to revoke it.  */
+            throw new Exception("Certificate has no ACME identifiers.");
+        }
+
         try {
             for (ACMEIdentifier identifier : identifiers) {
 


### PR DESCRIPTION
If there are no identifiers to check, authorisation will be vacuously
authorised.  Certificate use cases where there could be no ACME
identifiers include (but are not limited to) user or CA
certificates.  Prevent revocation unless there is at least one ACME
identifier we can check.