### PR TITLE
acme: include Location header in finalize response

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
@@ -95,6 +95,16 @@ public class ACMEFinalizeOrderService {
         ACMENonce nonce = engine.createNonce();
         builder.header("Replay-Nonce", nonce.getValue());
 
+        /* This is not required by ACME protocol but mod_md has a
+         * bug[1] causing it to fail if there is no Location header
+         * in the response.  So we add it.  This is also what
+         * boulder / Let's Encrypt do.
+         *
+         * [1] https://github.com/icing/mod_md/issues/216
+         */
+        URI orderURL = uriInfo.getBaseUriBuilder().path("order").path(orderID).build();
+        builder.location(orderURL);
+
         URI indexURL = uriInfo.getBaseUriBuilder().path("directory").build();
         builder.link(indexURL, "index");
 


### PR DESCRIPTION
mod_md fails when the finalize response does not include a Location
header.  For details see https://github.com/icing/mod_md/issues/216.

Work around the mod_md bug by including the Location header in the
finalize response.  This also brings us into line with the Boulder
(Let's Encrypt) behaviour, although this behaviour is not required
by RFC 8555.