### PR TITLE
Add Fedora 33 image, switch to r.fp.o

### DIFF
--- a/.github/workflows/required-tests.yml
+++ b/.github/workflows/required-tests.yml
@@ -13,10 +13,10 @@ jobs:
 
       name: Build PKI
       runs-on: ubuntu-latest
-      container: fedora:${{ matrix.os }}
+      container: registry.fedoraproject.org/fedora:${{ matrix.os }}
       strategy:
           matrix:
-            os: ['31', '32']
+            os: ['31', '32', '33']
       steps:
           - name: Update base image
             run: |
@@ -56,10 +56,10 @@ jobs:
       runs-on: ubuntu-latest
       env:
         COPR_REPO: "@pki/master"
-      container: fedora:${{ matrix.os }}
+      container: registry.fedoraproject.org/fedora:${{ matrix.os }}
       strategy:
           matrix:
-            os: ['31', '32']
+            os: ['31', '32', '33']
       steps:
         - name: Update base image
           run: |
@@ -103,7 +103,7 @@ jobs:
         COPR_REPO: "@pki/master"
       strategy:
         matrix:
-          os: ['31', '32']
+          os: ['31', '32', '33']
       steps:
         - name: Clone the repository
           uses: actions/checkout@v2
@@ -208,7 +208,7 @@ jobs:
         test_set: "test_caacl_plugin.py test_caacl_profile_enforcement.py test_cert_plugin.py test_certprofile_plugin.py test_ca_plugin.py test_vault_plugin.py"
       strategy:
         matrix:
-          os: ['31', '32']
+          os: ['31', '32', '33']
       steps:
         - name: Clone the repository
           uses: actions/checkout@v2

--- a/base/server/python/pki/server/pkidestroy.py
+++ b/base/server/python/pki/server/pkidestroy.py
@@ -284,8 +284,8 @@ def log_error_details():
     e_type, e_value, e_stacktrace = sys.exc_info()
     stacktrace_list = traceback.format_list(traceback.extract_tb(e_stacktrace))
     e_stacktrace = "%s: %s\n" % (e_type.__name__, e_value)
-    for l in stacktrace_list:
-        e_stacktrace += l
+    for trace in stacktrace_list:
+        e_stacktrace += trace
     logger.error(e_stacktrace)
     del e_type, e_value, e_stacktrace
 

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -924,8 +924,8 @@ def log_error_details():
     e_type, e_value, e_stacktrace = sys.exc_info()
     stacktrace_list = traceback.format_list(traceback.extract_tb(e_stacktrace))
     e_stacktrace = "%s: %s\n" % (e_type.__name__, e_value)
-    for l in stacktrace_list:
-        e_stacktrace += l
+    for trace in stacktrace_list:
+        e_stacktrace += trace
     logger.error(e_stacktrace)
     del e_type, e_value, e_stacktrace
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,5 @@
 ARG OS_VERSION=latest
-FROM fedora:$OS_VERSION
+FROM registry.fedoraproject.org/fedora:$OS_VERSION
 
 # Install systemd since pki runs as a systemd service
 RUN true \

--- a/tools/pylintrc
+++ b/tools/pylintrc
@@ -42,10 +42,12 @@ extension-pkg-whitelist=ldap,lxml,nss
 #  	String statement has no effect Used when a string is used as a statement (which of course has no effect). This is a particular case of W0104 with its own message so you can easily disable it if you’re   #       using those strings as documentation, instead of comments.
 # W0511 (fixme): Used when a warning note as FIXME or XXX is detected.
 # W0142: Used when a function or method is called using *args or **kwargs to dispatch arguments. This doesn't improve readability and should be used with care.
+# W0707: Consider explicitly re-raising using the 'from' keyword -- lots of
+# output currently.
 #
 # C and R messages are disabled by default. To clean up the code, enable C and
 # R messages temporarily.
-disable=W0511,W0105,W0142,C,R,W0232
+disable=W0511,W0105,W0142,C,R,W0232,W0707
 
 
 [REPORTS]


### PR DESCRIPTION
registry.fedoraproject.org (r.fp.o) has more up-to-date Fedora images
than Dockerhub does. This is because Dockerhub is external infra with
a review process, whereas registry.fedoraproject.org is directly
controlled by the Fedora Project, so images can be pushed directly.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`