### PR TITLE
Updating the IMG_NAME to execute QE test on F33

### DIFF
--- a/tests/dogtag/pytest-ansible/.gitlab-ci.yml
+++ b/tests/dogtag/pytest-ansible/.gitlab-ci.yml
@@ -2,7 +2,7 @@ image: bbhavsar/dogtagpki-test-essentials-container
 
 variables:
   HOSTFILE: $CI_PROJECT_DIR/tests/dogtag/pytest-ansible/provision/ansible_inventory
-  IMG_NAME: 'Fedora-Cloud-Base-32'
+  IMG_NAME: 'Fedora-Cloud-Base-33'
   PYTEST_DIR: $CI_PROJECT_DIR/tests/dogtag/pytest-ansible
 
 stages:


### PR DESCRIPTION
Currently QE test are getting executed on Fedora 32 and updating that to execute test cases on Fedora 33