### PR TITLE
Move PrettyPrint{Cert,Crl} to PKI_LIB classpath

### DIFF
--- a/base/java-tools/templates/pretty_print_cert_command_wrapper.in
+++ b/base/java-tools/templates/pretty_print_cert_command_wrapper.in
@@ -87,11 +87,7 @@ JAVA_OPTIONS=""
 ##      order this command wrapper uses to find jar files.                   ##
 ###############################################################################
 
-CP=${JNI_JAR_DIR}/jss4.jar
-CP=/usr/share/java/commons-codec.jar:${CP}
-CP=/usr/share/java/ldapjdk.jar:${CP}
-CP=/usr/share/java/${PRODUCT}/pki-cmsutil.jar:${CP}
-CP=/usr/share/java/${PRODUCT}/pki-tools.jar:${CP}
+CP="${PKI_LIB}/*"
 export CP
 
 
@@ -108,7 +104,7 @@ then
     then
         file $2 | grep -E 'ASCII text|PEM certificate' > /dev/null
         if [ $? -ne 0 ] ; then
-            ${JAVA} ${JAVA_OPTIONS} -cp ${CP} com.netscape.cmstools.${COMMAND}
+            ${JAVA} ${JAVA_OPTIONS} -cp "${CP}" com.netscape.cmstools.${COMMAND}
             printf "\n"
             printf " ERROR:  '$2' is not an ASCII file!\n\n"
             printf "         First, use 'BtoA $2 $2.b64'\n"
@@ -118,7 +114,7 @@ then
     else
         file $1 | grep -E 'ASCII text|PEM certificate' > /dev/null
         if [ $? -ne 0 ] ; then
-            ${JAVA} ${JAVA_OPTIONS} -cp ${CP} com.netscape.cmstools.${COMMAND}
+            ${JAVA} ${JAVA_OPTIONS} -cp "${CP}" com.netscape.cmstools.${COMMAND}
             printf "\n"
             printf " ERROR:  '$1' is not an ASCII file!\n\n"
             printf "         First, use 'BtoA $1 $1.b64'\n"
@@ -128,6 +124,6 @@ then
     fi
 fi
 
-${JAVA} ${JAVA_OPTIONS} -cp ${CP} com.netscape.cmstools.${COMMAND} "$@"
+${JAVA} ${JAVA_OPTIONS} -cp "${CP}" com.netscape.cmstools.${COMMAND} "$@"
 exit $?
 

--- a/base/java-tools/templates/pretty_print_crl_command_wrapper.in
+++ b/base/java-tools/templates/pretty_print_crl_command_wrapper.in
@@ -88,12 +88,7 @@ JAVA_OPTIONS=""
 ##      order this command wrapper uses to find jar files.                   ##
 ###############################################################################
 
-CP=${JNI_JAR_DIR}/jss4.jar
-
-CP=/usr/share/java/commons-codec.jar:${CP}
-CP=/usr/share/java/ldapjdk.jar:${CP}
-CP=/usr/share/java/${PRODUCT}/pki-cmsutil.jar:${CP}
-CP=/usr/share/java/${PRODUCT}/pki-tools.jar:${CP}
+CP="${PKI_LIB}/*"
 export CP
 
 
@@ -107,7 +102,7 @@ if [ $# -eq 1 ] ||
 then
     file $1 | grep 'ASCII text' > /dev/null
     if [ $? -ne 0 ] ; then
-        ${JAVA} ${JAVA_OPTIONS} -cp ${CP} com.netscape.cmstools.${COMMAND}
+        ${JAVA} ${JAVA_OPTIONS} -cp "${CP}" com.netscape.cmstools.${COMMAND}
         printf "\n"
         printf "ERROR:  '$1' is not an ASCII file!\n\n"
         printf "        First, use 'BtoA $1 $1.b64'\n"
@@ -116,6 +111,6 @@ then
     fi
 fi
 
-${JAVA} ${JAVA_OPTIONS} -cp ${CP} com.netscape.cmstools.${COMMAND} "$@"
+${JAVA} ${JAVA_OPTIONS} -cp "${CP}" com.netscape.cmstools.${COMMAND} "$@"
 exit $?
 


### PR DESCRIPTION
JDK since v1.6 supports passing a directory with a glob (*) after it to
include all JARs in that given directory on the classpath. That is the
mechanism used by `pki_java_command_wrapper.in` which we should reuse for
the two CLIs which don't use that wrapper.

Resolves: [rh-bz#1854043](https://bugzilla.redhat.com/show_bug.cgi?id=1854043)

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`