### PR TITLE
ACME performance improvements

### DIFF
--- a/base/acme/database/ds/index.ldif
+++ b/base/acme/database/ds/index.ldif
@@ -1,0 +1,49 @@
+dn: cn=acmeExpires,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeExpires
+
+dn: cn=acmeAccountId,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeAccountId
+
+dn: cn=acmeStatus,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeStatus
+
+dn: cn=acmeAuthorizationId,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeAuthorizationId
+
+dn: cn=acmeIdentifier,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeIdentifier
+
+dn: cn=acmeCertificateId,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: eq
+nsSystemindex: false
+cn: acmeCertificateId
+
+dn: cn=acmeAuthorizationWildcard,cn=index,cn=userroot,cn=ldbm database,cn=plugins,cn=config
+objectClass: top
+objectClass: nsIndex
+nsindexType: pres
+nsindexType: eq
+nsSystemindex: false
+cn: acmeAuthorizationWildcard

--- a/base/acme/database/ds/indextask.ldif
+++ b/base/acme/database/ds/indextask.ldif
@@ -1,0 +1,13 @@
+dn: cn=acme,cn=index,cn=tasks,cn=config
+objectclass: top
+objectclass: extensibleObject
+cn: acme
+ttl: 10
+nsinstance: userroot
+nsIndexAttribute: acmeExpires:eq
+nsIndexAttribute: acmeAccountId:eq
+nsIndexAttribute: acmeStatus:eq
+nsIndexAttribute: acmeAuthorizationId:eq
+nsIndexAttribute: acmeIdentifier:eq
+nsIndexAttribute: acmeCertificateId:eq
+nsIndexAttribute: acmeAuthorizationWildcard:eq,pres

--- a/base/ca/shared/profiles/ca/acmeServerCert.cfg
+++ b/base/ca/shared/profiles/ca/acmeServerCert.cfg
@@ -4,7 +4,8 @@ desc=This certificate profile is for enrolling server certificates via ACME prot
 visible=true
 enable=true
 enableBy=admin
-auth.class_id=
+auth.instance_id=SessionAuthentication
+authz.acl=group=Certificate Manager Agents
 name=ACME Server Certificate Enrollment
 input.list=i1,i2
 input.i1.class_id=certReqInputImpl

--- a/base/ca/src/org/dogtagpki/server/rest/CAInfoService.java
+++ b/base/ca/src/org/dogtagpki/server/rest/CAInfoService.java
@@ -128,9 +128,9 @@ public class CAInfoService extends PKIService implements CAInfoResource {
         CAEngine engine = CAEngine.getInstance();
         EngineConfig cs = engine.getConfig();
 
-        KRAInfoClient kraInfoClient = getKRAInfoClient(connInfo);
+        try (PKIClient client = createPKIClient(connInfo)) {
 
-        try {
+            KRAInfoClient kraInfoClient = new KRAInfoClient(client, "kra");
             KRAInfo kraInfo = kraInfoClient.getInfo();
 
             archivalMechanism = kraInfo.getArchivalMechanism();
@@ -172,9 +172,9 @@ public class CAInfoService extends PKIService implements CAInfoResource {
     }
 
     /**
-     * Construct KRAInfoClient given KRAConnectorInfo
+     * Construct PKIClient given KRAConnectorInfo
      */
-    private static KRAInfoClient getKRAInfoClient(KRAConnectorInfo connInfo) throws Exception {
+    private static PKIClient createPKIClient(KRAConnectorInfo connInfo) throws Exception {
 
         CAEngine engine = CAEngine.getInstance();
         EngineConfig cs = engine.getConfig();
@@ -196,7 +196,7 @@ public class CAInfoService extends PKIService implements CAInfoResource {
         }
         config.setCertNickname(nickname);
 
-        return new KRAInfoClient(new PKIClient(config), "kra");
+        return new PKIClient(config);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIClient.java
@@ -43,7 +43,7 @@ import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.util.CryptoProvider;
 
 
-public class PKIClient {
+public class PKIClient implements AutoCloseable {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIClient.class);
 
@@ -253,5 +253,9 @@ public class PKIClient {
 
     public void setOutput(File output) {
         connection.setOutput(output);
+    }
+
+    public void close() {
+        connection.close();
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
@@ -73,7 +73,7 @@ import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
 import org.mozilla.jss.ssl.SSLSocket;
 import org.mozilla.jss.ssl.SSLSocketListener;
 
-public class PKIConnection {
+public class PKIConnection implements AutoCloseable {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIConnection.class);
 
@@ -399,5 +399,11 @@ public class PKIConnection {
 
     public void setOutput(File output) {
         this.output = output;
+    }
+
+    public void close() {
+        client.close();
+        engine.close();
+        httpClient.close();
     }
 }

--- a/base/server/upgrade/10.11.0/02-FixACMEProfileAuth.py
+++ b/base/server/upgrade/10.11.0/02-FixACMEProfileAuth.py
@@ -1,0 +1,42 @@
+# Authors:
+#     Endi S. Dewata <edewata@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from __future__ import absolute_import
+import logging
+import os
+
+import pki
+
+logger = logging.getLogger(__name__)
+
+
+class FixACMEProfileAuth(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super(FixACMEProfileAuth, self).__init__()
+        self.message = 'Fix the authentication for acmeServerCert profile'
+
+    def upgrade_subsystem(self, instance, subsystem):
+
+        if subsystem.name != 'ca':
+            return
+
+        path = os.path.join(subsystem.base_dir, 'profiles', 'ca', 'acmeServerCert.cfg')
+        self.backup(path)
+
+        config = {}
+
+        logger.info('Loading %s', path)
+        pki.util.load_properties(path, config)
+
+        config.pop('auth.class_id', None)
+
+        config['auth.instance_id'] = 'SessionAuthentication'
+        config['authz.acl'] = 'group=Certificate Manager Agents'
+
+        logger.info('Storing %s', path)
+        pki.util.store_properties(path, config)

--- a/docs/installation/acme/Configuring_ACME_Database.md
+++ b/docs/installation/acme/Configuring_ACME_Database.md
@@ -78,15 +78,38 @@ $ ldapmodify -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
     -f /usr/share/pki/acme/database/ds/schema.ldif
 ```
 
-Next, prepare an LDIF file to create the ACME subtree.
-A sample LDIF file is available at [/usr/share/pki/acme/database/ds/create.ldif](../../../base/acme/database/ds/create.ldif).
-This example uses dc=acme,dc=pki,dc=example,dc=com as the base DN.
-Import the file with the following command:
+Next, create the ACME DS indexes by importing [/usr/share/pki/acme/database/ds/index.ldif](../../../base/acme/database/ds/index.ldif) with the following command:
+
+```
+$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/index.ldif
+```
+
+**Note:** By default the `index.ldif` will use `userroot` as the DS backend.
+
+If necessary, the database can be reindexed by importing [/usr/share/pki/acme/database/ds/indextask.ldif](../../../base/acme/database/ds/indextask.ldif) with the following command:
+
+```
+$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/indextask.ldif
+```
+
+The progress of the reindex task can be monitored with the following command:
+
+```
+$ ldapsearch -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -b "cn=acme,cn=index,cn=tasks,cn=config"
+```
+
+Once the indexes are ready, create the ACME subtree by importing
+[/usr/share/pki/acme/database/ds/create.ldif](../../../base/acme/database/ds/create.ldif) with the following command:
 
 ```
 $ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
     -f /usr/share/pki/acme/database/ds/create.ldif
 ```
+
+**Note:** By default the `create.ldif` will create the subtree under `dc=pki,dc=example,dc=com` which is mapped to `userroot` DS backend.
 
 A sample DS database configuration is available at
 [/usr/share/pki/acme/database/ds/database.conf](../../../base/acme/database/ds/database.conf).


### PR DESCRIPTION
This PR contains some changes that might improve ACME cert enrollment performance:
* reducing open connections by closing `PKIClient` objects used by `PKIIssuer`
* updating `acmeServerCert` profile to use session authentication instead of manual review/approval (including upgrade script)
* adding separate files to define ACME indexes and reindex task

COPR build: https://copr.fedorainfracloud.org/coprs/edewata/acme/builds/

Doc: https://github.com/edewata/pki/blob/bug-1916686/docs/installation/acme/Configuring_ACME_Database.md

https://bugzilla.redhat.com/show_bug.cgi?id=1916686