### PR TITLE
Fix java home migration

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -186,13 +186,13 @@ find_file(JAKARTA_ACTIVATION_JAR
     NAMES
         jakarta.activation.jar
         jakarta-activation.jar
-        jaxb.activation.jar
-        jaxb-activation.jar
+        javax.activation.jar
+        javax-activation.jar
     PATHS
         /usr/share/java/jakarta-activation
         /usr/share/java/jakarta
-        /usr/share/java/jaxb-activation
-        /usr/share/java/jaxb
+        /usr/share/java/javax-activation
+        /usr/share/java/javax
         /usr/share/java
 )
 

--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -615,17 +615,17 @@ class MigrateCLI(pki.cli.CLI):
             logger.debug("Refusing to migrate JAVA_HOME with missing environment variable")
             return
 
-        comment = "JAVA_HOME should be set in /etc/pki/pki.conf instead."
+        java_home = os.environ['JAVA_HOME']
 
         # Update in /etc/sysconfig/<instance>
-        result = self.update_java_home_in_config(instance.service_conf, comment)
+        result = self.update_java_home_in_config(instance.service_conf, java_home)
         self.write_config(instance.service_conf, result)
 
         # Update in /etc/pki/<instance>/tomcat.conf
-        result = self.update_java_home_in_config(instance.tomcat_conf, comment)
+        result = self.update_java_home_in_config(instance.tomcat_conf, java_home)
         self.write_config(instance.tomcat_conf, result)
 
-    def update_java_home_in_config(self, path, comment):
+    def update_java_home_in_config(self, path, java_home):
         result = []
 
         target = "JAVA_HOME="
@@ -635,9 +635,7 @@ class MigrateCLI(pki.cli.CLI):
                 if not line.startswith(target):
                     result.append(line)
                 else:
-                    comment_line = '# ' + comment + '\n'
-                    result.append(comment_line)
-                    new_line = '# ' + line
+                    new_line = target + '"' + java_home + '"\n'
                     result.append(new_line)
 
         return result

--- a/base/server/share/conf/tomcat.conf
+++ b/base/server/share/conf/tomcat.conf
@@ -8,6 +8,9 @@
 
 # Default NSS DB type is loaded from /usr/share/pki/etc/tomcat.conf
 
+# Where your java installation lives
+JAVA_HOME="[JAVA_HOME]"
+
 # Where your tomcat installation lives
 CATALINA_BASE="[PKI_INSTANCE_PATH]"
 

--- a/base/server/share/conf/tomcat.conf
+++ b/base/server/share/conf/tomcat.conf
@@ -8,9 +8,6 @@
 
 # Default NSS DB type is loaded from /usr/share/pki/etc/tomcat.conf
 
-# Where your java installation lives
-JAVA_HOME="[JAVA_HOME]"
-
 # Where your tomcat installation lives
 CATALINA_BASE="[PKI_INSTANCE_PATH]"
 

--- a/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
@@ -10,6 +10,8 @@ Environment="NAME=%i"
 Environment="STARTED_BY_SYSTEMD=1"
 Environment="WD_PIPE_NAME=%i"
 EnvironmentFile=-/etc/sysconfig/%i
+EnvironmentFile=/usr/share/pki/etc/pki.conf
+EnvironmentFile=/etc/pki/pki.conf
 
 ExecStartPre=+/usr/bin/setfacl -m u:pkiuser:wx /run/systemd/ask-password
 ExecStartPre=/usr/bin/pki-server-nuxwdog

--- a/base/server/share/lib/systemd/system/pki-tomcatd@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd@.service
@@ -8,6 +8,8 @@ EnvironmentFile=/usr/share/pki/etc/tomcat.conf
 EnvironmentFile=/etc/tomcat/tomcat.conf
 Environment="NAME=%i"
 EnvironmentFile=-/etc/sysconfig/%i
+EnvironmentFile=/usr/share/pki/etc/pki.conf
+EnvironmentFile=/etc/pki/pki.conf
 
 ExecStartPre=/usr/sbin/pki-server upgrade %i
 ExecStartPre=/usr/sbin/pki-server migrate %i

--- a/cmake/Modules/Java.cmake
+++ b/cmake/Modules/Java.cmake
@@ -84,6 +84,8 @@ function(javac target)
             -encoding UTF-8
             -cp ${native_classpath}
             -d ${output_dir}
+            -source 1.8
+            -target 1.8
             @${file_list}
         WORKING_DIRECTORY
             ${source_dir}


### PR DESCRIPTION
This syncs `master` to where `v10.9` is.  See #548 and #532.