### PR TITLE
Fix pylint issue in healthcheck

### DIFF
--- a/base/server/healthcheck/pki/server/healthcheck/certs/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/plugin.py
@@ -27,7 +27,7 @@ class CertsPlugin(Plugin):
 
 
 class CertsRegistry(Registry):
-    def initialize(self, framework, config):
+    def initialize(self, framework, config, options=None):
         # Read dogtag specific config values and merge with already existing config
         # before adding it to registry
         merge_dogtag_config(config)

--- a/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/plugin.py
@@ -26,7 +26,7 @@ class MetaPlugin(Plugin):
 
 
 class MetaRegistry(Registry):
-    def initialize(self, framework, config):
+    def initialize(self, framework, config, options=None):
         # Read dogtag specific config values and merge with already existing config
         # before adding it to registry
         merge_dogtag_config(config)


### PR DESCRIPTION
This patch fixes the pylint issue caught in our CI. This
is a regression of change introduced in freeipa-healthcheck:

https://github.com/freeipa/freeipa-healthcheck/commit/d247c6158169a4ff97cd35ac57fec4e355617c52#diff-3aa64e1b97b8e0bf584a86cbe79986c4

Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>