### PR TITLE
Add persistent option for ACME nonces

### DIFF
--- a/base/acme/conf/engine.conf
+++ b/base/acme/conf/engine.conf
@@ -5,6 +5,9 @@
 # Whether to enable the ACME service:
 enabled=true
 
+# By default nonces are not persistent (i.e. stored in memory).
+# nonces.persistent=false
+
 # Whether to accept wildcard DNS identifiers:
 policy.wildcard=true
 

--- a/base/acme/src/main/java/org/dogtagpki/acme/scheduler/ACMEMaintenanceTask.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/scheduler/ACMEMaintenanceTask.java
@@ -7,7 +7,6 @@ package org.dogtagpki.acme.scheduler;
 
 import java.util.Date;
 
-import org.dogtagpki.acme.database.ACMEDatabase;
 import org.dogtagpki.acme.server.ACMEEngine;
 
 /**
@@ -24,11 +23,6 @@ public class ACMEMaintenanceTask extends ACMETask {
         Date currentTime = new Date();
 
         ACMEEngine engine = ACMEEngine.getInstance();
-        ACMEDatabase database = engine.getDatabase();
-
-        database.removeExpiredNonces(currentTime);
-        database.removeExpiredAuthorizations(currentTime);
-        database.removeExpiredOrders(currentTime);
-        database.removeExpiredCertificates(currentTime);
+        engine.removeExpiredRecords(currentTime);
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfig.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngineConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class ACMEEngineConfig {
 
     private Boolean enabled = true;
+    private Boolean noncesPersistent;
 
     @JsonProperty("policy")
     private ACMEPolicyConfig policyConfig = new ACMEPolicyConfig();
@@ -32,6 +33,14 @@ public class ACMEEngineConfig {
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public Boolean getNoncesPersistent() {
+        return noncesPersistent;
+    }
+
+    public void setNoncePersistent(Boolean noncesPersistent) {
+        this.noncesPersistent = noncesPersistent;
     }
 
     public ACMEPolicyConfig getPolicyConfig() {
@@ -63,6 +72,9 @@ public class ACMEEngineConfig {
 
             if (key.equals("enabled")) {
                 config.setEnabled(new Boolean(value));
+
+            } else if (key.equals("nonces.persistent")) {
+                config.setNoncePersistent(new Boolean(value));
 
             } else if (key.startsWith("policy.")) {
 


### PR DESCRIPTION
Previously ACME nonces were stored in ACME database, which
could generate a lot of database traffic and might not work
well in clustered environment due to replication latency.

To address the performance issue, the ACME database has been
modified to store the nonces in memory by default, and provide
an option to store the nonces in the database if necessary.

The replication latency issue should be addressed using other
mechanisms (e.g. using static base URL in ACME directory).

A COPR build is available here:
https://copr.fedorainfracloud.org/coprs/edewata/acme/builds/

For example, install ACME with DS database as usual, then perform
a certificate enrollment. Check the `ou=nonces` subtree, it should be
empty. Also check the DS access logs, there should be nothing that
adds, searches, or deletes `acmeNonceId=...` entries.

Then configure the following in `/etc/pki/pki-tomcat/acme/engine.conf`
and restart the server:
```
nonces.persistent=true
```
Perform another certificate enrollment. There should be entries under
`ou=nonces` subtree and some access logs for `acmeNonceId=...`.
