### PR TITLE
acme: PKIIssuer: handle immediate issuance

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
@@ -123,6 +123,7 @@ public class PKIIssuer extends ACMEIssuer {
         AuthorityID aid = null;
         X500Name adn = null;
 
+        caClient.login();
         CACertClient certClient = new CACertClient(caClient);
         CertEnrollmentRequest certEnrollmentRequest = certClient.getEnrollmentTemplate(profile);
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
@@ -159,15 +159,19 @@ public class PKIIssuer extends ACMEIssuer {
             throw new Exception("Unable to generate certificate: " + error);
         }
 
-        CertReviewResponse reviewInfo = certClient.reviewRequest(requestId);
-        certClient.approveRequest(requestId, reviewInfo);
+        CertId id = null;
+        if (info.getRequestStatus() == RequestStatus.COMPLETE) {
+            id = info.getCertId();
+        } else {
+            CertReviewResponse reviewInfo = certClient.reviewRequest(requestId);
+            certClient.approveRequest(requestId, reviewInfo);
 
-        info = certClient.getRequest(requestId);
-        logger.info("Serial number: " + info.getCertId().toHexString());
+            info = certClient.getRequest(requestId);
+            id = info.getCertId();
+        }
 
-        CertId id = info.getCertId();
+        logger.info("Serial number: " + id.toHexString());
         BigInteger serialNumber = id.toBigInteger();
-
         return Base64.encodeBase64URLSafeString(serialNumber.toByteArray());
     }
 


### PR DESCRIPTION
Depending on profile configuration and user privileges, the cert could be
immediately issued.  Furthermore the user may not have agent permissions to
review/approve a request, but a profile configuration could allow immediate
issuance for particular users/groups.

Therefore we must detect when the certificate was immediately issued and if
so, skip the review/approve behaviour.