### PR TITLE
Fix CRMFPopClient, client-cert-create OAEP support in FIPS 

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertRequestCLI.java
@@ -108,6 +108,9 @@ public class ClientCertRequestCLI extends CommandCLI {
         option.setArgName("curve name");
         options.addOption(option);
 
+        option = new Option(null, "oaep", false, "Use OAEP key wrap algorithm.");
+        options.addOption(option);
+
         option = new Option(null, "ssl-ecdh", false, "SSL certificate with ECDH ECDSA");
         options.addOption(option);
 
@@ -276,6 +279,8 @@ public class ClientCertRequestCLI extends CommandCLI {
             mainCLI.init();
             client = getClient();
 
+            boolean useOAEP = cmd.hasOption("oaep");
+
             String encoded;
             if (transportCertFilename == null) {
                 CASystemCertClient certClient = new CASystemCertClient(client, "ca");
@@ -296,7 +301,7 @@ public class ClientCertRequestCLI extends CommandCLI {
 
             csr = generateCrmfRequest(transportCert, subjectDN, attributeEncoding,
                     algorithm, length, curve, sslECDH, temporary, sensitive, extractable, withPop,
-                    keyWrapAlgorithm);
+                    keyWrapAlgorithm, useOAEP);
 
         } else {
             throw new Exception("Unknown request type: " + requestType);
@@ -438,12 +443,14 @@ public class ClientCertRequestCLI extends CommandCLI {
             int sensitive,
             int extractable,
             boolean withPop,
-            KeyWrapAlgorithm keyWrapAlgorithm) throws Exception {
+            KeyWrapAlgorithm keyWrapAlgorithm,
+            boolean useOAEP) throws Exception {
 
         CryptoManager manager = CryptoManager.getInstance();
         CryptoToken token = manager.getThreadToken();
 
         CRMFPopClient client = new CRMFPopClient();
+        client.setUseOAEP(useOAEP);
 
         Name subject = client.createName(subjectDN, attributeEncoding);
 

--- a/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -2148,12 +2148,14 @@ public class CryptoUtil {
             WrappingParams params,
             AlgorithmIdentifier aid) throws Exception {
 
+        CryptoManager cm = CryptoManager.getInstance();
+
         SymmetricKey sessionKey = CryptoUtil.generateKey(
                 token,
                 params.getSkKeyGenAlgorithm(),
                 params.getSkLength(),
                 sess_key_usages,
-                false, false /* sensitive */);
+                false, cm.FIPSEnabled() /* sensitive */);
         byte[] key_data;
 
         if (passphraseData != null) {

--- a/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -2488,7 +2488,7 @@ public class CryptoUtil {
             KeyWrapAlgorithm alg) throws Exception {
         String method = "CryptoUtil.wrapUsingPublicKey ";
         KeyWrapper rsaWrap = token.getKeyWrapper(alg);
-        logger.debug(method + " KeyWwrapAlg: " + alg);
+        logger.debug(method + " KeyWrapAlg: " + alg);
         if (alg.equals(KeyWrapAlgorithm.RSA_OAEP)) {
             OAEPParameterSpec config = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256,
                     PSource.PSpecified.DEFAULT);
@@ -2514,7 +2514,7 @@ public class CryptoUtil {
             KeyWrapAlgorithm wrapAlgorithm) throws Exception {
         KeyWrapper keyWrapper = token.getKeyWrapper(wrapAlgorithm);
         String method = "CryptoUtil.unwrap";
-        logger.debug(method + " KeyWwrapAlg: " + wrapAlgorithm);
+        logger.debug(method + " KeyWrapAlg: " + wrapAlgorithm);
 
         if (wrapAlgorithm.equals(KeyWrapAlgorithm.RSA_OAEP)) {
             OAEPParameterSpec config = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256,


### PR DESCRIPTION
`org.mozilla.jss.netscape.security.util.WrappingParams` in JSS has an
shortcoming that it believes all RSA is RSA-PKCS1v1.5 and additionally,
that anything that isn't a EC key is RSA. :-)

Read the value of keyWrap.useOAEP to determine whether to override the
secret key wrapping algorithm with OAEP, prior to using and storing the
wrapping parameters.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

Eventually `WrappingParams` should be updated, but that is a lot more work than just OAEP support. 


Note that this does not fix SecurityDataProcessor fullly -- there's a similar issue with it as with the .p12 generation. However, this _does_ fix two other issues:

 - `CRMFPopClient` not working in FIPS mode,
 -  `client-cert-create` not supporting `--oaep` flag.