### PR TITLE
Add commands to enable/disable ACME services

### DIFF
--- a/base/acme/CMakeLists.txt
+++ b/base/acme/CMakeLists.txt
@@ -4,16 +4,16 @@ javac(pki-acme-classes
     SOURCES
         src/main/java/*.java
     CLASSPATH
-        ${SERVLET_JAR}
+        ${SERVLET_JAR} ${TOMCAT_CATALINA_JAR}
         ${JAXRS_API_JAR}
         ${SLF4J_API_JAR}
         ${COMMONS_CODEC_JAR} ${COMMONS_IO_JAR} ${COMMONS_LANG3_JAR}
         ${HTTPCLIENT_JAR} ${HTTPCORE_JAR}
         ${JACKSON2_ANNOTATIONS_JAR} ${JACKSON2_JAXB_ANNOTATIONS_JAR}
         ${JACKSON2_CORE_JAR} ${JACKSON2_DATABIND_JAR}
-        ${JSS_JAR} ${PKI_CMSUTIL_JAR} ${PKI_CERTSRV_JAR}
-        ${PKI_CMS_JAR}
+        ${JSS_JAR}
         ${LDAPJDK_JAR}
+        ${PKI_CMSUTIL_JAR} ${PKI_TOMCAT_JAR} ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
     DEPENDS
         pki-cmsutil-jar pki-certsrv-jar pki-cms-jar
     OUTPUT_DIR
@@ -99,6 +99,13 @@ install(
         issuer/
     DESTINATION
         ${DATA_INSTALL_DIR}/acme/issuer/
+)
+
+install(
+    DIRECTORY
+        realm/
+    DESTINATION
+        ${DATA_INSTALL_DIR}/acme/realm/
 )
 
 install(

--- a/base/acme/conf/realm.conf
+++ b/base/acme/conf/realm.conf
@@ -1,0 +1,1 @@
+class=org.dogtagpki.acme.realm.ACMERealm

--- a/base/acme/realm/ds/create.ldif
+++ b/base/acme/realm/ds/create.ldif
@@ -1,0 +1,21 @@
+dn: ou=people,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: users
+
+dn: uid=admin,ou=people,dc=acme,dc=pki,dc=example,dc=com
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+uid: admin
+cn: Administrator
+sn: Administrator
+userPassword: Secret.123
+
+dn: ou=groups,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+ou: groups
+
+dn: cn=Administrators,ou=groups,dc=acme,dc=pki,dc=example,dc=com
+objectClass: groupOfUniqueNames
+cn: Administrators
+uniqueMember: uid=admin,ou=users,dc=acme,dc=pki,dc=example,dc=com

--- a/base/acme/realm/ds/realm.conf
+++ b/base/acme/realm/ds/realm.conf
@@ -1,0 +1,7 @@
+class=org.dogtagpki.acme.realm.DSRealm
+url=ldap://localhost.localdomain:389
+authType=BasicAuth
+bindDN=cn=Directory Manager
+bindPassword=Secret.123
+usersDN=ou=people,dc=acme,dc=pki,dc=example,dc=com
+groupsDN=ou=groups,dc=acme,dc=pki,dc=example,dc=com

--- a/base/acme/src/main/java/org/dogtagpki/acme/realm/ACMERealm.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/realm/ACMERealm.java
@@ -1,0 +1,41 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.realm;
+
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMERealm {
+
+    private static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMERealm.class);
+
+    protected ACMERealmConfig config;
+
+    public ACMERealmConfig getConfig() {
+        return config;
+    }
+
+    public void setConfig(ACMERealmConfig config) {
+        this.config = config;
+    }
+
+    public void init() throws Exception {
+    }
+
+    public Principal authenticate(String username, String password) throws Exception {
+        return null;
+    }
+
+    public Principal authenticate(X509Certificate[] certs) throws Exception {
+        return null;
+    }
+
+    public void close() throws Exception {
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/realm/ACMERealmConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/realm/ACMERealmConfig.java
@@ -1,0 +1,104 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.realm;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Endi S. Dewata
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class ACMERealmConfig {
+
+    @JsonProperty("class")
+    private String className;
+
+    private Map<String, String> parameters = new LinkedHashMap<String, String>();
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters.clear();
+        this.parameters.putAll(parameters);
+    }
+
+    @JsonIgnore
+    public Collection<String> getParameterNames() {
+        return parameters.keySet();
+    }
+
+    public String getParameter(String name) {
+        return parameters.get(name);
+    }
+
+    public void setParameter(String name, String value) {
+        parameters.put(name, value);
+    }
+
+    public String removeParameter(String name) {
+        return parameters.remove(name);
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static ACMERealmConfig fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, ACMERealmConfig.class);
+    }
+
+    public static ACMERealmConfig fromProperties(Properties props) throws Exception {
+
+        ACMERealmConfig config = new ACMERealmConfig();
+
+        for (Entry<Object, Object> entry : props.entrySet()) {
+
+            String key = entry.getKey().toString();
+            String value = entry.getValue().toString();
+
+            if (key.equals("class")) {
+                config.setClassName(value);
+
+            } else {
+                config.setParameter(key, value);
+            }
+        }
+
+        return config;
+    }
+
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/realm/DSRealm.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/realm/DSRealm.java
@@ -1,0 +1,12 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.realm;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class DSRealm extends LDAPRealm {
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/realm/LDAPRealm.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/realm/LDAPRealm.java
@@ -1,0 +1,324 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.realm;
+
+import java.net.URI;
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.catalina.realm.GenericPrincipal;
+
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.base.FileConfigStore;
+import com.netscape.cmscore.ldapconn.LDAPAuthenticationConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapBoundConnFactory;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+import com.netscape.cmsutil.password.IPasswordStore;
+import com.netscape.cmsutil.password.PlainPasswordFile;
+
+import netscape.ldap.LDAPAttribute;
+import netscape.ldap.LDAPConnection;
+import netscape.ldap.LDAPEntry;
+import netscape.ldap.LDAPException;
+import netscape.ldap.LDAPSearchResults;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class LDAPRealm extends ACMERealm {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LDAPRealm.class);
+
+    String usersDN;
+    String groupsDN;
+
+    PKISocketConfig socketConfig;
+    LDAPConnectionConfig connConfig;
+    LDAPAuthenticationConfig authConfig;
+    LdapBoundConnFactory connFactory;
+
+    public void init() throws Exception {
+
+        EngineConfig cs;
+        IPasswordStore ps;
+        LDAPConfig ldapConfig;
+
+        String configFile = config.getParameter("configFile");
+
+        if (configFile == null) {
+
+            logger.info("Loading LDAP realm config from realm.conf");
+
+            cs = new EngineConfig();
+            ps = new PlainPasswordFile();
+            ldapConfig = new LDAPConfig(null);
+
+            for (String name : config.getParameterNames()) {
+                String value = config.getParameter(name);
+
+                if (name.equals("usersDN")) {
+                    continue;
+
+                } else if (name.equals("groupsDN")) {
+                    continue;
+
+                } else if (name.equals("url")) {
+                    logger.info("- URL: " + value);
+
+                    URI url = new URI(value);
+                    String host = url.getHost();
+                    String port = "" + url.getPort();
+
+                    String protocol = url.getScheme();
+                    String secureConn;
+                    if ("ldap".equals(protocol)) {
+                        secureConn = "false";
+                    } else if ("ldaps".equals(protocol)) {
+                        secureConn = "true";
+                    } else {
+                        throw new Exception("Unsupported LDAP protocol: " + protocol);
+                    }
+
+                    ldapConfig.put("ldapconn.host", host);
+                    ldapConfig.put("ldapconn.port", port);
+                    ldapConfig.put("ldapconn.secureConn", secureConn);
+
+                } else if (name.equals("authType")) {
+                    logger.info("- authentication type: " + value);
+                    ldapConfig.put("ldapauth.authtype", value);
+
+                } else if (name.equals("bindDN")) {
+                    logger.info("- bind DN: " + value);
+                    ldapConfig.put("ldapauth.bindDN", value);
+
+                } else if (name.equals("bindPassword")) {
+                    ldapConfig.put("ldapauth.bindPassword", value);
+
+                } else if (name.equals("nickname")) {
+                    logger.info("- nickname: " + value);
+                    ldapConfig.put("ldapauth.clientCertNickname", value);
+
+                } else if (name.equals("minConns")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else if (name.equals("maxConns")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else if (name.equals("maxResults")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else if (name.equals("errorIfDown")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else if (name.startsWith("ldapauth.")) {
+                    ldapConfig.put(name, value);
+                    logger.info("- " + name + ": " + value);
+
+                } else if (name.startsWith("ldapconn.")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else {
+                    cs.put(name, value);
+                }
+            }
+
+        } else {
+
+            logger.info("Loading LDAP realm config from " + configFile);
+
+            cs = new EngineConfig(new FileConfigStore(configFile));
+            cs.load();
+
+            ps = IPasswordStore.getPasswordStore("acme", cs.getProperties());
+            ldapConfig = cs.getSubStore("internaldb", LDAPConfig.class);
+        }
+
+        socketConfig = cs.getSocketConfig();
+        connConfig = ldapConfig.getConnectionConfig();
+        authConfig = ldapConfig.getAuthenticationConfig();
+
+        usersDN = config.getParameter("usersDN");
+        logger.info("- users DN: " + usersDN);
+
+        groupsDN = config.getParameter("groupsDN");
+        logger.info("- groups DN: " + groupsDN);
+
+        connFactory = new LdapBoundConnFactory("LDAPRealm");
+        connFactory.init(socketConfig, ldapConfig, ps);
+    }
+
+    public List<String> getUserRoles(LDAPConnection conn, LDAPEntry userEntry) throws Exception {
+
+        List<String> roles = new ArrayList<>();
+        String filter = "uniqueMember=" + userEntry.getDN();
+
+        logger.info("LDAPRealm: Getting user roles:");
+        logger.info("LDAPRealm: - base DN: " + groupsDN);
+        logger.info("LDAPRealm: - filter: " + filter);
+
+        LDAPSearchResults results = conn.search(
+                groupsDN,
+                LDAPConnection.SCOPE_ONE,
+                filter,
+                null, /* get all attributes*/
+                false /* return attribute values */
+        );
+
+        logger.info("LDAPRealm: Roles:");
+        while (results.hasMoreElements()) {
+            LDAPEntry groupEntry = results.next();
+            logger.info("LDAPRealm: - " + groupEntry.getDN());
+
+            LDAPAttribute cnAttr = groupEntry.getAttribute("cn");
+            String role = cnAttr.getStringValues().nextElement();
+            roles.add(role);
+        }
+
+        return roles;
+    }
+
+    public LDAPEntry findUserByUsername(LDAPConnection conn, String username) throws Exception {
+
+        String filter = "uid=" + username;
+
+        logger.info("LDAPRealm: Finding user by username:");
+        logger.info("LDAPRealm: - base DN: " + usersDN);
+        logger.info("LDAPRealm: - filter: " + filter);
+
+        LDAPSearchResults results = conn.search(
+                usersDN,
+                LDAPConnection.SCOPE_ONE,
+                filter,
+                null, /* get all attributes*/
+                false /* return attribute values */
+        );
+
+        if (!results.hasMoreElements()) {
+            logger.info("LDAPRealm: User not found");
+            return null;
+        }
+
+        LDAPEntry entry = results.next();
+        logger.info("LDAPRealm: User: " + entry.getDN());
+
+        return entry;
+    }
+
+    public String getCertID(X509Certificate cert) {
+        return cert.getVersion() + ";"
+                + cert.getSerialNumber() + ";"
+                + cert.getIssuerDN() + ";"
+                + cert.getSubjectDN();
+    }
+
+    public LDAPEntry findUserByCert(LDAPConnection conn, X509Certificate[] certs) throws Exception {
+
+        // sort certs from leaf to root
+        certs = CryptoUtil.sortCertificateChain(certs, true);
+
+        // get user cert
+        X509Certificate cert = certs[0];
+
+        String filter = "description=" + getCertID(cert);
+
+        logger.info("LDAPRealm: Finding user by cert:");
+        logger.info("LDAPRealm: - base DN: " + usersDN);
+        logger.info("LDAPRealm: - filter: " + filter);
+
+        LDAPSearchResults results = conn.search(
+                usersDN,
+                LDAPConnection.SCOPE_ONE,
+                filter,
+                null, /* get all attributes*/
+                false /* return attribute values */
+        );
+
+        if (!results.hasMoreElements()) {
+            logger.info("LDAPRealm: User not found");
+            return null;
+        }
+
+        LDAPEntry entry = results.next();
+        logger.info("LDAPRealm: User: " + entry.getDN());
+
+        return entry;
+    }
+
+    public Principal authenticate(String username, String password) throws Exception {
+        LDAPConnection conn = connFactory.getConn();
+        try {
+            LDAPEntry entry = findUserByUsername(conn, username);
+
+            if (entry == null) {
+                return null;
+            }
+
+            logger.info("LDAPRealm: Validating password");
+
+            PKISocketFactory socketFactory = new PKISocketFactory(connConfig.isSecure());
+            socketFactory.init(socketConfig);
+
+            LDAPConnection authConn = new LDAPConnection(socketFactory);
+            try {
+                authConn.connect(connConfig.getHostname(), connConfig.getPort());
+                authConn.authenticate(entry.getDN(), password);
+
+            } catch (LDAPException e) {
+                if (e.getLDAPResultCode() == LDAPException.INVALID_CREDENTIALS) {
+                    return null;
+                } else {
+                    throw e;
+                }
+            } finally {
+                authConn.close();
+            }
+
+            List<String> roles = getUserRoles(conn, entry);
+            return new GenericPrincipal(username, null, roles);
+
+        } finally {
+            connFactory.returnConn(conn);
+        }
+    }
+
+    public Principal authenticate(X509Certificate[] certs) throws Exception {
+
+        LDAPConnection conn = connFactory.getConn();
+        try {
+            LDAPEntry entry = findUserByCert(conn, certs);
+
+            if (entry == null) {
+                return null;
+            }
+
+            // cert already validated during SSL handshake
+
+            LDAPAttribute uid = entry.getAttribute("uid");
+            String username = uid.getStringValues().nextElement();
+
+            List<String> roles = getUserRoles(conn, entry);
+            return new GenericPrincipal(username, null, roles);
+
+        } finally {
+            connFactory.returnConn(conn);
+        }
+    }
+
+    public void close() throws Exception {
+        connFactory.shutdown();
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAccountOrdersService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAccountOrdersService.java
@@ -50,6 +50,7 @@ import org.dogtagpki.acme.ACMEOrder;
  * @author Endi S. Dewata
  */
 @Path("acct/{id}/orders")
+@ACMEManagedService
 public class ACMEAccountOrdersService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEAccountOrdersService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAccountService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAccountService.java
@@ -26,6 +26,7 @@ import org.dogtagpki.acme.JWS;
  * @author Endi S. Dewata
  */
 @Path("acct/{id}")
+@ACMEManagedService
 public class ACMEAccountService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEAccountService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
@@ -26,6 +26,9 @@ public class ACMEApplication extends Application {
 
         logger.info("Initializing ACMEApplication");
 
+        classes.add(ACMELoginService.class);
+        classes.add(ACMELogoutService.class);
+
         classes.add(ACMEDirectoryService.class);
         classes.add(ACMENewNonceService.class);
         classes.add(ACMENewAccountService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
@@ -28,6 +28,8 @@ public class ACMEApplication extends Application {
 
         classes.add(ACMELoginService.class);
         classes.add(ACMELogoutService.class);
+        classes.add(ACMEEnableService.class);
+        classes.add(ACMEDisableService.class);
 
         classes.add(ACMEDirectoryService.class);
         classes.add(ACMENewNonceService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAuthorizationService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAuthorizationService.java
@@ -33,6 +33,7 @@ import org.dogtagpki.acme.validator.ACMEValidator;
  * @author Endi S. Dewata
  */
 @Path("authz/{id}")
+@ACMEManagedService
 public class ACMEAuthorizationService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEAuthorizationService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMECertificateService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMECertificateService.java
@@ -24,6 +24,7 @@ import org.dogtagpki.acme.issuer.ACMEIssuer;
  * @author Endi S. Dewata
  */
 @Path("cert/{id}")
+@ACMEManagedService
 public class ACMECertificateService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMECertificateService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeService.java
@@ -29,6 +29,7 @@ import org.dogtagpki.acme.validator.ACMEValidator;
  * @author Endi S. Dewata
  */
 @Path("chall/{id}")
+@ACMEManagedService
 public class ACMEChallengeService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEChallengeService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDirectoryService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDirectoryService.java
@@ -22,6 +22,7 @@ import org.dogtagpki.acme.ACMEDirectory;
  * @author Endi S. Dewata
  */
 @Path("directory")
+@ACMEManagedService
 public class ACMEDirectoryService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEDirectoryService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDisableService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDisableService.java
@@ -1,0 +1,40 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Endi S. Dewata
+ */
+@Path("disable")
+public class ACMEDisableService {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEDisableService.class);
+
+    @Context
+    UriInfo uriInfo;
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response handlePOST() throws Exception {
+
+        logger.info("Disabling ACME services");
+
+        ACMEEngine engine = ACMEEngine.getInstance();
+        engine.setEnabled(false);
+
+        ResponseBuilder builder = Response.ok();
+        return builder.build();
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEnableService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEnableService.java
@@ -1,0 +1,35 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
+/**
+ * @author Endi S. Dewata
+ */
+@Path("enable")
+public class ACMEEnableService {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEEnableService.class);
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response handlePOST() throws Exception {
+
+        logger.info("Enabling ACME services");
+
+        ACMEEngine engine = ACMEEngine.getInstance();
+        engine.setEnabled(true);
+
+        ResponseBuilder builder = Response.ok();
+        return builder.build();
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEFinalizeOrderService.java
@@ -31,6 +31,7 @@ import org.mozilla.jss.netscape.security.util.Utils;
  * @author Endi S. Dewata
  */
 @Path("order/{id}/finalize")
+@ACMEManagedService
 public class ACMEFinalizeOrderService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEFinalizeOrderService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMELoginService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMELoginService.java
@@ -1,0 +1,72 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.security.Principal;
+import java.util.Arrays;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
+import org.apache.catalina.realm.GenericPrincipal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.certsrv.account.Account;
+
+/**
+ * @author Endi S. Dewata
+ */
+@Path("login")
+public class ACMELoginService {
+
+    public static Logger logger = LoggerFactory.getLogger(ACMELoginService.class);
+
+    @Context
+    protected HttpServletRequest servletRequest;
+
+    protected Account createAccount() {
+
+        Principal principal = servletRequest.getUserPrincipal();
+        String username = principal.getName();
+        logger.info("ACMELoginService: Principal: " + username);
+
+        Account account = new Account();
+        account.setID(username);
+
+        if (principal instanceof GenericPrincipal) {
+            String[] roles = ((GenericPrincipal) principal).getRoles();
+            logger.info("ACMELoginService: Roles:");
+            for (String role : roles) {
+                logger.info("ACMELoginService: - " + role);
+            }
+            account.setRoles(Arrays.asList(roles));
+        }
+
+        return account;
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response handlePOST() {
+
+        HttpSession session = servletRequest.getSession();
+        logger.info("ACMELoginService: Creating session " + session.getId());
+
+        Account account = createAccount();
+
+        ResponseBuilder builder = Response.ok();
+        builder.entity(account);
+        return builder.build();
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMELogoutService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMELogoutService.java
@@ -1,0 +1,46 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Endi S. Dewata
+ */
+@Path("logout")
+public class ACMELogoutService {
+
+    public static Logger logger = LoggerFactory.getLogger(ACMELogoutService.class);
+
+    @Context
+    protected HttpServletRequest servletRequest;
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response handlePOST() {
+
+        HttpSession session = servletRequest.getSession(false);
+
+        if (session != null) {
+            logger.info("ACMELogoutService: Destroying session " + session.getId());
+            session.invalidate();
+        }
+
+        ResponseBuilder builder = Response.noContent();
+        return builder.build();
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEManagedService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEManagedService.java
@@ -1,0 +1,22 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.NameBinding;
+
+/**
+ * @author Endi S. Dewata
+ */
+@NameBinding
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ACMEManagedService {
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewAccountService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewAccountService.java
@@ -27,6 +27,7 @@ import org.dogtagpki.acme.JWS;
  * @author Endi S. Dewata
  */
 @Path("new-account")
+@ACMEManagedService
 public class ACMENewAccountService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMENewAccountService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewNonceService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewNonceService.java
@@ -22,6 +22,7 @@ import org.dogtagpki.acme.ACMENonce;
  * @author Endi S. Dewata
  */
 @Path("new-nonce")
+@ACMEManagedService
 public class ACMENewNonceService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMENewNonceService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMENewOrderService.java
@@ -30,6 +30,7 @@ import org.dogtagpki.acme.JWS;
  * @author Endi S. Dewata
  */
 @Path("new-order")
+@ACMEManagedService
 public class ACMENewOrderService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMENewOrderService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEOrderService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEOrderService.java
@@ -28,6 +28,7 @@ import org.dogtagpki.acme.JWS;
  * @author Endi S. Dewata
  */
 @Path("order/{id}")
+@ACMEManagedService
 public class ACMEOrderService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEOrderService.class);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERequestFilter.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERequestFilter.java
@@ -8,14 +8,13 @@ package org.dogtagpki.acme.server;
 import javax.ws.rs.ServiceUnavailableException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.ext.Provider;
 
 /**
  * @author Fraser Tweedale
  */
 @Provider
-@PreMatching  // run filter before JAX-RS request matching
+@ACMEManagedService
 public class ACMERequestFilter implements ContainerRequestFilter {
 
     public static org.slf4j.Logger logger =
@@ -23,8 +22,11 @@ public class ACMERequestFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
+
         ACMEEngine engine = ACMEEngine.getInstance();
+
         if (!engine.isEnabled()) {
+            logger.info("ACMERequestFilter: ACME service is disabled");
             throw new ServiceUnavailableException("ACME service is disabled");
         }
     }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERevokeCertificateService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERevokeCertificateService.java
@@ -28,6 +28,7 @@ import org.dogtagpki.acme.issuer.ACMEIssuer;
  * @author Endi S. Dewata
  */
 @Path("revoke-cert")
+@ACMEManagedService
 public class ACMERevokeCertificateService {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMERevokeCertificateService.class);

--- a/base/acme/tomcat-8.5/conf/Catalina/localhost/acme.xml
+++ b/base/acme/tomcat-8.5/conf/Catalina/localhost/acme.xml
@@ -4,6 +4,19 @@ Copyright Red Hat, Inc.
 
 SPDX-License-Identifier: GPL-2.0-or-later
 -->
-<Context docBase="/usr/share/pki/acme/webapps/acme">
+<Context docBase="/usr/share/pki/acme/webapps/acme" crossContext="true">
+
+    <Manager secureRandomProvider="Mozilla-JSS" secureRandomAlgorithm="pkcs11prng"/>
+
+    <Valve className="com.netscape.cms.tomcat.ExternalAuthenticationValve" />
+
+    <Valve className="com.netscape.cms.tomcat.SSLAuthenticatorWithFallback"
+        alwaysUseSession="true"
+        secureRandomProvider="Mozilla-JSS"
+        secureRandomAlgorithm="pkcs11prng"/>
+
+    <Realm className="com.netscape.cms.tomcat.ProxyRealm" />
+
     <Resources allowLinking="true" />
+
 </Context>

--- a/base/acme/webapps/acme/WEB-INF/web.xml
+++ b/base/acme/webapps/acme/WEB-INF/web.xml
@@ -28,6 +28,16 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
     <servlet-mapping>
         <servlet-name>ACME</servlet-name>
+        <url-pattern>/login</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>ACME</servlet-name>
+        <url-pattern>/logout</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>ACME</servlet-name>
         <url-pattern>/directory</url-pattern>
     </servlet-mapping>
 
@@ -75,6 +85,32 @@ SPDX-License-Identifier: GPL-2.0-or-later
         <servlet-name>ACME</servlet-name>
         <url-pattern>/revoke-cert</url-pattern>
     </servlet-mapping>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Login Service</web-resource-name>
+            <url-pattern>/login</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+        <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+        </user-data-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Logout Service</web-resource-name>
+            <url-pattern>/logout</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+        <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+        </user-data-constraint>
+    </security-constraint>
 
     <login-config>
         <realm-name>ACME</realm-name>

--- a/base/acme/webapps/acme/WEB-INF/web.xml
+++ b/base/acme/webapps/acme/WEB-INF/web.xml
@@ -76,4 +76,16 @@ SPDX-License-Identifier: GPL-2.0-or-later
         <url-pattern>/revoke-cert</url-pattern>
     </servlet-mapping>
 
+    <login-config>
+        <realm-name>ACME</realm-name>
+    </login-config>
+
+    <security-role>
+        <role-name>Administrators</role-name>
+    </security-role>
+
+    <security-role>
+        <role-name>Enterprise ACME Administrators</role-name>
+    </security-role>
+
 </web-app>

--- a/base/acme/webapps/acme/WEB-INF/web.xml
+++ b/base/acme/webapps/acme/WEB-INF/web.xml
@@ -38,6 +38,16 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
     <servlet-mapping>
         <servlet-name>ACME</servlet-name>
+        <url-pattern>/enable</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>ACME</servlet-name>
+        <url-pattern>/disable</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>ACME</servlet-name>
         <url-pattern>/directory</url-pattern>
     </servlet-mapping>
 
@@ -106,6 +116,34 @@ SPDX-License-Identifier: GPL-2.0-or-later
         </web-resource-collection>
         <auth-constraint>
             <role-name>*</role-name>
+        </auth-constraint>
+        <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+        </user-data-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Enable ACME Service</web-resource-name>
+            <url-pattern>/enable</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Administrators</role-name>
+            <role-name>Enterprise ACME Administrators</role-name>
+        </auth-constraint>
+        <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+        </user-data-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Disable ACME Service</web-resource-name>
+            <url-pattern>/disable</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Administrators</role-name>
+            <role-name>Enterprise ACME Administrators</role-name>
         </auth-constraint>
         <user-data-constraint>
             <transport-guarantee>CONFIDENTIAL</transport-guarantee>

--- a/base/common/src/org/dogtagpki/acme/ACMEClient.java
+++ b/base/common/src/org/dogtagpki/acme/ACMEClient.java
@@ -1,0 +1,42 @@
+//--- BEGIN COPYRIGHT BLOCK ---
+//This program is free software; you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation; version 2 of the License.
+//
+//This program is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License along
+//with this program; if not, write to the Free Software Foundation, Inc.,
+//51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+//(C) 2012 Red Hat, Inc.
+//All rights reserved.
+//--- END COPYRIGHT BLOCK ---
+package org.dogtagpki.acme;
+
+import java.net.URISyntaxException;
+
+import javax.ws.rs.core.Response;
+
+import com.netscape.certsrv.client.Client;
+import com.netscape.certsrv.client.PKIClient;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMEClient extends Client {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEClient.class);
+
+    public ACMEClient(PKIClient client) throws URISyntaxException {
+        super(client, "acme", null, null);
+    }
+
+    public ACMEDirectory getDirectory() throws Exception {
+        Response response = get("directory");
+        return client.getEntity(response, ACMEDirectory.class);
+    }
+}

--- a/base/common/src/org/dogtagpki/acme/ACMEClient.java
+++ b/base/common/src/org/dogtagpki/acme/ACMEClient.java
@@ -21,6 +21,7 @@ import java.net.URISyntaxException;
 
 import javax.ws.rs.core.Response;
 
+import com.netscape.certsrv.account.Account;
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
 
@@ -33,6 +34,35 @@ public class ACMEClient extends Client {
 
     public ACMEClient(PKIClient client) throws URISyntaxException {
         super(client, "acme", null, null);
+    }
+
+    public Account login() throws Exception {
+        Response response = post("login");
+        Account account = client.getEntity(response, Account.class);
+
+        logger.info("Account: " + account.getID());
+
+        logger.info("Roles:");
+        for (String role : account.getRoles()) {
+            logger.info("- " + role);
+        }
+
+        return account;
+    }
+
+    public void enable() throws Exception {
+        Response response = post("enable");
+        client.getEntity(response, Void.class);
+    }
+
+    public void disable() throws Exception {
+        Response response = post("disable");
+        client.getEntity(response, Void.class);
+    }
+
+    public void logout() throws Exception {
+        Response response = post("logout");
+        client.getEntity(response, Void.class);
     }
 
     public ACMEDirectory getDirectory() throws Exception {

--- a/base/java-tools/src/com/netscape/cmstools/acme/ACMECLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/acme/ACMECLI.java
@@ -18,6 +18,8 @@ public class ACMECLI extends CLI {
         super("acme", "ACME management commands", mainCLI);
 
         addModule(new ACMEInfoCLI(this));
+        addModule(new ACMEEnableCLI(this));
+        addModule(new ACMEDisableCLI(this));
     }
 
     public String getFullName() {

--- a/base/java-tools/src/com/netscape/cmstools/acme/ACMECLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/acme/ACMECLI.java
@@ -1,0 +1,31 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.acme;
+
+import org.dogtagpki.cli.CLI;
+
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMECLI extends CLI {
+
+    public ACMECLI(MainCLI mainCLI) {
+        super("acme", "ACME management commands", mainCLI);
+
+        addModule(new ACMEInfoCLI(this));
+    }
+
+    public String getFullName() {
+        if (parent instanceof MainCLI) {
+            // do not include MainCLI's name
+            return name;
+        } else {
+            return parent.getFullName() + "-" + name;
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/acme/ACMEDisableCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/acme/ACMEDisableCLI.java
@@ -1,0 +1,60 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.acme;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.acme.ACMEClient;
+import org.dogtagpki.cli.CommandCLI;
+import org.dogtagpki.util.logging.PKILogger;
+import org.dogtagpki.util.logging.PKILogger.Level;
+
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMEDisableCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEDisableCLI.class);
+
+    public ACMEDisableCLI(ACMECLI acmeCLI) {
+        super("disable", "Disable ACME service", acmeCLI);
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+
+        } else if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(Level.INFO);
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        PKIClient client = mainCLI.getClient();
+        ACMEClient acmeClient = new ACMEClient(client);
+
+        acmeClient.login();
+
+        logger.info("Disabling ACME service");
+        acmeClient.disable();
+
+        acmeClient.logout();
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/acme/ACMEEnableCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/acme/ACMEEnableCLI.java
@@ -1,0 +1,60 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.acme;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.acme.ACMEClient;
+import org.dogtagpki.cli.CommandCLI;
+import org.dogtagpki.util.logging.PKILogger;
+import org.dogtagpki.util.logging.PKILogger.Level;
+
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMEEnableCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEEnableCLI.class);
+
+    public ACMEEnableCLI(ACMECLI acmeCLI) {
+        super("enable", "Enable ACME service", acmeCLI);
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+
+        } else if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(Level.INFO);
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        PKIClient client = mainCLI.getClient();
+        ACMEClient acmeClient = new ACMEClient(client);
+
+        acmeClient.login();
+
+        logger.info("Enabling ACME service");
+        acmeClient.enable();
+
+        acmeClient.logout();
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/acme/ACMEInfoCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/acme/ACMEInfoCLI.java
@@ -1,0 +1,75 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.acme;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.acme.ACMEClient;
+import org.dogtagpki.acme.ACMEDirectory;
+import org.dogtagpki.acme.ACMEMetadata;
+import org.dogtagpki.cli.CommandCLI;
+import org.dogtagpki.util.logging.PKILogger;
+import org.dogtagpki.util.logging.PKILogger.Level;
+
+import com.netscape.certsrv.base.PKIException;
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMEInfoCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEInfoCLI.class);
+
+    public ACMEInfoCLI(ACMECLI acmeCLI) {
+        super("info", "Display ACME metadata", acmeCLI);
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+
+        } else if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(Level.INFO);
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        PKIClient client = mainCLI.getClient();
+        ACMEClient acmeClient = new ACMEClient(client);
+
+        try {
+            ACMEDirectory directory = acmeClient.getDirectory();
+            System.out.println("  Status: Available");
+
+            ACMEMetadata metadata = directory.getMetadata();
+            System.out.println("  Terms of Service: " + metadata.getTermsOfService());
+            System.out.println("  Website: " + metadata.getWebsite());
+            System.out.println("  CAA Identities: " + String.join(", ", metadata.getCaaIdentities()));
+            System.out.println("  External Account Required: " + metadata.getExternalAccountRequired());
+
+        } catch (PKIException e) {
+            if (e.getCode() != Response.Status.SERVICE_UNAVAILABLE.getStatusCode()) {
+                throw e;
+            }
+            System.out.println("  Status: Unavailable");
+        }
+    }
+}

--- a/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/java-tools/src/com/netscape/cmstools/cli/MainCLI.java
@@ -61,6 +61,7 @@ import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.ca.CAClient;
 import com.netscape.certsrv.client.ClientConfig;
 import com.netscape.certsrv.client.PKIClient;
+import com.netscape.cmstools.acme.ACMECLI;
 import com.netscape.cmstools.ca.CACLI;
 import com.netscape.cmstools.cert.ProxyCertCLI;
 import com.netscape.cmstools.client.ClientCLI;
@@ -114,6 +115,7 @@ public class MainCLI extends CLI {
         addModule(new ProxyCLI(new SecurityDomainCLI(this), "ca"));
         addModule(new ProxyUserCLI(this));
 
+        addModule(new ACMECLI(this));
         addModule(new CACLI(this));
         addModule(new KRACLI(this));
         addModule(new OCSPCLI(this));

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -136,6 +136,11 @@ class ACMECreateCLI(pki.cli.CLI):
         logger.info('Creating %s', issuer_conf)
         instance.copy(issuer_template, issuer_conf, force=force)
 
+        realm_template = os.path.join(acme_share_dir, 'conf', 'realm.conf')
+        realm_conf = os.path.join(acme_conf_dir, 'realm.conf')
+        logger.info('Creating %s', realm_conf)
+        instance.copy(realm_template, realm_conf, force=force)
+
 
 class ACMERemoveCLI(pki.cli.CLI):
 

--- a/docs/admin/acme/Managing_PKI_ACME_Responder.md
+++ b/docs/admin/acme/Managing_PKI_ACME_Responder.md
@@ -1,0 +1,38 @@
+Managing PKI ACME Responder
+===========================
+
+## Overview
+
+This document describes how to manage PKI ACME responder.
+
+**Note:** The PKI ACME responder is currently a tech preview which means:
+* It is not intended for production.
+* It may corrupt your data.
+* There is no guarantee for correctness, security, or performance.
+* There is no guarantee for documentation or support.
+* The API, configuration, or the database may change in the future.
+* There may be no easy upgrade path to the future version.
+
+## Enabling/Disabling ACME Services
+
+Users that belong to the Administrators group can enable or disable services in PKI ACME responder.
+The user can authenticate either with basic authentication or client certificate authentication.
+
+To enable/disable ACME services with basic authentication, specify the username and password:
+
+```
+$ pki -u <username> -p <password> acme-<enable/disable>
+```
+
+To enable/disable ACME services with client certificate authentication,
+specify the certificate nickname and NSS database password:
+
+```
+$ pki -n <nickname> -c <password> acme-<enable/disable>
+```
+
+
+## See Also
+
+* [Installing PKI ACME Responder](../../installation/acme/Installing_PKI_ACME_Responder.md)
+* [Using PKI ACME Responder](../../user/acme/Using_PKI_ACME_Responder.md)

--- a/docs/installation/acme/Configuring_ACME_Realm.md
+++ b/docs/installation/acme/Configuring_ACME_Realm.md
@@ -1,0 +1,93 @@
+Configuring ACME Realm
+======================
+
+## Overview
+
+This document describes the process to configure a realm for ACME responder.
+The realm configuration is located at /etc/pki/pki-tomcat/acme/realm.conf.
+
+The `pki-server acme-realm-mod` can be used to configure the realm via command-line.
+If the command is invoked without any parameters, it will enter an interactive mode, for example:
+
+```
+$ pki-server acme-realm-mod
+The current value is displayed in the square brackets.
+To keep the current value, simply press Enter.
+To change the current value, enter the new value.
+To remove the current value, enter a blank space.
+
+Enter the type of the realm. Available types: ds.
+  Database Type: ds
+
+Enter the location of the LDAP server (e.g. ldap://localhost.localdomain:389).
+  Server URL [ldap://localhost.localdomain:389]:
+
+Enter the authentication type. Available types: BasicAuth, SslClientAuth.
+  Authentication Type [BasicAuth]:
+
+Enter the bind DN.
+  Bind DN [cn=Directory Manager]:
+
+Enter the bind password.
+  Bind Password [********]:
+
+Enter the base DN for the ACME users subtree.
+  Users DN [ou=people,dc=acme,dc=pki,dc=example,dc=com]:
+
+Enter the base DN for the ACME groups subtree.
+  Groups DN [ou=groups,dc=acme,dc=pki,dc=example,dc=com]:
+```
+
+If the command is invoked with `--type` parameter, it will create a new configuration based on the specified type.
+If the command is invoked with other parameters, it will update the specified parameters.
+
+## Configuring DS Realm
+
+The ACME responder can be configured with a DS realm.
+
+Prepare subtrees for ACME users and groups in DS.
+A sample LDIF file is available at [/usr/share/pki/acme/realm/ds/create.ldif](../../../base/acme/realm/ds/create.ldif).
+This example uses dc=acme,dc=pki,dc=example,dc=com as the base DN.
+Import the file with the following command:
+
+```
+$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/realm/ds/create.ldif
+```
+
+A sample DS realm configuration is available at
+[/usr/share/pki/acme/realm/ds/realm.conf](../../../base/acme/realm/ds/realm.conf).
+
+To use the DS realm, copy the sample realm.conf into the /etc/pki/pki-tomcat/acme folder,
+or execute the following command to customize some of the parameters:
+
+```
+$ pki-server acme-realm-mod --type ds \
+    -DbindPassword=Secret.123
+```
+
+Customize the configuration as needed. In a standalone ACME deployment, the realm.conf should look like the following:
+
+```
+class=org.dogtagpki.acme.realm.DSRealm
+url=ldap://<hostname>:389
+authType=BasicAuth
+bindDN=cn=Directory Manager
+bindPassword=Secret.123
+usersDN=ou=people,dc=acme,dc=pki,dc=example,dc=com
+groupsDN=ou=groups,dc=acme,dc=pki,dc=example,dc=com
+```
+
+In a shared CA and ACME deployment, the realm.conf should look like the following:
+
+```
+class=org.dogtagpki.acme.realm.DSRealm
+configFile=conf/ca/CS.cfg
+usersDN=ou=people,dc=ca,dc=pki,dc=example,dc=com
+groupsDN=ou=groups,dc=ca,dc=pki,dc=example,dc=com
+```
+
+## See Also
+
+* [Configuring PKI ACME Responder](https://www.dogtagpki.org/wiki/Configuring_PKI_ACME_Responder)
+* [Installing PKI ACME Responder](Installing_PKI_ACME_Responder.md)

--- a/docs/installation/acme/Installing_PKI_ACME_Responder.md
+++ b/docs/installation/acme/Installing_PKI_ACME_Responder.md
@@ -40,6 +40,10 @@ See [Configuring ACME Database](Configuring_ACME_Database.md).
 
 See [Configuring ACME Issuer](Configuring_ACME_Issuer.md).
 
+## Configuring ACME Realm
+
+See [Configuring ACME Realm](Configuring_ACME_Realm.md).
+
 ## Deploying ACME Responder
 
 Once everything is ready, deploy the ACME responder with the following command:
@@ -78,4 +82,5 @@ See also [pki-server-acme(8)](../../manuals/man8/pki-server-acme.8.md).
 ## See Also
 
 * [Installing CA](../ca/Installing_CA.md)
-* [Using PKI ACME Responder with Certbot](../../user/acme/Using_PKI_ACME_Responder_with_Certbot.md)
+* [Managing PKI ACME Responder](../../admin/acme/Managing_PKI_ACME_Responder.md)
+* [Using PKI ACME Responder](../../user/acme/Using_PKI_ACME_Responder.md)

--- a/docs/user/acme/Using_PKI_ACME_Responder.md
+++ b/docs/user/acme/Using_PKI_ACME_Responder.md
@@ -1,0 +1,43 @@
+Using PKI ACME Responder
+========================
+
+## Overview
+
+This document describes how to use PKI ACME responder.
+
+**Note:** The PKI ACME responder is currently a tech preview which means:
+* It is not intended for production.
+* It may corrupt your data.
+* There is no guarantee for correctness, security, or performance.
+* There is no guarantee for documentation or support.
+* The API, configuration, or the database may change in the future.
+* There may be no easy upgrade path to the future version.
+
+## Checking PKI ACME Responder Status
+
+To check the status of PKI ACME responder, execute the following command:
+
+```
+$ pki acme-info
+  Status: Available
+  Terms of Service: https://www.dogtagpki.org/wiki/PKI_ACME_Responder
+  Website: https://www.dogtagpki.org
+  CAA Identities: dogtagpki.org
+  External Account Required: false
+```
+
+If the services are disabled, the command will show the following result:
+
+```
+$ pki acme-info
+  Status: Unavailable
+```
+
+## Supported ACME Clients
+
+* [Certbot](Using_PKI_ACME_Responder_with_Certbot.md)
+
+## See Also
+
+* [Installing PKI ACME Responder](../../installation/acme/Installing_PKI_ACME_Responder.md)
+* [Managing PKI ACME Responder](../../admin/acme/Managing_PKI_ACME_Responder.md)

--- a/docs/user/acme/Using_PKI_ACME_Responder_with_Certbot.md
+++ b/docs/user/acme/Using_PKI_ACME_Responder_with_Certbot.md
@@ -143,4 +143,4 @@ $ certbot unregister --server http://$HOSTNAME:8080/acme/directory
 ## See Also
 
 * [certbot](https://certbot.eff.org)
-* [Installing PKI ACME Responder](../../installation/acme/Installing_PKI_ACME_Responder.md)
+* [Using PKI ACME Responder](Using_PKI_ACME_Responder.md)


### PR DESCRIPTION
This PR is providing a mechanism to define ACME realm and also commands to enable/disable ACME services.

Components:
* ACMEManagedService: annotation to mark services that can be enabled/disabled
* ACMERealm: base class for ACME realms
* LDAPRealm and DSRealm: LDAP/DS-specific implementation of ACME realm
* pki-server acme-realm-show/mod: server-side commands to configure ACME realm
* ACMELoginService/ACMELogoutService: REST services to authenticate users
* ACMEEnableService/ACMEDisableService: REST services to enable/disable managed services
* pki acme-info: client-side command to check ACME service status
* pki acme-enable/disable: client-side commands to enable/disable managed services

Docs:
* https://github.com/edewata/pki/blob/acme-dev/docs/installation/acme/Configuring_ACME_Realm.md
* https://github.com/edewata/pki/blob/acme-dev/docs/admin/acme/Managing_PKI_ACME_Responder.md
* https://github.com/edewata/pki/blob/acme-dev/docs/user/acme/Using_PKI_ACME_Responder.md
* https://github.com/dogtagpki/pki/wiki/PKI-ACME-REST-API