### PR TITLE
Allow generating PKCS#12 without any MacData

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1686,7 +1686,8 @@ class NSSDatabase(object):
                       append=False,
                       include_trust_flags=True,
                       include_key=True,
-                      include_chain=True):
+                      include_chain=True
+                      include_mac_data=True):
 
         tmpdir = tempfile.mkdtemp()
 
@@ -1730,6 +1731,9 @@ class NSSDatabase(object):
             if append:
                 cmd.extend(['--append'])
 
+            if not include_mac_data:
+                cmd.extend(['--no-mac-data'])
+
             if not include_trust_flags:
                 cmd.extend(['--no-trust-flags'])
 
@@ -1763,7 +1767,8 @@ class NSSDatabase(object):
             # the end certificate: rh-bz#1246371
             self.export_pkcs12(p12_file, pkcs12_password=password,
                                nicknames=[nickname], include_key=False,
-                               include_chain=True)
+                               include_chain=True, include_trust_flags=False,
+                               include_mac_data=False)
 
             # This command is similar to the one from server/__init__.py.
             # However, to work during the initial startup, we do not

--- a/base/java-tools/src/com/netscape/cmstools/pkcs12/PKCS12ExportCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/pkcs12/PKCS12ExportCLI.java
@@ -109,6 +109,7 @@ public class PKCS12ExportCLI extends CommandCLI {
         options.addOption(option);
 
         options.addOption(null, "append", false, "Append into an existing PKCS #12 file");
+        options.addOption(null, "no-mac-data", false, "Do not include optional MacData in PKCS #12");
         options.addOption(null, "no-trust-flags", false, "Do not include trust flags");
         options.addOption(null, "no-key", false, "Do not include private key");
         options.addOption(null, "no-chain", false, "Do not include certificate chain");
@@ -154,6 +155,7 @@ public class PKCS12ExportCLI extends CommandCLI {
         String keyEncryption = cmd.getOptionValue("key-encryption");
 
         boolean append = cmd.hasOption("append");
+        boolean includeMacData = !cmd.hasOption("no-mac-data");
         boolean includeTrustFlags = !cmd.hasOption("no-trust-flags");
         boolean includeKey = !cmd.hasOption("no-key");
         boolean includeChain = !cmd.hasOption("no-chain");
@@ -195,7 +197,7 @@ public class PKCS12ExportCLI extends CommandCLI {
                 }
             }
 
-            util.storeIntoFile(pkcs12, filename, password);
+            util.storeIntoFile(pkcs12, filename, password, includeMacData);
 
         } finally {
             password.clear();


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1857933 
Related: https://github.com/dogtagpki/jss/pull/620