### PR TITLE
Added NSSExtensionGenerator

### DIFF
--- a/base/common/src/org/dogtagpki/nss/NSSExtensionGenerator.java
+++ b/base/common/src/org/dogtagpki/nss/NSSExtensionGenerator.java
@@ -23,6 +23,7 @@ import org.mozilla.jss.netscape.security.x509.BasicConstraintsExtension;
 import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
 import org.mozilla.jss.netscape.security.x509.GeneralName;
 import org.mozilla.jss.netscape.security.x509.KeyIdentifier;
+import org.mozilla.jss.netscape.security.x509.KeyUsageExtension;
 import org.mozilla.jss.netscape.security.x509.SubjectKeyIdentifierExtension;
 import org.mozilla.jss.netscape.security.x509.URIName;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
@@ -246,6 +247,57 @@ public class NSSExtensionGenerator {
         return extension;
     }
 
+    public KeyUsageExtension createKeyUsageExtension() throws Exception {
+
+        String keyUsage = getParameter("keyUsage");
+        if (keyUsage == null) return null;
+
+        logger.info("Creating key usage extension:");
+
+        KeyUsageExtension extension = new KeyUsageExtension(false, new boolean[0]);
+
+        List<String> options = Arrays.asList(keyUsage.split("\\s*,\\s*"));
+        for (String option : options) {
+            logger.info("- " + option);
+
+            if ("critical".equals(option)) {
+                extension.setCritical(true);
+
+            } else if ("digitalSignature".equals(option)) {
+                extension.set(KeyUsageExtension.DIGITAL_SIGNATURE, true);
+
+            } else if ("nonRepudiation".equals(option)) {
+                extension.set(KeyUsageExtension.NON_REPUDIATION, true);
+
+            } else if ("keyEncipherment".equals(option)) {
+                extension.set(KeyUsageExtension.KEY_ENCIPHERMENT, true);
+
+            } else if ("dataEncipherment".equals(option)) {
+                extension.set(KeyUsageExtension.DATA_ENCIPHERMENT, true);
+
+            } else if ("keyAgreement".equals(option)) {
+                extension.set(KeyUsageExtension.KEY_AGREEMENT, true);
+
+            } else if ("keyCertSign".equals(option)) {
+                extension.set(KeyUsageExtension.KEY_CERTSIGN, true);
+
+            } else if ("cRLSign".equals(option)) {
+                extension.set(KeyUsageExtension.CRL_SIGN, true);
+
+            } else if ("encipherOnly".equals(option)) {
+                extension.set(KeyUsageExtension.ENCIPHER_ONLY, true);
+
+            } else if ("decipherOnly".equals(option)) {
+                extension.set(KeyUsageExtension.DECIPHER_ONLY, true);
+
+            } else {
+                throw new Exception("Unsupported key usage: " + option);
+            }
+        }
+
+        return extension;
+    }
+
     public CertificateExtensions createExtensions() throws Exception {
         return createExtensions(null, null);
     }
@@ -274,6 +326,11 @@ public class NSSExtensionGenerator {
         AuthInfoAccessExtension aiaExtension = createAIAExtension();
         if (aiaExtension != null) {
             extensions.parseExtension(aiaExtension);
+        }
+
+        KeyUsageExtension keyUsageExtension = createKeyUsageExtension();
+        if (keyUsageExtension != null) {
+            extensions.parseExtension(keyUsageExtension);
         }
 
         return extensions;

--- a/base/common/src/org/dogtagpki/nss/NSSExtensionGenerator.java
+++ b/base/common/src/org/dogtagpki/nss/NSSExtensionGenerator.java
@@ -1,0 +1,141 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.nss;
+
+import java.io.FileInputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.mozilla.jss.netscape.security.pkcs.PKCS10;
+import org.mozilla.jss.netscape.security.x509.BasicConstraintsExtension;
+import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class NSSExtensionGenerator {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSExtensionGenerator.class);
+
+    private Map<String, String> parameters = new LinkedHashMap<String, String>();
+
+    public NSSExtensionGenerator() {
+    }
+
+    /**
+     * Initialize cert extension generator with configuration file
+     * based on the following format:
+     * https://www.openssl.org/docs/manmaster/man5/x509v3_config.html
+     */
+    public void init(String filename) throws Exception {
+
+        Properties properties = new Properties();
+        properties.load(new FileInputStream(filename));
+
+        parameters.clear();
+        for (String name : properties.stringPropertyNames()) {
+            String value = properties.getProperty(name);
+            parameters.put(name, value);
+        }
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters.clear();
+        this.parameters.putAll(parameters);
+    }
+
+    public Collection<String> getParameterNames() {
+        return parameters.keySet();
+    }
+
+    public Collection<String> getParameterNames(String parent) {
+
+        String prefix = parent + ".";
+        int length = prefix.length();
+
+        return parameters.keySet().stream()
+            .filter(name -> name.startsWith(prefix))
+            .map(name -> name.substring(length))
+            .collect(Collectors.toSet());
+    }
+
+    public String getParameter(String name) {
+        return parameters.get(name);
+    }
+
+    public void setParameter(String name, String value) {
+        parameters.put(name, value);
+    }
+
+    public String removeParameter(String name) {
+        return parameters.remove(name);
+    }
+
+    public BasicConstraintsExtension createBasicConstraintsExtension() throws Exception {
+
+        String basicConstraints = getParameter("basicConstraints");
+        if (basicConstraints == null) return null;
+
+        logger.info("Creating basic constraint extension:");
+
+        boolean critical = false;
+        boolean ca = false;
+        int pathLength = -1;
+
+        List<String> options = Arrays.asList(basicConstraints.split("\\s*,\\s*"));
+        for (String option : options) {
+
+            if (option.equals("critical")) {
+                logger.info("- critical");
+                critical = true;
+                continue;
+            }
+
+            if (option.startsWith("CA:")) {
+                ca = Boolean.parseBoolean(option.substring(3));
+                logger.info("- CA: " + ca);
+                continue;
+            }
+
+            if (option.startsWith("pathlen:")) {
+                pathLength = Integer.parseInt(option.substring(8));
+                logger.info("- path length: " + pathLength);
+                continue;
+            }
+
+            throw new Exception("Unsupported option: " + option);
+        }
+
+        return new BasicConstraintsExtension(ca, critical, pathLength);
+    }
+
+    public CertificateExtensions createExtensions() throws Exception {
+        return createExtensions(null, null);
+    }
+
+    public CertificateExtensions createExtensions(
+            org.mozilla.jss.crypto.X509Certificate issuer,
+            PKCS10 pkcs10) throws Exception {
+
+        CertificateExtensions extensions = new CertificateExtensions();
+
+        BasicConstraintsExtension basicConstraintsExtension = createBasicConstraintsExtension();
+        if (basicConstraintsExtension != null) {
+            extensions.parseExtension(basicConstraintsExtension);
+        }
+
+        return extensions;
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -13,7 +13,9 @@ import org.apache.commons.cli.Option;
 import org.dogtag.util.cert.CertUtil;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.nss.NSSDatabase;
+import org.dogtagpki.nss.NSSExtensionGenerator;
 import org.mozilla.jss.netscape.security.pkcs.PKCS10;
+import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
 
 import com.netscape.certsrv.client.ClientConfig;
 import com.netscape.cmstools.cli.MainCLI;
@@ -55,6 +57,10 @@ public class NSSCertRequestCLI extends CommandCLI {
         option.setArgName("name");
         options.addOption(option);
 
+        option = new Option(null, "ext", true, "Certificate extensions configuration");
+        option.setArgName("path");
+        options.addOption(option);
+
         option = new Option(null, "csr", true, "Certificate signing request");
         option.setArgName("path");
         options.addOption(option);
@@ -72,6 +78,7 @@ public class NSSCertRequestCLI extends CommandCLI {
         String keySize = cmd.getOptionValue("key-size");
         String curve = cmd.getOptionValue("curve");
         String hash = cmd.getOptionValue("hash");
+        String extConf = cmd.getOptionValue("ext");
 
         if (subject == null) {
             throw new Exception("Missing subject name");
@@ -83,13 +90,21 @@ public class NSSCertRequestCLI extends CommandCLI {
         ClientConfig clientConfig = mainCLI.getConfig();
         NSSDatabase nssdb = mainCLI.getNSSDatabase();
 
+        CertificateExtensions extensions = null;
+        if (extConf != null) {
+            NSSExtensionGenerator generator = new NSSExtensionGenerator();
+            generator.init(extConf);
+            extensions = generator.createExtensions();
+        }
+
         PKCS10 pkcs10 = nssdb.createRequest(
                 subject,
                 keyID,
                 keyType,
                 keySize,
                 curve,
-                hash);
+                hash,
+                extensions);
 
         String format = cmd.getOptionValue("format");
         byte[] bytes;


### PR DESCRIPTION
The `NSSExtensionGenerator` has been added to create certificate
extension objects from a configuration file.
    
The `NSSDatabase` has been modified to support creating certificate
request or issuing certificates with extensions.

For example, define the certificate extensions in a file
(e.g. sslserver.conf) as follows:

```
basicConstraints       = critical, CA:FALSE
subjectKeyIdentifier   = hash
authorityKeyIdentifier = keyid:always
authorityInfoAccess    = OCSP;URI:http://ocsp.example.com, caIssuers;URI:http://cert.example.com
keyUsage               = critical, digitalSignature, keyEncipherment
extendedKeyUsage       = serverAuth, clientAuth
certificatePolicies    = 2.23.140.1.2.1, @cps_policy

cps_policy.id          = 1.3.6.1.4.1.44947.1.1.1
cps_policy.CPS.1       = http://cps.example.com
```

Create the certificate request as follows:

```
$ pki nss-cert-request \
    --subject "CN=$HOSTNAME" \
    --csr sslserver.csr
```

Issue a self-signed certificate as follows:

```
$ pki nss-cert-issue \
    --csr sslserver.csr \
    --ext sslserver.conf \
    --cert sslserver.crt
```

Then verify the extensions as follows:

```
$ openssl x509 -text -noout -in sslserver.crt
```

The doc is available at https://www.dogtagpki.org/wiki/PKI_NSS_CLI.