### PR TITLE
[broken!!] Switch Dogtag v10.9.x to JDK8 (again)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,20 @@ endif ()
 find_package(Java REQUIRED)
 find_package(JNI REQUIRED)
 
+# For convenience, update helpful variables if unset.
+if (NOT JRE_HOME)
+    if (EXISTS "${JAVA_HOME}/jre")
+        set(JRE_HOME "${JAVA_HOME}/jre")
+    else ()
+        set(JRE_HOME "${JAVA_HOME}")
+    endif ()
+endif ()
+if (NOT PKI_JAVA_PATH)
+    if (EXISTS "${JRE_HOME}/bin/java")
+        set(PKI_JAVA_PATH "${JRE_HOME}/bin/java")
+    endif ()
+endif ()
+
 # ONLY required for PKI_CORE
 if (BUILD_PKI_CORE)
     find_package(Ldap REQUIRED)

--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -98,6 +98,7 @@ class PKICLI(pki.cli.CLI):
 
         java_path = os.getenv('PKI_JAVA_PATH')
         java_home = os.getenv('JAVA_HOME')
+        jre_home = os.getenv('JRE_HOME')
         pki_lib = os.getenv('PKI_LIB')
         logging_config = os.getenv('PKI_LOGGING_CONFIG')
 
@@ -105,6 +106,8 @@ class PKICLI(pki.cli.CLI):
 
         if os.path.exists(java_path):
             cmd.extend([java_path])
+        elif os.path.exists(jre_home + '/bin/java'):
+            cmd.extend([jre_home + '/bin/java'])
         elif os.path.exists(java_home + '/jre/bin/java'):
             cmd.extend([java_home + '/jre/bin/java'])
         elif os.path.exists(java_home + '/bin/java'):

--- a/base/common/share/etc/pki.conf
+++ b/base/common/share/etc/pki.conf
@@ -6,9 +6,13 @@
 PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
 export PYTHON_EXECUTABLE
 
-# Java home
+# Java Development Kit or Java Runtime Environment home
 JAVA_HOME=${JAVA_HOME}
 export JAVA_HOME
+
+# Java Runtime Environment home
+JRE_HOME=${JRE_HOME}
+export JRE_HOME
 
 # Java interpreter
 PKI_JAVA_PATH=${Java_JAVA_EXECUTABLE}

--- a/base/java-tools/templates/pki_java_command_wrapper.in
+++ b/base/java-tools/templates/pki_java_command_wrapper.in
@@ -74,6 +74,8 @@ OS=`uname -s`
 ARCHITECTURE=`arch`
 if [ -e "${PKI_JAVA_PATH}" ]; then
     JAVA="${PKI_JAVA_PATH}"
+elif [ -e "${JRE_HOME}/bin/java" ]; then
+    JAVA="${JRE_HOME}/bin/java"
 elif [ -e "${JAVA_HOME}/jre/bin/java" ]; then
     JAVA="${JAVA_HOME}/jre/bin/java"
 elif [ -e "${JAVA_HOME}/bin/java" ]; then

--- a/base/java-tools/templates/pretty_print_cert_command_wrapper.in
+++ b/base/java-tools/templates/pretty_print_cert_command_wrapper.in
@@ -73,6 +73,8 @@ OS=`uname -s`
 ARCHITECTURE=`arch`
 if [ -e "${PKI_JAVA_PATH}" ]; then
     JAVA="${PKI_JAVA_PATH}"
+elif [ -e "${JRE_HOME}/bin/java" ]; then
+    JAVA="${JRE_HOME}/bin/java"
 elif [ -e "${JAVA_HOME}/jre/bin/java" ]; then
     JAVA="${JAVA_HOME}/jre/bin/java"
 elif [ -e "${JAVA_HOME}/bin/java" ]; then

--- a/base/java-tools/templates/pretty_print_crl_command_wrapper.in
+++ b/base/java-tools/templates/pretty_print_crl_command_wrapper.in
@@ -73,6 +73,8 @@ ARCHITECTURE=`arch`
 
 if [ -e "${PKI_JAVA_PATH}" ]; then
     JAVA="${PKI_JAVA_PATH}"
+elif [ -e "${JRE_HOME}/bin/java" ]; then
+    JAVA="${JRE_HOME}/bin/java"
 elif [ -e "${JAVA_HOME}/jre/bin/java" ]; then
     JAVA="${JAVA_HOME}/jre/bin/java"
 elif [ -e "${JAVA_HOME}/bin/java" ]; then

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -97,6 +97,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${JACKSON2_JAXRS_BASE_JAR} common/lib/jackson-jaxrs-base.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${JACKSON2_JAXRS_JSON_PROVIDER_JAR} common/lib/jackson-jaxrs-json-provider.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${JACKSON2_JAXB_ANNOTATIONS_JAR} common/lib/jackson-module-jaxb-annotations.jar
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${JAXB_API_JAR} common/lib/jaxb-api.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${JSS_JAR} common/lib/jss4.jar
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${LDAPJDK_JAR} common/lib/ldapjdk.jar
     COMMAND ln -sf /usr/share/java/pki/pki-cmsutil.jar ${CMAKE_CURRENT_BINARY_DIR}/common/lib/pki-cmsutil.jar

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -12,6 +12,7 @@
 [DEFAULT]
 
 JAVA_HOME=%(java_home)s
+JRE_HOME=%(jre_home)s
 
 # The sensitive_parameters contains a list of parameters which may contain
 # sensitive information which must not be displayed to the console nor stored
@@ -61,7 +62,7 @@ destroy_scriplets=
     finalization
 
 # By default, the following parameters will be set for Tomcat instances.
-# There is no reason to uncomment these.  They are provided for reference in 
+# There is no reason to uncomment these.  They are provided for reference in
 # case someone wants to override them in their config file.
 #
 # Tomcat instances:
@@ -234,7 +235,7 @@ pki_subsystem_conf_link=%(pki_subsystem_path)s/conf
 pki_subsystem_logs_link=%(pki_subsystem_path)s/logs
 pki_subsystem_registry_link=%(pki_subsystem_path)s/registry
 
- 
+
 ###############################################################################
 ##  Tomcat Configuration:                                                    ##
 ##                                                                           ##

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -322,6 +322,7 @@ class PKIServer(object):
 
         java_path = os.getenv('PKI_JAVA_PATH')
         java_home = self.config.get('JAVA_HOME')
+        jre_home = self.config.get('JRE_HOME')
         java_opts = self.config.get('JAVA_OPTS')
         security_manager = self.config.get('SECURITY_MANAGER')
 
@@ -345,6 +346,8 @@ class PKIServer(object):
         else:
             if os.path.exists(java_path):
                 cmd.extend([java_path])
+            elif os.path.exists(jre_home + '/bin/java'):
+                cmd.extend([jre_home + '/bin/java'])
             elif os.path.exists(java_home + '/jre/bin/java'):
                 cmd.extend([java_home + '/jre/bin/java'])
             elif os.path.exists(java_home + '/bin/java'):

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -257,6 +257,7 @@ class PKIConfigParser:
     def init_config(self, pki_instance_name=None):
         self.deployer.nss_db_type = self.get_nss_db_type()
         java_home = self._getenv('JAVA_HOME').strip()
+        jre_home = self._getenv('JRE_HOME').strip()
 
         # Check if a instance name is provided before assigning a default
         # instance_name
@@ -281,6 +282,7 @@ class PKIConfigParser:
             'pki_subsystem_type': self.deployer.subsystem_name.lower(),
             'nss_default_db_type': self.deployer.nss_db_type,
             'java_home': java_home,
+            'jre_home': jre_home,
             'home_dir': os.path.expanduser("~"),
             'pki_hostname': self.deployer.hostname,
             'pki_random_ajp_secret': pki.generate_password()})

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1081,6 +1081,7 @@ class PKISubsystem(object):
 
         java_path = os.getenv('PKI_JAVA_PATH')
         java_home = self.instance.config['JAVA_HOME']
+        jre_home = self.instance.config['JRE_HOME']
         java_opts = self.instance.config['JAVA_OPTS']
 
         classpath = [
@@ -1104,6 +1105,8 @@ class PKISubsystem(object):
 
         if os.path.exists(java_path):
             cmd.extend([java_path])
+        elif os.path.exists(jre_home + '/bin/java'):
+            cmd.extend([jre_home + '/bin/java'])
         elif os.path.exists(java_home + '/jre/bin/java'):
             cmd.extend([java_home + '/jre/bin/java'])
         elif os.path.exists(java_home + '/bin/java'):

--- a/base/server/share/conf/tomcat.conf
+++ b/base/server/share/conf/tomcat.conf
@@ -9,7 +9,7 @@
 # Default NSS DB type is loaded from /usr/share/pki/etc/tomcat.conf
 
 # Where your java installation lives
-JAVA_HOME="[JAVA_HOME]"
+JAVA_HOME="[JRE_HOME]"
 
 # Where your tomcat installation lives
 CATALINA_BASE="[PKI_INSTANCE_PATH]"
@@ -21,7 +21,7 @@ CATALINA_TMPDIR=[PKI_TMPDIR]
 # into a single line.
 #
 # Some parameters you might want to add are:
-# - parameters to the JVM like 
+# - parameters to the JVM like
 #   -Xminf0.1 -Xmaxf0.3
 # - parameters to set java.library.path for libtcnative.so
 #   -Djava.library.path=/usr/lib

--- a/pki.spec
+++ b/pki.spec
@@ -51,12 +51,21 @@ Source: https://github.com/dogtagpki/pki/archive/v%{version}%{?_phase}/pki-%{ver
 # Java
 ################################################################################
 
-%define java_home /usr/lib/jvm/jre-openjdk
+%define java_home /usr/lib/jvm/java-openjdk
+%define jre_home /usr/lib/jvm/jre-openjdk
 
 %if 0%{?fedora} && 0%{?fedora} >= 33
-%define min_java_version 1:11
+%define min_java_version 1:1.8.0
+%define java_devel java-1.8.0-openjdk-devel
+%define java_headless java-1.8.0-openjdk-headless
+%define java_home /usr/lib/jvm/java-1.8.0-openjdk
+%define jre_home /usr/lib/jvm/jre-1.8.0-openjdk
 %else
 %define min_java_version 1:1.8.0
+%define java_devel java-devel
+%define java_headless java-headless
+%define java_home /usr/lib/jvm/java-1.8.0-openjdk
+%define jre_home /usr/lib/jvm/jre-1.8.0-openjdk
 %endif
 
 ################################################################################
@@ -157,7 +166,7 @@ BuildRequires:    make
 BuildRequires:    cmake >= 3.0.2
 BuildRequires:    gcc-c++
 BuildRequires:    zip
-BuildRequires:    java-devel >= %{min_java_version}
+BuildRequires:    %java_devel >= %{min_java_version}
 BuildRequires:    javapackages-tools
 BuildRequires:    redhat-rpm-config
 BuildRequires:    ldapjdk >= 4.22.0
@@ -331,7 +340,7 @@ PKI consists of the following components:
 
 Summary:          PKI Symmetric Key Package
 
-Requires:         java-headless >= %{min_java_version}
+Requires:         %java_headless >= %{min_java_version}
 Requires:         jpackage-utils >= 0:1.7.5-10
 Requires:         jss >= 4.7.0
 Requires:         nss >= 3.38.0
@@ -399,7 +408,7 @@ This package contains PKI client library for Python 3.
 Summary:          PKI Base Java Package
 BuildArch:        noarch
 
-Requires:         java-headless >= %{min_java_version}
+Requires:         %java_headless >= %{min_java_version}
 Requires:         apache-commons-cli
 Requires:         apache-commons-codec
 Requires:         apache-commons-io
@@ -492,6 +501,7 @@ Requires:         tomcat >= 1:9.0.7
 %endif
 
 Requires:         velocity
+Requires:         sudo
 Requires:         systemd
 Requires(post):   systemd-units
 Requires(preun):  systemd-units
@@ -821,7 +831,8 @@ fi
     -DVAR_INSTALL_DIR:PATH=/var \
     -DP11_KIT_TRUST=/etc/alternatives/libnssckbi.so.%{_arch} \
     -DJAVA_HOME=%java_home \
-    -DPKI_JAVA_PATH=%java \
+    -DJRE_HOME=%jre_home \
+    -DPKI_JAVA_PATH=%jre_home/bin/java \
     -DJAVA_LIB_INSTALL_DIR=%{_jnidir} \
     -DSYSTEMD_LIB_INSTALL_DIR=%{_unitdir} \
     -DAPP_SERVER=$app_server \


### PR DESCRIPTION
This switches F33+ builds back to JDK8 for the time being.

---

Note that this patch is actually **broken**: Tomcat still runs under JDK8. Also, when submitting this via Koji, I ran into weird issues with [junit failing](https://kojipkgs.fedoraproject.org//work/tasks/3238/49623238/build.log):

```

[ 39%] Running JUnit test-pki-server
TestRunner: Test FAILED
TestRunner: See test reports in /builddir/build/BUILD/pki-10.9.1/x86_64-redhat-linux-gnu/base/server/test/reports
make[2]: *** [base/server/test/CMakeFiles/test-pki-server.dir/build.make:84: test-pki-server] Error 1
make[1]: *** [CMakeFiles/Makefile2:2620: base/server/test/CMakeFiles/test-pki-server.dir/all] Error 2
make: *** [Makefile:185: all] Error 2
error: Bad exit status from /var/tmp/rpm-tmp.qFsmpx (%build)
RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.qFsmpx (%build)
Child return code was: 1
EXCEPTION: [Error()]
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.8/site-packages/mockbuild/util.py", line 776, in do_with_status
    raise exception.Error("Command failed: \n # %s\n%s" % (command, output), child.returncode)
mockbuild.exception.Error: Command failed: 
 # bash --login -c /usr/bin/rpmbuild -bb --target x86_64 --nodeps /builddir/build/SPECS/pki-core.spec
```

This is an alternative approach to #525. Only one should be chosen. 

----

(In the below, the JDK refers to the `-devel` package, and JRE refers to the `-headless` package; we depend on the former only at build time, and the latter at both build and run time). 
(In the below, I use JDK<number> to refer to Java<number> and JDK<number> interchangeably; context should disambiguate).

Explanation of variables and their shortcomings:

 - `JAVA_HOME` was the original variable from PKI 10.8 and earlier. Under javapackage-tools, `%java_home` refers to a JDK path.
     - Under JDK8, `JAVA_HOME` can either be a JRE or a JDK home. Usually it is the JDK home, which is `/usr/lib/jvm/java-1.8.0-openjdk`; this is what `FindJava` detects by default (on a system without JDK11, or with JDK8 as the default JDK). Under this JDK path, the JRE is available at `$JAVA_HOME/jre` -- this includes `java` only; no `javac`. Obviously, the `javac` is available under JDK-based `JAVA_HOME`. On JDK8, `/usr/lib/jvm/jre-1.8.0-openjavadk` refers to a JRE home, without nested `jre` folder.
     - Under JDK11, `JAVA_HOME` can still either be a JRE or JDK home. However, `$JAVA_HOME/jre` no longer exists under a JDK11 JDK; instead, it is a completely separate path. This path is usually `/usr/lib/jvm/jre-11-openjdk`. Note that `/usr/lib/jvm/java-11-openjdk` still works as a JDK11 (with javac) path. 
    - The above is independent of Fedora version. The only difference is in F33+, `java-devel` points to JDK11 instead of JDK8. Hence, we need to explicitly depend on `java-1.8.0-openjdk-devel` to get JDK8 on F33+. 
 - `PKI_JAVA_PATH` was an attempt to fix this. Under javapackage tools, `%java` points to a JRE version of Java available at build and run time. This meant we could use a build-time specified JAVAC path; we don't really care about the entire JRE path, just the path to JAVAC in most all of our use cases.
    - Under Fedora 33+ however, javapackage tools was switched to use JDK11, with no real way to get JDK8 AFAIK (maybe I'm wrong?) -- this means, that, even if we depend on JDK8 explicitly (see above), `%java` isn't sufficient to get the path to the JRE java; it'll always be JDK11. No good! 
 - `JRE_HOME` (introduced in this PR) is an attempt to get a valid JRE directory to specify in `JAVA_HOME` for Tomcat, since it only needs a JRE and not a JDK. 
   - Note that, on JDK8 and JDK11, using `JAVA_HOME=%java_home` results in a JDK path not available at runtime.
   - However, we need `JAVA_HOME` to point to a JDK, otherwise CMake fails.
   - So, we need a new path to specify the path to the JRE available after package install, hence `JRE_HOME`.

Note that most of this shortcoming results in `JAVA_HOME` being an ambiguous term; half the time it points to a JDK, half the time to a JRE. We need to disambiguate the two so we can either define `JAVA_HOME=JDK_HOME` explicitly in cmake (and allow packagers to specify `JDK_HOME` and `JRE_HOME`, or make it by convention a JDK home (and allow packagers to specify `JAVA_HOME` and `JRE_HOME` -- the former they have already been doing). We need `JAVA_HOME` to make CMake work, so I went with the latter.   

---

In particular, when I say "CMake won't work" -- if we specify `JAVA_HOME` to a JDK8-JRE (`/usr/lib/jvm/jre-1.8.0-openjdk`) on a F33+ system, we result in CMake auto-detecting JDK11, and building PKI with JDK11. This results in JDK11+ class files, breaking stuff. We could add `source/target=1.8` to our build process, but that'll still result in compiling and running under two different JDKs, which should mostly be fine (on F33+). 