### PR TITLE
Added exception handeling in performance tests

### DIFF
--- a/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_enrollment.py
+++ b/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_enrollment.py
@@ -114,12 +114,15 @@ def run_test(id, number_of_tests_per_thread):
     sn_uid = "testuser{}".format(id)
     # execute the specified number of tests sequentially
     for i in range(1, number_of_tests_per_thread + 1):
-        logger.info("Client %s: Enrolling cert %s of %s", id, i, number_of_tests_per_thread)
-        start = timer()
-        serial_num = cert_enroll(id, sn_uid)
-        end = timer()
-        issuance_times.append(end - start)
-        cert_list.append(serial_num.cert_serial_number)
+        try:
+            logger.info("Client %s: Enrolling cert %s of %s", id, i, number_of_tests_per_thread)
+            start = timer()
+            serial_num = cert_enroll(id, sn_uid)
+            end = timer()
+            issuance_times.append(end - start)
+            cert_list.append(serial_num.cert_serial_number)
+        except Exception as error:
+            logger.error(error)
     # call cert_enroll(sn_uid)
 
 

--- a/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_revocation.py
+++ b/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_revocation.py
@@ -51,12 +51,14 @@ cert_client = CertClient(connection)
 def run_test(cert_sn, number_of_tests_per_thread):
     # execute the specified number of tests
     for sn in range(number_of_tests_per_thread):
-        start = timer()
-        revoke_data = cert_client.revoke_cert(cert_sn[sn], revocation_reason='Key_Compromise')
-        end = timer()
-        revocation_times.append(int(end - start))
-        if revoke_data.operation_result != 'success':
-            raise Exception("Cert enrollment failed : {}".format(revoke_data.request_id))
+        try:
+            start = timer()
+            log.info("Revoking Cert : {}".format(cert_sn[sn]))
+            revoke_data = cert_client.revoke_cert(cert_sn[sn], revocation_reason='Key_Compromise')
+            end = timer()
+            revocation_times.append(int(end - start))
+        except Exception as error:
+            log.error(error)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If there is a single exception in a request, the code throws it and exits the thread.
We do not want thread to be broken on exception in a single request,  as there are 1Lk certs we would like to enrol in single thread.

Added logging instead of throwing exception.

Signed-off-by: Shalini Khandelwal <skhandel@redhat.com>