### PR TITLE
Update README doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,95 @@
-Dogtag PKI
-==========
+# Dogtag PKI
 
-[![Build Status](https://travis-ci.org/dogtagpki/pki-nightly-test.svg?branch=master)](https://travis-ci.org/dogtagpki/pki-nightly-test)
+![Required Tests](https://github.com/dogtagpki/pki/workflows/Required%20Tests/badge.svg)
+![QE Tests](https://github.com/dogtagpki/pki/workflows/QE%20Tests/badge.svg)
 
-(C) 2008 Red Hat, Inc.
-All rights reserved.
+The Dogtag Certificate System is an enterprise-class open source Certificate Authority (CA). It is a full-featured system, and has been hardened by real-world deployments. It supports all aspects of certificate lifecycle management, including key archival, OCSP and smartcard management, and much more.
 
-This Certificate System is open-source software.
+There are 6 different subsystems included in the Dogtag PKI suite:
 
-Please comply with the LICENSE contained in each of
-the individual components, and the EXPORT CONTROL
-regulations defined at:
+1. [Certificate Authority (CA) subsystem](https://www.dogtagpki.org/wiki/Certificate_Authority)
+2. [Key Recovery Authority (KRA) subsystem](https://www.dogtagpki.org/wiki/Key_Recovery_Authority)
+3. [Online Certificate Status Protocol (OCSP) subsystem](https://www.dogtagpki.org/wiki/OCSP_Manager)
+4. [Token Key Service (TKS) subsystem](https://www.dogtagpki.org/wiki/Token_Key_Service)
+5. [Token Processing System (TPS) subsystem](https://www.dogtagpki.org/wiki/Token_Processing_System)
+6. [ACME Responder](https://www.dogtagpki.org/wiki/PKI_ACME_Responder)
 
-http://www.dogtagpki.org/wiki/PKI_Download
+## Documentation
 
-## Content
+The best place to start learning about the product is the [Dogtag PKI Wiki](https://www.dogtagpki.org)
 
-These directories contain the following:
+## Installing
 
-* base
+### Fedora
 
-  Contains most of the base source code
-  needed to build this project.  Note that
-  this directory does NOT contain
-  implementation specific user-interface
-  components required to build a working
-  Certificate System.
+To install the **whole Dogtag PKI suite**:
 
-* cmake
+````bash
+sudo dnf install dogtag-pki
+````
 
-  These files and this directory contain
-  the top-level files necessary to integrate
-  the CMake build system in pki.
+To install **individual subsystems**:
 
-* scripts
+````bash
+sudo dnf install pki-ca pki-kra pki-ocsp pki-tks pki-tps
+````
 
-  Contains "scripts" used by this
-  certificate system.  This directory
-  contains numerous "compose" scripts
-  useful for building RPMS/SRPMS of the
-  various certificate system components.
+To install **web UI theme packages**:
 
-* themes
+````bash
+sudo dnf install dogtag-pki-server-theme dogtag-pki-console-theme
+````
 
-  Contains the scripts and user-interface
-  components to customize PKI web UI and
-  console.
+## Deploying
 
-* tools
+After successful installation of the packages, follow the below steps to deploy intended subsystems:
 
-  Contains utilities useful to
-  certificate system components.
+- [Deploy CA](docs/installation/ca/Installing_CA.md)
+- [Deploy KRA](docs/installation/kra/Installing_KRA.md)
+- [Deploy OCSP](docs/installation/ocsp/Installing_OCSP.md)
+- [Deploy TKS](docs/installation/tks/Installing_TKS.md)
+- [Deploy TPS](docs/installation/tps/Installing_TPS.md)
+- [Deploy ACME](docs/installation/acme/Installing_PKI_ACME_Responder.md)
 
-## Development
+For other types of deployments (Sub-CA, Clones, HSMs, etc) please see under [docs/installation](docs/installation)
 
-To build the project, see [Building PKI](docs/development/Building_PKI.md).
+## Building
 
-## See Also
+### Fedora/CentOS/RHEL
 
-* [Dogtag PKI](http://www.dogtagpki.org)
+#### Prerequisites
+
+````bash
+sudo dnf install dnf-plugins-core rpm-build git
+
+# NOTE: Use the intendended branch name instead of "master" to pull right dependency version
+sudo dnf copr enable @pki/master
+
+sudo dnf builddep pki.spec
+````
+
+#### Build Procedure
+
+After successfully installing the prerequisites, the project can be built with a one-line command:
+
+````bash
+./build.sh
+````
+
+The built RPMS will be placed in `~/build/pki/` directory.
+
+See also [Building PKI](docs/development/Building_PKI.md)
+
+## Contributing
+
+There are multiple ways for you to be part of this project. Please see [CONTRIBUTING]( CONTRIBUTING.md) to learn more.
+
+## Contact
+
+You can reach the Dogtag PKI team over the **#dogtag-pki** channel on freenode.net. Note that you need to be a [registered user](https://freenode.net/kb/answer/registration) to message on this channel. You can also send an email to pki-users@redhat.com.
+
+See also [Contact Us](https://www.dogtagpki.org/wiki/Contact_Us)
+
+## License
+
+[GPL-2.0 License](LICENSE)


### PR DESCRIPTION
Our README.md currently has very low-level technical info
which might not serve its use for a beginner. The README
should act as a good cover page for the project to attract
more contributors and users and, provide minimal yet useful
information for new-users.

This patch updates the existing README.md file to include
**Getting Started** kind of information

Note: @edewata the reason I did not move the building/installing
info is because, we can always have README.md in the required
directory. As this is the root README.md, I wanted to keep it simple
yet concise.

Compiled version can be viewed here:
https://github.com/SilleBille/pki/blob/update-readme/README.md

`Signed-off-by: Dinesh Prasanth M K <dmoluguw@redhat.com>`