### PR TITLE
Updated build.sh to generate UTC timestamp

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -349,7 +349,7 @@ if [ "$DEBUG" = true ] ; then
 fi
 
 if [ "$WITH_TIMESTAMP" = true ] ; then
-    TIMESTAMP="$(date +"%Y%m%d%H%M%S")"
+    TIMESTAMP="$(date -u +"%Y%m%d%H%M%S%Z")"
     _TIMESTAMP=".$TIMESTAMP"
 fi
 


### PR DESCRIPTION
The build.sh has been modified to generate UTC timestamp such
that it is consistent across different time zones.