### PR TITLE
Replace deprecated PosixParser with DefaultParser

### DIFF
--- a/base/ca/src/test/java/com/netscape/cms/servlet/test/CATest.java
+++ b/base/ca/src/test/java/com/netscape/cms/servlet/test/CATest.java
@@ -22,10 +22,10 @@ import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.AlreadyInitializedException;
 import org.mozilla.jss.crypto.CryptoToken;
@@ -76,7 +76,7 @@ public class CATest {
         options.addOption("c", true, "Optional SSL Client cert Nickname");
 
         try {
-            CommandLineParser parser = new PosixParser();
+            CommandLineParser parser = new DefaultParser();
             CommandLine cmd = parser.parse(options, args);
 
             if (cmd.hasOption("h")) {

--- a/base/common/src/main/java/org/dogtagpki/cli/CLI.java
+++ b/base/common/src/main/java/org/dogtagpki/cli/CLI.java
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang3.StringUtils;
 
 import com.netscape.certsrv.client.ClientConfig;
@@ -44,7 +44,7 @@ public class CLI {
 
     public static boolean verbose;
 
-    public static CommandLineParser parser = new PosixParser();
+    public static CommandLineParser parser = new DefaultParser();
     public static HelpFormatter formatter = new HelpFormatter();
 
     public String name;

--- a/base/common/src/test/java/com/netscape/cms/servlet/test/ConfigurationTest.java
+++ b/base/common/src/test/java/com/netscape/cms/servlet/test/ConfigurationTest.java
@@ -28,10 +28,10 @@ import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.asn1.ASN1Util;
 import org.mozilla.jss.asn1.BIT_STRING;
@@ -92,7 +92,7 @@ public class ConfigurationTest {
         options.addOption("x", true, "Test number");
 
         try {
-            CommandLineParser parser = new PosixParser();
+            CommandLineParser parser = new DefaultParser();
             CommandLine cmd = parser.parse(options, args);
 
             if (cmd.hasOption("t")) {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/Console.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/Console.java
@@ -47,9 +47,9 @@ import javax.ws.rs.ProcessingException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.dogtagpki.common.Info;
 import org.dogtagpki.common.InfoClient;
@@ -1607,7 +1607,7 @@ public class Console implements CommClient {
         options.addOption(null, "debug", false, "Run in debug mode.");
         options.addOption("h", "help", false, "Show help message.");
 
-        CommandLineParser parser = new PosixParser();
+        CommandLineParser parser = new DefaultParser();
         CommandLine cmd = parser.parse(options, argv);
 
         String[] cmdArgs = cmd.getArgs();

--- a/base/kra/src/test/java/com/netscape/cms/servlet/test/GeneratePKIArchiveOptions.java
+++ b/base/kra/src/test/java/com/netscape/cms/servlet/test/GeneratePKIArchiveOptions.java
@@ -13,10 +13,10 @@ import java.io.OutputStream;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.asn1.OCTET_STRING;
@@ -119,7 +119,7 @@ public class GeneratePKIArchiveOptions {
         options.addOption("oaep",true, "Use OAEP key wrapping");
 
         try {
-            CommandLineParser parser = new PosixParser();
+            CommandLineParser parser = new DefaultParser();
             CommandLine cmd = parser.parse(options, args);
 
             if (cmd.hasOption("p")) {

--- a/base/tools/src/main/java/com/netscape/cmstools/CMCResponse.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/CMCResponse.java
@@ -32,10 +32,11 @@ import java.util.Locale;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
+import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.asn1.ASN1Util;
 import org.mozilla.jss.asn1.INTEGER;
 import org.mozilla.jss.asn1.InvalidBERException;
@@ -43,6 +44,10 @@ import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.asn1.OCTET_STRING;
 import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.asn1.SET;
+import org.mozilla.jss.netscape.security.pkcs.PKCS7;
+import org.mozilla.jss.netscape.security.util.CertPrettyPrint;
+import org.mozilla.jss.netscape.security.util.Utils;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.mozilla.jss.pkix.cert.Certificate;
 import org.mozilla.jss.pkix.cmc.CMCStatusInfoV2;
 import org.mozilla.jss.pkix.cmc.EncryptedPOP;
@@ -53,12 +58,6 @@ import org.mozilla.jss.pkix.cmc.TaggedAttribute;
 import org.mozilla.jss.pkix.cms.ContentInfo;
 import org.mozilla.jss.pkix.cms.EncapsulatedContentInfo;
 import org.mozilla.jss.pkix.cms.SignedData;
-import org.mozilla.jss.CryptoManager;
-
-import org.mozilla.jss.netscape.security.util.Utils;
-import org.mozilla.jss.netscape.security.pkcs.PKCS7;
-import org.mozilla.jss.netscape.security.util.CertPrettyPrint;
-import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 /**
  * Tool for parsing a CMC response
@@ -70,7 +69,7 @@ import org.mozilla.jss.netscape.security.x509.X509CertImpl;
  */
 public class CMCResponse {
 
-    static CommandLineParser parser = new PosixParser();
+    static CommandLineParser parser = new DefaultParser();
     static Options options = new Options();
     static HelpFormatter formatter = new HelpFormatter();
 
@@ -370,7 +369,7 @@ public class CMCResponse {
             System.exit(1);
         }
 
-        //Intialize the crypto manager, just in case we need to use the JSS Provider to parse 
+        //Intialize the crypto manager, just in case we need to use the JSS Provider to parse
         //algorithm parameters. All we have to do is initialize the manager and be done.
 
         if (dbdir == null)

--- a/base/tools/src/main/java/com/netscape/cmstools/CMCSharedToken.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/CMCSharedToken.java
@@ -25,9 +25,9 @@ import java.util.Arrays;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.EncryptionAlgorithm;
@@ -169,7 +169,7 @@ public class CMCSharedToken {
         CommandLine cmd = null;
 
         try {
-            CommandLineParser parser = new PosixParser();
+            CommandLineParser parser = new DefaultParser();
             cmd = parser.parse(options, args);
 
         } catch (Exception e) {

--- a/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
@@ -35,9 +35,9 @@ import javax.crypto.Mac;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -305,7 +305,7 @@ public class CRMFPopClient {
         CommandLine cmd = null;
 
         try {
-            CommandLineParser parser = new PosixParser();
+            CommandLineParser parser = new DefaultParser();
             cmd = parser.parse(options, args);
 
         } catch (Exception e) {

--- a/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
@@ -27,9 +27,9 @@ import java.net.UnknownHostException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
 import org.dogtagpki.util.logging.PKILogger;
 import org.mozilla.jss.CryptoManager;
 
@@ -125,7 +125,7 @@ public class OCSPClient {
 
         Options options = createOptions();
 
-        CommandLineParser parser = new PosixParser();
+        CommandLineParser parser = new DefaultParser();
         CommandLine cmd = parser.parse(options, args);
 
         if (cmd.hasOption("help")) {


### PR DESCRIPTION
Resolves #2655

A PR was merged 4 years ago to resolve this but it was reverted because of incompatible versions of the `apache-commons-cli` package. Some platforms were using 1.3 and others were still using 1.2 which doesn't have the `DefaultParser` class

I think this is no longer an issue though, as both Fedora and RHEL appear to have dropped v1.2:

`RHEL8: 1.4-4.module+el8+2452+b359bfcd` 
`F34: 1.4-12.fc34`