### PR TITLE
Fix installation with HSM

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -174,6 +174,20 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             nssdb.close()
             shutil.rmtree(tmpdir)
 
+        # Reset the NSS database ownership and permissions
+        # after importing the permanent SSL server cert
+        # since it might create new files.
+        pki.util.chown(
+            deployer.mdict['pki_server_database_path'],
+            deployer.mdict['pki_uid'],
+            deployer.mdict['pki_gid'])
+        pki.util.chmod(
+            deployer.mdict['pki_server_database_path'],
+            config.PKI_DEPLOYMENT_DEFAULT_SECURITY_DATABASE_PERMISSIONS)
+        os.chmod(
+            deployer.mdict['pki_server_database_path'],
+            pki.server.DEFAULT_DIR_MODE)
+
     def spawn(self, deployer):
 
         external = deployer.configuration_file.external

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -105,6 +105,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 deployer.mdict['pki_hsm_modulename'],
                 deployer.mdict['pki_hsm_libfile'])
 
+        # Set the initial NSS database ownership and permissions.
         pki.util.chown(
             deployer.mdict['pki_server_database_path'],
             deployer.mdict['pki_uid'],


### PR DESCRIPTION
During installation with HSM the server is stopped to import the permanent SSL server cert into the NSS database. This operation creates new files in the NSS database directory with a wrong ownership and permissions, so the server fails to start again.

To fix the problem the NSS database ownership and permissions need to be reset after importing the permanent SSL server cert.