### PR TITLE
Add tools tests workflow

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,0 +1,66 @@
+name: Tools Tests
+
+on: [push, pull_request]
+
+jobs:
+  # docs/development/Building_PKI.md
+  build:
+    name: Building PKI
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['32', '33']
+    steps:
+      - name: Install git
+        run: |
+          dnf install -y git
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          dnf install -y dnf-plugins-core rpm-build
+          dnf copr enable -y @pki/master
+          dnf builddep -y --allowerasing --spec ./pki.spec
+
+      - name: Build PKI packages
+        run: ./build.sh --with-pkgs=base --with-timestamp --with-commit-id --work-dir=build rpm
+
+      - name: Upload PKI packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: build/RPMS/
+
+  PKICertImport-test:
+    name: PKICertImport test
+    needs: build
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['32', '33']
+    steps:
+      - name: Install git
+        run: |
+          dnf install -y git
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download PKI packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: build/RPMS
+
+      - name: Install PKI packages
+        run: |
+          dnf install -y dnf-plugins-core
+          dnf copr enable -y @pki/master
+          dnf -y localinstall build/RPMS/*
+
+      - name: Run PKICertImport test
+        run: bash base/util/src/test/shell/test_PKICertImport.bash

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See also [Building PKI](docs/development/Building_PKI.md)
 | TKS       | ![TKS Tests](https://github.com/dogtagpki/pki/workflows/TKS%20Tests/badge.svg)       |
 | TPS       | ![TPS Tests](https://github.com/dogtagpki/pki/workflows/TPS%20Tests/badge.svg)       |
 | Python    | ![Python Tests](https://github.com/dogtagpki/pki/workflows/Python%20Tests/badge.svg) |
+| Tools     | ![Python Tests](https://github.com/dogtagpki/pki/workflows/Tools%20Tests/badge.svg)  |
 | QE        | ![QE Tests](https://github.com/dogtagpki/pki/workflows/QE%20Tests/badge.svg)         |
 | IPA       | ![IPA Tests](https://github.com/dogtagpki/pki/workflows/IPA%20Tests/badge.svg)       |
 

--- a/base/util/CMakeLists.txt
+++ b/base/util/CMakeLists.txt
@@ -72,11 +72,6 @@ add_junit_test(test-pki-util
         pki-util-test-classes
 )
 
-add_test(
-    NAME "test_PKICertImport"
-    COMMAND bash "${CMAKE_SOURCE_DIR}/base/util/src/test/shell/test_PKICertImport.bash"
-)
-
 install(
     FILES
         src/main/shell/PKICertImport.bash


### PR DESCRIPTION
The `PKICertImport` test has been moved into a new tools
tests workflow to shorten the build time without reducing test
coverage.