### PR TITLE
Fix Version.__getnewargs__

### DIFF
--- a/base/common/python/pki/info.py
+++ b/base/common/python/pki/info.py
@@ -75,7 +75,7 @@ class Version(tuple):
 
     def __getnewargs__(self):
         # pickle support
-        return str(self)
+        return (str(self),)
 
     @property
     def major(self):


### PR DESCRIPTION
According to the docs \[0\]:
>  object.__getnewargs__()
This method serves a similar purpose as __getnewargs_ex__(), but
supports only positional arguments. It must return a tuple of
arguments args which will be passed to the __new__() method upon
unpickling.

\[0\]: https://docs.python.org/3/library/pickle.html#object.__getnewargs__

Fixes: https://pagure.io/dogtagpki/issue/3200