### PR TITLE
Add HSM support for PKI NSS CLI

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -25,7 +25,7 @@ jobs:
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
 
       - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base --with-timestamp --with-commit-id --work-dir=build rpm
+        run: ./build.sh --with-pkgs=base,server --with-timestamp --with-commit-id --work-dir=build rpm
 
       - name: Upload PKI packages
         uses: actions/upload-artifact@v2
@@ -59,3 +59,123 @@ jobs:
 
       - name: Run PKICertImport test
         run: bash base/util/src/test/shell/test_PKICertImport.bash
+
+  # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
+  pki-nss-test:
+    name: PKI NSS CLI
+    needs: build
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['32', '33']
+    steps:
+      - name: Download PKI packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: build/RPMS
+
+      - name: Install PKI packages
+        run: |
+          dnf install -y dnf-plugins-core
+          dnf copr enable -y @pki/master
+          dnf -y localinstall build/RPMS/*
+
+      - name: Generate cert request with key
+        run: |
+          pki nss-cert-request \
+              --subject "CN=Certificate Authority" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr ca_signing.csr
+
+      - name: Issue self-signed cert
+        run: |
+          pki nss-cert-issue \
+              --csr ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert ca_signing.crt
+
+      - name: Import cert into
+        run: |
+          pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+      - name: Verify trust flags
+        run: |
+          echo "CTu,Cu,Cu" > flags1
+          certutil -L -d /root/.dogtag/nssdb | sed -n 's/^ca_signing *\(\S\+\)/\1/p' > flags2
+          diff flags1 flags2
+
+  # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
+  pki-nss-hsm-test:
+    name: PKI NSS CLI with HSM
+    needs: build
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    strategy:
+      matrix:
+        # NSS cannot find the SoftHSM token on F32
+        os: ['33']
+    steps:
+      - name: Download PKI packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: build/RPMS
+
+      - name: Install PKI packages
+        run: |
+          dnf install -y dnf-plugins-core softhsm
+          dnf copr enable -y @pki/master
+          dnf -y localinstall build/RPMS/*
+
+      - name: Create HSM token
+        run: |
+          softhsm2-util --init-token \
+              --label HSM \
+              --so-pin Secret.123 \
+              --pin Secret.123 \
+              --free
+          softhsm2-util --show-slots
+
+      - name: Generate cert request with key in HSM
+        run: |
+          echo "internal=" > password.conf
+          echo "hardware-HSM=Secret.123" >> password.conf
+          pki --token HSM -f password.conf nss-cert-request \
+              --subject "CN=Certificate Authority" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr ca_signing.csr
+
+      - name: Issue self-signed cert
+        run: |
+          pki --token HSM -f password.conf nss-cert-issue \
+              --csr ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert ca_signing.crt
+
+      - name: Import cert into internal token and HSM
+        run: |
+          pki --token HSM -f password.conf nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+      - name: Verify trust flags in internal token
+        run: |
+          echo "CT,C,C" > flags.internal1
+          echo "Secret.123" > password.txt
+          certutil -L -d /root/.dogtag/nssdb | sed -n 's/^ca_signing *\(\S\+\)/\1/p' > flags.internal2
+          diff flags.internal1 flags.internal2
+
+      - name: Verify trust flags in HSM
+        run: |
+          echo "CTu,Cu,Cu" > flags.hsm1
+          certutil -L -d /root/.dogtag/nssdb -h HSM -f password.txt | sed -n 's/^HSM:ca_signing *\(\S\+\)/\1/p' > flags.hsm2
+          diff flags.hsm1 flags.hsm2
+
+      - name: Remove HSM token
+        run: softhsm2-util --delete-token --token HSM

--- a/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
+++ b/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
@@ -860,7 +860,32 @@ public class NSSDatabase {
             String hash,
             CertificateExtensions extensions) throws Exception {
 
+        return createRequest(
+                null,
+                subject,
+                keyID,
+                keyType,
+                keySize,
+                curve,
+                hash,
+                extensions);
+    }
+
+    public PKCS10 createRequest(
+            String tokenName,
+            String subject,
+            String keyID,
+            String keyType,
+            String keySize,
+            String curve,
+            String hash,
+            CertificateExtensions extensions) throws Exception {
+
         logger.info("Creating certificate signing request for " + subject);
+
+        if (tokenName != null) {
+            logger.info("- token: " + tokenName);
+        }
 
         if (keyID != null) {
             logger.info("- key ID: " + keyID);
@@ -892,10 +917,15 @@ public class NSSDatabase {
             cmd.add("-d");
             cmd.add(path.toString());
 
+            if (tokenName != null) {
+                cmd.add("-h");
+                cmd.add(tokenName);
+            }
+
             if (passwordStore != null) {
 
-                // TODO: Add support for HSM.
-                String password = passwordStore.getPassword("internal", 0);
+                String tag = tokenName == null ? "internal" : "hardware-" + tokenName;
+                String password = passwordStore.getPassword(tag, 0);
 
                 if (password != null) {
                     Path passwordPath = tmpDir.resolve("password.txt");

--- a/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
+++ b/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
@@ -1041,6 +1041,23 @@ public class NSSDatabase {
             Integer monthsValid,
             CertificateExtensions extensions) throws Exception {
 
+        return createCertificate(
+                null, // token name
+                issuer,
+                pkcs10,
+                null, // serial number
+                monthsValid,
+                extensions);
+    }
+
+    public X509Certificate createCertificate(
+            String tokenName,
+            org.mozilla.jss.crypto.X509Certificate issuer,
+            PKCS10 pkcs10,
+            String serialNumber,
+            Integer monthsValid,
+            CertificateExtensions extensions) throws Exception {
+
         Path tmpDir = null;
 
         try {
@@ -1059,10 +1076,15 @@ public class NSSDatabase {
             cmd.add("-d");
             cmd.add(path.toString());
 
+            if (tokenName != null) {
+                cmd.add("-h");
+                cmd.add(tokenName);
+            }
+
             if (passwordStore != null) {
 
-                // TODO: Add support for HSM.
-                String password = passwordStore.getPassword("internal", 0);
+                String tag = tokenName == null ? "internal" : "hardware-" + tokenName;
+                String password = passwordStore.getPassword(tag, 0);
 
                 if (password != null) {
                     Path passwordPath = tmpDir.resolve("password.txt");

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertImportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertImportCLI.java
@@ -89,11 +89,13 @@ public class NSSCertImportCLI extends CommandCLI {
         ClientConfig clientConfig = mainCLI.getConfig();
         NSSDatabase nssdb = mainCLI.getNSSDatabase();
 
+        String tokenName = clientConfig.getTokenName();
+
         if (nickname == null) {
             nssdb.addCertificate(cert, trustAttributes);
 
         } else {
-            nssdb.addCertificate(nickname, cert, trustAttributes);
+            nssdb.addCertificate(tokenName, nickname, cert, trustAttributes);
         }
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertIssueCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertIssueCLI.java
@@ -102,7 +102,10 @@ public class NSSCertIssueCLI extends CommandCLI {
             extensions = generator.createExtensions(issuer, pkcs10);
         }
 
+        String tokenName = clientConfig.getTokenName();
+
         X509Certificate cert = nssdb.createCertificate(
+                tokenName,
                 issuer,
                 pkcs10,
                 serialNumber,

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -97,7 +97,10 @@ public class NSSCertRequestCLI extends CommandCLI {
             extensions = generator.createExtensions();
         }
 
+        String tokenName = clientConfig.getTokenName();
+
         PKCS10 pkcs10 = nssdb.createRequest(
+                tokenName,
                 subject,
                 keyID,
                 keyType,


### PR DESCRIPTION
This PR adds HSM support and CI tests for the following commands:

* pki nss-cert-request
* pki nss-cert-issue
* pki nss-cert-import