### PR TITLE
Remove SSL configuration; rely on crypto-policies

### DIFF
--- a/base/common/share/etc/pki.conf
+++ b/base/common/share/etc/pki.conf
@@ -38,33 +38,6 @@ export PKI_LOGGING_CONFIG
 PKI_CLI_OPTIONS=
 export PKI_CLI_OPTIONS
 
-# SSL version ranges
-# Valid values: SSL_3_0, TLS_1_0, TLS_1_1, TLS_1_2
-SSL_STREAM_VERSION_MIN="TLS_1_0"
-export SSL_STREAM_VERSION_MIN
-
-SSL_STREAM_VERSION_MAX="TLS_1_2"
-export SSL_STREAM_VERSION_MAX
-
-SSL_DATAGRAM_VERSION_MIN="TLS_1_1"
-export SSL_DATAGRAM_VERSION_MIN
-
-SSL_DATAGRAM_VERSION_MAX="TLS_1_2"
-export SSL_DATAGRAM_VERSION_MAX
-
-# SSL default ciphers
-# This boolean parameter determines whether to enable default SSL ciphers.
-SSL_DEFAULT_CIPHERS="true"
-export SSL_DEFAULT_CIPHERS
-
-# SSL ciphers
-# This parameter lists SSL ciphers to enable/disable in addition to the default ciphers.
-# The list contains IANA-registered cipher names or hex IDs separated by white spaces.
-# https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4
-# To disable a cipher, specify a "-" sign in front of the cipher name or ID.
-SSL_CIPHERS=""
-export SSL_CIPHERS
-
 # Key wrapping parameter set
 # This parameter specifies the encryption and key wrapping algorithms to use
 # when storing secrets in the KRA, or creating CRMF data using CRMFPopClient.

--- a/base/console/src/com/netscape/admin/certsrv/connection/JSSConnection.java
+++ b/base/console/src/com/netscape/admin/certsrv/connection/JSSConnection.java
@@ -48,8 +48,6 @@ import org.mozilla.jss.ssl.SSLClientCertificateSelectionCallback;
 import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
 import org.mozilla.jss.ssl.SSLSocket;
 import org.mozilla.jss.ssl.SSLSocketListener;
-import org.mozilla.jss.ssl.SSLVersion;
-import org.mozilla.jss.ssl.SSLVersionRange;
 import org.mozilla.jss.util.Password;
 import org.mozilla.jss.util.PasswordCallback;
 import org.mozilla.jss.util.PasswordCallbackInfo;
@@ -122,12 +120,6 @@ public class JSSConnection implements IConnection, SSLCertificateApprovalCallbac
             cryptoManager = CryptoManager.getInstance();
         } catch (Exception e) {
         }
-
-        SSLVersionRange streamRange = CryptoUtil.boundSSLStreamVersionRange(SSLVersion.TLS_1_0, SSLVersion.TLS_1_2);
-        SSLVersionRange datagramRange = CryptoUtil.boundSSLDatagramVersionRange(SSLVersion.TLS_1_1, SSLVersion.TLS_1_2);
-        CryptoUtil.setSSLStreamVersionRange(streamRange.getMinVersion(), streamRange.getMaxVersion());
-        CryptoUtil.setSSLDatagramVersionRange(datagramRange.getMinVersion(), datagramRange.getMaxVersion());
-        CryptoUtil.setDefaultSSLCiphers();
 
         s = new SSLSocket(host, port, null, 0, this, this);
 

--- a/base/console/src/com/netscape/admin/certsrv/connection/JSSConnection.java
+++ b/base/console/src/com/netscape/admin/certsrv/connection/JSSConnection.java
@@ -122,6 +122,7 @@ public class JSSConnection implements IConnection, SSLCertificateApprovalCallbac
         }
 
         s = new SSLSocket(host, port, null, 0, this, this);
+        s.enablePostHandshakeAuth(true);
 
         s.addSocketListener(new SSLSocketListener() {
 

--- a/base/java-tools/src/com/netscape/cmstools/HttpClient.java
+++ b/base/java-tools/src/com/netscape/cmstools/HttpClient.java
@@ -132,12 +132,6 @@ public class HttpClient {
 
                 SSLHandshakeCompletedListener listener = new ClientHandshakeCB(this);
 
-                SSLVersionRange streamRange = CryptoUtil.boundSSLStreamVersionRange(SSLVersion.TLS_1_0, SSLVersion.TLS_1_2);
-                SSLVersionRange datagramRange = CryptoUtil.boundSSLDatagramVersionRange(SSLVersion.TLS_1_1, SSLVersion.TLS_1_2);
-                CryptoUtil.setSSLStreamVersionRange(streamRange.getMinVersion(), streamRange.getMaxVersion());
-                CryptoUtil.setSSLDatagramVersionRange(datagramRange.getMinVersion(), datagramRange.getMaxVersion());
-                CryptoUtil.setDefaultSSLCiphers();
-
                 sslSocket = new SSLSocket(_host, _port);
                 // SSLSocket.setSSLVersionRange() needs to be exposed in JSS
                 // sslSocket.setSSLVersionRange(SSLVersionRange.tls1_0, SSLVersionRange.tls1_2);

--- a/base/java-tools/src/com/netscape/cmstools/HttpClient.java
+++ b/base/java-tools/src/com/netscape/cmstools/HttpClient.java
@@ -136,6 +136,7 @@ public class HttpClient {
                 // SSLSocket.setSSLVersionRange() needs to be exposed in JSS
                 // sslSocket.setSSLVersionRange(SSLVersionRange.tls1_0, SSLVersionRange.tls1_2);
                 sslSocket.addHandshakeCompletedListener(listener);
+                sslSocket.enablePostHandshakeAuth(true);
 
                 CryptoToken tt = cm.getThreadToken();
                 System.out.println("after SSLSocket created, thread token is "+ tt.getName());

--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -53,8 +53,6 @@ import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
-import org.mozilla.jss.ssl.SSLVersion;
-import org.mozilla.jss.ssl.SSLVersionRange;
 import org.mozilla.jss.util.IncorrectPasswordException;
 import org.mozilla.jss.util.Password;
 
@@ -571,36 +569,6 @@ public class MainCLI extends CLI {
 
         CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
         manager.setThreadToken(token);
-
-        // See default SSL configuration in /usr/share/pki/etc/pki.conf.
-
-        String streamVersionMin = System.getenv("SSL_STREAM_VERSION_MIN");
-        String streamVersionMax = System.getenv("SSL_STREAM_VERSION_MAX");
-
-        SSLVersionRange streamRange = CryptoUtil.boundSSLStreamVersionRange(
-                streamVersionMin == null ? SSLVersion.TLS_1_0 : SSLVersion.valueOf(streamVersionMin),
-                streamVersionMax == null ? SSLVersion.TLS_1_2 : SSLVersion.valueOf(streamVersionMax)
-        );
-        CryptoUtil.setSSLStreamVersionRange(streamRange.getMinVersion(), streamRange.getMaxVersion());
-
-        String datagramVersionMin = System.getenv("SSL_DATAGRAM_VERSION_MIN");
-        String datagramVersionMax = System.getenv("SSL_DATAGRAM_VERSION_MAX");
-
-        SSLVersionRange datagramRange = CryptoUtil.boundSSLDatagramVersionRange(
-                datagramVersionMin == null ? SSLVersion.TLS_1_1 : SSLVersion.valueOf(datagramVersionMin),
-                datagramVersionMax == null ? SSLVersion.TLS_1_2 : SSLVersion.valueOf(datagramVersionMax)
-        );
-        CryptoUtil.setSSLDatagramVersionRange(datagramRange.getMinVersion(), datagramRange.getMaxVersion());
-
-        String defaultCiphers = System.getenv("SSL_DEFAULT_CIPHERS");
-        if (defaultCiphers == null || Boolean.parseBoolean(defaultCiphers)) {
-            CryptoUtil.setDefaultSSLCiphers();
-        } else {
-            CryptoUtil.unsetSSLCiphers();
-        }
-
-        String ciphers = System.getenv("SSL_CIPHERS");
-        CryptoUtil.setSSLCiphers(ciphers);
 
         initialized = true;
     }

--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -53,6 +53,7 @@ import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
+import org.mozilla.jss.ssl.SSLSocket;
 import org.mozilla.jss.util.IncorrectPasswordException;
 import org.mozilla.jss.util.Password;
 
@@ -569,6 +570,8 @@ public class MainCLI extends CLI {
 
         CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
         manager.setThreadToken(token);
+
+        SSLSocket.enablePostHandshakeAuthDefault(true);
 
         initialized = true;
     }


### PR DESCRIPTION
When TLSv1.3 support landed in Fedora and RHEL, crypto-policies enabled
it everywhere including in FIPS mode. However, because we bounded the
range above by TLSv1.2, we wouldn't negotiate TLSv1.3 when communicating
with CA instances. crypto-policies should be the single source of truth
for these values, and we shouldn't limit ourselves artificially.
Instead, users should change crypto-policies to the correct policy for
their needs.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

--- 

This is the backport of a single commit from #537 that fixes the related BZ. 