### PR TITLE
Make failure to contact security domian non-fatal

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2511,8 +2511,6 @@ class SecurityDomain:
                 log.PKIHELPER_SECURITY_DOMAIN_UNREACHABLE_1,
                 secname)
             logger.error(log.PKI_SUBPROCESS_ERROR_1, exc)
-            if critical_failure:
-                raise
 
         return None
 


### PR DESCRIPTION
When deregistering a host out of the security domain, make it non-fatal.
We can use the `pki securitydomain-host-del` commands later to unregister
a host when the two mismatch due to communication failure.

Resolves: rh-bz#1481949

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

Note that I wasn't able to reproduce this with a single IPA installation (no replicas) on latest IPA and PKI F32 bits. 