### PR TITLE
Fix pki <subsystem>-audit-mod

### DIFF
--- a/base/server/src/org/dogtagpki/server/rest/AuditService.java
+++ b/base/server/src/org/dogtagpki/server/rest/AuditService.java
@@ -231,6 +231,9 @@ public class AuditService extends SubsystemService implements AuditResource {
                     if ("enabled".equals(value)) {
                         selected.add(name);
 
+                    } else if ("disabled".equals(value)) {
+                        // do not add disabled event into list of enabled events
+
                     } else {
                         PKIException e = new PKIException("Invalid event configuration: " + name + "=" + value);
                         auditModParams.put("Info", e.toString());


### PR DESCRIPTION
The `AuditService.updateAuditConfig()` has been modified to no longer throw an exception when it encounters a disabled
event. Instead, it will ignore the disabled event and not add it into the list of enabled events.

https://bugzilla.redhat.com/show_bug.cgi?id=1843416