### PR TITLE
Support f32->f33 upgrade (JDK8 -> JDK11)

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -186,13 +186,13 @@ find_file(JAKARTA_ACTIVATION_JAR
     NAMES
         jakarta.activation.jar
         jakarta-activation.jar
-        jaxb.activation.jar
-        jaxb-activation.jar
+        javax.activation.jar
+        javax-activation.jar
     PATHS
         /usr/share/java/jakarta-activation
         /usr/share/java/jakarta
-        /usr/share/java/jaxb-activation
-        /usr/share/java/jaxb
+        /usr/share/java/javax-activation
+        /usr/share/java/javax
         /usr/share/java
 )
 

--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -119,6 +119,7 @@ class MigrateCLI(pki.cli.CLI):
         self.migrate_nssdb(instance)
         self.migrate_tomcat(instance, tomcat_version)
         self.migrate_subsystems(instance, tomcat_version)
+        self.migrate_service(instance)
 
     def migrate_nssdb(self, instance):
 
@@ -601,3 +602,45 @@ class MigrateCLI(pki.cli.CLI):
 
         os.symlink(source, dest)
         os.lchown(dest, instance.uid, instance.gid)
+
+    def migrate_service(self, instance):
+        self.migrate_service_java_home(instance)
+
+    def migrate_service_java_home(self, instance):
+        # When JAVA_HOME in the Tomcat service config differs from the
+        # value in /usr/share/pki/etc/pki.conf, update the value in
+        # the service config.
+
+        if "JAVA_HOME" not in os.environ or not os.environ["JAVA_HOME"]:
+            logger.debug("Refusing to migrate JAVA_HOME with missing environment variable")
+
+        java_home = os.environ["JAVA_HOME"]
+
+        # Update in /etc/sysconfig/<instance>
+        result = self.update_java_home_in_config(instance.service_conf, java_home)
+        self.write_config(instance.service_conf, result)
+
+        # Update in /etc/pki/<instance>/tomcat.conf
+        result = self.update_java_home_in_config(instance.tomcat_conf, java_home)
+        self.write_config(instance.tomcat_conf, result)
+
+    def update_java_home_in_config(self, path, new_value):
+        result = []
+
+        with open(path, 'r') as conf_fp:
+            for line in conf_fp:
+                target="JAVA_HOME="
+                if target not in line:
+                    result.append(line)
+                else:
+                    target_offset = line.index(target)
+                    prefix = line[:target_offset]
+                    new_line = prefix + target + '"' + new_value + '"\n'
+                    result.append(new_line)
+
+        return result
+
+    def write_config(self, path, output):
+        with open(path, 'w') as conf_fp:
+            for line in output:
+                print(line, end='', file=conf_fp)

--- a/cmake/Modules/Java.cmake
+++ b/cmake/Modules/Java.cmake
@@ -84,6 +84,8 @@ function(javac target)
             -encoding UTF-8
             -cp ${native_classpath}
             -d ${output_dir}
+            -source 1.8
+            -target 1.8
             @${file_list}
         WORKING_DIRECTORY
             ${source_dir}


### PR DESCRIPTION
This is in three parts:

1. Fix jakarta-activation path on Debian/Ubuntu (`/usr/share/java/javax.activation.jar`), as reported by Timo
2. Upgrade `JAVA_HOME` to the value in the environment, because it is loaded from `/usr/.../pki.conf`). That's the value of `JAVA_HOME` we built with.
3. Make sure we build with JDK8 for the foreseeable future (so that even if JDK8 is still used at runtime, we still run fine). 