### PR TITLE
Disabled AIA and cert policy extensions in ACME examples

### DIFF
--- a/base/acme/issuer/nss/ca_signing.conf
+++ b/base/acme/issuer/nss/ca_signing.conf
@@ -1,8 +1,9 @@
 basicConstraints       = critical, CA:TRUE
 subjectKeyIdentifier   = hash
-authorityInfoAccess    = OCSP;URI:http://ocsp.example.com, caIssuers;URI:http://cert.example.com
 keyUsage               = critical, digitalSignature, keyCertSign, cRLSign
-certificatePolicies    = 2.23.140.1.2.1, @cps_policy
 
-cps_policy.id          = 1.3.6.1.4.1.44947.1.1.1
-cps_policy.CPS.1       = http://cps.example.com
+# authorityInfoAccess    = OCSP;URI:http://ocsp.example.com, caIssuers;URI:http://cert.example.com
+
+# certificatePolicies    = 2.23.140.1.2.1, @cps_policy
+# cps_policy.id          = 1.3.6.1.4.1.44947.1.1.1
+# cps_policy.CPS.1       = http://cps.example.com

--- a/base/acme/issuer/nss/sslserver.conf
+++ b/base/acme/issuer/nss/sslserver.conf
@@ -1,10 +1,11 @@
 basicConstraints       = critical, CA:FALSE
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid:always
-authorityInfoAccess    = OCSP;URI:http://ocsp.example.com, caIssuers;URI:http://cert.example.com
 keyUsage               = critical, digitalSignature, keyEncipherment
 extendedKeyUsage       = serverAuth, clientAuth
-certificatePolicies    = 2.23.140.1.2.1, @cps_policy
 
-cps_policy.id          = 1.3.6.1.4.1.44947.1.1.1
-cps_policy.CPS.1       = http://cps.example.com
+# authorityInfoAccess    = OCSP;URI:http://ocsp.example.com, caIssuers;URI:http://cert.example.com
+
+# certificatePolicies    = 2.23.140.1.2.1, @cps_policy
+# cps_policy.id          = 1.3.6.1.4.1.44947.1.1.1
+# cps_policy.CPS.1       = http://cps.example.com


### PR DESCRIPTION
The ACME NSS issuer has been modified to disable the AIA
and certificate policy extensions by default since they contain
non-functional URLs that might cause certbot to generate
error messages.