### PR TITLE
Update docs for deploying ACME with DS on OpenShift

### DIFF
--- a/base/acme/openshift/pki-acme-database.yaml
+++ b/base/acme/openshift/pki-acme-database.yaml
@@ -4,7 +4,30 @@ type: Opaque
 metadata:
   name: pki-acme-database
 stringData:
+  # In-Memory Database
+  # ------------------
   class: org.dogtagpki.acme.database.InMemoryDatabase
+  #
+  # DS Database
+  # -----------
+  # class: org.dogtagpki.acme.database.DSDatabase
+  # url: ldap://ds:389
+  # authType: BasicAuth
+  # bindDN: cn=Directory Manager
+  # bindPassword: Secret.123
+  # baseDN: dc=acme,dc=pki,dc=example,dc=com
+  #
+  # OpenLDAP Database
+  # -----------------
+  # class: org.dogtagpki.acme.database.OpenLDAPDatabase
+  # url: ldap://openldap:389
+  # authType: BasicAuth
+  # bindDN: cn=Manager,dc=example,dc=com
+  # bindPassword: Secret.123
+  # baseDN: dc=acme,dc=pki,dc=example,dc=com
+  #
+  # PostgreSQL Database
+  # -------------------
   # class: org.dogtagpki.acme.database.PostgreSQLDatabase
   # password: Secret.123
   # url: jdbc:postgresql://postgresql:5432/acme

--- a/base/acme/openshift/pki-acme-issuer.yaml
+++ b/base/acme/openshift/pki-acme-issuer.yaml
@@ -4,4 +4,14 @@ type: Opaque
 metadata:
   name: pki-acme-issuer
 stringData:
+  # NSS Issuer
+  # ----------
   class: org.dogtagpki.acme.issuer.NSSIssuer
+  #
+  # PKI Issuer
+  # ----------
+  # class: org.dogtagpki.acme.issuer.PKIIssuer
+  # url: https://pki-ca:8443
+  # profile: acmeServerCert
+  # username: caadmin
+  # password: Secret.123

--- a/base/acme/openshift/pki-acme-realm.yaml
+++ b/base/acme/openshift/pki-acme-realm.yaml
@@ -4,7 +4,22 @@ type: Opaque
 metadata:
   name: pki-acme-realm
 stringData:
+  # In-Memory Realm
+  # ---------------
   class: org.dogtagpki.acme.realm.InMemoryRealm
+  #
+  # DS Realm
+  # --------
+  # class: org.dogtagpki.acme.realm.DSRealm
+  # url: ldap://ds:389
+  # authType: BasicAuth
+  # bindDN: cn=Directory Manager
+  # bindPassword: Secret.123
+  # usersDN: ou=people,dc=acme,dc=pki,dc=example,dc=com
+  # groupsDN: ou=groups,dc=acme,dc=pki,dc=example,dc=com
+  #
+  # PostgreSQL Realm
+  # ----------------
   # class: org.dogtagpki.acme.realm.PostgreSQLRealm
   # password: Secret.123
   # url: jdbc:postgresql://postgresql:5432/acme

--- a/docs/installation/acme/Configuring-ACME-with-DS-Database.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-DS-Database.adoc
@@ -1,0 +1,95 @@
+# Configuring ACME with DS Database
+
+## Overview
+
+This document describes the process to configure ACME responder to use a DS database.
+It assumes that the DS database has been installed as described in
+link:https://github.com/dogtagpki/pki/wiki/DS-Installation[DS Installation].
+
+## Initializing DS Database
+
+First, add the ACME DS schema by importing
+link:../../../base/acme/database/ds/schema.ldif[/usr/share/pki/acme/database/ds/schema.ldif] with the following command:
+
+----
+$ ldapmodify -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/schema.ldif
+----
+
+Next, create the ACME DS indexes by importing
+link:../../../base/acme/database/ds/index.ldif[/usr/share/pki/acme/database/ds/index.ldif] with the following command:
+
+----
+$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/index.ldif
+----
+
+**Note:** By default the `index.ldif` will use `userroot` as the DS backend.
+
+If necessary, the database can be reindexed by importing
+link:../../../base/acme/database/ds/indextask.ldif[/usr/share/pki/acme/database/ds/indextask.ldif] with the following command:
+
+----
+$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/indextask.ldif
+----
+
+The progress of the reindex task can be monitored with the following command:
+
+----
+$ ldapsearch -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -b "cn=acme,cn=index,cn=tasks,cn=config"
+----
+
+Once the indexes are ready, create the ACME subtree by importing
+link:../../../base/acme/database/ds/create.ldif[/usr/share/pki/acme/database/ds/create.ldif] with the following command:
+
+----
+$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/create.ldif
+----
+
+**Note:** By default the `create.ldif` will create the subtree under `dc=pki,dc=example,dc=com` which is mapped to `userroot` DS backend.
+
+## Configuring ACME Database
+
+A sample database configuration is available at
+link:../../../base/acme/database/ds/database.conf[/usr/share/pki/acme/database/ds/database.conf].
+
+To use the DS database, copy the sample `database.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+or execute the following command to customize some of the parameters:
+
+----
+$ pki-server acme-database-mod --type ds \
+    -DbindPassword=Secret.123
+----
+
+Customize the database configuration as needed. In a standalone ACME deployment, the `database.conf` should look like the following:
+
+----
+class=org.dogtagpki.acme.database.DSDatabase
+url=ldap://<hostname>:389
+authType=BasicAuth
+bindDN=cn=Directory Manager
+bindPassword=Secret.123
+baseDN=dc=acme,dc=pki,dc=example,dc=com
+----
+
+In a shared CA and ACME deployment, the `database.conf` should look like the following:
+
+----
+class=org.dogtagpki.acme.database.DSDatabase
+configFile=conf/ca/CS.cfg
+baseDN=dc=acme,dc=pki,dc=example,dc=com
+----
+
+The DS database provides an ACME configuration monitor using search persistence.
+It can be enabled with the following parameter:
+
+----
+monitor.enabled=true
+----
+
+## See Also
+
+* link:Configuring_ACME_Database.md[Configuring ACME Database]

--- a/docs/installation/acme/Configuring-ACME-with-DS-Realm.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-DS-Realm.adoc
@@ -1,0 +1,56 @@
+# Configuring ACME with DS Realm
+
+## Overview
+
+This document describes the process to configure ACME responder to use a DS database for authentication realm.
+It assumes that the DS database has been installed as described in
+link:https://github.com/dogtagpki/pki/wiki/DS-Installation[DS Installation].
+
+## Initializing DS Realm
+
+Prepare subtrees for ACME users and groups in DS.
+A sample LDIF file is available at link:../../../base/acme/realm/ds/create.ldif[/usr/share/pki/acme/realm/ds/create.ldif].
+This example uses `dc=acme,dc=pki,dc=example,dc=com` as the base DN.
+Import the file with the following command:
+
+----
+$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/realm/ds/create.ldif
+----
+
+A sample realm configuration is available at
+link:../../../base/acme/realm/ds/realm.conf[/usr/share/pki/acme/realm/ds/realm.conf].
+
+To use the DS realm, copy the sample `realm.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+or execute the following command to customize some of the parameters:
+
+----
+$ pki-server acme-realm-mod --type ds \
+    -DbindPassword=Secret.123
+----
+
+Customize the realm configuration as needed. In a standalone ACME deployment, the `realm.conf` should look like the following:
+
+----
+class=org.dogtagpki.acme.realm.DSRealm
+url=ldap://<hostname>:389
+authType=BasicAuth
+bindDN=cn=Directory Manager
+bindPassword=Secret.123
+usersDN=ou=people,dc=acme,dc=pki,dc=example,dc=com
+groupsDN=ou=groups,dc=acme,dc=pki,dc=example,dc=com
+----
+
+In a shared CA and ACME deployment, the `realm.conf` should look like the following:
+
+----
+class=org.dogtagpki.acme.realm.DSRealm
+configFile=conf/ca/CS.cfg
+usersDN=ou=people,dc=ca,dc=pki,dc=example,dc=com
+groupsDN=ou=groups,dc=ca,dc=pki,dc=example,dc=com
+----
+
+## See Also
+
+* link:Configuring_ACME_Realm.md[Configuring ACME Realm]
+* link:../../admin/acme/Managing_DS_Realm.adoc[Managing DS Realm]

--- a/docs/installation/acme/Configuring_ACME_Database.md
+++ b/docs/installation/acme/Configuring_ACME_Database.md
@@ -45,7 +45,7 @@ when retrieving or updating the ACME configuration properties,
 which may increase the load on the database.
 Some databases might provide an ACME configuration monitor to reduce the load on the database.
 
-## Configuring In-Memory Database
+## Configuring ACME with In-Memory Database
 
 The ACME responder can be configured with an in-memory database.
 
@@ -67,88 +67,12 @@ class=org.dogtagpki.acme.database.InMemoryDatabase
 
 There are no parameters to configure for in-memory database.
 
-## Configuring DS Database
+## Configuring ACME with DS Database
 
 The ACME responder can be configured with a DS database.
+See [Configuring ACME with DS Database](Configuring-ACME-with-DS-Database.adoc).
 
-First, add the ACME DS schema by importing [/usr/share/pki/acme/database/ds/schema.ldif](../../../base/acme/database/ds/schema.ldif) with the following command:
-
-```
-$ ldapmodify -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ds/schema.ldif
-```
-
-Next, create the ACME DS indexes by importing [/usr/share/pki/acme/database/ds/index.ldif](../../../base/acme/database/ds/index.ldif) with the following command:
-
-```
-$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ds/index.ldif
-```
-
-**Note:** By default the `index.ldif` will use `userroot` as the DS backend.
-
-If necessary, the database can be reindexed by importing [/usr/share/pki/acme/database/ds/indextask.ldif](../../../base/acme/database/ds/indextask.ldif) with the following command:
-
-```
-$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ds/indextask.ldif
-```
-
-The progress of the reindex task can be monitored with the following command:
-
-```
-$ ldapsearch -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -b "cn=acme,cn=index,cn=tasks,cn=config"
-```
-
-Once the indexes are ready, create the ACME subtree by importing
-[/usr/share/pki/acme/database/ds/create.ldif](../../../base/acme/database/ds/create.ldif) with the following command:
-
-```
-$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ds/create.ldif
-```
-
-**Note:** By default the `create.ldif` will create the subtree under `dc=pki,dc=example,dc=com` which is mapped to `userroot` DS backend.
-
-A sample DS database configuration is available at
-[/usr/share/pki/acme/database/ds/database.conf](../../../base/acme/database/ds/database.conf).
-
-To use the DS database, copy the sample database.conf into the /etc/pki/pki-tomcat/acme folder,
-or execute the following command to customize some of the parameters:
-
-```
-$ pki-server acme-database-mod --type ds \
-    -DbindPassword=Secret.123
-```
-
-Customize the configuration as needed. In a standalone ACME deployment, the database.conf should look like the following:
-
-```
-class=org.dogtagpki.acme.database.DSDatabase
-url=ldap://<hostname>:389
-authType=BasicAuth
-bindDN=cn=Directory Manager
-bindPassword=Secret.123
-baseDN=dc=acme,dc=pki,dc=example,dc=com
-```
-
-In a shared CA and ACME deployment, the database.conf should look like the following:
-
-```
-class=org.dogtagpki.acme.database.DSDatabase
-configFile=conf/ca/CS.cfg
-baseDN=dc=acme,dc=pki,dc=example,dc=com
-```
-
-The DS database provides an ACME configuration monitor using search persistence.
-It can be enabled with the following parameter:
-
-```
-monitor.enabled=true
-```
-
-## Configuring OpenLDAP Database
+## Configuring ACME with OpenLDAP Database
 
 The ACME responder can be configured with an OpenLDAP database.
 
@@ -191,7 +115,7 @@ bindPassword=Secret.123
 baseDN=dc=acme,dc=pki,dc=example,dc=com
 ```
 
-## Configuring PosgreSQL Database
+## Configuring ACME with PosgreSQL Database
 
 The ACME responder can be configured with a PostgreSQL database.
 

--- a/docs/installation/acme/Configuring_ACME_Realm.md
+++ b/docs/installation/acme/Configuring_ACME_Realm.md
@@ -41,7 +41,7 @@ Enter the base DN for the ACME groups subtree.
 If the command is invoked with `--type` parameter, it will create a new configuration based on the specified type.
 If the command is invoked with other parameters, it will update the specified parameters.
 
-## Configuring In-Memory Realm
+## Configuring ACME with In-Memory Realm
 
 The ACME responder can be configured with an in-memory realm.
 
@@ -63,53 +63,12 @@ username=admin
 password=Secret.123
 ```
 
-## Configuring DS Realm
+## Configuring ACME with DS Realm
 
 The ACME responder can be configured with a DS realm.
+See [Configuring ACME with DS Realm](Configuring-ACME-with-DS-Realm.adoc).
 
-Prepare subtrees for ACME users and groups in DS.
-A sample LDIF file is available at [/usr/share/pki/acme/realm/ds/create.ldif](../../../base/acme/realm/ds/create.ldif).
-This example uses dc=acme,dc=pki,dc=example,dc=com as the base DN.
-Import the file with the following command:
-
-```
-$ ldapadd -h $HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/realm/ds/create.ldif
-```
-
-A sample DS realm configuration is available at
-[/usr/share/pki/acme/realm/ds/realm.conf](../../../base/acme/realm/ds/realm.conf).
-
-To use the DS realm, copy the sample realm.conf into the /etc/pki/pki-tomcat/acme folder,
-or execute the following command to customize some of the parameters:
-
-```
-$ pki-server acme-realm-mod --type ds \
-    -DbindPassword=Secret.123
-```
-
-Customize the configuration as needed. In a standalone ACME deployment, the realm.conf should look like the following:
-
-```
-class=org.dogtagpki.acme.realm.DSRealm
-url=ldap://<hostname>:389
-authType=BasicAuth
-bindDN=cn=Directory Manager
-bindPassword=Secret.123
-usersDN=ou=people,dc=acme,dc=pki,dc=example,dc=com
-groupsDN=ou=groups,dc=acme,dc=pki,dc=example,dc=com
-```
-
-In a shared CA and ACME deployment, the realm.conf should look like the following:
-
-```
-class=org.dogtagpki.acme.realm.DSRealm
-configFile=conf/ca/CS.cfg
-usersDN=ou=people,dc=ca,dc=pki,dc=example,dc=com
-groupsDN=ou=groups,dc=ca,dc=pki,dc=example,dc=com
-```
-
-## Configuring PosgreSQL Realm
+## Configuring ACME with PosgreSQL Realm
 
 The ACME responder can be configured with a PostgreSQL realm.
 
@@ -144,5 +103,4 @@ password=Secret.123
 
 * [Configuring PKI ACME Responder](https://www.dogtagpki.org/wiki/Configuring_PKI_ACME_Responder)
 * [Installing PKI ACME Responder](Installing_PKI_ACME_Responder.md)
-* [Managing DS Realm](../../admin/acme/Managing_DS_Realm.adoc)
 * [Managing PostgreSQL Realm](../../admin/acme/Managing_PostgreSQL_Realm.adoc)

--- a/docs/installation/openshift/Deploying_PKI_ACME_Responder_on_OpenShift.md
+++ b/docs/installation/openshift/Deploying_PKI_ACME_Responder_on_OpenShift.md
@@ -106,7 +106,9 @@ $ oc new-app postgresql-persistent \
     -p POSTGRESQL_DATABASE=acme
 ```
 
-Next, configure the PKI ACME responder to use the permanent database.
+Next, configure the PKI ACME responder to use the permanent database
+as described in [Configuring ACME Database](../acme/Configuring_ACME_Database.md).
+
 A sample database configuration for PKI ACME responder is available at
 [/usr/share/pki/acme/openshift/pki-acme-database.yaml](../../../base/acme/openshift/pki-acme-database.yaml).
 
@@ -136,6 +138,9 @@ $ oc rsh <pod name> \
 ```
 
 ## Deploying Permanent Realm
+
+Deploy a permanent realm, then configure the PKI ACME responder to use the permanent realm
+as described in [Configuring ACME Realm](../acme/Configuring_ACME_Realm.md).
 
 A sample realm configuration for PKI ACME responder is available at
 [/usr/share/pki/acme/openshift/pki-acme-realm.yaml](../../../base/acme/openshift/pki-acme-realm.yaml).


### PR DESCRIPTION
This PR updates docs for deploying ACME responder with DS database and realm on OpenShift.

**Note:** The docs do not describe how to deploy DS container on OpenShift. That procedure should be available from DS docs. The docs assume that the DS container is already deployed and ready to use.

Deployment configs:
* https://github.com/edewata/pki/blob/acme/base/acme/openshift/pki-acme-database.yaml
* https://github.com/edewata/pki/blob/acme/base/acme/openshift/pki-acme-realm.yaml

Docs:
* https://github.com/edewata/pki/blob/acme/docs/installation/openshift/Deploying_PKI_ACME_Responder_on_OpenShift.md
* https://github.com/edewata/pki/blob/acme/docs/installation/acme/Configuring_ACME_Database.md
* https://github.com/edewata/pki/blob/acme/docs/installation/acme/Configuring-ACME-with-DS-Database.adoc
* https://github.com/edewata/pki/blob/acme/docs/installation/openshift/Deploying_PKI_ACME_Responder_on_OpenShift.md
* https://github.com/edewata/pki/blob/acme/docs/installation/acme/Configuring_ACME_Realm.md
* https://github.com/edewata/pki/blob/acme/docs/installation/acme/Configuring-ACME-with-DS-Realm.adoc
