### PR TITLE
Remove redundant code in CryptoUtil.generateECCKeyPair()

### DIFF
--- a/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -672,8 +672,6 @@ public class CryptoUtil {
         KeyPairGenerator keygen = token.getKeyPairGenerator(alg);
 
         keygen.setKeyPairUsages(usage_ops, usage_mask);
-        keygen.initialize(keysize);
-        keygen.setKeyPairUsages(usage_ops, usage_mask);
 
         logger.info("CryptoUtil: - temporary: " + temporary);
         keygen.temporaryPairs(temporary);
@@ -748,7 +746,6 @@ public class CryptoUtil {
         KeyPairAlgorithm alg = KeyPairAlgorithm.EC;
         KeyPairGenerator keygen = token.getKeyPairGenerator(alg);
 
-        keygen.setKeyPairUsages(usage_ops, usage_mask);
         keygen.setKeyPairUsages(usage_ops, usage_mask);
 
         logger.info("CryptoUtil: - temporary: " + temporary);


### PR DESCRIPTION
Some redundant code in `CryptoUtil.generateECCKeyPair()`
has been removed. It was originally added in commit
db4f081db1ea6eb38c185b34b118ed73c6a2b67d.