### PR TITLE
Fix NPE in TPSProcessor.mapCredFromMsgResponse()

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/authentication/TPSAuthenticator.java
+++ b/base/tps/src/org/dogtagpki/server/tps/authentication/TPSAuthenticator.java
@@ -20,10 +20,9 @@ package org.dogtagpki.server.tps.authentication;
 import java.util.HashMap;
 
 import org.dogtagpki.server.authentication.IAuthManager;
+import org.dogtagpki.server.tps.TPSEngine;
 
 import com.netscape.certsrv.base.EBaseException;
-import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.authentication.AuthSubsystem;
 
 /**
@@ -33,7 +32,6 @@ import com.netscape.cmscore.authentication.AuthSubsystem;
  */
 public class TPSAuthenticator {
     private String id;
-    private IAuthManager authManager;
 
     /*
      *  for auths instance ui <locale, value>
@@ -71,10 +69,6 @@ public class TPSAuthenticator {
     public TPSAuthenticator(String authId)
             throws EBaseException {
         id = authId;
-        // retrieves and set authentication manager
-        CMSEngine engine = CMS.getCMSEngine();
-        AuthSubsystem authSub = engine.getAuthSubsystem();
-        authManager = authSub.getAuthManager(authId);
         uiTitle = new HashMap<String, String>();
         uiDescription = new HashMap<String, String>();
         uiParameters = new HashMap<String, AuthUIParameter>();
@@ -87,7 +81,9 @@ public class TPSAuthenticator {
     }
 
     public IAuthManager getAuthManager() {
-        return authManager;
+        TPSEngine engine = TPSEngine.getInstance();
+        AuthSubsystem authSub = engine.getAuthSubsystem();
+        return authSub.getAuthManager(id);
     }
 
     public void setUiTitle(String locale, String title) {

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSProcessor.java
@@ -84,7 +84,6 @@ import org.dogtagpki.tps.msg.StatusUpdateRequestMsg;
 import org.dogtagpki.tps.msg.TPSMessage;
 import org.dogtagpki.tps.msg.TokenPDURequestMsg;
 import org.dogtagpki.tps.msg.TokenPDUResponseMsg;
-
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
 import org.mozilla.jss.crypto.CryptoToken;
@@ -1416,7 +1415,8 @@ public class TPSProcessor {
         IAuthCredentials login =
                 new com.netscape.certsrv.authentication.AuthCredentials();
 
-        String[] requiredCreds = auth.getAuthManager().getRequiredCreds();
+        IAuthManager authManager = auth.getAuthManager();
+        String[] requiredCreds = authManager.getRequiredCreds();
         for (String cred : requiredCreds) {
             String name = auth.getCredMap(cred, extendedLogin);
             logger.debug("TPSProcessor.mapCredFromMsgResponse: cred=" + cred + " &name=" + name);
@@ -3817,8 +3817,7 @@ public class TPSProcessor {
                     tps.tdb.tdbActivity(ActivityDatabase.OP_ENROLLMENT, tokenRecord, session.getIpAddress(), msg,
                             "failure");
 
-                    throw new TPSException(msg,
-                            TPSStatus.STATUS_ERROR_LOGIN);
+                    throw new TPSException(msg, TPSStatus.STATUS_ERROR_LOGIN, e);
                 }
             } else {
                 throw new TPSException(


### PR DESCRIPTION
The TPSAuthenticator has been modified to no longer store a
reference to the authentication manager during initialization.
Instead, it will get the authentication manager directly from
the AuthSubsystem when requested in getAuthManager().

The TPSProcessor.checkAndAuthenticateUser() has also been
modified to chain the original exception to provide the complete
stack trace.