### PR TITLE
Replace deprecated java.awt.Dialog::{hide,show} with setVisible(boolean)

### DIFF
--- a/base/console/src/main/java/com/netscape/admin/certsrv/CMSAdmin.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/CMSAdmin.java
@@ -546,7 +546,7 @@ public class CMSAdmin extends AbstractServerObject
             // password-based authentication
             if (authType.equals("pwd")) {
                 CMSPassword d = new CMSPassword(mActiveFrame);
-                d.show();
+                d.setVisible(true);
                 if (d.isCancel())
                     return false;
                 mServerInfo = new CMSServerInfo(mHost, mPort, d.getUsername(),

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ACIDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ACIDialog.java
@@ -101,7 +101,7 @@ public class ACIDialog extends JDialog
     public void actionPerformed(ActionEvent evt) {
         if (evt.getSource().equals(mCancel)) {
             mDone = false;
-            this.hide();
+            this.setVisible(false);
         } else if (evt.getSource().equals(mOK)) {
             String acl = mACIText.getText().trim();
             Vector<String> v = parseExpressions(acl);
@@ -128,7 +128,7 @@ public class ACIDialog extends JDialog
 
             if (v.size() > 0 && allCorrect) {
                 mDone = true;
-                this.hide();
+                this.setVisible(false);
             } else {
                 String msg = mResource.getString(
                   PREFIX+"_DIALOG_INCORRECTSYNTAX_MESSAGE");
@@ -210,7 +210,7 @@ public class ACIDialog extends JDialog
             mACIText.setText(text);
         }
 
-        this.show();
+        this.setVisible(true);
     }
 
     public boolean getOK() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ACLEditDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ACLEditDialog.java
@@ -227,7 +227,7 @@ public class ACLEditDialog extends JDialog
     public void showDialog() {
         mEdit.setEnabled(false);
         mDelete.setEnabled(false);
-        this.show();
+        this.setVisible(true);
     }
 
     public void showDialog(NameValuePairs data) {
@@ -250,7 +250,7 @@ public class ACLEditDialog extends JDialog
         if (!mIsNew)
             mRightsText.setText(mOperations);
 
-        this.show();
+        this.setVisible(true);
     }
 
     private void setDisplay() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSAutoRecovery.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSAutoRecovery.java
@@ -207,7 +207,7 @@ public class CMSAutoRecovery extends JDialog implements ActionListener,
         gbm.setConstraints(action, gbc);
         getContentPane().add(action);
 
-        this.show();
+        this.setVisible(true);
     }
 
     private JPanel makeActionPane() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSBaseConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSBaseConfigDialog.java
@@ -366,7 +366,7 @@ public class CMSBaseConfigDialog extends JDialog
 		mPluginName.addMouseListener(this);
 		mPluginLabel.addMouseListener(this);
 
-        this.show();
+        this.setVisible(true);
     }
 
 	public String getDefaultInstanceName(String implName)

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSPasswordDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSPasswordDialog.java
@@ -176,7 +176,7 @@ public class CMSPasswordDialog extends JDialog
         mPassword="";
 
         setSize( WIDTH, HEIGHT );
-        this.show();
+        this.setVisible(true);
 
         /* Cancel if the window is closed */
         addWindowListener(

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CRLIPEditor.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CRLIPEditor.java
@@ -134,7 +134,7 @@ public class CRLIPEditor extends JDialog implements ActionListener {
 
         mEnableBox.setSelected(mEnable);
         enableCRLIP();
-        this.show();
+        this.setVisible(true);
     }
 
     public String getCRLName() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ConnectorEditor.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ConnectorEditor.java
@@ -262,7 +262,7 @@ public class ConnectorEditor extends JDialog implements ActionListener, MouseLis
         mEnableBox.setSelected(mEnable);
         enableConnector();
         //update(local);
-        this.show();
+        this.setVisible(true);
     }
 
     private void enableConnector() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/KeyCreateDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/KeyCreateDialog.java
@@ -17,17 +17,32 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.*;
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
+import java.awt.BorderLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.util.ResourceBundle;
 
-import javax.swing.event.*;
-import java.awt.event.*;
-import java.awt.*;
-import java.util.*;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
-import com.netscape.management.client.util.*;
-import com.netscape.certsrv.common.*;
+import com.netscape.admin.certsrv.CMSAdminResources;
+import com.netscape.admin.certsrv.CMSAdminUtil;
+import com.netscape.admin.certsrv.EAdminException;
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
+import com.netscape.certsrv.common.ScopeDef;
+import com.netscape.management.client.util.Debug;
 
 /**
  * Log Implementation Registration Editor
@@ -97,7 +112,7 @@ public class KeyCreateDialog extends JDialog
         //}
         mDestination=destination;
         mScope=scope;
-        this.show();
+        this.setVisible(true);
     }
 
     protected void setDestination(String destination) {
@@ -124,7 +139,7 @@ public class KeyCreateDialog extends JDialog
 
 	    if (evt.getSource().equals(mCancel)) {
             mIsOK = false;
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mOK)) {
@@ -154,7 +169,7 @@ public class KeyCreateDialog extends JDialog
                 return;
             }
             mIsOK = true;
-            this.hide();
+            this.setVisible(false);
         }
 	}
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/MNSchemeWizard.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/MNSchemeWizard.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.IWizardPanel;
+import com.netscape.admin.certsrv.wizard.WizardWidget;
 
 /**
  * Wizard for reconfiguring the Recovery MN Scheme
@@ -45,7 +47,7 @@ public class MNSchemeWizard extends WizardWidget {
         addPage(new WMNOldAgent());
         addPage(new WMNNewAgent());
         addPage(new WMNResultPage());
-        show();
+        setVisible(true);
     }
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/PanelMapperConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/PanelMapperConfigDialog.java
@@ -128,7 +128,7 @@ public class PanelMapperConfigDialog extends JDialog
         if (!refresh(name))
             return;
 
-        this.show();
+        this.setVisible(true);
     }
 
     public boolean isOK() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/PluginSelectionDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/PluginSelectionDialog.java
@@ -163,7 +163,7 @@ public class PluginSelectionDialog extends JDialog
             return;
         refresh();
         setArrowButtons();
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/PolicyRuleOrderDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/PolicyRuleOrderDialog.java
@@ -133,7 +133,7 @@ public class PolicyRuleOrderDialog extends JDialog
 
         refresh();
         setArrowButtons();
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileEditDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileEditDialog.java
@@ -771,7 +771,7 @@ public class ProfileEditDialog extends CMSBaseConfigDialog
         setProfileInfo(name);
         setProfileOtherInfo(name);
 
-        this.show();
+        this.setVisible(true);
     }
 
     private void setProfileInfo(String name) {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileNonPolicyNewDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileNonPolicyNewDialog.java
@@ -433,7 +433,7 @@ setLabelCellEditor(mTable, 1);
                  mDescField.setText(response.get("desc"));
 	    }
 
-        this.show();
+        this.setVisible(true);
     }
 
     protected void setLabelCellEditor(JTable table, int index) {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileNonPolicySelDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileNonPolicySelDialog.java
@@ -170,7 +170,7 @@ public class ProfileNonPolicySelDialog extends JDialog
 
         if(!update())
             return;
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicyEditDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicyEditDialog.java
@@ -678,7 +678,7 @@ public class ProfilePolicyEditDialog extends CMSBaseConfigDialog
          model.setInfo(d, colNames);
          mConstraintTable.setModel(model);
 
-        this.show();
+        this.setVisible(true);
     }
 
     protected void setLabelCellRenderer(JTable table, int index) {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicyNewDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicyNewDialog.java
@@ -655,7 +655,7 @@ public class ProfilePolicyNewDialog extends CMSBaseConfigDialog
           }
         }
 
-        this.show();
+        this.setVisible(true);
     }
 
     protected void setLabelCellEditor(JTable table, int index) {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicySelectionDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicySelectionDialog.java
@@ -189,7 +189,7 @@ public class ProfilePolicySelectionDialog extends JDialog
         refresh();
         setArrowButtons();
 */
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileRegisterDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileRegisterDialog.java
@@ -17,16 +17,31 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.*;
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import javax.swing.event.*;
-import java.awt.event.*;
-import java.awt.*;
-import java.util.*;
+import java.awt.BorderLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.util.ResourceBundle;
 
-import com.netscape.management.client.util.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import com.netscape.admin.certsrv.CMSAdminResources;
+import com.netscape.admin.certsrv.CMSAdminUtil;
+import com.netscape.admin.certsrv.EAdminException;
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
+import com.netscape.management.client.util.Debug;
 
 
 /**
@@ -96,7 +111,7 @@ public class ProfileRegisterDialog extends JDialog
         mDescField.setText("");
         mDestination=destination;
         mScope=scope;
-        this.show();
+        this.setVisible(true);
     }
 
     protected void setDestination(String destination) {
@@ -120,7 +135,7 @@ public class ProfileRegisterDialog extends JDialog
 
 	    if (evt.getSource().equals(mCancel)) {
             mIsOK = false;
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mOK)) {
@@ -150,7 +165,7 @@ public class ProfileRegisterDialog extends JDialog
                 return;
             }
             mIsOK = true;
-            this.hide();
+            this.setVisible(false);
         }
 	}
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/RegisterDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/RegisterDialog.java
@@ -17,16 +17,31 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.*;
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import javax.swing.event.*;
-import java.awt.event.*;
-import java.awt.*;
-import java.util.*;
+import java.awt.BorderLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.util.ResourceBundle;
 
-import com.netscape.management.client.util.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import com.netscape.admin.certsrv.CMSAdminResources;
+import com.netscape.admin.certsrv.CMSAdminUtil;
+import com.netscape.admin.certsrv.EAdminException;
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
+import com.netscape.management.client.util.Debug;
 
 /**
  * Registration Editor
@@ -86,7 +101,7 @@ public class RegisterDialog extends JDialog
         }
         mDestination=destination;
         mScope=scope;
-        this.show();
+        this.setVisible(true);
     }
 
     protected void setDestination(String destination) {
@@ -110,7 +125,7 @@ public class RegisterDialog extends JDialog
 
 	    if (evt.getSource().equals(mCancel)) {
             mIsOK = false;
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mOK)) {
@@ -140,7 +155,7 @@ public class RegisterDialog extends JDialog
                 return;
             }
             mIsOK = true;
-            this.hide();
+            this.setVisible(false);
         }
 	}
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ViewDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ViewDialog.java
@@ -85,7 +85,7 @@ public class ViewDialog extends JDialog
         mClassField.setText(classname);
         mTextArea.setText(CMSAdminUtil.wrapText(desc,50));
         mTextArea.setCaretPosition(0);
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================
@@ -95,7 +95,7 @@ public class ViewDialog extends JDialog
     //=== ACTIONLISTENER =====================
 	public void actionPerformed(ActionEvent evt) {
 	    if (evt.getSource().equals(mOK)) {
-	        this.hide();
+	        this.setVisible(false);
 	    }
 	}
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ViewSelfTestsDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ViewSelfTestsDialog.java
@@ -76,7 +76,7 @@ public class ViewSelfTestsDialog extends JDialog
         //initialize and setup
         mTextArea.setText( CMSAdminUtil.wrapText( desc, 80 ) );
         mTextArea.setCaretPosition( 0 );
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================
@@ -87,7 +87,7 @@ public class ViewSelfTestsDialog extends JDialog
     public void actionPerformed( ActionEvent evt )
     {
         if( evt.getSource().equals( mOK ) ) {
-            this.hide();
+            this.setVisible(false);
         }
     }
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/WarningDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/WarningDialog.java
@@ -67,7 +67,7 @@ public class WarningDialog extends JDialog
 
     public void actionPerformed(ActionEvent evt) {
         if (evt.getSource().equals(mClose)) {
-            this.hide();
+            this.setVisible(false);
             this.dispose();
         }
     }
@@ -108,7 +108,7 @@ public class WarningDialog extends JDialog
 
         getContentPane().add("Center",center);
 
-        this.show();
+        this.setVisible(true);
     }
 
     private JPanel makeActionPane() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/InstallWizard.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/InstallWizard.java
@@ -17,9 +17,14 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import java.awt.*;
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import java.awt.Cursor;
+
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.IWizardDone;
+import com.netscape.admin.certsrv.wizard.IWizardPanel;
+import com.netscape.admin.certsrv.wizard.WizardInfo;
+import com.netscape.admin.certsrv.wizard.WizardWidget;
 
 /**
  * Wizard for Installation wizard
@@ -166,7 +171,7 @@ public class InstallWizard extends WizardWidget implements Runnable {
         addPage(new WISingleSignonPage(this, parent));
         addPage(new WICertSetupStatusPage(this, parent));
 
-        show();
+        setVisible(true);
     }
 
     protected void callHelp() {
@@ -182,7 +187,7 @@ public class InstallWizard extends WizardWidget implements Runnable {
     }
 
     public void run() {
-        show();
+        setVisible(true);
     }
 
     public static void main(String[] args) {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/keycert/CertSetupWizard.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/keycert/CertSetupWizard.java
@@ -17,9 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.keycert;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.CMSBaseResourceModel;
+import com.netscape.admin.certsrv.wizard.IWizardPanel;
+import com.netscape.admin.certsrv.wizard.WizardWidget;
 
 /**
  * Wizard for Key and Certificate management
@@ -69,7 +71,7 @@ public class CertSetupWizard extends WizardWidget {
         addPage(new WPasteCertPage(this, frame));
         addPage(new WDisplayCertPage(this, frame));
         addPage(new WInstallStatusPage(this, frame));
-        show();
+        setVisible(true);
     }
 
     protected void callHelp() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/managecert/CertificateInfoDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/managecert/CertificateInfoDialog.java
@@ -104,7 +104,7 @@ public class CertificateInfoDialog extends JDialog
 			mStatusLbl.setText(statusStr);
 			changeLbl.setEnabled(false);
 		}
-        this.show();
+        this.setVisible(true);
     }
 
     public void showDialog(String name, String content, String trust,
@@ -117,7 +117,7 @@ public class CertificateInfoDialog extends JDialog
 
     public void actionPerformed(ActionEvent evt) {
         if (evt.getSource().equals(mClose)) {
-            this.hide();
+            this.setVisible(false);
             this.dispose();
         } else if (evt.getSource().equals(mActionBtn)) {
             String trustLbl = mActionBtn.getText().trim();

--- a/base/console/src/main/java/com/netscape/admin/certsrv/managecert/ManageCertDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/managecert/ManageCertDialog.java
@@ -84,7 +84,7 @@ public class ManageCertDialog extends JDialog implements ActionListener,
     public void showDialog(AdminConnection conn) {
         mConn = conn;
         refresh();
-        this.show();
+        this.setVisible(true);
     }
 
     private void refresh() {
@@ -246,7 +246,7 @@ public class ManageCertDialog extends JDialog implements ActionListener,
     public void actionPerformed(ActionEvent e) {
         Object source = e.getSource();
         if (source.equals(mClose)) {
-            this.hide();
+            this.setVisible(false);
             this.dispose();
         } else if (source.equals(mDelete)) {
             try {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/status/LogEntryViewDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/status/LogEntryViewDialog.java
@@ -88,7 +88,7 @@ public class LogEntryViewDialog extends JDialog
         mTime.setText(time);
         mTextArea.setText(desc);
         mTextArea.setCaretPosition(0);
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================
@@ -98,7 +98,7 @@ public class LogEntryViewDialog extends JDialog
     //=== ACTIONLISTENER =====================
 	public void actionPerformed(ActionEvent evt) {
 	    if (evt.getSource().equals(mOK)) {
-	        this.hide();
+	        this.setVisible(false);
 	    }
 	}
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/task/CMSMigrateCreate.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/task/CMSMigrateCreate.java
@@ -105,7 +105,7 @@ public class CMSMigrateCreate extends CGITask
 	    //show dialog
 	    CreateInstanceDialog dialog = new CreateInstanceDialog(mActiveFrame);
 	                  //  UtilConsoleGlobals.getActivatedFrame());
-	    dialog.show();
+	    dialog.setVisible(true);
 	    if (dialog.isCancel()) {
 	        return status;
 	    }

--- a/base/console/src/main/java/com/netscape/admin/certsrv/task/StatusDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/task/StatusDialog.java
@@ -84,7 +84,7 @@ public class StatusDialog extends JDialog
 	mDetails.setText("Details:");
         mTextArea.setText(desc);
         mTextArea.setCaretPosition(0);
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================
@@ -94,7 +94,7 @@ public class StatusDialog extends JDialog
     //=== ACTIONLISTENER =====================
 	public void actionPerformed(ActionEvent evt) {
 	    if (evt.getSource().equals(mOK)) {
-	        this.hide();
+	        this.setVisible(false);
 	    }
 	}
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/ug/AuthBaseDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/ug/AuthBaseDialog.java
@@ -148,7 +148,7 @@ public class AuthBaseDialog extends JDialog
             mAuthLabel.setText(name);
         }
 
-        this.show();
+        this.setVisible(true);
     }
 
     protected NameValuePairs getData() {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/ug/CertImportDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/ug/CertImportDialog.java
@@ -92,7 +92,7 @@ public class CertImportDialog extends JDialog
         //initialize and setup
         mTextArea.setText("");
         mIsOk = false;
-        this.show();
+        this.setVisible(true);
     }
 
     /**
@@ -123,7 +123,7 @@ public class CertImportDialog extends JDialog
         }
 
 	    if (evt.getSource().equals(mCancel)) {
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mOK)) {
@@ -131,7 +131,7 @@ public class CertImportDialog extends JDialog
             //set values
             mB64E = mTextArea.getText().trim();
             mIsOk = true;
-            this.hide();
+            this.setVisible(false);
         }
 	}
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/ug/CertManagementDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/ug/CertManagementDialog.java
@@ -125,7 +125,7 @@ public class CertManagementDialog extends JDialog
         if (!refresh())
             return;
         setButtons();
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/ug/CertViewDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/ug/CertViewDialog.java
@@ -92,7 +92,7 @@ public class CertViewDialog extends JDialog
         }
         mCertNameField.setText(certName);
         mTextArea.setText(pp);
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================
@@ -102,7 +102,7 @@ public class CertViewDialog extends JDialog
     //=== ACTIONLISTENER =====================
 	public void actionPerformed(ActionEvent evt) {
 	    if (evt.getSource().equals(mOK)) {
-	        this.hide();
+	        this.setVisible(false);
 	    }
 	}
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/ug/GroupEditor.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/ug/GroupEditor.java
@@ -159,7 +159,7 @@ public class GroupEditor extends JDialog
         }
 
         setButtons();
-        this.show();
+        this.setVisible(true);
     }
 
     /*==========================================================
@@ -205,14 +205,14 @@ public class GroupEditor extends JDialog
                 }
 
             }
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mCancel)) {
             Debug.println("Cancel Pressed");
 
             //display are you sure dialog
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mHelp)) {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/ug/GroupListDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/ug/GroupListDialog.java
@@ -116,7 +116,7 @@ public class GroupListDialog extends JDialog
             return;
         }
         mIsOk = false;
-        this.show();
+        this.setVisible(true);
     }
 
 
@@ -164,11 +164,11 @@ public class GroupListDialog extends JDialog
 
             //set return flag
             mIsOk = true;
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mCancel)) {
-            this.hide();
+            this.setVisible(false);
         }
     }
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/ug/UserEditor.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/ug/UserEditor.java
@@ -184,7 +184,7 @@ public class UserEditor extends JDialog
             return;
         }
         updateView();
-        this.show();
+        this.setVisible(true);
     }
 
     public boolean isUserAdded() {
@@ -245,14 +245,14 @@ public class UserEditor extends JDialog
                 }
 
             }
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mCancel)) {
             Debug.println("Cancel Pressed");
 
             //display are you sure dialog
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mHelp)) {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/ug/UserListDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/ug/UserListDialog.java
@@ -124,7 +124,7 @@ public class UserListDialog extends JDialog
         }
         setButtons();
         mIsOk = false;
-        this.show();
+        this.setVisible(true);
     }
 
 
@@ -161,11 +161,11 @@ public class UserListDialog extends JDialog
 
             //set return flag
             mIsOk = true;
-            this.hide();
+            this.setVisible(false);
         }
 
         if (evt.getSource().equals(mCancel)) {
-            this.hide();
+            this.setVisible(false);
         }
     }
 


### PR DESCRIPTION
These methods were deprecated in Java 1.5. They are overrides of methods
defined in java.awt.Component, which were themselves deprecated back in
Java 1.1! Some care required was required as we could change behaviour
if we defined a subclass of Dialog and override show() or hide(), but I
couldn't find any examples of this in the codebase so I think we're
fine.

Eclipse also did on-save replace of wildcard imports with explicit ones