### PR TITLE
CT: fix SCT verification

### DIFF
--- a/base/ca/src/com/netscape/ca/CAService.java
+++ b/base/ca/src/com/netscape/ca/CAService.java
@@ -1144,13 +1144,22 @@ public class CAService implements ICAService, IService {
                 // timestamp
                 byte ct_timestamp[] = timeStampHexStringToByteArray(timestamp_s);
 
-                byte ct_ext[] = new byte[] {0, 0}; // CT extension
+                String extensions_s = response.getExtensions();
+                if (extensions_s == null) {
+                    extensions_s = "";
+                }
+                byte[] ct_extensions = CryptoUtil.base64Decode(extensions_s);
+
                 // signature
                 byte ct_signature[] = CryptoUtil.base64Decode(response.getSignature());
                 logger.debug(method + " ct_signature: " + bytesToHex(ct_signature));
 
-                int sct_len = ct_version.length + ct_id.length +
-                        ct_timestamp.length + 2 /* ext */ + ct_signature.length;
+                int sct_len =
+                    ct_version.length
+                    + ct_id.length
+                    + ct_timestamp.length
+                    + 2 + ct_extensions.length
+                    + ct_signature.length;
                 ByteBuffer sct_len_bytes = ByteBuffer.allocate(4);
                 //sct_len_bytes.order(ByteOrder.BIG_ENDIAN);
                 sct_len_bytes.putInt(sct_len);
@@ -1165,7 +1174,11 @@ public class CAService implements ICAService, IService {
                 sct_ostream.write(ct_version);
                 sct_ostream.write(ct_id);
                 sct_ostream.write(ct_timestamp);
-                sct_ostream.write(ct_ext);
+
+                // 2 bytes for extensions len
+                sct_ostream.write(intToFixedWidthBytes(ct_extensions.length, 2));
+                sct_ostream.write(ct_extensions);
+
                 sct_ostream.write(ct_signature);
             }
 

--- a/base/ca/src/com/netscape/ca/CAService.java
+++ b/base/ca/src/com/netscape/ca/CAService.java
@@ -955,14 +955,26 @@ public class CAService implements ICAService, IService {
                             logger.debug(method + "Response from CT log server " + respS);
 
                             // verify the sct
+
+                            /* TODO this should be a configurable; hardcoded for now */
+                            boolean allowFailedSCTVerification = true;
+
                             boolean verified =
                                     verifySCT(CTResponse.fromJSON(respS), tbsCert, ls.getPublicKey());
-                            if (verified)
+                            if (verified) {
+                                logger.info("verifySCT returned true; SCT is valid");
+                            } else {
+                                // log at WARN if !verified, regardless of how we are treating
+                                // failed verifications, because it is indicative of log server
+                                // misbehavoiur
+                                logger.warn(
+                                    method
+                                    + "verifySCT returns false; SCT failed to verify"
+                                );
+                            }
+                            if (verified || allowFailedSCTVerification) {
                                 ctResponses.add(respS);
-                            else { // not verified
-                                errMsg = method + "verifySCT returns false; SCT failed to verify";
-                                logger.error(errMsg);
-                                // disallow failed verification
+                            } else {
                                 throw new EBaseException(errMsg);
                             }
                         }

--- a/base/ca/src/com/netscape/ca/CAService.java
+++ b/base/ca/src/com/netscape/ca/CAService.java
@@ -1251,16 +1251,35 @@ public class CAService implements ICAService, IService {
             logger.debug(method + " ct_timestamp: " + timestamp_s);
             // timestamp
             byte timestamp[] = timeStampHexStringToByteArray(timestamp_s);
-            byte ct_signature[] = CryptoUtil.base64Decode(response.getSignature());
-            logger.debug(method + " ct_signature len = "+ ct_signature.length);
-            // hard code for now for SHA256withEC signature size is 64
-            int sig_index = ct_signature.length - 64;
-            /*
-             * first 4 bytes are for algorithms
-             * e.g. 04030047 (sha256, ecdsa)
+
+            /* Signature hash and algorithm; values defined in
+             * https://tools.ietf.org/html/rfc5246#section-7.4.1.4.1
+             * and elsewhere.
+             *
+             * First byte is hash alg.
+             * Second byte is sig alg.
+             * Bytes 3 and 4 are length of signature data.
+             *
+             * struct {
+             *   SignatureAndHashAlgorithm algorithm;
+             *   opaque signature<0..2^16-1>;
+             * } DigitallySigned;
+             *
+             * enum {
+             *     none(0), md5(1), sha1(2), sha224(3), sha256(4), sha384(5),
+             *     sha512(6), (255)
+             * } HashAlgorithm;
+             *
+             * enum { anonymous(0), rsa(1), dsa(2), ecdsa(3), (255) }
+             *   SignatureAlgorithm;
+             *
+             * struct {
+             *       HashAlgorithm hash;
+             *       SignatureAlgorithm signature;
+             * } SignatureAndHashAlgorithm;
              */
-            byte[] signature = Arrays.copyOfRange(ct_signature, sig_index, ct_signature.length);
-            logger.debug(method + " signature len = "+ signature.length);
+            byte ct_signature[] = CryptoUtil.base64Decode(response.getSignature());
+            byte[] signature = Arrays.copyOfRange(ct_signature, 4, ct_signature.length);
 
             /* compose data */
             byte[] version = new byte[] {0}; // 1 byte; v1(0)


### PR DESCRIPTION
This PR includes the commit from https://github.com/dogtagpki/pki/pull/440 and
therefore supersedes it.  It adds additional fixes and cleanups.
As a result, SCT verification now works.

This PR preserves the behaviour that ignores failed SCT verification.

A future commit should turn this into a config knob, and probably should flip
the default to FAIL upon invalid SCT, because such failure indicates log server
misbehaviour.

Changes:

```
3f8c415c4 (Fraser Tweedale, 85 minutes ago)
   CT: extract "write fixed-width length field" method

   Define 'intToFixedWidthBytes' which encapsulates the logic of writing a
   length as a fixed-width big-endian uint.  This avoids repetition and makes
   things easier to follow at call sites.

b8ef03b05 (Fraser Tweedale, 62 minutes ago)
   CT: createSCTextension: handle SCT extensions properly

   To handle possible future extensions, read the extensions from the log
   server response(s) and copy them into the SCT extension.

2bf901d67 (Fraser Tweedale, 2 hours ago)
   CT: tidy up "allow failed SCT verification" control

   The "allow failed SCT verification" behaviour was a bit buggy.  If it got a
   boolean verification result it "correctly" ignored failed verification, but
   if an exception was thrown (e.g. due to malformed log server response) it
   returned 'false', aborting issuance.

   Extract the "allow failed verification" check out of verifySCT to the call
   site.  A single boolean now controls the behaviour.  It should be further
   extracted to a config knob in a future commit. For now the default remains
   to ignore failed verification.

6f8603f54 (Fraser Tweedale, 2 hours ago)
   CT: cleanups

037e6e5b7 (Fraser Tweedale, 16 hours ago)
   CT: decode signature value properly

   The CT signature is TLS-encoded structure with 4 leading bytes.  The rest
   of the signature is the signature value, which is a DER-encoded 
   ECDSA-Sig-Value per https://tools.ietf.org/html/rfc5480.  This is exactly
   what JSS needs, so only drop the first 4 bytes.

   With this change, SCT signature verification now works.

3dc377da6 (Christina Fu, 6 days ago)
   Bug 1805541 improvement over verifySCT - [RFE] CA Certificate Transparency
   with Embedded Signed Certificate Time stamp

   This patch made some more attempt to improve on verifySCT
    (though still not working; lack of the signed blob from sender
     makes it a bit challenging)

   It adds the following:
    - Include code to use LinkedHashMap instead of Hashtable (requires jss
   fix)
    - Added debugging code to be sure that the extensions didn’t get out of
   order through manipulation
    - Allow for CT lg connection issue, but disallow for failed CT
   verification (though still temporarily disable failure for signature
   verification)
    - For verifySCT
       - Added missing 3 byte length for tbsCert
       - Added processing for extensions, though most likely not needed for
   some time

   Note: the global on/off is rigid at this point without "per-profile"
   control;

   https://bugzilla.redhat.com/show_bug.cgi?id=1805541
```