### PR TITLE
Added runtime dependency on systemd

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -485,6 +485,7 @@ Requires:         tomcat >= 1:9.0.7
 %endif
 
 Requires:         velocity
+Requires:         systemd
 Requires(post):   systemd-units
 Requires(preun):  systemd-units
 Requires(postun): systemd-units


### PR DESCRIPTION
The pki-server package has been modified to explicitly require
systemd as runtime dependency since systemd is no longer part
of Fedora container image:
https://docs.fedoraproject.org/en-US/minimization/