### PR TITLE
CT: handle missing config

### DIFF
--- a/base/ca/src/org/dogtagpki/ct/sct/SCTProcessor.java
+++ b/base/ca/src/org/dogtagpki/ct/sct/SCTProcessor.java
@@ -36,7 +36,7 @@ public class SCTProcessor {
     }
 
     public boolean isCTEnabled() throws EPropertyNotFound, EBaseException {
-        return mConfig.getBoolean("enable");
+        return mConfig.getBoolean("enable", false);
     }
 
     /**


### PR DESCRIPTION
If Certificate Transparency config is not defined in CS.cfg, all
certificate issuance fails.  This situation can arise in upgrade
scenarios.

Tolerate the absense of the certTransparency.enable CS.cfg
directive, defaulting to false.