### PR TITLE
Restore pytest-ansible 2.2.3

### DIFF
--- a/tests/dogtag/pytest-ansible/requirements.txt
+++ b/tests/dogtag/pytest-ansible/requirements.txt
@@ -1,5 +1,5 @@
 ansible==2.9.13
-pytest-ansible
+pytest-ansible==2.2.3
 pytest-ansible-playbook
 pytest-logger
 pytest-autochecklog==0.2.0


### PR DESCRIPTION
Previously the `requirements.txt` was changed in commit a1afd9548bd241520d0ef3924fa57ef9569056be to remove the explicit version number for `pytest-ansible`. Since it's causing some problems the change is reverted.