### PR TITLE
Automatic purging of expired ACME authorizations and orders

### DIFF
--- a/base/acme/database/postgresql/statements.conf
+++ b/base/acme/database/postgresql/statements.conf
@@ -176,7 +176,7 @@ updateAuthorization=\
 UPDATE \
     "authorizations" \
 SET \
-    "status" = ? \
+    "status" = ?, "expires" = ? \
 WHERE \
     "id" = ?
 

--- a/base/acme/database/postgresql/statements.conf
+++ b/base/acme/database/postgresql/statements.conf
@@ -158,6 +158,14 @@ FROM \
 WHERE \
     "account_id" = ? and "status" = 'valid' and "expires" > ?
 
+getExpiredAuthorizationIDs=\
+SELECT \
+    "id" \
+FROM \
+    "authorizations" \
+WHERE \
+    "expires" <= ?
+
 getAuthorizationChallenges=\
 SELECT \
     "id", "type", "token", "status", "validated" \
@@ -177,6 +185,12 @@ UPDATE \
     "authorizations" \
 SET \
     "status" = ?, "expires" = ? \
+WHERE \
+    "id" = ?
+
+removeAuthorization=\
+DELETE FROM \
+    "authorizations" \
 WHERE \
     "id" = ?
 

--- a/base/acme/database/postgresql/statements.conf
+++ b/base/acme/database/postgresql/statements.conf
@@ -76,6 +76,14 @@ FROM \
 WHERE \
     "id" = ?
 
+getExpiredOrderIDs=\
+SELECT \
+    "id" \
+FROM \
+    "orders" \
+WHERE \
+    "expires" <= ?
+
 getOrderIdentifiers=\
 SELECT \
     "type", "value" \
@@ -120,17 +128,35 @@ INSERT INTO \
 VALUES \
     (?, ?, ?)
 
+removeOrderIdentifiers=\
+DELETE FROM \
+    "order_identifiers" \
+WHERE \
+    "order_id" = ?
+
 addOrderAuthorizations=\
 INSERT INTO \
     "order_authorizations" ("order_id", "authz_id") \
 VALUES \
     (?, ?)
 
+removeOrderAuthorizations=\
+DELETE FROM \
+    "order_authorizations" \
+WHERE \
+    "order_id" = ?
+
 updateOrder=\
 UPDATE \
     "orders" \
 SET \
     "status" = ?, "cert_id" = ?, "expires" = ? \
+WHERE \
+    "id" = ?
+
+removeOrder=\
+DELETE FROM \
+    "orders" \
 WHERE \
     "id" = ?
 

--- a/base/acme/database/postgresql/statements.conf
+++ b/base/acme/database/postgresql/statements.conf
@@ -130,7 +130,7 @@ updateOrder=\
 UPDATE \
     "orders" \
 SET \
-    "status" = ?, "cert_id" = ? \
+    "status" = ?, "cert_id" = ?, "expires" = ? \
 WHERE \
     "id" = ?
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
@@ -113,6 +113,10 @@ public abstract class ACMEDatabase {
     public abstract void addAuthorization(ACMEAuthorization authorization) throws Exception;
     public abstract void updateAuthorization(ACMEAuthorization authorization) throws Exception;
 
+    public void removeExpiredAuthorizations(Date currentTime) throws Exception {
+        throw new NotImplementedException();
+    }
+
     public X509Certificate getCertificate(String certID) throws Exception {
         throw new NotImplementedException();
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
@@ -71,6 +71,10 @@ public abstract class ACMEDatabase {
     public abstract void addOrder(ACMEOrder order) throws Exception;
     public abstract void updateOrder(ACMEOrder order) throws Exception;
 
+    public void removeExpiredOrders(Date currentTime) throws Exception {
+        throw new NotImplementedException();
+    }
+
     public abstract ACMEAuthorization getAuthorization(String authzID) throws Exception;
     public abstract ACMEAuthorization getAuthorizationByChallenge(String challengeID) throws Exception;
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
@@ -200,6 +200,11 @@ public class InMemoryDatabase extends ACMEDatabase {
         authorizations.put(authorization.getID(), authorization);
     }
 
+    public void removeExpiredAuthorizations(Date currentTime) throws Exception {
+        authorizations.values().removeIf(
+                n -> n.getExpirationTime() != null && !currentTime.before(n.getExpirationTime()));
+    }
+
     public X509Certificate getCertificate(String certID) throws Exception {
         return certificates.get(certID);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
@@ -103,6 +103,11 @@ public class InMemoryDatabase extends ACMEDatabase {
         orders.put(order.getID(), order);
     }
 
+    public void removeExpiredOrders(Date currentTime) throws Exception {
+        orders.values().removeIf(
+                n -> n.getExpirationTime() != null && !currentTime.before(n.getExpirationTime()));
+    }
+
     public ACMEAuthorization getAuthorization(String authzID) throws Exception {
         return authorizations.get(authzID);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
@@ -433,6 +433,18 @@ public class LDAPDatabase extends ACMEDatabase {
         ldapModify(dn, mods);
     }
 
+    public void removeExpiredOrders(Date currentTime) throws Exception {
+        String[] attrs = {"1.1"};  // suppress attrs for performance; we only need DN
+        List<LDAPEntry> entries = ldapSearch(
+            RDN_ORDER + "," + basedn,
+            "(" + ATTR_EXPIRES + "<=" + dateFormat.format(currentTime) + ")",
+            attrs
+        );
+        for (LDAPEntry entry : entries) {
+            ldapDelete(entry.getDN(), OnNoSuchObject.Ignore);
+        }
+    }
+
     public ACMEAuthorization getAuthorization(String authzID) throws Exception {
         return getAuthorization(authzID, LoadChallenges.DoLoad);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
@@ -708,6 +708,18 @@ public class LDAPDatabase extends ACMEDatabase {
         return !entries.isEmpty();
     }
 
+    public void removeExpiredAuthorizations(Date currentTime) throws Exception {
+        String[] attrs = {"1.1"};  // suppress attrs for performance; we only need DN
+        List<LDAPEntry> entries = ldapSearch(
+            RDN_AUTHORIZATION + "," + basedn,
+            "(" + ATTR_EXPIRES + "<=" + dateFormat.format(currentTime) + ")",
+            attrs
+        );
+        for (LDAPEntry entry : entries) {
+            ldapDelete(entry.getDN(), OnNoSuchObject.Ignore);
+        }
+    }
+
     public X509Certificate getCertificate(String certID) throws Exception {
         String dn = ATTR_CERTIFICATE_ID + "=" + certID + "," + RDN_CERTIFICATE + "," + basedn;
         LDAPEntry entry = ldapGet(dn);

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/PostgreSQLDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/PostgreSQLDatabase.java
@@ -603,7 +603,7 @@ public class PostgreSQLDatabase extends ACMEDatabase {
             ps.setString(3, order.getStatus());
 
             Date expirationTime = order.getExpirationTime();
-            ps.setTimestamp(4, new Timestamp(expirationTime.getTime()));
+            ps.setTimestamp(4, expirationTime == null ? null : new Timestamp(expirationTime.getTime()));
 
             Date notBefore = order.getNotBeforeTime();
             ps.setTimestamp(5, notBefore == null ? null : new Timestamp(notBefore.getTime()));
@@ -681,7 +681,11 @@ public class PostgreSQLDatabase extends ACMEDatabase {
 
             ps.setString(1, order.getStatus());
             ps.setString(2, order.getCertID());
-            ps.setString(3, orderID);
+
+            Date expirationTime = order.getExpirationTime();
+            ps.setTimestamp(3, expirationTime == null ? null : new Timestamp(expirationTime.getTime()));
+
+            ps.setString(4, orderID);
 
             ps.executeUpdate();
         }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/PostgreSQLDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/PostgreSQLDatabase.java
@@ -868,7 +868,7 @@ public class PostgreSQLDatabase extends ACMEDatabase {
             ps.setString(3, authorization.getStatus());
 
             Date expirationTime = authorization.getExpirationTime();
-            ps.setTimestamp(4, new Timestamp(expirationTime.getTime()));
+            ps.setTimestamp(4, expirationTime == null ? null : new Timestamp(expirationTime.getTime()));
 
             ACMEIdentifier identifier = authorization.getIdentifier();
             ps.setString(5, identifier.getType());
@@ -896,7 +896,11 @@ public class PostgreSQLDatabase extends ACMEDatabase {
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
 
             ps.setString(1, authorization.getStatus());
-            ps.setString(2, authzID);
+
+            Date expirationTime = authorization.getExpirationTime();
+            ps.setTimestamp(2, expirationTime == null ? null : new Timestamp(expirationTime.getTime()));
+
+            ps.setString(3, authzID);
 
             ps.executeUpdate();
         }

--- a/base/acme/src/main/java/org/dogtagpki/acme/scheduler/ACMEMaintenanceTask.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/scheduler/ACMEMaintenanceTask.java
@@ -27,5 +27,7 @@ public class ACMEMaintenanceTask extends ACMETask {
         ACMEDatabase database = engine.getDatabase();
 
         database.removeExpiredNonces(currentTime);
+        database.removeExpiredAuthorizations(currentTime);
+        database.removeExpiredOrders(currentTime);
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
@@ -124,6 +124,7 @@ public class ACMEChallengeProcessor implements Runnable {
 
             logger.info("Order " + order.getID() + " is ready");
             order.setStatus("ready");
+            order.setExpirationTime(null);
 
             engine.updateOrder(account, order);
         }
@@ -197,6 +198,7 @@ public class ACMEChallengeProcessor implements Runnable {
 
             logger.info("Order " + order.getID() + " is invalid");
             order.setStatus("invalid");
+            order.setExpirationTime(null);
 
             engine.updateOrder(account, order);
         }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -666,17 +666,7 @@ public class ACMEEngine implements ServletContextListener {
     }
 
     public void addOrder(ACMEAccount account, ACMEOrder order) throws Exception {
-
         order.setAccountID(account.getID());
-
-        // set order to expire in 30 minutes
-        // TODO: make it configurable
-
-        long currentTime = System.currentTimeMillis();
-        Date expirationTime = new Date(currentTime + 30 * 60 * 1000);
-
-        order.setExpirationTime(expirationTime);
-
         database.addOrder(order);
     }
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -624,17 +624,7 @@ public class ACMEEngine implements ServletContextListener {
     }
 
     public void addAuthorization(ACMEAccount account, ACMEAuthorization authorization) throws Exception {
-
         authorization.setAccountID(account.getID());
-
-        // set authorizations to expire in 30 minutes
-        // TODO: make it configurable
-
-        long currentTime = System.currentTimeMillis();
-        Date expirationTime = new Date(currentTime + 30 * 60 * 1000);
-
-        authorization.setExpirationTime(expirationTime);
-
         database.addAuthorization(authorization);
     }
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewOrderService.java
@@ -104,9 +104,11 @@ public class ACMENewOrderService {
 
             ACMEAuthorization authorization = new ACMEAuthorization();
             authorization.setID(authzID);
-            authorization.setStatus("pending");
             authorization.setIdentifier(identifier);
             authorization.setWildcard(wildcard);
+
+            authorization.setStatus("pending");
+            authorization.setExpirationTime(null);
 
             engine.addAuthorization(account, authorization);
 


### PR DESCRIPTION
As described in RFC 8555, the ACME responder has been modified to set the expiration time for:
* valid authorizations
* valid orders
* pending orders

The ACME maintenance task has also been modified to periodically remove the expired records.