### PR TITLE
Provision CA certificate for Security Domain check

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -175,7 +175,7 @@ pki_user=pkiuser
 pki_existing=False
 
 # DEPRECATED: Use 'pki_cert_chain_path' instead.
-pki_external_ca_cert_chain_path=%(pki_instance_configuration_path)s/external_ca_chain.cert
+pki_external_ca_cert_chain_path=
 
 # In addition to specifying an external CA certificate, this parameter
 # can be used with a one-shot installation process is used for installing

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -247,6 +247,9 @@ class PKIDeployer:
 
         ca_cert = os.path.join(self.mdict['pki_server_database_path'],
                                "ca.crt")
+        if not os.path.exists(ca_cert):
+            if os.path.exists(self.mdict['pki_cert_chain_path']):
+                ca_cert = self.mdict['pki_cert_chain_path']
 
         self.sd_connection = pki.client.PKIConnection(
             protocol='https',

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -366,6 +366,12 @@ def main(argv):
 
             else:
                 while True:
+                    ca_cert = os.path.join(deployer.mdict['pki_server_database_path'], "ca.crt")
+                    if not os.path.exists(ca_cert):
+                        parser.read_text('Security Domain CA Root Certificate',
+                                         deployer.subsystem_name,
+                                         'pki_cert_chain_path')
+
                     parser.read_text('Hostname',
                                      deployer.subsystem_name,
                                      'pki_security_domain_hostname')


### PR DESCRIPTION
When checking the Security Domain during `pkispawn`, we enforce
certificate validation. This is because we're also checking the
username/password given to us. This should go over a secured connection,
so simply setting `verify=False` would be a bad fix. Instead, ask the user
for a `pki_cert_chain_path` if one isn't given and use that to validate
the security domain's connection when the ca.crt path isn't already
populated.

This manifests itself as the following error:

      File "/usr/lib/python3.6/site-packages/pki/server/pkispawn.py", line 930, in <module>
        main(sys.argv)
      File "/usr/lib/python3.6/site-packages/pki/server/pkispawn.py", line 544, in main
        check_security_domain()
      File "/usr/lib/python3.6/site-packages/pki/server/pkispawn.py", line 716, in check_security_domain
        info = deployer.get_domain_info()
      File "/usr/lib/python3.6/site-packages/pki/server/deployment/__init__.py", line 270, in get_domain_info
        self.domain_info = sd_client.get_domain_info()
      File "/usr/lib/python3.6/site-packages/pki/system.py", line 270, in get_domain_info
        response = self.connection.get(self.domain_info_url, headers=headers)
      File "/usr/lib/python3.6/site-packages/pki/client.py", line 55, in wrapper
        return func(self, *args, **kwargs)
      File "/usr/lib/python3.6/site-packages/pki/client.py", line 259, in get
        timeout=timeout,
      File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 546, in get
        return self.request('GET', url, **kwargs)
      File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 533, in request
        resp = self.send(prep, **send_kwargs)
      File "/usr/lib/python3.6/site-packages/requests/sessions.py", line 646, in send
        r = adapter.send(request, **kwargs)
      File "/usr/lib/python3.6/site-packages/requests/adapters.py", line 514, in send
        raise SSLError(e, request=request)
    requests.exceptions.SSLError: HTTPSConnectionPool(host='pki1.example.com', port=20443): Max retries exceeded with url: /ca/rest/securityDomain/domainInfo (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:897)'),))

Related: rh-bz#1426572

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

-----

@edewata My concern is that `pki_cert_chain_path` already has a default value that is non-empty. Should we require it to be a valid path? But only if the CA cert from the subsystem doesn't already exist? Thoughts? 