### PR TITLE
Handle SCEP PKI message in POST request body

### DIFF
--- a/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -430,7 +430,7 @@ public class CRSEnrollment extends HttpServlet {
                     bstream.write(r);
                 }
 
-                message = Utils.base64encode(bstream.toByteArray(), true);
+                message = Utils.base64encode(bstream.toByteArray(), false);
             }
         } catch (IOException e) {
             logger.warn("CSREnrollment: exception while reading POST body: " + e.getMessage(), e);


### PR DESCRIPTION
This is a minimal implementation of parsing the SCEP PKI message from the body of the request. When a POST request is received in the servlet, the code expects binary data in the POST body and tries to parse it into the `message`, which is then handled the same way as the message from a GET parameter.

I am not sure whether Dogtag uses POST requests in the servlet internally but if it does, it might bring problems as reading the body clashes with current code for determining the parameters (AFAIK, the body of a servlet request may be read only _once_ and both the new code as well as the current code in the `toHashTable` method try to read the request body). Ideally, we should only read POST body when the `application/x-pki-message` content_type is [present in the request](https://tools.ietf.org/html/draft-gutmann-scep-16#section-4.3) but in reality it seems that many SCEP clients don't do that.