### PR TITLE
Add pki-server acme-deploy/undeploy --wait option

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -124,7 +124,7 @@ jobs:
           docker exec pki pki-server acme-database-mod --type ds
           docker exec pki pki-server acme-issuer-mod --type pki
           docker exec pki pki-server acme-realm-mod --type ds
-          docker exec pki pki-server acme-deploy
+          docker exec pki pki-server acme-deploy --wait
 
       - name: Gather config files
         if: always()
@@ -154,7 +154,7 @@ jobs:
 
       - name: Remove ACME
         run: |
-          docker exec pki pki-server acme-undeploy
+          docker exec pki pki-server acme-undeploy --wait
           docker exec pki pki-server acme-remove
 
       - name: Remove CA

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -232,6 +232,9 @@ class ACMEDeployCLI(pki.cli.CLI):
         print('Usage: pki-server acme-deploy [OPTIONS] [name]')
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('      --wait                         Wait until started.')
+        print('      --max-wait <seconds>           Maximum wait time (default: 60).')
+        print('      --timeout <seconds>            Connection timeout.')
         print('  -v, --verbose                      Run in verbose mode.')
         print('      --debug                        Run in debug mode.')
         print('      --help                         Show help message.')
@@ -242,6 +245,7 @@ class ACMEDeployCLI(pki.cli.CLI):
         try:
             opts, args = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=',
+                'wait', 'max-wait=', 'timeout=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -251,10 +255,22 @@ class ACMEDeployCLI(pki.cli.CLI):
 
         name = 'acme'
         instance_name = 'pki-tomcat'
+        wait = False
+        max_wait = 60
+        timeout = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
                 instance_name = a
+
+            elif o == '--wait':
+                wait = True
+
+            elif o == '--max-wait':
+                max_wait = int(a)
+
+            elif o == '--timeout':
+                timeout = int(a)
 
             elif o in ('-v', '--verbose'):
                 logging.getLogger().setLevel(logging.INFO)
@@ -287,7 +303,13 @@ class ACMEDeployCLI(pki.cli.CLI):
                                 'acme/webapps/acme')
 
         logger.info('Deploying %s webapp', name)
-        instance.deploy_webapp(name, descriptor, doc_base)
+        instance.deploy_webapp(
+            name,
+            descriptor,
+            doc_base,
+            wait=wait,
+            max_wait=max_wait,
+            timeout=timeout)
 
 
 class ACMEUndeployCLI(pki.cli.CLI):
@@ -300,6 +322,9 @@ class ACMEUndeployCLI(pki.cli.CLI):
         print('Usage: pki-server acme-undeploy [OPTIONS] [name]')
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('      --wait                         Wait until stopped.')
+        print('      --max-wait <seconds>           Maximum wait time (default: 60).')
+        print('      --timeout <seconds>            Connection timeout.')
         print('  -v, --verbose                      Run in verbose mode.')
         print('      --debug                        Run in debug mode.')
         print('      --help                         Show help message.')
@@ -310,6 +335,7 @@ class ACMEUndeployCLI(pki.cli.CLI):
         try:
             opts, args = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=',
+                'wait', 'max-wait=', 'timeout=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -319,10 +345,22 @@ class ACMEUndeployCLI(pki.cli.CLI):
 
         name = 'acme'
         instance_name = 'pki-tomcat'
+        wait = False
+        max_wait = 60
+        timeout = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
                 instance_name = a
+
+            elif o == '--wait':
+                wait = True
+
+            elif o == '--max-wait':
+                max_wait = int(a)
+
+            elif o == '--timeout':
+                timeout = int(a)
 
             elif o in ('-v', '--verbose'):
                 logging.getLogger().setLevel(logging.INFO)
@@ -350,7 +388,11 @@ class ACMEUndeployCLI(pki.cli.CLI):
         instance.load()
 
         logger.info('Undeploying %s webapp', name)
-        instance.undeploy_webapp(name)
+        instance.undeploy_webapp(
+            name,
+            wait=wait,
+            max_wait=max_wait,
+            timeout=timeout)
 
 
 class ACMEMetadataCLI(pki.cli.CLI):


### PR DESCRIPTION
A new option has been added to `pki-server acme-deploy/undeploy` commands to wait until ACME web application is actually
deployed/undeployed on the server. This option can be used to prevent the subsequent command from executing before the ACME
deployment/undeployment is complete. The CI test has been updated to use this option to improve its reliability.