### PR TITLE
Resolve: Bug 1710978 - TPS - Add logging to tdbAddCertificatesForCUID…

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
@@ -241,16 +241,62 @@ public class TPSTokendb {
 
         logger.debug(method + " found token " + cuid);
         logger.debug(method + " number of certs to update:" + certs.size());
+
+	// Keep track of which certs made it to the database and which didn't,
+        // in case of failure
+         class CnIssuerPair {
+             public final String cn;
+             public final String issuer;
+
+             public CnIssuerPair(String _cn, String _issuer) {
+                 cn = _cn;
+                 issuer = _issuer;
+             }
+
+             public String toString() {
+                 return "(cn=" + cn + ", issuerCn=" + issuer + ")";
+             }
+         }
+
+         ArrayList<CnIssuerPair> cnIssuerPairsRemaining = new ArrayList<CnIssuerPair>(certs.size());
+         for(TPSCertRecord cert : certs) {
+             String cn = cert.getId();
+             String issuerCn = cert.getIssuedBy();
+             cnIssuerPairsRemaining.add(new CnIssuerPair(cn, issuerCn));
+         }
+
+        boolean testAddCertsFailure = false;
+	//Contrive a very difficult to reproduce testing scenario
+        org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
+	try {
+	    EngineConfig configStore = engine.getConfig();
+            // get conn ID
+            String config = "op.enroll." + "testAddCertsToDBFailure";
+            testAddCertsFailure = configStore.getBoolean(config,false);
+        } catch (Exception e) {
+           testAddCertsFailure = false;
+        }
+
         try {
+	    int count = 0;
             for (TPSCertRecord cert : certs) {
                 try {
                     if (!isCertOnToken(cert, cuid)) {
                         logger.debug(method + " adding cert with serial: " + cert.getSerialNumber());
+			// After at least one cert is added correctly, perform the test of a failure
+                        // if so configured.
+                        if(count > 0 && testAddCertsFailure == true) {
+                            throw new Exception(method + ": "+ "Failed to add certificate to token db, as part of a test of failure condition.");
+                        }
                         tps.certDatabase.addRecord(cert.getId(), cert);
                     } else {
                         // cert already on token
                         logger.debug(method + "retain and skip adding with serial:" + cert.getSerialNumber());
                     }
+		    // Successfully added cert or verified it was already there, so remove
+                    // it from the 'remaining' list
+                    cnIssuerPairsRemaining.removeIf(p -> (p.cn == cert.getId() && p.issuer == cert.getIssuedBy()));
+                    count ++ ;
                 } catch (Exception e) {
                     logger.warn(method + "Exception after isCertOnToken call: "+ e.getMessage(), e);
                     // ignore; go to next;
@@ -258,8 +304,13 @@ public class TPSTokendb {
             }
         } catch (Exception e) {
             logger.error(method + e.getMessage(), e);
-            // TODO: what if it throws in the middle of the cert list -- some cert records already updated?
-            throw new TPSException(e.getMessage(), e);
+	     String subjectDn = certs.get(0).getSubject();
+             String logMsg = method + ": " + "Failed to add or verify the following certs for [" + subjectDn + "] in the Certificate DB: ";
+             for(CnIssuerPair pair : cnIssuerPairsRemaining) {
+                 logMsg += pair + "; ";
+             }
+
+             throw new TPSException(logMsg);
         }
     }
 

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
@@ -620,8 +620,19 @@ public class TPSEnrollProcessor extends TPSProcessor {
         ArrayList<TPSCertRecord> certRecords = certsInfo.toTPSCertRecords(tokenRecord.getId(), tokenRecord.getUserID());
 
         logger.debug(method + " adding certs to token with tdbAddCertificatesForCUID...");
-        tps.tdb.tdbAddCertificatesForCUID(tokenRecord.getId(), certRecords);
-        logger.debug(method + " tokendb updated with certs to the cuid so that it reflects what's on the token");
+
+        try {
+            tps.tdb.tdbAddCertificatesForCUID(tokenRecord.getId(), certRecords);
+            logger.debug(method + " tokendb updated with certs to the cuid so that it reflects what's on the token");
+        } catch(TPSException e) {
+            logger.debug(method + " Exception occurred in tdbAddCertificatesForCUID: " + e.getMessage());
+            try {
+                auditEnrollment(userid, "enrollment", appletInfo, "failure", channel.getKeyInfoData().toHexStringPlain(), null, null, e.getMessage());
+                tps.tdb.tdbActivity(ActivityDatabase.OP_ENROLLMENT, tokenRecord, session.getIpAddress(), e.getMessage(), "failure");
+            } catch(Exception f) {
+                logger.debug(method + " Failed to log previous exception: " + f);
+            }
+        }
 
         String finalAppletVersion = appletInfo.getFinalAppletVersion();
         if(finalAppletVersion == null)


### PR DESCRIPTION
… if adding or searching for cert record fails

Submitted by RHCS-maint.

This fix provides better logging when the update to the token db sufferes a partial or complete failure.

Due to the unlikelyness of this happening in practice, this fix provides a simple config based way to simulate
the issue, such that the log activity can be easily observed just as if had happened during an actual failure.

Set the following in the TPS's CS.cfg:

op.enroll.testAddCertsToDBFailure=true.

The setting is false by default.