### PR TITLE
Resolve: Bug 1454922 - [RFE] Need Ability to set the CRL This Update …

### DIFF
--- a/base/server/src/org/dogtagpki/server/ca/ICRLIssuingPoint.java
+++ b/base/server/src/org/dogtagpki/server/ca/ICRLIssuingPoint.java
@@ -540,4 +540,13 @@ public interface ICRLIssuingPoint {
      * @return list of CRL extensions
      */
     public ICMSCRLExtensions getCRLExtensions();
+
+    /**
+     * Set Optional Future thsUpdateValue to go into the CRL
+     *
+     */
+
+    public void setCustomFutureThisUpdateValue(Date futureThisUpdate);
+
+    public void setCancelCurFutureThisUpdateValue(boolean b);
 }


### PR DESCRIPTION
…to be a Future Date when Generating a CRL.

This fix allows the admin to request this feature only by using the command line sslget utility to make such a request.

The result will be haviing the "thisUpdate" field of the generated crl set to some arbitrary date in the future.
The nextUpdate field will be calculated as normal by calculating that as an offset to the future thisUpdate value requested.

There is also a new CS.cfg value designed to simply disallow the use of the feature whateover:

ca.crl.MasterCR=forbidFutureThisUpdateValue= true will ignore any attempts to use this feature.

This feature does not now GUI attached and will ONLY be available when ussing sslget to request a CRL update on demand.

Also theire is a parameter to sslget that will allow the user to erase the whole future thisUpdate and
return to normal. Examples to follow:

Example 1, request an updated CRL with a future thisUpdateValue:

sslget -n "PKI Administrator for localhost.localdomain" -e "crlIssuingPoint=MasterCRL&signatureAlgorithm&waitForUpdate=true&clearCRLCache=true&futureThisUpdateDateValue=2020:9:22:13:0:0"  -v -d . -p ""  -r /ca/agent/ca/updateCRL localhost.localdomain:8443

Note the param for this feature is futureThisUpdateDateValue=<date>
The date format is this: 2020:9:22:13:0:0

The linux date utility can be used to make a date in this format. It's simply
year,month,day, hour, min ,sec, with min and sec optional.
The month is based on 1, with Jan = 1.

Example 2: clear the whole future thisUpdate an get back to normal:

sslget -n "PKI Administrator for localhost.localdomain" -e "crlIssuingPoint=MasterCRL&signatureAlgorithm&waitForUpdate=true&clearCRLCache=true&ignoreCurFutureThisUpdateValue=true"  -v -d . -p ""  -r /ca/agent/ca/updateCRL localhost.localdomain:8443

This will erase the future thisUpdate and calculate the nextUpdate based on the san current time.

This fix was done without affecting the complext calculations made to calculate update frequency. This only allows one, if they desire, to set thisUpdate some futuristic time.

If a future thisUpdate time is chosen as in Ex 1, the nextUpdate time will be chosen based on that future date.

The Agent GUI can be used to display the CRL will reflect the new thisUpdate and nextUpdate values.