### PR TITLE
Address RHCS-1347 dd healthcheck to test the health of clone.

### DIFF
--- a/base/server/healthcheck/pki/server/healthcheck/clones/connectivity_and_data.py
+++ b/base/server/healthcheck/pki/server/healthcheck/clones/connectivity_and_data.py
@@ -1,0 +1,210 @@
+# Authors:
+#  Jack Magne    <jmagne@redhat.com> #
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+import logging
+
+from pki.server.healthcheck.clones.plugin import ClonesPlugin, registry
+from pki.client import PKIConnection
+from pki.cert import CertClient
+from ipahealthcheck.core.plugin import Result, duration
+from ipahealthcheck.core import constants
+
+logger = logging.getLogger(__name__)
+
+
+@registry
+class ClonesConnectivyAndDataCheck(ClonesPlugin):
+    """
+    Assure master and clones within a  pki instance are reachable
+    """
+    def check_ca_clones(self):
+        for host in self.clone_cas:
+            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
+            # Reach out and get some certs, to serve as a data and connectivity check
+            try:
+                connection = PKIConnection(protocol='https',
+                                           hostname=host.Hostname,
+                                           port=host.SecurePort,
+                                           verify=False)
+
+                cert_client = CertClient(connection)
+                # get the first 3 in case we cant to make a sanity check of replicated data
+                certs = cert_client.list_certs(size=3)
+
+                if certs is not None and len(certs.cert_data_info_list) == 3:
+                    logger.info('Cert data successfully obtained from clone.')
+                else:
+                    raise BaseException('CA clone problem reading data.' + cur_clone_msg)
+            except BaseException as e:
+                logger.error("Internal server error %s", e)
+                raise BaseException('Internal error testing CA clone.' + cur_clone_msg)
+
+        return
+
+    def check_kra_clones(self):
+        for host in self.clone_kras:
+            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
+            # Reach out and get some keys or requests , to serve as a data and connectivity check
+            try:
+                client_nick = self.security_domain.config.get('ca.connector.KRA.nickName')
+
+                output = self.contact_subsystem_using_pki(
+                    host.SecurePort, host.Hostname, client_nick,
+                    self.passwd, self.db_dir, 'kra-key-show', ['0x01'])
+
+                # check to see if we either got a key or a key not found exception
+                # of which either will imply a successful connection
+                if output is not None:
+                    key_found = output.find('Key ID:')
+                    key_not_found = output.find('KeyNotFoundException:')
+                    if key_found >= 0:
+                        logger.info('Key material found from kra clone.')
+
+                    if key_not_found >= 0:
+                        logger.info('key not found, possibly empty kra')
+
+                    if key_not_found == -1 and key_found == -1:
+                        logger.info('Failure to get key material from kra')
+                        raise BaseException('KRA clone problem detected ' + cur_clone_msg)
+                else:
+                    raise BaseException('No data obtained from KRA clone.' + cur_clone_msg)
+
+            except BaseException as e:
+                logger.error("Internal error testing KRA clone. %s", e)
+                raise BaseException('Internal error testing KRA clone.' + cur_clone_msg)
+
+        return
+
+    def check_ocsp_clones(self):
+        for host in self.clone_ocsps:
+            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
+            # Reach out to the ocsp clones
+            try:
+                output = self.contact_subsystem_using_sslget(
+                    host.SecurePort, host.Hostname, None,
+                    self.passwd, self.db_dir, None, '/ocsp/admin/ocsp/getStatus')
+
+                good_status = output.find('<State>1</State>')
+                if good_status == -1:
+                    raise BaseException('OCSP clone problem detected.' + cur_clone_msg)
+                logger.info('good_status %s ', good_status)
+            except BaseException as e:
+                logger.error("Internal error testing OCSP clone.  %s", e)
+                raise BaseException('Internal error testing OCSP clone.' + cur_clone_msg)
+
+        return
+
+    def check_tks_clones(self):
+        for host in self.clone_tkss:
+            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
+            # Reach out to the tks clones
+            try:
+                output = self.contact_subsystem_using_sslget(
+                    host.SecurePort, host.Hostname, None,
+                    self.passwd, self.db_dir, None, '/tks/admin/tks/getStatus')
+
+                good_status = output.find('<State>1</State>')
+                if good_status == -1:
+                    raise BaseException('TKS clone problem detected.' + cur_clone_msg)
+                logger.info('good_status %s ', good_status)
+            except BaseException as e:
+                logger.error("Internal error testing TKS clone. %s", e)
+                raise BaseException('Internal error testing TKS clone.' + cur_clone_msg)
+
+        return
+
+    def check_tps_clones(self):
+        for host in self.clone_tpss:
+            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
+            # Reach out to the tps clones
+            try:
+                output = self.contact_subsystem_using_sslget(
+                    host.SecurePort, host.Hostname, None,
+                    self.passwd, self.db_dir, None, '/tps/admin/tps/getStatus')
+
+                good_status = output.find('<State>1</State>')
+                if good_status == -1:
+                    raise BaseException('TPS clone problem detected.' + cur_clone_msg)
+                logger.info('good_status  %s ', good_status)
+            except BaseException as e:
+                logger.error("Internal error testing TPS clone. %s", e)
+                raise BaseException('Internal error testing TPS clone.' + cur_clone_msg)
+        return
+
+    @duration
+    def check(self):
+        logger.info("Entering ClonesConnectivityCheck : %s", self.instance.name)
+        if not self.instance.exists():
+            logger.debug('Invalid instance: %s', self.instance.name)
+            yield Result(self, constants.CRITICAL,
+                         status='Invalid PKI instance: %s' % self.instance.name)
+            return
+        self.instance.load()
+
+        security_domain_ca, sechost, secport = self.get_security_domain_ca()
+        logger.info('security_domain_ca: %s ', security_domain_ca)
+
+        logger.info('sechost %s secport %s ', sechost, secport)
+        if security_domain_ca is None:
+            yield Result(self, constants.SUCCESS,
+                         status='Instance  not a security domain. %s' % self.instance.name)
+        security_domain_data = self.get_security_domain_data(sechost, secport)
+
+        if security_domain_data is not None:
+            logger.info('About to check the subsystem clones')
+
+            hard_msg = ' Clones tested successfully, or not present.'
+            try:
+                self.check_ca_clones()
+                yield Result(self, constants.SUCCESS,
+                             instance_name=self.instance.name,
+                             status='CA' + hard_msg)
+
+            except BaseException as e:
+                yield Result(self, constants.ERROR,
+                             status='ERROR:  %s' % self.instance.name + ' : ' + str(e))
+
+            try:
+                self.check_kra_clones()
+                yield Result(self, constants.SUCCESS,
+                             instance_name=self.instance.name,
+                             status='KRA' + hard_msg)
+            except BaseException as e:
+                yield Result(self, constants.ERROR,
+                             status='ERROR:  %s' % self.instance.name + ' : ' + str(e))
+
+            try:
+                self.check_ocsp_clones()
+                yield Result(self, constants.SUCCESS,
+                             instance_name=self.instance.name,
+                             status='OCSP' + hard_msg)
+            except BaseException as e:
+                yield Result(self, constants.ERROR,
+                             status='ERROR:  %s' % self.instance.name + ' : ' + str(e))
+
+            try:
+                self.check_tks_clones()
+                yield Result(self, constants.SUCCESS,
+                             instance_name=self.instance.name,
+                             status='TKS' + hard_msg)
+            except BaseException as e:
+                yield Result(self, constants.ERROR,
+                             status='ERROR:  %s' % self.instance.name + ' : ' + str(e))
+
+            try:
+                self.check_tps_clones()
+                yield Result(self, constants.SUCCESS,
+                             instance_name=self.instance.name,
+                             status="TPS Clones tested successfully, or not present.")
+            except BaseException as e:
+                yield Result(self, constants.ERROR,
+                             status='ERROR:  %s' % self.instance.name + ' : ' + str(e))
+        else:
+            yield Result(self, constants.SUCCESS,
+                         instance_name=self.instance.name,
+                         status='Instance has no security domain.')
+
+        return

--- a/base/server/healthcheck/pki/server/healthcheck/clones/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/clones/plugin.py
@@ -1,0 +1,185 @@
+# Authors:
+#     Jack Magne <jmagne@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from ipahealthcheck.core.plugin import Plugin, Registry
+from pki.server.instance import PKIInstance
+from pki.client import PKIConnection
+from pki.system import SecurityDomainClient
+
+from pki.server.healthcheck.core.main import merge_dogtag_config
+
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# Temporary workaround to skip VERBOSE data. Fix already pushed to upstream
+# freeipa-healthcheck: https://github.com/freeipa/freeipa-healthcheck/pull/126
+logging.getLogger().setLevel(logging.WARNING)
+
+
+class ClonesPlugin(Plugin):
+    def __init__(self, registry):
+        # pylint: disable=redefined-outer-name
+        super(ClonesPlugin, self).__init__(registry)
+
+        self.security_domain = None
+        self.db_dir = None
+        self.subsystem_token = None
+        self.passwd = None
+
+        self.master_cas = []
+        self.clone_cas = []
+        self.master_kras = []
+        self.clone_kras = []
+        self.master_ocsps = []
+        self.clone_ocsps = []
+        self.master_tpss = []
+        self.clone_tpss = []
+        self.master_tkss = []
+        self.clone_tkss = []
+
+        self.instance = PKIInstance(self.config.instance_name)
+
+    def contact_subsystem_using_pki(
+            self, subport, subhost, subsystemnick,
+            token_pwd, db_path, cmd, exts=None):
+        command = ["/usr/bin/pki",
+                   "-p", str(subport),
+                   "-h", subhost,
+                   "-n", subsystemnick,
+                   "-P", "https",
+                   "-d", db_path,
+                   "-c", token_pwd,
+                   cmd]
+
+        if exts is not None:
+            command.extend(exts)
+
+        output = None
+        try:
+            output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode('utf-8')
+            return output
+
+        output = output.decode('utf-8')
+
+        return output
+
+    def contact_subsystem_using_sslget(
+            self, port, host, subsystemnick,
+            token_pwd, db_path, params, url):
+
+        command = ["/usr/bin/sslget"]
+
+        if subsystemnick is not None:
+            command.extend(["-n", subsystemnick])
+
+        command.extend(["-p", token_pwd, "-d", db_path])
+
+        if params is not None:
+            command.extend(["-e", params])
+
+        command.extend([
+            "-r", url, host + ":" + port])
+
+        logger.info(' command : %s ', command)
+        output = None
+        try:
+            output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode('utf-8')
+            return output
+
+        output = output.decode('utf-8')
+
+        return output
+
+    def get_security_domain_data(self, host, port):
+        domain_data = None
+
+        try:
+            connection = PKIConnection(protocol='http',
+                                       hostname=host,
+                                       port=port,
+                                       verify=False)
+
+            securityDomainClient = SecurityDomainClient(connection)
+            domain_data = securityDomainClient.get_domain_info()
+
+        except BaseException as e:
+            logger.error("Internal server error %s", e)
+            return domain_data
+
+        systems = domain_data.subsystems
+        for s in systems.values():
+            for h in s.hosts.values():
+                if s.id == 'CA':
+                    if h.Clone == 'TRUE':
+                        self.clone_cas.append(h)
+                    else:
+                        self.master_cas.append(h)
+                elif s.id == 'KRA':
+                    if h.Clone == 'TRUE':
+                        self.clone_kras.append(h)
+                    else:
+                        self.master_kras.append(h)
+                elif s.id == 'OCSP':
+                    if h.Clone == 'TRUE':
+                        self.clone_ocsps.append(h)
+                    else:
+                        self.master_ocsps.append(h)
+                elif s.id == 'TPS':
+                    if h.Clone == 'TRUE':
+                        self.clone_tpss.append(h)
+                    else:
+                        self.master_tpss.append(h)
+                elif s.id == 'TKS':
+                    if h.Clone == 'TRUE':
+                        self.clone_tkss.append(h)
+                    else:
+                        self.master_tkss.append(h)
+
+        return domain_data
+
+    def get_security_domain_ca(self):
+        sec_domain = None
+        sechost = None
+        secport = None
+        ca_subsystem = self.instance.get_subsystem('ca')
+        if(ca_subsystem):
+            # make sure this CA is the security domain
+            service_host = ca_subsystem.config.get('service.machineName')
+            service_port = ca_subsystem.config.get('service.unsecurePort')
+            sechost = ca_subsystem.config.get('securitydomain.host')
+            secport = ca_subsystem.config.get('securitydomain.httpport')
+
+            if sechost == service_host and secport == service_port:
+                sec_domain = ca_subsystem
+
+        if sec_domain:
+            self.security_domain = sec_domain
+            # Set some vars we will be using later
+            self.db_dir = self.security_domain.config.get('jss.configDir')
+            self.subsystem_token = self.security_domain.config.get('ca.subsystem.tokenname')
+            self.passwd = self.instance.get_password(self.subsystem_token)
+
+        return sec_domain, sechost, secport
+
+
+class ClonesRegistry(Registry):
+    def initialize(self, framework, config, options=None):
+        # Read dogtag specific config values and merge with already existing config
+        # before adding it to registry
+        merge_dogtag_config(config)
+
+        super(ClonesRegistry, self).initialize(framework, config)
+
+
+registry = ClonesRegistry()

--- a/base/server/healthcheck/setup.py
+++ b/base/server/healthcheck/setup.py
@@ -9,7 +9,8 @@ setup(
     packages=[
         'pki.server.healthcheck.core',
         'pki.server.healthcheck.meta',
-        'pki.server.healthcheck.certs'
+        'pki.server.healthcheck.certs',
+        'pki.server.healthcheck.clones',
     ],
     entry_points={
         # creates bin/pki-healthcheck
@@ -20,21 +21,27 @@ setup(
         'ipahealthcheck.registry': [
             'pkihealthcheck.meta = pki.server.healthcheck.meta.plugin:registry',
             'pkihealthcheck.certs = pki.server.healthcheck.certs.plugin:registry',
+            'pkihealthcheck.clones = pki.server.healthcheck.clones.plugin:registry',
         ],
         # register the plugin with pki-healthcheck
         'pkihealthcheck.registry': [
             'pkihealthcheck.meta = pki.server.healthcheck.meta.plugin:registry',
             'pkihealthcheck.certs = pki.server.healthcheck.certs.plugin:registry',
+            'pkihealthcheck.clones = pki.server.healthcheck.clones.plugin:registry',
         ],
         # plugin modules for pkihealthcheck.meta registry
         'pkihealthcheck.meta': [
             'pki_certs = pki.server.healthcheck.meta.csconfig',
-            'pki_connectivity = pki.server.healthcheck.meta.connectivity'
+            'pki_connectivity = pki.server.healthcheck.meta.connectivity',
         ],
         # plugin modules for pkihealthcheck.certs registry
         'pkihealthcheck.certs': [
             'trust_flags = pki.server.healthcheck.certs.trustflags',
             'expiration = pki.server.healthcheck.certs.expiration',
+        ],
+        # plugin modules for pkihealthcheck.clones registry
+        'pkihealthcheck.clones': [
+            'connectivity = pki.server.healthcheck.clones.connectivity_and_data',
         ],
     },
     classifiers=[


### PR DESCRIPTION
Simple test of clones associated with a pki instance.

Testing is predicated on locating within the given instance a CA security domain subsystem.

From there the security domain is consulted for a list of cloned subsystems.
Each clone found is checked in a simple fashion for a connectivity and for simple data,
when appropriate. For now the OCSP , TKS, and TPS clones are checked for connectivity.

Another caveat: Originally I wanted to pair up each discoverd clone with it's master and compare data
within the CA and KRA to match them up. This round I was nota able to easily figure out this mapping, so for
now the actual clones are tested.

Simple command line to run the test directly:

pki-healthcheck --debug  --source pki.server.healthcheck.clones.connectivity_and_data --check ClonesConnectivyAndDataCheck

The test reaches out provides a result for each group of ca, kra, ocsp, tps, and tks clones.

Note that we have issues with tps and ocsp clones at this point.