### PR TITLE
Healthcheck: RHCS healthcheck expiration

### DIFF
--- a/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
@@ -168,3 +168,32 @@ class OCSPSystemCertExpiryCheck(CertsPlugin):
 
         for cert in certs:
             yield check_cert_expiry_date(class_instance=self, cert=cert)
+
+
+@registry
+class TKSSystemCertExpiryCheck(CertsPlugin):
+    """
+    Check the expiry of TKS's system certs
+    """
+
+    @duration
+    def check(self):
+
+        if not self.instance.exists():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        tks = self.instance.get_subsystem('tks')
+
+        if not tks:
+            logger.info("No TKS configured, skipping TKS System Cert Expiry check")
+            return
+
+        certs = tks.find_system_certs()
+
+        for cert in certs:
+            yield check_cert_expiry_date(class_instance=self, cert=cert)

--- a/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
@@ -197,3 +197,32 @@ class TKSSystemCertExpiryCheck(CertsPlugin):
 
         for cert in certs:
             yield check_cert_expiry_date(class_instance=self, cert=cert)
+
+
+@registry
+class TPSSystemCertExpiryCheck(CertsPlugin):
+    """
+    Check the expiry of TPS's system certs
+    """
+
+    @duration
+    def check(self):
+
+        if not self.instance.exists():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        tps = self.instance.get_subsystem('tps')
+
+        if not tps:
+            logger.info("No TPS configured, skipping TPS System Cert Expiry check")
+            return
+
+        certs = tps.find_system_certs()
+
+        for cert in certs:
+            yield check_cert_expiry_date(class_instance=self, cert=cert)

--- a/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
@@ -139,3 +139,32 @@ class KRASystemCertExpiryCheck(CertsPlugin):
 
         for cert in certs:
             yield check_cert_expiry_date(class_instance=self, cert=cert)
+
+
+@registry
+class OCSPSystemCertExpiryCheck(CertsPlugin):
+    """
+    Check the expiry of OCSP's system certs
+    """
+
+    @duration
+    def check(self):
+
+        if not self.instance.exists():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         msg='Invalid PKI instance: %s' % self.instance.name)
+            return
+
+        self.instance.load()
+
+        ocsp = self.instance.get_subsystem('ocsp')
+
+        if not ocsp:
+            logger.info("No OCSP configured, skipping OCSP System Cert Expiry check")
+            return
+
+        certs = ocsp.find_system_certs()
+
+        for cert in certs:
+            yield check_cert_expiry_date(class_instance=self, cert=cert)


### PR DESCRIPTION
This is an extension to PR #435 

This PR adds new healthchecks to test the system cert
expiration of OCSP, TKS and TPS subsystems.