### PR TITLE
Bug1629025-handle large keys-ServerSideKeygen

### DIFF
--- a/base/kra/src/com/netscape/kra/RecoveryService.java
+++ b/base/kra/src/com/netscape/kra/RecoveryService.java
@@ -113,6 +113,8 @@ public class RecoveryService implements IService {
     private IKeyRecoveryAuthority mKRA = null;
     private IKeyRepository mStorage = null;
     private IStorageKeyUnit mStorageUnit = null;
+    // must match with EnrollProfile.REQUEST_ISSUED_CERT
+    public static final String REQUEST_ISSED_CERT = "req_issued_cert";
 
     /**
      * Constructs request processor.
@@ -263,10 +265,15 @@ public class RecoveryService implements IService {
 
         // see if the certificate matches the key
         byte pubData[] = keyRecord.getPublicKeyData();
+        // first check the cert expected from SSK
         X509Certificate x509cert =
-                request.getExtDataInCert(ATTR_USER_CERT);
+                request.getExtDataInCert(REQUEST_ISSED_CERT);
         if (x509cert == null) {
-            throw new EKRAException(CMS.getUserMessage("CMS_KRA_INVALID_KEYRECORD"));
+            x509cert =
+                    request.getExtDataInCert(ATTR_USER_CERT);
+            if (x509cert == null) {
+                throw new EKRAException(CMS.getUserMessage("CMS_KRA_INVALID_KEYRECORD"));
+            }
         }
         byte inputPubData[] = x509cert.getPublicKey().getEncoded();
 
@@ -560,10 +567,15 @@ public class RecoveryService implements IService {
 
         try {
             // create p12
+            // first check the cert expected from SSK
             X509Certificate x509cert =
-                    request.getExtDataInCert(ATTR_USER_CERT);
+                    request.getExtDataInCert(REQUEST_ISSED_CERT);
             if (x509cert == null) {
-                throw new EKRAException(CMS.getUserMessage("CMS_KRA_PKCS12_FAILED_1","Missing Certificate"));
+                x509cert =
+                        request.getExtDataInCert(ATTR_USER_CERT);
+                if (x509cert == null) {
+                    throw new EKRAException(CMS.getUserMessage("CMS_KRA_PKCS12_FAILED_1","Missing Certificate"));
+                }
             }
 
             logger.info("KRA adds certificate to P12");
@@ -752,10 +764,15 @@ public class RecoveryService implements IService {
 
         try {
             // create p12
+            // first check the cert expected from SSK
             X509Certificate x509cert =
-                    request.getExtDataInCert(ATTR_USER_CERT);
+                    request.getExtDataInCert(REQUEST_ISSED_CERT);
             if (x509cert == null) {
-                throw new EKRAException(CMS.getUserMessage("CMS_KRA_PKCS12_FAILED_1","Missing Certificate"));
+                x509cert =
+                        request.getExtDataInCert(ATTR_USER_CERT);
+                if (x509cert == null) {
+                    throw new EKRAException(CMS.getUserMessage("CMS_KRA_PKCS12_FAILED_1","Missing Certificate"));
+                }
             }
 
             logger.info("KRA adds certificate to P12");

--- a/base/server/src/com/netscape/cms/profile/common/CAEnrollProfile.java
+++ b/base/server/src/com/netscape/cms/profile/common/CAEnrollProfile.java
@@ -354,11 +354,13 @@ public class CAEnrollProfile extends EnrollProfile {
             request.setExtData(IRequest.SSK_STAGE, IRequest.SSK_STAGE_KEY_RETRIEVE);
             request.setExtData(IRequest.REQ_STATUS, "begin");
             request.setExtData("requestType", "recovery");
-            request.setExtData("cert", theCert); //recognized by kra
 
             // putting them back
             request.setExtData("serverSideKeygenP12PasswdEnc", sessionWrappedPassphrase);
             request.setExtData("serverSideKeygenP12PasswdTransSession", transWrappedSessionKey);
+
+            // debug
+            // CertUtils.printRequestContent(request);
 
             try {
                 IConnector kraConnector = caService.getKRAConnector();

--- a/base/server/src/com/netscape/cms/servlet/connector/ConnectorServlet.java
+++ b/base/server/src/com/netscape/cms/servlet/connector/ConnectorServlet.java
@@ -74,6 +74,7 @@ import com.netscape.cms.servlet.common.CMSRequest;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ArgBlock;
+import com.netscape.cmscore.cert.CertUtils;
 import com.netscape.cmscore.connector.HttpPKIMessage;
 import com.netscape.cmscore.connector.HttpRequestEncoder;
 
@@ -495,19 +496,8 @@ public class ConnectorServlet extends CMSServlet {
 
             // if not found process request.
             thisreq = queue.newRequest(msg.getReqType());
-            /* cfu: let's find out what's in the request
-            logger.debug("ConnectorServlet: cfu see what's in request");
-            Enumeration<String> ereq = thisreq.getExtDataKeys();
-            while (ereq.hasMoreElements()) {
-                String reqKey = ereq.nextElement();
-                String reqVal = thisreq.getExtDataInString(reqKey);
-                if (reqVal != null) {
-                    logger.debug("ConnectorServlet: - " + reqKey + ": " + reqVal);
-                } else {
-                    logger.debug("ConnectorServlet: - " + reqKey + ": no value");
-                }
-            }
-            */
+            // debug
+            // CertUtils.printRequestContent(thisreq);
 
             logger.debug("ConnectorServlet: created requestId=" +
                     thisreq.getRequestId().toString());

--- a/base/server/src/com/netscape/cmscore/cert/CertUtils.java
+++ b/base/server/src/com/netscape/cmscore/cert/CertUtils.java
@@ -35,6 +35,7 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Properties;
@@ -1640,6 +1641,21 @@ public class CertUtils {
             return "tps";
         }
         return null;
+    }
+
+    public static void printRequestContent(IRequest request) {
+        String method = "CertUtils.printRequestContent: ";
+        logger.debug(method + "Content of request: ");
+        Enumeration<String> ereq = request.getExtDataKeys();
+        while (ereq.hasMoreElements()) {
+            String reqKey = ereq.nextElement();
+            String reqVal = request.getExtDataInString(reqKey);
+            if (reqVal != null) {
+                logger.debug("  req entry - " + reqKey + ": " + reqVal);
+            } else {
+                logger.debug("  req entry - " + reqKey + ": no value");
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This patch addresses the issue that for ServerSideKeygen enrollments,
if the RSA keys are larger (3072 or 4096), the enrollment would fail.
It may very well have to do with Apache's limit on HTTP header.
While there might exist a better way to resolve this, I'm opting
to remove a duplicated "issued cert" entry in the request itself which
effectively resolves the issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1629025