### PR TITLE
Add ACME base URL parameter

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -224,3 +224,192 @@ jobs:
         with:
           name: pki-logs-${{ matrix.os }}
           path: pki-logs.tar
+
+  # This test verifies that in a cluster the baseURL parameter can be used
+  # to replace a server with another server without affecting the client.
+  acme-switchover-test:
+    name: Testing ACME server switchover
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      BUILDDIR: /tmp/workdir
+      PKIDIR: /tmp/workdir/pki
+      LOGS: ${GITHUB_WORKSPACE}/logs.txt
+      COPR_REPO: "@pki/master"
+    strategy:
+      matrix:
+        os: ['32', '33']
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download PKI packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: build/RPMS
+
+      - name: Download container
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load container
+        run: docker load --input /tmp/pki.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Run PKI container
+        run: |
+          IMAGE=pki \
+          NAME=pki \
+          HOSTNAME=pki.example.com \
+          ci/runner-init.sh
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com --alias server1.example.com
+
+      - name: Install dependencies in PKI container
+        run: |
+          docker exec pki dnf install -y findutils dnf-plugins-core wget 389-ds-base jq
+          docker exec pki dnf copr enable -y ${COPR_REPO}
+
+      - name: Install PKI packages in PKI container
+        run: docker exec pki bash -c "dnf -y localinstall ${PKIDIR}/build/RPMS/*"
+
+      - name: Install DS in PKI container
+        run: docker exec pki ${PKIDIR}/ci/ds-create.sh
+
+      - name: Install CA in PKI container
+        run: docker exec pki pkispawn -f /usr/share/pki/server/examples/installation/ca.cfg -s CA -v
+
+      - name: Install ACME in PKI container
+        run: |
+          docker exec pki pki-server acme-create
+          docker exec pki ldapmodify -h pki.example.com \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/database/ds/schema.ldif
+          docker exec pki ldapadd -h pki.example.com \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/database/ds/create.ldif
+          docker exec pki ldapadd -h pki.example.com \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/realm/ds/create.ldif
+          docker exec pki pki-server acme-database-mod --type ds
+          docker exec pki pki-server acme-issuer-mod --type pki
+          docker exec pki pki-server acme-realm-mod --type ds
+          docker exec pki bash -c "echo baseURL=http://server1.example.com:8080/acme >> /etc/pki/pki-tomcat/acme/engine.conf"
+          docker exec pki pki-server acme-deploy --wait
+
+      - name: Gather config files from PKI container
+        if: always()
+        run: docker exec pki tar cvf ${PKIDIR}/switchover-conf.tar -C / etc/pki
+
+      - name: Upload config files from PKI container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: switchover-conf-${{ matrix.os }}
+          path: switchover-conf.tar
+
+      - name: Run client container
+        run: |
+          IMAGE=pki \
+          NAME=client \
+          HOSTNAME=client.example.com \
+          ci/runner-init.sh
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client1.example.com --alias client2.example.com
+
+      - name: Install dependencies in client container
+        run: docker exec client dnf install -y certbot
+
+      - name: Verify ACME directory before switchover
+        run: |
+          echo http://server1.example.com:8080/acme/new-nonce > expected
+          docker exec pki bash -c "curl -s -k http://pki.example.com:8080/acme/directory | jq -r '.newNonce' > ${PKIDIR}/actual"
+          diff expected actual
+
+      - name: Verify registration and enrollment before switchover
+        run: |
+          docker exec client certbot register \
+              --server http://pki.example.com:8080/acme/directory \
+              --email user1@example.com \
+              --agree-tos \
+              --non-interactive
+          docker exec client certbot certonly \
+              --server http://pki.example.com:8080/acme/directory \
+              -d client1.example.com \
+               --standalone \
+              --non-interactive
+          docker exec client certbot certonly \
+              --server http://pki.example.com:8080/acme/directory \
+              -d client2.example.com \
+               --standalone \
+              --non-interactive
+
+      - name: Simulate ACME server switchover by replacing the baseURL parameter
+        run: |
+          docker network disconnect example pki
+          docker exec pki pki-server acme-undeploy --wait
+          docker exec pki sed -i "s/server1.example.com/server2.example.com/g" /etc/pki/pki-tomcat/acme/engine.conf
+          docker exec pki pki-server acme-deploy --wait
+          docker network connect example pki --alias pki.example.com --alias server2.example.com
+
+      - name: Verify ACME directory after switchover
+        run: |
+          echo http://server2.example.com:8080/acme/new-nonce > expected
+          docker exec pki bash -c "curl -s -k http://pki.example.com:8080/acme/directory | jq -r '.newNonce' > ${PKIDIR}/actual"
+          diff expected actual
+
+      - name: Verify renewal, revocation, account update and deactivation after switchover
+        run: |
+          docker exec client certbot renew \
+              --server http://pki.example.com:8080/acme/directory \
+              --cert-name client1.example.com \
+              --force-renewal \
+              --non-interactive
+          docker exec client certbot revoke \
+              --server http://pki.example.com:8080/acme/directory \
+              --cert-name client2.example.com \
+              --non-interactive
+          docker exec client certbot update_account \
+              --server http://pki.example.com:8080/acme/directory \
+              --email user2@example.com \
+              --non-interactive
+          docker exec client certbot unregister \
+              --server http://pki.example.com:8080/acme/directory \
+              --non-interactive
+
+      - name: Remove ACME from PKI container
+        run: |
+          docker exec pki pki-server acme-undeploy --wait
+          docker exec pki pki-server acme-remove
+
+      - name: Remove CA from PKI container
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Remove DS from PKI container
+        run: docker exec pki ${PKIDIR}/ci/ds-remove.sh
+
+      - name: Gather log files from PKI container
+        if: always()
+        run: |
+          docker exec pki bash -c "journalctl -u pki-tomcatd@pki-tomcat > /var/log/pki/pki-tomcat/systemd.log"
+          docker exec pki tar cvf ${PKIDIR}/switchover-logs.tar -C / var/log/pki
+
+      - name: Upload log files from PKI container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: switchover-logs-${{ matrix.os }}
+          path: switchover-logs.tar

--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -5,6 +5,9 @@
 # Whether to enable the ACME service:
 enabled=true
 
+# Base URL for ACME services
+# baseURL=https://<hostname>:<port>/acme
+
 # By default nonces are not persistent (i.e. stored in memory).
 # nonces.persistent=false
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDirectoryService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEDirectoryService.java
@@ -6,6 +6,7 @@
 package org.dogtagpki.acme.server;
 
 import java.net.URI;
+import java.net.URL;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -14,6 +15,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.dogtagpki.acme.ACMEDirectory;
@@ -36,21 +38,30 @@ public class ACMEDirectoryService {
 
         logger.info("Creating directory");
 
+        ACMEEngine engine = ACMEEngine.getInstance();
+        URL baseURL = engine.getBaseURL();
+
+        UriBuilder uriBuilder;
+        if (baseURL != null) {
+            uriBuilder = UriBuilder.fromUri(baseURL.toURI());
+        } else {
+            uriBuilder = uriInfo.getBaseUriBuilder();
+        }
+
         ACMEDirectory directory = new ACMEDirectory();
 
-        ACMEEngine engine = ACMEEngine.getInstance();
         directory.setMetadata(engine.getMetadata());
 
-        URI newNonceURL = uriInfo.getBaseUriBuilder().path("new-nonce").build();
+        URI newNonceURL = uriBuilder.clone().path("new-nonce").build();
         directory.setNewNonce(newNonceURL);
 
-        URI newAccountURL = uriInfo.getBaseUriBuilder().path("new-account").build();
+        URI newAccountURL = uriBuilder.clone().path("new-account").build();
         directory.setNewAccount(newAccountURL);
 
-        URI newOrderURL = uriInfo.getBaseUriBuilder().path("new-order").build();
+        URI newOrderURL = uriBuilder.clone().path("new-order").build();
         directory.setNewOrder(newOrderURL);
 
-        URI revokeCertURL = uriInfo.getBaseUriBuilder().path("revoke-cert").build();
+        URI revokeCertURL = uriBuilder.clone().path("revoke-cert").build();
         directory.setRevokeCert(revokeCertURL);
 
         logger.info("Directory:\n" + directory);

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.math.BigInteger;
+import java.net.URL;
 import java.security.KeyFactory;
 import java.security.MessageDigest;
 import java.security.Principal;
@@ -207,6 +208,10 @@ public class ACMEEngine implements ServletContextListener {
         config.setEnabled(enabled);
     }
 
+    public URL getBaseURL() {
+        return config.getBaseURL();
+    }
+
     public void loadConfig(String filename) throws Exception {
 
         File configFile = new File(filename);
@@ -223,6 +228,7 @@ public class ACMEEngine implements ServletContextListener {
 
         config = ACMEEngineConfig.fromProperties(props);
         logger.info("- enabled: " + config.isEnabled());
+        logger.info("- base URL: " + config.getBaseURL());
         logger.info("- nonces persistent: " + config.getNoncesPersistent());
 
         ACMEPolicyConfig policyConfig = config.getPolicyConfig();

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfig.java
@@ -5,6 +5,7 @@
 //
 package org.dogtagpki.acme.server;
 
+import java.net.URL;
 import java.util.Map.Entry;
 import java.util.Properties;
 
@@ -22,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class ACMEEngineConfig {
 
     private Boolean enabled = true;
+    private URL baseURL;
     private Boolean noncesPersistent;
 
     @JsonProperty("policy")
@@ -33,6 +35,14 @@ public class ACMEEngineConfig {
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public URL getBaseURL() {
+        return baseURL;
+    }
+
+    public void setBaseURL(URL baseURL) {
+        this.baseURL = baseURL;
     }
 
     public Boolean getNoncesPersistent() {
@@ -72,6 +82,9 @@ public class ACMEEngineConfig {
 
             if (key.equals("enabled")) {
                 config.setEnabled(new Boolean(value));
+
+            } else if (key.equals("baseURL")) {
+                config.setBaseURL(new URL(value));
 
             } else if (key.equals("nonces.persistent")) {
                 config.setNoncePersistent(new Boolean(value));


### PR DESCRIPTION
By default the ACME directory will return ACME service URLs
with the same hostname that the client uses to access the
directory. If the hostname is load-balanced, the client might
get redirected to different servers, which could trigger other
issues.

A new parameter has been added into `engine.conf` to override
the base URL of ACME services. This mechanism can be used to
pin the client to the current server.

A COPR build is available here:
https://copr.fedorainfracloud.org/coprs/edewata/acme/builds/

For example, configure this in `/etc/pki/pki-tomcat/acme/engine.conf` and restart the server:
```
baseURL=https://server1.example.com/acme
```
Then access the directory using the load-balanced hostname:
```
$ curl -s -k https://ipa-ca.example.com/acme/directory | python -m json.tool
```
Suppose the directory is served by server1.example.com, the client will get:
```
{
    "meta": {
        "caaIdentities": [
            "example.com"
        ],
        "externalAccountRequired": false,
        "termsOfService": "https://www.example.com/acme/tos.pdf",
        "website": "https://www.example.com"
    },
    "newAccount": "https://server1.example.com/acme/new-account",
    "newNonce": "https://server1.example.com/acme/new-nonce",
    "newOrder": "https://server1.example.com/acme/new-order",
    "revokeCert": "https://server1.example.com/acme/revoke-cert"
}
```
Presumably the client will be able to complete certificate enrollment using server1.example.com.