### PR TITLE
Remove net-tools

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -477,7 +477,6 @@ Summary:          PKI Server Package
 BuildArch:        noarch
 
 Requires:         hostname
-Requires:         net-tools
 
 Requires:         policycoreutils
 Requires:         procps-ng


### PR DESCRIPTION
As far as I can tell, these two packages aren't required by the new
pkispawn installer. As people are asking for them to be removed from
Fedora ELN, we should drop our dependency on them.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`