### PR TITLE
Added pki-acme RPM package

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -383,6 +383,7 @@ if (BUILD_PKI_CORE OR BUILD_PKI_CONSOLE)
 
         add_subdirectory(server)
 
+        add_subdirectory(acme)
         add_subdirectory(ca)
         add_subdirectory(kra)
         add_subdirectory(ocsp)
@@ -391,8 +392,6 @@ if (BUILD_PKI_CORE OR BUILD_PKI_CONSOLE)
 
         # required for native 'tpsclient' utility
         add_subdirectory(tps-client)
-
-        add_subdirectory(acme)
 
         list(APPEND PKI_JAVADOC_SOURCEPATH
             ${CMAKE_SOURCE_DIR}/base/server/src)

--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -33,7 +33,7 @@ EXPOSE 8080 8443
 RUN if [ -n "$COPR_REPO" ]; then dnf install -y dnf-plugins-core; dnf copr enable -y $COPR_REPO; fi
 
 # Install packages
-RUN dnf install -y bind-utils iputils abrt-java-connector postgresql postgresql-jdbc pki-server
+RUN dnf install -y bind-utils iputils abrt-java-connector postgresql postgresql-jdbc pki-acme
 
 # Install PostgreSQL JDBC driver
 RUN ln -s /usr/share/java/postgresql-jdbc/postgresql.jar /usr/share/pki/server/common/lib/postgresql.jar

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -786,7 +786,7 @@ public class ACMEEngine implements ServletContextListener {
             logger.info("- " + dnsName);
         }
 
-        // RFC 8555 §7.4 says: The CSR MUST indicate the exact same
+        // RFC 8555 Section 7.4 says: The CSR MUST indicate the exact same
         // set of requested identifiers as the initial newOrder request.
 
         // check for unauthorized names in CSR
@@ -891,7 +891,7 @@ public class ACMEEngine implements ServletContextListener {
                 // with unvalidated SAN values will be passed along to the
                 // CA, and these are likely to be accepted as-is.
                 //
-                // This is also required by RFC 8555 §7.4:
+                // This is also required by RFC 8555 Section 7.4:
                 //
                 //    The CSR MUST indicate the exact same set of requested
                 //    identifiers as the initial newOrder request.

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ usage() {
     echo "    --help                 Show help message."
     echo
     echo "Packages:"
-    echo "    base, server, ca, kra, ocsp, tks, tps, javadoc, console, theme, meta, tests, debug"
+    echo "    base, server, acme, ca, kra, ocsp, tks, tps, javadoc, console, theme, meta, tests, debug"
     echo
     echo "Target:"
     echo "    src    Generate RPM sources."

--- a/docs/installation/acme/Installing_PKI_ACME_Responder.md
+++ b/docs/installation/acme/Installing_PKI_ACME_Responder.md
@@ -16,7 +16,13 @@ It assumes that the CA was [installed](../ca/Installing_CA.md) with the default 
 
 ## Installing PKI ACME Responder
 
-To install PKI ACME responder on PKI server, execute the following command:
+To install PKI ACME responder RPM package, execute the following command:
+
+```
+$ dnf install pki-acme
+```
+
+To create PKI ACME responder in a PKI server instance, execute the following command:
 
 ```
 $ pki-server acme-create

--- a/pki.spec
+++ b/pki.spec
@@ -97,6 +97,7 @@ Source: https://github.com/dogtagpki/pki/archive/v%{version}%{?_phase}/pki-%{ver
 
 %package_option base
 %package_option server
+%package_option acme
 %package_option ca
 %package_option kra
 %package_option ocsp
@@ -264,6 +265,7 @@ to manage enterprise Public Key Infrastructure deployments.
 
 PKI consists of the following components:
 
+  * Automatic Certificate Management Environment (ACME) Responder
   * Certificate Authority (CA)
   * Key Recovery Authority (KRA)
   * Online Certificate Status Protocol (OCSP) Manager
@@ -288,6 +290,7 @@ Requires:         %{vendor_id}-pki-console-theme = %{version}
 
 # Make certain that this 'meta' package requires the latest version(s)
 # of ALL PKI core packages
+Requires:         pki-acme = %{version}
 Requires:         pki-ca = %{version}
 Requires:         pki-kra = %{version}
 Requires:         pki-ocsp = %{version}
@@ -315,6 +318,7 @@ to manage enterprise Public Key Infrastructure deployments.
 
 PKI consists of the following components:
 
+  * Automatic Certificate Management Environment (ACME) Responder
   * Certificate Authority (CA)
   * Key Recovery Authority (KRA)
   * Online Certificate Status Protocol (OCSP) Manager
@@ -521,16 +525,27 @@ Provides:         bundled(js-patternfly) = 3.59.2
 Provides:         bundled(js-underscore) = 1.9.2
 
 %description -n   pki-server
-The PKI Server Package contains libraries and utilities needed by the
-following PKI subsystems:
-
-    the Certificate Authority (CA),
-    the Key Recovery Authority (KRA),
-    the Online Certificate Status Protocol (OCSP) Manager,
-    the Token Key Service (TKS), and
-    the Token Processing Service (TPS).
+The PKI Server Package contains libraries and utilities needed by other
+PKI subsystems.
 
 # with server
+%endif
+
+%if %{with acme}
+################################################################################
+%package -n       pki-acme
+################################################################################
+
+Summary:          PKI ACME Package
+BuildArch:        noarch
+
+Requires:         pki-server = %{version}-%{release}
+
+%description -n   pki-acme
+The PKI ACME responder is a service that provides an automatic certificate
+management via ACME v2 protocol defined in RFC 8555.
+
+# with acme
 %endif
 
 %if %{with ca}
@@ -831,7 +846,7 @@ fi
     -DBUILD_PKI_CORE:BOOL=ON \
     -DPYTHON_EXECUTABLE=%{python_executable} \
     -DWITH_TEST:BOOL=%{?with_test:ON}%{!?with_test:OFF} \
-%if ! %{with server} && ! %{with ca} && ! %{with kra} && ! %{with ocsp} && ! %{with tks} && ! %{with tps}
+%if ! %{with server} && ! %{with acme} && ! %{with ca} && ! %{with kra} && ! %{with ocsp} && ! %{with tks} && ! %{with tps}
     -DWITH_SERVER:BOOL=OFF \
 %endif
     -DWITH_JAVADOC:BOOL=%{?with_javadoc:ON}%{!?with_javadoc:OFF} \
@@ -1162,10 +1177,20 @@ fi
 %{_mandir}/man8/pki-healthcheck.8.gz
 %{_datadir}/pki/setup/
 %{_datadir}/pki/server/
-%{_datadir}/pki/acme/
-%{_javadir}/pki/pki-acme.jar
 
 # with server
+%endif
+
+%if %{with acme}
+################################################################################
+%files -n pki-acme
+################################################################################
+
+%{_javadir}/pki/pki-acme.jar
+%dir %{_datadir}/pki/acme
+%{_datadir}/pki/acme/
+
+# with acme
 %endif
 
 %if %{with ca}


### PR DESCRIPTION
The ACME-related files have been moved from pki-server to a new
pki-acme package. The pki-javadoc has been modified to include
ACME classes.