### PR TITLE
PKIConnection: verify certificates

### DIFF
--- a/base/native-tools/src/bulkissuance/bulkissuance.c
+++ b/base/native-tools/src/bulkissuance/bulkissuance.c
@@ -604,6 +604,17 @@ client_main(
         }
         errExit("SSL_OptionSet SSL_SECURITY");
     }
+#ifdef SSL_ENABLE_POST_HANDSHAKE_AUTH
+    rv = SSL_OptionSet(model_sock,
+                       SSL_ENABLE_POST_HANDSHAKE_AUTH, PR_TRUE);
+    if (rv < 0) {
+        if( model_sock != NULL ) {
+            PR_Close( model_sock );
+            model_sock = NULL;
+        }
+        errExit("SSL_OptionSet SSL_ENABLE_POST_HANDSHAKE_AUTH");
+    }
+#endif
 
     SSL_SetURL(model_sock, hostName);
 

--- a/base/native-tools/src/revoker/revoker.c
+++ b/base/native-tools/src/revoker/revoker.c
@@ -586,6 +586,17 @@ client_main(
         }
         errExit("SSL_OptionSet SSL_SECURITY");
     }
+#ifdef SSL_ENABLE_POST_HANDSHAKE_AUTH
+    rv = SSL_OptionSet(model_sock,
+                       SSL_ENABLE_POST_HANDSHAKE_AUTH, PR_TRUE);
+    if (rv < 0) {
+        if( model_sock != NULL ) {
+            PR_Close( model_sock );
+            model_sock = NULL;
+        }
+        errExit("SSL_OptionSet SSL_ENABLE_POST_HANDSHAKE_AUTH");
+    }
+#endif
 
     SSL_SetURL(model_sock, hostName);
 

--- a/base/native-tools/src/sslget/sslget.c
+++ b/base/native-tools/src/sslget/sslget.c
@@ -714,6 +714,10 @@ client_main(
             /* do SSL configuration. */
 
             rv = SSL_OptionSet(model_sock, SSL_SECURITY, 1);
+#ifdef SSL_ENABLE_POST_HANDSHAKE_AUTH
+            SSL_OptionSet(model_sock,
+                          SSL_ENABLE_POST_HANDSHAKE_AUTH, PR_TRUE);
+#endif
 
             if (rv < 0) {
                 if( model_sock != NULL ) {

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -176,6 +176,12 @@ pki_existing=False
 
 # DEPRECATED: Use 'pki_cert_chain_path' instead.
 pki_external_ca_cert_chain_path=%(pki_instance_configuration_path)s/external_ca_chain.cert
+
+# In addition to specifying an external CA certificate, this parameter
+# can be used with a one-shot installation process is used for installing
+# non-CA subsystems on a new host, lacking any existing subsystems. This
+# cert is used to establish trust to an existing CA installation on another
+# system.
 pki_cert_chain_path=%(pki_external_ca_cert_chain_path)s
 
 # DEPRECATED: Use 'pki_cert_chain_nickname' instead.

--- a/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from pki.server.healthcheck.meta.plugin import MetaPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
@@ -27,6 +28,7 @@ class DogtagCACertsConnectivityCheck(MetaPlugin):
         self.instance.load()
 
         ca = self.instance.get_subsystem('ca')
+        ca_cert = os.path.join(self.instance.nssdb_dir, "ca.crt")
 
         if not ca:
             logger.info("No CA configured, skipping dogtag CA connectivity check")
@@ -38,11 +40,12 @@ class DogtagCACertsConnectivityCheck(MetaPlugin):
             if ca.is_ready():
                 logger.debug("CA instance is running")
 
-                # Make a plain HTTP GET to "find" one certificate, to test that
+                # Make a plain HTTPS GET to "find" one certificate, to test that
                 # the server is up AND is able to respond back
                 connection = PKIConnection(protocol='https',
                                            hostname='localhost',
-                                           port='8443')
+                                           port='8443',
+                                           cert_paths=ca_cert)
 
                 cert_client = CertClient(connection)
                 cert = cert_client.list_certs(size=1)
@@ -98,6 +101,7 @@ class DogtagKRAConnectivityCheck(MetaPlugin):
         self.instance.load()
 
         kra = self.instance.get_subsystem('kra')
+        ca_cert = os.path.join(self.instance.nssdb_dir, "ca.crt")
 
         if not kra:
             logger.info("No KRA configured, skipping dogtag KRA connectivity check")
@@ -109,11 +113,12 @@ class DogtagKRAConnectivityCheck(MetaPlugin):
             if kra.is_ready():
                 logger.info("KRA instance is running.")
 
-                # Make a plain HTTP GET to retrieve KRA transport cert, to test that
+                # Make a plain HTTPS GET to retrieve KRA transport cert, to test that
                 # the server is up AND is able to respond back
                 connection = PKIConnection(protocol='https',
                                            hostname='localhost',
-                                           port='8443')
+                                           port='8443',
+                                           cert_paths=ca_cert)
 
                 system_cert_client = SystemCertClient(connection)
 

--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -132,6 +132,10 @@ class MigrateCLI(pki.cli.CLI):
             # Only attempt to convert if target format is sql and DB is dbm
             if nssdb.needs_conversion():
                 nssdb.convert_db()
+
+            ca_path = os.path.join(instance.nssdb_dir, 'ca.crt')
+            nickname = instance.get_sslserver_cert_nickname()
+            nssdb.extract_ca_cert(ca_path, nickname)
         finally:
             nssdb.close()
 

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -245,11 +245,15 @@ class PKIDeployer:
 
         logger.info('Connecting to security domain at %s', sd_url)
 
+        ca_cert = os.path.join(self.mdict['pki_server_database_path'],
+                               "ca.crt")
+
         self.sd_connection = pki.client.PKIConnection(
             protocol='https',
             hostname=sd_hostname,
             port=sd_port,
-            trust_env=False)
+            trust_env=False,
+            cert_paths=ca_cert)
 
         return self.sd_connection
 

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2062,6 +2062,7 @@ class KRAConnector:
     def __init__(self, deployer):
         self.mdict = deployer.mdict
         self.password = deployer.password
+        self.ca_cert = os.path.join(self.mdict['pki_server_database_path'], "ca.crt")
 
     def deregister(self, critical_failure=False):
         krahost = None
@@ -2133,7 +2134,7 @@ class KRAConnector:
 
             try:
                 ca_list = self.get_ca_list_from_security_domain(
-                    sechost, secport)
+                    sechost, secport, self.ca_cert)
             except Exception as e:
                 logger.error(
                     "unable to access security domain. Continuing .. %s ",
@@ -2170,12 +2171,13 @@ class KRAConnector:
         return
 
     @staticmethod
-    def get_ca_list_from_security_domain(sechost, secport):
+    def get_ca_list_from_security_domain(sechost, secport, cert_paths):
         sd_connection = pki.client.PKIConnection(
             protocol='https',
             hostname=sechost,
             port=secport,
-            trust_env=False)
+            trust_env=False,
+            cert_paths=cert_paths)
         sd = pki.system.SecurityDomainClient(sd_connection)
         try:
             info = sd.get_domain_info()

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -533,11 +533,15 @@ class PKIConfigParser:
 
     def get_server_status(self, system_type, system_uri):
         parse = urlparse(self.mdict[system_uri])
+        # Because this is utilized exclusively during pkispawn, we can safely
+        # ignore validating the certificate; it might not yet have been
+        # configured anyways.
         conn = pki.client.PKIConnection(
             protocol=parse.scheme,
             hostname=parse.hostname,
             port=str(parse.port),
-            trust_env=False)
+            trust_env=False,
+            verify=False)
         client = pki.system.SystemStatusClient(conn, subsystem=system_type)
         response = client.get_status()
         root = ET.fromstring(response)

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -893,11 +893,14 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if config.str2bool(deployer.mdict['pki_enable_java_debugger']):
             config.wait_to_attach_an_external_java_debugger()
 
+        ca_cert = os.path.join(instance.nssdb_dir, "ca.crt")
+
         connection = pki.client.PKIConnection(
             protocol='https',
             hostname=deployer.mdict['pki_hostname'],
             port=deployer.mdict['pki_https_port'],
-            trust_env=False)
+            trust_env=False,
+            cert_paths=ca_cert)
 
         client = pki.system.SystemConfigClient(
             connection,

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -193,6 +193,19 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             finally:
                 nssdb.close()
 
+        ca_cert_path = deployer.mdict.get('pki_cert_chain_path')
+        if ca_cert_path and os.path.exists(ca_cert_path):
+            destination = os.path.join(instance.nssdb_dir, "ca.crt")
+            if not os.path.exists(destination):
+                # When we're passed a CA certificate file and we don't already
+                # have a CA file for some reason, we need to copy the passed
+                # file as the root CA certificate to establish trust in the
+                # Python code. It doesn't import it into the NSS DB for Java
+                # code, but so far we haven't had any issues with certificate
+                # validation there. This is only usually necessary when
+                # installing a non-CA subsystem on a fresh system.
+                instance.copyfile(ca_cert_path, destination)
+
         if len(deployer.instance.tomcat_instance_subsystems()) < 2:
 
             # Check to see if a secure connection is being used for the DS

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -748,9 +748,10 @@ class PKIInstance(pki.server.PKIServer):
         :raises pki.server.PKIServerException
 
         Either supply both username and password, or supply
-        client_nssdb and client_cert and
-        (client_nssdb_pass or client_nssdb_pass_file).
+        client_cert and (client_nssdb_pass or client_nssdb_pass_file).
 
+        Note that client_nssdb should be specified in either case, as it
+        contains the CA Certificate.
         """
         nssdb = self.open_nssdb()
         tmpdir = tempfile.mkdtemp()
@@ -804,7 +805,8 @@ class PKIInstance(pki.server.PKIServer):
                 logger.info('Trying to setup a secure connection to CA subsystem.')
                 if username and password:
                     connection = pki.server.PKIServer.setup_password_authentication(
-                        username, password, subsystem_name='ca', secure_port=secure_port)
+                        username, password, subsystem_name='ca', secure_port=secure_port,
+                        client_nssdb=client_nssdb)
                 else:
                     if not client_cert:
                         raise pki.server.PKIServerException('Client cert nick name required.')

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -371,12 +371,15 @@ class PKISubsystem(object):
             protocol = 'http'
             port = server_config.get_unsecure_port()
 
+        # When waiting for a connection to come alive, don't bother verifying
+        # the certificate at this stage.
         connection = pki.client.PKIConnection(
             protocol=protocol,
             hostname=socket.getfqdn(),
             port=port,
             accept='application/xml',
-            trust_env=False)
+            trust_env=False,
+            verify=False)
 
         client = pki.system.SystemStatusClient(connection, subsystem=self.name)
         response = client.get_status(timeout=timeout)

--- a/base/tps-client/src/httpClient/engine.cpp
+++ b/base/tps-client/src/httpClient/engine.cpp
@@ -612,6 +612,12 @@ PRFileDesc * Engine::_doConnect(PRNetAddr *addr, PRBool SSLOn,
         if ( SECSuccess == rv ) {
 			rv = SSL_OptionSet(sock, SSL_ENABLE_TLS, PR_TRUE);
 		}
+#ifdef SSL_ENABLE_POST_HANDSHAKE_AUTH
+        if ( SECSuccess == rv ) {
+            rv = SSL_OptionSet(sock,
+                               SSL_ENABLE_POST_HANDSHAKE_AUTH, PR_TRUE);
+        }
+#endif
         if ( SECSuccess != rv ) {
             error = PORT_GetError();
             if( sock != NULL ) {

--- a/docs/installation/Installing_KRA.md
+++ b/docs/installation/Installing_KRA.md
@@ -52,6 +52,13 @@ It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and c
 * server NSS database: /etc/pki/pki-tomcat/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
+**Note**: When KRA is installed on a new system without any other subsystems,
+it is necessary to provide the CA's root certificate. Specify the path to
+the CA PKCS#7 PEM file in the `pki_cert_chain_path`. This will allow the server
+to verify the CA's SSL server certificate when contacting the security domain.
+It is up to the administrator to securely transport the CA root certificate
+(public key only!) to the system prior to KRA installation.
+
 Verifying System Certificates
 -----------------------------
 

--- a/docs/installation/Installing_OCSP.md
+++ b/docs/installation/Installing_OCSP.md
@@ -51,6 +51,13 @@ It will install OCSP subsystem in a Tomcat instance (default is pki-tomcat) and 
 * server NSS database: /etc/pki/pki-tomcat/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ocsp/alias
 
+**Note**: When OCSP is installed on a new system without any other subsystems,
+it is necessary to provide the CA's root certificate. Specify the path to
+the CA PKCS#7 PEM file in the `pki_cert_chain_path`. This will allow the server
+to verify the CA's SSL server certificate when contacting the security domain.
+It is up to the administrator to securely transport the CA root certificate
+(public key only!) to the system prior to OCSP installation.
+
 Verifying System Certificates
 -----------------------------
 

--- a/docs/installation/Installing_TKS.md
+++ b/docs/installation/Installing_TKS.md
@@ -50,6 +50,13 @@ It will install TKS subsystem in a Tomcat instance (default is pki-tomcat) and c
 * server NSS database: /etc/pki/pki-tomcat/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/tks/alias
 
+**Note**: When TKS is installed on a new system without any other subsystems,
+it is necessary to provide the CA's root certificate. Specify the path to
+the CA PKCS#7 PEM file in the `pki_cert_chain_path`. This will allow the server
+to verify the CA's SSL server certificate when contacting the security domain.
+It is up to the administrator to securely transport the CA root certificate
+(public key only!) to the system prior to TKS installation.
+
 Verifying System Certificates
 -----------------------------
 

--- a/docs/installation/Installing_TPS.md
+++ b/docs/installation/Installing_TPS.md
@@ -50,6 +50,13 @@ It will install TPS subsystem in a Tomcat instance (default is pki-tomcat) and c
 * server NSS database: /etc/pki/pki-tomcat/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/tps/alias
 
+**Note**: When TPS is installed on a new system without any other subsystems,
+it is necessary to provide the CA's root certificate. Specify the path to
+the CA PKCS#7 PEM file in the `pki_cert_chain_path`. This will allow the server
+to verify the CA's SSL server certificate when contacting the security domain.
+It is up to the administrator to securely transport the CA root certificate
+(public key only!) to the system prior to TPS installation.
+
 Verifying System Certificates
 -----------------------------
 

--- a/docs/manuals/man1/pki.1.md
+++ b/docs/manuals/man1/pki.1.md
@@ -211,11 +211,20 @@ created during the configuration portion of the basic PKI installation of the as
 
 The third command shows the information about the imported client certificate (including its nickname).
 
-**Note:** When issuing the first **pki** command using the authentication parameters
-(after completion of the setup of the NSS database),
-a user may be greeted with a warning message which indicates that an untrusted issuer was encountered.
-Simply reply 'Y' to import the CA certificate, and, presuming that the displayed CA server URL is valid,
-press the carriage return.
+Additionally, provision the root CA certificate into this NSS DB.
+This certificate must be imported into the NSS DB and copied as a PEM format
+certificate into the NSS DB directory, named 'ca.crt'.
+To do so:
+
+```
+$ certutil -A -d <NSS database location> -n "CA Root Certificate" -a -i /path/to/ca.crt
+$ cp /path/to/ca.crt <NSS database location>/ca.crt
+```
+
+This will ensure all parts of the client can successfully connect with the
+PKI instance and validate the certificate used to sign the web UI. If an
+external CA certificate was used to approve the sslserver certificate, import
+that certificate instead.
 
 ### Client Authentication
 


### PR DESCRIPTION
This subsumes @tiran's pr-#224 for his initial work on a SSL adapter. I've modified it to actually enable PHA.

---

This pull request enables certificate verification in `PKIConnection`; previously the `verify` flag was set to `False`. In order to do this, we need a method for specifying the location of our CA certificate. The default location for a PEM-encoded CA certificate will be `~/.dogtag/nssdb/ca.crt` as this certificate should also be imported into the client's NSS DB directory. Additionally, there'll be an instance under `/etc/pki/<instance>/alias/ca.crt` for use with server-side operations. IPA is then free to pass its own CA path (`/etc/ipa/ca.crt`) or link our certificate to there. We also need 

TODO:

 - [x] Enable `verify=True`
 - [x] Add default CA location (`~/.dogtag/nssdb/ca.crt` and `/etc/pki/<instance>/alias/ca.crt`).
 - [x] Add pkispawn parameter
 - [ ] Migrate usages of PKIConnection
    - [x] Healthcheck connectivity check
    - [x] `pki/server/__init__.py`
    - [x] `pki/server/deployment/__init__.py`
    - [x] `pki/server/deployment/pkihelper.py`
    - [x] `pki/server/deployment/scriptlets/configuration.py`
    - [x] `pki/server/deployment/pkiparser.py`
    - [x] `pki/server/subsystem.py`
    - [x] `pki/feature.py` (Test case not migrated)
    - [x] `pki/profile.py` (Test case not migrated)
    - [x] `pki/cert.py` (Test case not migrated)
    - [x] `pki/kra.py` (Test case not migrated)
    - [x] `pki/client.py`
    - [x] `pki/system.py` (Test case not migrated)
    - [x] `pki/authority.py` (Test case not migrated)
    - [x] `pki/account.py` (Test case not migrated)
    - [ ] `kra/functional/drmtest.py` -- does this get used? 
 - [x] Add upgrade scriptlet to create the CA certificate.
 - [x] IPA pull request to pass their CA paths. See: [freeipa/freeipa#4820](https://github.com/freeipa/freeipa/pull/4820).
 - [x] Documentation
 - [ ] Test, test, tests

Resolves: rh-bz#1426572

--- 

Pylint bug: https://github.com/PyCQA/pylint/issues/3691 (breaks CI)