### PR TITLE
Bug1629025: KRA transporCert nick: Server-Side keygen Enrollment for EE

### DIFF
--- a/base/server/src/com/netscape/cms/profile/def/ServerKeygenUserKeyDefault.java
+++ b/base/server/src/com/netscape/cms/profile/def/ServerKeygenUserKeyDefault.java
@@ -292,7 +292,7 @@ public class ServerKeygenUserKeyDefault extends EnrollDefault {
             try {
                 CMSEngine engine = CMS.getCMSEngine();
                 ICertificateAuthority CA = (ICertificateAuthority) engine.getSubsystem(ICertificateAuthority.ID);
-                String transportNickname = CA.getConfigStore().getString("ca.connector.KRA.transportCertNickname", "KRA Transport Certificate");
+                String transportNickname = CA.getConfigStore().getString("connector.KRA.transportCertNickname", "KRA Transport Certificate");
                 transCert = cm.findCertByNickname(transportNickname);
             } catch (Exception e) {
                 logger.debug(method + "'KRA transport certificate' not found in nssdb; need to be manually setup for Server-Side keygen enrollment");


### PR DESCRIPTION
This patch fixes the issue where CA attempts to get
ca.ca.connector.KRA.transportCertNickname
instead of
ca.connector.KRA.transportCertNickname
from it's CS.cfg

https://bugzilla.redhat.com/show_bug.cgi?id=1629025