### PR TITLE
Fix KRA/OCSP installation with external certs on HSM

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1368,6 +1368,9 @@ class NSSDatabase(object):
 
         if self.token:
             cmd.extend(['--token', self.token])
+            fullname = self.token + ':' + nickname
+        else:
+            fullname = nickname
 
         cmd.extend(['nss-cert-export'])
 
@@ -1377,7 +1380,7 @@ class NSSDatabase(object):
         if output_format:
             cmd.extend(['--format', output_format])
 
-        cmd.extend([nickname, output_file])
+        cmd.extend([fullname, output_file])
 
         logger.debug('Command: %s', ' '.join(map(str, cmd)))
         subprocess.check_call(cmd)

--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -138,10 +138,14 @@ class MigrateCLI(pki.cli.CLI):
             nssdb.close()
 
         ca_path = os.path.join(instance.nssdb_dir, 'ca.crt')
+
         token = pki.nssdb.INTERNAL_TOKEN_NAME
         nickname = instance.get_sslserver_cert_nickname()
+
         if ':' in nickname:
-            token = nickname.split(':', 1)[0]
+            parts = nickname.split(':', 1)
+            token = parts[0]
+            nickname = parts[1]
 
         # Re-open NSS DB with correct token name
         nssdb = instance.open_nssdb(token=token)


### PR DESCRIPTION
The `NSSDatabase.export_cert_from_db()` has been modified
to use the fullname when exporting a cert from HSM.

https://bugzilla.redhat.com/show_bug.cgi?id=1890639