### PR TITLE
Add missing required targets for pki-acme-classes target

### DIFF
--- a/base/acme/CMakeLists.txt
+++ b/base/acme/CMakeLists.txt
@@ -14,6 +14,8 @@ javac(pki-acme-classes
         ${JSS_JAR} ${PKI_CMSUTIL_JAR} ${PKI_CERTSRV_JAR}
         ${PKI_CMS_JAR}
         ${LDAPJDK_JAR}
+    DEPENDS
+        pki-cmsutil-jar pki-certsrv-jar pki-cms-jar
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )


### PR DESCRIPTION
Parallel build fails because of the races caused by the missing
(not yet built) jars.

Fixes: https://pagure.io/dogtagpki/issue/3196