### PR TITLE
Fix KRA/OCSP installation with external certs on HSM

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -1218,16 +1218,16 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             # earlier in external/standalone installation.
 
             if not (standalone or external and subsystem.name in ['kra', 'ocsp']):
-
-                nickname = system_certs['sslserver']['nickname']
-                token = pki.nssdb.normalize_token(system_certs['sslserver']['token'])
-
-                if not token:
-                    token = deployer.mdict['pki_token_name']
-
-                instance.set_sslserver_cert_nickname(nickname, token)
-
                 self.import_perm_sslserver_cert(deployer, instance, system_certs['sslserver'])
+
+            # Store perm SSL server cert nickname and token
+            nickname = system_certs['sslserver']['nickname']
+            token = pki.nssdb.normalize_token(system_certs['sslserver']['token'])
+
+            if not token:
+                token = deployer.mdict['pki_token_name']
+
+            instance.set_sslserver_cert_nickname(nickname, token)
 
             logger.info('Starting server')
             instance.start()


### PR DESCRIPTION
Previously `pkispawn` did not update `serverCertNick.conf` during KRA or OCSP installation with external certs or standalone
installation. If the SSL server cert was stored in HSM the file would not have the token name so the installation would fail.

To fix the problem the deployment scriptlet has been modified to store the SSL server cert nickname and token name in `serverCertNick.conf` in all installation cases.

https://bugzilla.redhat.com/show_bug.cgi?id=1890639