### PR TITLE
CT: Minor bug fixes

### DIFF
--- a/base/ca/src/com/netscape/ca/CAService.java
+++ b/base/ca/src/com/netscape/ca/CAService.java
@@ -131,8 +131,6 @@ public class CAService implements ICAService, IService {
     public static final String CHALLENGE_PHRASE = "challengePhrase";
     public static final String SERIALNO_ARRAY = "serialNoArray";
 
-    public static final String GoogleTestTube_Pub = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEw8i8S7qiGEs9NXv0ZJFh6uuOmR2Q7dPprzk9XNNGkUXjzqx2SDvRfiwKYwBljfWujozHESVPQyydGaHhkaSz/g==";
-
     // CCA->CLA connector
     protected static IConnector mCLAConnector = null;
 
@@ -925,7 +923,7 @@ public class CAService implements ICAService, IService {
                             logger.debug("Response from log server " + respS);
 
                             // verify the sct: TODO - not working, need to fix
-                            verifySCT(CTResponse.fromJSON(respS), cert.getTBSCertificate());
+                            // verifySCT(CTResponse.fromJSON(respS), cert.getTBSCertificate(), ls.getPublicKey());
 
                             ctResponses.add(respS);
                         }
@@ -1158,7 +1156,7 @@ public class CAService implements ICAService, IService {
            TBSCertificate tbs_certificate;
          } PreCert;
     */
-    void verifySCT(CTResponse response, byte[] cert)
+    void verifySCT(CTResponse response, byte[] cert, String logPublicKey)
             throws Exception {
 
         String method = "CAService:verifySCT: ";
@@ -1177,7 +1175,7 @@ public class CAService implements ICAService, IService {
         byte[] version = new byte[] {0}; // v1(0)
         byte[] signature_type = new byte[] {0}; // certificate_timestamp(0)
         byte[] entry_type = new byte[] {0, 1}; // LogEntryType: precert_entry(1)
-        byte google_pub[] = CryptoUtil.base64Decode(GoogleTestTube_Pub);
+        byte google_pub[] = CryptoUtil.base64Decode(logPublicKey);
         PublicKey google_pubKey = KeyFactory.getInstance("RSA").generatePublic(
                 new X509EncodedKeySpec(google_pub));
         /*

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -44,6 +44,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${SLF4J_API_JAR} lib/slf4j-api.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${SLF4J_JDK14_JAR} lib/slf4j-jdk14.jar
     COMMAND ln -sf ${P11_KIT_TRUST} lib/p11-kit-trust.so
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${COMMONS_NET_JAR} lib/commons-net.jar
 )
 
 add_custom_target(pki-man ALL

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -113,6 +113,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${XERCES_JAR} common/lib/xerces-j2.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${XML_COMMONS_APIS_JAR} common/lib/xml-commons-apis.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${XML_COMMONS_RESOLVER_JAR} common/lib/xml-commons-resolver.jar
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${COMMONS_NET_JAR} common/lib/commons-net.jar
 )
 
 # Create /usr/share/pki/server/webapps/pki/WEB-INF/lib. This can be customized for different platforms in RPM spec.


### PR DESCRIPTION
 This patch includes:

- In PR #406 a new LogServer object was introduced to store Log Server
information. However, the public key of Log Server was never used.
This patch removes the usage of hardcoded Public Key and uses the
one defined in CS.cfg

- Dependency to apache-commons-net was introduced in the commit:
https://github.com/dogtagpki/pki/commit/fca6d89dcd2b9e6592879c85a2f2278ed1a28e2f
The symlink to JARs need to be created for new instance installations as well as
existing instances. This patch adds symlink to the new dependency.

- Comments out the call to `VerifySCT()` method as some rework is requried

**NOTE:** This PR **does not** fix existing instances.
  
**TODO:** The upgrade script to add symlinks to existing instances. This effort
should be done when CT moves out of the prototype phase.