### PR TITLE
Remove i686 builds in the future

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -31,6 +31,14 @@ Source: https://github.com/dogtagpki/pki/archive/v%{version}%{?_phase}/pki-%{ver
 #     > pki-VERSION-RELEASE.patch
 # Patch: pki-VERSION-RELEASE.patch
 
+# md2man isn't available on i686. Additionally, we aren't generally multi-lib
+# compatible (https://fedoraproject.org/wiki/Packaging:Java)
+# so dropping i686 everywhere but RHEL-8 (which we've already shipped) seems
+# safest.
+%if ! 0%{?rhel} || 0%{?rhel} > 8
+ExcludeArch: i686
+%endif
+
 ################################################################################
 # NSS
 ################################################################################


### PR DESCRIPTION
For Fedora and RHEL-9, we probably should drop i686 builds. This is
partially due to the lack `md2man` (for converting our man pages) but also
due to the lack of multilib compatible Java packages. Best to ship
64-bit only packages then.

Discussed with Alexander Bokovoy in #freeipa.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`

---

@edewata: Does this approach look good? I've rebuild f34/rawhide with it. 