### PR TITLE
 Added OpenLDAP database for ACME

### DIFF
--- a/base/acme/database/ds/create.ldif
+++ b/base/acme/database/ds/create.ldif
@@ -1,0 +1,27 @@
+dn: dc=acme,dc=pki,dc=example,dc=com
+objectClass: dcObject
+dc: acme
+
+dn: ou=nonces,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: nonces
+
+dn: ou=accounts,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: accounts
+
+dn: ou=orders,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: orders
+
+dn: ou=authorizations,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: authorizations
+
+dn: ou=challenges,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: challenges
+
+dn: ou=certificates,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: certificates

--- a/base/acme/database/ds/database.conf
+++ b/base/acme/database/ds/database.conf
@@ -1,0 +1,6 @@
+class=org.dogtagpki.acme.database.DSDatabase
+url=ldap://localhost.localdomain:389
+authType=BasicAuth
+bindDN=cn=Directory Manager
+bindPassword=Secret.123
+baseDN=dc=acme,dc=pki,dc=example,dc=com

--- a/base/acme/database/ds/schema.ldif
+++ b/base/acme/database/ds/schema.ldif
@@ -1,0 +1,97 @@
+dn: cn=schema
+changetype: modify
+add: attributeTypes
+attributeTypes: ( acmeCreated-oid NAME 'acmeCreated'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch
+  SINGLE-VALUE )
+attributeTypes: ( acmeExpires-oid NAME 'acmeExpires'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch
+  SINGLE-VALUE )
+attributeTypes: ( acmeValidatedAt-oid NAME 'acmeValidatedAt'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch
+  SINGLE-VALUE )
+attributeTypes: ( acmeStatus-oid NAME 'acmeStatus'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch
+  SINGLE-VALUE )
+attributeTypes: ( acmeError-oid NAME 'acmeError'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE )
+attributeTypes: ( acmeNonceId-oid NAME 'acmeNonceId'
+  SUP name
+  SINGLE-VALUE )
+attributeTypes: ( acmeAccountId-oid NAME 'acmeAccountId'
+  SUP name
+  SINGLE-VALUE )
+attributeTypes: ( acmeAccountContact-oid NAME 'acmeAccountContact'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+attributeTypes: ( acmeAccountKey-oid NAME 'acmeAccountKey'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE )
+attributeTypes: ( acmeOrderId-oid NAME 'acmeOrderId'
+  SUP name
+  SINGLE-VALUE )
+attributeTypes: ( acmeIdentifier-oid NAME 'acmeIdentifier'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch )
+attributeTypes: ( acmeAuthorizationId-oid NAME 'acmeAuthorizationId'
+  SUP name )
+attributeTypes: ( acmeAuthorizationWildcard-oid NAME 'acmeAuthorizationWildcard'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  EQUALITY booleanMatch
+  SINGLE-VALUE )
+attributeTypes: ( acmeChallengeId-oid NAME 'acmeChallengeId'
+  SUP name
+  SINGLE-VALUE )
+attributeTypes: ( acmeToken-oid NAME 'acmeToken'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( acmeCertificateId-oid NAME 'acmeCertificateId'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseExactMatch
+  SINGLE-VALUE )
+-
+add: objectClasses
+objectClasses: ( acmeNonce-oid NAME 'acmeNonce'
+  STRUCTURAL
+  MUST ( acmeNonceId $ acmeCreated $ acmeExpires ) )
+objectClasses: ( acmeAccount-oid NAME 'acmeAccount'
+  STRUCTURAL
+  MUST ( acmeAccountId $ acmeCreated $ acmeAccountKey $ acmeStatus )
+  MAY acmeAccountContact )
+objectClasses: ( acmeOrder-oid NAME 'acmeOrder'
+  STRUCTURAL
+  MUST ( acmeOrderId $ acmeAccountId $ acmeCreated $ acmeStatus $ acmeIdentifier $ acmeAuthorizationId )
+  MAY ( acmeError $ acmeCertificateId $ acmeExpires ) )
+objectClasses: ( acmeAuthorization-oid NAME 'acmeAuthorization'
+  STRUCTURAL
+  MUST ( acmeAuthorizationId $ acmeAccountId $ acmeCreated $ acmeIdentifier $ acmeAuthorizationWildcard $ acmeStatus )
+  MAY acmeExpires )
+# Why have seperate object classes for different challenge types?
+# the dns-01 and http-01 challenge types both only store a 'token'.
+# But challenge types could involve storing other data.  So we
+# define a different object class for each challenge type, and each
+# class specifies the challenge-specific attribute types.
+objectClasses: ( acmeChallenge-oid NAME 'acmeChallenge'
+  ABSTRACT
+  MUST ( acmeChallengeId $ acmeAccountId $ acmeAuthorizationId $ acmeStatus )
+  MAY ( acmeValidatedAt $ acmeError ) )
+objectClasses: ( acmeChallengeDns01-oid NAME 'acmeChallengeDns01'
+  SUP acmeChallenge
+  STRUCTURAL
+  MUST acmeToken )
+objectClasses: ( acmeChallengeHttp01-oid NAME 'acmeChallengeHttp01'
+  SUP acmeChallenge
+  STRUCTURAL
+  MUST acmeToken )
+objectClasses: ( acmeCertificate-oid NAME 'acmeCertificate'
+  STRUCTURAL
+  MUST ( acmeCertificateId $ acmeCreated $ userCertificate )
+  MAY acmeExpires )

--- a/base/acme/database/openldap/create.ldif
+++ b/base/acme/database/openldap/create.ldif
@@ -1,0 +1,29 @@
+dn: dc=acme,dc=pki,dc=example,dc=com
+objectClass: dcObject
+objectclass: organization
+o: ACME
+dc: acme
+
+dn: ou=nonces,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: nonces
+
+dn: ou=accounts,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: accounts
+
+dn: ou=orders,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: orders
+
+dn: ou=authorizations,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: authorizations
+
+dn: ou=challenges,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: challenges
+
+dn: ou=certificates,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: certificates

--- a/base/acme/database/openldap/database.conf
+++ b/base/acme/database/openldap/database.conf
@@ -1,0 +1,6 @@
+class=org.dogtagpki.acme.database.OpenLDAPDatabase
+url=ldap://localhost.localdomain:389
+authType=BasicAuth
+bindDN=cn=Manager,dc=example,dc=com
+bindPassword=Secret.123
+baseDN=dc=acme,dc=pki,dc=example,dc=com

--- a/base/acme/database/openldap/schema.ldif
+++ b/base/acme/database/openldap/schema.ldif
@@ -1,0 +1,95 @@
+dn: cn=acme,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: acme
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.1 NAME 'acmeCreated'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.2 NAME 'acmeExpires'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.3 NAME 'acmeValidatedAt'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.4 NAME 'acmeStatus'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.5 NAME 'acmeError'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.6 NAME 'acmeNonceId'
+  SUP name
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.7 NAME 'acmeAccountId'
+  SUP name
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.8 NAME 'acmeAccountContact'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.9 NAME 'acmeAccountKey'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.10 NAME 'acmeOrderId'
+  SUP name
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.11 NAME 'acmeIdentifier'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.12 NAME 'acmeAuthorizationId'
+  SUP name )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.13 NAME 'acmeAuthorizationWildcard'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  EQUALITY booleanMatch
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.14 NAME 'acmeChallengeId'
+  SUP name
+  SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.15 NAME 'acmeToken'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.16 NAME 'acmeCertificateId'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseExactMatch
+  SINGLE-VALUE )
+olcObjectClasses: ( 2.16.840.1.113730.5.2.2.1 NAME 'acmeNonce'
+  STRUCTURAL
+  MUST ( acmeNonceId $ acmeCreated $ acmeExpires ) )
+olcObjectClasses: ( 2.16.840.1.113730.5.2.2.2 NAME 'acmeAccount'
+  STRUCTURAL
+  MUST ( acmeAccountId $ acmeCreated $ acmeAccountKey $ acmeStatus )
+  MAY acmeAccountContact )
+olcObjectClasses: ( 2.16.840.1.113730.5.2.2.3 NAME 'acmeOrder'
+  STRUCTURAL
+  MUST ( acmeOrderId $ acmeAccountId $ acmeCreated $ acmeStatus $ acmeIdentifier $ acmeAuthorizationId )
+  MAY ( acmeError $ acmeCertificateId $ acmeExpires ) )
+olcObjectClasses: ( 2.16.840.1.113730.5.2.2.4 NAME 'acmeAuthorization'
+  STRUCTURAL
+  MUST ( acmeAuthorizationId $ acmeAccountId $ acmeCreated $ acmeIdentifier $ acmeAuthorizationWildcard $ acmeStatus )
+  MAY acmeExpires )
+# Why have seperate object classes for different challenge types?
+# the dns-01 and http-01 challenge types both only store a 'token'.
+# But challenge types could involve storing other data.  So we
+# define a different object class for each challenge type, and each
+# class specifies the challenge-specific attribute types.
+olcObjectClasses: ( 2.16.840.1.113730.5.2.2.5 NAME 'acmeChallenge'
+  ABSTRACT
+  MUST ( acmeChallengeId $ acmeAccountId $ acmeAuthorizationId $ acmeStatus )
+  MAY ( acmeValidatedAt $ acmeError ) )
+olcObjectClasses: ( 2.16.840.1.113730.5.2.2.6 NAME 'acmeChallengeDns01'
+  SUP acmeChallenge
+  STRUCTURAL
+  MUST acmeToken )
+olcObjectClasses: ( 2.16.840.1.113730.5.2.2.7 NAME 'acmeChallengeHttp01'
+  SUP acmeChallenge
+  STRUCTURAL
+  MUST acmeToken )
+olcObjectClasses: ( 2.16.840.1.113730.5.2.2.8 NAME 'acmeCertificate'
+  STRUCTURAL
+  MUST ( acmeCertificateId $ acmeCreated $ userCertificate )
+  MAY acmeExpires )

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/DSDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/DSDatabase.java
@@ -1,0 +1,9 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.database;
+
+public class DSDatabase extends LDAPDatabase {
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
@@ -88,7 +88,7 @@ public class LDAPDatabase extends ACMEDatabase {
     static final String ATTR_ORDER_ID = "acmeOrderId";
     static final String ATTR_STATUS = "acmeStatus";
     static final String ATTR_TOKEN = "acmeToken";
-    static final String ATTR_USER_CERTIFICATE = "userCertificate";
+    static final String ATTR_USER_CERTIFICATE = "userCertificate;binary";
     static final String ATTR_VALIDATED_AT = "acmeValidatedAt";
 
     static final String OBJ_ACCOUNT = "acmeAccount";

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/OpenLDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/OpenLDAPDatabase.java
@@ -1,0 +1,9 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.database;
+
+public class OpenLDAPDatabase extends LDAPDatabase {
+}

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -21,6 +21,7 @@ import pki.server.instance
 DATABASE_CLASSES = {
     'in-memory': 'org.dogtagpki.acme.database.InMemoryDatabase',
     'ldap': 'org.dogtagpki.acme.database.LDAPDatabase',
+    'openldap': 'org.dogtagpki.acme.database.OpenLDAPDatabase',
     'postgresql': 'org.dogtagpki.acme.database.PostgreSQLDatabase'
 }
 
@@ -607,7 +608,7 @@ class ACMEDatabaseShowCLI(pki.cli.CLI):
         database_type = DATABASE_TYPES.get(database_class)
         print('  Database Type: %s' % database_type)
 
-        if database_type == 'ldap':
+        if database_type in ['ldap', 'openldap']:
 
             url = config.get('url')
             if url:
@@ -786,7 +787,7 @@ class ACMEDatabaseModifyCLI(pki.cli.CLI):
             config.pop('user', None)
             config.pop('password', None)
 
-        elif database_type == 'ldap':
+        elif database_type in ['ldap', 'openldap']:
 
             print()
             print('Enter the location of the LDAP server '

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -19,6 +19,7 @@ import pki.server.instance
 
 # TODO: auto-populate this map from /usr/share/pki/acme/database
 DATABASE_CLASSES = {
+    'ds': 'org.dogtagpki.acme.database.DSDatabase',
     'in-memory': 'org.dogtagpki.acme.database.InMemoryDatabase',
     'ldap': 'org.dogtagpki.acme.database.LDAPDatabase',
     'openldap': 'org.dogtagpki.acme.database.OpenLDAPDatabase',
@@ -608,7 +609,7 @@ class ACMEDatabaseShowCLI(pki.cli.CLI):
         database_type = DATABASE_TYPES.get(database_class)
         print('  Database Type: %s' % database_type)
 
-        if database_type in ['ldap', 'openldap']:
+        if database_type in ['ds', 'ldap', 'openldap']:
 
             url = config.get('url')
             if url:
@@ -787,7 +788,7 @@ class ACMEDatabaseModifyCLI(pki.cli.CLI):
             config.pop('user', None)
             config.pop('password', None)
 
-        elif database_type in ['ldap', 'openldap']:
+        elif database_type in ['ds', 'ldap', 'openldap']:
 
             print()
             print('Enter the location of the LDAP server '

--- a/docs/installation/acme/Configuring_ACME_Database.md
+++ b/docs/installation/acme/Configuring_ACME_Database.md
@@ -80,6 +80,50 @@ configFile=conf/ca/CS.cfg
 baseDN=dc=acme,dc=pki,dc=example,dc=com
 ```
 
+## Configuring OpenLDAP Database
+
+The ACME responder can be configured with an OpenLDAP database.
+
+First, add the ACME OpenLDAP schema by importing [/usr/share/pki/acme/database/openldap/schema.ldif](../../../base/acme/database/openldap/schema.ldif) with the following command:
+
+```
+$ ldapadd -H ldapi:/// -Y EXTERNAL \
+    -f /usr/share/pki/acme/database/openldap/schema.ldif
+```
+
+Next, prepare an LDIF file to create the ACME subtree.
+An sample LDIF file is available at [/usr/share/pki/acme/database/openldap/create.ldif](../../../base/acme/database/openldap/create.ldif).
+This example uses dc=acme,dc=pki,dc=example,dc=com as the base DN.
+Import the file with the following command:
+
+```
+$ ldapadd -h $HOSTNAME -x -D "cn=Manager,dc=example,dc=com" -w Secret.123 \
+    -f /usr/share/pki/acme/database/openldap/create.ldif
+```
+
+A sample OpenLDAP database configuration is available at
+[/usr/share/pki/acme/database/openldap/database.conf](../../../base/acme/database/openldap/database.conf).
+
+To use the OpenLDAP database, copy the sample database.conf into the /etc/pki/pki-tomcat/acme folder,
+or execute the following command to customize some of the parameters:
+
+```
+$ pki-server acme-database-mod --type openldap \
+    -DbaseDN=dc=acme,dc=pki,dc=example,dc=com \
+    -DbindPassword=Secret.123
+```
+
+Customize the configuration as needed. The database.conf should look like the following:
+
+```
+class=org.dogtagpki.acme.database.OpenLDAPDatabase
+url=ldap://<hostname>:389
+authType=BasicAuth
+bindDN=cn=Manager,dc=example,dc=com
+bindPassword=Secret.123
+baseDN=dc=acme,dc=pki,dc=example,dc=com
+```
+
 ## Configuring PosgreSQL Database
 
 The ACME responder can be configured with a PostgreSQL database.

--- a/docs/installation/acme/Configuring_ACME_Database.md
+++ b/docs/installation/acme/Configuring_ACME_Database.md
@@ -28,35 +28,35 @@ class=org.dogtagpki.acme.database.InMemoryDatabase
 
 There are no parameters to configure for in-memory database.
 
-## Configuring LDAP Database
+## Configuring DS Database
 
-The ACME responder can be configured with an LDAP database.
+The ACME responder can be configured with a DS database.
 
-First, add the ACME LDAP schema by importing [/usr/share/pki/acme/database/ldap/schema.ldif](../../../base/acme/database/ldap/schema.ldif) with the following command:
+First, add the ACME DS schema by importing [/usr/share/pki/acme/database/ds/schema.ldif](../../../base/acme/database/ds/schema.ldif) with the following command:
 
 ```
 $ ldapmodify -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ldap/schema.ldif
+    -f /usr/share/pki/acme/database/ds/schema.ldif
 ```
 
-Next, prepare an LDIF file to create the ACME LDAP tree.
-An sample LDIF file is available at [/usr/share/pki/acme/database/ldap/create.ldif](../../../base/acme/database/ldap/create.ldif).
+Next, prepare an LDIF file to create the ACME subtree.
+An sample LDIF file is available at [/usr/share/pki/acme/database/ds/create.ldif](../../../base/acme/database/ds/create.ldif).
 This example uses dc=acme,dc=pki,dc=example,dc=com as the base DN.
 Import the file with the following command:
 
 ```
 $ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ldap/create.ldif
+    -f /usr/share/pki/acme/database/ds/create.ldif
 ```
 
-A sample LDAP database configuration is available at
-[/usr/share/pki/acme/database/ldap/database.conf](../../../base/acme/database/ldap/database.conf).
+A sample DS database configuration is available at
+[/usr/share/pki/acme/database/ds/database.conf](../../../base/acme/database/ds/database.conf).
 
-To use the LDAP database, copy the sample database.conf into the /etc/pki/pki-tomcat/acme folder,
+To use the DS database, copy the sample database.conf into the /etc/pki/pki-tomcat/acme folder,
 or execute the following command to customize some of the parameters:
 
 ```
-$ pki-server acme-database-mod --type ldap \
+$ pki-server acme-database-mod --type ds \
     -DbaseDN=dc=acme,dc=pki,dc=example,dc=com \
     -DbindPassword=Secret.123
 ```
@@ -64,7 +64,7 @@ $ pki-server acme-database-mod --type ldap \
 Customize the configuration as needed. In a standalone ACME deployment, the database.conf should look like the following:
 
 ```
-class=org.dogtagpki.acme.database.LDAPDatabase
+class=org.dogtagpki.acme.database.DSDatabase
 url=ldap://<hostname>:389
 authType=BasicAuth
 bindDN=cn=Directory Manager
@@ -75,7 +75,7 @@ baseDN=dc=acme,dc=pki,dc=example,dc=com
 In a shared CA and ACME deployment, the database.conf should look like the following:
 
 ```
-class=org.dogtagpki.acme.database.LDAPDatabase
+class=org.dogtagpki.acme.database.DSDatabase
 configFile=conf/ca/CS.cfg
 baseDN=dc=acme,dc=pki,dc=example,dc=com
 ```


### PR DESCRIPTION
A new `OpenLDAPDatabase` class has been added to support OpenLDAP database for ACME. The class is currently identical to the existing `LDAPDatabase` class, but it's provided for implementing OpenLDAP-specific code in the future.

A new schema file, a sample initialization file, and a sample configuration file for OpenLDAP have been added.

The `pki-server acme-database-*` commands have also been modified to support an `openldap` type.

The ACME database documentation has been updated as well:
https://github.com/edewata/pki/blob/acme-openldap/docs/installation/acme/Configuring_ACME_Database.md

Changes to `LDAPDatabase` class:
* Previously the certificate data for ACME certificates was stored as `userCertificate=<data>` in DS, which doesn't seem to work in OpenLDAP. To support both LDAP servers, the certificate data is now stored as `userCertificate;binary=<data>`.

* Previously the identifiers for ACME order and authorization records were stored as `acmeIdentifier;<type>=<value>` in DS, which doesn't seem to be supported in OpenLDAP. To support both LDAP servers, the identifiers are now stored as `acmeIdentifier=<type>:<value>`.