### PR TITLE
Remove incomplete ACME challenges

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
@@ -524,21 +524,17 @@ public class LDAPDatabase extends ACMEDatabase {
         return challenge;
     }
 
-    /** Get the authorization for the given challenge.
-     * NOTE: we do not load all challenges for the authorization,
-     * only the challenge with the given challengeID.
+    /**
+     * Get the authorization for the given challenge.
      */
     public ACMEAuthorization getAuthorizationByChallenge(String challengeID) throws Exception {
         ACMEChallenge challenge = getChallenge(challengeID);
         if (challenge == null) return null;
 
-        ACMEAuthorization authz = getAuthorization(challenge.getAuthzID(), LoadChallenges.DontLoad);
-        if (authz == null) return null;
-
-        List<ACMEChallenge> l = new ArrayList<>(1);
-        l.add(challenge);
-        authz.setChallenges(l);
-        return authz;
+        // Load all challenges for the authorization such that
+        // other challenges do not unintentionally get deleted
+        // when the authorization is updated.
+        return getAuthorization(challenge.getAuthzID());
     }
 
     public void addAuthorization(ACMEAuthorization authorization) throws Exception {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
@@ -70,6 +70,11 @@ public class ACMEChallengeProcessor implements Runnable {
         challenge.setStatus("valid");
         challenge.setValidationTime(new Date());
 
+        // RFC 8555 Section 7.1.6: Status Changes
+        //
+        // If one of the challenges listed in the authorization transitions to the
+        // "valid" state, then the authorization also changes to the "valid" state.
+
         logger.info("Authorization " + authzID + " is valid");
         authorization.setStatus("valid");
 
@@ -120,6 +125,15 @@ public class ACMEChallengeProcessor implements Runnable {
 
         logger.info("Challenge " + challengeID + " is invalid");
         challenge.setStatus("invalid");
+
+        // RFC 8555 Section 7.1.6: Status Changes
+        //
+        // If the client attempts to fulfill a challenge and fails, or if there
+        // is an error while the authorization is still pending, then the
+        // authorization transitions to the "invalid" state.
+
+        logger.info("Authorization " + authzID + " is invalid");
+        authorization.setStatus("invalid");
 
         engine.updateAuthorization(account, authorization);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
@@ -5,6 +5,7 @@
 //
 package org.dogtagpki.acme.server;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
@@ -70,6 +71,15 @@ public class ACMEChallengeProcessor implements Runnable {
         challenge.setStatus("valid");
         challenge.setValidationTime(new Date());
 
+        // RFC 8555 Section 7.5.1: Responding to Challenges
+        //
+        // When finalizing an authorization, the server MAY remove challenges other
+        // than the one that was completed, and it may modify the "expires" field.
+
+        Collection<ACMEChallenge> challenges = new ArrayList<>();
+        challenges.add(challenge);
+        authorization.setChallenges(challenges);
+
         // RFC 8555 Section 7.1.6: Status Changes
         //
         // If one of the challenges listed in the authorization transitions to the
@@ -125,6 +135,15 @@ public class ACMEChallengeProcessor implements Runnable {
 
         logger.info("Challenge " + challengeID + " is invalid");
         challenge.setStatus("invalid");
+
+        // RFC 8555 Section 7.5.1: Responding to Challenges
+        //
+        // When finalizing an authorization, the server MAY remove challenges other
+        // than the one that was completed, and it may modify the "expires" field.
+
+        Collection<ACMEChallenge> challenges = new ArrayList<>();
+        challenges.add(challenge);
+        authorization.setChallenges(challenges);
 
         // RFC 8555 Section 7.1.6: Status Changes
         //


### PR DESCRIPTION
The code that finalizes ACME authorizations has been modified
to retain the completed challenge (either valid or invalid) and
remove the incomplete ones.

This PR depends on PR #476.