### PR TITLE
CI: Change the entrypoint to /sbin/init

### DIFF
--- a/.github/workflows/required-tests.yml
+++ b/.github/workflows/required-tests.yml
@@ -108,8 +108,11 @@ jobs:
         - name: Clone the repository
           uses: actions/checkout@v2
 
+        - name: Build pki-test container image with systemd
+          run: docker build ci/ -t pki-fedora-${{ matrix.os }} --build-arg OS_VERSION=${{ matrix.os }}
+
         - name: Setup required test environment
-          run: IMAGE=fedora:${{ matrix.os }} ci/runner-init.sh
+          run: IMAGE=pki-fedora-${{ matrix.os }} ci/runner-init.sh
 
         - name: Download PKI binaries from Build job
           uses: actions/download-artifact@v1
@@ -205,8 +208,11 @@ jobs:
         - name: Clone the repository
           uses: actions/checkout@v2
 
+        - name: Build pki-test container image with systemd
+          run: docker build ci/ -t pki-fedora-${{ matrix.os }} --build-arg OS_VERSION=${{ matrix.os }}
+
         - name: Setup required test environment
-          run: IMAGE=fedora:${{ matrix.os }} ci/runner-init.sh
+          run: IMAGE=pki-fedora-${{ matrix.os }} ci/runner-init.sh
 
         - name: Download PKI binaries from Build job
           uses: actions/download-artifact@v1

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,8 @@
+ARG OS_VERSION=latest
+FROM fedora:$OS_VERSION
+
+# Install systemd since pki runs as a systemd service
+RUN true \
+        && dnf update -y --refresh \
+        && dnf install -y systemd \
+        && true

--- a/ci/runner-init.sh
+++ b/ci/runner-init.sh
@@ -8,7 +8,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-docker pull ${IMAGE}
+# list the available images
+docker images
 
 docker run \
     --detach \


### PR DESCRIPTION
Build custom PKI container image with systemd, to use as the testbed
for running other PKI tests

Resolves the mysteriously missing `/usr/sbin/init` that appeared in this ci run:
https://github.com/dogtagpki/pki/runs/859677421#step:3:23

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`