### PR TITLE
CI: Use NFS instead of virtualbox guest

### DIFF
--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -16,7 +16,7 @@ jobs:
       container: fedora:${{ matrix.os }}
       strategy:
           matrix:
-            os: ['31', '32']
+            os: ['32']
       steps:
           - name: Update base image
             run: |
@@ -65,7 +65,7 @@ jobs:
         TOPOLOGY: "topology-02"
       strategy:
         matrix:
-          os: ['31', '32']
+          os: ['32']  # NOTE: In F31, NFS client installation fails!
       steps:
 
         - name: Clone the repository
@@ -91,10 +91,6 @@ jobs:
                     -e "s/TOPOLOGY/${TOPOLOGY}/g" \
                     inventory > ../inventory
                 cd ../
-
-        # Let vagrant take care of installing the required Virtualbox guest additions
-        - name: Install Virtualbox guest additions plugin
-          run: vagrant plugin install vagrant-vbguest
 
         # Don't provision the VMs as they might not be ready for inter communication
         - name: Boot the "controller" VM without provisioning

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
 
   config.ssh.username = "root"
   config.vm.box = "fedora/RELEASE-cloud-base"
-  config.vm.synced_folder "./", "/vagrant", type: "virtualbox"
+  config.vm.synced_folder "./", "/vagrant", type: "nfs"
 
   config.vm.define "controller" , primary: true do |controller|
     controller.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
VBGuest addition to a VM requires a rebuild of plugins, causing
a whole lot of packages to be installed. This patch removes the
dependency on VBGuest and uses NFS to sync the folders between
guest and host.

Note that since we plan to add more tests, we are cutting out
F31 from this patch (ie) we will be running our tests on latest
stable fedora release

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`