### PR TITLE
Updated retention policy for ACME authorizations, orders, and certificates

### DIFF
--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -24,5 +24,14 @@ policy.retention.validAuthorizations.unit=MINUTES
 policy.retention.pendingOrders.length=30
 policy.retention.pendingOrders.unit=MINUTES
 
+policy.retention.invalidOrders.length=30
+policy.retention.invalidOrders.unit=MINUTES
+
+policy.retention.readyOrders.length=30
+policy.retention.readyOrders.unit=MINUTES
+
+policy.retention.processingOrders.length=30
+policy.retention.processingOrders.unit=MINUTES
+
 policy.retention.validOrders.length=30
 policy.retention.validOrders.unit=MINUTES

--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -12,6 +12,12 @@ policy.wildcard=true
 policy.retention.nonces.length=30
 policy.retention.nonces.unit=MINUTES
 
+policy.retention.pendingAuthorizations.length=30
+policy.retention.pendingAuthorizations.unit=MINUTES
+
+policy.retention.invalidAuthorizations.length=30
+policy.retention.invalidAuthorizations.unit=MINUTES
+
 policy.retention.validAuthorizations.length=30
 policy.retention.validAuthorizations.unit=MINUTES
 

--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -8,15 +8,15 @@ enabled=true
 # Whether to accept wildcard DNS identifiers:
 policy.wildcard=true
 
-# Validity policies
-policy.nonceValidity.length=30
-policy.nonceValidity.unit=MINUTES
+# Database record retention policies:
+policy.retention.nonces.length=30
+policy.retention.nonces.unit=MINUTES
 
-policy.validAuthorizationValidity.length=30
-policy.validAuthorizationValidity.unit=MINUTES
+policy.retention.validAuthorizations.length=30
+policy.retention.validAuthorizations.unit=MINUTES
 
-policy.pendingOrderValidity.length=30
-policy.pendingOrderValidity.unit=MINUTES
+policy.retention.pendingOrders.length=30
+policy.retention.pendingOrders.unit=MINUTES
 
-policy.validOrderValidity.length=30
-policy.validOrderValidity.unit=MINUTES
+policy.retention.validOrders.length=30
+policy.retention.validOrders.unit=MINUTES

--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -35,3 +35,6 @@ policy.retention.processingOrders.unit=MINUTES
 
 policy.retention.validOrders.length=30
 policy.retention.validOrders.unit=MINUTES
+
+policy.retention.certificates.length=30
+policy.retention.certificates.unit=DAYS

--- a/base/acme/database/ldap/schema.ldif
+++ b/base/acme/database/ldap/schema.ldif
@@ -88,4 +88,5 @@ objectClasses: ( acmeChallengeHttp01-oid NAME 'acmeChallengeHttp01'
   MUST acmeToken )
 objectClasses: ( acmeCertificate-oid NAME 'acmeCertificate'
   STRUCTURAL
-  MUST ( acmeCertificateId $ userCertificate ) )
+  MUST ( acmeCertificateId $ userCertificate )
+  MAY acmeExpires )

--- a/base/acme/database/postgresql/create.sql
+++ b/base/acme/database/postgresql/create.sql
@@ -56,5 +56,6 @@ CREATE TABLE "authorization_challenges" (
 
 CREATE TABLE "certificates" (
     "id"               VARCHAR PRIMARY KEY,
-    "data"             BYTEA
+    "data"             BYTEA,
+    "expires"          TIMESTAMP
 );

--- a/base/acme/database/postgresql/statements.conf
+++ b/base/acme/database/postgresql/statements.conf
@@ -234,7 +234,7 @@ VALUES \
 
 getCertificate=\
 SELECT \
-    "data" \
+    "data", "expires" \
 FROM \
     "certificates" \
 WHERE \

--- a/base/acme/database/postgresql/statements.conf
+++ b/base/acme/database/postgresql/statements.conf
@@ -240,11 +240,19 @@ FROM \
 WHERE \
     "id" = ?
 
+getExpiredCertificateIDs=\
+SELECT \
+    "id" \
+FROM \
+    "certificates" \
+WHERE \
+    "expires" <= ?
+
 addCertificate=\
 INSERT INTO \
-    "certificates" ("id", "data") \
+    "certificates" ("id", "data", "expires") \
 VALUES \
-    (?, ?)
+    (?, ?, ?)
 
 removeCertificate=\
 DELETE FROM \

--- a/base/acme/src/main/java/org/dogtagpki/acme/ACMECertificate.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/ACMECertificate.java
@@ -1,0 +1,81 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Endi S. Dewata
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ACMECertificate {
+
+    @JsonIgnore
+    private String id;
+
+    byte[] data;
+
+    @JsonIgnore
+    private Date expirationTime;
+
+    public String getID() {
+        return id;
+    }
+
+    public void setID(String id) {
+        this.id = id;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+
+    public Date getExpirationTime() {
+        return expirationTime;
+    }
+
+    public void setExpirationTime(Date expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+
+    public String getExpires() {
+        return expirationTime == null ? null : ACME.DATE_FORMAT.format(expirationTime);
+    }
+
+    public void setExpires(String expires) throws ParseException {
+        expirationTime = ACME.DATE_FORMAT.parse(expires);
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static ACMECertificate fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, ACMECertificate.class);
+    }
+
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
@@ -129,7 +129,7 @@ public abstract class ACMEDatabase {
         throw new NotImplementedException();
     }
 
-    public void removeCertificate(String certID) throws Exception {
+    public void removeExpiredCertificates(Date currentTime) throws Exception {
         throw new NotImplementedException();
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
@@ -5,13 +5,13 @@
 //
 package org.dogtagpki.acme.database;
 
-import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Date;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.dogtagpki.acme.ACMEAccount;
 import org.dogtagpki.acme.ACMEAuthorization;
+import org.dogtagpki.acme.ACMECertificate;
 import org.dogtagpki.acme.ACMEIdentifier;
 import org.dogtagpki.acme.ACMENonce;
 import org.dogtagpki.acme.ACMEOrder;
@@ -121,11 +121,11 @@ public abstract class ACMEDatabase {
         throw new NotImplementedException();
     }
 
-    public X509Certificate getCertificate(String certID) throws Exception {
+    public ACMECertificate getCertificate(String certID) throws Exception {
         throw new NotImplementedException();
     }
 
-    public void addCertificate(String certID, X509Certificate cert) throws Exception {
+    public void addCertificate(String certID, ACMECertificate certificate) throws Exception {
         throw new NotImplementedException();
     }
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
@@ -216,7 +216,7 @@ public class InMemoryDatabase extends ACMEDatabase {
         certificates.put(certID, cert);
     }
 
-    public void removeCertificate(String certID) throws Exception {
-        certificates.remove(certID);
+    public void removeExpiredCertificates(Date currentTime) throws Exception {
+        certificates.values().removeIf(n -> !currentTime.before(n.getNotAfter()));
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/InMemoryDatabase.java
@@ -5,7 +5,6 @@
 //
 package org.dogtagpki.acme.database;
 
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -14,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.dogtagpki.acme.ACMEAccount;
 import org.dogtagpki.acme.ACMEAuthorization;
+import org.dogtagpki.acme.ACMECertificate;
 import org.dogtagpki.acme.ACMEIdentifier;
 import org.dogtagpki.acme.ACMENonce;
 import org.dogtagpki.acme.ACMEOrder;
@@ -29,7 +29,7 @@ public class InMemoryDatabase extends ACMEDatabase {
     private Map<String, ACMEAccount> accounts = new ConcurrentHashMap<>();
     private Map<String, ACMEOrder> orders = new ConcurrentHashMap<>();
     private Map<String, ACMEAuthorization> authorizations = new ConcurrentHashMap<>();
-    private Map<String, X509Certificate> certificates = new ConcurrentHashMap<>();
+    private Map<String, ACMECertificate> certificates = new ConcurrentHashMap<>();
 
     public void init() throws Exception {
         logger.info("Initializing in-memory database");
@@ -208,15 +208,16 @@ public class InMemoryDatabase extends ACMEDatabase {
                 n -> n.getExpirationTime() != null && !currentTime.before(n.getExpirationTime()));
     }
 
-    public X509Certificate getCertificate(String certID) throws Exception {
+    public ACMECertificate getCertificate(String certID) throws Exception {
         return certificates.get(certID);
     }
 
-    public void addCertificate(String certID, X509Certificate cert) throws Exception {
-        certificates.put(certID, cert);
+    public void addCertificate(String certID, ACMECertificate certificate) throws Exception {
+        certificates.put(certID, certificate);
     }
 
     public void removeExpiredCertificates(Date currentTime) throws Exception {
-        certificates.values().removeIf(n -> !currentTime.before(n.getNotAfter()));
+        certificates.values().removeIf(
+                n -> n.getExpirationTime() != null && !currentTime.before(n.getExpirationTime()));
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/NSSIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/NSSIssuer.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.security.cert.X509Certificate;
 
 import org.apache.commons.codec.binary.Base64;
+import org.dogtagpki.acme.ACMECertificate;
 import org.dogtagpki.acme.database.ACMEDatabase;
 import org.dogtagpki.acme.server.ACMEEngine;
 import org.dogtagpki.nss.NSSDatabase;
@@ -109,7 +110,13 @@ public class NSSIssuer extends ACMEIssuer {
 
         BigInteger serialNumber = cert.getSerialNumber();
         String certID = Base64.encodeBase64URLSafeString(serialNumber.toByteArray());
-        acmeDatabase.addCertificate(certID, cert);
+
+        ACMECertificate certificate = new ACMECertificate();
+        certificate.setID(certID);
+        certificate.setData(cert.getEncoded());
+        certificate.setExpirationTime(cert.getNotAfter());
+
+        acmeDatabase.addCertificate(certID, certificate);
 
         return certID;
     }
@@ -135,7 +142,8 @@ public class NSSIssuer extends ACMEIssuer {
         ACMEEngine engine = ACMEEngine.getInstance();
         ACMEDatabase acmeDatabase = engine.getDatabase();
 
-        X509Certificate cert = acmeDatabase.getCertificate(certID);
+        ACMECertificate certificate = acmeDatabase.getCertificate(certID);
+        X509Certificate cert = new X509CertImpl(certificate.getData());
         X509Certificate[] certChain = getCACertificateChain();
 
         StringWriter sw = new StringWriter();

--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/NSSIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/NSSIssuer.java
@@ -11,6 +11,7 @@ import java.math.BigInteger;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.cert.X509Certificate;
+import java.util.Date;
 
 import org.apache.commons.codec.binary.Base64;
 import org.dogtagpki.acme.ACMECertificate;
@@ -114,7 +115,9 @@ public class NSSIssuer extends ACMEIssuer {
         ACMECertificate certificate = new ACMECertificate();
         certificate.setID(certID);
         certificate.setData(cert.getEncoded());
-        certificate.setExpirationTime(cert.getNotAfter());
+
+        Date expirationTime = engine.getPolicy().getCertificateExpirationTime(cert.getNotAfter());
+        certificate.setExpirationTime(expirationTime);
 
         acmeDatabase.addCertificate(certID, certificate);
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/scheduler/ACMEMaintenanceTask.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/scheduler/ACMEMaintenanceTask.java
@@ -29,5 +29,6 @@ public class ACMEMaintenanceTask extends ACMETask {
         database.removeExpiredNonces(currentTime);
         database.removeExpiredAuthorizations(currentTime);
         database.removeExpiredOrders(currentTime);
+        database.removeExpiredCertificates(currentTime);
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
@@ -129,6 +129,8 @@ public class ACMEChallengeProcessor implements Runnable {
 
     public void finalizeInvalidAuthorization(Exception e) throws Exception {
 
+        Date currentTime = new Date();
+
         ACMEEngine engine = ACMEEngine.getInstance();
         String authzID = authorization.getID();
         String challengeID = challenge.getID();
@@ -164,7 +166,9 @@ public class ACMEChallengeProcessor implements Runnable {
 
         logger.info("Authorization " + authzID + " is invalid");
         authorization.setStatus("invalid");
-        authorization.setExpirationTime(null);
+
+        Date expirationTime = engine.getPolicy().getInvalidAuthorizationExpirationTime(currentTime);
+        authorization.setExpirationTime(expirationTime);
 
         engine.updateAuthorization(account, authorization);
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeProcessor.java
@@ -121,7 +121,9 @@ public class ACMEChallengeProcessor implements Runnable {
 
             logger.info("Order " + order.getID() + " is ready");
             order.setStatus("ready");
-            order.setExpirationTime(null);
+
+            Date orderExpirationTime = engine.getPolicy().getReadyOrderExpirationTime(currentTime);
+            order.setExpirationTime(orderExpirationTime);
 
             engine.updateOrder(account, order);
         }
@@ -199,7 +201,9 @@ public class ACMEChallengeProcessor implements Runnable {
 
             logger.info("Order " + order.getID() + " is invalid");
             order.setStatus("invalid");
-            order.setExpirationTime(null);
+
+            Date orderExpirationTime = engine.getPolicy().getInvalidOrderExpirationTime(currentTime);
+            order.setExpirationTime(orderExpirationTime);
 
             engine.updateOrder(account, order);
         }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -205,10 +205,10 @@ public class ACMEEngine implements ServletContextListener {
 
         ACMEPolicyConfig policyConfig = config.getPolicyConfig();
         logger.info("- wildcard: " + policyConfig.getEnableWildcards());
-        logger.info("- nonce validity: " + policyConfig.getNonceValidity());
-        logger.info("- valid authorization validity: " + policyConfig.getValidAuthorizationValidity());
-        logger.info("- pending order validity: " + policyConfig.getPendingOrderValidity());
-        logger.info("- valid order validity: " + policyConfig.getValidOrderValidity());
+        logger.info("- nonce retention: " + policyConfig.getRetention().getNonces());
+        logger.info("- valid authorization retention: " + policyConfig.getRetention().getValidAuthorizations());
+        logger.info("- pending order retention: " + policyConfig.getRetention().getPendingOrders());
+        logger.info("- valid order retention: " + policyConfig.getRetention().getValidOrders());
 
         policy = new ACMEPolicy(policyConfig);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -210,8 +210,12 @@ public class ACMEEngine implements ServletContextListener {
         logger.info("  - pending: " + policyConfig.getRetention().getPendingAuthorizations());
         logger.info("  - invalid: " + policyConfig.getRetention().getInvalidAuthorizations());
         logger.info("  - valid: " + policyConfig.getRetention().getValidAuthorizations());
-        logger.info("- pending order retention: " + policyConfig.getRetention().getPendingOrders());
-        logger.info("- valid order retention: " + policyConfig.getRetention().getValidOrders());
+        logger.info("- order retention:");
+        logger.info("  - pending: " + policyConfig.getRetention().getPendingOrders());
+        logger.info("  - invalid: " + policyConfig.getRetention().getInvalidOrders());
+        logger.info("  - ready: " + policyConfig.getRetention().getReadyOrders());
+        logger.info("  - processing: " + policyConfig.getRetention().getProcessingOrders());
+        logger.info("  - valid: " + policyConfig.getRetention().getValidOrders());
 
         policy = new ACMEPolicy(policyConfig);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -206,7 +206,10 @@ public class ACMEEngine implements ServletContextListener {
         ACMEPolicyConfig policyConfig = config.getPolicyConfig();
         logger.info("- wildcard: " + policyConfig.getEnableWildcards());
         logger.info("- nonce retention: " + policyConfig.getRetention().getNonces());
-        logger.info("- valid authorization retention: " + policyConfig.getRetention().getValidAuthorizations());
+        logger.info("- authorization retention:");
+        logger.info("  - pending: " + policyConfig.getRetention().getPendingAuthorizations());
+        logger.info("  - invalid: " + policyConfig.getRetention().getInvalidAuthorizations());
+        logger.info("  - valid: " + policyConfig.getRetention().getValidAuthorizations());
         logger.info("- pending order retention: " + policyConfig.getRetention().getPendingOrders());
         logger.info("- valid order retention: " + policyConfig.getRetention().getValidOrders());
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -216,6 +216,7 @@ public class ACMEEngine implements ServletContextListener {
         logger.info("  - ready: " + policyConfig.getRetention().getReadyOrders());
         logger.info("  - processing: " + policyConfig.getRetention().getProcessingOrders());
         logger.info("  - valid: " + policyConfig.getRetention().getValidOrders());
+        logger.info("- certificate retention: " + policyConfig.getRetention().getCertificates());
 
         policy = new ACMEPolicy(policyConfig);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
@@ -70,7 +70,9 @@ public class ACMEFinalizeOrderService {
         }
 
         order.setStatus("processing");
-        order.setExpirationTime(null);
+
+        Date processingOrderExpirationTime = engine.getPolicy().getProcessingOrderExpirationTime(new Date());
+        order.setExpirationTime(processingOrderExpirationTime);
 
         engine.updateOrder(account, order);
 
@@ -99,8 +101,8 @@ public class ACMEFinalizeOrderService {
 
         order.setStatus("valid");
 
-        Date expirationTime = engine.getPolicy().getValidOrderExpirationTime(new Date());
-        order.setExpirationTime(expirationTime);
+        Date validOrderExpirationTime = engine.getPolicy().getValidOrderExpirationTime(new Date());
+        order.setExpirationTime(validOrderExpirationTime);
 
         engine.updateOrder(account, order);
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewOrderService.java
@@ -43,6 +43,7 @@ public class ACMENewOrderService {
     public Response createNewOrder(JWS jws) throws Exception {
 
         logger.info("Creating new order");
+        Date currentTime = new Date();
 
         String protectedHeader = new String(jws.getProtectedHeaderAsBytes(), "UTF-8");
         logger.info("Header: " + protectedHeader);
@@ -108,7 +109,9 @@ public class ACMENewOrderService {
             authorization.setWildcard(wildcard);
 
             authorization.setStatus("pending");
-            authorization.setExpirationTime(null);
+
+            Date expirationTime = engine.getPolicy().getPendingAuthorizationExpirationTime(currentTime);
+            authorization.setExpirationTime(expirationTime);
 
             engine.addAuthorization(account, authorization);
 
@@ -135,7 +138,7 @@ public class ACMENewOrderService {
 
         order.setStatus("pending");
 
-        Date expirationTime = engine.getPolicy().getPendingOrderExpirationTime(new Date());
+        Date expirationTime = engine.getPolicy().getPendingOrderExpirationTime(currentTime);
         order.setExpirationTime(expirationTime);
 
         engine.addOrder(account, order);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
@@ -125,4 +125,8 @@ public class ACMEPolicy {
     public Date getValidOrderExpirationTime(Date currentTime) {
         return config.getRetention().getValidOrders().getExpirationTime(currentTime);
     }
+
+    public Date getCertificateExpirationTime(Date currentTime) {
+        return config.getRetention().getCertificates().getExpirationTime(currentTime);
+    }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
@@ -110,6 +110,18 @@ public class ACMEPolicy {
         return config.getRetention().getPendingOrders().getExpirationTime(currentTime);
     }
 
+    public Date getInvalidOrderExpirationTime(Date currentTime) {
+        return config.getRetention().getInvalidOrders().getExpirationTime(currentTime);
+    }
+
+    public Date getReadyOrderExpirationTime(Date currentTime) {
+        return config.getRetention().getReadyOrders().getExpirationTime(currentTime);
+    }
+
+    public Date getProcessingOrderExpirationTime(Date currentTime) {
+        return config.getRetention().getProcessingOrders().getExpirationTime(currentTime);
+    }
+
     public Date getValidOrderExpirationTime(Date currentTime) {
         return config.getRetention().getValidOrders().getExpirationTime(currentTime);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
@@ -91,18 +91,18 @@ public class ACMEPolicy {
     }
 
     public Date getNonceExpirationTime(Date currentTime) {
-        return config.getNonceValidity().getExpirationTime(currentTime);
+        return config.getRetention().getNonces().getExpirationTime(currentTime);
     }
 
     public Date getValidAuthorizationExpirationTime(Date currentTime) {
-        return config.getValidAuthorizationValidity().getExpirationTime(currentTime);
+        return config.getRetention().getValidAuthorizations().getExpirationTime(currentTime);
     }
 
     public Date getPendingOrderExpirationTime(Date currentTime) {
-        return config.getPendingOrderValidity().getExpirationTime(currentTime);
+        return config.getRetention().getPendingOrders().getExpirationTime(currentTime);
     }
 
     public Date getValidOrderExpirationTime(Date currentTime) {
-        return config.getValidOrderValidity().getExpirationTime(currentTime);
+        return config.getRetention().getValidOrders().getExpirationTime(currentTime);
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicy.java
@@ -94,6 +94,14 @@ public class ACMEPolicy {
         return config.getRetention().getNonces().getExpirationTime(currentTime);
     }
 
+    public Date getPendingAuthorizationExpirationTime(Date currentTime) {
+        return config.getRetention().getPendingAuthorizations().getExpirationTime(currentTime);
+    }
+
+    public Date getInvalidAuthorizationExpirationTime(Date currentTime) {
+        return config.getRetention().getInvalidAuthorizations().getExpirationTime(currentTime);
+    }
+
     public Date getValidAuthorizationExpirationTime(Date currentTime) {
         return config.getRetention().getValidAuthorizations().getExpirationTime(currentTime);
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicyConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEPolicyConfig.java
@@ -5,8 +5,6 @@
 //
 package org.dogtagpki.acme.server;
 
-import java.lang.reflect.Field;
-import java.time.temporal.ChronoUnit;
 import java.util.Map.Entry;
 import java.util.Properties;
 
@@ -28,10 +26,8 @@ public class ACMEPolicyConfig {
     @JsonProperty("wildcard")
     private Boolean enableWildcardIssuance = true;
 
-    private ACMEValidityConfig nonceValidity = new ACMEValidityConfig(30l, ChronoUnit.MINUTES);
-    private ACMEValidityConfig validAuthorizationValidity = new ACMEValidityConfig(30l, ChronoUnit.MINUTES);
-    private ACMEValidityConfig pendingOrderValidity = new ACMEValidityConfig(30l, ChronoUnit.MINUTES);
-    private ACMEValidityConfig validOrderValidity = new ACMEValidityConfig(30l, ChronoUnit.MINUTES);
+    @JsonProperty("retention")
+    private ACMERetentionConfig retention = new ACMERetentionConfig();
 
     public ACMEPolicyConfig() {}
 
@@ -44,36 +40,12 @@ public class ACMEPolicyConfig {
         enableWildcardIssuance = on;
     }
 
-    public ACMEValidityConfig getNonceValidity() {
-        return nonceValidity;
+    public ACMERetentionConfig getRetention() {
+        return retention;
     }
 
-    public void setNonceValidity(ACMEValidityConfig nonceValidity) {
-        this.nonceValidity = nonceValidity;
-    }
-
-    public ACMEValidityConfig getValidAuthorizationValidity() {
-        return validAuthorizationValidity;
-    }
-
-    public void setValidAuthorizationValidity(ACMEValidityConfig validAuthorizationValidity) {
-        this.validAuthorizationValidity = validAuthorizationValidity;
-    }
-
-    public ACMEValidityConfig getPendingOrderValidity() {
-        return pendingOrderValidity;
-    }
-
-    public void setPendingOrderValidity(ACMEValidityConfig pendingOrderValidity) {
-        this.pendingOrderValidity = pendingOrderValidity;
-    }
-
-    public ACMEValidityConfig getValidOrderValidity() {
-        return validOrderValidity;
-    }
-
-    public void setValidOrderValidity(ACMEValidityConfig validOrderValidity) {
-        this.validOrderValidity = validOrderValidity;
+    public void setRetention(ACMERetentionConfig retentionPolicy) {
+        this.retention = retentionPolicy;
     }
 
     public void setProperty(String key, String value) throws Exception {
@@ -83,21 +55,10 @@ public class ACMEPolicyConfig {
             return;
         }
 
-        // split key by dots
-        String[] parts = key.split("\\.");
-        String validityName = parts[0];
-        String validityParam = parts[1];
-
-        Field field = ACMEPolicyConfig.class.getDeclaredField(validityName);
-        field.setAccessible(true);
-
-        ACMEValidityConfig validity = (ACMEValidityConfig) field.get(this);
-        if (validity == null) {
-            validity = new ACMEValidityConfig();
-            field.set(this, validity);
+        if (key.startsWith("retention.")) {
+            String retentionKey = key.substring(10);
+            retention.setProperty(retentionKey, value);
         }
-
-        validity.setProperty(validityParam, value);
     }
 
     public String toJSON() throws Exception {
@@ -132,7 +93,7 @@ public class ACMEPolicyConfig {
     }
 
     public static void main(String[] args) {
-        ACMEPolicyConfig policyConfig = new ACMEPolicyConfig();
-        System.out.println(policyConfig);
+        ACMEPolicyConfig config = new ACMEPolicyConfig();
+        System.out.println(config);
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetention.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetention.java
@@ -21,16 +21,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class ACMEValidityConfig {
+public class ACMERetention {
 
     private Long length;
     private ChronoUnit unit;
 
-    public ACMEValidityConfig() {
+    public ACMERetention() {
     }
 
-    public ACMEValidityConfig(Long length, ChronoUnit unit) {
+    public ACMERetention(Long length, ChronoUnit unit) {
         this.length = length;
+        this.unit = unit;
+    }
+
+    public ACMERetention(Integer length, ChronoUnit unit) {
+        this.length = Long.valueOf(length);
         this.unit = unit;
     }
 
@@ -81,9 +86,9 @@ public class ACMEValidityConfig {
         return mapper.writeValueAsString(this);
     }
 
-    public static ACMEValidityConfig fromJSON(String json) throws Exception {
+    public static ACMERetention fromJSON(String json) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, ACMEValidityConfig.class);
+        return mapper.readValue(json, ACMERetention.class);
     }
 
     public String toString() {
@@ -95,7 +100,7 @@ public class ACMEValidityConfig {
     }
 
     public static void main(String[] args) {
-        ACMEValidityConfig validityConfig = new ACMEValidityConfig(30l, ChronoUnit.MINUTES);
-        System.out.println(validityConfig);
+        ACMERetention retention = new ACMERetention(30, ChronoUnit.MINUTES);
+        System.out.println(retention);
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetentionConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetentionConfig.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class ACMERetentionConfig {
 
     private ACMERetention nonces = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention pendingAuthorizations = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention invalidAuthorizations = new ACMERetention(30, ChronoUnit.MINUTES);
     private ACMERetention validAuthorizations = new ACMERetention(30, ChronoUnit.MINUTES);
     private ACMERetention pendingOrders = new ACMERetention(30, ChronoUnit.MINUTES);
     private ACMERetention validOrders = new ACMERetention(30, ChronoUnit.MINUTES);
@@ -32,6 +34,22 @@ public class ACMERetentionConfig {
 
     public void setNonces(ACMERetention nonces) {
         this.nonces = nonces;
+    }
+
+    public ACMERetention getPendingAuthorizations() {
+        return pendingAuthorizations;
+    }
+
+    public void setPendingAuthorizations(ACMERetention pendingAuthorizations) {
+        this.pendingAuthorizations = pendingAuthorizations;
+    }
+
+    public ACMERetention getInvalidAuthorizations() {
+        return invalidAuthorizations;
+    }
+
+    public void setInvalidAuthorizations(ACMERetention invalidAuthorizations) {
+        this.invalidAuthorizations = invalidAuthorizations;
     }
 
     public ACMERetention getValidAuthorizations() {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetentionConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetentionConfig.java
@@ -1,0 +1,115 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.lang.reflect.Field;
+import java.time.temporal.ChronoUnit;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ACMERetentionConfig {
+
+    private ACMERetention nonces = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention validAuthorizations = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention pendingOrders = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention validOrders = new ACMERetention(30, ChronoUnit.MINUTES);
+
+    public ACMERetentionConfig() {}
+
+    public ACMERetention getNonces() {
+        return nonces;
+    }
+
+    public void setNonces(ACMERetention nonces) {
+        this.nonces = nonces;
+    }
+
+    public ACMERetention getValidAuthorizations() {
+        return validAuthorizations;
+    }
+
+    public void setValidAuthorizations(ACMERetention validAuthorizations) {
+        this.validAuthorizations = validAuthorizations;
+    }
+
+    public ACMERetention getPendingOrders() {
+        return pendingOrders;
+    }
+
+    public void setPendingOrders(ACMERetention pendingOrders) {
+        this.pendingOrders = pendingOrders;
+    }
+
+    public ACMERetention getValidOrders() {
+        return validOrders;
+    }
+
+    public void setValidOrders(ACMERetention validOrders) {
+        this.validOrders = validOrders;
+    }
+
+    public void setProperty(String key, String value) throws Exception {
+
+        // split key by dots
+        String[] parts = key.split("\\.");
+        String name = parts[0];
+        String param = parts[1];
+
+        Field field = ACMERetentionConfig.class.getDeclaredField(name);
+        field.setAccessible(true);
+
+        ACMERetention retention = (ACMERetention) field.get(this);
+        if (retention == null) {
+            retention = new ACMERetention();
+            field.set(this, retention);
+        }
+
+        retention.setProperty(param, value);
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static ACMERetentionConfig fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, ACMERetentionConfig.class);
+    }
+
+    public static ACMERetentionConfig fromProperties(Properties props) throws Exception {
+
+        ACMERetentionConfig config = new ACMERetentionConfig();
+
+        for (Entry<Object, Object> entry : props.entrySet()) {
+            String key = entry.getKey().toString();
+            String value = entry.getValue().toString();
+            config.setProperty(key, value);
+        }
+
+        return config;
+    }
+
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        ACMERetentionConfig config = new ACMERetentionConfig();
+        System.out.println(config);
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetentionConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetentionConfig.java
@@ -28,6 +28,7 @@ public class ACMERetentionConfig {
     private ACMERetention readyOrders = new ACMERetention(30, ChronoUnit.MINUTES);
     private ACMERetention processingOrders = new ACMERetention(30, ChronoUnit.MINUTES);
     private ACMERetention validOrders = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention certificates = new ACMERetention(30, ChronoUnit.DAYS);
 
     public ACMERetentionConfig() {}
 
@@ -101,6 +102,14 @@ public class ACMERetentionConfig {
 
     public void setValidOrders(ACMERetention validOrders) {
         this.validOrders = validOrders;
+    }
+
+    public ACMERetention getCertificates() {
+        return certificates;
+    }
+
+    public void setCertificates(ACMERetention certificates) {
+        this.certificates = certificates;
     }
 
     public void setProperty(String key, String value) throws Exception {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetentionConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERetentionConfig.java
@@ -24,6 +24,9 @@ public class ACMERetentionConfig {
     private ACMERetention invalidAuthorizations = new ACMERetention(30, ChronoUnit.MINUTES);
     private ACMERetention validAuthorizations = new ACMERetention(30, ChronoUnit.MINUTES);
     private ACMERetention pendingOrders = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention invalidOrders = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention readyOrders = new ACMERetention(30, ChronoUnit.MINUTES);
+    private ACMERetention processingOrders = new ACMERetention(30, ChronoUnit.MINUTES);
     private ACMERetention validOrders = new ACMERetention(30, ChronoUnit.MINUTES);
 
     public ACMERetentionConfig() {}
@@ -66,6 +69,30 @@ public class ACMERetentionConfig {
 
     public void setPendingOrders(ACMERetention pendingOrders) {
         this.pendingOrders = pendingOrders;
+    }
+
+    public ACMERetention getInvalidOrders() {
+        return invalidOrders;
+    }
+
+    public void setInvalidOrders(ACMERetention invalidOrders) {
+        this.invalidOrders = invalidOrders;
+    }
+
+    public ACMERetention getReadyOrders() {
+        return readyOrders;
+    }
+
+    public void setReadyOrders(ACMERetention readyOrders) {
+        this.readyOrders = readyOrders;
+    }
+
+    public ACMERetention getProcessingOrders() {
+        return processingOrders;
+    }
+
+    public void setProcessingOrders(ACMERetention processingOrders) {
+        this.processingOrders = processingOrders;
     }
 
     public ACMERetention getValidOrders() {


### PR DESCRIPTION
The ACME responder has been modified to support retention
policies ACME authorization and order records in any state
and also certificate records.