### PR TITLE
Fix: Bug 1942687 - TPS not populating Token Policy, or switching PIN_…

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
@@ -200,9 +200,13 @@ public class TPSTokendb {
 
     public void tdbAddTokenEntry(TokenRecord tokenRecord, TokenStatus status)
             throws Exception {
+
+        String method = "TPSTokendb.tdbAddTokenEntry: ";
         tokenRecord.setTokenStatus(status);
 
         tps.tokenDatabase.addRecord(tokenRecord.getId(), tokenRecord);
+
+        CMS.debug(method + "Added tokenRecord.");
     }
 
     public void tdbUpdateTokenEntry(TokenRecord tokenRecord)

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSPinResetProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSPinResetProcessor.java
@@ -121,13 +121,13 @@ public class TPSPinResetProcessor extends TPSProcessor {
                     TPSStatus.STATUS_ERROR_UNKNOWN_TOKEN);
         }
 
-        TPSTokenPolicy tokenPolicy = new TPSTokenPolicy(tps);
-
         fillTokenRecord(tokenRecord, appletInfo);
         session.setTokenRecord(tokenRecord);
 
         String cuid = appletInfo.getCUIDhexStringPlain();
         String tokenType = null;
+
+        TPSTokenPolicy tokenPolicy = new TPSTokenPolicy(tps,cuid);
 
         if(isExternalReg) {
             CMS.debug(method + " isExternalReg: ON");
@@ -309,7 +309,7 @@ public class TPSPinResetProcessor extends TPSProcessor {
 
         }
 
-        boolean pinResetAllowed = tokenPolicy.isAllowedPinReset(tokenRecord.getId());
+        boolean pinResetAllowed = tokenPolicy.isAllowedPinReset();
 
         CMS.debug(method + ": PinResetPolicy: Pin Reset Allowed:  " + pinResetAllowed);
         logMsg = method + " PinReset Policy forbids pin reset operation.";
@@ -362,6 +362,14 @@ public class TPSPinResetProcessor extends TPSProcessor {
             throw new TPSException(logMsg, TPSStatus.STATUS_ERROR_UPDATE_TOKENDB_FAILED);
         }
 
+        //If policy tells us to disallow pin reset after
+        //a successfull pin reset, do so.
+        //
+        if(tokenPolicy.isAllowedResetPinResetToNo()) {
+            tokenPolicy.setAllowedPinReset(false); 
+            tokenPolicy.updatePolicySet();
+            CMS.debug(method + ": Updating pin reset policy to NO.");
+        }
         CMS.debug(method + ": Token Pin successfully reset!");
 
     }

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSProcessor.java
@@ -1531,6 +1531,26 @@ public class TPSProcessor {
 
     }
 
+    protected void fillTokenRecordDefaultPolicy(TokenRecord tokenRecord) throws TPSException {
+
+        String method = "TPSProcessor.fillTokenRecordDefaultPolicy: ";
+ 
+        try {
+            IConfigStore configStore = CMS.getConfigStore();
+
+            String config = "tokendb.defaultPolicy";
+            String defaultPolicy = configStore.getString(config);
+
+            CMS.debug(method + " default token policy: " + defaultPolicy);
+
+            tokenRecord.setPolicy(defaultPolicy);
+        } catch (Exception e) {
+            CMS.debug(method + "Problem with  adding the default policy to the token.");
+            throw new TPSException(e.toString(),TPSStatus.STATUS_ERROR_MISCONFIGURATION);
+        }
+
+    }
+
     protected TokenRecord isTokenRecordPresent(AppletInfo appletInfo) throws TPSException {
 
         if (appletInfo == null) {
@@ -2353,6 +2373,7 @@ public class TPSProcessor {
             try {
                 tps.tdb.tdbAddTokenEntry(tokenRecord, TokenStatus.UNFORMATTED);
                 tps.tdb.tdbActivity(ActivityDatabase.OP_ADD, tokenRecord, session.getIpAddress(), logMsg, "success");
+                fillTokenRecordDefaultPolicy(tokenRecord);
                 CMS.debug("TPSProcessor.format: token added");
             } catch (Exception e) {
                 logMsg = logMsg + ":" + e.toString();


### PR DESCRIPTION
…RESET=YES to NO .

    Now the behavior will be the following:

    When a new token entry gets created in the token db, due to a token operation such
    as format or enrollment, the db entry will get populated with the contents of the
    CS.cfg value:
    ex:
    tokendb.defaultPolicy=RE_ENROLL=YES;RENEW=NO;FORCE_FORMAT=NO;PIN_RESET=NO;RESET_PIN_RESET_TO_NO=NO

    Now the value of RESET_PIN_RESET_TO_NO is actually observed.
    If this value is set to YES and pin reset is allowed, after a successful pin reset,
    the value of PIN_RESET will be set to NO, thus not allowing further pin resets on this
    token, until the value is manually changed in the token db entry.

    Also, the class itself has been simplified to allow the cuid token number at constructor
    time. Now if another token is desired , we must instantiate a new TPSTokenPolicy object for
    that additional token.