### PR TITLE
Bug1875563-part2-auditProfileUpgrade

### DIFF
--- a/base/ca/shared/conf/caAuditSigningCert.profile
+++ b/base/ca/shared/conf/caAuditSigningCert.profile
@@ -4,8 +4,8 @@
 id=caAuditSigningCert.profile
 name=CA Audit Signing Certificate Profile
 description=This profile creates a CA Audit signing certificate that is valid for audit log signing purpose.
-profileIDMapping=caSignedLogCert
-profileSetIDMapping=caLogSigningSet
+profileIDMapping=caAuditSigningCert
+profileSetIDMapping=auditSigningCertSet
 list=2,4,6,8
 2.default.class=com.netscape.cms.profile.def.ValidityDefault
 2.default.name=Validity Default

--- a/base/ca/shared/profiles/ca/caSignedLogCert.cfg
+++ b/base/ca/shared/profiles/ca/caSignedLogCert.cfg
@@ -1,9 +1,9 @@
-desc=This profile is for enrolling audit log signing certificates
+desc=(deprecated; use caAuditSigningCert) This profile is for enrolling audit log signing certificates
 visible=false
-enable=false
+enable=true
 enableBy=admin
 auth.class_id=
-name=Manual Log Signing Certificate Enrollment
+name=(deprecated; use caAuditSigningCert) Manual Log Signing Certificate Enrollment
 input.list=i1,i2
 input.i1.class_id=certReqInputImpl
 input.i2.class_id=submitterInfoInputImpl

--- a/base/server/upgrade/10.10.0/04-AddProfileCaAuditSigningCert.py
+++ b/base/server/upgrade/10.10.0/04-AddProfileCaAuditSigningCert.py
@@ -25,6 +25,21 @@ class AddProfileCaAuditSigningCert(pki.server.upgrade.PKIServerUpgradeScriptlet)
         if subsystem.name != 'ca':
             return
 
+        # enable old profile caSignedLogCert to properly deprecate
+        opath = os.path.join(subsystem.base_dir, 'profiles', 'ca', 'caSignedLogCert.cfg')
+        self.backup(opath)
+
+        oconfig = {}
+
+        pki.util.load_properties(opath, oconfig)
+
+        oconfig['enable'] = 'true'
+        oconfig['desc'] = '(deprecated; use caAuditSigningCert) This profile is for enrolling audit log signing certificates'
+        oconfig['name'] = '(deprecated; use caAuditSigningCert) Manual Audit Log Signing Certificate Enrollment'
+
+        pki.util.store_properties(opath, oconfig)
+
+        # now handle new profile
         path = os.path.join(subsystem.base_dir, 'profiles', 'ca', 'caAuditSigningCert.cfg')
 
         if not os.path.exists(path):


### PR DESCRIPTION
    This patch addresses the issue where when caSignedLogCert.cfg was renamed
    caAuditSigningCert where
      * The profileIDMapping and profileSetIDMapping params in the following
        profile still contains the old names:
          base/ca/shared/conf/caAuditSigningCert.profile
      * at renewal time, the profile will no longer be available

    The solution provided is to
      * correct the two mapping param names in caAuditSigningCert.profile
      * re-enable caSignedLogCert.cfg (but kept invisible)

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1875563