### PR TITLE
Remove the exception on debug log while deferring approval

### DIFF
--- a/base/ca/src/com/netscape/cms/servlet/cert/CertProcessor.java
+++ b/base/ca/src/com/netscape/cms/servlet/cert/CertProcessor.java
@@ -260,7 +260,7 @@ public class CertProcessor extends CAProcessor {
 
             } catch (EDeferException e) {
 
-                logger.warn("Certificate request deferred: " + e.getMessage(), e);
+                logger.warn("Certificate request deferred: " + e.getMessage());
 
                 req.setRequestStatus(RequestStatus.PENDING);
                 // need to notify

--- a/base/ca/src/com/netscape/cms/servlet/profile/ProfileSubmitCMCServlet.java
+++ b/base/ca/src/com/netscape/cms/servlet/profile/ProfileSubmitCMCServlet.java
@@ -899,7 +899,7 @@ public class ProfileSubmitCMCServlet extends ProfileServlet {
                         notify.notify(reqs[k]);
                     }
 
-                    logger.warn("ProfileSubmitCMCServlet: submit " + e.getMessage(), e);
+                    logger.warn("ProfileSubmitCMCServlet: submit " + e.getMessage());
                     errorCode = "2";
                     errorReason = CMS.getUserMessage(locale,
                                 "CMS_PROFILE_DEFERRED",


### PR DESCRIPTION
This patch removes the java exception stacktrace when a certificate
request submitted gets deferred for manual approval.

### Before this patch (debug level set to default 10)
````
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: - req_seq_num: 0
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: - profilesetid: serverCertSet
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: - req_subject_name.uid:
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: - profileremoteaddr: 192.168.1.66
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: - requesttype: enrollment
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: - req_extensions: owIwAA==
 
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: - req_subject_name: MCAxHjAcBgNVBAMMFXNpbGxlYmlsbGUudGVzdGN0LmNvbQ==
 
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: - profileremotehost: 192.168.1.66
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: CertProcessor: Submitting certificate request to caServerCertWithSCT profile
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: KeyConstraint: Key algorithnm: RSA
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: KeyConstraint: Key type: RSA
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] WARNING: Certificate request deferred: defer request
defer request
        at com.netscape.cms.profile.common.EnrollProfile.submit(EnrollProfile.java:676)
        at com.netscape.cms.servlet.cert.CertProcessor.submitRequests(CertProcessor.java:246)
        at com.netscape.cms.servlet.cert.EnrollmentProcessor.processEnrollment(EnrollmentProcessor.java:207)
        at com.netscape.cms.servlet.cert.EnrollmentProcessor.processEnrollment(EnrollmentProcessor.java:97)
        at org.dogtagpki.server.ca.rest.CertRequestDAO.submitRequest(CertRequestDAO.java:216)
        at org.dogtagpki.server.ca.rest.CertRequestService.enrollCert(CertRequestService.java:169)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:140)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:295)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:249)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:236)
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:406)
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:213)
        at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:228)
        at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56)
        at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
        at sun.reflect.GeneratedMethodAccessor59.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.catalina.security.SecurityUtil$1.run(SecurityUtil.java:282)
        at org.apache.catalina.security.SecurityUtil$1.run(SecurityUtil.java:279)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAsPrivileged(Subject.java:549)
        at org.apache.catalina.security.SecurityUtil.execute(SecurityUtil.java:314)
        at org.apache.catalina.security.SecurityUtil.doAsPrivilege(SecurityUtil.java:170)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:225)
        at org.apache.catalina.core.ApplicationFilterChain.access$000(ApplicationFilterChain.java:47)
        at org.apache.catalina.core.ApplicationFilterChain$1.run(ApplicationFilterChain.java:149)
        at org.apache.catalina.core.ApplicationFilterChain$1.run(ApplicationFilterChain.java:145)
        at java.security.AccessController.doPrivileged(Native Method)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
        at sun.reflect.GeneratedMethodAccessor58.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.catalina.security.SecurityUtil$1.run(SecurityUtil.java:282)
        at org.apache.catalina.security.SecurityUtil$1.run(SecurityUtil.java:279)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAsPrivileged(Subject.java:549)
        at org.apache.catalina.security.SecurityUtil.execute(SecurityUtil.java:314)
        at org.apache.catalina.security.SecurityUtil.doAsPrivilege(SecurityUtil.java:253)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:191)
        at org.apache.catalina.core.ApplicationFilterChain.access$000(ApplicationFilterChain.java:47)
        at org.apache.catalina.core.ApplicationFilterChain$1.run(ApplicationFilterChain.java:149)
        at org.apache.catalina.core.ApplicationFilterChain$1.run(ApplicationFilterChain.java:145)
        at java.security.AccessController.doPrivileged(Native Method)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:144)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:526)
        at com.netscape.cms.tomcat.ExternalAuthenticationValve.invoke(ExternalAuthenticationValve.java:82)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
        at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:408)
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:860)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1589)
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.lang.Thread.run(Thread.java:748)
 
2020-04-30 11:54:53 [https-jsse-nio-8443-exec-15] INFO: Updating certificate request
````


### With this patch (debug level set to default 10)
````
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: - req_seq_num: 0
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: - profilesetid: serverCertSet
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: - req_subject_name.uid: 
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: - profileremoteaddr: 192.168.1.66
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: - requesttype: enrollment
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: - req_extensions: owIwAA==

2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: - req_subject_name: MCAxHjAcBgNVBAMMFXNpbGxlYmlsbGUudGVzdGN0LmNvbQ==

2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: - profileremotehost: 192.168.1.66
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: CertProcessor: Submitting certificate request to caServerCertWithSCT profile
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: KeyConstraint: Key algorithnm: RSA
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: KeyConstraint: Key type: RSA
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] WARNING: Certificate request deferred: defer request
2020-05-05 19:29:27 [https-jsse-nio-8443-exec-6] INFO: Updating certificate request
````

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`