### PR TITLE
Bug-1912493: Added_boolean_fix_for_fips_check

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -857,7 +857,7 @@ class Instance:
 
         """
 
-        fips_mode = not pki.FIPS.is_enabled()
+        fips_mode = pki.FIPS.is_enabled()
         logger.info('FIPS mode: %s', fips_mode)
 
         # must use 'http' protocol when FIPS mode is enabled


### PR DESCRIPTION
Removed boolean 'not' to print correct FIPS mode while pkispawn

Fixes : [1912493](https://bugzilla.redhat.com/show_bug.cgi?id=1912493)

Signed-off-by: Pritam Singh <prisingh@redhat.com>