### PR TITLE
Move to versionless java dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ configure_file(cmake/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 add_definitions(-DHAVE_CONFIG_H)
 
+# handle custom PKI Java path
+if (PKI_JAVA_PATH STREQUAL "")
+    set(PKI_JAVA_PATH "${Java_JAVA_EXECUTABLE}")
+endif ()
+
 # uninstall target
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
                "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"

--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -96,16 +96,27 @@ class PKICLI(pki.cli.CLI):
 
         self.set_nss_default_db_type()
 
+        java_path = os.getenv('PKI_JAVA_PATH')
         java_home = os.getenv('JAVA_HOME')
         pki_lib = os.getenv('PKI_LIB')
         logging_config = os.getenv('PKI_LOGGING_CONFIG')
 
-        cmd = [
-            java_home + '/bin/java',
+        cmd = []
+
+        if os.path.exists(java_path):
+            cmd.extend([java_path])
+        elif os.path.exists(java_home + '/jre/bin/java'):
+            cmd.extend([java_home + '/jre/bin/java'])
+        elif os.path.exists(java_home + '/bin/java'):
+            cmd.extend([java_home + '/bin/java'])
+        else:
+            cmd.extend(['/usr/bin/env', 'java'])
+
+        cmd.extend([
             '-cp', pki_lib + '/*',
             '-Djava.util.logging.config.file=' + logging_config,
             'com.netscape.cmstools.cli.MainCLI'
-        ]
+        ])
 
         # restore options for Java commands
 

--- a/base/common/share/etc/pki.conf
+++ b/base/common/share/etc/pki.conf
@@ -10,6 +10,10 @@ export PYTHON_EXECUTABLE
 JAVA_HOME=${JAVA_HOME}
 export JAVA_HOME
 
+# Java interpreter
+PKI_JAVA_PATH=${Java_JAVA_EXECUTABLE}
+export PKI_JAVA_PATH
+
 # JNI jar file location
 JNI_JAR_DIR=/usr/lib/java
 export JNI_JAR_DIR

--- a/base/java-tools/templates/pki_java_command_wrapper.in
+++ b/base/java-tools/templates/pki_java_command_wrapper.in
@@ -71,44 +71,17 @@ invalid_architecture() {
 
 OS=`uname -s`
 
-if [ "${OS}" = "Linux" ] ; then
-    ARCHITECTURE=`arch`
+ARCHITECTURE=`arch`
+if [ -e "${PKI_JAVA_PATH}" ]; then
+    JAVA="${PKI_JAVA_PATH}"
+elif [ -e "${JAVA_HOME}/jre/bin/java" ]; then
+    JAVA="${JAVA_HOME}/jre/bin/java"
+elif [ -e "${JAVA_HOME}/bin/java" ]; then
     JAVA="${JAVA_HOME}/bin/java"
-    JAVA_OPTIONS=""
-elif [ "${OS}" = "SunOS" ] ; then
-    ARCHITECTURE=`uname -p`
-    if [ "${ARCHITECTURE}" = "sparc" ] &&
-       [ -d "/usr/lib/sparcv9/" ] ; then
-        ARCHITECTURE="sparcv9"
-    fi
-    if [ "${ARCHITECTURE}" = "sparc" ] ; then
-        JAVA="/usr/jdk/instances/jdk1.5.0/jre/bin/java"
-        JAVA_OPTIONS=""
-
-        LD_LIBRARY_PATH=/usr/lib:/lib
-        LD_LIBRARY_PATH=/usr/lib/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/${PRODUCT}:${LD_LIBRARY_PATH}
-        export LD_LIBRARY_PATH
-    elif [ "${ARCHITECTURE}" = "sparcv9" ] ; then
-        JAVA="/usr/jdk/instances/jdk1.5.0/jre/bin/java"
-        JAVA_OPTIONS="-d64"
-
-        LD_LIBRARY_PATH=/usr/lib:/lib
-        LD_LIBRARY_PATH=/usr/lib/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/${PRODUCT}:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9:/lib/sparcv9:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9/${PRODUCT}:${LD_LIBRARY_PATH}
-        export LD_LIBRARY_PATH
-    else
-        invalid_architecture "${ARCHITECTURE}"
-        exit 255
-    fi
 else
-    invalid_operating_system "${OS}"
-    exit 255
+    JAVA="/usr/bin/env java"
 fi
-
+JAVA_OPTIONS=""
 
 ###############################################################################
 ##  (5) Execute the java command specified by this java command wrapper      ##

--- a/base/java-tools/templates/pretty_print_cert_command_wrapper.in
+++ b/base/java-tools/templates/pretty_print_cert_command_wrapper.in
@@ -70,45 +70,17 @@ invalid_architecture() {
 ###############################################################################
 
 OS=`uname -s`
-
-if [ "${OS}" = "Linux" ] ; then
-    ARCHITECTURE=`arch`
+ARCHITECTURE=`arch`
+if [ -e "${PKI_JAVA_PATH}" ]; then
+    JAVA="${PKI_JAVA_PATH}"
+elif [ -e "${JAVA_HOME}/jre/bin/java" ]; then
+    JAVA="${JAVA_HOME}/jre/bin/java"
+elif [ -e "${JAVA_HOME}/bin/java" ]; then
     JAVA="${JAVA_HOME}/bin/java"
-    JAVA_OPTIONS=""
-elif [ "${OS}" = "SunOS" ] ; then
-    ARCHITECTURE=`uname -p`
-    if [ "${ARCHITECTURE}" = "sparc" ] &&
-       [ -d "/usr/lib/sparcv9/" ] ; then
-        ARCHITECTURE="sparcv9"
-    fi
-    if [ "${ARCHITECTURE}" = "sparc" ] ; then
-        JAVA="/usr/jdk/instances/jdk1.5.0/jre/bin/java"
-        JAVA_OPTIONS=""
-
-        LD_LIBRARY_PATH=/usr/lib:/lib
-        LD_LIBRARY_PATH=/usr/lib/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/${PRODUCT}:${LD_LIBRARY_PATH}
-        export LD_LIBRARY_PATH
-    elif [ "${ARCHITECTURE}" = "sparcv9" ] ; then
-        JAVA="/usr/jdk/instances/jdk1.5.0/jre/bin/java"
-        JAVA_OPTIONS="-d64"
-
-        LD_LIBRARY_PATH=/usr/lib:/lib
-        LD_LIBRARY_PATH=/usr/lib/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/${PRODUCT}:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9:/lib/sparcv9:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9/${PRODUCT}:${LD_LIBRARY_PATH}
-        export LD_LIBRARY_PATH
-    else
-        invalid_architecture "${ARCHITECTURE}"
-        exit 255
-    fi
 else
-    invalid_operating_system "${OS}"
-    exit 255
+    JAVA="/usr/bin/env java"
 fi
-
+JAVA_OPTIONS=""
 
 ###############################################################################
 ##  (5) Set the CP environment variable to determine the search              ##

--- a/base/java-tools/templates/pretty_print_crl_command_wrapper.in
+++ b/base/java-tools/templates/pretty_print_crl_command_wrapper.in
@@ -69,44 +69,18 @@ invalid_architecture() {
 ###############################################################################
 
 OS=`uname -s`
+ARCHITECTURE=`arch`
 
-if [ "${OS}" = "Linux" ] ; then
-    ARCHITECTURE=`arch`
+if [ -e "${PKI_JAVA_PATH}" ]; then
+    JAVA="${PKI_JAVA_PATH}"
+elif [ -e "${JAVA_HOME}/jre/bin/java" ]; then
+    JAVA="${JAVA_HOME}/jre/bin/java"
+elif [ -e "${JAVA_HOME}/bin/java" ]; then
     JAVA="${JAVA_HOME}/bin/java"
-    JAVA_OPTIONS=""
-elif [ "${OS}" = "SunOS" ] ; then
-    ARCHITECTURE=`uname -p`
-    if [ "${ARCHITECTURE}" = "sparc" ] &&
-       [ -d "/usr/lib/sparcv9/" ] ; then
-        ARCHITECTURE="sparcv9"
-    fi
-    if [ "${ARCHITECTURE}" = "sparc" ] ; then
-        JAVA="/usr/jdk/instances/jdk1.5.0/jre/bin/java"
-        JAVA_OPTIONS=""
-
-        LD_LIBRARY_PATH=/usr/lib:/lib
-        LD_LIBRARY_PATH=/usr/lib/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/${PRODUCT}:${LD_LIBRARY_PATH}
-        export LD_LIBRARY_PATH
-    elif [ "${ARCHITECTURE}" = "sparcv9" ] ; then
-        JAVA="/usr/jdk/instances/jdk1.5.0/jre/bin/java"
-        JAVA_OPTIONS="-d64"
-
-        LD_LIBRARY_PATH=/usr/lib:/lib
-        LD_LIBRARY_PATH=/usr/lib/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/${PRODUCT}:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9:/lib/sparcv9:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9/${PRODUCT}:${LD_LIBRARY_PATH}
-        export LD_LIBRARY_PATH
-    else
-        invalid_architecture "${ARCHITECTURE}"
-        exit 255
-    fi
 else
-    invalid_operating_system "${OS}"
-    exit 255
+    JAVA="/usr/bin/env java"
 fi
+JAVA_OPTIONS=""
 
 
 ###############################################################################

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -318,6 +318,7 @@ class PKIServer(object):
             if current_user != self.user:
                 prefix.extend(['sudo', '-u', self.user])
 
+        java_path = os.getenv('PKI_JAVA_PATH')
         java_home = self.config.get('JAVA_HOME')
         java_opts = self.config.get('JAVA_OPTS')
         security_manager = self.config.get('SECURITY_MANAGER')
@@ -340,10 +341,14 @@ class PKIServer(object):
             cmd.extend(['jdb'])
 
         else:
-            if java_home:
+            if os.path.exists(java_path):
+                cmd.extend([java_path])
+            elif os.path.exists(java_home + '/jre/bin/java'):
+                cmd.extend([java_home + '/jre/bin/java'])
+            elif os.path.exists(java_home + '/bin/java'):
                 cmd.extend([java_home + '/bin/java'])
             else:
-                cmd.extend(['java'])
+                cmd.extend(['/usr/bin/env', 'java'])
 
         if agentpath:
             cmd.extend(['-agentpath:%s' % agentpath])

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1079,6 +1079,7 @@ class PKISubsystem(object):
 
     def run(self, args, as_current_user=False):
 
+        java_path = os.getenv('PKI_JAVA_PATH')
         java_home = self.instance.config['JAVA_HOME']
         java_opts = self.instance.config['JAVA_OPTS']
 
@@ -1101,8 +1102,16 @@ class PKISubsystem(object):
             if username != self.instance.user:
                 cmd.extend(['sudo', '-u', self.instance.user])
 
+        if os.path.exists(java_path):
+            cmd.extend([java_path])
+        elif os.path.exists(java_home + '/jre/bin/java'):
+            cmd.extend([java_home + '/jre/bin/java'])
+        elif os.path.exists(java_home + '/bin/java'):
+            cmd.extend([java_home + '/bin/java'])
+        else:
+            cmd.extend(['/usr/bin/env', 'java'])
+
         cmd.extend([
-            java_home + '/bin/java',
             '-classpath', os.pathsep.join(classpath),
             '-Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory',
             '-Dcatalina.base=' + self.instance.base_dir,

--- a/pki.spec
+++ b/pki.spec
@@ -51,7 +51,13 @@ Source: https://github.com/dogtagpki/pki/archive/v%{version}%{?_phase}/pki-%{ver
 # Java
 ################################################################################
 
-%define java_home %{_usr}/lib/jvm/jre-1.8.0-openjdk
+%define java_home /usr/lib/jvm/jre-openjdk
+
+%if 0%{?fedora} && 0%{?fedora} >= 33
+%define min_java_version 1:11
+%else
+%define min_java_version 1:1.8.0
+%endif
 
 ################################################################################
 # RESTEasy
@@ -151,7 +157,8 @@ BuildRequires:    make
 BuildRequires:    cmake >= 3.0.2
 BuildRequires:    gcc-c++
 BuildRequires:    zip
-BuildRequires:    java-1.8.0-openjdk-devel
+BuildRequires:    java-devel >= %{min_java_version}
+BuildRequires:    javapackages-tools
 BuildRequires:    redhat-rpm-config
 BuildRequires:    ldapjdk >= 4.22.0
 BuildRequires:    apache-commons-cli
@@ -324,7 +331,7 @@ PKI consists of the following components:
 
 Summary:          PKI Symmetric Key Package
 
-Requires:         java-1.8.0-openjdk-headless
+Requires:         java-headless >= %{min_java_version}
 Requires:         jpackage-utils >= 0:1.7.5-10
 Requires:         jss >= 4.7.0
 Requires:         nss >= 3.38.0
@@ -392,7 +399,7 @@ This package contains PKI client library for Python 3.
 Summary:          PKI Base Java Package
 BuildArch:        noarch
 
-Requires:         java-1.8.0-openjdk-headless
+Requires:         java-headless >= %{min_java_version}
 Requires:         apache-commons-cli
 Requires:         apache-commons-codec
 Requires:         apache-commons-io
@@ -814,7 +821,8 @@ cd build
     -DVERSION=%{version}-%{release} \
     -DVAR_INSTALL_DIR:PATH=/var \
     -DP11_KIT_TRUST=/etc/alternatives/libnssckbi.so.%{_arch} \
-    -DJAVA_HOME=%{java_home} \
+    -DJAVA_HOME=%java_home \
+    -DPKI_JAVA_PATH=%java \
     -DJAVA_LIB_INSTALL_DIR=%{_jnidir} \
     -DSYSTEMD_LIB_INSTALL_DIR=%{_unitdir} \
     -DAPP_SERVER=$app_server \


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

As part of JDK11 support, move to versionless Java dependencies.

Note that we might want to add `-source 1.8` and `-target 1.8` to our build process also to ensure we don't break RHEL where we'll still need to support Java8.