### PR TITLE
Add PostgreSQLConfigMonitor

### DIFF
--- a/base/acme/database/postgresql/create.sql
+++ b/base/acme/database/postgresql/create.sql
@@ -1,3 +1,8 @@
+CREATE TABLE "config" (
+    "id"               VARCHAR PRIMARY KEY,
+    "value"            VARCHAR
+);
+
 CREATE TABLE "nonces" (
     "id"               VARCHAR PRIMARY KEY,
     "created"          TIMESTAMPTZ NOT NULL,

--- a/base/acme/database/postgresql/drop.sql
+++ b/base/acme/database/postgresql/drop.sql
@@ -7,3 +7,4 @@ DROP TABLE "orders";
 DROP TABLE "account_contacts";
 DROP TABLE "accounts";
 DROP TABLE "nonces";
+DROP TABLE "config";

--- a/base/acme/database/postgresql/statements.conf
+++ b/base/acme/database/postgresql/statements.conf
@@ -1,3 +1,31 @@
+getConfig=\
+SELECT \
+    "value" \
+FROM \
+    "config" \
+WHERE \
+    "id" = ?
+
+addConfig=\
+INSERT INTO \
+    "config" ("id", "value") \
+VALUES \
+    (?, ?)
+
+updateConfig=\
+UPDATE \
+    "config" \
+SET \
+    "value" = ? \
+WHERE \
+    "id" = ?
+
+removeConfig=\
+DELETE FROM \
+    "config" \
+WHERE \
+    "id" = ?
+
 getNonce=\
 SELECT \
     "created", "expires" \

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/PostgreSQLConfigMonitor.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/PostgreSQLConfigMonitor.java
@@ -1,0 +1,74 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.database;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PostgreSQLConfigMonitor implements Runnable {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PostgreSQLConfigMonitor.class);
+
+    public final static int DEFAULT_INTERVAL = 5; // minutes
+
+    PostgreSQLDatabase database;
+    int interval = DEFAULT_INTERVAL;
+    boolean running;
+
+    public PostgreSQLConfigMonitor() {
+    }
+
+    public PostgreSQLDatabase getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(PostgreSQLDatabase database) {
+        this.database = database;
+    }
+
+    public int getInterval() {
+        return interval;
+    }
+
+    public void setInterval(int interval) {
+        this.interval = interval;
+    }
+
+    public void run() {
+
+        logger.info("Start monitoring ACME configuration");
+
+        running = true;
+
+        while (running) {
+            try {
+                database.connect();
+
+                logger.info("Updating ACME configuration");
+                // update the config in memory only
+
+                String value = database.getConfig("enabled");
+                database.enabled = value == null ? null : Boolean.valueOf(value);
+                logger.info("- enabled: " + database.enabled);
+
+            } catch (Exception e) {
+                logger.error("Unable to monitor ACME configuration: " + e.getMessage(), e);
+            }
+
+            try {
+                Thread.sleep(interval * 60 * 1000);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        logger.info("Stop monitoring ACME configuration");
+    }
+
+    public void stop() throws Exception {
+        running = false; // terminate the loop gracefully
+    }
+}

--- a/docs/installation/acme/Configuring_ACME_Database.md
+++ b/docs/installation/acme/Configuring_ACME_Database.md
@@ -199,6 +199,14 @@ user=acme
 password=Secret.123
 ```
 
+The PostgreSQL database provides a mechanism to monitor ACME configuration periodically.
+It can be enabled with the following parameters:
+
+```
+monitor.enabled=true
+monitor.interval=5  # minutes
+```
+
 ## See Also
 
 * [Configuring PKI ACME Responder](https://www.dogtagpki.org/wiki/Configuring_PKI_ACME_Responder)


### PR DESCRIPTION
The `PostgreSQLConfigMonitor` has been added to periodically
monitor ACME config properties stored in PostgreSQL database.

Update docs:
* https://github.com/edewata/pki/blob/acme-dev/docs/installation/acme/Configuring_ACME_Database.md