### PR TITLE
Fixed JAVA_OPTS parsing in PKISubsystem.run()

### DIFF
--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1123,7 +1123,9 @@ class PKISubsystem(object):
         ])
 
         if java_opts:
-            cmd.extend(java_opts.split(' '))
+            opts = java_opts.split(' ')
+            non_empty_opts = [opt for opt in opts if opt]
+            cmd.extend(non_empty_opts)
 
         cmd.extend(['org.dogtagpki.server.cli.PKIServerCLI'])
 


### PR DESCRIPTION
The `PKISubsystem.run()` parses `JAVA_OPTS` into a list of strings
and uses it as Java arguments. In some cases the list might
contain empty strings which can cause problems. The code has
been modified to remove empty strings from the list.