### PR TITLE
CI: Run QE playbooks on upstream CI pipeline over Vagrant

### DIFF
--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -98,8 +98,11 @@ jobs:
           run: vagrant plugin install vagrant-vbguest
 
         # Don't provision the VMs as they might not be ready for inter communication
-        - name: Boot the VMs without provisioning
-          run: vagrant up --no-provision
+        - name: Boot the "controller" VM without provisioning
+          run: vagrant up controller --no-provision
+
+        - name: Boot the "master" without provisioning
+          run: vagrant up master --no-provision
 
         - name: Install the built PKI packages on "master"
           run: vagrant provision master

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -1,0 +1,112 @@
+name: QE Tests
+
+on: [push, pull_request]
+
+jobs:
+    # "Build" job
+    build:
+      # This job tries to build PKI from src on a fresh docker container.
+      # The docker container is spawned by github itself and we merely just
+      # run the build commands. We then upload the artifact for consumption
+      # by the test jobs + for the public to consume. This job **does not**
+      # upload any build logs as they are visible in the log console itself.
+
+      name: Build PKI
+      runs-on: ubuntu-latest
+      container: fedora:${{ matrix.os }}
+      strategy:
+          matrix:
+            os: ['31', '32']
+      steps:
+          - name: Update base image
+            run: |
+                  set -x &&
+                  dnf update -y &&
+                  dnf install -y dnf-plugins-core rpm-build git
+
+          - name: Clone the repository
+            uses: actions/checkout@v2
+
+          - name: Install PKI build deps
+            run: |
+                  dnf copr enable -y @pki/master
+                  dnf builddep -y --allowerasing --spec ./pki.spec
+
+          - name: Build PKI packages
+            run: ./build.sh --with-timestamp --with-commit-id --work-dir=../packages rpm
+
+          - name: Compress RPMS
+            run: tar -czf pki-rpms.tar.gz ../packages/RPMS/*
+
+          # upload-artifact runs on host-vm rather than inside the container. Fixed in v2 (unreleased)
+          # Bug: https://github.com/actions/upload-artifact/issues/13#issuecomment-532936650
+          - name: Upload RPM artifacts
+            uses: actions/upload-artifact@v1
+            with:
+              name: pki-build-${{ matrix.os }}
+              path: pki-rpms.tar.gz
+
+    # Tier 0
+    installation-sanity:
+      # This job depends on the 'build' job and waits till it completes.
+      # This job needs container to be started manually, as Github provided
+      # container **does not** use /usr/bin/init as its ENTRYPOINT.
+      name: installation-sanity
+      needs: build
+      runs-on: macos-latest
+      env:
+        CONTAINER: pkitest
+        BUILDDIR: /tmp/workdir
+        PKIDIR: /tmp/workdir/pki
+        LOGS: ${GITHUB_WORKSPACE}/logs.txt
+        COPR_REPO: "@pki/master"
+        HOSTFILE: /tmp/hostfile
+        CONTROLLER_IP: "192.168.33.10"
+        MASTER_IP: "192.168.33.20"
+        TOPOLOGY: "topology-02"
+      strategy:
+        matrix:
+          os: ['31', '32']
+      steps:
+
+        - name: Clone the repository
+          uses: actions/checkout@v2
+
+        - name: Download PKI binaries from Build job
+          uses: actions/download-artifact@v1
+          with:
+            name: pki-build-${{ matrix.os }}
+
+        - name: Extract tar.gz for rpms
+          run: tar -xzf pki-build-${{ matrix.os }}/pki-rpms.tar.gz
+
+        - name: Modify the vagrant file per requirement
+          run: |
+                cd ci
+                sed -e "s/MASTER_IP/${MASTER_IP}/g" \
+                    -e "s/CONTROLLER_IP/${CONTROLLER_IP}/g" \
+                    -e "s/RELEASE/${{ matrix.os }}/g" \
+                    Vagrantfile > ../Vagrantfile
+
+                sed -e "s/MASTER_IP/${MASTER_IP}/g" \
+                    -e "s/TOPOLOGY/${TOPOLOGY}/g" \
+                    inventory > ../inventory
+                cd ../
+
+        # Let vagrant take care of installing the required Virtualbox guest additions
+        - name: Install Virtualbox guest additions plugin
+          run: vagrant plugin install vagrant-vbguest
+
+        # Don't provision the VMs as they might not be ready for inter communication
+        - name: Boot the VMs without provisioning
+          run: vagrant up --no-provision
+
+        - name: Install the built PKI packages on "master"
+          run: vagrant provision master
+
+        - name: Set up PKI deployment by running playbook on "controller"
+          run: vagrant provision controller
+
+        - name: Setup tmate session
+          if: failure()
+          uses: mxschmitt/action-tmate@v2

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -48,9 +48,8 @@ jobs:
 
     # Tier 0
     installation-sanity:
-      # This job depends on the 'build' job and waits till it completes.
-      # This job needs container to be started manually, as Github provided
-      # container **does not** use /usr/bin/init as its ENTRYPOINT.
+      # This job uses Ansible playbooks in the tests/ dir to setup a PKI deployment.
+      # All 5 subsystems are deployed on "discrete" instances
       name: installation-sanity
       needs: build
       runs-on: macos-latest

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -7,22 +7,9 @@ Vagrant.configure("2") do |config|
   config.vm.box = "fedora/RELEASE-cloud-base"
   config.vm.synced_folder "./", "/vagrant", type: "virtualbox"
 
-  config.vm.provider :virtualbox do |domain, override|
-    # Defaults for masters and clone
-    # WARNING: Do not overcommit CPUs, it causes issues during
-    # provisioning, when RPMs are installed
-    domain.cpus = 1
-
-    # GH hosted runners provide 8GB. Use conservatively if provisioning a clone VM
-    # Note: Assigning 3000 causes the provisioning to fail sometimes
-    domain.memory = 2750
-
-  end
-
   config.vm.define "controller" , primary: true do |controller|
-    config.vm.provider :virtualbox do |domain, override|
-      # Less resources needed for controller
-      domain.memory = 930
+    controller.vm.provider :virtualbox do |vb|
+          vb.customize ["modifyvm", :id, "--memory", "950"]
     end
     controller.vm.provision "ansible_local" do |ansible|
       # Disable default limit to connect to all the machines
@@ -42,6 +29,9 @@ Vagrant.configure("2") do |config|
   config.vm.define "master"  do |master|
     master.vm.network :private_network, ip: "MASTER_IP"
     master.vm.provision "shell", inline: "find /vagrant -name '*.rpm' -and -not -name '*debuginfo*' | xargs sudo dnf -y install"
+    master.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--memory", "2750"]
+    end
   end
 
 #  config.vm.define "clone0"  do |clone0|

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  config.ssh.username = "root"
+  config.vm.box = "fedora/RELEASE-cloud-base"
+  config.vm.synced_folder "./", "/vagrant", type: "virtualbox"
+
+  config.vm.provider :virtualbox do |domain, override|
+    # Defaults for masters and clone
+    # WARNING: Do not overcommit CPUs, it causes issues during
+    # provisioning, when RPMs are installed
+    domain.cpus = 1
+
+    # GH hosted runners provide 8GB. Use conservatively if provisioning a clone VM
+    # Note: Assigning 3000 causes the provisioning to fail sometimes
+    domain.memory = 2750
+
+  end
+
+  config.vm.define "controller" , primary: true do |controller|
+    config.vm.provider :virtualbox do |domain, override|
+      # Less resources needed for controller
+      domain.memory = 930
+    end
+    controller.vm.provision "ansible_local" do |ansible|
+      # Disable default limit to connect to all the machines
+      ansible.limit = "all"
+      ansible.install_mode = "pip_args_only"
+      ansible.pip_args = "-r /vagrant/tests/dogtag/pytest-ansible/requirements.txt"
+      ansible.become = true
+      ansible.playbook = "/vagrant/tests/dogtag/pytest-ansible/installation/main.yml"
+      ansible.inventory_path = "/vagrant/inventory"
+      ansible.verbose = "vv"
+      ansible.raw_arguments  = "-M /vagrant/tests/dogtag/pytest-ansible/common-modules/"
+    end
+
+    controller.vm.network :private_network, ip: "CONTROLLER_IP"
+  end
+
+  config.vm.define "master"  do |master|
+    master.vm.network :private_network, ip: "MASTER_IP"
+    master.vm.provision "shell", inline: "find /vagrant -name '*.rpm' -and -not -name '*debuginfo*' | xargs sudo dnf -y install"
+  end
+
+#  config.vm.define "clone0"  do |clone0|
+#  clone0.vm.network :private_network, ip: "CLONE_IP"
+#  end
+end

--- a/ci/inventory
+++ b/ci/inventory
@@ -1,0 +1,12 @@
+controller ansible_connection=local
+MASTER_IP ansible_ssh_host=MASTER_IP ansible_user='root' ansible_ssh_private_key_file=/vagrant/.vagrant/machines/master/virtualbox/private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+[master]
+MASTER_IP
+
+[localhost]
+controller
+
+[all:vars]
+topology=TOPOLOGY
+ansible_python_interpreter=/usr/bin/python3

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/files/test/script
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/files/test/script
@@ -29,24 +29,24 @@ echo "Generating shared secret"
 /usr/bin/tkstool -T -d $tks_alias -n $tks_shared_secret -f $tks_password -z $tks_noise > $tks_secret_output < $tks_input_file
 /usr/bin/tkstool -L -d $tks_alias -n $tks_shared_secret -f $tks_password > /tmp/sharedSecretList1.out
 grep "$tks_shared_secret" /tmp/sharedSecretList1.out
-first_session_tmp1=$(cat $tks_secret_output | grep -A1 "first\ssession\skey\sshare:")
+first_session_tmp1=$(cat $tks_secret_output | grep -A1 "first\ssession\skey\sshare:" -a)
 first_session_tmp2=$(echo $first_session_tmp1 | sed 's/^first session key share://')
 first_session_key=$(echo ${first_session_tmp2%% })
-first_session_KCV_tmp1=$(cat $tks_secret_output | grep "first\ssession\skey\sshare\sKCV:")
+first_session_KCV_tmp1=$(cat $tks_secret_output | grep "first\ssession\skey\sshare\sKCV:" -a)
 first_session_KCV_tmp2=$(echo $first_session_KCV_tmp1 | sed 's/^first session key share KCV://')
 first_session_KCV_key=$(echo ${first_session_KCV_tmp2%% })
 
-second_session_tmp1=$(cat $tks_secret_output | grep -A1 "second\ssession\skey\sshare:")
+second_session_tmp1=$(cat $tks_secret_output | grep -A1 "second\ssession\skey\sshare:" -a)
 second_session_tmp2=$(echo $second_session_tmp1 | sed 's/^second session key share://')
 second_session_key=$(echo ${second_session_tmp2%% })
-second_session_KCV_tmp1=$(cat $tks_secret_output | grep "second\ssession\skey\sshare\sKCV:")
+second_session_KCV_tmp1=$(cat $tks_secret_output | grep "second\ssession\skey\sshare\sKCV:" -a)
 second_session_KCV_tmp2=$(echo $second_session_KCV_tmp1 | sed 's/^second session key share KCV://')
 second_session_KCV_key=$(echo ${second_session_KCV_tmp2%% })
 
-third_session_tmp1=$(cat $tks_secret_output | grep -A1 "third\ssession\skey\sshare:")
+third_session_tmp1=$(cat $tks_secret_output | grep -A1 "third\ssession\skey\sshare:" -a)
 third_session_tmp2=$(echo $third_session_tmp1 | sed 's/^third session key share://')
 third_session_key=$(echo ${third_session_tmp2%% })
-third_session_KCV_tmp1=$(cat $tks_secret_output | grep "third\ssession\skey\sshare\sKCV:")
+third_session_KCV_tmp1=$(cat $tks_secret_output | grep "third\ssession\skey\sshare\sKCV:" -a)
 third_session_KCV_tmp2=$(echo $third_session_KCV_tmp1 | sed 's/^third session key share KCV://')
 third_session_KCV_key=$(echo ${third_session_KCV_tmp2%% })
 

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_ca.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_ca.yml
@@ -31,4 +31,6 @@
   when: debug == "true" or ca_debug == "true"
 
 - name: Starting CA Subsystem
-  shell: systemctl start pki-tomcatd@{{ topology }}-CA.service
+  service:
+    name: pki-tomcatd@{{ topology }}-CA.service
+    state: started

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_kra.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_kra.yml
@@ -1,3 +1,6 @@
+- name: Sleep for a while to give time of any other instances to come up.
+  shell: sleep 7s
+
 - name: Install KRA master
   shell: pkispawn -s KRA -f /tmp/test_dir/kra.cfg
 
@@ -26,8 +29,6 @@
   block:
   - name: Checking for right CA certificate and picking default name
     shell: sed -i "s/ocspSigningCert cert-pki-ca/Directory Server CA certificate/g" /etc/pki/{{ topology }}-KRA/server.xml
-    notify:
-      - STARTKRA
   when: tls_ldap == "true"
 
 - name: Enable OCSP Policy to Native for tls as false
@@ -37,8 +38,6 @@
 
   - name: Importing OCSP certificate in kra nssdb
     shell: certutil -A -d /etc/pki/{{ topology }}-KRA/alias -n "ocspSigningCert cert-pki-ca" -t "C,," -i  /tmp/test_dir/ocsp_signing.crt -f /tmp/test_dir/certutil_password
-    notify:
-      - STARTKRA
 
   - name: Removing file generated with password
     file:
@@ -47,3 +46,8 @@
     with_items:
       -  /tmp/test_dir/certutil_password
   when: tls_ldap == "false"
+
+- name: Starting KRA Subsystem
+  service:
+    name: pki-tomcatd@{{ topology }}-KRA.service
+    state: started

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_ocsp.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_ocsp.yml
@@ -1,5 +1,5 @@
 - name: sleep
-  shell: sleep 5s
+  shell: sleep 10s
   
 - name: Install OCSP master
   shell: pkispawn -s OCSP -f /tmp/test_dir/ocsp.cfg
@@ -27,8 +27,6 @@
   block:
   - name: Checking for right CA certificate
     shell: sed -i "s/ocspSigningCert cert-pki-ca/Directory Server CA certificate/g" /etc/pki/{{ topology }}-OCSP/server.xml
-    notify:
-      - STARTOCSP
   when: tls_ldap == "true"
 
 
@@ -39,8 +37,6 @@
 
   - name: Importing OCSP certificate in ocsp nssdb
     shell: certutil -A -d /etc/pki/{{ topology }}-OCSP/alias -n "ocspSigningCert cert-pki-ca" -t "C,," -i  /tmp/test_dir/ocsp_signing.crt -f /tmp/test_dir/certutil_password
-    notify:
-      - STARTOCSP
 
   - name: Removing file generated with password
     file:
@@ -49,3 +45,8 @@
     with_items:
       -  /tmp/test_dir/certutil_password
   when: tls_ldap == "false"
+
+- name: Starting OCSP Subsystem
+  service:
+    name: pki-tomcatd@{{ topology }}-OCSP.service
+    state: started

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_shared.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_shared.yml
@@ -27,5 +27,8 @@
     - tks
     - tps
 
-- name : Starting pki-tomcat Instance
-  shell: systemctl start pki-tomcatd@pki-tomcat.service
+
+- name: Starting pki-tomcat Instance
+  service:
+    name: pki-tomcatd@pki-tomcat.service
+    state: started

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_subca.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_subca.yml
@@ -1,7 +1,10 @@
-- name: Install CA master
+- name: Sleep for a while to give time of any other instances to come up.
+  shell: sleep 5s
+
+- name: Install SubCA
   shell: pkispawn -s CA -f /tmp/test_dir/subca.cfg
 
-- name : Stopping CA Subsystem
+- name : Stopping SubCA Subsystem
   shell: systemctl stop pki-tomcatd@{{ topology }}-CA.service
 
 - name: Enable SignedAudit for Subsystem
@@ -14,5 +17,7 @@
 - name: Importing client certificate for OCSP
   shell: certutil -L -d /var/lib/pki/{{ topology }}-CA/alias -n "{{ nickname_ocsp.stdout }}" -a > /tmp/test_dir/ocsp_signing.crt
 
-- name : Starting CA Subsystem
-  shell: systemctl start pki-tomcatd@{{ topology }}-CA.service
+- name: Starting SubCA Subsystem
+  service:
+    name: pki-tomcatd@{{ topology }}-CA.service
+    state: started

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_tks.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_tks.yml
@@ -1,3 +1,6 @@
+- name: Sleep for a while to give time of any other instances to come up.
+  shell: sleep 7s
+
 - name: Install TKS master
   shell: pkispawn -s TKS -f /tmp/test_dir/tks.cfg
 
@@ -26,8 +29,6 @@
   block:
   - name: Checking for right CA certificate
     shell: sed -i "s/ocspSigningCert cert-pki-ca/Directory Server CA certificate/g" /etc/pki/{{ topology }}-TKS/server.xml
-    notify:
-      - STARTTKS
   when: tls_ldap == "true"
 
 - name: Enable OCSP Policy to Native for tls as false
@@ -37,8 +38,6 @@
 
   - name: Importing OCSP certificate in TKS nssdb
     shell: certutil -A -d /etc/pki/{{ topology }}-TKS/alias -n "ocspSigningCert cert-pki-ca" -t "C,," -i  /tmp/test_dir/ocsp_signing.crt -f /tmp/test_dir/certutil_password
-    notify:
-      - STARTTKS
 
   - name: Removing file generated with password
     file:
@@ -49,6 +48,11 @@
   when: tls_ldap == "false"
 
 - meta: flush_handlers
+
+- name: Starting TKS Subsystem
+  service:
+    name: pki-tomcatd@{{ topology }}-TKS.service
+    state: started
 
 - name: Sleep for a while to start TKS
   shell: sleep 3s

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_tps.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_tps.yml
@@ -1,3 +1,6 @@
+- name: Sleep for a while to give time of any other instances to come up.
+  shell: sleep 7s
+
 - name: Install TPS master
   shell: pkispawn -s TPS -f /tmp/test_dir/tps.cfg
 
@@ -29,8 +32,6 @@
   block:
   - name: Checking for right CA certificate
     shell: sed -i "s/ocspSigningCert cert-pki-ca/Directory Server CA certificate/g" /etc/pki/{{ topology }}-TPS/server.xml
-    notify:
-      - STARTTPS
   when: tls_ldap == "true"
 
 - name: Enable OCSP Policy to Native for tls as false
@@ -40,8 +41,6 @@
 
   - name: Importing OCSP certificate in tps nssdb
     shell: certutil -A -d /etc/pki/{{ topology }}-TPS/alias -n "ocspSigningCert cert-pki-ca" -t "C,," -i  /tmp/test_dir/ocsp_signing.crt -f /tmp/test_dir/certutil_password
-    notify:
-      - STARTTPS
 
   - name: Removing file generated with password
     file:
@@ -50,3 +49,8 @@
     with_items:
       -  /tmp/test_dir/certutil_password
   when: tls_ldap == "false"
+
+- name: Starting TPS Subsystem
+  service:
+    name: pki-tomcatd@{{ topology }}-TPS.service
+    state: started

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/test/script
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Trigger/files/test/script
@@ -29,24 +29,24 @@ echo "Generating shared secret"
 /usr/bin/tkstool -T -d $tks_alias -n $tks_shared_secret -f $tks_password -z $tks_noise > $tks_secret_output < $tks_input_file
 /usr/bin/tkstool -L -d $tks_alias -n $tks_shared_secret -f $tks_password > /tmp/sharedSecretList1.out
 grep "$tks_shared_secret" /tmp/sharedSecretList1.out
-first_session_tmp1=$(cat $tks_secret_output | grep -A1 "first\ssession\skey\sshare:")
+first_session_tmp1=$(cat $tks_secret_output | grep -A1 "first\ssession\skey\sshare:" -a)
 first_session_tmp2=$(echo $first_session_tmp1 | sed 's/^first session key share://')
 first_session_key=$(echo ${first_session_tmp2%% })
-first_session_KCV_tmp1=$(cat $tks_secret_output | grep "first\ssession\skey\sshare\sKCV:")
+first_session_KCV_tmp1=$(cat $tks_secret_output | grep "first\ssession\skey\sshare\sKCV:" -a)
 first_session_KCV_tmp2=$(echo $first_session_KCV_tmp1 | sed 's/^first session key share KCV://')
 first_session_KCV_key=$(echo ${first_session_KCV_tmp2%% })
 
-second_session_tmp1=$(cat $tks_secret_output | grep -A1 "second\ssession\skey\sshare:")
+second_session_tmp1=$(cat $tks_secret_output | grep -A1 "second\ssession\skey\sshare:" -a)
 second_session_tmp2=$(echo $second_session_tmp1 | sed 's/^second session key share://')
 second_session_key=$(echo ${second_session_tmp2%% })
-second_session_KCV_tmp1=$(cat $tks_secret_output | grep "second\ssession\skey\sshare\sKCV:")
+second_session_KCV_tmp1=$(cat $tks_secret_output | grep "second\ssession\skey\sshare\sKCV:" -a)
 second_session_KCV_tmp2=$(echo $second_session_KCV_tmp1 | sed 's/^second session key share KCV://')
 second_session_KCV_key=$(echo ${second_session_KCV_tmp2%% })
 
-third_session_tmp1=$(cat $tks_secret_output | grep -A1 "third\ssession\skey\sshare:")
+third_session_tmp1=$(cat $tks_secret_output | grep -A1 "third\ssession\skey\sshare:" -a)
 third_session_tmp2=$(echo $third_session_tmp1 | sed 's/^third session key share://')
 third_session_key=$(echo ${third_session_tmp2%% })
-third_session_KCV_tmp1=$(cat $tks_secret_output | grep "third\ssession\skey\sshare\sKCV:")
+third_session_KCV_tmp1=$(cat $tks_secret_output | grep "third\ssession\skey\sshare\sKCV:" -a)
 third_session_KCV_tmp2=$(echo $third_session_KCV_tmp1 | sed 's/^third session key share KCV://')
 third_session_KCV_key=$(echo ${third_session_KCV_tmp2%% })
 


### PR DESCRIPTION
Provision 2 Vagrant VMs inside host (only Mac is supported in
GH actions):

**controller:**
  VM used to run the ansible playbook. The playbook is provisioned
  using Vagrant's inbuilt provisioners
**master:**
  VM acts as the PKI master node. _topology-02_ (discrete instance) is
  used to configure this node.

*Note1:* Static inventory file is used. This is because the playbook
is being executed from the guest VM (controller) and autogenerated
hostfile is unreliable.

*Note2:* When creating vagrant VMs, provisioning is suspended. This is
to resolve dependency b/w master and controller (ie) the latest built
packages need to be installed in master first before controller tries
to execute playbooks.

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`