### PR TITLE
Update ACME docs for Podman and OpenShift

### DIFF
--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -77,6 +77,9 @@ RUN cp /usr/share/pki/acme/database/in-memory/database.conf /var/lib/tomcats/pki
 # Use NSS issuer by default
 RUN cp /usr/share/pki/acme/issuer/nss/issuer.conf /var/lib/tomcats/pki/conf/acme
 
+# Use in-memory realm by default
+RUN cp /usr/share/pki/acme/realm/in-memory/realm.conf /var/lib/tomcats/pki/conf/acme
+
 # Remove PKI ACME web application logging.properties so the logs will appear on the console
 RUN rm -f /usr/share/pki/acme/webapps/acme/WEB-INF/classes/logging.properties
 

--- a/base/acme/bin/pki-acme-run
+++ b/base/acme/bin/pki-acme-run
@@ -182,6 +182,27 @@ else
 fi
 
 echo "################################################################################"
+
+# import realm configuration if available
+if [ -d /var/lib/tomcats/pki/conf/acme/realm ] && \
+   [ "$(ls /var/lib/tomcats/pki/conf/acme/realm)" ]
+then
+    echo "INFO: Importing realm configuration"
+
+    # empty current realm configuration
+    > /var/lib/tomcats/pki/conf/acme/realm.conf
+
+    # import realm configuration parameters
+    for filename in $(ls /var/lib/tomcats/pki/conf/acme/realm)
+    do
+        value=$(cat /var/lib/tomcats/pki/conf/acme/realm/$filename)
+        echo "$filename=$value" >> /var/lib/tomcats/pki/conf/acme/realm.conf
+    done
+else
+    echo "INFO: Using default realm configuration"
+fi
+
+echo "################################################################################"
 echo "INFO: Starting PKI ACME responder"
 
 ${PYTHON_EXECUTABLE} -I -m pki.server.pkiserver run tomcat@pki --as-current-user

--- a/base/acme/openshift/pki-acme-deployment.yaml
+++ b/base/acme/openshift/pki-acme-deployment.yaml
@@ -27,6 +27,8 @@ spec:
               name: pki-acme-database
             - mountPath: /var/lib/tomcats/pki/conf/acme/issuer
               name: pki-acme-issuer
+            - mountPath: /var/lib/tomcats/pki/conf/acme/realm
+              name: pki-acme-realm
       volumes:
         - name: pki-acme-certs
           secret:
@@ -40,6 +42,9 @@ spec:
         - name: pki-acme-issuer
           secret:
             secretName: pki-acme-issuer
+        - name: pki-acme-realm
+          secret:
+            secretName: pki-acme-realm
   triggers:
     - imageChangeParams:
         automatic: true

--- a/base/acme/openshift/pki-acme-realm.yaml
+++ b/base/acme/openshift/pki-acme-realm.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: pki-acme-realm
+stringData:
+  class: org.dogtagpki.acme.realm.InMemoryRealm
+  # class: org.dogtagpki.acme.realm.PostgreSQLRealm
+  # password: Secret.123
+  # url: jdbc:postgresql://postgresql:5432/acme
+  # user: acme

--- a/base/acme/realm/in-memory/realm.conf
+++ b/base/acme/realm/in-memory/realm.conf
@@ -1,0 +1,3 @@
+class=org.dogtagpki.acme.realm.InMemoryRealm
+username=admin
+password=Secret.123

--- a/base/acme/src/main/java/org/dogtagpki/acme/realm/InMemoryRealm.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/realm/InMemoryRealm.java
@@ -1,0 +1,56 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.realm;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.netscape.cms.realm.PKIPrincipal;
+import com.netscape.cmscore.usrgrp.User;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class InMemoryRealm extends ACMERealm {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InMemoryRealm.class);
+
+    String username;
+    String password;
+
+    User user;
+    List<String> roles;
+
+    @Override
+    public void init() throws Exception {
+
+        username = config.getParameter("username");
+        password = config.getParameter("password");
+
+        user = new User();
+        user.setUserID(username);
+        user.setFullName("Administrator");
+
+        roles = new ArrayList<>();
+        roles.add("Administrators");
+    }
+
+    public Principal authenticate(String username, String password) throws Exception {
+
+        logger.info("Authenticating user " + username + " with password");
+
+        if (!this.username.equals(username)) {
+            return null;
+        }
+
+        if (!this.password.equals(password)) {
+            return null;
+        }
+
+        return new PKIPrincipal(user, null, roles);
+    }
+}

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -39,6 +39,7 @@ ISSUER_TYPES = {value: key for key, value in ISSUER_CLASSES.items()}
 # TODO: auto-populate this map from /usr/share/pki/acme/realm
 REALM_CLASSES = {
     'ds': 'org.dogtagpki.acme.realm.DSRealm',
+    'in-memory': 'org.dogtagpki.acme.realm.InMemoryRealm',
     'postgresql': 'org.dogtagpki.acme.realm.PostgreSQLRealm'
 }
 
@@ -1266,7 +1267,16 @@ class ACMERealmShowCLI(pki.cli.CLI):
         realm_type = REALM_TYPES.get(realm_class)
         print('  Realm Type: %s' % realm_type)
 
-        if realm_type == 'ds':
+        if realm_type == 'in-memory':
+            username = config.get('username')
+            if username:
+                print('  Admin Username: %s' % username)
+
+            password = config.get('password')
+            if password:
+                print('  Admin Password: ********')
+
+        elif realm_type == 'ds':
 
             url = config.get('url')
             if url:
@@ -1441,7 +1451,25 @@ class ACMERealmModifyCLI(pki.cli.CLI):
             logger.info('Loading %s', source)
             pki.util.load_properties(source, config)
 
-        if realm_type == 'ds':
+        if realm_type == 'in-memory':
+
+            print()
+            print('Enter the admin username.')
+            username = config.get('username')
+            username = pki.util.read_text('  Admin Username', default=username, required=True)
+            pki.util.set_property(config, 'username', username)
+
+            print()
+            print('Enter the admin password.')
+            password = config.get('password')
+            password = pki.util.read_text(
+                '  Admin Password',
+                default=password,
+                password=True,
+                required=True)
+            pki.util.set_property(config, 'password', password)
+
+        elif realm_type == 'ds':
 
             print()
             print('Enter the location of the LDAP server '

--- a/docs/installation/acme/Configuring_ACME_Realm.md
+++ b/docs/installation/acme/Configuring_ACME_Realm.md
@@ -41,6 +41,28 @@ Enter the base DN for the ACME groups subtree.
 If the command is invoked with `--type` parameter, it will create a new configuration based on the specified type.
 If the command is invoked with other parameters, it will update the specified parameters.
 
+## Configuring In-Memory Realm
+
+The ACME responder can be configured with an in-memory realm.
+
+A sample in-memory realm configuration is available at
+[/usr/share/pki/acme/realm/in-memory/realm.conf](../../../base/acme/realm/in-memory/realm.conf).
+
+To use an in-memory realm, copy the sample realm.conf into the /etc/pki/pki-tomcat/acme folder,
+or execute the following command:
+
+```
+$ pki-server acme-realm-mod --type in-memory
+```
+
+The realm.conf should look like the following:
+
+```
+class=org.dogtagpki.acme.realm.InMemoryRealm
+username=admin
+password=Secret.123
+```
+
 ## Configuring DS Realm
 
 The ACME responder can be configured with a DS realm.

--- a/docs/installation/openshift/Deploying_PKI_ACME_Responder_on_OpenShift.md
+++ b/docs/installation/openshift/Deploying_PKI_ACME_Responder_on_OpenShift.md
@@ -7,12 +7,16 @@ This document describes the process to deploy PKI ACME responder as a container 
 The container image is available at [quay.io/dogtagpki/pki-acme](https://quay.io/repository/dogtagpki/pki-acme).
 
 By default the responder will use a temporary CA signing certificate.
-The temporary certificate is self-signed and if the responder is restarted the certificate will be recreated .
+A new self-signed CA certificate will be created every time the responder is restarted.
 It is possible to replace it with a permanent CA signing certificate.
 
-Also, by default the responder will use a temporary database.
-This temporary database is non-persistent, so if the responder is restarted the database will disappear.
-It is possible to replace it with a persistent database.
+By default the responder will use a temporary database.
+A new empty in-memory database will be created every time the responder is restarted.
+It is possible to replace it with a permanent database.
+
+By default the responder will use a temporary realm.
+A new empty in-memory realm will be created every time the responder is restarted.
+It is possible to replace it with a permanent realm.
 
 **Note:** The PKI ACME responder is currently a tech preview which means:
 * It is not intended for production.
@@ -30,6 +34,7 @@ A sample configuration for PKI ACME responder is available at:
 - [/usr/share/pki/acme/openshift/pki-acme-metadata.yaml](../../../base/acme/openshift/pki-acme-metadata.yaml)
 - [/usr/share/pki/acme/openshift/pki-acme-database.yaml](../../../base/acme/openshift/pki-acme-database.yaml)
 - [/usr/share/pki/acme/openshift/pki-acme-issuer.yaml](../../../base/acme/openshift/pki-acme-issuer.yaml)
+- [/usr/share/pki/acme/openshift/pki-acme-realm.yaml](../../../base/acme/openshift/pki-acme-realm.yaml)
 - [/usr/share/pki/acme/openshift/pki-acme-is.yaml](../../../base/acme/openshift/pki-acme-is.yaml)
 - [/usr/share/pki/acme/openshift/pki-acme-deployment.yaml](../../../base/acme/openshift/pki-acme-deployment.yaml)
 - [/usr/share/pki/acme/openshift/pki-acme-svc.yaml](../../../base/acme/openshift/pki-acme-svc.yaml)
@@ -38,7 +43,7 @@ A sample configuration for PKI ACME responder is available at:
 Customize the configuration as needed. Deploy the responder with the following command:
 
 ```
-$ oc apply -f/usr/share/pki/acme/openshift/pki-acme-{certs,metadata,database,issuer,is,deployment,svc,route}.yaml
+$ oc apply -f/usr/share/pki/acme/openshift/pki-acme-{certs,metadata,database,issuer,realm,is,deployment,svc,route}.yaml
 ```
 
 Once it's deployed, get the route's hostname with the following command:
@@ -97,9 +102,9 @@ Once it's deployed, restart the responder by deleting the current pods with the 
 $ oc delete pods -l app=pki-acme
 ```
 
-## Deploying Persistent Database
+## Deploying Permanent Database
 
-To deploy a persistent database, use OpenShift console or **oc new-app** command.
+To deploy a permanent database, use OpenShift console or **oc new-app** command.
 For example, deploy a PostgreSQL database with the following command:
 
 ```
@@ -109,7 +114,7 @@ $ oc new-app postgresql-persistent \
     -p POSTGRESQL_DATABASE=acme
 ```
 
-Next, configure the PKI ACME responder to use the persistent database.
+Next, configure the PKI ACME responder to use the permanent database.
 A sample database configuration for PKI ACME responder is available at
 [/usr/share/pki/acme/openshift/pki-acme-database.yaml](../../../base/acme/openshift/pki-acme-database.yaml).
 
@@ -136,6 +141,23 @@ Select one of the pods, then execute the following command:
 ```
 $ oc rsh <pod name> \
     psql postgres://acme:Secret.123@postgresql/acme
+```
+
+## Deploying Permanent Realm
+
+A sample realm configuration for PKI ACME responder is available at
+[/usr/share/pki/acme/openshift/pki-acme-realm.yaml](../../../base/acme/openshift/pki-acme-realm.yaml).
+
+Customize the configuration as needed. Deploy the configuration with the following command:
+
+```
+$ oc apply -f /usr/share/pki/acme/openshift/pki-acme-realm.yaml
+```
+
+Restart the responder by deleting the current pods with the following command:
+
+```
+$ oc delete pods -l app=pki-acme
 ```
 
 ## Deploying Secure Route


### PR DESCRIPTION
The `InMemoryRealm` has been added to provide a simple realm that contains just the admin user.

The `Dockerfile` and the `pki-acme-run` script have been modified to use the `InMemoryRealm` by default and provide a mechanism to change it.

The OpenShift deployment files have been modified to use the `InMemoryRealm` by default and provide a mechanism to change it.

Updated docs:
* https://github.com/edewata/pki/blob/acme-docs/docs/installation/podman/Deploying_PKI_ACME_Responder_on_Podman.md
* https://github.com/edewata/pki/blob/acme-docs/docs/installation/openshift/Deploying_PKI_ACME_Responder_on_OpenShift.md