### PR TITLE
Bug1952628 CRMF requests with non-SKID extensions

### DIFF
--- a/base/server/src/com/netscape/cms/profile/common/EnrollProfile.java
+++ b/base/server/src/com/netscape/cms/profile/common/EnrollProfile.java
@@ -2405,7 +2405,7 @@ public abstract class EnrollProfile extends Profile {
                         ext = new SubjectKeyIdentifierExtension(false,
                                 jssext.getExtnValue().toByteArray());
                     } else {
-                        new Extension(oid, isCritical, extValue);
+                        ext = new Extension(oid, isCritical, extValue);
                     }
 
                     extensions.parseExtension(ext);


### PR DESCRIPTION
This patch address the issue where if a CRMF request bears any extension
 other than SKID then it fails to process.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1952628