### PR TITLE
Re-enable COPR

### DIFF
--- a/.github/workflows/required-tests.yml
+++ b/.github/workflows/required-tests.yml
@@ -10,7 +10,7 @@ jobs:
       # run the build commands. We then upload the artifact for consumption
       # by the test jobs + for the public to consume. This job **does not**
       # upload any build logs as they are visible in the log console itself.
- 
+
       name: Build PKI
       runs-on: ubuntu-latest
       container: fedora:${{ matrix.os }}
@@ -29,7 +29,7 @@ jobs:
 
           - name: Install PKI build deps
             run: |
-                  # dnf copr enable @pki/master
+                  dnf copr enable -y @pki/master
                   dnf builddep -y --allowerasing --spec ./pki.spec
 
           - name: Build PKI packages
@@ -45,7 +45,7 @@ jobs:
             with:
               name: pki-build-${{ matrix.os }}
               path: pki-rpms.tar.gz
-    
+
     # Test job
     pki-tests:
       # This job depends on the 'build' job and waits till it completes.
@@ -81,11 +81,11 @@ jobs:
         - name: Install required packages
           run: docker exec -i ${CONTAINER} dnf install -y findutils dnf-plugins-core sudo wget 389-ds-base
 
+        - name: Enable PKI COPR repo
+          run: docker exec -i ${CONTAINER} dnf copr enable -y ${COPR_REPO}
+
         - name: Install PKI packages
           run: docker exec -i ${CONTAINER} bash -c "find ${PKIDIR} -name '*.rpm' -and -not -name '*debuginfo*' | xargs dnf -y install"
-        
-        #- name: Enable PKI COPR repo
-        #  run: docker exec -i ${CONTAINER} dnf copr enable -y ${COPR_REPO}
 
         - name: Install DS
           run: docker exec -i ${CONTAINER} ${PKIDIR}/ci/ds-create.sh
@@ -176,8 +176,8 @@ jobs:
         - name: Enable freeipa nightly COPR
           run: docker exec -i ${CONTAINER} dnf copr enable -y @freeipa/freeipa-master-nightly
 
-        #- name: Enable PKI COPR repo
-        #  run: docker exec -i ${CONTAINER} dnf copr enable -y ${COPR_REPO}
+        - name: Enable PKI COPR repo
+          run: docker exec -i ${CONTAINER} dnf copr enable -y ${COPR_REPO}
 
         - name: Install FreeIPA packages
           run: docker exec -i ${CONTAINER} dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad python3-ipatests

--- a/pki.spec
+++ b/pki.spec
@@ -218,8 +218,8 @@ BuildRequires:  python3-pytest-runner
 
 BuildRequires:    junit
 BuildRequires:    jpackage-utils >= 0:1.7.5-10
-BuildRequires:    jss >= 4.6.0
-BuildRequires:    tomcatjss >= 7.4.1
+BuildRequires:    jss >= 4.7.0
+BuildRequires:    tomcatjss >= 7.5.0
 BuildRequires:    systemd-units
 
 %if 0%{?rhel}
@@ -335,7 +335,7 @@ Summary:          PKI Symmetric Key Package
 
 Requires:         java-1.8.0-openjdk-headless
 Requires:         jpackage-utils >= 0:1.7.5-10
-Requires:         jss >= 4.6.0
+Requires:         jss >= 4.7.0
 Requires:         nss >= 3.38.0
 
 # Ensure we end up with a useful installation
@@ -413,7 +413,7 @@ Requires:         glassfish-jaxb-api
 Requires:         slf4j
 Requires:         slf4j-jdk14
 Requires:         jpackage-utils >= 0:1.7.5-10
-Requires:         jss >= 4.6.0
+Requires:         jss >= 4.7.0
 Requires:         ldapjdk >= 4.21.0
 Requires:         pki-base = %{version}
 
@@ -498,7 +498,7 @@ Requires(post):   systemd-units
 Requires(preun):  systemd-units
 Requires(postun): systemd-units
 Requires(pre):    shadow-utils
-Requires:         tomcatjss >= 7.4.1
+Requires:         tomcatjss >= 7.5.0
 
 # pki-healthcheck depends on the following library
 %if 0%{?rhel}


### PR DESCRIPTION
Since `SSLEngine` is in a working state, and when used in a `SSLSocket`, its performance isn't that much worse than other implementations, we should go ahead and re-enable COPR in our CI instance.
