### PR TITLE
Removed hard-coded ACME validity policies

### DIFF
--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -3,4 +3,4 @@
 # above.
 #
 # Whether to enable the ACME service:
-enabled=1
+enabled=true

--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -4,3 +4,6 @@
 #
 # Whether to enable the ACME service:
 enabled=true
+
+# Whether to accept wildcard DNS identifiers:
+policy.wildcard=true

--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -7,3 +7,16 @@ enabled=true
 
 # Whether to accept wildcard DNS identifiers:
 policy.wildcard=true
+
+# Validity policies
+policy.nonceValidity.length=30
+policy.nonceValidity.unit=MINUTES
+
+policy.validAuthorizationValidity.length=30
+policy.validAuthorizationValidity.unit=MINUTES
+
+policy.pendingOrderValidity.length=30
+policy.pendingOrderValidity.unit=MINUTES
+
+policy.validOrderValidity.length=30
+policy.validOrderValidity.unit=MINUTES

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
@@ -63,7 +63,7 @@ public class ACMEChallengeProcessor implements Runnable {
 
     public void finalizeValidAuthorization() throws Exception {
 
-        long currentTime = System.currentTimeMillis();
+        Date currentTime = new Date();
 
         ACMEEngine engine = ACMEEngine.getInstance();
         String authzID = authorization.getID();
@@ -71,7 +71,7 @@ public class ACMEChallengeProcessor implements Runnable {
 
         logger.info("Challenge " + challengeID + " is valid");
         challenge.setStatus("valid");
-        challenge.setValidationTime(new Date(currentTime));
+        challenge.setValidationTime(currentTime);
 
         // RFC 8555 Section 7.5.1: Responding to Challenges
         //
@@ -95,10 +95,7 @@ public class ACMEChallengeProcessor implements Runnable {
         // If the final state is "valid", then the server MUST include an "expires"
         // field.
 
-        // set valid authorization to expire in 30 minutes
-        // TODO: make it configurable
-
-        Date expirationTime = new Date(currentTime + 30 * 60 * 1000);
+        Date expirationTime = engine.getPolicy().getValidAuthorizationExpirationTime(currentTime);
         authorization.setExpirationTime(expirationTime);
 
         engine.updateAuthorization(account, authorization);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -205,6 +205,10 @@ public class ACMEEngine implements ServletContextListener {
 
         ACMEPolicyConfig policyConfig = config.getPolicyConfig();
         logger.info("- wildcard: " + policyConfig.getEnableWildcards());
+        logger.info("- nonce validity: " + policyConfig.getNonceValidity());
+        logger.info("- valid authorization validity: " + policyConfig.getValidAuthorizationValidity());
+        logger.info("- pending order validity: " + policyConfig.getPendingOrderValidity());
+        logger.info("- valid order validity: " + policyConfig.getValidOrderValidity());
 
         policy = new ACMEPolicy(policyConfig);
     }
@@ -475,13 +479,8 @@ public class ACMEEngine implements ServletContextListener {
 
         nonce.setValue(value);
 
-        // set nonce to expire in 30 minutes
-        // TODO: make it configurable
-
-        long currentTime = System.currentTimeMillis();
-        long expirationTime = currentTime + 30 * 60 * 1000;
-
-        nonce.setExpirationTime(new Date(expirationTime));
+        Date expirationTime = policy.getNonceExpirationTime(new Date());
+        nonce.setExpirationTime(expirationTime);
 
         database.addNonce(nonce);
         logger.info("Created nonce: " + nonce);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfig.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -22,12 +23,23 @@ public class ACMEEngineConfig {
 
     private Boolean enabled = true;
 
+    @JsonProperty("policy")
+    private ACMEPolicyConfig policyConfig = new ACMEPolicyConfig();
+
     public Boolean isEnabled() {
         return enabled;
     }
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public ACMEPolicyConfig getPolicyConfig() {
+        return policyConfig;
+    }
+
+    public void setPolicyConfig(ACMEPolicyConfig wildcard) {
+        this.policyConfig = wildcard;
     }
 
     public String toJSON() throws Exception {
@@ -51,6 +63,13 @@ public class ACMEEngineConfig {
 
             if (key.equals("enabled")) {
                 config.setEnabled(new Boolean(value));
+
+            } else if (key.startsWith("policy.")) {
+
+                String policyKey = key.substring(7);
+
+                ACMEPolicyConfig policyConfig = config.getPolicyConfig();
+                policyConfig.setProperty(policyKey, value);
             }
         }
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfig.java
@@ -1,0 +1,72 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Endi S. Dewata
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ACMEEngineConfig {
+
+    private Boolean enabled = true;
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static ACMEEngineConfig fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, ACMEEngineConfig.class);
+    }
+
+    public static ACMEEngineConfig fromProperties(Properties props) throws Exception {
+
+        ACMEEngineConfig config = new ACMEEngineConfig();
+
+        for (Entry<Object, Object> entry : props.entrySet()) {
+
+            String key = entry.getKey().toString();
+            String value = entry.getValue().toString();
+
+            if (key.equals("enabled")) {
+                config.setEnabled(new Boolean(value));
+            }
+        }
+
+        return config;
+    }
+
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        ACMEEngineConfig engineConfig = new ACMEEngineConfig();
+        System.out.println(engineConfig);
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfigFileSource.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfigFileSource.java
@@ -68,7 +68,7 @@ class ACMEEngineConfigFileSource
                 enabled = !("0".equals(s) || "false".equalsIgnoreCase(s));
             }
 
-            s = props.getProperty("wildcard");
+            s = props.getProperty("policy.wildcard");
             if (s != null) {
                 wildcard = !("0".equals(s) || "false".equalsIgnoreCase(s));
             }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
@@ -97,13 +97,9 @@ public class ACMEFinalizeOrderService {
         //    in [RFC3339].  This field is REQUIRED for objects with "pending"
         //    or "valid" in the status field.
 
-        // set valid order to expire in 30 minutes
-        // TODO: make it configurable
-
-        long currentTime = System.currentTimeMillis();
-        Date expirationTime = new Date(currentTime + 30 * 60 * 1000);
-
         order.setStatus("valid");
+
+        Date expirationTime = engine.getPolicy().getValidOrderExpirationTime(new Date());
         order.setExpirationTime(expirationTime);
 
         engine.updateOrder(account, order);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewOrderService.java
@@ -133,13 +133,9 @@ public class ACMENewOrderService {
         //    in [RFC3339].  This field is REQUIRED for objects with "pending"
         //    or "valid" in the status field.
 
-        // set pending order to expire in 30 minutes
-        // TODO: make it configurable
-
-        long currentTime = System.currentTimeMillis();
-        Date expirationTime = new Date(currentTime + 30 * 60 * 1000);
-
         order.setStatus("pending");
+
+        Date expirationTime = engine.getPolicy().getPendingOrderExpirationTime(new Date());
         order.setExpirationTime(expirationTime);
 
         engine.addOrder(account, order);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
@@ -3,27 +3,20 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-package org.dogtagpki.acme;
+package org.dogtagpki.acme.server;
+
+import org.dogtagpki.acme.ACMEIdentifier;
 
 /**
  * This class includes mechanisms to enforce various policy and security
  * restrictions explicitly or implicitly enumerated by ACME.
  */
 public class ACMEPolicy {
-    private boolean enableWildcardIssuance;
 
-    public ACMEPolicy() {}
+    private ACMEPolicyConfig config;
 
-    public ACMEPolicy(boolean wildcards) {
-        enableWildcardIssuance = wildcards;
-    }
-
-    public boolean getEnableWildcards() {
-        return enableWildcardIssuance;
-    }
-
-    public void setEnableWildcards(boolean on) {
-        enableWildcardIssuance = on;
+    public ACMEPolicy(ACMEPolicyConfig config) {
+        this.config = config;
     }
 
     /**
@@ -86,7 +79,7 @@ public class ACMEPolicy {
             throw new Exception(msg);
         }
 
-        if (!getEnableWildcards()) {
+        if (!config.getEnableWildcards()) {
             String msg = "ACME Order Identifier `" + record + "` disallowed ";
             msg += "by ACME Policy because it contains a wildcard.";
             throw new Exception(msg);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
@@ -5,6 +5,8 @@
 //
 package org.dogtagpki.acme.server;
 
+import java.util.Date;
+
 import org.dogtagpki.acme.ACMEIdentifier;
 
 /**
@@ -86,5 +88,21 @@ public class ACMEPolicy {
         }
 
         return;
+    }
+
+    public Date getNonceExpirationTime(Date currentTime) {
+        return config.getNonceValidity().getExpirationTime(currentTime);
+    }
+
+    public Date getValidAuthorizationExpirationTime(Date currentTime) {
+        return config.getValidAuthorizationValidity().getExpirationTime(currentTime);
+    }
+
+    public Date getPendingOrderExpirationTime(Date currentTime) {
+        return config.getPendingOrderValidity().getExpirationTime(currentTime);
+    }
+
+    public Date getValidOrderExpirationTime(Date currentTime) {
+        return config.getValidOrderValidity().getExpirationTime(currentTime);
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicyConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicyConfig.java
@@ -1,0 +1,81 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * This class includes mechanisms to enforce various policy and security
+ * restrictions explicitly or implicitly enumerated by ACME.
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ACMEPolicyConfig {
+
+    @JsonProperty("wildcard")
+    private Boolean enableWildcardIssuance = true;
+
+    public ACMEPolicyConfig() {}
+
+    @JsonIgnore
+    public boolean getEnableWildcards() {
+        return enableWildcardIssuance;
+    }
+
+    public void setEnableWildcards(boolean on) {
+        enableWildcardIssuance = on;
+    }
+
+    public void setProperty(String key, String value) throws Exception {
+        if (key.equals("wildcard")) {
+            enableWildcardIssuance = new Boolean(value);
+        }
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static ACMEPolicyConfig fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, ACMEPolicyConfig.class);
+    }
+
+    public static ACMEPolicyConfig fromProperties(Properties props) throws Exception {
+
+        ACMEPolicyConfig config = new ACMEPolicyConfig();
+
+        for (Entry<Object, Object> entry : props.entrySet()) {
+            String key = entry.getKey().toString();
+            String value = entry.getValue().toString();
+            config.setProperty(key, value);
+        }
+
+        return config;
+    }
+
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        ACMEPolicyConfig policyConfig = new ACMEPolicyConfig();
+        System.out.println(policyConfig);
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEValidityConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEValidityConfig.java
@@ -1,0 +1,101 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Endi S. Dewata
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ACMEValidityConfig {
+
+    private Long length;
+    private ChronoUnit unit;
+
+    public ACMEValidityConfig() {
+    }
+
+    public ACMEValidityConfig(Long length, ChronoUnit unit) {
+        this.length = length;
+        this.unit = unit;
+    }
+
+    public Long getLength() {
+        return length;
+    }
+
+    public void setLength(Long length) {
+        this.length = length;
+    }
+
+    public ChronoUnit getUnit() {
+        return unit;
+    }
+
+    public void setUnit(ChronoUnit unit) {
+        this.unit = unit;
+    }
+
+    public Date getExpirationTime(Date currentTime) {
+
+        if (length == null || unit == null) return null;
+
+        Instant now = currentTime.toInstant();
+        Instant expirationTime = now.plus(length, unit);
+        return Date.from(expirationTime);
+    }
+
+    public void setProperty(String key, String value) throws Exception {
+        if (key.equals("length")) {
+            if (StringUtils.isEmpty(value)) {
+                length = null;
+            } else {
+                length = new Long(value);
+            }
+
+        } else if (key.equals("unit")) {
+            if (StringUtils.isEmpty(value)) {
+                unit = null;
+            } else {
+                unit = ChronoUnit.valueOf(value);
+            }
+        }
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static ACMEValidityConfig fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, ACMEValidityConfig.class);
+    }
+
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        ACMEValidityConfig validityConfig = new ACMEValidityConfig(30l, ChronoUnit.MINUTES);
+        System.out.println(validityConfig);
+    }
+}


### PR DESCRIPTION
The hard-coded validity policies for ACME nonces, valid
authorizations, pending and valid orders have been replaced
with configurable properties in engine.conf.