### PR TITLE
cert-fix: avoid crash on missing CS.cfg param

### DIFF
--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -1295,6 +1295,13 @@ class CertFixCLI(pki.cli.CLI):
 def suppress_selftest(subsystems):
     """Suppress selftests in the given subsystems."""
     for subsystem in subsystems:
+        # Log a warning if no startup tests are configured
+        if len(subsystem.get_startup_tests()) == 0:
+            logger.warning(
+                'No selftests configured in %s (selftests.container.order.startup).',
+                subsystem.cs_conf
+            )
+
         subsystem.set_startup_test_criticality(False)
         subsystem.save()
     logger.info(

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -713,7 +713,13 @@ class PKISubsystem(object):
 
     def get_startup_tests(self):
         # Split the line 'selftest.container.selftests.startup'
-        available_tests = self.config['selftests.container.order.startup'].split(',')
+        v = self.config.get('selftests.container.order.startup', '').strip()
+        if len(v) == 0:
+            # special case; empty value -> empty list
+            available_tests = []
+        else:
+            available_tests = v.split(',')
+
         target_tests = {}
         for testInfo in available_tests:
             temp = testInfo.split(':')


### PR DESCRIPTION
`pki-server cert-fix` reads (and writes) the CS.cfg parameter
`selftests.container.order.startup`.  If this parameter is missing,
the resulting `KeyError` crashes the program.  We have seen several
cases where this parameter is missing, and its absense is otherwise
benign.

Update the relevant subroutine to avoid a crash in the case where
the `selftests.container.order.startup` parameter is missing.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1930586