### PR TITLE
1917539 Server-side-keygen job broke in pki-core gating [id: 9456]

### DIFF
--- a/base/ca/src/com/netscape/cms/profile/def/ServerKeygenUserKeyDefault.java
+++ b/base/ca/src/com/netscape/cms/profile/def/ServerKeygenUserKeyDefault.java
@@ -318,7 +318,7 @@ public class ServerKeygenUserKeyDefault extends EnrollDefault {
                 boolean useOAEP = caCfg.getBoolean("keyWrap.useOAEP",false);
 
                 KeyWrapAlgorithm wrapAlgorithm = KeyWrapAlgorithm.RSA;
-                if(useOAEP == false) {
+                if(useOAEP == true) {
                     wrapAlgorithm = KeyWrapAlgorithm.RSA_OAEP;
                 }
 


### PR DESCRIPTION
This patch fixes an error in ServerKeygenUserKeyDefault.java where
userOAEP is erronously enabled regardless of the CS.cfg config setting
for keyWrap.useOAEP

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1917539