### PR TITLE
Fix to allow the SHA512withRSA/PSS algorithm to operate properly.

### DIFF
--- a/base/util/src/netscape/security/x509/AlgorithmId.java
+++ b/base/util/src/netscape/security/x509/AlgorithmId.java
@@ -763,7 +763,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
         } else if ("SHA384withRSA/PSS".equals(algName)) {
             pssSpec = new PSSParameterSpec("SHA-384", "MGF1", MGF1ParameterSpec.SHA384, 48, 1);
 
-        } else if ("SHA384withRSA/PSS".equals(algName)) {
+        } else if ("SHA512withRSA/PSS".equals(algName)) {
             pssSpec = new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1);
         }
         try {


### PR DESCRIPTION
Previously signature using this alg has had the params malformed within.