### PR TITLE
Keep JAVA_HOME in tomcat.conf

### DIFF
--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -615,17 +615,17 @@ class MigrateCLI(pki.cli.CLI):
             logger.debug("Refusing to migrate JAVA_HOME with missing environment variable")
             return
 
-        comment = "JAVA_HOME should be set in /etc/pki/pki.conf instead."
+        java_home = os.environ['JAVA_HOME']
 
         # Update in /etc/sysconfig/<instance>
-        result = self.update_java_home_in_config(instance.service_conf, comment)
+        result = self.update_java_home_in_config(instance.service_conf, java_home)
         self.write_config(instance.service_conf, result)
 
         # Update in /etc/pki/<instance>/tomcat.conf
-        result = self.update_java_home_in_config(instance.tomcat_conf, comment)
+        result = self.update_java_home_in_config(instance.tomcat_conf, java_home)
         self.write_config(instance.tomcat_conf, result)
 
-    def update_java_home_in_config(self, path, comment):
+    def update_java_home_in_config(self, path, java_home):
         result = []
 
         target = "JAVA_HOME="
@@ -635,9 +635,7 @@ class MigrateCLI(pki.cli.CLI):
                 if not line.startswith(target):
                     result.append(line)
                 else:
-                    comment_line = '# ' + comment + '\n'
-                    result.append(comment_line)
-                    new_line = '# ' + line
+                    new_line = target + '"' + java_home + '"\n'
                     result.append(new_line)
 
         return result

--- a/base/server/share/conf/tomcat.conf
+++ b/base/server/share/conf/tomcat.conf
@@ -8,6 +8,9 @@
 
 # Default NSS DB type is loaded from /usr/share/pki/etc/tomcat.conf
 
+# Where your java installation lives
+JAVA_HOME="[JAVA_HOME]"
+
 # Where your tomcat installation lives
 CATALINA_BASE="[PKI_INSTANCE_PATH]"
 


### PR DESCRIPTION
Despite the name `tomcat.conf`, this is also the main configuration file
loaded by instances. Instances (especially `pkispawn`) expect config to be
only the Tomcat configuration, despite loading configuration from the
environment as well. Eventually, we should migrate all of this to use
the global configuration rather than the per-instance configuration.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---