### PR TITLE
New healthchecks to test CA and KRA connectivity

### DIFF
--- a/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
@@ -5,8 +5,9 @@ from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
 from pki.client import PKIConnection
 from pki.cert import CertClient
+from pki.systemcert import SystemCertClient
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 @registry
@@ -18,7 +19,7 @@ class DogtagCACertsConnectivityCheck(CSPlugin):
     @duration
     def check(self):
         if not self.instance.is_valid():
-            logging.debug('Invalid instance: %s', self.instance.name)
+            logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
                          msg='Invalid PKI instance: %s' % self.instance.name)
             return
@@ -31,14 +32,12 @@ class DogtagCACertsConnectivityCheck(CSPlugin):
             logger.debug("No CA configured, skipping dogtag CA connectivity check")
             return
 
-        # Make a plain HTTP GET request to /ca/admin/ca/getStatus REST api end point
-        # and check if the CA is ready
-        if ca.is_ready():
-            logger.debug("CA instance is running")
-            connection = None
-            cert_client = None
+        try:
+            # Make a plain HTTP GET request to /ca/admin/ca/getStatus REST api end point
+            # and check if the CA is ready
+            if ca.is_ready():
+                logger.debug("CA instance is running")
 
-            try:
                 # Make a plain HTTP GET to "find" one certificate, to test that
                 # the server is up AND is able to respond back
                 connection = PKIConnection(protocol='https',
@@ -54,9 +53,7 @@ class DogtagCACertsConnectivityCheck(CSPlugin):
                         logger.info("Serial number of retrieved cert: %s", cert_info.serial_number)
                         yield Result(self, constants.SUCCESS,
                                      serial_number=cert_info.serial_number,
-                                     subject_dn=cert_info.subject_dn,
-                                     type=cert_info.type,
-                                     status=cert_info.status)
+                                     subject_dn=cert_info.subject_dn)
                     else:
                         logger.info("Serial number cannot retrieved for cert: %s", cert_info)
                         yield Result(self, constants.ERROR,
@@ -71,13 +68,87 @@ class DogtagCACertsConnectivityCheck(CSPlugin):
                                  serverURI=connection.serverURI,
                                  rest_path=cert_client.cert_url)
 
-            except BaseException as e:
-                logger.error("Internal server error %s", e)
+            else:
                 yield Result(self, constants.CRITICAL,
-                             msg="Internal server error. Is your PKI server and LDAP up?",
-                             serverURI=connection.serverURI,
-                             rest_path=cert_client.cert_url,
-                             exception="%s" % e)
-        else:
+                             msg='CA subsystem is down')
+
+        except BaseException as e:
+            logger.error("Internal server error %s", e)
             yield Result(self, constants.CRITICAL,
-                         msg='CA subsystem is down')
+                         msg="Internal server error. Is your PKI server and LDAP up?",
+                         exception="%s" % e)
+
+
+@registry
+class DogtagKRAConnectivityCheck(CSPlugin):
+    """
+    Test basic KRA connectivity by trying to fetch the transport cert using REST endpoint.
+    """
+
+    @duration
+    def check(self):
+        if not self.instance.is_valid():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        kra = self.instance.get_subsystem('kra')
+
+        if not kra:
+            logger.debug("No KRA configured, skipping dogtag KRA connectivity check")
+            return
+
+        try:
+            # Make a plain HTTP GET request to /kra/admin/kra/getStatus REST api end point
+            # and check if the KRA is up
+            if kra.is_ready():
+                logger.info("KRA instance is running.")
+
+                # Make a plain HTTP GET to retrieve KRA transport cert, to test that
+                # the server is up AND is able to respond back
+                connection = PKIConnection(protocol='https',
+                                           hostname='localhost',
+                                           port='8443')
+
+                system_cert_client = SystemCertClient(connection)
+
+                # This gets the KRA cert from CS.cfg via REST API. In future, the system
+                # certs will be moved into LDAP. This means that even if LDAP is down
+                # there will be a SUCCESSFUL response if KRA is running.
+                transport_cert = system_cert_client.get_transport_cert()
+
+                if transport_cert:
+
+                    if transport_cert.serial_number:
+                        logger.info("Serial number of retrieved transport cert: %s",
+                                    transport_cert.serial_number)
+                        yield Result(self, constants.SUCCESS,
+                                     serial_number=transport_cert.serial_number,
+                                     subject_dn=transport_cert.subject_dn)
+                    else:
+                        logger.info("Serial number cannot retrieved for transport cert: %s",
+                                    transport_cert)
+                        yield Result(self, constants.ERROR,
+                                     msg="Unable to read serial number from retrieved cert",
+                                     cert_info=transport_cert,
+                                     serverURI=connection.serverURI,
+                                     rest_path=system_cert_client.cert_url)
+                else:
+                    logger.info("Request was made but the transport cert cannot be retrieved")
+                    yield Result(self, constants.ERROR,
+                                 msg="KRA server is up. But, unable to retrieve transport cert",
+                                 serverURI=connection.serverURI,
+                                 rest_path=system_cert_client.cert_url)
+
+            else:
+                yield Result(self, constants.CRITICAL,
+                             msg='KRA subsystem is down')
+
+        except BaseException as e:
+            logger.error("Internal server error %s", e)
+            yield Result(self, constants.CRITICAL,
+                         msg="Internal server error. Is your PKI server and LDAP up?",
+                         exception="%s" % e)

--- a/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
@@ -1,0 +1,83 @@
+import logging
+
+from pki.server.healthcheck.meta.plugin import CSPlugin, registry
+from ipahealthcheck.core.plugin import Result, duration
+from ipahealthcheck.core import constants
+from pki.client import PKIConnection
+from pki.cert import CertClient
+
+logger = logging.getLogger()
+
+
+@registry
+class DogtagCACertsConnectivityCheck(CSPlugin):
+    """
+    Test basic CA connectivity by using cert-find to fetch a cert
+    """
+
+    @duration
+    def check(self):
+        if not self.instance.is_valid():
+            logging.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        ca = self.instance.get_subsystem('ca')
+
+        if not ca:
+            logger.debug("No CA configured, skipping dogtag CA connectivity check")
+            return
+
+        # Make a plain HTTP GET request to /ca/admin/ca/getStatus REST api end point
+        # and check if the CA is ready
+        if ca.is_ready():
+            logger.debug("CA instance is running")
+            connection = None
+            cert_client = None
+
+            try:
+                # Make a plain HTTP GET to "find" one certificate, to test that
+                # the server is up AND is able to respond back
+                connection = PKIConnection(protocol='https',
+                                           hostname='localhost',
+                                           port='8443')
+
+                cert_client = CertClient(connection)
+                cert = cert_client.list_certs(size=1)
+                cert_info = cert.cert_data_info_list[0]
+                if cert_info:
+                    # All we care is whether the serial_number is not NONE
+                    if cert_info.serial_number:
+                        logger.info("Serial number of retrieved cert: %s", cert_info.serial_number)
+                        yield Result(self, constants.SUCCESS,
+                                     serial_number=cert_info.serial_number,
+                                     subject_dn=cert_info.subject_dn,
+                                     type=cert_info.type,
+                                     status=cert_info.status)
+                    else:
+                        logger.info("Serial number cannot retrieved for cert: %s", cert_info)
+                        yield Result(self, constants.ERROR,
+                                     msg="Unable to read serial number from retrieved cert",
+                                     cert_info=cert_info,
+                                     serverURI=connection.serverURI,
+                                     cert_url=cert_client.cert_url)
+                else:
+                    logger.info("Request was made but none of the certs were retrieved")
+                    yield Result(self, constants.ERROR,
+                                 msg="PKI server is up. But, unable to retrieve any certs",
+                                 serverURI=connection.serverURI,
+                                 rest_path=cert_client.cert_url)
+
+            except BaseException as e:
+                logger.error("Internal server error %s", e)
+                yield Result(self, constants.CRITICAL,
+                             msg="Internal server error. Is your PKI server and LDAP up?",
+                             serverURI=connection.serverURI,
+                             rest_path=cert_client.cert_url,
+                             exception="%s" % e)
+        else:
+            yield Result(self, constants.CRITICAL,
+                         msg='CA subsystem is down')

--- a/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
@@ -16,7 +16,7 @@ from ipahealthcheck.core import constants
 
 from pki.server import PKIServer
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 @registry
@@ -27,7 +27,7 @@ class DogtagCertsConfigCheck(CSPlugin):
     @duration
     def check(self):
         if not self.instance.exists():
-            logging.debug('Invalid instance: %s', self.instance.name)
+            logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
                          msg='Invalid PKI instance: %s' % self.instance.name)
             return

--- a/base/server/healthcheck/setup.py
+++ b/base/server/healthcheck/setup.py
@@ -26,6 +26,7 @@ setup(
         # plugin modules for pkihealthcheck.pki registry
         'pkihealthcheck.pki': [
             'pki_certs = pki.server.healthcheck.meta.csconfig',
+            'pki_connectivity = pki.server.healthcheck.meta.connectivity'
         ],
     },
     classifiers=[


### PR DESCRIPTION
This patch adds 2 new healthchecks:

### DogtagCACertsConnectivityCheck
Tests whether a cert can be retrieved from LDAP (similar to executing `pki ca-cert-find --size=1`)

### DogtagKRAConnectivityCheck
Tests whether the transport cert can be retrieved by hitting the end point. Note that the cert returned is pulled from CS.cfg. This test will turn more comprehensive when we move system certs from CS.cfg into LDAP, in future.