### PR TITLE
Fix JSS initialization in pki-server <subsystem>-user-cert-add

### DIFF
--- a/base/server/src/org/dogtagpki/server/cli/SubsystemUserCertAddCLI.java
+++ b/base/server/src/org/dogtagpki/server/cli/SubsystemUserCertAddCLI.java
@@ -70,6 +70,13 @@ public class SubsystemUserCertAddCLI extends CommandCLI {
         String filename = cmd.getOptionValue("cert");
         String format = cmd.getOptionValue("format");
 
+        String catalinaBase = System.getProperty("catalina.base");
+        String serverXml = catalinaBase + "/conf/server.xml";
+
+        TomcatJSS tomcatjss = TomcatJSS.getInstance();
+        tomcatjss.loadTomcatConfig(serverXml);
+        tomcatjss.init();
+
         byte[] bytes;
         if (filename == null) {
             // read from standard input
@@ -91,13 +98,6 @@ public class SubsystemUserCertAddCLI extends CommandCLI {
         }
 
         X509CertImpl cert = new X509CertImpl(bytes);
-
-        String catalinaBase = System.getProperty("catalina.base");
-        String serverXml = catalinaBase + "/conf/server.xml";
-
-        TomcatJSS tomcatjss = TomcatJSS.getInstance();
-        tomcatjss.loadTomcatConfig(serverXml);
-        tomcatjss.init();
 
         String subsystem = parent.getParent().getParent().getName();
         String configDir = catalinaBase + File.separator + subsystem;


### PR DESCRIPTION
The `pki-server <subsystem>-user-cert-add` failed with
`NoSuchProviderException` when importing a certificate with
RSA/PSS algorithm. It turns out the JSS has to be initialized
before parsing the certificate using `X509CertImpl`.