### PR TITLE
Fix build with CMake out-of-source build change

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -807,8 +807,6 @@ else
     app_server=tomcat-$tomcat_version
 fi
 
-%{__mkdir_p} build
-cd build
 %cmake \
     --no-warn-unused-cli \
     -DVERSION=%{version}-%{release} \
@@ -830,7 +828,9 @@ cd build
     -DWITH_JAVADOC:BOOL=%{?with_javadoc:ON}%{!?with_javadoc:OFF} \
     -DBUILD_PKI_CONSOLE:BOOL=%{?with_console:ON}%{!?with_console:OFF} \
     -DTHEME=%{?with_theme:%{vendor_id}} \
-    ..
+    -B %{_vpath_builddir}
+
+cd %{_vpath_builddir}
 
 # Do not use _smp_mflags to preserve build order
 %{__make} \
@@ -845,7 +845,7 @@ cd build
 %install
 ################################################################################
 
-cd build
+cd %{_vpath_builddir}
 
 %{__make} \
     VERBOSE=%{?_verbose} \


### PR DESCRIPTION
Fedora 33 has introduced the following change proposal:

https://fedoraproject.org/wiki/Changes/CMake_to_do_out-of-source_builds

This makes CMake do out-of-source builds by default. However, Fedora has
opted to use the `%{_vpath_builddir}` macro as the location of the default
build directory, instead of the more standard (in the CMake community)
`build/` directory. `%{_vpath_builddir}` expands to `%{_target_platform}`,
giving a per-architecture build directory.

Replace `build/` references with `%{_vpath_builddir}` in the RPM spec. In
the future, we could move `%{__make}` to `%cmake_build` instead.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`