### PR TITLE
CVE-2021-20179: Fix renewal profile approval process - v10.9

### DIFF
--- a/base/ca/src/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/com/netscape/ca/CertificateAuthority.java
@@ -2962,6 +2962,16 @@ public class CertificateAuthority
         }
 
         ProfileSubsystem ps = engine.getProfileSubsystem();
+        /* NOTE: hard-coding the profile to use for Lightweight CA renewal
+         * might be OK, but caManualRenewal was not the right one to use.
+         * As a consequence, we have an undesirable special case in
+         * RenewalProcessor.processRenewal().
+         *
+         * We should introduce a new profile specifically for LWCA renewal,
+         * with an authenticator and ACLs to match the authz requirements
+         * for the renewAuthority REST resource itself.  Then we can use
+         * it here, and remove the workaround from RenewalProcessor.
+         */
         Profile profile = ps.getProfile("caManualRenewal");
         CertEnrollmentRequest req = CertEnrollmentRequestFactory.create(
             new ArgBlock(), profile, httpReq.getLocale());


### PR DESCRIPTION
Due to a recent change in PKI CLI, the CLI now passes along user
authentication with submissions to the renewal endpoint. Unlike the EE
pages, the REST API has passed along this authentication for a while.
Due to a bug in the `RenewalProcessor`, requests with credentials against
profiles with no authentication method and no ACLs result in the
certificiate automatically being approved. This occurs because, when
an earlier commit (cb9eb967b5e24f5fde8bbf8ae87aa615b7033db7) modified
the code to allow Light-Weight SubCAs to issue certificates, validation
wasn't done on the passed principal, to see if it was a trusted agent.
Because profiles requiring Agent approval have an empty ACL list (as, no
user should be able to submit a certificate request and have it
automatically signed without agent approval), authorize allows any user
to approve this request and thus accepts the AuthToken.

Critical analysis: the `RenewalProcessor` code interprets (`authToken`
`!= null`) as evidence that the authenticated user is _authorized_ to
immediately issue the certificate.  This mismatch of concerns (`authn`
vs `authz`) resulted in a misunderstanding of system behaviour.  The
"latent" `AuthToken` (from the HTTP request) was assigned to `authToken`
without realising that authorization needed to be performed.

We fix this by splitting the logic on whether the profile defines an
authenticator.  If so, we (re)authenticate and authorize the user
according to the profile configuration.

If the profile does not define an authenticator but there is a
principal in the HTTP request, if (and only if) the user has
permission to approve certificate requests *and* the requested
renewal profile is `caManualRenewal` (which is hardcoded to be used
for LWCA renewal), then we issue the certificate immediately.  This
special case ensures that LWCA renewal keeps working.

Otherwise, if there is no principal in the HTTP request or the
principal does not have permission to approve certificate requests,
we leave the authToken unset.  The resulting renewal request will be
created with status PENDING, i.e. enqueued for agent review.

```
Signed-off-by: Fraser Tweedale <ftweedal@redhat.com>
Signed-off-by: Alexander Scheel <ascheel@redhat.com>
```

--------

References: [CVE-2021-20179](https://access.redhat.com/security/cve/cve-2021-20179)
Resolves: [rh-bz#1914379](https://bugzilla.redhat.com/show_bug.cgi?id=1914379)