### PR TITLE
Changes done to run the upstream pytest-ansible tests on Fedora32 and with latest packages

### DIFF
--- a/tests/dogtag/pytest-ansible/.gitlab-ci.yml
+++ b/tests/dogtag/pytest-ansible/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 image: bbhavsar/dogtagpki-test-essentials-container
 
 variables:
-  HOSTFILE: $CI_PROJECT_DIR/linchpin-openstack/inventories/openstack_topo.inventory
-  IMG_BRANCH: fedora28_1master
-  POST_PROV: 'https://gitlab.cee.redhat.com/snippets/393/raw'
+  HOSTFILE: $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/provision/ansible_inventory
+  IMG_NAME: 'Fedora-Cloud-Base-32'
+  PYTEST_DIR: $CI_PROJECT_DIR/tests/dogtag/pytest-ansible
 
 stages:
   - tier0
@@ -26,47 +26,45 @@ before_script:
   - eval $(ssh-agent -s)
   - echo "$certsys_priv_key" | tr -d '\r' | ssh-add - > /dev/null
   - mkdir -p ~/.ssh && chmod 700 ~/.ssh
-  - GIT_SSL_NO_VERIFY=true git clone -b $IMG_BRANCH https://gitlab.cee.redhat.com/idm/linchpin-openstack
-  - wget -O - https://gitlab.cee.redhat.com/snippets/250/raw --no-check-certificate | python
-  - linchpin -v -w linchpin-openstack --creds-path linchpin-openstack/credentials up
-  - cat linchpin-openstack/inventories/openstack_topo.inventory
-  - sleep 30s
-  - wget -O repo.yml $POST_PROV --no-check-certificate
-  - ansible-playbook -u fedora --become -i $HOSTFILE repo.yml -e 'ansible_python_interpreter="/usr/bin/python3"' -vv
+  - pip install -r $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/requirements.txt
   - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
-  - export ANSIBLE_LIBRARY=$CI_PROJECT_DIR/tests/dogtag/pytest-ansible/common-modules/
-
+  - python $PYTEST_DIR/provision/osp_provision.py up --image "$IMG_NAME" --server-type master --inventory $HOSTFILE
+  - mkdir -p /etc/ansible; echo -e "[ssh_connection]\nretries = 8" > /etc/ansible/ansible.cfg
+  - cat $HOSTFILE
+  - sleep 30s
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/provision/post_provision.yml -e 'ansible_python_interpreter="/usr/bin/python3"' -vv
+  - export ANSIBLE_LIBRARY=$PYTEST_DIR/common-modules/
 
 after_script:
-  - linchpin -w linchpin-openstack --creds-path linchpin-openstack/credentials destroy
+  - python $PYTEST_DIR/provision/osp_provision.py down --inventory $HOSTFILE
 
 
 installation-sanity:
   stage: tier0
   <<: *job_definition
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
 
 installation-sanity-ecc:
   stage: tier1
   <<: *job_definition
   script:
-  - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-ecc" -vv  | sed 's/\\n/\n/g'
+  - ansible-playbook -u fedora --become --private-key=ssh-priv-key -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-ecc" -vv  | sed 's/\\n/\n/g'
 
 banner-cli:
   stage: tier1
   <<: *job_definition
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
-  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
+  - cd $PYTEST_DIR
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/banner/test_banner_cli.py -q -s --junitxml $CI_PROJECT_DIR/bannercli_junit.xml -vvvv
 
 tps-config-cli:
   stage: tier1
   <<: *job_definition
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
-  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
+  - cd $PYTEST_DIR
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/tps/tps_config/*.py -q -s --junitxml $CI_PROJECT_DIR/tps_config_cli_junit.xml -vv
 
 
@@ -74,8 +72,8 @@ tps-activity-cli:
   stage: tier1
   <<: *job_definition
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
-  - cd $CI_PROJECT_DIR/pki/tests/dogtag/pytest-ansible/
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv  | sed 's/\\n/\n/g'
+  - cd $PYTEST_DIR
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/tps/tps_activity/*.py -q -s --junitxml $CI_PROJECT_DIR/tps_activity_junit.xml -vv
 
 
@@ -83,8 +81,8 @@ ca-bugzillas:
   stage: tier1
   <<: *job_definition
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
+  - cd $PYTEST_DIR
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/ocsp/test_bug_1523443_HAProxy_rejection.py -q -s --junitxml $CI_PROJECT_DIR/BZ_1523443_junit.xml -vv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/bugzilla/test_bug_1465103_missing_JDAP_filters.py -q -s --junitxml $CI_PROJECT_DIR/BZ_1465103_junit.xml -vv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/bugzilla/test_bug_1539198_inconsistent_cert_req_outcomes.py -q -s --junitxml $CI_PROJECT_DIR/BZ_1539198_junit.xml -vv
@@ -93,8 +91,8 @@ ca_authplugins:
   stage: tier1
   <<: *job_definition
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
+  - cd $PYTEST_DIR
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/auth_plugins/*.py -q -s --junitxml $CI_PROJECT_DIR/auth_plugins_junit.xml -vvvv
 
 
@@ -102,8 +100,8 @@ securitydomain-cli:
   stage: tier1
   <<: *job_definition
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
+  - cd $PYTEST_DIR
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/sanity/test_role_users.py -qsvvv --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml 
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/ca/securitydomain/*.py -qsvvv --junitxml $CI_PROJECT_DIR/securitydomain_junit.xml
 
@@ -111,17 +109,17 @@ pki-pkcs12-cli:
   <<: *job_definition
   stage: tier1
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
+  - cd $PYTEST_DIR
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvv
-  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE --ansible-playbook-directory $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/pytest/ca/pki_pkcs12/ pytest/ca/pki_pkcs12/*.py -qsvv --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_junit.xml
+  - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE --ansible-playbook-directory $CI_PROJECT_DIR/$PYTEST_DIR/pytest/ca/pki_pkcs12/ pytest/ca/pki_pkcs12/*.py -qsvv --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_junit.xml
 
 pki_server:
   <<: *job_definition
   stage: tier1
   script:
-  - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-  - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+  - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
+  - cd $PYTEST_DIR
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/sanity/test_role_users.py -q -s --junitxml $CI_PROJECT_DIR/role_user_creation_junit.xml -vvvv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/ca/pki_server/*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_ca_junit.xml -vv
   - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master --ansible-playbook-inventory $HOSTFILE pytest/kra/pki_server/*.py -qs --junitxml $CI_PROJECT_DIR/${CI_JOB_NAME}_kra_junit.xml -vv
@@ -134,20 +132,20 @@ role-user-creation-topo-02:
   stage: tier0
   <<: *job_definition
   script:
-    - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
-    - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+    - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-02" -vv
+    - cd $PYTEST_DIR
     - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/sanity/test_role_users_kra.py --junitxml $CI_PROJECT_DIR/role-user-creation_junit.xml -qsvvvv
 
 topo-01-role-user-creation:
   stage: tier0
   <<: *job_definition
   script:
-    - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-01" -vv
-    - cd $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
+    - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=topology-01" -vv
+    - cd $PYTEST_DIR
     - py.test --ansible-user=fedora --ansible-become --ansible-inventory $HOSTFILE --ansible-host-pattern master pytest/sanity/test_role_users_kra.py --junitxml $CI_PROJECT_DIR/role-user-creation_kra_junit.xml -qsvvvv
 
 installation-acme:
   <<: *job_definition
   stage: tier0
   script:
-    - ansible-playbook -u fedora --become -i $HOSTFILE tests/dogtag/pytest-ansible/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=acme" -vv
+    - ansible-playbook -u fedora --become -i $HOSTFILE $PYTEST_DIR/installation/main.yml -e 'ansible_python_interpreter="/usr/bin/python3"' --extra-vars "topology=acme" -vv

--- a/tests/dogtag/pytest-ansible/.gitlab-ci.yml
+++ b/tests/dogtag/pytest-ansible/.gitlab-ci.yml
@@ -28,7 +28,7 @@ before_script:
   - mkdir -p ~/.ssh && chmod 700 ~/.ssh
   - pip install -r $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/requirements.txt
   - pip install $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/
-  - python $PYTEST_DIR/provision/osp_provision.py up --image "$IMG_NAME" --server-type master --inventory $HOSTFILE
+  - python $PYTEST_DIR/provision/osp_provision.py up --image "$IMG_NAME" --server-type master --inventory $HOSTFILE || { echo 'Failed to get inventory for test runs.' ; exit 1; }
   - mkdir -p /etc/ansible; echo -e "[ssh_connection]\nretries = 8" > /etc/ansible/ansible.cfg
   - cat $HOSTFILE
   - sleep 30s

--- a/tests/dogtag/pytest-ansible/provision/osp_provision.py
+++ b/tests/dogtag/pytest-ansible/provision/osp_provision.py
@@ -15,7 +15,6 @@ CI_FLAVOR_NAME = os.getenv('CI_FLAVOR_NAME')
 DOMAIN_NAME = os.getenv('DOMAIN_NAME')
 OS_PASSWORD = os.getenv('OS_PASSWORD')
 OS_NETWORK_ID = os.getenv('OS_NETWORK_ID').split(',')
-# OS_NETWORK_ID = random.choice(OS_NETWORK_ID)
 
 inventory_file = "ansible_inventory"
 instance_record = '/tmp/instance_record.txt'
@@ -46,26 +45,21 @@ def spawn_server(conn, image_name, server_type='master'):
         server_name = 'OSP_API_Client_{}'.format(random.randint(999, 99999))
     image = conn.compute.find_image(image_name)
     flavor = conn.compute.find_flavor(CI_FLAVOR_NAME)
-    try:
-        server = conn.compute.create_server(name=server_name, image_id=image.id,
-                                            flavor_id=flavor.id, networks=[{"uuid": OS_NETWORK_ID}],
-                                            key_name=OS_KEYPAIR_NAME)
+    server = conn.compute.create_server(name=server_name, image_id=image.id,
+                                        flavor_id=flavor.id, networks=[{"uuid": OS_NETWORK_ID}],
+                                        key_name=OS_KEYPAIR_NAME)
 
+    # Writing server details in the inventory file which is used at the time of teardown.
+    if os.path.isfile(instance_record):
+        with open(instance_record, 'a') as f:
+            f.write('{}\n'.format(server.name))
+    else:
+        with open(instance_record, 'w') as f:
+            f.write('{}\n'.format(server.name))
 
-        # Writing server details in the inventory file which is used at the time of teardown.
-        if os.path.isfile(instance_record):
-            with open(instance_record, 'a') as f:
-                f.write('{}\n'.format(server.name))
-        else:
-            with open(instance_record, 'w') as f:
-                f.write('{}\n'.format(server.name))
-
-        # Wait time for VM to come active is 10 min
-        server = conn.compute.wait_for_server(server, status='ACTIVE', failures='ERROR', interval=2, wait=600)
-        return server
-    except Exception as e:
-        print(e)
-        sys.exit(1)
+    # Wait time for VM to come active is 10 min
+    server = conn.compute.wait_for_server(server, status='ACTIVE', failures='ERROR', interval=2, wait=600)
+    return server
 
 
 def delete_server(conn, server_name):
@@ -118,9 +112,8 @@ def cli():
 @click.option('-v', '--verbose', is_flag=True, help="Verbose")
 def up(inventory, image, image_type, server_type, verbose):
 
-    python_interpreter = ''
     if not image:
-        image_name = 'Fedora 31'
+        image_name = 'Fedora-Cloud-Base-32'
     else:
         image_name = image
 
@@ -134,69 +127,68 @@ def up(inventory, image, image_type, server_type, verbose):
     image_list = list_images(conn, image)
 
     network = None
-    if image_name in image_list:
-        print("Using Image: {}".format(image_name))
-        server = spawn_server(conn, image_name, server_type=server_type)
-        print(server)
-        if server:
-            for key in server.addresses.keys():
-                network = server.addresses[key][0]
-                print("OSP Machine name: {}".format(server.name))
-                print("Server ip: {}".format(network['addr']))
-
-            data = ["[all]\n"]
-            if os.path.isfile(inventory):
-                with open(inventory, 'r') as f:
-                    data = f.readlines()
-
-            data = [i.strip() for i in data]
-            index = data.index("[all]")
-            data.insert(index + 1, "{} hostname={} {}".format(network['addr'], network['addr'],
-                                                              python_interpreter))
-            if "[{}]".format(server_type) in data:
-                index = data.index("[{}]".format(server_type))
-                data.insert(index + 1, "{} hostname={} {}".format(network['addr'], network['addr'],
-                                                                  python_interpreter))
-            else:
-                data.extend(["\n[{}]".format(server_type),
-                             "{} hostname={} {}".format(network['addr'], network['addr'],
-                                                        python_interpreter)])
-            with open(inventory, 'w') as f:
-                print(data)
-                file_data = "\n".join(data)
-                f.write(file_data)
-        else:
-            print("ERROR: Unable to provision machine")
-            sys.exit(1)
-
-    else:
+    if image_name not in image_list:
         print("ERROR: No image found.")
         sys.exit(1)
+
+    print("Using Image: {}".format(image_name))
+    server = spawn_server(conn, image_name, server_type=server_type)
+
+    if not server:
+        print("ERROR: Unable to provision machine")
+        sys.exit(1)
+
+    for key in server.addresses.keys():
+        network = server.addresses[key][0]
+        print("OSP Machine name: {}".format(server.name))
+        print("Server ip: {}".format(network['addr']))
+
+    data = ["[all]\n"]
+    if os.path.isfile(inventory):
+        with open(inventory, 'r') as f:
+            data = f.readlines()
+
+    data = [i.strip() for i in data]
+    index = data.index("[all]")
+    data.insert(index + 1, "{} hostname={}".format(network['addr'], network['addr']))
+    if "[{}]".format(server_type) in data:
+        index = data.index("[{}]".format(server_type))
+        data.insert(index + 1, "{} hostname={}".format(network['addr'], network['addr']))
+    else:
+        data.extend(["\n[{}]".format(server_type),
+                     "{} hostname={} {}".format(network['addr'], network['addr'])])
+    with open(inventory, 'w') as f:
+        print(data)
+        file_data = "\n".join(data)
+        f.write(file_data)
 
 
 @cli.command()
 @click.option('--inventory', default='ansible_inventory', help='Inventory file path')
 def down(inventory):
+
     name = None
     if not inventory:
         inventory = inventory_file
-    if os.path.isfile(instance_record):
-        conn = create_connection(OS_AUTH_URL, OS_REGION_NAME,
-                                 OS_PROJECT_NAME, OS_USERNAME,
-                                 OS_PASSWORD)
-        vm_list = open(instance_record, 'r').read()
-        for record in vm_list.split("\n"):
-            if record.strip():
-                name = record.split()[0].strip()
-                print("Removing Machine: {}".format(name))
-                delete_server(conn, name)
-            print("Removed Machine: {}".format(name))
-    else:
+
+    if not os.path.isfile(instance_record):
         print("ERROR: No record file found. Delete instances manually.")
-    print("Removed record.")
+        os.remove(inventory)
+        print("Removed inventory file.")
+        sys.exit(1)
+
+    conn = create_connection(OS_AUTH_URL, OS_REGION_NAME,
+                             OS_PROJECT_NAME, OS_USERNAME,
+                             OS_PASSWORD)
+    vm_list = open(instance_record, 'r').read()
+    for record in vm_list.split("\n"):
+        if record.strip():
+            name = record.split()[0].strip()
+            print("Removing Machine: {}".format(name))
+            delete_server(conn, name)
+        print("Removed Machine: {}".format(name))
     os.remove(instance_record)
-    print("Removed inventory.")
-    os.remove(inventory)
+    print("Removed record.")
 
 
 cli.add_command(up)

--- a/tests/dogtag/pytest-ansible/provision/osp_provision.py
+++ b/tests/dogtag/pytest-ansible/provision/osp_provision.py
@@ -1,0 +1,206 @@
+import os
+import random
+import sys
+
+import click
+import openstack
+
+
+OS_AUTH_URL = os.getenv('OS_AUTH_URL')
+OS_PROJECT_NAME = os.getenv('OS_PROJECT_NAME')
+OS_USERNAME = os.getenv('OS_USERNAME')
+OS_REGION_NAME = os.getenv('OS_REGION_NAME')
+OS_KEYPAIR_NAME = os.getenv('OS_KEYPAIR_NAME')
+CI_FLAVOR_NAME = os.getenv('CI_FLAVOR_NAME')
+DOMAIN_NAME = os.getenv('DOMAIN_NAME')
+OS_PASSWORD = os.getenv('OS_PASSWORD')
+OS_NETWORK_ID = os.getenv('OS_NETWORK_ID').split(',')
+# OS_NETWORK_ID = random.choice(OS_NETWORK_ID)
+
+inventory_file = "ansible_inventory"
+instance_record = '/tmp/instance_record.txt'
+
+
+def create_connection(auth_url, region, project_name, username, password):
+    return openstack.connect(auth_url=auth_url,
+                             project_name=project_name,
+                             username=username,
+                             password=password,
+                             user_domain_name=DOMAIN_NAME,
+                             project_domain_name=DOMAIN_NAME,
+                             region_name=region)
+
+
+def spawn_server(conn, image_name, server_type='master'):
+    """
+    This method spawns a server for provided image.
+    The method looks for available network and also sets an inventory which is used in teardown state.
+    """
+
+    print("Spawning server: ")
+    set_available_network(conn)
+
+    if server_type == 'master':
+        server_name = 'OSP_API_Master_{}'.format(random.randint(999, 99999))
+    else:
+        server_name = 'OSP_API_Client_{}'.format(random.randint(999, 99999))
+    image = conn.compute.find_image(image_name)
+    flavor = conn.compute.find_flavor(CI_FLAVOR_NAME)
+    try:
+        server = conn.compute.create_server(name=server_name, image_id=image.id,
+                                            flavor_id=flavor.id, networks=[{"uuid": OS_NETWORK_ID}],
+                                            key_name=OS_KEYPAIR_NAME)
+
+
+        # Writing server details in the inventory file which is used at the time of teardown.
+        if os.path.isfile(instance_record):
+            with open(instance_record, 'a') as f:
+                f.write('{}\n'.format(server.name))
+        else:
+            with open(instance_record, 'w') as f:
+                f.write('{}\n'.format(server.name))
+
+        # Wait time for VM to come active is 10 min
+        server = conn.compute.wait_for_server(server, status='ACTIVE', failures='ERROR', interval=2, wait=600)
+        return server
+    except Exception as e:
+        print(e)
+        sys.exit(1)
+
+
+def delete_server(conn, server_name):
+    print("Removing Server")
+    server = conn.compute.find_server(server_name)
+    conn.compute.delete_server(server)
+
+
+def list_images(conn, name):
+    print("List Images:")
+    image_list = []
+    for image in conn.image.images():
+        if ("latest" in image.name and image.name.startswith(name)) or (name in image.name):
+            image_list.append(image.name)
+            print("Found Image: {}".format(image.name))
+    return image_list
+
+
+def set_available_network(conn):
+    """
+    This method searches for network with available IPs.
+    And sets the network for server spawining.
+    """
+    print('Getting network availability')
+    global OS_NETWORK_ID
+    for net_id in OS_NETWORK_ID:
+        print net_id
+        used_ips = conn.network.get_network_ip_availability('60cacaff-86a6-4f88-82a4-ed3023724df1').used_ips
+        total_ips = conn.network.get_network_ip_availability('60cacaff-86a6-4f88-82a4-ed3023724df1').total_ips
+        print(used_ips)
+        print(total_ips)
+        if total_ips - used_ips > 10:
+            OS_NETWORK_ID = net_id
+            print('Using network : {} \n Available IPs : {}'.format(net_id, str(total_ips - used_ips)))
+            break
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.option('--image', default='Fedora-Cloud-Base-32', help="Image to provision.")
+@click.option('--inventory', default='/root/host', help='Generate inventory file.')
+@click.option('--image-type', type=click.Choice(['nightly', 'production']), default='nightly',
+              help="Image type (nightly, production)")
+@click.option('--server-type', type=click.Choice(['master', 'client']), default='server',
+              help="Machine type (master, client)")
+@click.option('-v', '--verbose', is_flag=True, help="Verbose")
+def up(inventory, image, image_type, server_type, verbose):
+
+    python_interpreter = ''
+    if not image:
+        image_name = 'Fedora 31'
+    else:
+        image_name = image
+
+    if verbose:
+        openstack.enable_logging(True, stream=sys.stdout)
+
+    conn = create_connection(OS_AUTH_URL, OS_REGION_NAME,
+                             OS_PROJECT_NAME, OS_USERNAME,
+                             OS_PASSWORD)
+    print(image)
+    image_list = list_images(conn, image)
+
+    network = None
+    if image_name in image_list:
+        print("Using Image: {}".format(image_name))
+        server = spawn_server(conn, image_name, server_type=server_type)
+        print(server)
+        if server:
+            for key in server.addresses.keys():
+                network = server.addresses[key][0]
+                print("OSP Machine name: {}".format(server.name))
+                print("Server ip: {}".format(network['addr']))
+
+            data = ["[all]\n"]
+            if os.path.isfile(inventory):
+                with open(inventory, 'r') as f:
+                    data = f.readlines()
+
+            data = [i.strip() for i in data]
+            index = data.index("[all]")
+            data.insert(index + 1, "{} hostname={} {}".format(network['addr'], network['addr'],
+                                                              python_interpreter))
+            if "[{}]".format(server_type) in data:
+                index = data.index("[{}]".format(server_type))
+                data.insert(index + 1, "{} hostname={} {}".format(network['addr'], network['addr'],
+                                                                  python_interpreter))
+            else:
+                data.extend(["\n[{}]".format(server_type),
+                             "{} hostname={} {}".format(network['addr'], network['addr'],
+                                                        python_interpreter)])
+            with open(inventory, 'w') as f:
+                print(data)
+                file_data = "\n".join(data)
+                f.write(file_data)
+        else:
+            print("ERROR: Unable to provision machine")
+            sys.exit(1)
+
+    else:
+        print("ERROR: No image found.")
+        sys.exit(1)
+
+
+@cli.command()
+@click.option('--inventory', default='ansible_inventory', help='Inventory file path')
+def down(inventory):
+    name = None
+    if not inventory:
+        inventory = inventory_file
+    if os.path.isfile(instance_record):
+        conn = create_connection(OS_AUTH_URL, OS_REGION_NAME,
+                                 OS_PROJECT_NAME, OS_USERNAME,
+                                 OS_PASSWORD)
+        vm_list = open(instance_record, 'r').read()
+        for record in vm_list.split("\n"):
+            if record.strip():
+                name = record.split()[0].strip()
+                print("Removing Machine: {}".format(name))
+                delete_server(conn, name)
+            print("Removed Machine: {}".format(name))
+    else:
+        print("ERROR: No record file found. Delete instances manually.")
+    print("Removed record.")
+    os.remove(instance_record)
+    print("Removed inventory.")
+    os.remove(inventory)
+
+
+cli.add_command(up)
+cli.add_command(down)
+
+if __name__ == '__main__':
+    cli()

--- a/tests/dogtag/pytest-ansible/provision/post_provision.yml
+++ b/tests/dogtag/pytest-ansible/provision/post_provision.yml
@@ -1,0 +1,15 @@
+- hosts: master
+  gather_facts: true
+
+  tasks:
+
+    - name: Install list of packages for CS Master for Fedora
+      dnf : pkg={{item}} state=latest
+      with_items:
+        - setools
+        - dnf-plugins-core
+      when: ansible_distribution == "Fedora"
+
+    - name: set PKI master copr repo
+      shell: dnf copr enable @pki/master -y
+      when: ansible_distribution == "Fedora"

--- a/tests/dogtag/pytest-ansible/requirements.txt
+++ b/tests/dogtag/pytest-ansible/requirements.txt
@@ -3,3 +3,5 @@ pytest-ansible==2.0.2
 pytest-ansible-playbook
 pytest-logger
 pytest-autochecklog==0.2.0
+configparser
+pytest-html


### PR DESCRIPTION
Changes done to run the upstream pytest-ansible tests on Fedora32 and with latest packages

- Changes includes:
- Change in .gitlab_ci.yml to spawn instance by using latest osp_provision.py
   [with PSI resource issues].
- Change in .gitlab_ci.yml to use Fedora 32 image.
- Addition of post_provision.yml to get latest repo.
