### PR TITLE
Support f32->f33 upgrade on v10.9

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -186,13 +186,13 @@ find_file(JAKARTA_ACTIVATION_JAR
     NAMES
         jakarta.activation.jar
         jakarta-activation.jar
-        jaxb.activation.jar
-        jaxb-activation.jar
+        javax.activation.jar
+        javax-activation.jar
     PATHS
         /usr/share/java/jakarta-activation
         /usr/share/java/jakarta
-        /usr/share/java/jaxb-activation
-        /usr/share/java/jaxb
+        /usr/share/java/javax-activation
+        /usr/share/java/javax
         /usr/share/java
 )
 

--- a/base/server/share/conf/tomcat.conf
+++ b/base/server/share/conf/tomcat.conf
@@ -8,9 +8,6 @@
 
 # Default NSS DB type is loaded from /usr/share/pki/etc/tomcat.conf
 
-# Where your java installation lives
-JAVA_HOME="[JAVA_HOME]"
-
 # Where your tomcat installation lives
 CATALINA_BASE="[PKI_INSTANCE_PATH]"
 

--- a/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
@@ -10,6 +10,8 @@ Environment="NAME=%i"
 Environment="STARTED_BY_SYSTEMD=1"
 Environment="WD_PIPE_NAME=%i"
 EnvironmentFile=-/etc/sysconfig/%i
+EnvironmentFile=/usr/share/pki/etc/pki.conf
+EnvironmentFile=/etc/pki/pki.conf
 
 ExecStartPre=+/usr/bin/setfacl -m u:pkiuser:wx /run/systemd/ask-password
 ExecStartPre=/usr/bin/pki-server-nuxwdog

--- a/base/server/share/lib/systemd/system/pki-tomcatd@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd@.service
@@ -8,6 +8,8 @@ EnvironmentFile=/usr/share/pki/etc/tomcat.conf
 EnvironmentFile=/etc/tomcat/tomcat.conf
 Environment="NAME=%i"
 EnvironmentFile=-/etc/sysconfig/%i
+EnvironmentFile=/usr/share/pki/etc/pki.conf
+EnvironmentFile=/etc/pki/pki.conf
 
 ExecStartPre=/usr/sbin/pki-server upgrade %i
 ExecStartPre=/usr/sbin/pki-server migrate %i

--- a/cmake/Modules/Java.cmake
+++ b/cmake/Modules/Java.cmake
@@ -84,6 +84,8 @@ function(javac target)
             -encoding UTF-8
             -cp ${native_classpath}
             -d ${output_dir}
+            -source 1.8
+            -target 1.8
             @${file_list}
         WORKING_DIRECTORY
             ${source_dir}


### PR DESCRIPTION
This is in three parts:

1. Fix jakarta-activation path on Debian/Ubuntu (`/usr/share/java/javax.activation.jar`), as reported by Timo
2. Upgrade `JAVA_HOME` to the value in the environment, because it is loaded from `/usr/.../pki.conf`). That's the value of `JAVA_HOME` we built with.
3. Make sure we build with JDK8 for the foreseeable future (so that even if JDK8 is still used at runtime, we still run fine); also ensures we don't introduce JDK11-specific code yet. 

----

@edewata Where should we document that `JAVA_HOME` now must be overridden in `/etc/pki/pki.conf`?