### PR TITLE
Enhancment to Bug 1858860 - TPS - Update Error Codes returned to clie…

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSPinResetProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSPinResetProcessor.java
@@ -50,7 +50,19 @@ public class TPSPinResetProcessor extends TPSProcessor {
 
     @Override
     public void process(BeginOpMsg beginMsg) throws TPSException, IOException {
-        if (beginMsg == null) {
+        org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
+        EngineConfig configStore = engine.getConfig();
+
+        // Use this only for testing, not for normal operation.
+        String configName = "op.pinReset.testNoBeginMsg";
+        boolean testPinResetNoBeginMsg = false;
+        try {
+            testPinResetNoBeginMsg = configStore.getBoolean(configName,false);
+        } catch (EBaseException e) {
+            testPinResetNoBeginMsg = false;          
+        }
+
+        if (beginMsg == null || testPinResetNoBeginMsg == true) {
 	    throw new TPSException("TPSPinResetProcessor.process: invalid input data, no beginMsg provided.",
                      TPSStatus.STATUS_ERROR_MAC_RESET_PIN_PDU);
         }
@@ -326,7 +338,22 @@ public class TPSPinResetProcessor extends TPSProcessor {
 
         statusUpdate(100, "PROGRESS_PIN_RESET_COMPLETE");
         logMsg = "update token during pin reset";
+
+        EngineConfig configStore = engine.getConfig();
+      
+        // Use this only for testing, not for normal operation.
+        String configName = "op.pinReset.testUpdateDBFailure";
+        boolean testUpdateDBFailure = false;
         try {
+            testUpdateDBFailure = configStore.getBoolean(configName,false);
+        } catch (EBaseException e) {
+            testUpdateDBFailure = false;
+        }
+
+        try {
+            if(testUpdateDBFailure == true) {
+                throw new Exception("Test failure to update DB for Pin Reset!");
+            }
             tps.tdb.tdbUpdateTokenEntry(tokenRecord);
             tps.tdb.tdbActivity(ActivityDatabase.OP_PIN_RESET, tokenRecord, session.getIpAddress(), logMsg, "success");
             logger.debug(method + ": token record updated!");


### PR DESCRIPTION
…nt (CIW/ESC) to Match CS8.

This enhancement allows config values to be used to test the unlikely error conditions addressed in the original bug:

To test one two scenarios, use these settings one at a time:

op.pinReset.testNoBeginMsg=false
op.pinReset.testUpdateDBFailure=false

The first one will test the error code returned when the beginOp message is missing when atempting
a pin Reset operation. The error returned should be error "4".

The second one will test if the update of the db for the token does not complete properly.

The error returned in this scenario should be "41".

The tpsclient utility can be used to test these two scenarios. Once again try them separately
because the first error will stop the pin reset procedure before the second scenario can even happen.