### PR TITLE
Helathcheck: RHCS trust flags

### DIFF
--- a/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
@@ -209,6 +209,68 @@ class OCSPSystemCertTrustFlagCheck(CertsPlugin):
                              nickname=cert['nickname'])
 
 
+@registry
+class TKSSystemCertTrustFlagCheck(CertsPlugin):
+    """
+    Compare the NSS trust for the TKS certs to a known good value
+    """
+    @duration
+    def check(self):
+
+        if not self.instance.exists():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        # Make a list of known good trust flags for ALL system certs
+        expected_trust = {
+            'sslserver': 'u,u,u',
+            'subsystem': 'u,u,u',
+            'audit_signing': 'u,u,Pu'
+        }
+
+        tks = self.instance.get_subsystem('tks')
+
+        if not tks:
+            logger.debug("No TKS configured, skipping TKS System Cert Trust Flag check")
+            return
+
+        certs = tks.find_system_certs()
+
+        # Iterate on TKS's all system certificate to check with list of expected trust flags
+        for cert in certs:
+            cert_id = cert['id']
+
+            # Load cert trust from NSSDB
+            with nssdb_connection(self.instance) as nssdb:
+                try:
+                    cert_trust = nssdb.get_trust(
+                        nickname=cert['nickname'],
+                        token=cert['token']
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug('Unable to load cert from NSSDB: %s', str(e))
+                    yield Result(self, constants.ERROR,
+                                 key=cert_id,
+                                 nssdbDir=self.instance.nssdb_dir,
+                                 msg='Unable to load cert from NSSDB: %s' % str(e))
+                    continue
+            if cert_trust != expected_trust[cert_id]:
+                yield Result(self, constants.ERROR,
+                             cert_id=cert_id,
+                             nickname=cert['nickname'],
+                             token=cert['token'],
+                             cert_trust=cert_trust,
+                             msg='Incorrect NSS trust for %s. Got %s expected %s'
+                                 % (cert['nickname'], cert_trust, expected_trust[cert_id]))
+            else:
+                yield Result(self, constants.SUCCESS,
+                             cert_id=cert_id,
+                             nickname=cert['nickname'])
+
 @contextmanager
 def nssdb_connection(instance):
     """Open a connection to nssdb containing System Certificates"""

--- a/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
@@ -43,7 +43,7 @@ class CASystemCertTrustFlagCheck(CertsPlugin):
         ca = self.instance.get_subsystem('ca')
 
         if not ca:
-            logger.debug("No CA configured, skipping CA System Cert Trust Flag check")
+            logger.info("No CA configured, skipping CA System Cert Trust Flag check")
             return
 
         certs = ca.find_system_certs()
@@ -108,7 +108,7 @@ class KRASystemCertTrustFlagCheck(CertsPlugin):
         kra = self.instance.get_subsystem('kra')
 
         if not kra:
-            logger.debug("No KRA configured, skipping KRA System Cert Trust Flag check")
+            logger.info("No KRA configured, skipping KRA System Cert Trust Flag check")
             return
 
         certs = kra.find_system_certs()
@@ -172,7 +172,7 @@ class OCSPSystemCertTrustFlagCheck(CertsPlugin):
         ocsp = self.instance.get_subsystem('ocsp')
 
         if not ocsp:
-            logger.debug("No OCSP configured, skipping OCSP System Cert Trust Flag check")
+            logger.info("No OCSP configured, skipping OCSP System Cert Trust Flag check")
             return
 
         certs = ocsp.find_system_certs()
@@ -235,7 +235,7 @@ class TKSSystemCertTrustFlagCheck(CertsPlugin):
         tks = self.instance.get_subsystem('tks')
 
         if not tks:
-            logger.debug("No TKS configured, skipping TKS System Cert Trust Flag check")
+            logger.info("No TKS configured, skipping TKS System Cert Trust Flag check")
             return
 
         certs = tks.find_system_certs()
@@ -298,7 +298,7 @@ class TPSSystemCertTrustFlagCheck(CertsPlugin):
         tps = self.instance.get_subsystem('tps')
 
         if not tps:
-            logger.debug("No TPS configured, skipping TPS System Cert Trust Flag check")
+            logger.info("No TPS configured, skipping TPS System Cert Trust Flag check")
             return
 
         certs = tps.find_system_certs()

--- a/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
@@ -271,6 +271,70 @@ class TKSSystemCertTrustFlagCheck(CertsPlugin):
                              cert_id=cert_id,
                              nickname=cert['nickname'])
 
+
+@registry
+class TPSSystemCertTrustFlagCheck(CertsPlugin):
+    """
+    Compare the NSS trust for the TPS certs to a known good value
+    """
+    @duration
+    def check(self):
+
+        if not self.instance.exists():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        # Make a list of known good trust flags for ALL system certs
+        expected_trust = {
+            'sslserver': 'u,u,u',
+            'subsystem': 'u,u,u',
+            'audit_signing': 'u,u,Pu'
+        }
+
+        tps = self.instance.get_subsystem('tps')
+
+        if not tps:
+            logger.debug("No TPS configured, skipping TPS System Cert Trust Flag check")
+            return
+
+        certs = tps.find_system_certs()
+
+        # Iterate on TPS's all system certificate to check with list of expected trust flags
+        for cert in certs:
+            cert_id = cert['id']
+
+            # Load cert trust from NSSDB
+            with nssdb_connection(self.instance) as nssdb:
+                try:
+                    cert_trust = nssdb.get_trust(
+                        nickname=cert['nickname'],
+                        token=cert['token']
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug('Unable to load cert from NSSDB: %s', str(e))
+                    yield Result(self, constants.ERROR,
+                                 key=cert_id,
+                                 nssdbDir=self.instance.nssdb_dir,
+                                 msg='Unable to load cert from NSSDB: %s' % str(e))
+                    continue
+            if cert_trust != expected_trust[cert_id]:
+                yield Result(self, constants.ERROR,
+                             cert_id=cert_id,
+                             nickname=cert['nickname'],
+                             token=cert['token'],
+                             cert_trust=cert_trust,
+                             msg='Incorrect NSS trust for %s. Got %s expected %s'
+                                 % (cert['nickname'], cert_trust, expected_trust[cert_id]))
+            else:
+                yield Result(self, constants.SUCCESS,
+                             cert_id=cert_id,
+                             nickname=cert['nickname'])
+
+
 @contextmanager
 def nssdb_connection(instance):
     """Open a connection to nssdb containing System Certificates"""

--- a/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
@@ -29,7 +29,7 @@ class DogtagCACertsConnectivityCheck(MetaPlugin):
         ca = self.instance.get_subsystem('ca')
 
         if not ca:
-            logger.debug("No CA configured, skipping dogtag CA connectivity check")
+            logger.info("No CA configured, skipping dogtag CA connectivity check")
             return
 
         try:
@@ -100,7 +100,7 @@ class DogtagKRAConnectivityCheck(MetaPlugin):
         kra = self.instance.get_subsystem('kra')
 
         if not kra:
-            logger.debug("No KRA configured, skipping dogtag KRA connectivity check")
+            logger.info("No KRA configured, skipping dogtag KRA connectivity check")
             return
 
         try:
@@ -178,7 +178,7 @@ class DogtagOCSPConnectivityCheck(MetaPlugin):
         ocsp = self.instance.get_subsystem('ocsp')
 
         if not ocsp:
-            logger.debug("No OCSP configured, skipping dogtag OCSP connectivity check")
+            logger.info("No OCSP configured, skipping dogtag OCSP connectivity check")
             return
 
         try:
@@ -226,7 +226,7 @@ class DogtagTKSConnectivityCheck(MetaPlugin):
         tks = self.instance.get_subsystem('tks')
 
         if not tks:
-            logger.debug("No TKS configured, skipping dogtag TKS connectivity check")
+            logger.info("No TKS configured, skipping dogtag TKS connectivity check")
             return
 
         try:
@@ -274,7 +274,7 @@ class DogtagTPSConnectivityCheck(MetaPlugin):
         tps = self.instance.get_subsystem('tps')
 
         if not tps:
-            logger.debug("No TPS configured, skipping dogtag TPS connectivity check")
+            logger.info("No TPS configured, skipping dogtag TPS connectivity check")
             return
 
         try:


### PR DESCRIPTION
This PR is an extension to PR #428 

This patch
- checks trust flag for remaining subsystems
- Change `debug` to `info` to notify users if the subsystem is not configured