### PR TITLE
Add support for certificate renewal via SCEP

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -227,6 +227,7 @@ ca.scep._004=##     ca.scep.nickname=
 ca.scep._005=##     ca.scep.tokenname=
 ca.scep._006=##
 ca.scep.enable=false
+ca.scep.enableRenewal=false
 ca.scep.hashAlgorithm=SHA256
 ca.scep.allowedHashAlgorithms=SHA256,SHA512
 ca.scep.encryptionAlgorithm=DES3

--- a/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -17,8 +17,7 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cms.servlet.cert.scep;
 
-import java.io.ByteArrayInputStream;
-import java.io.FileOutputStream;
+import java.io.*;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -1154,6 +1153,11 @@ public class CRSEnrollment extends HttpServlet {
             logger.debug(Debug.dump(decryptedP10bytes));
 
             req.setP10(new PKCS10(decryptedP10bytes));
+
+            // debug the pkcs10 request
+            OutputStream output = new ByteArrayOutputStream();
+            req.getP10().print(new PrintStream(output));
+            logger.debug(output.toString());
         } catch (Exception e) {
             logger.error("failed to unwrap PKCS10 " + e.getMessage(), e);
             throw new CRSFailureException("Could not unwrap PKCS10 blob: " + e.getMessage());

--- a/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1039,6 +1039,14 @@ public class CRSEnrollment extends HttpServlet {
         @SuppressWarnings("unused")
         byte[] reqAAsig = req.getAADigest(); // check for errors
 
+        // new code below:
+        logger.debug("Verifying SCEP request");
+        try {
+            req.verify();
+        } catch (Exception e) {
+            throw new CRSInvalidSignatureException("An exception occurred while verifying SCEP request signature", e);
+        }
+        logger.debug("Request verification successful");
     }
 
     /**
@@ -2239,6 +2247,9 @@ public class CRSEnrollment extends HttpServlet {
         public CRSInvalidSignatureException(String s) {
             super(s);
         }
+
+        public CRSInvalidSignatureException(String s, Exception e) { super(s, e); }
+
     }
 
     class CRSPolicyException extends Exception {

--- a/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -881,7 +881,8 @@ public class CRSEnrollment extends HttpServlet {
             }
 
             // now run appropriate code, depending on message type
-            if (mRenewalEnabled && mt.equals(CRSPKIMessage.mType_RenewalReq)) {
+            if (mRenewalEnabled && (mt.equals(CRSPKIMessage.mType_RenewalReq)
+                || (mt.equals(CRSPKIMessage.mType_PKCSReq) && !authorizeSignerCertificate(req)))) {
                 logger.debug("Processing RenewalReq");
                 try {
                     // The same checks as for PKCSReq below.

--- a/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -728,10 +728,8 @@ public class CRSPKIMessage {
         logger.debug("digested data (content_type: " + digestedDataContentType.toDottedString() + "):");
         logger.debug(dump(digestedData));
 
-        // get the message digest algorithm
-        SET algorithmIds = sd.getDigestAlgorithmIdentifiers();
-        AlgorithmIdentifier algorithmId = (AlgorithmIdentifier) algorithmIds.elementAt(0);
-        String algorithmName = DigestAlgorithm.fromOID(algorithmId.getOID()).toString();
+        // get the signer's message digest algorithm
+        String algorithmName = si.getDigestAlgorithm().toString();
         logger.debug("digest algorithm: " + algorithmName);
 
         // compute the digest

--- a/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -117,6 +117,7 @@ public class CRSPKIMessage {
 
     // Strings given in 'messageType' authenticated attribute
     public final static String mType_PKCSReq = "19";
+    public final static String mType_RenewalReq = "17";
     public final static String mType_CertRep = "3";
     public final static String mType_GetCertInitial = "20";
     public final static String mType_GetCert = "21";
@@ -883,6 +884,9 @@ public class CRSPKIMessage {
 
         if (messageType.equals(mType_PKCSReq)) {
             return "PKCSReq";
+        }
+        if (messageType.equals(mType_RenewalReq)) {
+            return "RenewalReq";
         }
         if (messageType.equals(mType_CertRep)) {
             return "CertRep";


### PR DESCRIPTION
Hello,

this is the last PR that I'm bringing here for your kind consideration. I've implemented this for a client and successfully tested it using a Cisco client.

This PR adds support for renewing a certificate via the SCEP protocol (the scep servlet). The renewal process tries to follow the new SCEP draft and has the following assumptions:

- a SCEP request is recognized as a certificate renewal request when **at least one of the following conditions is met**:
  - the SCEP messageType is equal to `17`, i.e. it is a `RenewalReq` message type
  - or the SCEP messageType is the same as in initial cert enrollment (`19` = `PKCSReq`) but the SCEP message is signed with a cert issued by this CA, not with a self-signed cerfiticate
  - this second option is here intentionally to support clients that don't use message type 17 (i.e. don't obey the newest draft spec); Cisco was among them
- the client must generate a PKCS10 request (as in initial cert enrollment), generate a new private key and sign the PKCS10 request with this key
- however, the SCEP message must be signed with the **previously issued certificate**, not a self-signed certificate (as in initial enrollment) - i.e. the previous cert must be present in the `SignerInfo` structure of the SCEP message
- this signing certificate must still be valid, i.e. not expired and not revoked
- the newly issued certificate will be exactly the same as the previous one, except for:
  - the public key - this is taken from the PKCS10 request
  - the validity from / to - left for the CA to decide and set this freshly
- the CA then issues a new certificate using the `RENEWAL_REQUEST` (see the `postRenewalRequest` method) and typically returns it to the client immediately

The feature can be switched on in the `CS.cfg` configuration file using:

```
ca.scep.enableRenewal=false
```

(by default this is false, i.e. renewal support is switched off).

#### SCEP message integrity checking

During implementing this I noticed that the integrity of the SCEP messages coming from the clients is not verified in the `verifyRequest` method in the servlet. Thus, I added an implementation of this verification as it is an essential part of the renewal process (the client is not authenticated via external means, e.g. a password, but only via previous certificate - we must make sure that the client possesses the private key for this signing cert). The SCEP verification works as follows (see the `verify` method in `CRSPKIMessage`):

- it considers the SCEP message as a PKCS7 message and uses the appropriate method in the `pkcs7` package
- for this it computes the message digest of the data (the inner PKCS7 message) using the algorithm taken from the SignerInfo structure
- if this verification passes, we have a proof that the SCEP message was signed using the cert from the SignerInfo structure and that the client possesses the corresponding private key.

Thus, in case of cert renewal, we can consider such a message as verified.

Please don't hesitate to contact me if you have any questions or need further work on this. Thanks!