### PR TITLE
systemd sd_notify support

### DIFF
--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -24,11 +24,13 @@ add_custom_command(
     COMMAND ln -sf /usr/share/java/pki/pki-ca.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-ca.jar
 )
 
+if(WITH_SYSTEMD_NOTIFICATION)
 add_custom_target(pki-ca-links-systemd-jar ALL
     COMMENT "Creating link to pki-systemd.jar for CA webapp library"
     DEPENDS pki-ca-links
     COMMAND ln -sf /usr/share/java/pki/pki-systemd.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-systemd.jar
 )
+endif(WITH_SYSTEMD_NOTIFICATION)
 
 # install directories
 install(

--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -24,6 +24,12 @@ add_custom_command(
     COMMAND ln -sf /usr/share/java/pki/pki-ca.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-ca.jar
 )
 
+add_custom_target(pki-ca-links-systemd-jar ALL
+    COMMENT "Creating link to pki-systemd.jar for CA webapp library"
+    DEPENDS pki-ca-links
+    COMMAND ln -sf /usr/share/java/pki/pki-systemd.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-systemd.jar
+)
+
 # install directories
 install(
     DIRECTORY

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -27,7 +27,9 @@ add_subdirectory(src)
 add_subdirectory(cmsbundle)
 add_subdirectory(test)
 add_subdirectory(healthcheck)
+if(WITH_SYSTEMD_NOTIFICATION)
 add_subdirectory(systemd)
+endif(WITH_SYSTEMD_NOTIFICATION)
 
 # build server classes
 javac(pki-server-classes

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -119,6 +119,14 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${COMMONS_NET_JAR} common/lib/commons-net.jar
 )
 
+if(WITH_SYSTEMD_NOTIFICATION)
+add_custom_target(pki-server-common-lib-jna ALL
+    COMMENT "Creating link to jna.jar for PKI server common library"
+    DEPENDS pki-server-common-lib
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${JNA_JAR} common/lib/jna.jar
+)
+endif(WITH_SYSTEMD_NOTIFICATION)
+
 if(JAVA_VERSION GREATER 10)
     add_custom_target(pki-server-java11plus-lib ALL
         DEPENDS pki-server-common-lib

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(src)
 add_subdirectory(cmsbundle)
 add_subdirectory(test)
 add_subdirectory(healthcheck)
+add_subdirectory(systemd)
 
 # build server classes
 javac(pki-server-classes

--- a/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
@@ -164,6 +164,8 @@ public class CMSEngine implements ServletContextListener {
     public String unsecurePort;
     public String securePort;
 
+    private Map<String, StartupNotifier> startupNotifiers = new LinkedHashMap<>();
+
     private static final int PW_OK =0;
     //private static final int PW_BAD_SETUP = 1;
     private static final int PW_INVALID_PASSWORD = 2;
@@ -1019,6 +1021,17 @@ public class CMSEngine implements ServletContextListener {
         mStartupTime = System.currentTimeMillis();
 
         logger.info(name + " engine started");
+
+        for (Map.Entry<String, StartupNotifier> kv : startupNotifiers.entrySet()) {
+            try {
+                kv.getValue().notifyReady();
+            } catch (Throwable e) {
+                logger.warn(
+                    "Startup notification failed for notifier '" + kv.getKey() + "'.",
+                    e
+                );
+            }
+        }
     }
 
     public boolean isInRunningState() {

--- a/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
@@ -1041,12 +1041,11 @@ public class CMSEngine implements ServletContextListener {
         logger.info(name + " engine started");
 
         for (Map.Entry<String, StartupNotifier> kv : startupNotifiers.entrySet()) {
-            try {
-                kv.getValue().notifyReady();
-            } catch (Throwable e) {
+            StartupNotifier.NotifyResult r = kv.getValue().notifyReady();
+            if (r.getStatus() == StartupNotifier.NotifyResultStatus.Failure) {
                 logger.warn(
-                    "Startup notification failed for notifier '" + kv.getKey() + "'.",
-                    e
+                    "Startup notification failed for notifier '" + kv.getKey() + "': "
+                    + r.getMessage()
                 );
             }
         }

--- a/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/com/netscape/cmscore/apps/CMSEngine.java
@@ -267,6 +267,23 @@ public class CMSEngine implements ServletContextListener {
         debug.init(debugConfig);
     }
 
+    public void initStartupNotifiers() throws Exception {
+        IConfigStore snConfig = config.getSubStore("startupNotifiers");
+        String ids = snConfig.getString("list", null);
+        if (ids == null) return;
+        for (String id : ids.split(",")) {
+            id = id.trim();
+            if (id.isEmpty()) continue;
+            IConfigStore instanceConfig = snConfig.getSubStore(id);
+            String className = instanceConfig.getString("class");
+            Class<? extends StartupNotifier> clazz =
+                Class.forName(className).asSubclass(StartupNotifier.class);
+            StartupNotifier sn = clazz.newInstance();
+            sn.init(instanceConfig);
+            startupNotifiers.put(id, sn);
+        }
+    }
+
     public void initPasswordStore() throws Exception {
 
         int state = config.getState();
@@ -980,6 +997,7 @@ public class CMSEngine implements ServletContextListener {
 
         initDebug();
         initPasswordStore();
+        initStartupNotifiers();
         initSecurityProvider();
         initPluginRegistry();
         initDatabase();

--- a/base/server/src/com/netscape/cmscore/apps/StartupNotifier.java
+++ b/base/server/src/com/netscape/cmscore/apps/StartupNotifier.java
@@ -6,6 +6,12 @@
 
 package com.netscape.cmscore.apps;
 
+import com.netscape.certsrv.base.IConfigStore;
+
 public interface StartupNotifier {
+    default void init(IConfigStore cs) {
+        // default implementation ignores value
+    };
+
     void notifyReady() throws RuntimeException;
 }

--- a/base/server/src/com/netscape/cmscore/apps/StartupNotifier.java
+++ b/base/server/src/com/netscape/cmscore/apps/StartupNotifier.java
@@ -10,5 +10,25 @@ import com.netscape.certsrv.base.IConfigStore;
 
 public interface StartupNotifier {
     void init(IConfigStore cs);
-    void notifyReady() throws RuntimeException;
+    NotifyResult notifyReady();
+
+    class NotifyResult {
+        NotifyResultStatus status;
+        String message;
+
+        public NotifyResult(NotifyResultStatus status, String message) {
+            this.status = status;
+            this.message = message;
+        }
+
+        public NotifyResultStatus getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    enum NotifyResultStatus { Failure, Success };
 }

--- a/base/server/src/com/netscape/cmscore/apps/StartupNotifier.java
+++ b/base/server/src/com/netscape/cmscore/apps/StartupNotifier.java
@@ -9,9 +9,6 @@ package com.netscape.cmscore.apps;
 import com.netscape.certsrv.base.IConfigStore;
 
 public interface StartupNotifier {
-    default void init(IConfigStore cs) {
-        // default implementation ignores value
-    };
-
+    void init(IConfigStore cs);
     void notifyReady() throws RuntimeException;
 }

--- a/base/server/src/com/netscape/cmscore/apps/StartupNotifier.java
+++ b/base/server/src/com/netscape/cmscore/apps/StartupNotifier.java
@@ -1,0 +1,11 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+
+package com.netscape.cmscore.apps;
+
+public interface StartupNotifier {
+    void notifyReady() throws RuntimeException;
+}

--- a/base/server/systemd/CMakeLists.txt
+++ b/base/server/systemd/CMakeLists.txt
@@ -1,0 +1,41 @@
+project(pki-systemd)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/pki-systemd.mf
+    ${CMAKE_CURRENT_BINARY_DIR}/pki-systemd.mf
+)
+
+# build systemd classes
+javac(pki-systemd-classes
+    SOURCES
+        *.java
+    CLASSPATH
+        ${PKI_CMS_JAR}
+    OUTPUT_DIR
+        ${CMAKE_CURRENT_BINARY_DIR}/classes
+    DEPENDS
+        pki-cms-jar
+)
+
+# build pki-systemd.jar
+jar(pki-systemd-jar
+    CREATE
+        ${CMAKE_BINARY_DIR}/dist/pki-systemd.jar
+    OPTIONS
+        m
+    PARAMS
+        ${CMAKE_CURRENT_BINARY_DIR}/pki-systemd.mf
+    INPUT_DIR
+        ${CMAKE_CURRENT_BINARY_DIR}/classes
+    DEPENDS
+        pki-systemd-classes
+)
+
+install(
+    FILES
+        ${CMAKE_BINARY_DIR}/dist/pki-systemd.jar
+    DESTINATION
+        ${JAVA_JAR_INSTALL_DIR}/pki
+)
+
+set(PKI_SYSTEMD_JAR ${CMAKE_BINARY_DIR}/dist/pki-systemd.jar CACHE INTERNAL "pki-systemd jar file")

--- a/base/server/systemd/CMakeLists.txt
+++ b/base/server/systemd/CMakeLists.txt
@@ -17,7 +17,7 @@ javac(pki-systemd-classes
     SOURCES
         *.java
     CLASSPATH
-        ${JNA_JAR} ${PKI_CMS_JAR}
+        ${JNA_JAR} ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     DEPENDS

--- a/base/server/systemd/CMakeLists.txt
+++ b/base/server/systemd/CMakeLists.txt
@@ -5,12 +5,19 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/pki-systemd.mf
 )
 
+find_file(JNA_JAR
+    NAMES
+        jna.jar
+    PATHS
+        /usr/share/java
+)
+
 # build systemd classes
 javac(pki-systemd-classes
     SOURCES
         *.java
     CLASSPATH
-        ${PKI_CMS_JAR}
+        ${JNA_JAR} ${PKI_CMS_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     DEPENDS

--- a/base/server/systemd/SystemdStartupNotifier.java
+++ b/base/server/systemd/SystemdStartupNotifier.java
@@ -5,10 +5,42 @@
 //
 package com.netscape.cmscore.systemd;
 
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+
 import com.netscape.cmscore.apps.StartupNotifier;
 
 public class SystemdStartupNotifier implements StartupNotifier {
+    interface Systemd extends Library {
+        public int sd_booted();
+        public int sd_notify(int unset_environment, String state);
+    }
+
+    /* loadLibrary is deprecated in jna >= 5; replaced with load()
+     * which avoids the cast.  But RHEL 8 has jna 4.5 so we must put
+     * up with deprecation warnings on Fedora. */
+    static Systemd systemd = (Systemd) Native.loadLibrary("systemd", Systemd.class);
+
+    static boolean isNotifyService = hasNotifySocket() && systemdBooted();
+
+    private static boolean systemdBooted() {
+        return systemd.sd_booted() > 0;
+    }
+
+    private static boolean hasNotifySocket() {
+        return System.getenv("NOTIFY_SOCKET") != null;
+    }
+
+    private static void notify(String status) {
+        if (isNotifyService) {
+            System.out.println("Notifying systemd:\n" + status);
+            systemd.sd_notify(0 /* unset_environment */, status);
+        } else {
+            System.err.println("Failed to notify systemd (isNotifyService = false)");
+        }
+    }
+
     public void notifyReady() {
-        System.out.println("Notifying systemd... not!");
+        notify("READY=1");
     }
 }

--- a/base/server/systemd/SystemdStartupNotifier.java
+++ b/base/server/systemd/SystemdStartupNotifier.java
@@ -1,0 +1,14 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmscore.systemd;
+
+import com.netscape.cmscore.apps.StartupNotifier;
+
+public class SystemdStartupNotifier implements StartupNotifier {
+    public void notifyReady() {
+        System.out.println("Notifying systemd... not!");
+    }
+}

--- a/base/server/systemd/pki-systemd.mf
+++ b/base/server/systemd/pki-systemd.mf
@@ -1,0 +1,3 @@
+Name: pki-systemd
+Specification-Version: ${APPLICATION_VERSION}
+Implementation-Version: ${VERSION}

--- a/pki.spec
+++ b/pki.spec
@@ -1186,6 +1186,8 @@ fi
 %{_javadir}/pki/pki-cms.jar
 %{_javadir}/pki/pki-cmsbundle.jar
 %{_javadir}/pki/pki-tomcat.jar
+# TODO make pki-systemd.jar conditional
+%{_javadir}/pki/pki-systemd.jar
 %dir %{_sharedstatedir}/pki
 %{_mandir}/man1/pkidaemon.1.gz
 %{_mandir}/man5/pki_default.cfg.5.gz

--- a/pki.spec
+++ b/pki.spec
@@ -513,6 +513,12 @@ Requires(postun): systemd-units
 Requires(pre):    shadow-utils
 Requires:         tomcatjss >= 7.5.0
 
+# JNA is used to bind to libsystemd
+%if %{with sdnotify}
+BuildRequires:    jna
+Requires:         jna
+%endif
+
 # pki-healthcheck depends on the following library
 %if 0%{?rhel}
 Requires:         ipa-healthcheck-core

--- a/pki.spec
+++ b/pki.spec
@@ -117,6 +117,8 @@ Source: https://github.com/dogtagpki/pki/archive/v%{version}%{?_phase}/pki-%{ver
 %define debug_package %{nil}
 %endif
 
+%bcond_without sdnotify
+
 # ignore unpackaged files from native 'tpsclient'
 # REMINDER:  Remove this '%%define' once 'tpsclient' is rewritten as a Java app
 %define _unpackaged_files_terminate_build 0
@@ -870,6 +872,7 @@ cd build
 %if ! %{with server} && ! %{with acme} && ! %{with ca} && ! %{with kra} && ! %{with ocsp} && ! %{with tks} && ! %{with tps}
     -DWITH_SERVER:BOOL=OFF \
 %endif
+    -DWITH_SYSTEMD_NOTIFICATION:BOOL=%{?with_sdnotify:ON}%{!?with_sdnotify:OFF} \
     -DWITH_JAVADOC:BOOL=%{?with_javadoc:ON}%{!?with_javadoc:OFF} \
     -DBUILD_PKI_CONSOLE:BOOL=%{?with_console:ON}%{!?with_console:OFF} \
     -DTHEME=%{?with_theme:%{vendor_id}} \
@@ -1186,8 +1189,6 @@ fi
 %{_javadir}/pki/pki-cms.jar
 %{_javadir}/pki/pki-cmsbundle.jar
 %{_javadir}/pki/pki-tomcat.jar
-# TODO make pki-systemd.jar conditional
-%{_javadir}/pki/pki-systemd.jar
 %dir %{_sharedstatedir}/pki
 %{_mandir}/man1/pkidaemon.1.gz
 %{_mandir}/man5/pki_default.cfg.5.gz
@@ -1211,6 +1212,10 @@ fi
 %{_mandir}/man8/pki-healthcheck.8.gz
 %{_datadir}/pki/setup/
 %{_datadir}/pki/server/
+
+%if %{with sdnotify}
+%{_javadir}/pki/pki-systemd.jar
+%endif
 
 # with server
 %endif


### PR DESCRIPTION
```
8896c2986 (Fraser Tweedale, 9 minutes ago)
   startup notification: complete systemd notifier

   Complete the implementation of SystemdStartupNotifier.  We use JNA to bind
   to libsystemd.  The dependency on 'jna' package only occurs when %{with
   sdnotify}.

   The systemd unit template file is left alone, retaining Type=simple. In
   order to enable systemd startup notification, you can override the Type in
   the "drop-in" directory. For example, if the instance name is 'pki-tomcat',
   write to the file:

     /etc/systemd/system/pki-tomcatd@pki-tomcat.service.d/notify.conf

   the content:

     [Service]
    Type=notify

   See systemd.unit(5) for more details.

   Fixes: https://pagure.io/dogtagpki/issue/1233

d27de20ca (Fraser Tweedale, 5 hours ago)
   startup notification: make the systemd class optional

   Add the `sdnotify` RPM bcond to make the SystemdStartupNotifier class
   optional.  When enabled, it is supplied in a separate JAR
   (part of the pki-server package), and the webapp symlink is added in the
   pki-ca package.  It is enabled by default.

   Note that on Fedora and presumably RHEL also, libsystemd.so is always
   present.  sd_booted(3) can be used to determine whether pid 1 is systemd or
   not, so having a systemd notifier implementation present doesn't imply that
   systemd must be used.

   Nevertheless, it was requested to make this component optional.  So here we
   are.

   Part of: https://pagure.io/dogtagpki/issue/1233

bee6ff9f8 (Fraser Tweedale, 5 hours ago)
   startup notification: add pki-systemd jar

   Implement SystemdStartupNotifier, which does not actually notify systemd
   yet (this will be implemented in a subsequent commit). Ship this class in
   its own jar.  The inclusion of this jar in the pki-server package will be
   made conditional on an RPM macro in the next commit.

   Part of: https://pagure.io/dogtagpki/issue/1233

59787e9c0 (Fraser Tweedale, 11 hours ago)
   startup notification: initialise from CS.cfg

   Initialise StartupNotifier instances configured in CS.cfg.  The 
   configuration scheme is:

     startupNotifiers.list=systemd,foo
    startupNotifiers.systemd.class=package.and.ClassName
    startupNotifiers.foo.class=com.netscape.cmscore.apps.FooNotifier
    startupNotifiers.foo.paramA=valueA
    startupNotifiers.foo.paramB=valueB

   `startupNotifiers.list' gives a list of substore names, one for each 
   StartupNotifier instance.  The 'class' parameter of each substore specifies
   the Java class name.  The config substore is passed to the 
   StartupNotifier.init() method.

   Part of: https://pagure.io/dogtagpki/issue/1233

7b77eaf3f (Fraser Tweedale, 12 hours ago)
   startup notification: add StartupNotifier interface

   Add the StartupNotifier interface.  Update CMSEngine to invoke
   .notifyReady() for each configured notifier when startup is completed.

   Loading of notifiers and a systemd notifier instance will be implemented in
   subsequent commits.

   Part of: https://pagure.io/dogtagpki/issue/1233
```