### PR TITLE
Simplified ACME LDAP database parameters

### DIFF
--- a/base/acme/database/ldap/database.conf
+++ b/base/acme/database/ldap/database.conf
@@ -1,9 +1,6 @@
 class=org.dogtagpki.acme.database.LDAPDatabase
-basedn=dc=acme,dc=pki,dc=example,dc=com
-internaldb.ldapauth.authtype=BasicAuth
-internaldb.ldapauth.bindDN=cn=Directory Manager
-internaldb.ldapauth.bindPWPrompt=internaldb
-internaldb.ldapconn.host=localhost.localdomain
-internaldb.ldapconn.port=389
-internaldb.ldapconn.secureConn=false
-password.internaldb=Secret.123
+url=ldap://localhost.localdomain:389
+authType=BasicAuth
+bindDN=cn=Directory Manager
+bindPassword=Secret.123
+baseDN=dc=acme,dc=pki,dc=example,dc=com

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -604,43 +604,36 @@ class ACMEDatabaseShowCLI(pki.cli.CLI):
 
         if database_type == 'ldap':
 
-            hostname = config.get('internaldb.ldapconn.host')
-            if hostname:
-                print('  Hostname: %s' % hostname)
+            url = config.get('url')
+            if url:
+                print('  Server URL: %s' % url)
 
-            port = config.get('internaldb.ldapconn.port')
-            if port:
-                print('  Port: %s' % port)
-
-            secure_connection = config.get('internaldb.ldapconn.secureConn')
-            if secure_connection:
-                print('  Secure Connection: %s' % secure_connection)
-
-            auth_type = config.get('internaldb.ldapauth.authtype')
+            auth_type = config.get('authType')
             if auth_type:
                 print('  Authentication Type: %s' % auth_type)
 
             if auth_type == 'BasicAuth':
 
-                bind_dn = config.get('internaldb.ldapauth.bindDN')
+                bind_dn = config.get('bindDN')
                 if bind_dn:
                     print('  Bind DN: %s' % bind_dn)
 
-                password_name = config.get('internaldb.ldapauth.bindPWPrompt')
-                if password_name:
-                    print('  Password Name: %s' % password_name)
-
-                password = config.get('password.%s' % password_name)
+                password = config.get('bindPassword')
                 if password:
-                    print('  Password for %s: ********' % password_name)
+                    print('  Bind Password: ********')
 
             elif auth_type == 'SslClientAuth':
 
-                nickname = config.get('internaldb.ldapauth.clientCertNickname')
+                nickname = config.get('nickname')
                 if nickname:
                     print('  Client Certificate: %s' % nickname)
 
             base_dn = config.get('basedn')
+            if base_dn:
+                logger.warning('The basedn parameter has been deprecated. Use baseDN instead.')
+            else:
+                base_dn = config.get('baseDN')
+
             if base_dn:
                 print('  Base DN: %s' % base_dn)
 
@@ -784,78 +777,59 @@ class ACMEDatabaseModifyCLI(pki.cli.CLI):
         elif database_type == 'ldap':
 
             print()
-            print('Enter the server hostname.')
-            hostname = config.get('internaldb.ldapconn.host')
-            hostname = pki.util.read_text('  Hostname', default=hostname, required=True)
-            pki.util.set_property(config, 'internaldb.ldapconn.host', hostname)
-
-            print()
-            print('Enter the server port.')
-            port = config.get('internaldb.ldapconn.port')
-            port = pki.util.read_text('  Port', default=port, required=True)
-            pki.util.set_property(config, 'internaldb.ldapconn.port', port)
-
-            print()
-            print('Enter true for secure connection, and false otherwise.')
-            secure_connection = config.get('internaldb.ldapconn.secureConn')
-            secure_connection = pki.util.read_text(
-                '  Secure Connection',
-                options=['true', 'false'],
-                default=secure_connection,
-                required=True)
-            pki.util.set_property(config, 'internaldb.ldapconn.secureConn', secure_connection)
+            print('Enter the location of the LDAP server.')
+            url = config.get('url')
+            url = pki.util.read_text('  Server URL', default=url, required=True)
+            pki.util.set_property(config, 'url', url)
 
             print()
             print('Enter the authentication type. Available types: BasicAuth, SslClientAuth.')
-            auth_type = config.get('internaldb.ldapauth.authtype')
+            auth_type = config.get('authType')
             auth_type = pki.util.read_text(
                 '  Authentication Type',
                 options=['BasicAuth', 'SslClientAuth'],
                 default=auth_type,
                 required=True)
-            pki.util.set_property(config, 'internaldb.ldapauth.authtype', auth_type)
+            pki.util.set_property(config, 'authType', auth_type)
 
             if auth_type == 'BasicAuth':
 
                 print()
                 print('Enter the bind DN.')
-                bind_dn = config.get('internaldb.ldapauth.bindDN')
+                bind_dn = config.get('bindDN')
                 bind_dn = pki.util.read_text('  Bind DN', default=bind_dn, required=True)
-                pki.util.set_property(config, 'internaldb.ldapauth.bindDN', bind_dn)
+                pki.util.set_property(config, 'bindDN', bind_dn)
 
                 print()
-                print('Enter the password name.')
-                password_name = config.get('internaldb.ldapauth.bindPWPrompt')
-                password_name = pki.util.read_text(
-                    '  Password Name', default=password_name, required=True)
-                pki.util.set_property(config, 'internaldb.ldapauth.bindPWPrompt', password_name)
-
-                print()
-                print('Enter the password for %s.' % password_name)
-                password = config.get('password.%s' % password_name)
+                print('Enter the bind password.')
+                password = config.get('bindPassword')
                 password = pki.util.read_text(
-                    '  Password for %s' % password_name,
+                    '  Bind Password',
                     default=password,
                     password=True,
                     required=True)
-                pki.util.set_property(config, 'password.%s' % password_name, password)
+                pki.util.set_property(config, 'bindPassword', password)
 
             elif auth_type == 'SslClientAuth':
 
                 print()
                 print('Enter the client certificate.')
-                nickname = config.get('internaldb.ldapauth.clientCertNickname')
+                nickname = config.get('nickname')
                 nickname = pki.util.read_text(
                     '  Client Certificate',
                     default=nickname,
                     required=True)
-                pki.util.set_property(config, 'internaldb.ldapauth.clientCertNickname', nickname)
+                pki.util.set_property(config, 'nickname', nickname)
 
             print()
             print('Enter the base DN for the ACME subtree.')
-            base_dn = config.get('basedn')
+
+            base_dn = config.pop('basedn', None)
+            if not base_dn:
+                base_dn = config.get('baseDN')
+
             base_dn = pki.util.read_text('  Base DN', default=base_dn, required=True)
-            pki.util.set_property(config, 'basedn', base_dn)
+            pki.util.set_property(config, 'baseDN', base_dn)
 
         elif database_type == 'postgresql':
 

--- a/docs/installation/acme/Configuring_ACME_Database.md
+++ b/docs/installation/acme/Configuring_ACME_Database.md
@@ -57,22 +57,19 @@ or execute the following command to customize some of the parameters:
 
 ```
 $ pki-server acme-database-mod --type ldap \
-    -Dbasedn=dc=acme,dc=pki,dc=example,dc=com \
-    -Dpassword.internaldb=Secret.123
+    -DbaseDN=dc=acme,dc=pki,dc=example,dc=com \
+    -DbindPassword=Secret.123
 ```
 
 Customize the configuration as needed. In a standalone ACME deployment, the database.conf should look like the following:
 
 ```
 class=org.dogtagpki.acme.database.LDAPDatabase
-basedn=dc=acme,dc=pki,dc=example,dc=com
-internaldb.ldapauth.authtype=BasicAuth
-internaldb.ldapauth.bindDN=cn=Directory Manager
-internaldb.ldapauth.bindPWPrompt=internaldb
-internaldb.ldapconn.host=<hostname>
-internaldb.ldapconn.port=389
-internaldb.ldapconn.secureConn=false
-password.internaldb=Secret.123
+url=ldap://<hostname>:389
+authType=BasicAuth
+bindDN=cn=Directory Manager
+bindPassword=Secret.123
+baseDN=dc=acme,dc=pki,dc=example,dc=com
 ```
 
 In a shared CA and ACME deployment, the database.conf should look like the following:
@@ -80,7 +77,7 @@ In a shared CA and ACME deployment, the database.conf should look like the follo
 ```
 class=org.dogtagpki.acme.database.LDAPDatabase
 configFile=conf/ca/CS.cfg
-basedn=dc=acme,dc=pki,dc=example,dc=com
+baseDN=dc=acme,dc=pki,dc=example,dc=com
 ```
 
 ## Configuring PosgreSQL Database

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_acme.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_acme.yml
@@ -26,8 +26,8 @@
 - name: Updating acme ldap password
   replace:
    path: "{{variable.ACME_CONFIG_PATH}}/database/ldap/database.conf"
-   regexp: 'password.internaldb=.*'
-   replace: 'password.internaldb={{variable.LDAP_PASSWD}}'
+   regexp: 'bindPassword=.*'
+   replace: 'bindPassword={{variable.LDAP_PASSWD}}'
 
 - name: Removing existing ldap entry
   command: sed -i 1,3d "{{variable.ACME_CONFIG_PATH}}/database/ldap/create.ldif"


### PR DESCRIPTION
The LDAPDatabase parameters have been simplified:
- `basedn` -> `baseDN`
- `internaldb.ldapconn.host,port,secureConn` -> `url`
- `internaldb.ldapauth.authtype` -> `authType`
- `internaldb.ldapauth.bindDN` -> `bindDN`
- `internaldb.ldapauth.clientCertNickname` -> `nickname`
- `password.internaldb` -> `bindPassword`

IPA uses the old `basedn` parameter, so it will continue
to work but it has been deprecated. Hopefully IPA can be
updated to use the new `baseDN` parameter.

The `internaldb.ldapauth.bindPWPrompt` is no longer used so
it has been removed.

The Ansible test has been updated as well.