### PR TITLE
Re-fix sanitization in CMSTemplate

### DIFF
--- a/base/server/src/com/netscape/cms/servlet/common/CMSTemplate.java
+++ b/base/server/src/com/netscape/cms/servlet/common/CMSTemplate.java
@@ -348,7 +348,7 @@ public class CMSTemplate extends CMSFile {
      */
 
     public static String escapeJavaScriptString(String v) {
-        return StringEscapeUtils.escapeJavaScript(v);
+        return escapeJavaScriptStringHTML(v);
     }
 
     /**


### PR DESCRIPTION
When fixing CVE-2019-10179 originally in
8884b4344225bd6656876d9e2a58b3268e9a899b,
I had switched to Apache Commons Lang2's
sanitzation framework. However, I didn't
enable the HTML sanitization necessary to
fix this CVE.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

I've re-tested this following Deepak's steps and it works as intended.