### PR TITLE
Fix profile auth in PKIIssuer.issueCertificate()

### DIFF
--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -82,26 +82,32 @@ jobs:
       - name: Load container
         run: docker load --input /tmp/ipa.tar
 
-      - name: Run container
+      - name: Create network
+        run: docker network create example
+
+      - name: Run IPA container
         run: |
           IMAGE=ipa \
           NAME=ipa \
           HOSTNAME=ipa.example.com \
           ci/runner-init.sh
 
-      - name: Install dependencies
+      - name: Connect IPA container to network
+        run: docker network connect example ipa --alias ipa.example.com --alias ipa-ca.example.com
+
+      - name: Install dependencies in IPA container
         run: |
           docker exec ipa dnf install -y findutils dnf-plugins-core
           docker exec ipa dnf copr enable -y @freeipa/freeipa-master-nightly
           docker exec ipa dnf copr enable -y ${COPR_REPO}
 
-      - name: Install IPA packages
+      - name: Install IPA packages in IPA container
         run: docker exec ipa dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad python3-ipatests freeipa-healthcheck
 
-      - name: Install PKI packages
+      - name: Install PKI packages in IPA container
         run: docker exec ipa bash -c "dnf -y localinstall ${PKIDIR}/build/RPMS/*"
 
-      - name: Install IPA server
+      - name: Install IPA server in IPA container
         run: |
           docker exec ipa sysctl net.ipv6.conf.lo.disable_ipv6=0
           docker exec ipa ipa-server-install \
@@ -115,7 +121,7 @@ jobs:
           docker exec ipa bash -c "echo Secret.123 | kinit admin"
           docker exec ipa ipa ping
 
-      - name: Verify CA admin
+      - name: Verify CA admin in IPA container
         run: |
           docker exec ipa pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec ipa pki client-cert-import ca_signing --ca-cert ca_signing.crt
@@ -124,30 +130,107 @@ jobs:
               --pkcs12-password Secret.123
           docker exec ipa pki -n ipa-ca-agent ca-user-show admin
 
-      - name: Gather config files
+      - name: Enable ACME in IPA container
+        run: |
+          docker exec ipa ipa-acme-manage enable
+          docker exec ipa ipa-acme-manage status
+          echo "Available" > expected
+          docker exec ipa bash -c "pki acme-info | sed -n 's/\s*Status:\s\+\(\S\+\).*/\1/p' > ${PKIDIR}/actual"
+          diff expected actual
+
+      - name: Run client container
+        run: |
+          docker run \
+              --detach \
+              --name=client \
+              --hostname=client.example.com \
+              --privileged \
+              ipa:latest \
+              /usr/sbin/init
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Install dependencies in client container
+        run: |
+          docker exec client dnf install -y dnf-plugins-core
+          docker exec client dnf copr enable -y @freeipa/freeipa-master-nightly
+          docker exec client dnf install -y freeipa-client certbot
+
+      - name: Install IPA client in client container
+        run: |
+          docker exec client sysctl net.ipv6.conf.lo.disable_ipv6=0
+          docker exec client ipa-client-install \
+              -U \
+              --server=ipa.example.com \
+              --domain=example.com \
+              --realm=EXAMPLE.COM \
+              -p admin \
+              -w Secret.123
+          docker exec client bash -c "echo Secret.123 | kinit admin"
+          docker exec client klist
+
+      - name: Verify certbot in client container
+        run: |
+          docker exec client certbot register \
+              --server https://ipa-ca.example.com/acme/directory \
+              --email user1@example.com \
+              --agree-tos \
+              --non-interactive
+          docker exec client certbot certonly \
+              --server https://ipa-ca.example.com/acme/directory \
+              -d client.example.com \
+               --standalone \
+              --non-interactive
+          docker exec client certbot renew \
+              --server https://ipa-ca.example.com/acme/directory \
+              --cert-name client.example.com \
+              --force-renewal \
+              --non-interactive
+          docker exec client certbot revoke \
+              --server https://ipa-ca.example.com/acme/directory \
+              --cert-name client.example.com \
+              --non-interactive
+          docker exec client certbot update_account \
+              --server https://ipa-ca.example.com/acme/directory \
+              --email user2@example.com \
+              --non-interactive
+          docker exec client certbot unregister \
+              --server https://ipa-ca.example.com/acme/directory \
+              --non-interactive
+
+      - name: Disable ACME in IPA container
+        run: |
+          docker exec ipa ipa-acme-manage disable
+          docker exec ipa ipa-acme-manage status
+          echo "Unavailable" > expected
+          docker exec ipa bash -c "pki acme-info | sed -n 's/\s*Status:\s\+\(\S\+\).*/\1/p' > ${PKIDIR}/actual"
+          diff expected actual
+
+      - name: Gather config files from IPA container
         if: always()
         run: docker exec ipa tar cvf ${PKIDIR}/ipa-conf.tar -C / etc/pki
 
-      - name: Upload config files
+      - name: Upload config files from IPA container
         if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ipa-conf-${{ matrix.os }}
           path: ipa-conf.tar
 
-      - name: Run IPA tests
+      - name: Run IPA tests in IPA container
         run: docker exec ipa ${PKIDIR}/ci/ipa-test.sh
 
-      - name: Remove IPA server
+      - name: Remove IPA server from IPA container
         run: docker exec ipa ipa-server-install --uninstall -U
 
-      - name: Gather log files
+      - name: Gather log files from IPA container
         if: always()
         run: |
           docker exec ipa bash -c "journalctl -u pki-tomcatd@pki-tomcat > /var/log/pki/pki-journalctl.log"
           docker exec ipa bash -c "tar cvf ${PKIDIR}/ipa-logs.tar /var/log/ipa* /var/log/pki*"
 
-      - name: Upload log files
+      - name: Upload log files from IPA container
         if: always()
         uses: actions/upload-artifact@v2
         with:

--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
@@ -115,6 +115,34 @@ public class PKIIssuer extends ACMEIssuer {
 
         PKIClient pkiClient = new PKIClient(clientConfig);
         CAClient caClient = new CAClient(pkiClient);
+
+        // Here the agent credentials are stored in the ClientConfig and will
+        // be sent to the CA automatically if any of the methods being called
+        // requires REST authentication. However, the methods being called
+        // depend on the cert profile being used.
+        //
+        // If the profile has an authenticator, the request can be completed
+        // with the following methods:
+        // - CACertClient.getEnrollmentTemplate()
+        // - CACertClient.enrollRequest()
+        //
+        // The above methods do not require REST authentication, but the
+        // profile still requires authentication, so the credentials must be
+        // provided either through the request itself (i.e. using profile
+        // authentication) or by calling CAClient.login() (i.e. using REST
+        // authentication).
+        //
+        // If the profile does not have an authenticator, the request must
+        // be reviewed and approved with the following additional methods:
+        // - CACertClient.reviewRequest()
+        // - CACertClient.approveRequest()
+        //
+        // The above methods do require REST authentication so in this case
+        // it's not actually necessary to call CAClient.login(). However, to
+        // support both types of profiles the CAClient.login() needs to be
+        // called explicitly.
+        caClient.login();
+
         CACertClient certClient = new CACertClient(caClient);
         CertEnrollmentRequest certEnrollmentRequest = certClient.getEnrollmentTemplate(profile);
 


### PR DESCRIPTION
In commit 1b6b426ad4724e2f9595340027482a0a36fc3655 the `PKIClient.login()` was removed from `PKIIssuer.issueCertificate()` and that caused enrollments with a profile that requires authentication (e.g. `acmeIPAServerCert`) to fail.

To fix the problem the `PKIClient.login()` has been restored.

The IPA test has been modified to perform ACME tests using certbot.

https://bugzilla.redhat.com/show_bug.cgi?id=1919282
