### PR TITLE
Added pki nss-cert-request/issue

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSCertCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSCertCLI.java
@@ -13,5 +13,6 @@ public class NSSCertCLI extends CLI {
         super("cert", "NSS certificate management commands", nssCLI);
 
         addModule(new NSSCertImportCLI(this));
+        addModule(new NSSCertRequestCLI(this));
     }
 }

--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSCertCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSCertCLI.java
@@ -14,5 +14,6 @@ public class NSSCertCLI extends CLI {
 
         addModule(new NSSCertImportCLI(this));
         addModule(new NSSCertRequestCLI(this));
+        addModule(new NSSCertIssueCLI(this));
     }
 }

--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSCertIssueCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSCertIssueCLI.java
@@ -1,0 +1,113 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.cert.X509Certificate;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtag.util.cert.CertUtil;
+import org.dogtagpki.cli.CommandCLI;
+import org.dogtagpki.nss.NSSDatabase;
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.netscape.security.pkcs.PKCS10;
+
+import com.netscape.certsrv.client.ClientConfig;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class NSSCertIssueCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSCertIssueCLI.class);
+
+    public NSSCertIssueCLI(NSSCertCLI nssCertCLI) {
+        super("issue", "Issue certificate", nssCertCLI);
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "issuer", true, "Issuer nickname (default is self-signed)");
+        option.setArgName("nickname");
+        options.addOption(option);
+
+        option = new Option(null, "csr", true, "Certificate signing request");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "months-valid", true, "Months valid (default is 3)");
+        option.setArgName("months");
+        options.addOption(option);
+
+        option = new Option(null, "cert", true, "Certificate");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "format", true, "Certificate format: PEM (default), DER");
+        option.setArgName("format");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String issuerNickname = cmd.getOptionValue("issuer");
+        String csrFile = cmd.getOptionValue("csr");
+        String monthsValid = cmd.getOptionValue("months-valid");
+
+        if (csrFile == null) {
+            throw new Exception("Missing certificate signing request");
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        ClientConfig clientConfig = mainCLI.getConfig();
+        NSSDatabase nssdb = mainCLI.getNSSDatabase();
+
+        org.mozilla.jss.crypto.X509Certificate issuer;
+        if (issuerNickname == null) {
+            issuer = null;
+
+        } else {
+            CryptoManager cm = CryptoManager.getInstance();
+            issuer = cm.findCertByNickname(issuerNickname);
+        }
+
+        String csrPEM = new String(Files.readAllBytes(Paths.get(csrFile)));
+        byte[] csrBytes = CertUtil.parseCSR(csrPEM);
+        PKCS10 pkcs10 = new PKCS10(csrBytes);
+
+        X509Certificate cert = nssdb.createCertificate(
+                issuer,
+                pkcs10,
+                monthsValid == null ? null : new Integer(monthsValid));
+
+        String format = cmd.getOptionValue("format");
+        byte[] bytes;
+
+        if (format == null || "PEM".equalsIgnoreCase(format)) {
+            bytes = CertUtil.toPEM(cert).getBytes();
+
+        } else if ("DER".equalsIgnoreCase(format)) {
+            bytes = cert.getEncoded();
+
+        } else {
+            throw new Exception("Unsupported format: " + format);
+        }
+
+        String filename = cmd.getOptionValue("cert");
+
+        if (filename != null) {
+            Files.write(Paths.get(filename) , bytes);
+
+        } else {
+            System.out.write(bytes);
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -1,0 +1,116 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtag.util.cert.CertUtil;
+import org.dogtagpki.cli.CommandCLI;
+import org.dogtagpki.nss.NSSDatabase;
+import org.mozilla.jss.netscape.security.pkcs.PKCS10;
+
+import com.netscape.certsrv.client.ClientConfig;
+import com.netscape.cmstools.cli.MainCLI;
+
+public class NSSCertRequestCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSCertRequestCLI.class);
+
+    public NSSCertRequestCLI(NSSCertCLI nssCertCLI) {
+        super("request", "Generate certificate signing request", nssCertCLI);
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "subject", true, "Subject name");
+        option.setArgName("name");
+        options.addOption(option);
+
+        option = new Option(null, "key-id", true, "Key ID");
+        option.setArgName("ID");
+        options.addOption(option);
+
+        option = new Option(null, "key-type", true, "Key type: RSA (default), EC, DSA");
+        option.setArgName("type");
+        options.addOption(option);
+
+        option = new Option(null, "key-size", true, "RSA key size (default is 2048)");
+        option.setArgName("size");
+        options.addOption(option);
+
+        option = new Option(null, "curve", true, "Elliptic curve name");
+        option.setArgName("name");
+        options.addOption(option);
+
+        option = new Option(null, "hash", true, "Hash algorithm");
+        option.setArgName("name");
+        options.addOption(option);
+
+        option = new Option(null, "csr", true, "Certificate signing request");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "format", true, "Certificate signing request format: PEM (default), DER");
+        option.setArgName("format");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String subject = cmd.getOptionValue("subject");
+        String keyID = cmd.getOptionValue("key-id");
+        String keyType = cmd.getOptionValue("key-type");
+        String keySize = cmd.getOptionValue("key-size");
+        String curve = cmd.getOptionValue("curve");
+        String hash = cmd.getOptionValue("hash");
+
+        if (subject == null) {
+            throw new Exception("Missing subject name");
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        ClientConfig clientConfig = mainCLI.getConfig();
+        NSSDatabase nssdb = mainCLI.getNSSDatabase();
+
+        PKCS10 pkcs10 = nssdb.createRequest(
+                subject,
+                keyID,
+                keyType,
+                keySize,
+                curve,
+                hash);
+
+        String format = cmd.getOptionValue("format");
+        byte[] bytes;
+
+        if (format == null || "PEM".equalsIgnoreCase(format)) {
+            bytes = CertUtil.toPEM(pkcs10).getBytes();
+
+        } else if ("DER".equalsIgnoreCase(format)) {
+            bytes = pkcs10.toByteArray();
+
+        } else {
+            throw new Exception("Unsupported format: " + format);
+        }
+
+        String filename = cmd.getOptionValue("csr");
+
+        if (filename != null) {
+            Files.write(Paths.get(filename) , bytes);
+
+        } else {
+            System.out.write(bytes);
+        }
+    }
+}


### PR DESCRIPTION
This PR is adding `pki nss-cert-request` and `pki nss-cert-issue` CLIs to create a certificate request and to issue a certificate using a local NSS database. The code can be used later to create a standalone ACME responder that contains an embedded CA (without a dependency on a remote CA). It can also be used to generate system certificates for PKI server while the server is offline.

For simplicity, the current CLIs do not support certificate extensions. They will be added in a separate PR.

To create a certificate request:

```
$ pki nss-cert-request \
    --subject "CN=$HOSTNAME" \
    --csr sslserver.csr
```

To issue a self-signed certificate:

```
$ pki nss-cert-issue \
    --csr sslserver.csr \
    --cert sslserver.crt
```

To issue a certificate signed by a CA certificate:

```
$ pki nss-cert-issue \
    --issuer ca_signing \
    --csr sslserver.csr \
    --cert sslserver.crt
```

Internally, the code is currently calling `certutil`, but in the future it will be replaced with JSS.

The Wiki doc is available at https://www.dogtagpki.org/wiki/PKI_NSS_CLI.

Please note that the extensions will be added as a separate PR.