### PR TITLE
Healthcheck support custom instance

### DIFF
--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -141,6 +141,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/man/man5
     COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man5/pki_default.cfg.5.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man5/pki_default.cfg.5
     COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man5/pki-server-logging.5.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man5/pki-server-logging.5
+    COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man5/pki_healthcheck.conf.5.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man5/pki_healthcheck.conf.5
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/man/man8
     COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man8/pki-server.8.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man8/pki-server.8
     COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man8/pki-server-acme.8.md -out ${CMAKE_CURRENT_BINARY_DIR}/man/man8/pki-server-acme.8

--- a/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
@@ -10,8 +10,6 @@ import time
 
 from datetime import datetime
 
-from pki.server.instance import PKIInstance
-
 from pki.server.healthcheck.certs.plugin import CertsPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
@@ -70,13 +68,16 @@ def check_cert_expiry_date(class_instance, cert):
                       cert_id=cert['id'],
                       msg='Expiring within next 24 hours')
 
-    elif delta_days < 30:
+    elif delta_days < int(class_instance.config.cert_expiration_days):
         # Expiring in a month
-        logger.warning("Expiring in less than 30 days: %s", cert['id'])
+        logger.warning("Expiring in less than %s days: %s",
+                       class_instance.config.cert_expiration_days,
+                       cert['id'])
         return Result(class_instance, constants.WARNING,
                       cert_id=cert['id'],
                       expiry_date=expiry_date_human,
-                      msg='Your certificate expires within 30 days.')
+                      msg='Your certificate expires within %s days.' %
+                          class_instance.config.cert_expiration_days)
     else:
         # Valid certificate
         logger.info("VALID certificate: %s", cert['id'])

--- a/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
@@ -10,6 +10,8 @@ import time
 
 from datetime import datetime
 
+from pki.server.instance import PKIInstance
+
 from pki.server.healthcheck.certs.plugin import CertsPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
@@ -91,7 +93,6 @@ class CASystemCertExpiryCheck(CertsPlugin):
 
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
@@ -120,7 +121,6 @@ class KRASystemCertExpiryCheck(CertsPlugin):
 
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
@@ -149,7 +149,6 @@ class OCSPSystemCertExpiryCheck(CertsPlugin):
 
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
@@ -178,7 +177,6 @@ class TKSSystemCertExpiryCheck(CertsPlugin):
 
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
@@ -207,7 +205,6 @@ class TPSSystemCertExpiryCheck(CertsPlugin):
 
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,

--- a/base/server/healthcheck/pki/server/healthcheck/certs/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/plugin.py
@@ -22,8 +22,8 @@ class CertsPlugin(Plugin):
     def __init__(self, registry):
         # pylint: disable=redefined-outer-name
         super(CertsPlugin, self).__init__(registry)
-        # TODO: Support custom instance names
-        self.instance = PKIInstance('pki-tomcat')
+
+        self.instance = PKIInstance(self.config.instance_name)
 
 
 class CertsRegistry(Registry):
@@ -33,7 +33,6 @@ class CertsRegistry(Registry):
         merge_dogtag_config(config)
 
         super(CertsRegistry, self).initialize(framework, config)
-        pass
 
 
 registry = CertsRegistry()

--- a/base/server/healthcheck/pki/server/healthcheck/certs/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/plugin.py
@@ -9,6 +9,8 @@
 from ipahealthcheck.core.plugin import Plugin, Registry
 from pki.server.instance import PKIInstance
 
+from pki.server.healthcheck.core.main import merge_dogtag_config
+
 import logging
 
 # Temporary workaround to skip VERBOSE data. Fix already pushed to upstream
@@ -26,6 +28,11 @@ class CertsPlugin(Plugin):
 
 class CertsRegistry(Registry):
     def initialize(self, framework, config):
+        # Read dogtag specific config values and merge with already existing config
+        # before adding it to registry
+        merge_dogtag_config(config)
+
+        super(CertsRegistry, self).initialize(framework, config)
         pass
 
 

--- a/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
@@ -8,8 +8,6 @@
 import logging
 from contextlib import contextmanager
 
-from pki.server.instance import PKIInstance
-
 from pki.server.healthcheck.certs.plugin import CertsPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants

--- a/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
@@ -8,6 +8,8 @@
 import logging
 from contextlib import contextmanager
 
+from pki.server.instance import PKIInstance
+
 from pki.server.healthcheck.certs.plugin import CertsPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
@@ -22,7 +24,6 @@ class CASystemCertTrustFlagCheck(CertsPlugin):
     """
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
@@ -87,7 +88,6 @@ class KRASystemCertTrustFlagCheck(CertsPlugin):
     """
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
@@ -152,7 +152,6 @@ class OCSPSystemCertTrustFlagCheck(CertsPlugin):
     """
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
@@ -216,7 +215,6 @@ class TKSSystemCertTrustFlagCheck(CertsPlugin):
     """
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
@@ -279,7 +277,6 @@ class TPSSystemCertTrustFlagCheck(CertsPlugin):
     """
     @duration
     def check(self):
-
         if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,

--- a/base/server/healthcheck/pki/server/healthcheck/core/main.py
+++ b/base/server/healthcheck/pki/server/healthcheck/core/main.py
@@ -18,7 +18,9 @@ logger = logging.getLogger()
 
 DOGTAG_CONFIG_FILE = "/etc/pki/healthcheck.conf"
 DOGTAG_CONFIG_SECTION = "dogtag"
-DOGTAG_DEFAULT_INSTANCE = "pki-tomcat"
+DOGTAG_DEFAULT_CONFIG = {
+    'instance_name': 'pki-tomcat',
+}
 
 dogtag_config_parsed = False
 
@@ -51,15 +53,11 @@ def merge_dogtag_config(config):
             logger.error("Unable to parse %s: %s", DOGTAG_CONFIG_FILE, e)
             return
 
-        if not parser.has_section(DOGTAG_CONFIG_SECTION):
-            # If "dogtag" section is missing, initialize with default instance name
-            config['ca_instance_name'] = DOGTAG_DEFAULT_INSTANCE
-            config['kra_instance_name'] = DOGTAG_DEFAULT_INSTANCE
-            config['ocsp_instance_name'] = DOGTAG_DEFAULT_INSTANCE
-            config['tks_instance_name'] = DOGTAG_DEFAULT_INSTANCE
-            config['tps_instance_name'] = DOGTAG_DEFAULT_INSTANCE
+        # Initialize with default config values
+        config.merge(DOGTAG_DEFAULT_CONFIG)
 
-            # There is no point in re-reading the config file.
+        if not parser.has_section(DOGTAG_CONFIG_SECTION):
+            # There is no point in re-reading the config file. So, mark it as processed
             dogtag_config_parsed = True
             return
 

--- a/base/server/healthcheck/pki/server/healthcheck/core/main.py
+++ b/base/server/healthcheck/pki/server/healthcheck/core/main.py
@@ -11,12 +11,61 @@ import logging
 import sys
 
 from ipahealthcheck.core.core import RunChecks
+from configparser import ConfigParser, ParsingError
 
 logging.basicConfig(format='%(message)s')
 logger = logging.getLogger()
 
+DOGTAG_CONFIG_FILE = "/etc/pki/healthcheck.conf"
+DOGTAG_CONFIG_SECTION = "dogtag"
+DOGTAG_DEFAULT_INSTANCE = "pki-tomcat"
+
+dogtag_config_parsed = False
+
 
 def main():
     checks = RunChecks(['pkihealthcheck.registry'],
-                       '/etc/pki/healthcheck.conf')
+                       DOGTAG_CONFIG_FILE)
     sys.exit(checks.run_healthcheck())
+
+
+def merge_dogtag_config(config):
+    # TODO: Move this method into ipa-healthcheck-core library
+    """
+    Merge "dogtag" specific config values into the provided `config` object.
+    If "dogtag" section is missing in config, appends the default instance
+    name "pki-tomcat"
+
+    :param config: config object containing prefilled values
+    :return: None
+    """
+    global dogtag_config_parsed
+
+    if not dogtag_config_parsed:
+        logger.info("Reading Dogtag specific config values")
+        parser = ConfigParser()
+
+        try:
+            parser.read(DOGTAG_CONFIG_FILE)
+        except ParsingError as e:
+            logger.error("Unable to parse {}: {}".format(DOGTAG_CONFIG_FILE, e))
+            return
+
+        if not parser.has_section(DOGTAG_CONFIG_SECTION):
+            # If "dogtag" section is missing, initialize with default instance name
+            config['ca_instance_name'] = DOGTAG_DEFAULT_INSTANCE
+            config['kra_instance_name'] = DOGTAG_DEFAULT_INSTANCE
+            config['ocsp_instance_name'] = DOGTAG_DEFAULT_INSTANCE
+            config['tks_instance_name'] = DOGTAG_DEFAULT_INSTANCE
+            config['tps_instance_name'] = DOGTAG_DEFAULT_INSTANCE
+
+            # There is no point in re-reading the config file.
+            dogtag_config_parsed = True
+            return
+
+        items = parser.items(DOGTAG_CONFIG_SECTION)
+
+        for (key, value) in items:
+            config[key] = value
+
+        dogtag_config_parsed = True

--- a/base/server/healthcheck/pki/server/healthcheck/core/main.py
+++ b/base/server/healthcheck/pki/server/healthcheck/core/main.py
@@ -39,7 +39,7 @@ def merge_dogtag_config(config):
     :param config: config object containing prefilled values
     :return: None
     """
-    global dogtag_config_parsed
+    global dogtag_config_parsed  # pylint: disable=global-statement
 
     if not dogtag_config_parsed:
         logger.info("Reading Dogtag specific config values")
@@ -48,7 +48,7 @@ def merge_dogtag_config(config):
         try:
             parser.read(DOGTAG_CONFIG_FILE)
         except ParsingError as e:
-            logger.error("Unable to parse {}: {}".format(DOGTAG_CONFIG_FILE, e))
+            logger.error("Unable to parse %s: %s", DOGTAG_CONFIG_FILE, e)
             return
 
         if not parser.has_section(DOGTAG_CONFIG_SECTION):

--- a/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
@@ -6,7 +6,6 @@ from ipahealthcheck.core import constants
 from pki.client import PKIConnection
 from pki.cert import CertClient
 from pki.systemcert import SystemCertClient
-from pki.server.instance import PKIInstance
 
 logger = logging.getLogger(__name__)
 

--- a/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
@@ -6,6 +6,7 @@ from ipahealthcheck.core import constants
 from pki.client import PKIConnection
 from pki.cert import CertClient
 from pki.systemcert import SystemCertClient
+from pki.server.instance import PKIInstance
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ class DogtagCACertsConnectivityCheck(MetaPlugin):
 
     @duration
     def check(self):
-        if not self.instance.is_valid():
+        if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
                          msg='Invalid PKI instance: %s' % self.instance.name)
@@ -90,7 +91,7 @@ class DogtagKRAConnectivityCheck(MetaPlugin):
 
     @duration
     def check(self):
-        if not self.instance.is_valid():
+        if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
                          msg='Invalid PKI instance: %s' % self.instance.name)
@@ -169,7 +170,7 @@ class DogtagOCSPConnectivityCheck(MetaPlugin):
 
     @duration
     def check(self):
-        if not self.instance.is_valid():
+        if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
                          msg='Invalid PKI instance: %s' % self.instance.name)
@@ -217,7 +218,7 @@ class DogtagTKSConnectivityCheck(MetaPlugin):
 
     @duration
     def check(self):
-        if not self.instance.is_valid():
+        if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
                          msg='Invalid PKI instance: %s' % self.instance.name)
@@ -265,7 +266,7 @@ class DogtagTPSConnectivityCheck(MetaPlugin):
 
     @duration
     def check(self):
-        if not self.instance.is_valid():
+        if not self.instance.exists():
             logger.debug('Invalid instance: %s', self.instance.name)
             yield Result(self, constants.CRITICAL,
                          msg='Invalid PKI instance: %s' % self.instance.name)

--- a/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
@@ -14,7 +14,6 @@ from pki.server.healthcheck.meta.plugin import MetaPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
 
-from pki.server.subsystem import PKISubsystem
 from pki.server.instance import PKIInstance
 
 logger = logging.getLogger(__name__)
@@ -27,7 +26,7 @@ def compare_nssdb_with_cs(class_instance, subsystem, cert_tag):
     :param class_instance: Reporting Class Instance
     :type class_instance: object
     :param subsystem: Subsystem
-    :type subsystem: PKISubsystem
+    :type subsystem: pki.server.subsystem.PKISubsystem
     :param cert_tag: Certificate tag name
     :type cert_tag: str
     :return: Result object with prefilled args

--- a/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/csconfig.py
@@ -14,8 +14,6 @@ from pki.server.healthcheck.meta.plugin import MetaPlugin, registry
 from ipahealthcheck.core.plugin import Result, duration
 from ipahealthcheck.core import constants
 
-from pki.server.instance import PKIInstance
-
 logger = logging.getLogger(__name__)
 
 

--- a/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
@@ -21,8 +21,8 @@ class MetaPlugin(Plugin):
     def __init__(self, registry):
         # pylint: disable=redefined-outer-name
         super(MetaPlugin, self).__init__(registry)
-        # TODO: Support custom instance names
-        self.instance = PKIInstance('pki-tomcat')
+
+        self.instance = PKIInstance(self.config.instance_name)
 
 
 class MetaRegistry(Registry):

--- a/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
@@ -10,6 +10,8 @@
 from ipahealthcheck.core.plugin import Plugin, Registry
 from pki.server.instance import PKIInstance
 
+from pki.server.healthcheck.core.main import merge_dogtag_config
+
 import logging
 
 logging.getLogger().setLevel(logging.WARNING)
@@ -25,7 +27,11 @@ class MetaPlugin(Plugin):
 
 class MetaRegistry(Registry):
     def initialize(self, framework, config):
-        pass
+        # Read dogtag specific config values and merge with already existing config
+        # before adding it to registry
+        merge_dogtag_config(config)
+
+        super(MetaRegistry, self).initialize(framework, config)
 
 
 registry = MetaRegistry()

--- a/docs/admin/PKI_Health_Check_Tool.md
+++ b/docs/admin/PKI_Health_Check_Tool.md
@@ -34,6 +34,9 @@ Severity of a problem is defined as:
 ### Checks Included
 
 1. System certificate sync between CS.cfg and NSS database
+2. System certificate expiry
+3. System certificate trust flags in NSS database
+4. Subsystem connectivity check
 
 (More checks will be added in the future)
 
@@ -43,10 +46,15 @@ The `pki-healthcheck` tool will store its configuration in `/etc/pki/healthcheck
 
     [global]
     plugin_timeout=300
+    cert_expiration_days=30
+
+    # Dogtag specific section
+    [dogtag]
+    instance_name=pki-tomcat
 
 ### Limitations
 
-Due to [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1789991) in the base framework, currently the healthcheck can only be executed on a system with **single** pki instance named **pki-tomcat**
+Currently, the healthcheck tool can only be executed on a **single machine** with **single PKI instance**.
 
 ### Testing
 

--- a/docs/manuals/man5/pki_healthcheck.conf.5.md
+++ b/docs/manuals/man5/pki_healthcheck.conf.5.md
@@ -46,11 +46,7 @@ The following options are relevant for the healthcheck tool:
 cert_expiration_days = 30  
 
 [dogtag]  
-ca_instance_name = pki-ca  
-kra_instance_name = pki-kra  
-ocsp_instance_name = pki-ocsp  
-tks_instance_name = pki-tks  
-tps_instance_name = pki-tps  
+instance_name = pki-tomcat
 
 ## FILES
 

--- a/docs/manuals/man5/pki_healthcheck.conf.5.md
+++ b/docs/manuals/man5/pki_healthcheck.conf.5.md
@@ -1,0 +1,71 @@
+# pki_healthcheck.conf 5 "June 29, 2020" PKI "PKI Healthcheck Configuration"
+
+## NAME
+
+pki_healthcheck.conf - PKI Healthcheck configuration file.
+
+## DESCRIPTION
+
+The healthcheck.conf configuration file is used to set the defaults when running pki-healthcheck tool.
+
+## SYNTAX
+
+The configuration options are not case sensitive. The values may be case sensitive, depending on the option.
+
+Blank lines are ignored.
+Lines beginning with # are comments and are ignored.
+
+Valid lines consist of an option name, an equals sign and a value. Spaces surrounding equals sign are ignored. An option terminates at the end of a line.
+
+Values should not be quoted, the quotes will not be stripped.
+
+    # Wrong - don't include quotes
+    verbose = "True"
+
+    # Right - Properly formatted options
+    verbose = True
+    verbose=True
+
+Options must appear in the section named *[default]* or *[dogtag]*. There are no other sections defined or used currently.
+
+Options may be defined that are not used. Be careful of misspellings, they will not be rejected.
+
+## OPTIONS
+
+The following options are relevant for the healthcheck tool:
+
+**cert_expiration_days**  
+    The number of days left before a certificate expires to start displaying a warning. The default is 28.
+
+**instance_name**  
+    The name of the PKI instance. The default is **pki-tomcat**
+
+## EXAMPLES
+
+[default]  
+cert_expiration_days = 30  
+
+[dogtag]  
+ca_instance_name = pki-ca  
+kra_instance_name = pki-kra  
+ocsp_instance_name = pki-ocsp  
+tks_instance_name = pki-tks  
+tps_instance_name = pki-tps  
+
+## FILES
+
+/etc/pki/healthcheck.conf
+
+## SEE ALSO
+
+pki-healthcheck (8)
+
+## AUTHORS
+
+Dinesh Prasanth M K \<dmoluguw@redhat.com>
+
+## COPYRIGHT
+
+Copyright (c) 2020 Red Hat, Inc.
+This is licensed under the GNU General Public License, version 2 (GPLv2).
+A copy of this license is  available  at <http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.

--- a/docs/manuals/man8/pki-healthcheck.8.md
+++ b/docs/manuals/man8/pki-healthcheck.8.md
@@ -81,11 +81,16 @@ The results are displayed in a more human-readable format.
 ### CHECKS INCLUDED
 
 **Certificate sync between CS.cfg and NSS database**  
-Checks whether the system certificates in CS.cfg and NSS database are the same
+    Checks whether the system certificates in CS.cfg and NSS database are the same
 
-## BUGS
+**System certificate expiry**  
+    Checks the expiry status of the installed system certificates
 
-**pki-healthcheck** tool can operate only on a *single instance* PKI installation with the instance name as *pki-tomcat*
+**System certificate trust flags**  
+    Checks whether the installed system certificates carry the correct Trust flags
+
+**Subsystem connectivity check**  
+    Checks whether a subsystem is running and able to respond to requests
 
 ## EXAMPLES
 


### PR DESCRIPTION
This PR includes several improvements to `pki-healthcheck`:

1. Allows the Health-check to use the custom instance
names provided via the pki specific healthcheck config file. This
will allow healthcheck to be executed in standalone Dogtag PKI
environments. (workaround to [RFE](https://bugzilla.redhat.com/show_bug.cgi?id=1789991)
in `ipa-healthcheck-core` framework)

2. Refactors `*DogtagCertsConfigCheck` to accommodate other
subsystems: OCSP, TKS and TPS

3. Documentation updates to `pki-healthcheck` and new man page
for `pki_healthcheck.conf (5)`

4. Minor improvements to Expiration check; use config specified values
to report warnings when executing System certificate expiration check


`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`