### PR TITLE
Fix instance nssdb directory ownership

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -108,7 +108,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         pki.util.chown(
             deployer.mdict['pki_server_database_path'],
             deployer.mdict['pki_uid'],
-            deployer.mdict['pki_uid'])
+            deployer.mdict['pki_gid'])
         pki.util.chmod(
             deployer.mdict['pki_server_database_path'],
             config.PKI_DEPLOYMENT_DEFAULT_SECURITY_DATABASE_PERMISSIONS)


### PR DESCRIPTION
There was a typo in code which sets the ownership
of NSSdb directory and its content. This results
in the group with the same gid as pkiuser uid
can control this directory.

Fixes: https://pagure.io/dogtagpki/issue/3195