### PR TITLE
Fix unittest DeprecationWarning

### DIFF
--- a/tests/python/test_authority.py
+++ b/tests/python/test_authority.py
@@ -70,8 +70,8 @@ class AuthorityTests(unittest.TestCase):
     def test_should_create_subca(self):
         authority_data = authority.AuthorityData(** self.subca_data)
         ca = self.authority_client.create_ca(authority_data)
-        self.assertEquals(ca.aid, self.aid)
-        self.assertEquals(ca.dn, self.dn)
+        self.assertEqual(ca.aid, self.aid)
+        self.assertEqual(ca.dn, self.dn)
 
     def test_create_should_raise_ca_data_not_defined(self):
         self.assertRaises(
@@ -113,8 +113,8 @@ class AuthorityTests(unittest.TestCase):
         self.connection.get.return_value = get_return
 
         ca = self.authority_client.get_ca(self.aid)
-        self.assertEquals(ca.aid, self.aid)
-        self.assertEquals(ca.dn, self.dn)
+        self.assertEqual(ca.aid, self.aid)
+        self.assertEqual(ca.dn, self.dn)
 
     def test_should_list_cas(self):
         get_return = mock.MagicMock()
@@ -126,6 +126,6 @@ class AuthorityTests(unittest.TestCase):
         for ca in cas:
             self.assertIsInstance(ca, authority.AuthorityData)
             if ca.aid == self.aid2:
-                self.assertEquals(ca.dn, self.dn2)
+                self.assertEqual(ca.dn, self.dn2)
             else:
-                self.assertEquals(ca.dn, self.dn)
+                self.assertEqual(ca.dn, self.dn)

--- a/tests/python/test_pki_keyring.py
+++ b/tests/python/test_pki_keyring.py
@@ -44,7 +44,7 @@ class KeyringTests(unittest.TestCase):
 
     def get_key_id(self, key_name, orig_key_id):
         retrieved_key_id = self.keyring.get_key_id(key_name=key_name)
-        self.assertEquals(retrieved_key_id, orig_key_id)
+        self.assertEqual(retrieved_key_id, orig_key_id)
 
     def get_key_value_raw(self, key_name, orig_pass):
         retrieved_pass_raw = self.keyring.get_password(key_name=key_name, output_format='raw')
@@ -57,7 +57,7 @@ class KeyringTests(unittest.TestCase):
         retrieved_pass_hex = retrieved_pass_hex.split('\n')[1]
         # Remove spaces in the retrieved hex value
         retrieved_pass_hex = retrieved_pass_hex.replace(' ', '')
-        self.assertEquals(retrieved_pass_hex.strip(), orig_pass.encode().hex())
+        self.assertEqual(retrieved_pass_hex.strip(), orig_pass.encode().hex())
 
     def clear_pass(self, key_name):
         self.keyring.clear_keyring()


### PR DESCRIPTION
`assertEquals` is deprecated in favor of `assertEqual` since Python3.2:
https://docs.python.org/3/whatsnew/3.2.html

Fixes: https://pagure.io/dogtagpki/issue/3201