### PR TITLE
Move COPR to v10.9

### DIFF
--- a/.github/workflows/required-tests.yml
+++ b/.github/workflows/required-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
           - name: Install PKI build deps
             run: |
-                  dnf copr enable -y @pki/master
+                  dnf copr enable -y @pki/10.9
                   dnf builddep -y --allowerasing --spec ./pki.spec
 
           - name: Build PKI packages
@@ -55,7 +55,7 @@ jobs:
       needs: build
       runs-on: ubuntu-latest
       env:
-        COPR_REPO: "@pki/master"
+        COPR_REPO: "@pki/10.9"
       container: fedora:${{ matrix.os }}
       strategy:
           matrix:
@@ -100,7 +100,7 @@ jobs:
         BUILDDIR: /tmp/workdir
         PKIDIR: /tmp/workdir/pki
         LOGS: ${GITHUB_WORKSPACE}/logs.txt
-        COPR_REPO: "@pki/master"
+        COPR_REPO: "@pki/10.9"
       strategy:
         matrix:
           os: ['31', '32']
@@ -199,7 +199,7 @@ jobs:
         BUILDDIR: /tmp/workdir
         PKIDIR: /tmp/workdir/pki
         LOGS: ${GITHUB_WORKSPACE}/logs.txt
-        COPR_REPO: "@pki/master"
+        COPR_REPO: "@pki/10.9"
         test_set: "test_caacl_plugin.py test_caacl_profile_enforcement.py test_cert_plugin.py test_certprofile_plugin.py test_ca_plugin.py test_vault_plugin.py"
       strategy:
         matrix:

--- a/tests/dogtag/pytest-ansible/provision/post_provision.yml
+++ b/tests/dogtag/pytest-ansible/provision/post_provision.yml
@@ -11,5 +11,5 @@
       when: ansible_distribution == "Fedora"
 
     - name: set PKI master copr repo
-      shell: dnf copr enable @pki/master -y
+      shell: dnf copr enable @pki/10.9 -y
       when: ansible_distribution == "Fedora"


### PR DESCRIPTION
Because v10.9 has been branched from master and a new COPR repo has been
created, we should use it instead of the v10.10/master branch COPR repo.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`