### PR TITLE
Bug 1925311 RFE Add a Boolean to Not Allow a CA Certificate Issued Pa…

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CAService.java
+++ b/base/ca/src/main/java/com/netscape/ca/CAService.java
@@ -697,18 +697,27 @@ public class CAService implements ICAService, IService {
             }
 
             if (end.after(caNotAfter)) {
+                logger.debug("CAService: issueX509Cert: notAfter past CA's NOT_AFTER");
                 if (!is_ca) {
                     if (!engine.getEnablePastCATime()) {
                         end = caNotAfter;
                         certi.set(CertificateValidity.NAME,
                                 new CertificateValidity(begin, caNotAfter));
-                        logger.debug("CAService: issueX509Cert: cert past CA's NOT_AFTER...ca.enablePastCATime != true...resetting");
+                        logger.debug("CAService: issueX509Cert: ca.enablePastCATime != true...resetting to match CA's notAfter");
                     } else {
-                        logger.debug("CAService: issueX509Cert: cert past CA's NOT_AFTER...ca.enablePastCATime = true...not resetting");
+                        logger.debug("CAService: issueX509Cert: ca.enablePastCATime = true...not resetting");
                     }
-                } else {
-                    logger.debug("CAService: issueX509Cert: CA cert issuance past CA's NOT_AFTER.");
-                } //!is_ca
+                } else { //is_ca
+                    logger.debug("CAService: issueX509Cert: request issuance of a ca signing cert");
+                    if (!engine.getEnablePastCATime_caCert()) {
+                        end = caNotAfter;
+                        certi.set(CertificateValidity.NAME,
+                                new CertificateValidity(begin, caNotAfter));
+                        logger.debug("CAService: issueX509Cert: ca.enablePastCATime_caCert != true...resetting to match CA's notAfter");
+                    } else {
+                        logger.debug("CAService: issueX509Cert: ca.enablePastCATime_caCert = true...not resetting");
+                    }
+                }
 
                 logger.info(CMS.getLogMessage("CMSCORE_CA_PAST_NOT_AFTER"));
             }

--- a/base/ca/src/main/java/com/netscape/cms/profile/def/CAValidityDefault.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/def/CAValidityDefault.java
@@ -193,7 +193,8 @@ public class CAValidityDefault extends EnrollDefault {
                             locale, "CMS_INVALID_PROPERTY", name));
             }
         } else if (name.equals(VAL_BYPASS_CA_NOTAFTER)) {
-            boolean bypassCAvalidity = Boolean.valueOf(value).booleanValue();
+            logger.debug("CAValidityDefault: setValue: " + value);
+            boolean bypassCAvalidity = getConfigBoolean(VAL_BYPASS_CA_NOTAFTER);
             logger.debug("CAValidityDefault: setValue: bypassCAvalidity=" + bypassCAvalidity);
 
             BasicConstraintsExtension ext = (BasicConstraintsExtension)

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -119,6 +119,7 @@ public class CAEngine extends CMSEngine implements ServletContextListener {
     protected CertificateVersion defaultCertVersion;
     protected long defaultCertValidity;
     protected boolean enablePastCATime;
+    protected boolean enablePastCATime_caCert;
     protected boolean enableOCSP;
 
     protected int fastSigning = CertificateAuthority.FASTSIGNING_DISABLED;
@@ -237,13 +238,23 @@ public class CAEngine extends CMSEngine implements ServletContextListener {
     }
 
     /**
-     * Is this CA allowed to issue certificate that has longer
-     * validty than the CA's.
+     * Is this CA allowed to issue non-ca certificates that have
+     * validty past the CA's own validity.
      *
      * @return true if allows certificates to have validity longer than CA's
      */
     public boolean getEnablePastCATime() {
         return enablePastCATime;
+    }
+
+    /**
+     * Is this CA allowed to issue CA certificate that have
+     * validty past the CA's own validity.
+     *
+     * @return true if allows CA certificates to have validity longer than CA's
+     */
+    public boolean getEnablePastCATime_caCert() {
+        return enablePastCATime_caCert;
     }
 
     public boolean getEnableOCSP() {
@@ -736,6 +747,9 @@ public class CAEngine extends CMSEngine implements ServletContextListener {
 
         enablePastCATime = caConfig.getBoolean(CertificateAuthority.PROP_ENABLE_PAST_CATIME, false);
         logger.info("CAEngine: - enable past CA time: " + enablePastCATime);
+
+        enablePastCATime_caCert = caConfig.getBoolean(CertificateAuthority.PROP_ENABLE_PAST_CATIME_CACERT, false);
+        logger.info("CAEngine: - enable past CA time for CA certs: " + enablePastCATime_caCert);
 
         enableOCSP = caConfig.getBoolean(CertificateAuthority.PROP_ENABLE_OCSP, true);
 

--- a/base/server/src/main/java/org/dogtagpki/server/ca/ICertificateAuthority.java
+++ b/base/server/src/main/java/org/dogtagpki/server/ca/ICertificateAuthority.java
@@ -70,6 +70,7 @@ public interface ICertificateAuthority extends ISubsystem {
 
     public final static String PROP_X509CERT_VERSION = "X509CertVersion";
     public final static String PROP_ENABLE_PAST_CATIME = "enablePastCATime";
+    public final static String PROP_ENABLE_PAST_CATIME_CACERT = "enablePastCATime_caCert";
     public final static String PROP_DEF_VALIDITY = "DefaultIssueValidity";
     public final static String PROP_FAST_SIGNING = "fastSigning";
     public static final String PROP_ENABLE_ADMIN_ENROLL =


### PR DESCRIPTION
…st Issuing CA's Validity

This RFE was to request for a boolean to disallow ca certs being issued past
the CA's own validity.  As it turns out, such a boolean does exist in
CAValidityDefault.java which is a profile default plugin that's used
by the profile caCACert.cfg.  The variable is called bypassCAnotafter.
When it's true, the requested ca signing cert is allowed  to past the
signing CA's notAfter, while if false (which is the default), the natAfter time
would be reset to match that of the signing CA's.
The problem is, as I found out during my investigation, there is a bug in
the plugin so it is always treated as false.  I have it fixed in this patch.
However, I think the reporter didn't use this profile default plugin, as
if so they would not have reported the issue;  I think the proper solution
should be a system-wide boolean in CS.cfg, although the additional one in
the plugin to allows for finer control.
I'm leaving the fix in CAValidityDefault.java to get some feedback from
the reviewer.
The new bolean in CS.cfg is called ca.enablePastCATime

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1925311