### PR TITLE
Fix HTTP Request formatting in AdminConnection

### DIFF
--- a/base/console/src/com/netscape/admin/certsrv/connection/AdminConnection.java
+++ b/base/console/src/com/netscape/admin/certsrv/connection/AdminConnection.java
@@ -176,8 +176,6 @@ public class AdminConnection {
             }
         }
 
-        b64.append('\n');
-
         return b64.toString();
     }
 
@@ -736,11 +734,11 @@ public class AdminConnection {
         } else {
           sb.append("POST /" + request.getPrefix());
         }
-            sb.append(" HTTP/1.0\n");
+            sb.append(" HTTP/1.0\r\n");
 
         StringBuffer sb1 = new StringBuffer();
         if (!useGET) {
-            sb.append("Content-type: application/x-www-form-urlencoded\n");
+            sb.append("Content-type: application/x-www-form-urlencoded\r\n");
           Enumeration<String> names = request.getElements();
           while (names.hasMoreElements()) {
             String name = names.nextElement();
@@ -752,12 +750,12 @@ public class AdminConnection {
             if (names.hasMoreElements())
               sb1.append("&");
           }
-            sb.append("Content-length: " + sb1.toString().length() + "\n");
+            sb.append("Content-length: " + sb1.toString().length() + "\r\n");
         }
 
-        sb.append("Pragma: no-cache\n");
+        sb.append("Pragma: no-cache\r\n");
         if (mIsKeepAlive) {
-                sb.append("Connection: Keep-Alive\n");
+                sb.append("Connection: Keep-Alive\r\n");
         }
 
         if (mAuthType.equals("") || mAuthType.equals("pwd")) {
@@ -765,15 +763,17 @@ public class AdminConnection {
             // sun.misc.BASE64Encoder encoder = new sun.misc.BASE64Encoder();
             // sb.append("Authorization: Basic " +
             //          encoder.encodeBuffer((auth.getUserid() +
-            //                               ":" + auth.getPassword()).getBytes()) + "\n");
+            //                               ":" + auth.getPassword()).getBytes()) + "\r\n");
             sb.append("Authorization: Basic " +
                       b64encode((auth.getUserid() +
-                                          ":" + auth.getPassword()).getBytes()) + "\n");
-        } else if (mAuthType.equals("sslclientauth")) {
-            sb.append("\n");
-        } else {
+                                          ":" + auth.getPassword()).getBytes()) + "\r\n");
+        } else if (!mAuthType.equals("sslclientauth")) {
             throw new EAdminException(CMSAdminResources.AUTHENNOTSUPPORTED, false);
         }
+
+        // Append a second CRLF after the request headers and before the
+        // request body.
+        sb.append("\r\n");
 
         if (!useGET) {
             sb.append(sb1.toString());


### PR DESCRIPTION
`AdminConnection`'s `processRequest` method creates a hand-rolled HTTP
request to the remote server. This is used by PKI Console when
authenticated as an administrator. Because of the recent CVE fix in
Tomcat (CVE-2020-1935), Tomcat will no longer accept `\n` (Line Feed)
terminated requests and headers, and instead reject them as a bad
request. We fix this by adding the missing and required CR, per HTTP
specification.

This fixes the following exception in PKIConsole:

    java.io.IOException: 400
        at com.netscape.admin.certsrv.connection.JSSConnection.readHeader(JSSConnection.java:537)
        at com.netscape.admin.certsrv.connection.JSSConnection.initReadResponse(JSSConnection.java:497)
        at com.netscape.admin.certsrv.connection.JSSConnection.sendRequest(JSSConnection.java:411)
        at com.netscape.admin.certsrv.connection.AdminConnection.processRequest(AdminConnection.java:788)
        at com.netscape.admin.certsrv.connection.AdminConnection.sendRequest(AdminConnection.java:681)
        at com.netscape.admin.certsrv.connection.AdminConnection.sendRequest(AdminConnection.java:646)
        at com.netscape.admin.certsrv.connection.AdminConnection.authType(AdminConnection.java:379)
        at com.netscape.admin.certsrv.CMSServerInfo.getAuthType(CMSServerInfo.java:128)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`