### PR TITLE
Update pki pkcs12-cert-mod

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12CertModCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12CertModCLI.java
@@ -75,6 +75,10 @@ public class PKCS12CertModCLI extends CommandCLI {
         option.setArgName("path");
         options.addOption(option);
 
+        option = new Option(null, "friendly-name", true, "Certificate nickname");
+        option.setArgName("nickname");
+        options.addOption(option);
+
         option = new Option(null, "trust-flags", true, "Certificate trust flags");
         option.setArgName("flags");
         options.addOption(option);
@@ -122,11 +126,8 @@ public class PKCS12CertModCLI extends CommandCLI {
             throw new Exception("Missing PKCS #12 password.");
         }
 
+        String friendlyName = cmd.getOptionValue("friendly-name");
         String trustFlags = cmd.getOptionValue("trust-flags");
-
-        if (trustFlags == null) {
-            throw new Exception("Missing trust flags.");
-        }
 
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
@@ -160,6 +161,10 @@ public class PKCS12CertModCLI extends CommandCLI {
 
             if (certInfo == null) {
                 throw new Exception("Certificate " + nickname + " not found");
+            }
+
+            if (friendlyName != null) {
+                certInfo.setFriendlyName(friendlyName);
             }
 
             if (trustFlags != null) {


### PR DESCRIPTION

The `pki pkcs12-cert-mod` has been modified to search for the cert to modify in a PKCS #12 file by its ID in addition to its nickname. If a cert ID is provided, there will be at most one cert matching the ID. If a nickname is provided, there could be multiple certs matching the nickname, but only the first one will be processed.

The `pki pkcs12-cert-mod` has been modified to provide a `--friendly-name` option to change the nickname of a cert in PKCS #12 file.
    
The `--trust-flags` option has been changed to become optional.

Docs:
https://github.com/dogtagpki/pki/wiki/PKI-PKCS12-CLI#modifying-certificate-in-pkcs-12-file