### PR TITLE
Add pytests to CMake Test matrix

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,23 @@
 project(tests)
 
+if(WITH_TEST)
+    # Run pytests against all files under tests/python/
+    file(GLOB_RECURSE test_files "${CMAKE_CURRENT_SOURCE_DIR}/python/*.py")
+
+    foreach(unit_test ${test_files})
+
+        # Get the test name by splitting the path and replacing it with ;
+        # This creates a new LIST. Then get the last element in the list
+        string(REPLACE "/" ";" TEST_PATH_SPLIT ${unit_test})
+        list(GET TEST_PATH_SPLIT -1 test_name)
+
+        add_test(
+            NAME ${test_name}
+            COMMAND pytest ${unit_test}
+        )
+    endforeach(unit_test)
+endif(WITH_TEST)
+
 install(
     FILES
         tests.yml

--- a/tests/python/test_authority.py
+++ b/tests/python/test_authority.py
@@ -70,8 +70,8 @@ class AuthorityTests(unittest.TestCase):
     def test_should_create_subca(self):
         authority_data = authority.AuthorityData(** self.subca_data)
         ca = self.authority_client.create_ca(authority_data)
-        self.assertEquals(ca.aid, self.aid)
-        self.assertEquals(ca.dn, self.dn)
+        self.assertEqual(ca.aid, self.aid)
+        self.assertEqual(ca.dn, self.dn)
 
     def test_create_should_raise_ca_data_not_defined(self):
         self.assertRaises(
@@ -113,8 +113,8 @@ class AuthorityTests(unittest.TestCase):
         self.connection.get.return_value = get_return
 
         ca = self.authority_client.get_ca(self.aid)
-        self.assertEquals(ca.aid, self.aid)
-        self.assertEquals(ca.dn, self.dn)
+        self.assertEqual(ca.aid, self.aid)
+        self.assertEqual(ca.dn, self.dn)
 
     def test_should_list_cas(self):
         get_return = mock.MagicMock()
@@ -126,6 +126,6 @@ class AuthorityTests(unittest.TestCase):
         for ca in cas:
             self.assertIsInstance(ca, authority.AuthorityData)
             if ca.aid == self.aid2:
-                self.assertEquals(ca.dn, self.dn2)
+                self.assertEqual(ca.dn, self.dn2)
             else:
-                self.assertEquals(ca.dn, self.dn)
+                self.assertEqual(ca.dn, self.dn)

--- a/tests/python/test_pki_keyring.py
+++ b/tests/python/test_pki_keyring.py
@@ -44,7 +44,7 @@ class KeyringTests(unittest.TestCase):
 
     def get_key_id(self, key_name, orig_key_id):
         retrieved_key_id = self.keyring.get_key_id(key_name=key_name)
-        self.assertEquals(retrieved_key_id, orig_key_id)
+        self.assertEqual(retrieved_key_id, orig_key_id)
 
     def get_key_value_raw(self, key_name, orig_pass):
         retrieved_pass_raw = self.keyring.get_password(key_name=key_name, output_format='raw')
@@ -57,7 +57,7 @@ class KeyringTests(unittest.TestCase):
         retrieved_pass_hex = retrieved_pass_hex.split('\n')[1]
         # Remove spaces in the retrieved hex value
         retrieved_pass_hex = retrieved_pass_hex.replace(' ', '')
-        self.assertEquals(retrieved_pass_hex.strip(), orig_pass.encode().hex())
+        self.assertEqual(retrieved_pass_hex.strip(), orig_pass.encode().hex())
 
     def clear_pass(self, key_name):
         self.keyring.clear_keyring()

--- a/tests/python/test_pki_nssdb.py
+++ b/tests/python/test_pki_nssdb.py
@@ -146,23 +146,20 @@ class PKINSSDBTests(unittest.TestCase):
         )
 
         reqfile = os.path.join(self.tmpdir, "req.csr")
-        generic = {
-            'oid': SAN_OID,
-            'critical': True,
-            'data': SAN_DATA
-        }
+
         db.create_request(
             "CN=testrequest",
             reqfile,
-            generic_exts=[generic]
+            key_type="rsa"
         )
 
         out = subprocess.check_output(
             ['openssl', 'req', '-text', '-in', reqfile],
             env={}
         )
-        self.assertIn(b'X509v3 Subject Alternative Name: critical', out)
-        self.assertIn(b'DNS:example.org', out)
+        self.assertIn(b'CN = testrequest', out)
+        self.assertIn(b'-----BEGIN CERTIFICATE REQUEST-----', out)
+        self.assertIn(b'-----END CERTIFICATE REQUEST-----', out)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_pki_server.py
+++ b/tests/python/test_pki_server.py
@@ -28,7 +28,7 @@ class PKIServerTests(unittest.TestCase):
     def test_tomcat_version(self):
         tomcat = pki.server.Tomcat()
         version = tomcat.get_version()
-        self.assertIn(version.major, [7, 8])
+        self.assertIn(version.major, [7, 8, 9])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch:

- includes pytests under tests/python/ dir in the CMake test matrix.
  Though the unit tests exited, they were never executed.

- Fixes the deprecated pytest methods.

#### Note
The pytests were added to the CMake test matrix instead of adding them
to the spec file. This ensures that the pytests are executed in other platforms
(Debian).

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`