### PR TITLE
Make PKI use JDK8 everywhere again

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -54,9 +54,13 @@ Source: https://github.com/dogtagpki/pki/archive/v%{version}%{?_phase}/pki-%{ver
 %define java_home /usr/lib/jvm/jre-openjdk
 
 %if 0%{?fedora} && 0%{?fedora} >= 33
-%define min_java_version 1:11
+%define min_java_version 1:1.8.0
+%define java_devel java-1.8.0-openjdk-devel
+%define java_headless java-1.8.0-openjdk-headless
 %else
 %define min_java_version 1:1.8.0
+%define java_devel java-devel
+%define java_headless java-headless
 %endif
 
 ################################################################################
@@ -158,7 +162,7 @@ BuildRequires:    make
 BuildRequires:    cmake >= 3.0.2
 BuildRequires:    gcc-c++
 BuildRequires:    zip
-BuildRequires:    java-devel >= %{min_java_version}
+BuildRequires:    %java_devel >= %{min_java_version}
 BuildRequires:    javapackages-tools
 BuildRequires:    redhat-rpm-config
 BuildRequires:    ldapjdk >= 4.22.0
@@ -335,7 +339,7 @@ PKI consists of the following components:
 
 Summary:          PKI Symmetric Key Package
 
-Requires:         java-headless >= %{min_java_version}
+Requires:         %java_headless >= %{min_java_version}
 Requires:         jpackage-utils >= 0:1.7.5-10
 Requires:         jss >= 4.7.0
 Requires:         nss >= 3.38.0
@@ -403,7 +407,7 @@ This package contains PKI client library for Python 3.
 Summary:          PKI Base Java Package
 BuildArch:        noarch
 
-Requires:         java-headless >= %{min_java_version}
+Requires:         %java_headless >= %{min_java_version}
 Requires:         apache-commons-cli
 Requires:         apache-commons-codec
 Requires:         apache-commons-io


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`