### PR TITLE
Move from sudo to runuser

### DIFF
--- a/.github/workflows/required-tests.yml
+++ b/.github/workflows/required-tests.yml
@@ -123,7 +123,7 @@ jobs:
           run: tar -xzf pki-build-${{ matrix.os }}/pki-rpms.tar.gz
 
         - name: Install required packages
-          run: docker exec -i ${CONTAINER} dnf install -y findutils dnf-plugins-core sudo wget 389-ds-base
+          run: docker exec -i ${CONTAINER} dnf install -y findutils dnf-plugins-core wget 389-ds-base
 
         - name: Enable PKI COPR repo
           run: docker exec -i ${CONTAINER} dnf copr enable -y ${COPR_REPO}

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -316,7 +316,7 @@ class PKIServer(object):
 
             # switch to systemd user if different from current user
             if current_user != self.user:
-                prefix.extend(['sudo', '-u', self.user])
+                prefix.extend(['runuser', '-u', self.user, '--'])
 
         java_path = os.getenv('PKI_JAVA_PATH')
         java_home = self.config.get('JAVA_HOME')

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -198,7 +198,7 @@ class PKIInstance(pki.server.PKIServer):
 
                 # switch to systemd user if different from current user
                 if current_user != self.user:
-                    prefix.extend(['sudo', '-u', self.user])
+                    prefix.extend(['runuser', '-u', self.user, '--'])
 
             cmd = prefix + ['/usr/sbin/pki-server', 'upgrade']
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1100,7 +1100,7 @@ class PKISubsystem(object):
             # switch to systemd user if different from current user
             username = pwd.getpwuid(os.getuid()).pw_name
             if username != self.instance.user:
-                cmd.extend(['sudo', '-u', self.instance.user])
+                cmd.extend(['runuser', '-u', self.instance.user, '--'])
 
         if os.path.exists(java_path):
             cmd.extend([java_path])


### PR DESCRIPTION
This patch migrates usage of sudo to runuser. In containers,
sudo is not installed by default. Whereas, `runuser` is part of
'util-linux' pacakge, whcih is installed by default

Fixes: https://pagure.io/dogtagpki/issue/3171

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`