### PR TITLE
CI: Run healthcheck in CI pipeline

### DIFF
--- a/.github/workflows/required-tests.yml
+++ b/.github/workflows/required-tests.yml
@@ -149,6 +149,11 @@ jobs:
         - name: Install TPS
           run: docker exec -i ${CONTAINER} ${PKIDIR}/ci/tps-create.sh
 
+        - name: Run PKI Healthcheck
+          run: |
+                docker exec -i ${CONTAINER} bash -c "echo 'instance_name=pkitest' >> /etc/pki/healthcheck.conf"
+                docker exec -i ${CONTAINER} bash -c "/usr/sbin/pki-healthcheck --debug"
+
         - name: Gather instance config
           if: always()
           run: docker exec -i ${CONTAINER} bash -c "cp -rf /etc/pki /var/log/pki/etc-pki"
@@ -232,7 +237,7 @@ jobs:
           run: docker exec -i ${CONTAINER} dnf copr enable -y ${COPR_REPO}
 
         - name: Install FreeIPA packages
-          run: docker exec -i ${CONTAINER} dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad python3-ipatests
+          run: docker exec -i ${CONTAINER} dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad python3-ipatests freeipa-healthcheck
 
         - name: Install newly built PKI packages
           run: docker exec -i ${CONTAINER} bash -c "find ${PKIDIR} -name '*.rpm' -and -not -name '*debuginfo*' | xargs dnf -y install"

--- a/ci/ipa-test.sh
+++ b/ci/ipa-test.sh
@@ -59,6 +59,8 @@ ipa-run-tests \
 --verbose \
 ${cert_test_file_loc} 2>&1
 
+ipa-healthcheck --debug
+
 echo "Test complete"
 
 # Uninstall ipa-server


### PR DESCRIPTION
This patch executes both PKI healthcheck and IPA healthcheck
tools in corresponding CI jobs.

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`