### PR TITLE
Fix undefined variable in 01-AddProfileCaAuditSigningCert

### DIFF
--- a/base/server/upgrade/10.5.18/01-AddProfileCaAuditSigningCert
+++ b/base/server/upgrade/10.5.18/01-AddProfileCaAuditSigningCert
@@ -130,7 +130,7 @@ policyset.auditSigningCertSet.9.default.params.signingAlg=-
             self.backup(path)
 
             with open(path, 'w') as outfile:
-                outfile.write(caAuditSigningCert)
+                outfile.write(self.caAuditSigningCert)
 
             os.chown(path, instance.uid, instance.gid)
             os.chmod(path, 0o0660)


### PR DESCRIPTION
The `01-AddProfileCaAuditSigningCert` has been modified to use
`self` when referring to `caAuditSigningCert` instance variable.

https://bugzilla.redhat.com/show_bug.cgi?id=1883639