### PR TITLE
Add nuxwdog status to pki-server status

### DIFF
--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -146,6 +146,7 @@ class PKIServerCLI(pki.cli.CLI):
     def print_status(instance):
         print('  Instance ID: %s' % instance.name)
         print('  Active: %s' % instance.is_active())
+        print('  Nuxwdog Enabled: %s' % instance.type.endswith('-nuxwdog'))
 
         server_config = instance.get_server_config()
 


### PR DESCRIPTION
Display whether nuxwdog is enabled on the system when executing
pki-server status

Extension to: [BZ#1732981](https://bugzilla.redhat.com/show_bug.cgi?id=1732981)

````
 # pki-server status
  Instance ID: pki-tomcat
  Active: True
  Nuxwdog Enabled: True
  Unsecure Port: 8080
  Secure Port: 8443
  Tomcat Port: 8005

~snip~
````

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`