### PR TITLE
Bug 1392616 - KRA key recovery cli kra-key-retrieve generates an inva…

### DIFF
--- a/base/kra/src/org/dogtagpki/server/kra/rest/KeyService.java
+++ b/base/kra/src/org/dogtagpki/server/kra/rest/KeyService.java
@@ -791,8 +791,14 @@ public class KeyService extends SubsystemService implements KeyResource {
         KeyData keyData = new KeyData();
         keyData.setP12Data(pkcs12base64encoded);
 
-        queue.processRequest(request);
-        queue.markAsServiced(request);
+        try {
+            queue.processRequest(request);
+            logger.debug(method + "queue.processRequest returned");
+            queue.markAsServiced(request);
+        } catch (EBaseException e) {
+            // intentionally not propagating
+            logger.debug(method + "queue.processRequest failed bug ignored: " + e.toString());
+        }
 
         return keyData;
     }

--- a/docs/manuals/man1/pki-kra-key.1.md
+++ b/docs/manuals/man1/pki-kra-key.1.md
@@ -147,7 +147,7 @@ $ pki <agent authentication> kra-key-recover --keyID <Key Identifier>
 The request ID returned by this operation must be approved using the **key-request-review** command
 before the actual key retrieval.
 
-This step is performed internally by the kra-key-retrieve command.
+To actually recover (retrieve) the PKCS12 of the private key, use the "recovery request template" method listed above under "Retrieving a key"
 
 ### Generating a Symmetric Key
 
@@ -324,13 +324,13 @@ Following is the description of the various parameters in the key retrieval temp
 
 - keyID - Key identifier
 - requestID - Key request identifier
-- nonceData - Base64 encoded string of nonce used during encryption
+- nonceData - Base64 encoded string of nonce used during encryption (unused for PKCS12 key recovery)
 - passphrase - passphrase to encrypt the secret with/ passphrase for the PKCS12 file returned
-- sessionWrappedpassphrase - Base64 encoded string of - Passphrase encrypted with a session key.
-- transWrapedSessionKey - Base64 encoded string of - session key encrypted with KRA's transport key.
+- sessionWrappedpassphrase - Base64 encoded string of - Passphrase encrypted with a session key. (unused for PKCS12 key recovery)
+- transWrapedSessionKey - Base64 encoded string of - session key encrypted with KRA's transport key. (unused for PKCS12 key recovery)
 - certificate - Base64 encoded certificate for recovering the key.
 
-To create a retrieval request using the template file:
+To retrieve (recover) keys using the template file (note: key recovery into PKCS12 can only use a template file):
 
 ```
 $ pki -d <CERT_DB> -c <CERT_DB_PWD> -n <Certificate_Nickname> kra-key-retrieve \
@@ -370,7 +370,7 @@ $ pki -d <CERT_DB> -c <CERT_DB_PWD> -n <Certificate_Nickname> kra-key-generate \
 ## AUTHORS
 
 Ade Lee &lt;alee@redhat.com&gt;, Endi S. Dewata &lt;edewata@redhat.com&gt;,
-Matthew Harmsen &lt;mharmsen@redhat.com&gt;, and Abhishek Koneru &lt;akoneru@redhat.com&gt;.
+Matthew Harmsen &lt;mharmsen@redhat.com&gt;, Christina Fu lt;cfu@redhat.com;, and Abhishek Koneru &lt;akoneru@redhat.com&gt;.
 
 ## COPYRIGHT
 


### PR DESCRIPTION
…lid p12 file

This patch is to add back the try/catch block that was in place back in
DOGTAG_10_5_BRANCH. Initially I was going to just remove the two lines:
            queue.processRequest(request);
            queue.markAsServiced(request);
however, it's unclear to me if there is any scenario where they will be needed.
I'm leaving them the same as before.

Also, the reported issue might be misunderstanding due to unclear documentation.
From the code, it seems the only way to download p12 is through the use
of a template file, which I will give example in the bug.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1392616