### PR TITLE
Fix pki-server cert-fix

### DIFF
--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1350,7 +1350,6 @@ def ldap_password_authn(
     is ``None``.
 
     """
-    logger.info('Configuring LDAP password authentication')
     orig = {}
     try:
         password = instance.passwords['internaldb']
@@ -1367,6 +1366,9 @@ def ldap_password_authn(
     ldappasswd_performed = False
 
     for subsystem in subsystems:
+
+        logger.info('Configuring LDAP connection for %s', subsystem.type)
+
         cfg = subsystem.get_db_config()
         orig[subsystem] = cfg.copy()  # copy because dict is mutable
 
@@ -1397,9 +1399,10 @@ def ldap_password_authn(
         yield
 
     finally:
-        logger.info('Restoring previous LDAP configuration')
-
         for subsystem, cfg in orig.items():
+
+            logger.info('Restoring LDAP connection for %s', subsystem.type)
+
             subsystem.set_db_config(cfg)
             subsystem.save()
 


### PR DESCRIPTION
In commit e680746ac4926367aef5c3ae3404dbb23c07eb19 the
ResourceMessage was modified to no longer include empty
attributes. Because of this in certain cases the server
might return a CertEnrollmentRequest object (which extends
ResourceMessage) without the Input or Output attributes,
which broke the pki-server cert-fix command.

To fix the problem, the CertEnrollmentRequest.from_json()
has been modified to check whether the response contains
Input and Output before parsing the attributes.

https://bugzilla.redhat.com/show_bug.cgi?id=1897120