### PR TITLE
Include trust flag info in pki-server cert-* operation

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1342,6 +1342,7 @@ class NSSDatabase(object):
 
         cert['not_before'] = self.convert_time_to_millis(cert_obj.not_valid_before)
         cert['not_after'] = self.convert_time_to_millis(cert_obj.not_valid_after)
+        cert['trust_flags'] = self.get_trust(nickname=nickname, token=token)
 
         return cert
 

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -87,6 +87,10 @@ class CertCLI(pki.cli.CLI):
         if not_after:
             print('  Not Valid After: %s' % CertCLI.convert_millis_to_date(not_after))
 
+        trust_flags = cert.get('trust_flags')
+        if trust_flags:
+            print('  NSSDB Trust flag: %s' % trust_flags)
+
         if show_all:
             print('  Certificate: %s' % cert['data'])
             print('  Request: %s' % cert['request'])

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -155,6 +155,8 @@ class PKISubsystem(object):
     def get_subsystem_cert(self, cert_id):
 
         cert = self.get_cert_info(cert_id)
+
+        # If nickname is empty, then cert cannot be queried for in NSSDB
         if not cert['nickname']:
             return cert
 


### PR DESCRIPTION
This patch includes trust flags when running cert-show or cert-find
in its output, to provide more information to the user

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`