### PR TITLE
Fix reflected XSS attack when hitting getCookie endpoint

### DIFF
--- a/base/server/src/com/netscape/cms/servlet/csadmin/GetCookie.java
+++ b/base/server/src/com/netscape/cms/servlet/csadmin/GetCookie.java
@@ -28,6 +28,8 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 import com.netscape.certsrv.authentication.IAuthToken;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.common.ICMSRequest;
@@ -116,7 +118,7 @@ public class GetCookie extends CMSServlet {
             u = new URL(url_e);
         } catch (Exception eee) {
             throw new ECMSGWException(
-                    "Unable to parse URL: " + url);
+                    "Unable to parse URL: " + StringEscapeUtils.escapeHtml(url));
         }
 
         int index2 = url_e.indexOf("subsystem=");
@@ -139,7 +141,7 @@ public class GetCookie extends CMSServlet {
             header.addStringValue("host", u.getHost());
             header.addStringValue("sdhost", engine.getEESSLHost());
             header.addStringValue("subsystem", subsystem);
-            header.addStringValue("url", url_e);
+            header.addStringValue("url", StringEscapeUtils.escapeHtml(url_e));
             header.addStringValue("errorString", "Failed Authentication");
             String sdname = cs.getString("securitydomain.name", "");
             header.addStringValue("sdname", sdname);
@@ -202,7 +204,7 @@ public class GetCookie extends CMSServlet {
                         */
                     }
 
-                    header.addStringValue("url", url);
+                    header.addStringValue("url", StringEscapeUtils.escapeHtml(url));
                     header.addStringValue("session_id", cookie);
 
                     try {


### PR DESCRIPTION
This patch sanitizes the Server generated error message in `getCookie`, to escape
HTML tags, if present.

Resolves: [BZ#1789907](https://bugzilla.redhat.com/show_bug.cgi?id=1789907) [CVE-2019-10221](https://bugzilla.redhat.com/show_bug.cgi?id=1732565)

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`