### PR TITLE
Consolidate ECC key pair usages masks

### DIFF
--- a/base/kra/src/com/netscape/kra/KeyRecoveryAuthority.java
+++ b/base/kra/src/com/netscape/kra/KeyRecoveryAuthority.java
@@ -1815,26 +1815,17 @@ public class KeyRecoveryAuthority implements IAuthority, IKeyService, IKeyRecove
 
         if (kpAlg == KeyPairAlgorithm.EC) {
 
-            boolean isECDHE = false;
             KeyPair pair = null;
 
-            // used with isECDHE == true
-            org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage usages_mask_ECDSA[] = {
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.DERIVE
-            };
-
-            // used with isECDHE == false
-            org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage usages_mask_ECDH[] = {
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN,
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN_RECOVER
-            };
-
             try {
-                pair = CryptoUtil.generateECCKeyPair(token,
-                    keyCurve /*ECC_curve default*/,
-                    null,
-                    (isECDHE==true) ? usages_mask_ECDSA: usages_mask_ECDH,
-                    tp /*temporary*/, sp? 1:0 /*sensitive*/, ep? 1:0 /*extractable*/);
+                pair = CryptoUtil.generateECCKeyPair(
+                        token,
+                        keyCurve /* ECC_curve default */,
+                        null,
+                        CryptoUtil.ECDH_USAGES_MASK,
+                        tp /* temporary */,
+                        sp ? 1 : 0 /* sensitive */,
+                        ep ? 1 : 0 /* extractable */);
                 logger.debug("NetkeyKeygenService: after key pair generation" );
             } catch (Exception e) {
                 logger.warn("NetkeyKeygenService: key pair generation with exception: " + e.getMessage(), e);

--- a/base/server/src/com/netscape/cms/servlet/csadmin/Configurator.java
+++ b/base/server/src/com/netscape/cms/servlet/csadmin/Configurator.java
@@ -360,23 +360,12 @@ public class Configurator {
         KeyPair pair = null;
         logger.info("Configurator: - type: " + ecType);
 
-        // ECDHE needs "SIGN" but no "DERIVE"
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage usages_mask[] = {
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.DERIVE
-        };
-
-        // ECDH needs "DERIVE" but no any kind of "SIGN"
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage ECDH_usages_mask[] = {
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN,
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN_RECOVER,
-        };
-
         do {
             if (tag.equals("sslserver") && ecType.equalsIgnoreCase("ECDH")) {
-                pair = CryptoUtil.generateECCKeyPair(token, curveName, null, ECDH_usages_mask);
+                pair = CryptoUtil.generateECCKeyPair(token, curveName, null, CryptoUtil.ECDH_USAGES_MASK);
 
             } else {
-                pair = CryptoUtil.generateECCKeyPair(token, curveName, null, usages_mask);
+                pair = CryptoUtil.generateECCKeyPair(token, curveName, null, CryptoUtil.ECDHE_USAGES_MASK);
             }
 
             // XXX - store curve , w

--- a/base/server/src/com/netscape/cmscore/security/JssSubsystem.java
+++ b/base/server/src/com/netscape/cmscore/security/JssSubsystem.java
@@ -972,22 +972,11 @@ public final class JssSubsystem implements ICryptoSubsystem {
 
         String ectype = getECType(certType);
 
-        // ECDHE needs "SIGN" but no "DERIVE"
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage usages_mask[] = {
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.DERIVE
-        };
-
-        // ECDH needs "DERIVE" but no any kind of "SIGN"
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage ECDH_usages_mask[] = {
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN,
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN_RECOVER,
-        };
-
         try {
             if (ectype.equals("ECDHE"))
-                pair = CryptoUtil.generateECCKeyPair(token, keyCurve, null, usages_mask);
+                pair = CryptoUtil.generateECCKeyPair(token, keyCurve, null, CryptoUtil.ECDHE_USAGES_MASK);
             else
-                pair = CryptoUtil.generateECCKeyPair(token, keyCurve, null, ECDH_usages_mask);
+                pair = CryptoUtil.generateECCKeyPair(token, keyCurve, null, CryptoUtil.ECDH_USAGES_MASK);
 
         } catch (NotInitializedException e) {
             logger.error("JssSubsystem: " + CMS.getLogMessage("CMSCORE_SECURITY_GET_ECC_KEY", e.toString()), e);

--- a/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
@@ -659,25 +659,18 @@ public class CRMFPopClient {
             boolean temporary,
             int sensitive,
             int extractable) throws Exception {
-        /*
-         * used with SSL server cert that does ECDH ECDSA
-         *  ** can only be used with POP_NONE **
-         */
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage[] usagesMaskECDH = {
-            org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN,
-            org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN_RECOVER
-        };
 
-        /* used for other certs including SSL server cert that does ECDHE ECDSA */
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage[] usagesMask = {
-            org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.DERIVE
-        };
+        // ECDH_USAGES_MASK: used with SSL server cert that does ECDH ECDSA;
+        // can only be used with POP_NONE
+
+        // ECDHE_USAGES_MASK: used for other certs including SSL server cert
+        // that does ECDHE ECDSA
 
         return CryptoUtil.generateECCKeyPair(
                 token,
                 curve,
                 null,
-                sslECDH ? usagesMaskECDH : usagesMask,
+                sslECDH ? CryptoUtil.ECDH_USAGES_MASK : CryptoUtil.ECDHE_USAGES_MASK,
                 temporary,
                 sensitive,
                 extractable);

--- a/base/tools/src/main/java/com/netscape/cmstools/PKCS10Client.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/PKCS10Client.java
@@ -235,21 +235,13 @@ public class PKCS10Client {
                 pair = CryptoUtil.generateRSAKeyPair(token, rsa_keylen);
 
             }  else if (alg.equals("ec")) {
-                // used with SSL server cert that does ECDH ECDSA
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage usages_mask_ECDH[] = {
-                    org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN,
-                    org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN_RECOVER
-                };
-
-                // used for other certs including SSL server cert that does ECDHE ECDSA
-                org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage usages_mask[] = {
-                  org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.DERIVE
-                };
 
                 pair = CryptoUtil.generateECCKeyPair(token, ecc_curve,
                        null,
-                       usages_mask, ec_temporary /*temporary*/,
-                       ec_sensitive /*sensitive*/, ec_extractable /*extractable*/);
+                       CryptoUtil.ECDHE_USAGES_MASK,
+                       ec_temporary,
+                       ec_sensitive,
+                       ec_extractable);
                 if (pair == null) {
                     System.out.println("PKCS10Client: pair null.");
                     System.exit(1);

--- a/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -181,6 +181,17 @@ public class CryptoUtil {
         SymmetricKey.Usage.DECRYPT
     };
 
+    // ECDHE needs SIGN but no DERIVE
+    public final static KeyPairGeneratorSpi.Usage[] ECDHE_USAGES_MASK = {
+            KeyPairGeneratorSpi.Usage.DERIVE
+    };
+
+    // ECDH needs DERIVE but no any kind of SIGN
+    public final static KeyPairGeneratorSpi.Usage[] ECDH_USAGES_MASK = {
+            KeyPairGeneratorSpi.Usage.SIGN,
+            KeyPairGeneratorSpi.Usage.SIGN_RECOVER,
+    };
+
     static public final Integer[] clientECCiphers = {
 /*
         SSLSocket.TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,


### PR DESCRIPTION
Previously the ECC key pair usages masks were defined
multiple times in various locations. They now have been
consolidated into `CryptoUtil`.