### PR TITLE
Added client-side prevention for XSS in recoveryID endpoint

### DIFF
--- a/base/kra/shared/webapps/kra/agent/kra/GrantRecovery.html
+++ b/base/kra/shared/webapps/kra/agent/kra/GrantRecovery.html
@@ -32,7 +32,7 @@ Use this form to approve a key recovery.
     <td  valign="top" align="right">
       <font size="-1" face="PrimaSans BT, Verdana, sans-serif">Recovery authorization reference number:<br></font>
     </td>
-    <td><INPUT TYPE="TEXT" NAME="recoveryID" SIZE=10 MAXLENGTH=99"></td>
+    <td><INPUT TYPE="NUMBER" NAME="recoveryID" MIN=0"></td>
   </tr>
 </table>
 


### PR DESCRIPTION
This patch will prevent strings or crafted payload entered via recoveryID input field and only accepts a number format data.

Signed-off-by: Pritam Singh <prisingh@redhat.com>