### PR TITLE
Disabling allow failure on QE upstream pipeline

### DIFF
--- a/tests/dogtag/pytest-ansible/.gitlab-ci.yml
+++ b/tests/dogtag/pytest-ansible/.gitlab-ci.yml
@@ -19,7 +19,6 @@ stages:
   - triggers
   - web
   - schedules
-  allow_failure: true
   artifacts:
     paths:
     - $CI_PROJECT_DIR/*_junit.xml


### PR DESCRIPTION
Disabling allow_failure in ci yaml file. By default it's disabled by CI. 