### PR TITLE
Add ACME config monitor in LDAPDatabase

### DIFF
--- a/base/acme/database/ds/create.ldif
+++ b/base/acme/database/ds/create.ldif
@@ -2,6 +2,11 @@ dn: dc=acme,dc=pki,dc=example,dc=com
 objectClass: dcObject
 dc: acme
 
+dn: ou=config,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: extensibleObject
+ou: config
+
 dn: ou=nonces,dc=acme,dc=pki,dc=example,dc=com
 objectClass: organizationalUnit
 ou: nonces

--- a/base/acme/database/ds/schema.ldif
+++ b/base/acme/database/ds/schema.ldif
@@ -57,6 +57,10 @@ attributeTypes: ( acmeCertificateId-oid NAME 'acmeCertificateId'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   EQUALITY caseExactMatch
   SINGLE-VALUE )
+attributeTypes: ( acmeEnabled-oid NAME 'acmeEnabled'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  EQUALITY booleanMatch
+  SINGLE-VALUE )
 -
 add: objectClasses
 objectClasses: ( acmeNonce-oid NAME 'acmeNonce'

--- a/base/acme/database/ldap/create.ldif
+++ b/base/acme/database/ldap/create.ldif
@@ -2,6 +2,11 @@ dn: dc=acme,dc=pki,dc=example,dc=com
 objectClass: dcObject
 dc: acme
 
+dn: ou=config,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: extensibleObject
+ou: config
+
 dn: ou=nonces,dc=acme,dc=pki,dc=example,dc=com
 objectClass: organizationalUnit
 ou: nonces

--- a/base/acme/database/ldap/schema.ldif
+++ b/base/acme/database/ldap/schema.ldif
@@ -57,6 +57,10 @@ attributeTypes: ( acmeCertificateId-oid NAME 'acmeCertificateId'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   EQUALITY caseExactMatch
   SINGLE-VALUE )
+attributeTypes: ( acmeEnabled-oid NAME 'acmeEnabled'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  EQUALITY booleanMatch
+  SINGLE-VALUE )
 -
 add: objectClasses
 objectClasses: ( acmeNonce-oid NAME 'acmeNonce'

--- a/base/acme/database/openldap/create.ldif
+++ b/base/acme/database/openldap/create.ldif
@@ -4,6 +4,11 @@ objectclass: organization
 o: ACME
 dc: acme
 
+dn: ou=config,dc=acme,dc=pki,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: extensibleObject
+ou: config
+
 dn: ou=nonces,dc=acme,dc=pki,dc=example,dc=com
 objectClass: organizationalUnit
 ou: nonces

--- a/base/acme/database/openldap/schema.ldif
+++ b/base/acme/database/openldap/schema.ldif
@@ -57,6 +57,10 @@ olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.16 NAME 'acmeCertificateId'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   EQUALITY caseExactMatch
   SINGLE-VALUE )
+olcAttributeTypes: ( 2.16.840.1.113730.5.2.1.17 NAME 'acmeEnabled'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  EQUALITY booleanMatch
+  SINGLE-VALUE )
 olcObjectClasses: ( 2.16.840.1.113730.5.2.2.1 NAME 'acmeNonce'
   STRUCTURAL
   MUST ( acmeNonceId $ acmeCreated $ acmeExpires ) )

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
@@ -37,6 +37,14 @@ public abstract class ACMEDatabase {
     public void close() throws Exception {
     }
 
+    public Boolean getEnabled() throws Exception {
+        return null;
+    }
+
+    public void setEnabled(Boolean enabled) throws Exception {
+        // ignore
+    }
+
     public abstract void addNonce(ACMENonce nonce) throws Exception;
     public abstract ACMENonce removeNonce(String nonceID) throws Exception;
     public abstract void removeExpiredNonces(Date currentTime) throws Exception;

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPConfigMonitor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPConfigMonitor.java
@@ -1,0 +1,100 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.database;
+
+import netscape.ldap.LDAPAttribute;
+import netscape.ldap.LDAPConnection;
+import netscape.ldap.LDAPEntry;
+import netscape.ldap.LDAPSearchConstraints;
+import netscape.ldap.LDAPSearchResults;
+import netscape.ldap.controls.LDAPPersistSearchControl;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class LDAPConfigMonitor implements Runnable {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LDAPConfigMonitor.class);
+
+    LDAPDatabase database;
+    LDAPPersistSearchControl searchControl;
+    boolean running;
+
+    public LDAPConfigMonitor(LDAPDatabase database) {
+        this.database = database;
+
+        searchControl = new LDAPPersistSearchControl(
+                LDAPPersistSearchControl.MODIFY,
+                false, // return initial entry and subsequent changes
+                true,  // return controls
+                true); // persistent search control is critical
+    }
+
+    public void run() {
+
+        running = true;
+
+        while (running) { // restart persistent search in case it's interrupted
+
+            LDAPConnection conn = null;
+            try {
+                conn = database.connFactory.getConn();
+
+                LDAPSearchConstraints searchConstraints = conn.getSearchConstraints();
+                searchConstraints.setServerControls(searchControl);
+                searchConstraints.setBatchSize(1);
+                searchConstraints.setServerTimeLimit(0);
+
+                logger.info("Start monitoring ACME configuration");
+
+                LDAPSearchResults results = conn.search(
+                        LDAPDatabase.RDN_CONFIG + "," + database.baseDN,
+                        LDAPConnection.SCOPE_BASE,
+                        "(objectClass=*)",
+                        null,  // return all attributes
+                        false, // return attribute values
+                        searchConstraints);
+
+                while (running && results.hasMoreElements()) { // process config updates
+
+                    LDAPEntry entry = results.next();
+                    logger.info("Updating ACME configuration");
+
+                    // update the config in memory only
+
+                    LDAPAttribute acmeEnabled = entry.getAttribute(LDAPDatabase.ATTR_ENABLED);
+                    if (acmeEnabled == null) {
+                        database.enabled = null;
+                    } else {
+                        String value = acmeEnabled.getStringValueArray()[0];
+                        database.enabled = Boolean.parseBoolean(value);
+                    }
+
+                    logger.info("- enabled: " + database.enabled);
+                }
+
+                logger.info("Stop monitoring ACME configuration");
+
+            } catch (Throwable e) {
+                logger.error("Unable to monitor ACME configuration: " + e.getMessage(), e);
+                try {
+                    Thread.sleep(10 * 1000); // wait 10s then restart persistent search
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+
+            } finally {
+                if (conn != null) {
+                    database.connFactory.returnConn(conn);
+                }
+            }
+        }
+    }
+
+    public void stop() throws Exception {
+        running = false; // terminate the loop gracefully
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDisableService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDisableService.java
@@ -14,6 +14,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import org.dogtagpki.acme.database.ACMEDatabase;
+
 /**
  * @author Endi S. Dewata
  */
@@ -32,7 +34,8 @@ public class ACMEDisableService {
         logger.info("Disabling ACME services");
 
         ACMEEngine engine = ACMEEngine.getInstance();
-        engine.setEnabled(false);
+        ACMEDatabase database = engine.getDatabase();
+        database.setEnabled(false);
 
         ResponseBuilder builder = Response.ok();
         return builder.build();

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEnableService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEnableService.java
@@ -12,6 +12,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
+import org.dogtagpki.acme.database.ACMEDatabase;
+
 /**
  * @author Endi S. Dewata
  */
@@ -27,7 +29,8 @@ public class ACMEEnableService {
         logger.info("Enabling ACME services");
 
         ACMEEngine engine = ACMEEngine.getInstance();
-        engine.setEnabled(true);
+        ACMEDatabase database = engine.getDatabase();
+        database.setEnabled(true);
 
         ResponseBuilder builder = Response.ok();
         return builder.build();

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERequestFilter.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMERequestFilter.java
@@ -5,10 +5,14 @@
 //
 package org.dogtagpki.acme.server;
 
+import java.io.IOException;
+
 import javax.ws.rs.ServiceUnavailableException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.ext.Provider;
+
+import org.dogtagpki.acme.database.ACMEDatabase;
 
 /**
  * @author Fraser Tweedale
@@ -21,11 +25,25 @@ public class ACMERequestFilter implements ContainerRequestFilter {
         org.slf4j.LoggerFactory.getLogger(ACMERequestFilter.class);
 
     @Override
-    public void filter(ContainerRequestContext requestContext) {
+    public void filter(ContainerRequestContext requestContext) throws IOException {
 
         ACMEEngine engine = ACMEEngine.getInstance();
+        ACMEDatabase database = engine.getDatabase();
 
-        if (!engine.isEnabled()) {
+        Boolean enabled = null;
+        try {
+            // get config property from database
+            enabled = database.getEnabled();
+        } catch (Exception e) {
+            throw new IOException("Unable to access ACME database: " + e.getMessage(), e);
+        }
+
+        if (enabled == null) {
+            // config property is unset in database, get it from config file instead
+            enabled = engine.isEnabled();
+        }
+
+        if (!enabled) {
             logger.info("ACMERequestFilter: ACME service is disabled");
             throw new ServiceUnavailableException("ACME service is disabled");
         }

--- a/docs/installation/acme/Configuring_ACME_Database.md
+++ b/docs/installation/acme/Configuring_ACME_Database.md
@@ -38,6 +38,13 @@ Enter the base DN for the ACME subtree.
 If the command is invoked with `--type` parameter, it will create a new configuration based on the specified type.
 If the command is invoked with other parameters, it will update the specified parameters.
 
+Some ACME configuration properties are stored in the database such that
+all ACME responders in the cluster can be configured consistently.
+By default the ACME responder will access the database directly
+when retrieving or updating the ACME configuration properties,
+which may increase the load on the database.
+Some databases might provide an ACME configuration monitor to reduce the load on the database.
+
 ## Configuring In-Memory Database
 
 The ACME responder can be configured with an in-memory database.
@@ -109,6 +116,13 @@ In a shared CA and ACME deployment, the database.conf should look like the follo
 class=org.dogtagpki.acme.database.DSDatabase
 configFile=conf/ca/CS.cfg
 baseDN=dc=acme,dc=pki,dc=example,dc=com
+```
+
+The DS database provides an ACME configuration monitor using search persistence.
+It can be enabled with the following parameter:
+
+```
+monitor.enabled=true
 ```
 
 ## Configuring OpenLDAP Database


### PR DESCRIPTION
The `LDAPDatabase` has been modified to create a thread to monitor ACME config properties stored in the database using persistent search.

The `ACMEEnableService` and `ACMEDisableService` have been modified to update the `enabled` config property in the database.

The `ACMERequestFilter` has been modified to use the `enabled` config property from the database. However, if the property
is not set in the database, the filter will use the property from the config file instead.

**Note:** For the initial implementation I added the monitor into `LDAPDatabase`. I'm thinking to eventually use `ACMEEngineConfigSource`, but the class probably needs some refactoring which might not happen until the next release.

If you want to try the current code the build is available from this COPR repo:
https://copr.fedorainfracloud.org/coprs/edewata/acme/builds/

Docs: https://github.com/edewata/pki/blob/acme-dev/docs/installation/acme/Configuring_ACME_Database.md
