### PR TITLE
Include all contents from pkidaemon into pki-server status

### DIFF
--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -179,6 +179,7 @@ class PKIServerCLI(pki.cli.CLI):
                 subsystem_type += ' (Security Domain)'
             print('    Type:                %s' % subsystem_type)
 
+            print('    SD Name:             %s' % ca.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 ca.config['securitydomain.host'],
                 ca.config['securitydomain.httpsadminport'])
@@ -209,6 +210,7 @@ class PKIServerCLI(pki.cli.CLI):
                 subsystem_type += ' (Standalone)'
             print('    Type:                %s' % subsystem_type)
 
+            print('    SD Name:             %s' % kra.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 kra.config['securitydomain.host'],
                 kra.config['securitydomain.httpsadminport'])
@@ -235,6 +237,7 @@ class PKIServerCLI(pki.cli.CLI):
                 subsystem_type += ' (Standalone)'
             print('    Type:                %s' % subsystem_type)
 
+            print('    SD Name:             %s' % ocsp.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 ocsp.config['securitydomain.host'],
                 ocsp.config['securitydomain.httpsadminport'])
@@ -263,6 +266,7 @@ class PKIServerCLI(pki.cli.CLI):
                 subsystem_type += ' Clone'
             print('    Type:                %s' % subsystem_type)
 
+            print('    SD Name:             %s' % tks.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 tks.config['securitydomain.host'],
                 tks.config['securitydomain.httpsadminport'])
@@ -287,6 +291,7 @@ class PKIServerCLI(pki.cli.CLI):
                 subsystem_type += ' Clone'
             print('    Type:                %s' % subsystem_type)
 
+            print('    SD Name:             %s' % tps.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 tps.config['securitydomain.host'],
                 tps.config['securitydomain.httpsadminport'])

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -876,10 +876,22 @@ class PKIServerFactory(object):
             instance_type = parts[0]
             instance_name = parts[1]
 
+        sysconfig_file = os.path.join('/etc/sysconfig', instance_name)
+
+        with open(sysconfig_file) as f:
+
+            nuxwdog_status = re.search('^USE_NUXWDOG=\"(.*)\"', f.read(), re.MULTILINE)
+
+            # Check if the regex was matched and then check if nuxwdog is enabled.
+            if nuxwdog_status and nuxwdog_status.group(1) == "true":
+                instance_type += '-nuxwdog'
+
+        logger.info("Loading instance type: %s", instance_type)
+
         if instance_type == 'tomcat':
             return pki.server.PKIServer(instance_name)
 
-        if instance_type == 'pki-tomcatd':
-            return PKIInstance(instance_name)
+        if instance_type.startswith('pki-tomcatd'):
+            return PKIInstance(instance_name, instance_type=instance_type)
 
         raise Exception('Unsupported instance type: %s' % instance_type)


### PR DESCRIPTION
This patch:

1. Includes the Security Domain Name in the `pki-server status` CLI (mimics `pkidaemon`)
2. Allows `pki-server status` to pickup the right systemd unit file based on the nuxwdog status

Fixes: [BZ#1732981](https://bugzilla.redhat.com/show_bug.cgi?id=1732981) and [2806](https://pagure.io/dogtagpki/issue/2806)

### Comparison
#### `pkidaemon`

````
WARNING: pkidaemon status has been deprecated. Use pki-server status instead.
Status for pki-tomcat: pki-tomcat is running ..

    [CA Status Definitions]
    Secure Agent URL    = https://mkd.fedora.office:8443/ca/agent/ca
    Secure EE URL       = https://mkd.fedora.office:8443/ca/ee/ca
    Secure Admin URL    = https://mkd.fedora.office:8443/ca/services
    PKI Console Command = pkiconsole https://mkd.fedora.office:8443/ca
    Tomcat Port         = 8005 (for shutdown)

    [KRA Status Definitions]
    Secure Admin URL    = https://mkd.fedora.office:8443/kra/services
    PKI Console Command = pkiconsole https://mkd.fedora.office:8443/kra
    Tomcat Port         = 8005 (for shutdown)

    [OCSP Status Definitions]
    Secure Agent URL    = https://mkd.fedora.office:8443/ocsp/agent/ocsp
    Secure EE URL       = https://mkd.fedora.office:8443/ocsp/ee/ocsp/<ocsp request blob>
    Secure Admin URL    = https://mkd.fedora.office:8443/ocsp/services
    PKI Console Command = pkiconsole https://mkd.fedora.office:8443/ocsp
    Tomcat Port         = 8005 (for shutdown)

    [TKS Status Definitions]
    Secure Admin URL    = https://mkd.fedora.office:8443/tks/services
    PKI Console Command = pkiconsole https://mkd.fedora.office:8443/tks
    Tomcat Port         = 8005 (for shutdown)

    [TPS Status Definitions]
    Secure URL          = https://mkd.fedora.office:8443/tps
    Unsecure PHONE HOME = http://mkd.fedora.office:8080/tps/phoneHome
    Secure PHONE HOME   = https://mkd.fedora.office:8443/tps/phoneHome
    Tomcat Port         = 8005 (for shutdown)

    [CA Configuration Definitions]
    PKI Instance Name:   pki-tomcat

    PKI Subsystem Type:  Subordinate CA (Security Domain)

    Registered PKI Security Domain Information:
    ==========================================================================
    Name:  EXAMPLE                         
    URL:   https://mkd.fedora.office:8443
    ==========================================================================

    [KRA Configuration Definitions]
    PKI Instance Name:   pki-tomcat

    PKI Subsystem Type:  KRA

    Registered PKI Security Domain Information:
    ==========================================================================
    Name:  EXAMPLE
    URL:   https://mkd.fedora.office:8443
    ==========================================================================

    [OCSP Configuration Definitions]
    PKI Instance Name:   pki-tomcat

    PKI Subsystem Type:  OCSP

    Registered PKI Security Domain Information:
    ==========================================================================
    Name:  EXAMPLE
    URL:   https://mkd.fedora.office:8443
    ==========================================================================

    [TKS Configuration Definitions]
    PKI Instance Name:   pki-tomcat

    PKI Subsystem Type:  TKS

    Registered PKI Security Domain Information:
    ==========================================================================
    Name:  EXAMPLE
    URL:   https://mkd.fedora.office:8443
    ==========================================================================

    [TPS Configuration Definitions]
    PKI Instance Name:   pki-tomcat

    PKI Subsystem Type:  TPS

    Registered PKI Security Domain Information:
    ==========================================================================
    Name:  EXAMPLE
    URL:   https://mkd.fedora.office:8443
    ==========================================================================
````

#### `pkiserver status`

````
# pki-server status
  Instance ID: pki-tomcat
  Active: True
  Unsecure Port: 8080
  Secure Port: 8443
  Tomcat Port: 8005

  CA Subsystem:
    Type:                Subordinate CA (Security Domain)
    SD Name:             EXAMPLE
    SD Registration URL: https://mkd.fedora.office:8443
    Enabled:             True
    Unsecure URL:        http://mkd.fedora.office:8080/ca/ee/ca
    Secure Agent URL:    https://mkd.fedora.office:8443/ca/agent/ca
    Secure EE URL:       https://mkd.fedora.office:8443/ca/ee/ca
    Secure Admin URL:    https://mkd.fedora.office:8443/ca/services
    PKI Console URL:     https://mkd.fedora.office:8443/ca

  KRA Subsystem:
    Type:                KRA
    SD Name:             EXAMPLE
    SD Registration URL: https://mkd.fedora.office:8443
    Enabled:             True
    Secure Agent URL:    https://mkd.fedora.office:8443/kra/agent/kra
    Secure Admin URL:    https://mkd.fedora.office:8443/kra/services
    PKI Console URL:     https://mkd.fedora.office:8443/kra

  OCSP Subsystem:
    Type:                OCSP
    SD Name:             EXAMPLE
    SD Registration URL: https://mkd.fedora.office:8443
    Enabled:             True
    Unsecure URL:        http://mkd.fedora.office:8080/ocsp/ee/ocsp/<ocsp request blob>
    Secure Agent URL:    https://mkd.fedora.office:8443/ocsp/agent/ocsp
    Secure EE URL:       https://mkd.fedora.office:8443/ocsp/ee/ocsp/<ocsp request blob>
    Secure Admin URL:    https://mkd.fedora.office:8443/ocsp/services
    PKI Console URL:     https://mkd.fedora.office:8443/ocsp

  TKS Subsystem:
    Type:                TKS
    SD Name:             EXAMPLE
    SD Registration URL: https://mkd.fedora.office:8443
    Enabled:             True
    Secure Agent URL:    https://mkd.fedora.office:8443/tks/agent/tks
    Secure Admin URL:    https://mkd.fedora.office:8443/tks/services
    PKI Console URL:     https://mkd.fedora.office:8443/tks

  TPS Subsystem:
    Type:                TPS
    SD Name:             EXAMPLE
    SD Registration URL: https://mkd.fedora.office:8443
    Enabled:             True
    Unsecure URL:        http://mkd.fedora.office:8080/tps
    Unsecure PHONE HOME: http://mkd.fedora.office:8080/tps/phoneHome
    Secure URL:          https://mkd.fedora.office:8443/tps
    Secure PHONE HOME:   https://mkd.fedora.office:8443/tps/phoneHome
````