### PR TITLE
bug1949656 CRMF requests with non-SKID extensions

### DIFF
--- a/base/server/cms/src/com/netscape/cms/profile/common/EnrollProfile.java
+++ b/base/server/cms/src/com/netscape/cms/profile/common/EnrollProfile.java
@@ -2286,7 +2286,7 @@ public abstract class EnrollProfile extends BasicProfile
                         ext = new SubjectKeyIdentifierExtension(false,
                                 jssext.getExtnValue().toByteArray());
                     } else {
-                        new Extension(oid, isCritical, extValue);
+                        ext = new Extension(oid, isCritical, extValue);
                     }
 
                     extensions.parseExtension(ext);


### PR DESCRIPTION
This patch address the issue where if a CRMF request bears any extension
other than SKID then it fails to process.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1949656