### PR TITLE
Use password during NSS DB creation

### DIFF
--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -98,6 +98,7 @@ public class MainCLI extends CLI {
     String output;
 
     boolean initialized;
+    boolean optionsParsed;
 
     public MainCLI() throws Exception {
         super("pki", "PKI command-line interface");
@@ -465,6 +466,8 @@ public class MainCLI extends CLI {
         String messageFormat = cmd.getOptionValue("message-format");
         config.setMessageFormat(messageFormat);
         logger.info("Message format: " + messageFormat);
+
+        optionsParsed = true;
     }
 
     public void convertCertStatusList(String list, Collection<Integer> statuses) throws Exception {
@@ -490,9 +493,18 @@ public class MainCLI extends CLI {
             return;
         }
 
+        if (!optionsParsed) {
+            throw new Exception("Unable to call MainCLI.init() without first calling MainCLI.parseOptions()");
+        }
+
         if (!nssdb.exists()) {
-            // Create a default NSS database without password
-            nssdb.create();
+            // Create the NSS DB with the specified password, if one has been
+            // specified.
+            if (config.getNSSPassword() != null) {
+                nssdb.create(config.getNSSPassword());
+            } else {
+                nssdb.create();
+            }
         }
 
         logger.info("Initializing NSS");


### PR DESCRIPTION
In most instances, `MainCLI` has already parsed options prior to executing
`MainCLI.init()`. Require the caller to ensure this holds. When a NSS DB
password has been provided, use it to create the NSS DB when one doesn't
yet exists. This matches users's expectations.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1843537

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

I tried:

 1. Manual NSS DB creation (`nss-create`), and
 2. Implicit NSS DB creation (`ca-cert-find`)

With both:

 - Password
 - Password file

and appears to work as expected. Exception does not get tripped, but figured best to add it in case something weird happens. 