### PR TITLE
Fix runuser to use absolute path

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -318,7 +318,7 @@ class PKIServer(object):
 
             # switch to systemd user if different from current user
             if current_user != self.user:
-                prefix.extend(['runuser', '-u', self.user, '--'])
+                prefix.extend(['/usr/sbin/runuser', '-u', self.user, '--'])
 
         java_path = os.getenv('PKI_JAVA_PATH')
         java_home = self.config.get('JAVA_HOME')

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -198,7 +198,7 @@ class PKIInstance(pki.server.PKIServer):
 
                 # switch to systemd user if different from current user
                 if current_user != self.user:
-                    prefix.extend(['runuser', '-u', self.user, '--'])
+                    prefix.extend(['/usr/sbin/runuser', '-u', self.user, '--'])
 
             cmd = prefix + ['/usr/sbin/pki-server', 'upgrade']
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1100,7 +1100,7 @@ class PKISubsystem(object):
             # switch to systemd user if different from current user
             username = pwd.getpwuid(os.getuid()).pw_name
             if username != self.instance.user:
-                cmd.extend(['runuser', '-u', self.instance.user, '--'])
+                cmd.extend(['/usr/sbin/runuser', '-u', self.instance.user, '--'])
 
         if os.path.exists(java_path):
             cmd.extend([java_path])


### PR DESCRIPTION
When `pki-server` is called as `root`, the following message is displayed
when trying to use `runuser`:

    DEBUG: Command: runuser -u pkiuser -- /usr/sbin/pki-server upgrade --debug pki-tomcat
    ERROR: [Errno 2] No such file or directory: 'runuser'
    Traceback (most recent call last):
      File "/usr/lib/python3.9/site-packages/pki/server/pkiserver.py", line 40, in <module>
        cli.execute(sys.argv)
      File "/usr/lib/python3.9/site-packages/pki/server/cli/__init__.py", line 143, in execute
        super(PKIServerCLI, self).execute(args)
      File "/usr/lib/python3.9/site-packages/pki/cli/__init__.py", line 197, in execute
        module.execute(module_args)
      File "/usr/lib/python3.9/site-packages/pki/server/cli/__init__.py", line 770, in execute
        instance.run(
      File "/usr/lib/python3.9/site-packages/pki/server/__init__.py", line 290, in run
        p = self.execute(
      File "/usr/lib/python3.9/site-packages/pki/server/instance.py", line 214, in execute
        subprocess.run(cmd, env=self.config, check=True)
      File "/usr/lib64/python3.9/subprocess.py", line 501, in run
        with Popen(*popenargs, **kwargs) as process:
      File "/usr/lib64/python3.9/subprocess.py", line 947, in __init__
        self._execute_child(args, executable, preexec_fn, close_fds,
      File "/usr/lib64/python3.9/subprocess.py", line 1819, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'runuser'

This is because `sudo` lives under `/usr/bin`, which exists on `PATH` by
default, but because `runuser` lives under `/usr/sbin` (which is admin-only)
it doesn't live on `PATH` by default. Thus, an absolute path to the
executable needs to be provided.

This change was merged in 49585867207922479644a03078c29548de02cd03.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`