### PR TITLE
Docs update

### DIFF
--- a/docs/installation/ca/Installing_CA.md
+++ b/docs/installation/ca/Installing_CA.md
@@ -10,14 +10,7 @@ Before beginning with the installation, please ensure that you have configured t
 server and added base entries.
 The step is described [here](https://github.com/dogtagpki/pki/wiki/DS-Installation).
 
-Additionally, please verify that your FQDN is correctly reported by the following command:
-
-    python -c 'import socket; print(socket.getfqdn())'
-
-If it isn't, please add an entry at the beginning of the `/etc/hosts` file:
-
-    127.0.0.1 server.example.com
-    ::1 server.example.com
+Additionally, make sure the FQDN has been [configured](../server/FQDN_Configuration.adoc) correctly.
 
 CA Subsystem Installation
 -------------------------

--- a/docs/installation/ca/Installing_CA_Clone.md
+++ b/docs/installation/ca/Installing_CA_Clone.md
@@ -10,14 +10,7 @@ Before beginning with the installation, please ensure that you have configured t
 server and added base entries.
 The step is described [here](https://github.com/dogtagpki/pki/wiki/DS-Installation).
 
-Additionally, please verify that your FQDN is correctly reported by the following command:
-
-    python -c 'import socket; print(socket.getfqdn())'
-
-If it isn't, please add an entry at the beginning of the `/etc/hosts` file:
-
-    127.0.0.1 clone.example.com
-    ::1 clone.example.com
+Additionally, make sure the FQDN has been [configured](../server/FQDN_Configuration.adoc) correctly.
 
 Some useful tips:
 

--- a/docs/installation/ca/Installing_CA_with_ECC.md
+++ b/docs/installation/ca/Installing_CA_with_ECC.md
@@ -10,14 +10,7 @@ Before beginning with the installation, please ensure that you have configured t
 server and added base entries.
 The step is described [here](https://github.com/dogtagpki/pki/wiki/DS-Installation).
 
-Additionally, please verify that your FQDN is correctly reported by the following command:
-
-    python -c 'import socket; print(socket.getfqdn())'
-
-If it isn't, please add and entry at the beginning of the `/etc/hosts` file:
-
-    127.0.0.1 server.example.com
-    ::1 server.example.com
+Additionally, make sure the FQDN has been [configured](../server/FQDN_Configuration.adoc) correctly.
 
 Supported ECC curves:
 

--- a/docs/installation/server/FQDN_Configuration.adoc
+++ b/docs/installation/server/FQDN_Configuration.adoc
@@ -1,0 +1,27 @@
+= FQDN Configuration =
+
+== Overview ==
+
+In order to have a properly functioning PKI system,
+each machine in the system must have a correct fully qualified domain name.
+
+This page describes the process to verify and configure
+the fully qualified domain name on each machine.
+
+== Verifying FQDN ==
+
+To verify the current FQDN, execute the following command:
+
+----
+$ python -c 'import socket; print(socket.getfqdn())'
+server.example.com
+----
+
+== Configuring FQDN ==
+
+To configure the FQDN, specify the FQDN in `/etc/hosts`, for example:
+
+----
+127.0.0.1 server.example.com
+::1 server.example.com
+----


### PR DESCRIPTION
Some CLIs have been replaced for clarity and consistency:

* pki client-cert-import --pkcs12 --> pki pkcs12-import
* pki client-cert-import --cert/--ca-cert --> pki nss-cert-import
* pki client-init --> pki nss-create

The old CLIs are still working, but they will be deprecated in the future. Test cases that depend on the old command should be updated.