### PR TITLE
CommonNameToSANDefault: allow label starting with digit

### DIFF
--- a/base/server/src/com/netscape/cms/profile/def/CommonNameToSANDefault.java
+++ b/base/server/src/com/netscape/cms/profile/def/CommonNameToSANDefault.java
@@ -182,7 +182,8 @@ public class CommonNameToSANDefault extends EnrollExtDefault {
             if (cs.length < 1 || cs.length > 63)
                 return false;
 
-            if (!isLetter(cs[0]))
+            // RFC 1123 allows label to start with letter or digit
+            if (!isLetDig(cs[0]))
                 return false;
 
             if (!isLetDig(cs[cs.length - 1]))


### PR DESCRIPTION
https://tools.ietf.org/html/rfc1123#section-2 relaxes the grammar
specified in https://tools.ietf.org/html/rfc1034#section-3.5,
allowing a DNS label to start with a number.  RFC 5280 explicitly
adopts the modifications of RFC 1123, so the current check that
requires a label to start with a letter is too strict.  Update the
check to allow labels to start with number or letter.

Fixes: https://github.com/dogtagpki/pki/issues/3339