### PR TITLE
Address Bug 1462291 - CRL autoupdate from CS.cfg

### DIFF
--- a/base/ca/src/com/netscape/ca/CRLIssuingPointConfig.java
+++ b/base/ca/src/com/netscape/ca/CRLIssuingPointConfig.java
@@ -293,4 +293,12 @@ public class CRLIssuingPointConfig extends PropConfigStore {
     public void setCRLEndSerialNo(BigInteger crlEndSerialNo) {
         putBigInteger("crlEndSerialNo", crlEndSerialNo);
     }
+
+    public boolean getAutoUpdateIntervalEffectiveAtStart()  throws EBaseException {
+        return getBoolean("autoUpdateInterval.effectiveAtStart",false);
+    }
+
+    public void setAutoUpdateIntervalEffectiveAtStart(Boolean updated) {
+        putBoolean("autoUpdateInterval.effectiveAtStart",updated);
+    }
 }


### PR DESCRIPTION
This fix allows the admin to request that a change to this crl CS.cfg setting:

ca.crl.MasterCRL.autoUpdateInterval=xxx

This fix will allow the system to attempt to use the new value of auto update
immediately. The previous longstanding behavior was to have the new interval take affect,
AFTER the currently scheduled nextUpdate time.

What this fix does is allow the use of a new CS.cfg parameter:

ca.crl.MasterCRL.scheduleUpdated=true

This parameter must be inserted before a restart to allow this behavior to take place at all.
Without the param everything should be working as normal.

After changing the CS.cfg value, the server must be restarted.

At this point the delay time for the next update will be calculated based on the new auto update interval.

Previously the code would simply ignore the new calculated value and take whatever is already encoded into the
"nextUpdate" field of the crl.

This fix allows the new value to be accepted. Here are some caveats on how this thing behaves:

1. If the autoUpdate interval is made smaller , this thing works as expected, having the next update take place
in roughly the amount of time in the new interval.

2. If making the interval smaller, makes the calculated next update in the past, the update will occur now and then the
nextUpdate will be calculated with the new schedule..

3. If the admin makes the autoUpdate interval larger, the behavior is a little different.
Due to the fact that the calculations made with the new interval, is based off of starting with the time stamp
for "yesterday" or the very first daily update from yesterday, the new nextUPdate time calculated may be less
than simply adding the the new interval to the last update.

This fix was coded by allowing the current very comnplicated algorithm to calculate the nextUpdate do it's thing
while at the end of the process, this code simply chooses what is calculated instead of what is already encoded within
the crl's nextUpdate field.

Therefore if the new param is never set, nothing changes. This param should be used with care.

If the agent goes to the display crl page, the new value can easily be viewed as well as the debug log.

4. After the operation takes place the flag inside the server will be cleared and this feature will no longer
be attempted while the server is running.

5. The admin must clear the schedulUpdated setting before the restart to assure normal operation after the next restart.