### PR TITLE
Convert QE test to use Docker

### DIFF
--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -10,7 +10,7 @@ jobs:
     container: fedora:${{ matrix.os }}
     strategy:
       matrix:
-        os: ['32']
+        os: ['32', '33']
     steps:
       - name: Install git
         run: dnf install -y git
@@ -18,20 +18,37 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
 
-      - name: Install PKI build deps
+      - name: Install dependencies
         run: |
-          dnf install -y dnf-plugins-core rpm-build
+          dnf install -y dnf-plugins-core rpm-build docker
           dnf copr enable -y @pki/master
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
 
       - name: Build PKI packages
         run: ./build.sh --with-timestamp --with-commit-id --work-dir=build rpm
 
-      - name: Upload RPM artifacts
+      - name: Upload PKI packages
         uses: actions/upload-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
           path: build/RPMS/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build container with systemd
+        uses: docker/build-push-action@v2
+        with:
+          file: ci/Dockerfile
+          build-args: OS_VERSION=${{ matrix.os }}
+          tags: pki:latest
+          outputs: type=docker,dest=/tmp/pki.tar
+
+      - name: Upload container
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-${{ matrix.os }}
+          path: /tmp/pki.tar
 
   # Tier 0
   installation-sanity:
@@ -39,20 +56,21 @@ jobs:
     # All 5 subsystems are deployed on "discrete" instances
     name: installation-sanity
     needs: build
-    runs-on: macos-latest
+    # TODO: Replace with ubuntu-latest once the rollout is complete:
+    # https://github.com/actions/virtual-environments/issues/1816
+    runs-on: ubuntu-20.04
     env:
       BUILDDIR: /tmp/workdir
       PKIDIR: /tmp/workdir/pki
       LOGS: ${GITHUB_WORKSPACE}/logs.txt
       COPR_REPO: "@pki/master"
-      HOSTFILE: /tmp/hostfile
-      CONTROLLER_IP: "192.168.33.10"
-      MASTER_IP: "192.168.33.20"
-      TOPOLOGY: "topology-02"
     strategy:
       matrix:
-        os: ['32']  # NOTE: In F31, NFS client installation fails!
+        os: ['32', '33']
     steps:
+      - name: Install dependencies
+        run: sudo apt-get install ansible python3-pip python3-pytest python3-docutils
+
       - name: Clone the repository
         uses: actions/checkout@v2
 
@@ -62,42 +80,69 @@ jobs:
           name: pki-build-${{ matrix.os }}
           path: build/RPMS
 
-      - name: Modify the vagrant file per requirement
+      - name: Download container
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load container
+        run: docker load --input /tmp/pki.tar
+
+      - name: Run master container
         run: |
-          cd ci
-          sed -e "s/MASTER_IP/${MASTER_IP}/g" \
-              -e "s/CONTROLLER_IP/${CONTROLLER_IP}/g" \
-              -e "s~COPR_REPO~${COPR_REPO}~g" \
-              -e "s/RELEASE/${{ matrix.os }}/g" \
-              Vagrantfile > ../Vagrantfile
+          IMAGE=pki \
+          NAME=pki1 \
+          HOSTNAME=pki1.example.com \
+          ci/runner-init.sh
 
-          sed -e "s/MASTER_IP/${MASTER_IP}/g" \
-              -e "s/TOPOLOGY/${TOPOLOGY}/g" \
-              inventory > ../inventory
-          cd ../
-
-      # Don't provision the VMs as they might not be ready for inter communication
-      - name: Boot the "controller" VM without provisioning
-        run: vagrant up controller --no-provision
-
-      - name: Boot the "master" without provisioning
-        run: vagrant up master --no-provision
-
-      - name: Install the built PKI packages on "master"
-        run: vagrant provision master
-
-      - name: Set up PKI deployment by running playbook on "controller"
-        run: vagrant provision controller
-
-      - name: Run CA related tests
+      - name: Install dependencies in master container
         run: |
-          vagrant ssh controller -c \
-          'pytest --ansible-host-pattern master \
-          --ansible-inventory /vagrant/inventory \
-          --ansible-module-path /vagrant/tests/dogtag/pytest-ansible/common-modules/ \
-          /vagrant/tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py \
-          --junit-xml pki_cert_junit.xml -qsvvv'
+          docker exec pki1 dnf install -y dnf-plugins-core wget 389-ds-base
+          docker exec pki1 dnf copr enable -y ${COPR_REPO}
+          docker exec pki1 bash -c "dnf -y localinstall ${PKIDIR}/build/RPMS/*"
 
-      - name: Setup tmate session
-        if: failure()
-        uses: mxschmitt/action-tmate@v2
+      - name: Set up inventory
+        run: |
+          sed -e "s/TOPOLOGY/topology-02/g" ci/inventory > inventory
+          ansible -i inventory -m setup master
+
+      - name: Set up topology-02
+        run: |
+          mkdir -p /tmp/test_dir
+          ansible-playbook \
+              -b \
+              -i inventory \
+              -l all \
+              -M tests/dogtag/pytest-ansible/common-modules \
+              -vvv \
+              tests/dogtag/pytest-ansible/installation/main.yml
+
+      - name: Run sanity test
+        run: |
+          pip3 install -r tests/dogtag/pytest-ansible/requirements.txt
+          pip3 install -e tests/dogtag/pytest-ansible
+          pytest-3 \
+              --ansible-host-pattern master \
+              --ansible-inventory inventory \
+              --ansible-module-path tests/dogtag/pytest-ansible/common-modules \
+              --junit-xml pki_cert_junit.xml \
+              -qsvvv \
+              tests/dogtag/pytest-ansible/pytest/sanity/test_role_users.py
+
+      - name: Gather log files from master container
+        if: always()
+        run: |
+          docker exec pki1 bash -c "journalctl -u pki-tomcatd@topology-02-CA > /var/log/pki/topology-02-CA/systemd.log"
+          docker exec pki1 bash -c "journalctl -u pki-tomcatd@topology-02-KRA > /var/log/pki/topology-02-KRA/systemd.log"
+          docker exec pki1 bash -c "journalctl -u pki-tomcatd@topology-02-OCSP > /var/log/pki/topology-02-OCSP/systemd.log"
+          docker exec pki1 bash -c "journalctl -u pki-tomcatd@topology-02-TKS > /var/log/pki/topology-02-TKS/systemd.log"
+          docker exec pki1 bash -c "journalctl -u pki-tomcatd@topology-02-TPS > /var/log/pki/topology-02-TPS/systemd.log"
+          docker exec pki1 tar cvf ${PKIDIR}/pki1-logs.tar -C / var/log/pki
+
+      - name: Upload log files from master container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki1-logs-${{ matrix.os }}
+          path: pki1-logs.tar

--- a/ci/inventory
+++ b/ci/inventory
@@ -1,11 +1,8 @@
-controller ansible_connection=local
-MASTER_IP ansible_ssh_host=MASTER_IP ansible_user='root' ansible_ssh_private_key_file=/vagrant/.vagrant/machines/master/virtualbox/private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
-
 [master]
-MASTER_IP
+pki1 ansible_connection=docker
 
-[localhost]
-controller
+[controller]
+localhost ansible_connection=local
 
 [all:vars]
 topology=TOPOLOGY

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_common.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_common.yml
@@ -5,33 +5,43 @@
 - name : Set hostname for machines Bydefault we choose pki1 for master and pki2 for clones.
   hostname: name=pki1.example.com
   tags: platform-ci
+  when: ansible_connection != "docker"
 
 - name: Install a required package for modify hostname task below
   dnf: pkg={{item}} state=latest
   with_items:
     - python3-libselinux
-  when: ansible_distribution == "Fedora"
+  when:
+    - ansible_connection != "docker"
+    - ansible_distribution == "Fedora"
 
 - name : Modify hostname for master in  /etc/hosts
   lineinfile: dest=/etc/hosts regexp='.*{{ inventory_hostname }}$' create=yes insertafter=EOF line="{{ inventory_hostname }} {{ansible_fqdn}}" state=present
   tags: platform-ci
+  when: ansible_connection != "docker"
 
 - name: Add 127.0.0.1 mapping to master hostname in /etc/hosts for 389ds
   lineinfile: dest=/etc/hosts create=yes insertafter=ROF line="127.0.0.1 {{ansible_fqdn}}" state=present
+  when: ansible_connection != "docker"
 
 - name: check the hostname/ip for the remote instance
   set_fact: inventory_ip={{ inventory_hostname }}
+  when: ansible_connection != "docker"
 
 - name: Check for private ip if exist for openstack instance
   shell: hostname -I
   register: private_addr
+  when: ansible_connection != "docker"
 
 - name: Set the private ip in a variable
   set_fact: private_ip={{ private_addr.stdout }}
+  when: ansible_connection != "docker"
 
 - name: Change in /etc/hosts to set right private/public ip for instance to be reachable
   replace: path=/etc/hosts regexp={{ inventory_ip }} replace={{ private_ip }}
-  when:  inventory_ip not in private_ip
+  when:
+    - ansible_connection != "docker"
+    - inventory_ip not in private_ip
 
 - name: pip install pexpect
   shell: pip3 install pexpect
@@ -39,7 +49,8 @@
 - name : fetch file in  master in  /etc/hosts
   fetch: src=/etc/hosts dest=/etc/ flat=yes validate_checksum=no
   tags: platform-ci
-  
+  when: ansible_connection != "docker"
+
 - name: Install list of packages for CS Master for Redhat
   yum : pkg={{item}} state=latest
   with_items:


### PR DESCRIPTION
Previously the QE test was running on Vagrant which can only run on macOS runners on GitHub:
https://stackoverflow.com/questions/66261101/using-vagrant-on-github-actions-ideally-incl-virtualbox

However, there is a performance issue with the macOS runners which is causing the test to fail occasionally:
https://github.com/actions/virtual-environments/issues/1336

To improve the reliability, the QE test has been converted to run on Docker instead. Some steps for configuring the machine hostname in `configure_common.yml` have been removed since it's no longer necessary.
