### PR TITLE
Bug1856368- pki cli kra-key-generate request is failing

### DIFF
--- a/base/common/src/com/netscape/certsrv/key/KeyClient.java
+++ b/base/common/src/com/netscape/certsrv/key/KeyClient.java
@@ -990,7 +990,11 @@ public class KeyClient extends Client {
         data.setKeyAlgorithm(keyAlgorithm);
         data.setKeySize(keySize);
         data.setUsages(usages);
-        data.setTransWrappedSessionKey(Utils.base64encode(transWrappedSessionKey, false));
+        if (transWrappedSessionKey !=null) {
+            // Caller by default calls in with transWrappedSessionKey null;
+            // And the underlying Java code does not like null;
+            data.setTransWrappedSessionKey(Utils.base64encode(transWrappedSessionKey, false));
+        }
         data.setRealm(realm);
 
         return submitRequest(data);


### PR DESCRIPTION
This patch fixes the issue with failed kra-key-generate from pki cli.
Investigation revealed that the underlying JSS changes where
base64encodeSingleLine call into
   Base64.getEncoder().encodeToString(bytes);
does not tolerate null parameter.
Reference: Remove code dependency on Apache Commons Codec
https://github.com/dogtagpki/jss/commit/8de4440c5652f6f1af5b4b923a15730ba84f29e1#diff-b2e907677520a5d671a037de2e60e656L376

in PKI, since the caller for generateAsymmetricKey() in KeyClient.java
deliberately passed in "null" for transWrappedSessionKey, it is
safe to just skip over the following line when transWrappedSessionKey is null:
data.setTransWrappedSessionKey(Utils.base64encode(transWrappedSessionKey, false));

the CRMF issue reported in the same bug is very likley a separate issue
and should be filed in a separate bug.

https://bugzilla.redhat.com/show_bug.cgi?id=1856368