### PR TITLE
System cert trust flag

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1193,10 +1193,10 @@ class NSSDatabase(object):
             if p.returncode != 0:
                 logger.warning('certutil returned non-zero exit code (bug #1539996)')
 
-            re_compile = re.compile(r'^' + fullname + r'(.*$)', re.MULTILINE)
+            re_compile = re.compile(r'^' + fullname + r'\s+(\S+)$', re.MULTILINE)
             cert_trust = re.search(re_compile, output.decode()).group(1)
 
-            return cert_trust.strip()
+            return cert_trust
 
         finally:
             shutil.rmtree(tmpdir)

--- a/base/server/healthcheck/pki/server/healthcheck/certs/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/plugin.py
@@ -1,0 +1,30 @@
+# Authors:
+#     Dinesh Prasanth M K <dmoluguw@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from ipahealthcheck.core.plugin import Plugin, Registry
+from pki.server.instance import PKIInstance
+
+import logging
+
+logging.getLogger().setLevel(logging.WARNING)
+
+
+class CertsPlugin(Plugin):
+    def __init__(self, registry):
+        # pylint: disable=redefined-outer-name
+        super(CertsPlugin, self).__init__(registry)
+        # TODO: Support custom instance names
+        self.instance = PKIInstance('pki-tomcat')
+
+
+class CertsRegistry(Registry):
+    def initialize(self, framework, config):
+        pass
+
+
+registry = CertsRegistry()

--- a/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
@@ -80,6 +80,71 @@ class CASystemCertTrustFlagCheck(CertsPlugin):
                              nickname=cert['nickname'])
 
 
+@registry
+class KRASystemCertTrustFlagCheck(CertsPlugin):
+    """
+    Compare the NSS trust for the KRA certs to a known good value
+    """
+    @duration
+    def check(self):
+
+        if not self.instance.exists():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        # Make a list of known good trust flags for ALL system certs
+        expected_trust = {
+            'sslserver': 'u,u,u',
+            'subsystem': 'u,u,u',
+            'transport': 'u,u,u',
+            'storage': 'u,u,u',
+            'audit_signing': 'u,u,Pu'
+        }
+
+        kra = self.instance.get_subsystem('kra')
+
+        if not kra:
+            logger.debug("No KRA configured, skipping KRA System Cert Trust Flag check")
+            return
+
+        certs = kra.find_system_certs()
+
+        # Iterate on KRA's all system certificate to check with list of expected trust flags
+        for cert in certs:
+            cert_id = cert['id']
+
+            # Load cert trust from NSSDB
+            with nssdb_connection(self.instance) as nssdb:
+                try:
+                    cert_trust = nssdb.get_trust(
+                        nickname=cert['nickname'],
+                        token=cert['token']
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug('Unable to load cert from NSSDB: %s', str(e))
+                    yield Result(self, constants.ERROR,
+                                 key=cert_id,
+                                 nssdbDir=self.instance.nssdb_dir,
+                                 msg='Unable to load cert from NSSDB: %s' % str(e))
+                    continue
+            if cert_trust != expected_trust[cert_id]:
+                yield Result(self, constants.ERROR,
+                             cert_id=cert_id,
+                             nickname=cert['nickname'],
+                             token=cert['token'],
+                             cert_trust=cert_trust,
+                             msg='Incorrect NSS trust for %s. Got %s expected %s'
+                                 % (cert['nickname'], cert_trust, expected_trust[cert_id]))
+            else:
+                yield Result(self, constants.SUCCESS,
+                             cert_id=cert_id,
+                             nickname=cert['nickname'])
+
+
 @contextmanager
 def nssdb_connection(instance):
     """Open a connection to nssdb containing System Certificates"""

--- a/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
@@ -1,0 +1,90 @@
+# Authors:
+#     Dinesh Prasanth M K <dmoluguw@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+import logging
+from contextlib import contextmanager
+
+from pki.server.healthcheck.certs.plugin import CertsPlugin, registry
+from ipahealthcheck.core.plugin import Result, duration
+from ipahealthcheck.core import constants
+
+logger = logging.getLogger(__name__)
+
+
+@registry
+class CASystemCertTrustFlagCheck(CertsPlugin):
+    """
+    Compare the NSS trust for the CA certs to a known good value
+    """
+    @duration
+    def check(self):
+
+        if not self.instance.exists():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        # Make a list of known good trust flags for ALL system certs
+        expected_trust = {
+            'signing': 'CTu,Cu,Cu',
+            'ocsp_signing': 'u,u,u',
+            'audit_signing': 'u,u,Pu',
+            'sslserver': 'u,u,u',
+            'subsystem': 'u,u,u'
+        }
+
+        ca = self.instance.get_subsystem('ca')
+
+        if not ca:
+            logger.debug("No CA configured, skipping CA System Cert Trust Flag check")
+            return
+
+        certs = ca.find_system_certs()
+
+        # Iterate on CA's all system certificate to check with list of expected trust flags
+        for cert in certs:
+            cert_id = cert['id']
+
+            # Load cert trust from NSSDB
+            with nssdb_connection(self.instance) as nssdb:
+                try:
+                    cert_trust = nssdb.get_trust(
+                        nickname=cert['nickname'],
+                        token=cert['token']
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug('Unable to load cert from NSSDB: %s', str(e))
+                    yield Result(self, constants.ERROR,
+                                 key=cert_id,
+                                 nssdbDir=self.instance.nssdb_dir,
+                                 msg='Unable to load cert from NSSDB: %s' % str(e))
+                    continue
+            if cert_trust != expected_trust[cert_id]:
+                yield Result(self, constants.ERROR,
+                             cert_id=cert_id,
+                             nickname=cert['nickname'],
+                             token=cert['token'],
+                             cert_trust=cert_trust,
+                             msg='Incorrect NSS trust for %s. Got %s expected %s'
+                             % (cert['nickname'], cert_trust, expected_trust[cert_id]))
+            else:
+                yield Result(self, constants.SUCCESS,
+                             cert_id=cert_id,
+                             nickname=cert['nickname'])
+
+
+@contextmanager
+def nssdb_connection(instance):
+    """Open a connection to nssdb containing System Certificates"""
+    nssdb = instance.open_nssdb()
+    try:
+        yield nssdb
+    finally:
+        nssdb.close()

--- a/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
@@ -1,6 +1,6 @@
 import logging
 
-from pki.server.healthcheck.meta.plugin import CSPlugin, registry
+from pki.server.healthcheck.meta.plugin import MetaPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
 from pki.client import PKIConnection
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 @registry
-class DogtagCACertsConnectivityCheck(CSPlugin):
+class DogtagCACertsConnectivityCheck(MetaPlugin):
     """
     Test basic CA connectivity by using cert-find to fetch a cert
     """
@@ -82,7 +82,7 @@ class DogtagCACertsConnectivityCheck(CSPlugin):
 
 
 @registry
-class DogtagKRAConnectivityCheck(CSPlugin):
+class DogtagKRAConnectivityCheck(MetaPlugin):
     """
     Test basic KRA connectivity by trying to fetch the transport cert using REST endpoint.
     """
@@ -159,7 +159,7 @@ class DogtagKRAConnectivityCheck(CSPlugin):
 
 
 @registry
-class DogtagOCSPConnectivityCheck(CSPlugin):
+class DogtagOCSPConnectivityCheck(MetaPlugin):
     """
     Test basic OCSP connectivity by trying to hit REST api endpoint. Note that this
     test DOES NOT fetch any objects from LDAP. This only tests whether OCSP is running.
@@ -207,7 +207,7 @@ class DogtagOCSPConnectivityCheck(CSPlugin):
 
 
 @registry
-class DogtagTKSConnectivityCheck(CSPlugin):
+class DogtagTKSConnectivityCheck(MetaPlugin):
     """
     Test basic TKS connectivity by trying to hit REST api endpoint. Note that this
     test DOES NOT fetch any objects from LDAP. This only tests whether TKS is running.
@@ -255,7 +255,7 @@ class DogtagTKSConnectivityCheck(CSPlugin):
 
 
 @registry
-class DogtagTPSConnectivityCheck(CSPlugin):
+class DogtagTPSConnectivityCheck(MetaPlugin):
     """
     Test basic TPS connectivity by trying to hit REST api endpoint. Note that this
     test DOES NOT fetch any objects from LDAP. This only tests whether TPS is running.

--- a/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
@@ -10,7 +10,7 @@
 import logging
 from contextlib import contextmanager
 
-from pki.server.healthcheck.meta.plugin import CSPlugin, registry
+from pki.server.healthcheck.meta.plugin import MetaPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
 
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @registry
-class DogtagCertsConfigCheck(CSPlugin):
+class DogtagCertsConfigCheck(MetaPlugin):
     """
     Compare the cert blob in the NSS database to that stored in CS.cfg
     """

--- a/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
@@ -15,17 +15,17 @@ import logging
 logging.getLogger().setLevel(logging.WARNING)
 
 
-class CSPlugin(Plugin):
+class MetaPlugin(Plugin):
     def __init__(self, registry):
         # pylint: disable=redefined-outer-name
-        super(CSPlugin, self).__init__(registry)
+        super(MetaPlugin, self).__init__(registry)
         # TODO: Support custom instance names
         self.instance = PKIInstance('pki-tomcat')
 
 
-class CSRegistry(Registry):
+class MetaRegistry(Registry):
     def initialize(self, framework, config):
         pass
 
 
-registry = CSRegistry()
+registry = MetaRegistry()

--- a/base/server/healthcheck/setup.py
+++ b/base/server/healthcheck/setup.py
@@ -17,14 +17,14 @@ setup(
         ],
         # register the plugin with ipa-healthcheck
         'ipahealthcheck.registry': [
-            'pkihealthcheck.pki = pki.server.healthcheck.meta.plugin:registry',
+            'pkihealthcheck.meta = pki.server.healthcheck.meta.plugin:registry',
         ],
         # register the plugin with pki-healthcheck
         'pkihealthcheck.registry': [
-            'pkihealthcheck.pki = pki.server.healthcheck.meta.plugin:registry',
+            'pkihealthcheck.meta = pki.server.healthcheck.meta.plugin:registry',
         ],
-        # plugin modules for pkihealthcheck.pki registry
-        'pkihealthcheck.pki': [
+        # plugin modules for pkihealthcheck.meta registry
+        'pkihealthcheck.meta': [
             'pki_certs = pki.server.healthcheck.meta.csconfig',
             'pki_connectivity = pki.server.healthcheck.meta.connectivity'
         ],

--- a/base/server/healthcheck/setup.py
+++ b/base/server/healthcheck/setup.py
@@ -9,6 +9,7 @@ setup(
     packages=[
         'pki.server.healthcheck.core',
         'pki.server.healthcheck.meta',
+        'pki.server.healthcheck.certs'
     ],
     entry_points={
         # creates bin/pki-healthcheck
@@ -18,15 +19,21 @@ setup(
         # register the plugin with ipa-healthcheck
         'ipahealthcheck.registry': [
             'pkihealthcheck.meta = pki.server.healthcheck.meta.plugin:registry',
+            'pkihealthcheck.certs = pki.server.healthcheck.certs.plugin:registry',
         ],
         # register the plugin with pki-healthcheck
         'pkihealthcheck.registry': [
             'pkihealthcheck.meta = pki.server.healthcheck.meta.plugin:registry',
+            'pkihealthcheck.certs = pki.server.healthcheck.certs.plugin:registry',
         ],
         # plugin modules for pkihealthcheck.meta registry
         'pkihealthcheck.meta': [
             'pki_certs = pki.server.healthcheck.meta.csconfig',
             'pki_connectivity = pki.server.healthcheck.meta.connectivity'
+        ],
+        # plugin modules for pkihealthcheck.certs registry
+        'pkihealthcheck.certs': [
+            'trust_flags = pki.server.healthcheck.certs.trustflags',
         ],
     },
     classifiers=[


### PR DESCRIPTION
This PR:
- Adds a reusable method to get System Cert trust flags from NSSDB
- Adds healthchecks to verify `CA` and `KRA` subsystem's system certificate trust flags
- Renames the old generic plugin name to allow for more meaningful plugin names