### PR TITLE
acme: reject CSRs with unrecognised identifiers (and other checks)

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -769,6 +769,19 @@ public class ACMEEngine implements ServletContextListener {
             if (generalName instanceof DNSName) {
                 String dnsName = ((DNSName) generalName).getValue();
                 dnsNames.add(dnsName.toLowerCase());
+            } else {
+                // Unrecognised identifier type
+                //
+                // We cannot allow this to pass through, otherwise a CSR
+                // with unvalidated SAN values will be passed along to the
+                // CA, and these are likely to be accepted as-is.
+                //
+                // This is also required by RFC 8555 §7.4:
+                //
+                //    The CSR MUST indicate the exact same set of requested
+                //    identifiers as the initial newOrder request.
+                //
+                throw new Exception("Unauthorized identifier: " + generalName.toString());
             }
         }
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -682,12 +682,27 @@ public class ACMEEngine implements ServletContextListener {
             logger.info("- " + dnsName);
         }
 
+        // RFC 8555 §7.4 says: The CSR MUST indicate the exact same
+        // set of requested identifiers as the initial newOrder request.
+
+        // check for unauthorized names in CSR
         Set<String> unauthorizedDNSNames = new HashSet<>(dnsNames);
         unauthorizedDNSNames.removeAll(authorizedDNSNames);
-
         if (!unauthorizedDNSNames.isEmpty()) {
             // TODO: generate proper exception
-            throw new Exception("Unauthorized DNS names: " + StringUtils.join(unauthorizedDNSNames, ", "));
+            throw new Exception(
+                "Unauthorized DNS names: "
+                + StringUtils.join(unauthorizedDNSNames, ", "));
+        }
+
+        // check for authorized names missing from CSR
+        Set<String> extraAuthorizedDNSNames = new HashSet<>(authorizedDNSNames);
+        extraAuthorizedDNSNames.removeAll(dnsNames);
+        if (!extraAuthorizedDNSNames.isEmpty()) {
+            // TODO: generate proper exception
+            throw new Exception(
+                "Missing DNS names from order: "
+                + StringUtils.join(extraAuthorizedDNSNames, ", "));
         }
 
         // TODO: validate other things in CSR


### PR DESCRIPTION
```
4c3794c5d (Fraser Tweedale, 38 minutes ago)
   acme: ensure all identifiers from order appear in CSR

   RFC 8555 §7.4 states:

      The CSR MUST indicate the exact same
     set of requested identifiers as the initial newOrder request.

   We were already checking that unauthorised DNS names were not present in
   the CSR.  But we did not check that /all/ the names from the order were
   present in the CSR.  Add this check.

a661afacf (Fraser Tweedale, 59 minutes ago)
   acme: reject CSR with unknown indentifiers

   Unknown identifiers must be treated as unauthorised.  Otherwise a CSR with
   only authorised DNS names but e.g. *also* an RFC822 name, would be passed
   through to the CA and (under a standard profile configuration) issued with
   the unrecognised name.

   This is an unacceptable security flaw and also violates RFC 8555
   §7.4.
```