### PR TITLE
Fixed ACME schema installation

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -59,8 +59,7 @@ DEFAULT_FILE_MODE = 0o0660
 DEFAULT_LINK_MODE = 0o0777
 
 SCHEMA_FILES = [
-    '/usr/share/pki/server/conf/schema.ldif',
-    '/usr/share/pki/acme/database/ldap/schema.ldif'
+    '/usr/share/pki/server/conf/schema.ldif'
 ]
 
 logger = logging.getLogger(__name__)

--- a/base/server/src/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
+++ b/base/server/src/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
@@ -85,9 +85,6 @@ public class LDAPConfigurator {
     public void setupSchema() throws Exception {
         logger.info("Setting up PKI schema");
         importSchemaFile("/usr/share/pki/server/conf/schema.ldif");
-
-        logger.info("Setting up ACME schema");
-        importSchemaFile("/usr/share/pki/acme/database/ldap/schema.ldif");
     }
 
     public void createContainers(String subsystem) throws Exception {


### PR DESCRIPTION
Previously the ACME schema was installed by default whenever
any PKI subsystem was installed. Since all ACME files have
been moved into an optional pki-acme package, the ACME schema
should no longer be installed by default. Instead, the ACME
schema should be installed separately as described in ACME
installation document.

https://github.com/dogtagpki/pki/blob/master/docs/installation/acme/Configuring_ACME_Database.md
