### PR TITLE
Related: Bug 1710109 - add RSA PSS support.

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/CMCResponse.java
+++ b/base/java-tools/src/com/netscape/cmstools/CMCResponse.java
@@ -53,6 +53,7 @@ import org.mozilla.jss.pkix.cmc.TaggedAttribute;
 import org.mozilla.jss.pkix.cms.ContentInfo;
 import org.mozilla.jss.pkix.cms.EncapsulatedContentInfo;
 import org.mozilla.jss.pkix.cms.SignedData;
+import org.mozilla.jss.CryptoManager;
 
 import com.netscape.cmsutil.util.Utils;
 import netscape.security.pkcs.PKCS7;
@@ -352,8 +353,7 @@ public class CMCResponse {
 
         CommandLine cmd = parser.parse(options, args, true);
 
-        @SuppressWarnings("unused")
-        String database = cmd.getOptionValue("d");
+        String dbdir = cmd.getOptionValue("d");
 
         String input = cmd.getOptionValue("i");
         String output = cmd.getOptionValue("o");
@@ -369,6 +369,14 @@ public class CMCResponse {
             System.err.println("Try 'CMCResponse --help' for more information.");
             System.exit(1);
         }
+
+        //Intialize the crypto manager, just in case we need to use the JSS Provider to parse 
+        //algorithm parameters. All we have to do is initialize the manager and be done.
+
+        if (dbdir == null)
+            dbdir = ".";
+
+        CryptoManager.initialize(dbdir);
 
         // load CMC response
         byte[] data = Files.readAllBytes(Paths.get(input));


### PR DESCRIPTION
This fix is to the CMCRespone tool.

The tool currently does not initialize the CryptoManager.
Doing so is necessary to register the JSS Provider which provides the
encoding / parsing support for the RSAPSS algorithm parameters.