### PR TITLE
Clean up deployment loggers

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -65,7 +65,7 @@ if selinux.is_selinux_enabled():
         if sys.version_info.major == 2:
             raise
 
-logger = logging.getLogger('pkihelper')
+logger = logging.getLogger(__name__)
 
 
 class Identity:

--- a/base/server/python/pki/server/deployment/pkilogging.py
+++ b/base/server/python/pki/server/deployment/pkilogging.py
@@ -44,7 +44,7 @@ def log_format(given_dict):
 
 
 # PKI Deployment Logging Functions
-def enable_pki_logger(filename, name):
+def enable_pki_logger(filename):
 
     # Configure console handler
     console = logging.StreamHandler()
@@ -57,26 +57,6 @@ def enable_pki_logger(filename, name):
                                     '%Y-%m-%d %H:%M:%S')
     log_file.setFormatter(file_format)
 
-    # Configure PKI deployment loggers
-    modules = [
-        'pki',
-        'pkihelper',
-        'pkimanifest',
-        'pkiparser',
-        'initialization',
-        'infrastructure',
-        'instance',
-        'subsystem',
-        'webapp',
-        'nssdb',
-        'selinux',
-        'keygen',
-        'configuration',
-        'finalization',
-        name
-    ]
-
-    for module in modules:
-        logger = logging.getLogger(module)
-        logger.addHandler(console)
-        logger.addHandler(log_file)
+    logger = logging.getLogger('pki')
+    logger.addHandler(console)
+    logger.addHandler(log_file)

--- a/base/server/python/pki/server/deployment/pkimanifest.py
+++ b/base/server/python/pki/server/deployment/pkimanifest.py
@@ -27,7 +27,7 @@ import logging
 # PKI Deployment Imports
 from . import pkimessages as log
 
-logger = logging.getLogger('pkimanifest')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Manifest Constants

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -44,7 +44,7 @@ from . import pkiconfig as config
 from . import pkimessages as log
 from . import pkilogging
 
-logger = logging.getLogger('pkiparser')
+logger = logging.getLogger(__name__)
 
 
 class PKIConfigParser:

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -40,7 +40,7 @@ import pki.server.instance
 import pki.system
 import pki.util
 
-logger = logging.getLogger('configuration')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Configuration Scriptlet

--- a/base/server/python/pki/server/deployment/scriptlets/finalization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/finalization.py
@@ -26,7 +26,7 @@ from .. import pkiconfig as config
 from .. import pkimessages as log
 from .. import pkiscriptlet
 
-logger = logging.getLogger('finalization')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Finalization Scriptlet

--- a/base/server/python/pki/server/deployment/scriptlets/infrastructure_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/infrastructure_layout.py
@@ -27,7 +27,7 @@ from .. import pkiconfig as config
 from .. import pkiscriptlet
 import pki.util
 
-logger = logging.getLogger('infrastructure')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Top-Level Infrastructure Layout Scriptlet

--- a/base/server/python/pki/server/deployment/scriptlets/initialization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/initialization.py
@@ -30,7 +30,7 @@ from .. import pkiconfig as config
 from .. import pkimessages as log
 from .. import pkiscriptlet
 
-logger = logging.getLogger('initialization')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Initialization Scriptlet

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -31,7 +31,7 @@ import pki.util
 from .. import pkiconfig as config
 from .. import pkiscriptlet
 
-logger = logging.getLogger('instance')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Instance Layout Scriptlet

--- a/base/server/python/pki/server/deployment/scriptlets/keygen.py
+++ b/base/server/python/pki/server/deployment/scriptlets/keygen.py
@@ -33,7 +33,7 @@ import pki.util
 from .. import pkiconfig as config
 from .. import pkiscriptlet
 
-logger = logging.getLogger('keygen')
+logger = logging.getLogger(__name__)
 
 
 class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -34,7 +34,7 @@ import pki.util
 from .. import pkiconfig as config
 from .. import pkiscriptlet
 
-logger = logging.getLogger('nssdb')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Security Databases Scriptlet

--- a/base/server/python/pki/server/deployment/scriptlets/selinux_setup.py
+++ b/base/server/python/pki/server/deployment/scriptlets/selinux_setup.py
@@ -39,7 +39,7 @@ if selinux.is_selinux_enabled():
         if sys.version_info.major == 2:
             raise
 
-logger = logging.getLogger('selinux')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Selinux Setup Scriptlet

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -31,7 +31,7 @@ import pki.util
 from .. import pkiconfig as config
 from .. import pkiscriptlet
 
-logger = logging.getLogger('subsystem')
+logger = logging.getLogger(__name__)
 
 
 # PKI Deployment Subsystem Layout Scriptlet

--- a/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
+++ b/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
@@ -31,7 +31,7 @@ import pki.util
 from .. import pkiconfig as config
 from .. import pkiscriptlet
 
-logger = logging.getLogger('webapp')
+logger = logging.getLogger(__name__)
 
 
 # PKI Web Application Deployment Scriptlet

--- a/base/server/python/pki/server/pkidestroy.py
+++ b/base/server/python/pki/server/pkidestroy.py
@@ -36,7 +36,7 @@ from pki.server.deployment.pkiparser import PKIConfigParser
 from pki.server.deployment import pkilogging
 from pki.server.deployment import pkimessages as log
 
-logger = logging.getLogger('pkidestroy')
+logger = logging.getLogger(__name__)
 
 deployer = pki.server.deployment.PKIDeployer()
 
@@ -231,7 +231,7 @@ def main(argv):
     log_file = os.path.join(log_dir, log_name)
     print('Uninstallation log: %s' % log_file)
 
-    pkilogging.enable_pki_logger(log_file, 'pkidestroy')
+    pkilogging.enable_pki_logger(log_file)
 
     # Add force_destroy to master dictionary
     parser.mdict['pki_force_destroy'] = force_destroy

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -40,7 +40,7 @@ from pki.server.deployment.pkiparser import PKIConfigParser
 from pki.server.deployment import pkilogging
 from pki.server.deployment import pkimessages as log
 
-logger = logging.getLogger('pkispawn')
+logger = logging.getLogger(__name__)
 
 deployer = pki.server.deployment.PKIDeployer()
 
@@ -542,7 +542,7 @@ def main(argv):
     log_file = os.path.join(log_dir, log_name)
     print('Installation log: %s' % log_file)
 
-    pkilogging.enable_pki_logger(log_file, 'pkispawn')
+    pkilogging.enable_pki_logger(log_file)
 
     if not interactive and \
             not config.str2bool(parser.mdict['pki_skip_configuration']):


### PR DESCRIPTION
All loggers used for deployment have been changed to
use the module name such that they can be referred to
collectively as `pki`.