### PR TITLE
Updated version number to 10.10.0-alpha1

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -10,11 +10,11 @@ URL:              http://www.dogtagpki.org/
 # The entire source code is GPLv2 except for 'pki-tps' which is LGPLv2
 License:          GPLv2 and LGPLv2
 
-# For development (unsupported) releases, use x.y.z-0.n.unstable with alpha/beta phase.
-# For official (supported) releases, use x.y.z-r where r >=1 without alpha/beta phase.
-Version:          10.9.0
-Release:          1%{?_timestamp}%{?_commit_id}%{?dist}
-#global           _phase -a1
+# For development (i.e. unsupported) releases, use x.y.z-0.n.<phase>.
+# For official (i.e. supported) releases, use x.y.z-r where r >=1.
+Version:          10.10.0
+Release:          0.1.alpha1%{?_timestamp}%{?_commit_id}%{?dist}
+%global           _phase -alpha1
 
 # To create a tarball from a version tag:
 # $ git archive \


### PR DESCRIPTION
This marks the start of PKI 10.10 development in `master` branch.
Changes for PKI 10.9 should be made in `v10.9` branch.