### PR TITLE
Fix PKCS10Client -x parameter

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/PKCS10Client.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/PKCS10Client.java
@@ -238,7 +238,7 @@ public class PKCS10Client {
 
                 pair = CryptoUtil.generateECCKeyPair(token, ecc_curve,
                        null,
-                       CryptoUtil.ECDHE_USAGES_MASK,
+                       ec_ssl_ecdh ? CryptoUtil.ECDH_USAGES_MASK : CryptoUtil.ECDHE_USAGES_MASK,
                        ec_temporary,
                        ec_sensitive,
                        ec_extractable);


### PR DESCRIPTION
Previously the `-x` parameter in `PKCS10Client` was parsed into
`ec_ssl_ecdh` variable but the variable was never used. The code
has been modified to use the variable to select the key usage mask
when generating an EC key.