### PR TITLE
Add dependencies in Java11-specific libraries

### DIFF
--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -48,6 +48,7 @@ add_custom_command(
 
 if(JAVA_VERSION GREATER 10)
     add_custom_target(pki-java11plus-lib ALL
+        DEPENDS pki-lib
         COMMENT "Creating links for library required in Java 11+")
 
     add_custom_command(

--- a/base/common/share/etc/pki.conf
+++ b/base/common/share/etc/pki.conf
@@ -11,7 +11,7 @@ JAVA_HOME=${JAVA_HOME}
 export JAVA_HOME
 
 # Java interpreter
-PKI_JAVA_PATH=${Java_JAVA_EXECUTABLE}
+PKI_JAVA_PATH=${PKI_JAVA_PATH}
 export PKI_JAVA_PATH
 
 # JNI jar file location

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -118,6 +118,7 @@ add_custom_command(
 
 if(JAVA_VERSION GREATER 10)
     add_custom_target(pki-server-java11plus-lib ALL
+        DEPENDS pki-server-common-lib
         COMMENT "Creating links for server library required in Java 11+")
 
     add_custom_command(

--- a/pki.spec
+++ b/pki.spec
@@ -855,7 +855,7 @@ cd build
     -DVERSION=%{version}-%{release} \
     -DVAR_INSTALL_DIR:PATH=/var \
     -DP11_KIT_TRUST=/etc/alternatives/libnssckbi.so.%{_arch} \
-    -DJAVA_VERSION=%{java_version} \
+    -DJAVA_VERSION=${java_version} \
     -DJAVA_HOME=%java_home \
     -DPKI_JAVA_PATH=%java \
     -DJAVA_LIB_INSTALL_DIR=%{_jnidir} \


### PR DESCRIPTION
This ensures lib/ gets created prior to any Java11-specific symlinks.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`