### PR TITLE
Add "dynamic profiles" to SCEP

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -232,6 +232,7 @@ ca.scep.allowedHashAlgorithms=SHA256,SHA512
 ca.scep.encryptionAlgorithm=DES3
 ca.scep.allowedEncryptionAlgorithms=DES3
 ca.scep.nonceSizeLimit=16
+ca.scep.allowedDynamicProfileIds=caRouterCert,caServerCert
 ca.Policy._000=##
 ca.Policy._001=## Certificate Policy Framework (deprecated)
 ca.Policy._002=##

--- a/base/ca/shared/webapps/ca/WEB-INF/web.xml
+++ b/base/ca/shared/webapps/ca/WEB-INF/web.xml
@@ -2000,6 +2000,13 @@
    </servlet>
 
    <servlet>
+      <servlet-name>  caDynamicProfileSCEP  </servlet-name>
+      <servlet-class> com.netscape.cms.servlet.cert.scep.CRSEnrollment  </servlet-class>
+             <init-param><param-name>  authority  </param-name>
+                         <param-value> ca       </param-value> </init-param>
+   </servlet>
+
+   <servlet>
       <servlet-name>  caRASCEP  </servlet-name>
       <servlet-class> com.netscape.cms.servlet.cert.scep.CRSEnrollment  </servlet-class>
              <init-param><param-name>  authority  </param-name>
@@ -2610,6 +2617,11 @@
    <servlet-mapping>
       <servlet-name>  caSCEP </servlet-name>
       <url-pattern>   /cgi-bin/pkiclient.exe </url-pattern>
+   </servlet-mapping>
+
+   <servlet-mapping>
+      <servlet-name>  caDynamicProfileSCEP </servlet-name>
+      <url-pattern>   /scep/* </url-pattern>
    </servlet-mapping>
 
    <servlet-mapping>


### PR DESCRIPTION
Hello all,

as a followup to my intro [message to the pki-devel list](https://www.redhat.com/archives/pki-devel/2020-August/msg00011.html), I'd like you to kindly consider a few pull requests that I am implementing for a client of mine. All of them will be dealing with SCEP and should bring a few enhancements.

This one **generalizes the profile used for certificate enrollment using SCEP**. The current master uses a hardwired profile `caRouterCert` while the proposed code allows the SCEP administrator to predefine a set of allowed profiles and the **client is then able to choose the profile ID dynamically**.

To stay compatible with most SCEP implementations, this PR allows to choose the profile ID via the URL of the SCEP request, which is usually configurable in the clients. Instead of the current default SCEP URL (`http://dogtag.example.com:8080/ca/cgi-bin/pkiclient.exe`), the proposed "dynamic profiles" implementation uses URL in the following form:

```
http://dogtag.example.com:8080/ca/scep/PROFILE_ID/pkiclient.exe
```

where `PROFILE_ID` is the profile name. The profile name must be one of the profiles listed in the `ca.scep.allowedDynamicProfileIds` config option in the main configuration file. By default, the new URL accepts the `caRouterCert` and `caServerCert` profiles. (I'm leaving up to your consideration whether such default should not be blank instead, so that the "dynamic profiles" SCEP feature is disabled by default.)

By the way, this solution is inspired by a similar thing in [EJBCA SCEP](https://download.primekey.se/docs/EJBCA-Enterprise/latest/SCEP.html) implementation, see the "ALIAS" in the "SCEP Configuration" section.

For this to work I added a new servlet mapping to `web.xml` which maps the dynamic URL to the same servlet, `CRSEnrollment.java`. I could probably generalize the current servlet mapping but I didn't want to mess with the current code too much... The proposed code tries to leave the current SCEP internals as much as possible.

In the `init` method, the new code loads the configuration options, logs them, and based on the servlet name decides whether it should run in the "dynamic profiles" mode or the default one (with the profile hardwired). 

In the `service` method, in the dynamic profile mode, it parses the profile_id from the URL and checks whether this is an allowed profile (configured in the `ca.scep.allowedDynamicProfileIds` option). If yes, it sets the `mProfileId` field and the rest of the code runs completely the same as before, i.e. the cert is enrolled but this time with a dynamically chosen profile.

I also slightly refactored the `isAlgorithmAllowed` method to a little more generic method `isInAllowedList`, because I use it in a new context (but in the same way as it was used before).

I am ready for your suggestions, also I am not sure whether there are any automated tests to add, please guide me if so. Thanks!
