### PR TITLE
Refactor Certificate Transparency request - JSON parameter

### DIFF
--- a/base/ca/src/com/netscape/ca/CTRequest.java
+++ b/base/ca/src/com/netscape/ca/CTRequest.java
@@ -1,0 +1,58 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+
+package com.netscape.ca;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Dinesh Prasanth M K
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CTRequest {
+
+    private List<String> certs = new ArrayList<>();
+
+    public CTRequest() {
+    }
+
+    @JsonGetter("chain")
+    public List<String> getCerts() {
+        return certs;
+    }
+
+    @JsonSetter("chain")
+    public void setCerts(List<String> certs) {
+        this.certs = certs;
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static CTRequest fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CTRequest.class);
+    }
+
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
This patch:

- Generates JSON for certificate Transparency using jackson
- Sorts the certificate chain, from subCA to rootCA, before
  embedding on the JSON request

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`