### PR TITLE
Drop pytest-runner dependency

### DIFF
--- a/base/server/healthcheck/setup.py
+++ b/base/server/healthcheck/setup.py
@@ -48,6 +48,4 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     python_requires='!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
 )

--- a/pki.spec
+++ b/pki.spec
@@ -216,10 +216,6 @@ BuildRequires:    python3-libselinux
 BuildRequires:    python3-requests >= 2.6.0
 BuildRequires:    python3-six
 
-%if 0%{?fedora} || 0%{?rhel} > 8
-BuildRequires:    python3-pytest-runner
-%endif
-
 BuildRequires:    junit
 BuildRequires:    jpackage-utils >= 0:1.7.5-10
 BuildRequires:    jss >= 4.9.0


### PR DESCRIPTION
The dependency on `pytest-runner` has been dropped since
it has been deprecated.

Resolves: #1961613