### PR TITLE
Invalidate ACME authorization and orders on validation failure

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
@@ -70,6 +70,11 @@ public class ACMEChallengeProcessor implements Runnable {
         challenge.setStatus("valid");
         challenge.setValidationTime(new Date());
 
+        // RFC 8555 Section 7.1.6: Status Changes
+        //
+        // If one of the challenges listed in the authorization transitions to the
+        // "valid" state, then the authorization also changes to the "valid" state.
+
         logger.info("Authorization " + authzID + " is valid");
         authorization.setStatus("valid");
 
@@ -120,6 +125,15 @@ public class ACMEChallengeProcessor implements Runnable {
 
         logger.info("Challenge " + challengeID + " is invalid");
         challenge.setStatus("invalid");
+
+        // RFC 8555 Section 7.1.6: Status Changes
+        //
+        // If the client attempts to fulfill a challenge and fails, or if there
+        // is an error while the authorization is still pending, then the
+        // authorization transitions to the "invalid" state.
+
+        logger.info("Authorization " + authzID + " is invalid");
+        authorization.setStatus("invalid");
 
         engine.updateAuthorization(account, authorization);
     }


### PR DESCRIPTION
If the client fails to fulfill the challenge, the server should invalidate the
authorization and all orders that depend on that authorization.