### PR TITLE
Resolve XSS in ca queryCert pagination

### DIFF
--- a/base/ca/shared/webapps/ca/ee/ca/queryCert.template
+++ b/base/ca/shared/webapps/ca/ee/ca/queryCert.template
@@ -390,6 +390,27 @@ function renderHidden(name,value)
 	return 	"<INPUT TYPE='hidden' NAME='"+ name +"' VALUE=''>\n";
 }
 
+function renderHiddenElement(name, value)
+{
+    var result = document.createElement("input");
+    result.type = 'hidden';
+    result.name = name;
+    result.value = value ? value : '';
+    return result;
+}
+
+function renderNextButtonElement(name, label, disabled)
+{
+    var result = document.createElement("button");
+    result.name = name;
+    result.value = label;
+    result.innerText = label;
+    result.width = 72;
+    result.disabled = disabled ? true : false;
+    result.onClick = () => doNext(result);
+    return result;
+}
+
 function doNext(element)
 {
 	var form = element.form;
@@ -428,48 +449,45 @@ function doNext(element)
 
 function displayNextForm()
 {
-	document.write(
-//"<div align=center> \n"+
-"<FORM NAME ='nextForm' METHOD=POST ACTION=''>\n"+
-renderHidden("op"));
+    var nextForm = document.createElement("form");
+    nextForm.name = 'nextForm';
+    nextForm.method = 'POST';
+    nextForm.action = '';
 
-if (result.header.revokeAll != null) {
-	document.write(renderHidden("revokeAll"));
-}
+    nextForm.appendChild(renderHiddenElement("op"));
 
-if (result.header.queryFilterHash != null) {
-    document.write(renderHidden("queryFilterHash"));
-}
+    if (result.header.revokeAll != null) {
+        nextForm.appendChild(renderHiddenElement("revokeAll"));
+    }
 
-var disabledDown = ((result.header.querySentinelDown == null) ||
-                    (result.fixed.maxCount+1 >= result.header.currentRecordCount)) ? "disabled='true'" : "";
-var disabledUp = (result.header.querySentinelUp != null && result.header.querySentinelUp <= 1) ? "disabled='true'" : "";
+    if (result.header.queryFilterHash != null) {
+        nextForm.appendChild(renderHiddenElement("queryFilterHash"));
+    }
 
-document.write(
-"<button NAME=begin onClick='doNext(this)' VALUE='|<<' width='72'>|&lt;&lt;</button>\n"+
-"<button "+disabledUp+" NAME=up onClick='doNext(this)' VALUE='<' width='72'>&lt;</button>\n"+
-"<INPUT TYPE=hidden NAME=totalRecordCount VALUE='"+
-result.header.totalRecordCount+ "'>\n"+
-"<INPUT TYPE=hidden NAME=queryCertFilter VALUE='"+
-result.header.queryCertFilter+ "'>\n"+
-"<INPUT TYPE=hidden NAME=skipRevoked VALUE='"+
-(result.header.skipRevoked ? result.header.skipRevoked : "") + "'>\n"+
-"<INPUT TYPE=hidden NAME=skipNonValid VALUE='"+
-(result.header.skipNonValid ? result.header.skipNonValid : "") + "'>\n"+
-"<INPUT TYPE=hidden NAME=querySentinelDown VALUE='"+
-result.header.querySentinelDown+ "'>\n"+
-"<INPUT TYPE=hidden NAME=querySentinelUp VALUE='"+
-result.header.querySentinelUp+ "'>\n"+
-"<INPUT TYPE=hidden NAME=serialTo VALUE='"+
-result.header.serialTo+ "'>\n"+
-"<INPUT TYPE=hidden NAME=direction VALUE='"+
-result.header.direction+ "'>\n"+
-"<INPUT style='padding-left: 2px;' TYPE=text SIZE=16 NAME=maxCount VALUE='"+
-result.header.maxCount+ "'>\n"+
+    var disabledDown = ((result.header.querySentinelDown == null) ||
+                        (result.fixed.maxCount+1 >= result.header.currentRecordCount));
+    var disabledUp = (result.header.querySentinelUp != null && result.header.querySentinelUp <= 1);
 
-"<button "+disabledDown+" NAME=down onClick='doNext(this)' VALUE='>' width='72'>&gt;</button>\n"+
-"<button NAME=end onClick='doNext(this)' VALUE='>>|' width='72'>&gt;&gt;|</button>\n"+
-"</FORM>\n");
+    nextForm.appendChild(renderNextButtonElement("begin", "|<<"));
+    nextForm.appendChild(renderNextButtonElement("up", "<", disabledUp));
+
+    for (let element of ["totalRecordCount", "queryCertFilter", "skipRevoked", "skipNonValid", "querySentinelDown", "querySentinelUp", "serialTo", "direction"]) {
+        nextForm.appendChild(renderHiddenElement(element, result.header[element]));
+    }
+
+    var maxCount = document.createElement('input');
+    maxCount.style = 'padding-left: 2px;';
+    maxCount.type = 'text';
+    maxCount.size = '16';
+    maxCount.name = 'maxCount';
+    maxCount.value = result.header.maxCount;
+    nextForm.appendChild(maxCount);
+
+    nextForm.appendChild(renderNextButtonElement("down", ">", disabledDown));
+    nextForm.appendChild(renderNextButtonElement("end", ">>|"));
+
+    document.body.appendChild(nextForm);
+    return nextForm;
 }
 
 function doRevokeAll(form)

--- a/base/ca/src/com/netscape/cms/servlet/cert/ListCerts.java
+++ b/base/ca/src/com/netscape/cms/servlet/cert/ListCerts.java
@@ -532,9 +532,9 @@ public class ListCerts extends CMSServlet {
             logger.debug("ListCerts: no next record");
         }
 
-        header.addStringValue("op", req.getParameter("op"));
+        header.addStringValue("op", CMSTemplate.escapeJavaScriptString(req.getParameter("op")));
         if (revokeAll != null)
-            header.addStringValue("revokeAll", revokeAll);
+            header.addStringValue("revokeAll", CMSTemplate.escapeJavaScriptString(revokeAll));
 
         if (mAuthName != null)
             header.addStringValue("issuerName", mAuthName.toString());
@@ -546,10 +546,10 @@ public class ListCerts extends CMSServlet {
         header.addStringValue("queryCertFilter", filter);
 
         String skipRevoked = req.getParameter("skipRevoked");
-        header.addStringValue("skipRevoked", skipRevoked == null ? "" : skipRevoked);
+        header.addStringValue("skipRevoked", skipRevoked == null ? "" : (skipRevoked.equals("on") ? "on" : "off"));
 
         String skipNonValid = req.getParameter("skipNonValid");
-        header.addStringValue("skipNonValid", skipNonValid == null ? "" : skipNonValid);
+        header.addStringValue("skipNonValid", skipNonValid == null ? "" : (skipNonValid.equals("on") ? "on" : "off"));
 
         header.addStringValue("templateName", "queryCert");
         header.addStringValue("queryFilter", filter);
@@ -644,7 +644,7 @@ public class ListCerts extends CMSServlet {
         if (cert.getSubjectDN().toString().equals("")) {
             rarg.addStringValue("subject", " ");
         } else
-            rarg.addStringValue("subject", cert.getSubjectDN().toString());
+            rarg.addStringValue("subject", CMSTemplate.escapeJavaScriptString(cert.getSubjectDN().toString()));
 
         rarg.addStringValue("type", "X.509");
 
@@ -678,11 +678,11 @@ public class ListCerts extends CMSServlet {
 
         if (issuedBy == null)
             issuedBy = "";
-        rarg.addStringValue("issuedBy", issuedBy); // cert.getIssuerDN().toString()
+        rarg.addStringValue("issuedBy", CMSTemplate.escapeJavaScriptString(issuedBy)); // cert.getIssuerDN().toString()
         rarg.addLongValue("issuedOn", rec.getCreateTime().getTime() / 1000);
 
         rarg.addStringValue("revokedBy",
-                ((rec.getRevokedBy() == null) ? "" : rec.getRevokedBy()));
+                ((rec.getRevokedBy() == null) ? "" : CMSTemplate.escapeJavaScriptString(rec.getRevokedBy())));
         if (rec.getRevokedOn() == null) {
             rarg.addStringValue("revokedOn", null);
         } else {

--- a/base/server/src/com/netscape/cms/servlet/common/CMSTemplate.java
+++ b/base/server/src/com/netscape/cms/servlet/common/CMSTemplate.java
@@ -358,6 +358,10 @@ public class CMSTemplate extends CMSFile {
      */
 
     public static String escapeJavaScriptStringHTML(String v) {
+        if (v == null) {
+            return null;
+        }
+
         return StringEscapeUtils.escapeEcmaScript(StringEscapeUtils.escapeHtml4(v));
     }
 


### PR DESCRIPTION
Several values in ListCerts were reflected back to the caller, making a
reflected XSS attack possible. These values were sanitized and the
front-end template fixed to prevent this type of attack in general.

Resolves: CVE-2020-25715

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

This was [unembargoed today](https://access.redhat.com/security/cve/CVE-2020-25715); I'm pushing my patch for it upstream.