### PR TITLE
Added NSSIssuer

### DIFF
--- a/base/acme/conf/issuer/nss/ca_signing.conf
+++ b/base/acme/conf/issuer/nss/ca_signing.conf
@@ -1,0 +1,8 @@
+basicConstraints       = critical, CA:TRUE
+subjectKeyIdentifier   = hash
+authorityInfoAccess    = OCSP;URI:http://ocsp.example.com, caIssuers;URI:http://cert.example.com
+keyUsage               = critical, digitalSignature, keyCertSign, cRLSign
+certificatePolicies    = 2.23.140.1.2.1, @cps_policy
+
+cps_policy.id          = 1.3.6.1.4.1.44947.1.1.1
+cps_policy.CPS.1       = http://cps.example.com

--- a/base/acme/conf/issuer/nss/issuer.conf
+++ b/base/acme/conf/issuer/nss/issuer.conf
@@ -1,0 +1,3 @@
+class=org.dogtagpki.acme.issuer.NSSIssuer
+issuer=ca_signing
+extensions=/usr/share/pki/acme/conf/issuer/nss/sslserver.conf

--- a/base/acme/conf/issuer/nss/sslserver.conf
+++ b/base/acme/conf/issuer/nss/sslserver.conf
@@ -1,0 +1,10 @@
+basicConstraints       = critical, CA:FALSE
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid:always
+authorityInfoAccess    = OCSP;URI:http://ocsp.example.com, caIssuers;URI:http://cert.example.com
+keyUsage               = critical, digitalSignature, keyEncipherment
+extendedKeyUsage       = serverAuth, clientAuth
+certificatePolicies    = 2.23.140.1.2.1, @cps_policy
+
+cps_policy.id          = 1.3.6.1.4.1.44947.1.1.1
+cps_policy.CPS.1       = http://cps.example.com

--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/NSSIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/NSSIssuer.java
@@ -1,0 +1,159 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.issuer;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.cert.X509Certificate;
+
+import org.apache.commons.codec.binary.Base64;
+import org.dogtagpki.acme.database.ACMEDatabase;
+import org.dogtagpki.acme.server.ACMEEngine;
+import org.dogtagpki.nss.NSSDatabase;
+import org.dogtagpki.nss.NSSExtensionGenerator;
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.netscape.security.pkcs.PKCS10;
+import org.mozilla.jss.netscape.security.util.Cert;
+import org.mozilla.jss.netscape.security.util.Utils;
+import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+
+import com.netscape.cmsutil.password.IPasswordStore;
+import com.netscape.cmsutil.password.PlainPasswordFile;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class NSSIssuer extends ACMEIssuer {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSIssuer.class);
+
+    NSSDatabase nssDatabase;
+    IPasswordStore passwordStore;
+
+    org.mozilla.jss.crypto.X509Certificate issuer;
+
+    NSSExtensionGenerator extGenerator;
+    Integer monthsValid;
+
+    public void init() throws Exception {
+
+        logger.info("Initializing NSS issuer");
+
+        Path instanceDir = Paths.get(System.getProperty("catalina.base"));
+
+        String database = config.getParameter("database");
+        if (database == null) database = "conf/alias";
+        Path databasePath = instanceDir.resolve(database);
+        logger.info("- database: " + databasePath);
+
+        nssDatabase = new NSSDatabase(databasePath);
+
+        String passwords = config.getParameter("passwords");
+        if (passwords == null) passwords = "conf/password.conf";
+
+        logger.info("- passwords: " + passwords);
+
+        Path passwordsPath = instanceDir.resolve(passwords);
+        passwordStore = new PlainPasswordFile();
+        passwordStore.init(passwordsPath.toString());
+        nssDatabase.setPasswordStore(passwordStore);
+
+        String extensions = config.getParameter("extensions");
+        if (extensions != null) {
+            logger.info("- extensions: " + extensions);
+
+            Path extPath = instanceDir.resolve(extensions);
+            extGenerator = new NSSExtensionGenerator();
+            extGenerator.init(extPath.toString());
+        }
+
+        String issuer = config.getParameter("issuer");
+        if (issuer != null) {
+            logger.info("- issuer: " + issuer);
+
+            CryptoManager cm = CryptoManager.getInstance();
+            this.issuer = cm.findCertByNickname(issuer);
+        }
+
+        String monthsValid = config.getParameter("monthsValid");
+        if (monthsValid != null) {
+            logger.info("- months valid: " + monthsValid);
+
+            this.monthsValid = new Integer(monthsValid);
+        }
+    }
+
+    public String issueCertificate(PKCS10 pkcs10) throws Exception {
+
+        logger.info("Issuing certificate");
+
+        ACMEEngine engine = ACMEEngine.getInstance();
+        ACMEDatabase acmeDatabase = engine.getDatabase();
+
+        CertificateExtensions extensions = null;
+        if (extGenerator != null) {
+            extensions = extGenerator.createExtensions(issuer, pkcs10);
+        }
+
+        X509Certificate cert = nssDatabase.createCertificate(
+                issuer,
+                pkcs10,
+                monthsValid,
+                extensions);
+
+        BigInteger serialNumber = cert.getSerialNumber();
+        String certID = Base64.encodeBase64URLSafeString(serialNumber.toByteArray());
+        acmeDatabase.addCertificate(certID, cert);
+
+        return certID;
+    }
+
+    public X509Certificate[] getCACertificateChain() throws Exception {
+
+        CryptoManager cm = CryptoManager.getInstance();
+        org.mozilla.jss.crypto.X509Certificate[] caCertChain = cm.buildCertificateChain(issuer);
+
+        X509Certificate[] caCertChainImpl = new X509Certificate[caCertChain.length];
+        for (int i = 0; i < caCertChain.length; i++) {
+            org.mozilla.jss.crypto.X509Certificate cert = caCertChain[i];
+            caCertChainImpl[i] = new X509CertImpl(cert.getEncoded());
+        }
+
+        return caCertChainImpl;
+    }
+
+    public String getCertificateChain(String certID) throws Exception {
+
+        logger.info("Retrieving certificate");
+
+        ACMEEngine engine = ACMEEngine.getInstance();
+        ACMEDatabase acmeDatabase = engine.getDatabase();
+
+        X509Certificate cert = acmeDatabase.getCertificate(certID);
+        X509Certificate[] certChain = getCACertificateChain();
+
+        StringWriter sw = new StringWriter();
+
+        try (PrintWriter out = new PrintWriter(sw, true)) {
+
+            out.println(Cert.HEADER);
+            out.print(Utils.base64encodeMultiLine(cert.getEncoded()));
+            out.println(Cert.FOOTER);
+
+            for (X509Certificate caCert : certChain) {
+                out.println(Cert.HEADER);
+                out.print(Utils.base64encodeMultiLine(caCert.getEncoded()));
+                out.println(Cert.FOOTER);
+            }
+        }
+
+        return sw.toString();
+    }
+}

--- a/docs/installation/acme/Configuring_ACME_Issuer.md
+++ b/docs/installation/acme/Configuring_ACME_Issuer.md
@@ -8,6 +8,8 @@ The issuer configuration is located at /etc/pki/pki-tomcat/acme/issuer.conf.
 
 ## Configuring PKI Issuer
 
+The ACME responder can be configured to issue certificates using a PKI issuer.
+
 To configure a PKI issuer, copy the sample [issuer.conf](../../../base/acme/conf/issuer/pki/issuer.conf) with the following command:
 
 ```
@@ -24,6 +26,46 @@ profile=acmeServerCert
 username=caadmin
 password=Secret.123
 ```
+
+The **url** parameter is used to specify the PKI issuer location.
+
+The **profile** parameter is used to specify the certificate profile to use.
+
+To use client certificate authentication, specify the client certificate nickname in the **nickname** parameter.
+
+To use basic authentication, specify the username in the **username** parameter
+and the password in the **password** parameter.
+
+
+## Configuring NSS Issuer
+
+The ACME responder can be configured to issue certificates using a local NSS database.
+
+To configure an NSS issuer, copy the sample [issuer.conf](../../../base/acme/conf/issuer/nss/issuer.conf) with the following command:
+
+```
+$ cp /usr/share/pki/acme/conf/issuer/nss/issuer.conf \
+    /etc/pki/pki-tomcat/acme/issuer.conf
+```
+
+Customize the configuration as needed. The issuer.conf should look like the following:
+
+```
+class=org.dogtagpki.acme.issuer.NSSIssuer
+issuer=ca_signing
+extensions=/usr/share/pki/acme/conf/issuer/nss/sslserver.conf
+```
+
+The **issuer** parameter is used to specify the nickname of the CA signing certificate
+in the NSS database.
+
+The **extensions** parameter can be used to configure the certificate extensions for the issued certificates.
+Sample extension configuration files are available at:
+
+* [/usr/share/pki/acme/conf/issuer/nss/sslserver.conf](../../../base/acme/conf/issuer/nss/sslserver.conf)
+* [/usr/share/pki/acme/conf/issuer/nss/ca_signing.conf](../../../base/acme/conf/issuer/nss/ca_signing.conf)
+
+Customize the configuration as needed. The format is based on [OpenSSL x509v3_config](https://www.openssl.org/docs/manmaster/man5/x509v3_config.html).
 
 ## See Also
 


### PR DESCRIPTION
The `NSSIssuer` has been added to provide an embedded
CA for the ACME responder using a local NSS database.

Updated doc:
https://github.com/edewata/pki/blob/acme-dev/docs/installation/acme/Configuring_ACME_Issuer.md