### PR TITLE
pki password fix for FIPS

### DIFF
--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -949,6 +949,7 @@ class PKISubsystem(object):
         cmd = [
             'pki',
             '-d', self.instance.nssdb_dir,
+            '-f', self.instance.password_conf,
             '-U', master_url,
             '%s-range-request' % self.name,
             range_type,
@@ -996,6 +997,7 @@ class PKISubsystem(object):
         cmd = [
             'pki',
             '-d', self.instance.nssdb_dir,
+            '-f', self.instance.password_conf,
             '-U', master_url,
             '%s-config-export' % self.name,
             '--names', ','.join(names),


### PR DESCRIPTION
NSS DB in FIPS mode seems to require a password in all cases. When pki
attemps to open NSS DB without password in FIPS mode, it blocks with a
prompt to enter a password. This breaks installation in FIPS mode:

    Enter password for NSS FIPS 140-2 User Private Key

Signed-off-by: Christian Heimes <cheimes@redhat.com>