### PR TITLE
acme: don't fail on resubmitted valid challenges

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEChallengeService.java
@@ -108,6 +108,9 @@ public class ACMEChallengeService {
             // avoid denial-of-service attacks via client-initiated retries, servers
             // SHOULD rate-limit such requests.
 
+	} else if (challengeStatus.equals("valid")) {
+		logger.info("Challenge is already valid");
+
         } else {
             // TODO: generate proper exception
             throw new Exception("Challenge is already " + challengeStatus);


### PR DESCRIPTION
Some acme clients, like cert-manager, happen to resubmit already valid challenges. This is not 100% in line with RFC8555, but it is
not a reason to throw Exception.

Fixes dogtagpki/pki/issues/3462