### PR TITLE
Fix Secure connection issue when server is down

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -33,6 +33,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import socket
 
 import ldap
 import ldap.filter
@@ -956,7 +957,7 @@ class PKIServer(object):
         Return a PKIConnection, logged in using username and password.
         """
         ca_cert = PKIServer.build_ca_files(client_nssdb)
-        connection = pki.client.PKIConnection('https', os.environ['HOSTNAME'], secure_port,
+        connection = pki.client.PKIConnection('https', socket.getfqdn(), secure_port,
                                               cert_paths=ca_cert)
         connection.authenticate(username, password)
         account_client = pki.account.AccountClient(connection, subsystem=subsystem_name)
@@ -1073,7 +1074,7 @@ class PKIServer(object):
         ca_cert = PKIServer.build_ca_files(client_nssdb)
 
         # Create a PKIConnection object that stores the details of subsystem.
-        connection = pki.client.PKIConnection('https', os.environ['HOSTNAME'], secure_port,
+        connection = pki.client.PKIConnection('https', socket.getfqdn(), secure_port,
                                               subsystem_name, cert_paths=ca_cert)
 
         # Bind the authentication with the connection object

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1232,8 +1232,9 @@ class CertFixCLI(pki.cli.CLI):
                     for cert_id in fix_certs:
                         logger.info('Requesting new cert for %s', cert_id)
                         instance.cert_create(
-                            cert_id=cert_id, renew=True,
-                            username=agent_uid, password=agent_pass, secure_port=port)
+                            cert_id=cert_id, renew=True, username=agent_uid,
+                            password=agent_pass, secure_port=port,
+                            client_nssdb=instance.nssdb_dir)
                     for serial in extra_certs:
                         output = instance.cert_file('{}-renewed'.format(serial))
                         logger.info(
@@ -1241,8 +1242,9 @@ class CertFixCLI(pki.cli.CLI):
                             serial, output)
                         try:
                             instance.cert_create(
-                                serial=serial, renew=True, output=output,
-                                username=agent_uid, password=agent_pass, secure_port=port)
+                                serial=serial, renew=True, output=output, username=agent_uid,
+                                password=agent_pass, secure_port=port,
+                                client_nssdb=instance.nssdb_dir)
                         except pki.PKIException as e:
                             logger.error("Failed to renew certificate %s: %s", serial, e)
 


### PR DESCRIPTION
When the PKI server is down due to expired system certs,
`pki-server cert-fix` is used. The server is temporarily
brought up using a temporary SSL server cert. This cert,
of course, is not signed by the official CA. As a result
the secure connection will always fail.

This patch:

* Uses the system NSSDB as the client db during the
  cert-fix (offline cert renewal process) execution.
* Gets the hostname using socket instead of from env
  variable

Fixes the following error:
````
ERROR: HTTPSConnectionPool(host='pki1.example.com', port=20443): Max retries exceeded with url: /ca/rest/account/login (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:897)'),))
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 343, in _make_request
    self._validate_conn(conn)
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 839, in _validate_conn
    conn.connect()
  File "/usr/lib/python3.6/site-packages/urllib3/connection.py", line 344, in connect
    ssl_context=context)
  File "/usr/lib/python3.6/site-packages/urllib3/util/ssl_.py", line 354, in ssl_wrap_socket
    return context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/lib64/python3.6/ssl.py", line 365, in wrap_socket
    _context=self, _session=session)
  File "/usr/lib64/python3.6/ssl.py", line 776, in __init__
    self.do_handshake()
  File "/usr/lib64/python3.6/ssl.py", line 1036, in do_handshake
    self._sslobj.do_handshake()
  File "/usr/lib64/python3.6/ssl.py", line 648, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:897)
 ````

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`