### PR TITLE
Fix cert file loading in CryptographyCryptoProvider

### DIFF
--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -365,7 +365,7 @@ class CryptographyCryptoProvider(CryptoProvider):
 
         if not isinstance(transport_cert, cryptography.x509.Certificate):
             # it's a file name
-            with open(transport_cert, 'r') as f:
+            with open(transport_cert, 'rb') as f:
                 transport_pem = f.read()
             transport_cert = cryptography.x509.load_pem_x509_certificate(
                 transport_pem,


### PR DESCRIPTION
As suggested by cheimes, the `CryptographyCryptoProvider`
has been modified to load the cert file as binary.

Resolves: https://github.com/dogtagpki/pki/issues/3499