### PR TITLE
Replace SimpleDateFormat with FastDateFormat

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
@@ -7,7 +7,6 @@ package org.dogtagpki.acme.database;
 
 import java.net.URI;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -17,6 +16,7 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.dogtagpki.acme.ACMEAccount;
 import org.dogtagpki.acme.ACMEAuthorization;
 import org.dogtagpki.acme.ACMECertificate;
@@ -105,12 +105,9 @@ public class LDAPDatabase extends ACMEDatabase {
 
     static final String IDENTIFIER_TYPE_DNS = "dns";
 
-    // The LDAP Generalized Time syntax
-    static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmssZ");
-
-    static {
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
+    // The LDAP Generalized Time syntax (e.g. 20200101000000+0000)
+    static final FastDateFormat dateFormat = FastDateFormat.getInstance(
+            "yyyyMMddHHmmssZ", TimeZone.getTimeZone("UTC"));
 
     enum LoadChallenges { DoLoad , DontLoad };
     enum OnNoSuchObject { Ignore , Throw };

--- a/base/common/src/main/java/org/dogtagpki/acme/ACME.java
+++ b/base/common/src/main/java/org/dogtagpki/acme/ACME.java
@@ -5,13 +5,13 @@
 //
 package org.dogtagpki.acme;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import org.apache.commons.lang3.time.FastDateFormat;
 
 /**
  * @author Endi S. Dewata
  * @author Alexander M. Scheel
  */
 public class ACME {
-    public final static DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+    // e.g. 2020-01-01T00:00:00.00-00:00
+    public final static FastDateFormat DATE_FORMAT = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssXXX");
 }


### PR DESCRIPTION
The `SimpleDateFormat` has been replaced with `FastDateFormat`
which is thread-safe.

A Fedora build is available in this COPR repository:
https://copr.fedorainfracloud.org/coprs/edewata/acme/builds/

More info:
https://stackoverflow.com/questions/4021151/java-dateformat-is-not-threadsafe-what-does-this-leads-to

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1889691