### PR TITLE
Update pki pkcs7 commands

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -179,3 +179,135 @@ jobs:
 
       - name: Remove HSM token
         run: softhsm2-util --delete-token --token HSM
+
+  # docs/user/tools/Using-PKI-PKCS7-CLI.adoc
+  pki-pkcs7-test:
+    name: PKI PKCS7 CLI
+    needs: build
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['32', '33']
+    steps:
+      - name: Download PKI packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: build/RPMS
+
+      - name: Install PKI packages
+        run: |
+          dnf install -y dnf-plugins-core
+          dnf copr enable -y @pki/master
+          dnf -y localinstall build/RPMS/*
+
+      - name: Generate CA signing cert request
+        run: |
+          pki nss-cert-request \
+              --subject "CN=Certificate Authority" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr ca_signing.csr
+
+      - name: Issue self-signed CA signing cert
+        run: |
+          pki nss-cert-issue \
+              --csr ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert ca_signing.crt
+
+      - name: Import CA signing cert
+        run: |
+          pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+      - name: Generate SSL server cert request
+        run: |
+          pki nss-cert-request \
+              --subject "CN=localhost.localdomain" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr sslserver.csr
+
+      - name: Issue SSL server cert signed by CA signing cert
+        run: |
+          pki nss-cert-issue \
+              --issuer ca_signing \
+              --csr sslserver.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert sslserver.crt
+
+      - name: Import SSL server cert
+        run: pki nss-cert-import sslserver --cert sslserver.crt
+
+      - name: "Export SSL server cert chain into PKCS #7 chain"
+        run: |
+          pki pkcs7-export sslserver --pkcs7 cert_chain.p7b
+          pki pkcs7-cert-find --pkcs7 cert_chain.p7b
+
+      - name: Convert cert chain into separate PEM certificates
+        run: |
+          pki pkcs7-cert-export --pkcs7 cert_chain.p7b --output-prefix cert- --output-suffix .pem
+          cat cert-0.pem
+          cat cert-1.pem
+
+      - name: "Merge PEM certificates into a PKCS #7 chain"
+        run: |
+          rm -f cert_chain.p7b
+          pki pkcs7-cert-import --pkcs7 cert_chain.p7b --input-file cert-0.pem
+          pki pkcs7-cert-import --pkcs7 cert_chain.p7b --input-file cert-1.pem --append
+          pki pkcs7-cert-find --pkcs7 cert_chain.p7b
+
+      - name: Remove certs from NSS database
+        run: |
+          certutil -D -d /root/.dogtag/nssdb -n sslserver
+          certutil -D -d /root/.dogtag/nssdb -n ca_signing
+          certutil -L -d /root/.dogtag/nssdb
+
+      - name: "Import PKCS #7 chain into NSS database"
+        run: |
+          pki pkcs7-import sslserver --pkcs7 cert_chain.p7b
+          certutil -L -d /root/.dogtag/nssdb
+
+      - name: Verify CA signing cert trust flags
+        run: |
+          echo "CTu,Cu,Cu" > flags1
+          certutil -L -d /root/.dogtag/nssdb | sed -n 's/^Certificate Authority *\(\S\+\)/\1/p' > flags2
+          diff flags1 flags2
+
+      - name: Verify SSL server cert trust flags
+        run: |
+          echo "u,u,u" > flags1
+          certutil -L -d /root/.dogtag/nssdb | sed -n 's/^sslserver *\(\S\+\)/\1/p' > flags2
+          diff flags1 flags2
+
+      - name: "Convert PKCS #7 chain into a series of PEM certificates"
+        run: |
+          pki pkcs7-cert-export --pkcs7 cert_chain.p7b --output-file cert_chain.pem
+          cat cert_chain.pem
+
+      - name: Remove certs from NSS database
+        run: |
+          certutil -D -d /root/.dogtag/nssdb -n sslserver
+          certutil -D -d /root/.dogtag/nssdb -n "Certificate Authority"
+          certutil -L -d /root/.dogtag/nssdb
+
+      - name: Import PEM certificates into NSS database
+        run: |
+          rm -f cert_chain.p7b
+          pki pkcs7-cert-import --pkcs7 cert_chain.p7b --input-file cert_chain.pem
+          pki pkcs7-import sslserver --pkcs7 cert_chain.p7b
+          certutil -L -d /root/.dogtag/nssdb
+
+      - name: Verify CA signing cert trust flags
+        run: |
+          echo "CTu,Cu,Cu" > flags1
+          certutil -L -d /root/.dogtag/nssdb | sed -n 's/^Certificate Authority *\(\S\+\)/\1/p' > flags2
+          diff flags1 flags2
+
+      - name: Verify SSL server cert trust flags
+        run: |
+          echo "u,u,u" > flags1
+          certutil -L -d /root/.dogtag/nssdb | sed -n 's/^sslserver *\(\S\+\)/\1/p' > flags2
+          diff flags1 flags2

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7CLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7CLI.java
@@ -32,6 +32,7 @@ public class PKCS7CLI extends CLI {
 
         addModule(new PKCS7CertCLI(this));
         addModule(new PKCS7ImportCLI(this));
+        addModule(new PKCS7ExportCLI(this));
     }
 
     public String getFullName() {

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7CertCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7CertCLI.java
@@ -33,6 +33,7 @@ public class PKCS7CertCLI extends CLI {
         this.pkcs7CLI = pkcs7CLI;
 
         addModule(new PKCS7CertFindCLI(this));
+        addModule(new PKCS7CertImportCLI(this));
         addModule(new PKCS7CertExportCLI(this));
     }
 

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7CertFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7CertFindCLI.java
@@ -48,14 +48,25 @@ public class PKCS7CertFindCLI extends CommandCLI {
     }
 
     public void createOptions() {
-        Option option = new Option(null, "pkcs7-file", true, "PKCS #7 file");
+        Option option = new Option(null, "pkcs7", true, "PKCS #7 file");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "pkcs7-file", true, "DEPRECATED: PKCS #7 file");
         option.setArgName("path");
         options.addOption(option);
     }
 
     public void execute(CommandLine cmd) throws Exception {
 
-        String filename = cmd.getOptionValue("pkcs7-file");
+        String filename = cmd.getOptionValue("pkcs7");
+
+        if (filename == null) {
+            filename = cmd.getOptionValue("pkcs7-file");
+            if (filename != null) {
+                logger.warn("The --pkcs7-file has been deprecated. Use --pkcs7 instead.");
+            }
+        }
 
         if (filename == null) {
             throw new Exception("Missing PKCS #7 file.");

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7CertImportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7CertImportCLI.java
@@ -1,0 +1,126 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.pkcs7;
+
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.cert.X509Certificate;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CommandCLI;
+import org.mozilla.jss.netscape.security.pkcs.PKCS7;
+import org.mozilla.jss.netscape.security.x509.CertificateChain;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS7CertImportCLI extends CommandCLI {
+
+    private static Logger logger = LoggerFactory.getLogger(PKCS7CertImportCLI.class);
+
+    public PKCS7CertCLI certCLI;
+
+    public PKCS7CertImportCLI(PKCS7CertCLI certCLI) {
+        super("import", "Import a certificate into a PKCS #7 file", certCLI);
+        this.certCLI = certCLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "pkcs7", true, "PKCS #7 file");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "input-file", true, "Path to certificate file to import");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "input-format", true, "Certificate format: PEM (default), DER");
+        option.setArgName("format");
+        options.addOption(option);
+
+        options.addOption(null, "append", false, "Import into an existing PKCS #7 file");
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String filename = cmd.getOptionValue("pkcs7");
+        if (filename == null) {
+            throw new Exception("Missing PKCS #7 file");
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        CertificateChain certChain = new CertificateChain();
+
+        Path path = Paths.get(filename);
+        boolean append = cmd.hasOption("append");
+
+        if (Files.exists(path) && append) {
+
+            logger.info("Loading certificates from " + path);
+            byte[] bytes = Files.readAllBytes(path);
+
+            PKCS7 pkcs7 = new PKCS7(new String(bytes));
+            for (X509Certificate cert : pkcs7.getCertificates()) {
+                logger.info(" - " + cert.getSubjectDN());
+            }
+
+            certChain.addPKCS7(pkcs7);
+        }
+
+        String inputFilename = cmd.getOptionValue("input-file");
+        if (inputFilename != null) {
+
+            logger.info("Importing certificates from " + inputFilename);
+            byte[] bytes = Files.readAllBytes(Paths.get(inputFilename));
+
+            String inputFormat = cmd.getOptionValue("input-format", "PEM");
+            if ("PEM".equalsIgnoreCase(inputFormat)) {
+
+                CertificateChain inputChain = CertificateChain.fromPEMString(new String(bytes));
+                for (X509Certificate cert : inputChain.getCertificates()) {
+                    logger.info(" - " + cert.getSubjectDN());
+                }
+
+                certChain.addCertificateChain(inputChain);
+
+            } else if ("DER".equalsIgnoreCase(inputFormat)) {
+
+                X509CertImpl cert = new X509CertImpl(bytes);
+                logger.info(" - " + cert.getSubjectDN());
+
+                certChain.addCertificate(cert);
+
+            } else {
+                throw new Exception("Unsupported format: " + inputFormat);
+            }
+        }
+
+        logger.info("Storing certificates into " + path);
+        PKCS7 pkcs7 = certChain.toPKCS7();
+
+        for (X509Certificate cert : pkcs7.getCertificates()) {
+            logger.info("- " + cert.getSubjectDN());
+        }
+
+        try (PrintWriter os = new PrintWriter(path.toFile())) {
+            os.print(pkcs7.toPEMString());
+        }
+    }
+}

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7ExportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7ExportCLI.java
@@ -1,0 +1,86 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.pkcs7;
+
+import java.io.PrintWriter;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.KeyManagerFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CommandCLI;
+import org.mozilla.jss.netscape.security.pkcs.PKCS7;
+import org.mozilla.jss.netscape.security.x509.CertificateChain;
+import org.mozilla.jss.provider.javax.crypto.JSSKeyManager;
+
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKCS7ExportCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKCS7ExportCLI.class);
+
+    public PKCS7CLI pkcs7CLI;
+
+    public PKCS7ExportCLI(PKCS7CLI pkcs7CLI) {
+        super("export", "Export PKCS #7 file from NSS database", pkcs7CLI);
+        this.pkcs7CLI = pkcs7CLI;
+    }
+
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <nickname>", options);
+    }
+
+    public void createOptions() {
+        Option option = new Option(null, "pkcs7", true, "PKCS #7 file");
+        option.setArgName("path");
+        options.addOption(option);
+    }
+
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+        if (cmdArgs.length == 0) {
+            throw new Exception("Missing certificate nickname");
+        }
+
+        String nickname = cmdArgs[0];
+
+        String filename = cmd.getOptionValue("pkcs7");
+        if (filename == null) {
+            throw new Exception("Missing PKCS #7 file");
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        logger.info("Loading certificate chain from NSS database");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("NssX509", "Mozilla-JSS");
+        JSSKeyManager km = (JSSKeyManager) kmf.getKeyManagers()[0];
+
+        X509Certificate[] certs = km.getCertificateChain(nickname);
+        if (certs == null || certs.length == 0) {
+            throw new Exception("Certificate not found: " + nickname);
+        }
+
+        CertificateChain certChain = new CertificateChain(certs);
+        certChain.sort();
+
+        logger.info("Storing certificate chain into " + filename);
+        PKCS7 pkcs7 = certChain.toPKCS7();
+
+        for (X509Certificate cert : certChain.getCertificates()) {
+            logger.info("- " + cert.getSubjectDN());
+        }
+
+        try (PrintWriter out = new PrintWriter(filename)) {
+            out.print(pkcs7.toPEMString());
+        }
+    }
+}

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7ImportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs7/PKCS7ImportCLI.java
@@ -7,6 +7,7 @@ package com.netscape.cmstools.pkcs7;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.cert.X509Certificate;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -64,11 +65,17 @@ public class PKCS7ImportCLI extends CommandCLI {
         String filename = cmd.getOptionValue("pkcs7");
         if (filename == null) {
             filename = cmd.getOptionValue("input-file");
+            if (filename != null) {
+                logger.warn("The --input-file has been deprecated. Use --pkcs7 instead.");
+            }
         }
 
         String trustAttributes = cmd.getOptionValue("trust");
         if (trustAttributes == null) {
             trustAttributes = cmd.getOptionValue("trust-flags");
+            if (trustAttributes != null) {
+                logger.warn("The --trust-flags has been deprecated. Use --trust instead.");
+            }
         }
 
         String input;
@@ -85,6 +92,10 @@ public class PKCS7ImportCLI extends CommandCLI {
         mainCLI.init();
 
         PKCS7 pkcs7 = new PKCS7(input);
+        for (X509Certificate cert : pkcs7.getCertificates()) {
+            logger.info("- " + cert.getSubjectDN());
+        }
+
         CryptoUtil.importPKCS7(pkcs7, nickname, trustAttributes);
     }
 }

--- a/docs/user/tools/Using-PKI-PKCS7-CLI.adoc
+++ b/docs/user/tools/Using-PKI-PKCS7-CLI.adoc
@@ -1,0 +1,72 @@
+= Using PKI PKCS7 CLI =
+
+== Importing Certificate Chain into NSS Database ==
+
+To import a PKCS #7 file that contains a certificate chain into NSS database (default: `~/.dogtag/nssdb`):
+
+----
+$ pki pkcs7-import --pkcs7 cert_chain.p7b
+----
+
+Optionally, the nickname and the trust flags for the leaf certificate can be specified as follows:
+
+----
+$ pki pkcs7-import --pkcs7 cert_chain.p7b --trust-flags <trust flags> <nickname>
+----
+
+== Exporting Certificate Chain from NSS Database ==
+
+To export a certificate chain from NSS database into a PKCS #7 file:
+
+----
+$ pki pkcs7-export <nickname> --pkcs7 cert_chain.p7b
+----
+
+== Listing Certificates in PKCS #7 File ==
+
+To list the certificates in a PKCS #7 file:
+
+----
+$ pki pkcs7-cert-find --pkcs7 cert_chain.p7b
+  Serial Number: 0x1
+  Subject DN: CN=CA Signing Certificate,O=EXAMPLE
+  Issuer DN: CN=CA Signing Certificate,O=EXAMPLE
+
+  Serial Number: 0x5
+  Subject DN: CN=localhost.localdomain
+  Issuer DN: CN=CA Signing Certificate,O=EXAMPLE
+----
+
+== Importing Certificates into PKCS #7 File ==
+
+To import a certificate into a new PKCS #7 file:
+
+----
+$ pki pkcs7-cert-import --pkcs7 cert_chain.p7b --input-file ca_signing.crt
+----
+
+To append a certificate into an existing PKCS #7 file:
+
+----
+$ pki pkcs7-cert-import --pkcs7 cert_chain.p7b --input-file sslserver.crt --append
+----
+
+*Note:* The `pki pkcs7-cert-import` command can import a file that contains
+a single PEM certificate, multiple PEM certificates, or PKCS #7 data.
+
+== Exporting Certificates from PKCS #7 File ==
+
+To export certificates from a PKCS #7 file into a series of PEM certificates
+in a single file:
+
+----
+$ pki pkcs7-cert-export --pkcs7 cert_chain.p7b --output-file cert_chain.crt
+----
+
+To export certificates from a PKCS #7 file into PEM certificates in separate files:
+
+----
+$ pki pkcs7-cert-export --pkcs7 cert_chain.p7b --output-prefix cert- --output-suffix .crt
+Exported cert-0.crt: CN=CA Signing Certificate,O=EXAMPLE
+Exported cert-1.crt: CN=localhost.localdomain
+----


### PR DESCRIPTION
This PR is updating the `pki pkcs7` commands to support convertions between a series of PEM certificates and PKCS #7 data.
Some tests and doc have been added.

Doc: https://github.com/edewata/pki/blob/pkcs7/docs/user/tools/Using-PKI-PKCS7-CLI.adoc
