### PR TITLE
Remove redundant superinterface implementations

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/authentication/CMCUserSignedAuth.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/CMCUserSignedAuth.java
@@ -128,8 +128,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  *
  * @version $Revision$, $Date$
  */
-public class CMCUserSignedAuth implements AuthManager, IExtendedPluginInfo,
-        ProfileAuthenticator {
+public class CMCUserSignedAuth implements IExtendedPluginInfo, ProfileAuthenticator {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CMCUserSignedAuth.class);
     private static Logger signedAuditLogger = SignedAuditLogger.getLogger();

--- a/base/ca/src/main/java/com/netscape/cms/jobs/PublishCertsJob.java
+++ b/base/ca/src/main/java/com/netscape/cms/jobs/PublishCertsJob.java
@@ -31,7 +31,6 @@ import com.netscape.certsrv.base.IConfigStore;
 import com.netscape.certsrv.base.IExtendedPluginInfo;
 import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.certsrv.base.MetaInfo;
-import com.netscape.certsrv.jobs.IJob;
 import com.netscape.certsrv.jobs.IJobCron;
 import com.netscape.certsrv.notification.IEmailFormProcessor;
 import com.netscape.certsrv.request.IRequest;
@@ -62,7 +61,7 @@ import com.netscape.cmscore.request.RequestRepository;
  * @version $Revision$, $Date$
  */
 public class PublishCertsJob extends AJobBase
-        implements IJob, Runnable, IExtendedPluginInfo {
+        implements IExtendedPluginInfo {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PublishCertsJob.class);
 

--- a/base/ca/src/main/java/com/netscape/cms/jobs/RenewalNotificationJob.java
+++ b/base/ca/src/main/java/com/netscape/cms/jobs/RenewalNotificationJob.java
@@ -33,7 +33,6 @@ import com.netscape.certsrv.base.IExtendedPluginInfo;
 import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.certsrv.base.MetaInfo;
 import com.netscape.certsrv.dbs.IElementProcessor;
-import com.netscape.certsrv.jobs.IJob;
 import com.netscape.certsrv.jobs.IJobCron;
 import com.netscape.certsrv.notification.ENotificationException;
 import com.netscape.certsrv.notification.IEmailFormProcessor;
@@ -87,7 +86,7 @@ import com.netscape.cmscore.notification.ReqCertSANameEmailResolver;
  */
 public class RenewalNotificationJob
         extends AJobBase
-        implements IJob, Runnable, IExtendedPluginInfo {
+        implements IExtendedPluginInfo {
 
     // config parameters...
     public static final String PROP_CRON = "cron";

--- a/base/ca/src/main/java/com/netscape/cms/jobs/UnpublishExpiredJob.java
+++ b/base/ca/src/main/java/com/netscape/cms/jobs/UnpublishExpiredJob.java
@@ -31,7 +31,6 @@ import com.netscape.certsrv.base.IConfigStore;
 import com.netscape.certsrv.base.IExtendedPluginInfo;
 import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.certsrv.base.MetaInfo;
-import com.netscape.certsrv.jobs.IJob;
 import com.netscape.certsrv.jobs.IJobCron;
 import com.netscape.certsrv.notification.IEmailFormProcessor;
 import com.netscape.certsrv.request.IRequest;
@@ -62,7 +61,7 @@ import com.netscape.cmscore.request.RequestRepository;
  * @version $Revision$, $Date$
  */
 public class UnpublishExpiredJob extends AJobBase
-        implements IJob, Runnable, IExtendedPluginInfo {
+        implements IExtendedPluginInfo {
 
     CertificateAuthority mCa;
     RequestRepository requestRepository;

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 
 import org.apache.commons.lang3.StringUtils;
@@ -107,7 +106,7 @@ import netscape.ldap.LDAPModificationSet;
 import netscape.ldap.LDAPSearchResults;
 
 @WebListener
-public class CAEngine extends CMSEngine implements ServletContextListener {
+public class CAEngine extends CMSEngine {
 
     protected CertificateRepository certificateRepository;
     protected CRLRepository crlRepository;

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
@@ -50,7 +50,6 @@ import org.apache.http.client.params.AuthPolicy;
 import org.apache.http.client.params.HttpClientParams;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeLayeredSocketFactory;
-import org.apache.http.conn.scheme.SchemeSocketFactory;
 import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.impl.client.ClientParamsStack;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -274,7 +273,7 @@ public class PKIConnection implements AutoCloseable {
         }
     }
 
-    private class JSSProtocolSocketFactory implements SchemeSocketFactory, SchemeLayeredSocketFactory {
+    private class JSSProtocolSocketFactory implements SchemeLayeredSocketFactory {
 
         @Override
         public Socket createSocket(HttpParams params) throws IOException {

--- a/base/console/src/main/java/com/netscape/admin/certsrv/CMSResourcePage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/CMSResourcePage.java
@@ -33,7 +33,7 @@ import com.netscape.management.client.ResourcePage;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv
  */
-public class CMSResourcePage extends ResourcePage implements Cloneable {
+public class CMSResourcePage extends ResourcePage {
 
     /*==========================================================
      * variables

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSBaseLDAPPanel.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSBaseLDAPPanel.java
@@ -23,7 +23,6 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import java.util.StringTokenizer;
 
 import javax.swing.JCheckBox;
@@ -52,7 +51,7 @@ import com.netscape.management.client.util.UtilConsoleGlobals;
  * @author Christine Ho
  * @version $Revision$, $Date$
  */
-public abstract class CMSBaseLDAPPanel extends CMSBaseTab implements ItemListener {
+public abstract class CMSBaseLDAPPanel extends CMSBaseTab {
     private static final String SERVER_CERT_NICKNAME = "Server-Cert";
     private JTextField mHostNameText;
     private JTextField mPortText;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSCAGeneralPanel.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSCAGeneralPanel.java
@@ -20,7 +20,6 @@ package com.netscape.admin.certsrv.config;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
-import java.awt.event.ItemListener;
 import java.math.BigInteger;
 import java.util.StringTokenizer;
 
@@ -46,7 +45,7 @@ import com.netscape.management.client.util.Debug;
  * @author Christine Ho
  * @version $Revision$, $Date$
  */
-public class CMSCAGeneralPanel extends CMSBaseTab implements ItemListener {
+public class CMSCAGeneralPanel extends CMSBaseTab {
 
     private static String PANEL_NAME = "CAGENERAL";
     private static CMSBaseResourceModel mModel;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSEAGeneralPanel.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSEAGeneralPanel.java
@@ -17,13 +17,23 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.*;
-import com.netscape.certsrv.common.*;
-import com.netscape.management.client.util.*;
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+import com.netscape.admin.certsrv.CMSAdminUtil;
+import com.netscape.admin.certsrv.CMSBaseResourceModel;
+import com.netscape.admin.certsrv.EAdminException;
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.DestDef;
+import com.netscape.certsrv.common.NameValuePairs;
+import com.netscape.certsrv.common.ScopeDef;
+import com.netscape.management.client.util.Debug;
 
 /**
  * KRA General Setting
@@ -31,7 +41,7 @@ import java.awt.event.*;
  * @author Ade Lee
  * @version $Revision: 1211 $, $Date: 2010-08-18 13:15:37 -0400 (Wed, 18 Aug 2010) $
  */
-public class CMSEAGeneralPanel extends CMSBaseTab implements ItemListener {
+public class CMSEAGeneralPanel extends CMSBaseTab {
 
     private static String PANEL_NAME = "EAGENERAL";
     private static CMSBaseResourceModel mModel;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSOCSPGeneralPanel.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSOCSPGeneralPanel.java
@@ -20,7 +20,6 @@ package com.netscape.admin.certsrv.config;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
-import java.awt.event.ItemListener;
 import java.util.StringTokenizer;
 
 import javax.swing.JComboBox;
@@ -43,7 +42,7 @@ import com.netscape.management.client.util.Debug;
  * @author Christine Ho
  * @version $Revision$, $Date$
  */
-public class CMSOCSPGeneralPanel extends CMSBaseTab implements ItemListener {
+public class CMSOCSPGeneralPanel extends CMSBaseTab {
 
     private static String PANEL_NAME = "OCSPGENERAL";
     private static CMSBaseResourceModel mModel;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSSSL2CipherPreference.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSSSL2CipherPreference.java
@@ -17,7 +17,6 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.security.*;
 /**
  * Constructs panel containing a SSL2 cipher suites
  *
@@ -26,8 +25,7 @@ import com.netscape.admin.certsrv.security.*;
  * @see com.netscape.admin.certsrv.config
  */
 
-public class CMSSSL2CipherPreference extends CMSCipherPreferencePane
-  implements ICipherConstants {
+public class CMSSSL2CipherPreference extends CMSCipherPreferencePane {
 
     public CMSSSL2CipherPreference(boolean isDomestic) {
         super(new CMSSSL2CipherSet(isDomestic), true);

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSSSL3CipherPreference.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMSSSL3CipherPreference.java
@@ -17,8 +17,6 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.security.*;
-
 /**
  * Constructs panel containing a SSL3 cipher suites
  *
@@ -27,8 +25,7 @@ import com.netscape.admin.certsrv.security.*;
  * @see com.netscape.admin.certsrv.config
  */
 
-public class CMSSSL3CipherPreference extends CMSCipherPreferencePane
-  implements ICipherConstants {
+public class CMSSSL3CipherPreference extends CMSCipherPreferencePane {
 
     public CMSSSL3CipherPreference(boolean isDomestic, boolean hasFortezza) {
         super(new CMSSSL3CipherSet(isDomestic, hasFortezza), true);

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CMStoAdminEncryptionPane.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CMStoAdminEncryptionPane.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
+import java.awt.event.ActionEvent;
+
 import com.netscape.admin.certsrv.security.EncryptionPane;
-import com.netscape.management.client.console.*;
-import com.netscape.management.client.util.*;
-import java.awt.event.*;
+import com.netscape.management.client.console.ConsoleInfo;
+import com.netscape.management.client.util.Debug;
 
 /**
  * Encryption set preference panel glue between CMS and KingPin
@@ -38,7 +39,6 @@ import java.awt.event.*;
 public class CMStoAdminEncryptionPane extends EncryptionPane implements IPluginConfigPanel{
 */
 public class CMStoAdminEncryptionPane extends EncryptionPane
-    implements ActionListener
 {
     protected boolean mEncryptionPaneDirty = false;
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/CRLExtensionsConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/CRLExtensionsConfigDialog.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.event.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
 
 /**
  * CRL Extensions Parameter Configuration Dialog
@@ -29,7 +30,6 @@ import com.netscape.certsrv.common.*;
  * @see com.netscape.admin.certsrv.config
  */
 public class CRLExtensionsConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
     /*==========================================================
      * constructors

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/JobsConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/JobsConfigDialog.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.event.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
 
 /**
  * Jobs Parameter Configuration Dialog
@@ -30,7 +31,6 @@ import com.netscape.certsrv.common.*;
  * @see com.netscape.admin.certsrv.config
  */
 public class JobsConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/JobsSettingPanel.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/JobsSettingPanel.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ItemListener;
 
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -44,7 +43,7 @@ import com.netscape.certsrv.common.ScopeDef;
  * @author cfu
  * @version $Revision$, $Date$
  */
-public class JobsSettingPanel extends CMSBaseTab implements ItemListener {
+public class JobsSettingPanel extends CMSBaseTab {
     private static final String HELPINDEX =
       "jobsscheduler-certsrv-setting-jobrule-help";
     private JTextField mFrequencyText;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/LogConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/LogConfigDialog.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.event.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
 
 /**
  * Log Parameter Configuration Dialog
@@ -30,7 +31,6 @@ import com.netscape.certsrv.common.*;
  * @see com.netscape.admin.certsrv.config
  */
 public class LogConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/MapperConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/MapperConfigDialog.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.event.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
 
 /**
  * Mapper Parameter Configuration Dialog
@@ -30,7 +31,6 @@ import com.netscape.certsrv.common.*;
  * @see com.netscape.admin.certsrv.config
  */
 public class MapperConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/OCSPStoresConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/OCSPStoresConfigDialog.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.event.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
 
 /**
  * CRL Extensions Parameter Configuration Dialog
@@ -29,7 +30,6 @@ import com.netscape.certsrv.common.*;
  * @see com.netscape.admin.certsrv.config
  */
 public class OCSPStoresConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
     /*==========================================================
      * constructors

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/PolicyConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/PolicyConfigDialog.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.event.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
 
 /**
  * Policy Parameter Configuration Dialog
@@ -30,7 +31,6 @@ import com.netscape.certsrv.common.*;
  * @see com.netscape.admin.certsrv.config
  */
 public class PolicyConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileConfigDialog.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.Vector;
 
 import javax.swing.JButton;
@@ -54,7 +53,6 @@ import com.netscape.management.client.util.JButtonFactory;
  * @see com.netscape.admin.certsrv.config
  */
 public class ProfileConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
  protected JButton mRefresh, mEdit, mAdd, mDelete, mOrder, mHelp;
     protected JTextField mAuthField=null,mNameField=null, mDescField=null, mConfigField=null;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileEditDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileEditDialog.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.StringTokenizer;
 import java.util.Vector;
 
@@ -60,7 +59,7 @@ import com.netscape.management.client.util.JButtonFactory;
  * @see com.netscape.admin.certsrv.config
  */
 public class ProfileEditDialog extends CMSBaseConfigDialog
-    implements ActionListener, ChangeListener
+    implements ChangeListener
 {
     protected JButton mRefresh, mOrder, mHelp;
     protected JTextField mAuthField=null,mNameField=null, mDescField=null, mConfigField=null;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileNonPolicyNewDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfileNonPolicyNewDialog.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.Vector;
 
 import javax.swing.DefaultCellEditor;
@@ -53,7 +52,6 @@ import com.netscape.management.client.util.Debug;
  * @see com.netscape.admin.certsrv.config
  */
 public class ProfileNonPolicyNewDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
  protected JButton mRefresh, mEdit, mAdd, mDelete, mOrder, mHelp;
     protected JTextField mNameField=null, mDescField=null, mConfigField=null;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicyEditDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicyEditDialog.java
@@ -23,9 +23,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
 import java.util.Vector;
@@ -64,7 +62,6 @@ import com.netscape.management.client.util.JButtonFactory;
  * @see com.netscape.admin.certsrv.config
  */
 public class ProfilePolicyEditDialog extends CMSBaseConfigDialog
-    implements ActionListener, FocusListener
 {
  protected JButton mRefresh, mEdit, mAdd, mDelete, mOrder, mHelp;
     protected JTextField mNameField=null, mIdField=null, mDescField=null, mConfigField=null;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicyNewDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/ProfilePolicyNewDialog.java
@@ -23,9 +23,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
 import java.util.Vector;
@@ -64,7 +62,6 @@ import com.netscape.management.client.util.JButtonFactory;
  * @see com.netscape.admin.certsrv.config
  */
 public class ProfilePolicyNewDialog extends CMSBaseConfigDialog
-    implements ActionListener, FocusListener
 {
  protected JButton mRefresh, mEdit, mAdd, mDelete, mOrder, mHelp;
     protected JTextField mNameField=null, mIdField=null, mDescField=null, mConfigField=null;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/PublisherConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/PublisherConfigDialog.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.event.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
 
 /**
  * Publisher Parameter Configuration Dialog
@@ -30,7 +31,6 @@ import com.netscape.certsrv.common.*;
  * @see com.netscape.admin.certsrv.config
  */
 public class PublisherConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
 
     /*==========================================================

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/RuleConfigDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/RuleConfigDialog.java
@@ -17,10 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config;
 
-import com.netscape.admin.certsrv.connection.*;
-import javax.swing.*;
-import java.awt.event.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.NameValuePairs;
 
 /**
  * Rule Parameter Configuration Dialog
@@ -30,7 +31,6 @@ import com.netscape.certsrv.common.*;
  * @see com.netscape.admin.certsrv.config
  */
 public class RuleConfigDialog extends CMSBaseConfigDialog
-    implements ActionListener
 {
     /*==========================================================
      * constructors

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WICACert2Page.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WICACert2Page.java
@@ -17,9 +17,9 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import com.netscape.admin.certsrv.*;
-import com.netscape.admin.certsrv.wizard.*;
-import com.netscape.admin.certsrv.config.*;
+import com.netscape.admin.certsrv.CMSAdminUtil;
+import com.netscape.admin.certsrv.config.WBaseDNPage;
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 
 /**
  * CA signing cert for installation wizard.
@@ -28,7 +28,7 @@ import com.netscape.admin.certsrv.config.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WICACert2Page extends WBaseDNPage implements IWizardPanel {
+class WICACert2Page extends WBaseDNPage {
     private static final String PANELNAME = "CACERT2WIZARD";
     private static final String HELPINDEX =
       "configuration-kra-wizard-change-keyscheme-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WICACertSubmitPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WICACertSubmitPage.java
@@ -17,9 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
+import com.netscape.certsrv.common.Constants;
 
 /**
  * CA Certificate Submission.
@@ -28,7 +30,7 @@ import com.netscape.certsrv.common.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WICACertSubmitPage extends WICertSubmitPage implements IWizardPanel {
+class WICACertSubmitPage extends WICertSubmitPage {
     private static final String PANELNAME = "INSTALLCACERTWIZARD";
     private static final String CAHELPINDEX = "install-catype-wizard-help";
     private static final String CAKRAHELPINDEX = "install-cakratype-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WICAKeyPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WICAKeyPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -28,7 +30,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WICAKeyPage extends WIKeyPage implements IWizardPanel {
+class WICAKeyPage extends WIKeyPage {
     private static final String PANELNAME = "INSTALLCAKEYWIZARD";
     private static final String CALOCALHELPINDEX =
       "install-cakeylocal-configuration-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WICATokenLogonPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WICATokenLogonPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 
 /**
  * This panel asks for the information of the current internal database.
@@ -27,7 +29,7 @@ import com.netscape.admin.certsrv.wizard.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WICATokenLogonPage extends WITokenLogonPage implements IWizardPanel {
+class WICATokenLogonPage extends WITokenLogonPage {
 
     private static final String HELPINDEX = "install-catoken-logon-wizard-help";
     private static final String PANELNAME = "CATOKENLOGONWIZARD";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIInternalTokenLogonPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIInternalTokenLogonPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -28,7 +30,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIInternalTokenLogonPage extends WITokenLogonPage implements IWizardPanel {
+class WIInternalTokenLogonPage extends WITokenLogonPage {
 
     private static final String HELPINDEX = "install-internaltoken-logon-wizard-help";
     private static final String PANELNAME = "INTERNALTOKENLOGONWIZARD";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIKRACertSubmitPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIKRACertSubmitPage.java
@@ -20,7 +20,6 @@ package com.netscape.admin.certsrv.config.install;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 
-import com.netscape.admin.certsrv.wizard.IWizardPanel;
 import com.netscape.admin.certsrv.wizard.WizardInfo;
 import com.netscape.certsrv.common.Constants;
 
@@ -31,7 +30,7 @@ import com.netscape.certsrv.common.Constants;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIKRACertSubmitPage extends WICertSubmitPage implements IWizardPanel {
+class WIKRACertSubmitPage extends WICertSubmitPage {
     private static final String PANELNAME = "INSTALLKRACERTWIZARD";
     private static final String KRAHELPINDEX = "install-kratype-wizard-help";
     private static final String RAKRAHELPINDEX = "install-rakratype-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIKRAKeyPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIKRAKeyPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -28,7 +30,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIKRAKeyPage extends WIKeyPage implements IWizardPanel {
+class WIKRAKeyPage extends WIKeyPage {
     private static final String PANELNAME = "INSTALLKRAKEYWIZARD";
     private static final String KRAHELPINDEX =
       "install-krakeysub-configuration-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIKRATokenLogonPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIKRATokenLogonPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 
 /**
  * This panel asks for the information of the current internal database.
@@ -27,7 +29,7 @@ import com.netscape.admin.certsrv.wizard.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIKRATokenLogonPage extends WITokenLogonPage implements IWizardPanel {
+class WIKRATokenLogonPage extends WITokenLogonPage {
 
     private static final String HELPINDEX = "install-kratoken-logon-wizard-help";
     private static final String PANELNAME = "KRATOKENLOGONWIZARD";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIKeyPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIKeyPage.java
@@ -23,7 +23,6 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import java.util.StringTokenizer;
 
 import javax.swing.JComboBox;
@@ -51,7 +50,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIKeyPage extends WizardBasePanel implements IWizardPanel, ItemListener {
+class WIKeyPage extends WizardBasePanel implements IWizardPanel {
     protected Color mActiveColor;
     protected JComboBox<String> mKeyTypeBox, mKeyLengthBox, mDSAKeyLengthBox, mTokenBox;
     protected JTextField mKeyLengthText;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIMigrationPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIMigrationPage.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
 
@@ -55,7 +54,7 @@ import com.netscape.management.client.console.ConsoleInfo;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIMigrationPage extends WizardBasePanel implements IWizardPanel, ItemListener {
+class WIMigrationPage extends WizardBasePanel implements IWizardPanel {
     private JLabel mTransportLbl;
     private JPasswordField mTransportPassword;
     private JLabel mCAPasswdLbl, mCAPasswdAgainLbl, mCASOPLbl;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIOCSPCertSubmitPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIOCSPCertSubmitPage.java
@@ -17,9 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
+import com.netscape.certsrv.common.Constants;
 
 /**
  * OCSP Certificate Submission.
@@ -28,7 +30,7 @@ import com.netscape.certsrv.common.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIOCSPCertSubmitPage extends WICertSubmitPage implements IWizardPanel {
+class WIOCSPCertSubmitPage extends WICertSubmitPage {
     private static final String PANELNAME = "INSTALLOCSPCERTWIZARD";
     private static final String OCSPHELPINDEX = "install-ocsptype-wizard-help";
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIOCSPKeyPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIOCSPKeyPage.java
@@ -17,9 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
+import com.netscape.certsrv.common.Constants;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -29,7 +31,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIOCSPKeyPage extends WIKeyPage implements IWizardPanel {
+class WIOCSPKeyPage extends WIKeyPage {
     private static final String PANELNAME = "INSTALLOCSPKEYWIZARD";
     private static final String OCSPHELPINDEX =
       "install-ocspkey-configuration-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIOCSPTokenLogonPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIOCSPTokenLogonPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 
 /**
  * This panel asks for the information of the current internal database.
@@ -27,7 +29,7 @@ import com.netscape.admin.certsrv.wizard.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIOCSPTokenLogonPage extends WITokenLogonPage implements IWizardPanel {
+class WIOCSPTokenLogonPage extends WITokenLogonPage {
 
     private static final String OCSPHELPINDEX = "install-ocsptoken-logon-wizard-help";
     private static final String PANELNAME = "OCSPTOKENLOGONWIZARD";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIRACertSubmitPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIRACertSubmitPage.java
@@ -17,9 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
+import com.netscape.certsrv.common.Constants;
 
 /**
  * RA Certificate Submission.
@@ -28,7 +30,7 @@ import com.netscape.certsrv.common.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIRACertSubmitPage extends WICertSubmitPage implements IWizardPanel {
+class WIRACertSubmitPage extends WICertSubmitPage {
     private static final String PANELNAME = "INSTALLRACERTWIZARD";
     private static final String RAHELPINDEX = "install-ratype-wizard-help";
     private static final String RAKRAHELPINDEX = "install-rakratype-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIRAKeyPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIRAKeyPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -28,7 +30,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIRAKeyPage extends WIKeyPage implements IWizardPanel {
+class WIRAKeyPage extends WIKeyPage {
     private static final String PANELNAME = "INSTALLRAKEYWIZARD";
     private static final String RAHELPINDEX =
       "install-rakey-configuration-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIRATokenLogonPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIRATokenLogonPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 
 /**
  * This panel asks for the information of the current internal database.
@@ -27,7 +29,7 @@ import com.netscape.admin.certsrv.wizard.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIRATokenLogonPage extends WITokenLogonPage implements IWizardPanel {
+class WIRATokenLogonPage extends WITokenLogonPage {
 
     private static final String HELPINDEX = "install-ratoken-logon-wizard-help";
     private static final String PANELNAME = "RATOKENLOGONWIZARD";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WISSLTokenLogonPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WISSLTokenLogonPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 
 /**
  * This panel asks for the information of the current internal database.
@@ -27,7 +29,7 @@ import com.netscape.admin.certsrv.wizard.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WISSLTokenLogonPage extends WITokenLogonPage implements IWizardPanel {
+class WISSLTokenLogonPage extends WITokenLogonPage {
 
     private static final String HELPINDEX = "install-ssltoken-logon-wizard-help";
     private static final String PANELNAME = "SSLTOKENLOGONWIZARD";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIServerCertSubmitPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIServerCertSubmitPage.java
@@ -17,9 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
-import com.netscape.certsrv.common.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
+import com.netscape.certsrv.common.Constants;
 
 /**
  * Server Certificate Submission.
@@ -28,7 +30,7 @@ import com.netscape.certsrv.common.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIServerCertSubmitPage extends WICertSubmitPage implements IWizardPanel {
+class WIServerCertSubmitPage extends WICertSubmitPage {
     private static final String PANELNAME = "INSTALLSERVERCERTWIZARD";
     private static final String CALOCALHELPINDEX = "install-cassltypelocal-wizard-help";
     private static final String CAREMOTEHELPINDEX = "install-cassltypesub-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIServerKeyPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/install/WIServerKeyPage.java
@@ -17,8 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.config.install;
 
-import javax.swing.*;
-import com.netscape.admin.certsrv.wizard.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import com.netscape.admin.certsrv.wizard.WizardInfo;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -28,7 +30,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WIServerKeyPage extends WIKeyPage implements IWizardPanel {
+class WIServerKeyPage extends WIKeyPage {
     private static final String PANELNAME = "INSTALLSERVERKEYWIZARD";
     private static final String LOCALHELPINDEX =
       "install-serverkeylocal-configuration-wizard-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/connection/PromptForTrustDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/connection/PromptForTrustDialog.java
@@ -47,13 +47,12 @@ import com.netscape.management.client.util.GridBagUtil;
 import com.netscape.management.client.util.JButtonFactory;
 import com.netscape.management.client.util.ModalDialogUtil;
 import com.netscape.management.client.util.MultilineLabel;
-import com.netscape.management.nmclf.SuiConstants;
 
 /**
  * Dialog box that prompts user to either accept or reject
  * an untrusted certificate.
  */
-public class PromptForTrustDialog extends AbstractDialog implements SuiConstants {
+public class PromptForTrustDialog extends AbstractDialog {
 
     private static boolean certIsAccepted = false;
     private X509Certificate mCert;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/keycert/WCertDNPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/keycert/WCertDNPage.java
@@ -17,14 +17,19 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.keycert;
 
-import javax.swing.*;
-import javax.swing.border.*;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.border.TitledBorder;
 
-import com.netscape.admin.certsrv.*;
-import com.netscape.admin.certsrv.connection.*;
-import com.netscape.admin.certsrv.wizard.*;
-import com.netscape.certsrv.common.*;
-import com.netscape.admin.certsrv.config.*;
+import com.netscape.admin.certsrv.CMSAdminUtil;
+import com.netscape.admin.certsrv.EAdminException;
+import com.netscape.admin.certsrv.config.WBaseDNPage;
+import com.netscape.admin.certsrv.connection.AdminConnection;
+import com.netscape.admin.certsrv.wizard.WizardInfo;
+import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.common.DestDef;
+import com.netscape.certsrv.common.NameValuePairs;
+import com.netscape.certsrv.common.ScopeDef;
 
 /**
  * CA signing cert for installation wizard.
@@ -33,7 +38,7 @@ import com.netscape.admin.certsrv.config.*;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WCertDNPage extends WBaseDNPage implements IWizardPanel {
+class WCertDNPage extends WBaseDNPage {
     private static final String PANELNAME = "CERTDNWIZARD";
     private static final String HELPINDEX =
       "configuration-keycert-wizard-subjectdn-help";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/keycert/WCertTypePage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/keycert/WCertTypePage.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JComboBox;
@@ -51,8 +50,7 @@ import com.netscape.certsrv.common.ScopeDef;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.keycert
  */
-class WCertTypePage extends WizardBasePanel implements IWizardPanel,
-  ItemListener {
+class WCertTypePage extends WizardBasePanel implements IWizardPanel {
     private String mCASigningCert;
     private String mRASigningCert;
     private String mOCSPSigningCert;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/keycert/WKeyPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/keycert/WKeyPage.java
@@ -23,7 +23,6 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
 import java.util.StringTokenizer;
 
 import javax.swing.ButtonGroup;
@@ -59,7 +58,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  * @version $Revision$, $Date$
  * @see com.netscape.admin.certsrv.config.install
  */
-class WKeyPage extends WizardBasePanel implements IWizardPanel, ItemListener {
+class WKeyPage extends WizardBasePanel implements IWizardPanel {
     private Color mActiveColor;
     private JPanel mNicknamePanel;
     private JRadioButton mExistingKeyBtn;

--- a/base/console/src/main/java/com/netscape/admin/certsrv/notification/RequestCompletePanel.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/notification/RequestCompletePanel.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ItemListener;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
@@ -47,7 +46,7 @@ import com.netscape.certsrv.common.ScopeDef;
  * @author cfu
  * @version $Revision$, $Date$
  */
-public class RequestCompletePanel extends CMSBaseTab implements ItemListener {
+public class RequestCompletePanel extends CMSBaseTab {
     private static final String RA_HELPINDEX =
       "notification-ra-certissued-help";
     private static final String CA_HELPINDEX =

--- a/base/console/src/main/java/com/netscape/admin/certsrv/notification/RequestInQPanel.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/notification/RequestInQPanel.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ItemListener;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
@@ -47,7 +46,7 @@ import com.netscape.certsrv.common.ScopeDef;
  * @author cfu
  * @version $Revision$, $Date$
  */
-public class RequestInQPanel extends CMSBaseTab implements ItemListener {
+public class RequestInQPanel extends CMSBaseTab {
     private static final String RA_HELPINDEX =
       "notification-ra-reqinq-help";
     private static final String CA_HELPINDEX =

--- a/base/console/src/main/java/com/netscape/admin/certsrv/notification/RequestRevokedPanel.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/notification/RequestRevokedPanel.java
@@ -22,7 +22,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ItemListener;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
@@ -47,7 +46,7 @@ import com.netscape.certsrv.common.ScopeDef;
  * @author cfu
  * @version $Revision$, $Date$
  */
-public class RequestRevokedPanel extends CMSBaseTab implements ItemListener {
+public class RequestRevokedPanel extends CMSBaseTab {
     private static final String RA_HELPINDEX =
       "configuration-notifications";
     private static final String CA_HELPINDEX =

--- a/base/console/src/main/java/com/netscape/admin/certsrv/security/CRLAddCertDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/security/CRLAddCertDialog.java
@@ -37,7 +37,7 @@ import com.netscape.management.client.util.ResourceSet;
 import com.netscape.management.client.util.UtilConsoleGlobals;
 import com.netscape.management.nmclf.SuiConstants;
 
-class CRLAddCertDialog extends AbstractDialog implements SuiConstants {
+class CRLAddCertDialog extends AbstractDialog {
 
     ConsoleInfo _consoleInfo;
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/security/CRLDeleteCertDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/security/CRLDeleteCertDialog.java
@@ -36,7 +36,7 @@ import com.netscape.management.client.util.ResourceSet;
 import com.netscape.management.client.util.UtilConsoleGlobals;
 import com.netscape.management.nmclf.SuiConstants;
 
-class CRLDeleteCertDialog extends AbstractDialog implements SuiConstants {
+class CRLDeleteCertDialog extends AbstractDialog {
 
 
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/security/CertDetailInfoDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/security/CertDetailInfoDialog.java
@@ -17,14 +17,21 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.admin.certsrv.security;
 
-import javax.swing.*;
-import javax.swing.border.*;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 
-import java.awt.*;
-import com.netscape.management.client.util.*;
-import com.netscape.management.nmclf.*;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.EtchedBorder;
 
-class CertDetailInfoDialog extends AbstractDialog implements SuiConstants {
+import com.netscape.management.client.util.AbstractDialog;
+import com.netscape.management.client.util.GridBagUtil;
+import com.netscape.management.client.util.ResourceSet;
+
+class CertDetailInfoDialog extends AbstractDialog {
 
 
     JLabel serialNumber = new JLabel();

--- a/base/console/src/main/java/com/netscape/admin/certsrv/security/CertInfoDialog.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/security/CertInfoDialog.java
@@ -45,7 +45,6 @@ import com.netscape.management.client.util.MultilineLabel;
 import com.netscape.management.client.util.ResourceSet;
 import com.netscape.management.client.util.UITools;
 import com.netscape.management.client.util.UtilConsoleGlobals;
-import com.netscape.management.nmclf.SuiConstants;
 
 /**
  *
@@ -59,7 +58,7 @@ import com.netscape.management.nmclf.SuiConstants;
  * @see com.netscape.admin.certsrv.security.CertInfo
  *
  */
-class CertInfoDialog extends AbstractDialog implements SuiConstants {
+class CertInfoDialog extends AbstractDialog {
 
 
     /**

--- a/base/console/src/main/java/com/netscape/admin/certsrv/security/SSL2CipherPreference.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/security/SSL2CipherPreference.java
@@ -29,7 +29,7 @@ package com.netscape.admin.certsrv.security;
  * @see com.netscape.admin.certsrv.security.ToggleCipherPreferencePane
  * @see com.netscape.admin.certsrv.security.SSL3CipherPreference
  */
-public class SSL2CipherPreference extends ToggleCipherPreferencePane implements ICipherConstants {
+public class SSL2CipherPreference extends ToggleCipherPreferencePane {
 
     //private static final String  sslVersion = "SSL 2.0 Ciphers";
 

--- a/base/console/src/main/java/com/netscape/admin/certsrv/security/SSL3CipherPreference.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/security/SSL3CipherPreference.java
@@ -29,7 +29,7 @@ package com.netscape.admin.certsrv.security;
  * @see com.netscape.admin.certsrv.security.ToggleCipherPreferencePane
  * @see com.netscape.admin.certsrv.security.SSL2CipherPreference
  */
-public class SSL3CipherPreference extends ToggleCipherPreferencePane implements ICipherConstants {
+public class SSL3CipherPreference extends ToggleCipherPreferencePane {
 
 
     /**

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/KRAEngine.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/KRAEngine.java
@@ -18,7 +18,6 @@
 
 package org.dogtagpki.server.kra;
 
-import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 
 import com.netscape.certsrv.base.IConfigStore;
@@ -31,7 +30,7 @@ import com.netscape.cmscore.request.KeyRequestRepository;
 import com.netscape.kra.KeyRecoveryAuthority;
 
 @WebListener
-public class KRAEngine extends CMSEngine implements ServletContextListener {
+public class KRAEngine extends CMSEngine {
 
     public KRAEngine() throws Exception {
         super("KRA");

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/ProofOfArchival.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/ProofOfArchival.java
@@ -19,7 +19,6 @@ package org.dogtagpki.server.kra;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -71,7 +70,7 @@ import com.netscape.cmscore.apps.CMS;
  * @author thomask
  * @version $Revision$, $Date$
  */
-public class ProofOfArchival implements IDBObj, IProofOfArchival, Serializable {
+public class ProofOfArchival implements IDBObj, IProofOfArchival {
 
     private static final long serialVersionUID = -2533562170977678799L;
 

--- a/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
+++ b/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
@@ -51,7 +51,6 @@ import org.mozilla.jss.pkix.primitive.Name;
 import com.netscape.certsrv.authority.IAuthority;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.IConfigStore;
-import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.logging.event.OCSPSigningInfoEvent;
 import com.netscape.certsrv.ocsp.IDefStore;
@@ -87,7 +86,7 @@ import com.netscape.cmsutil.ocsp.TBSRequest;
  * @author lhsiao
  * @version $Revision$, $Date$
  */
-public class OCSPAuthority implements IOCSPAuthority, IOCSPService, ISubsystem, IAuthority {
+public class OCSPAuthority implements IOCSPAuthority, IOCSPService, IAuthority {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OCSPAuthority.class);
     private static final Logger signedAuditLogger = SignedAuditLogger.getLogger();

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
@@ -18,7 +18,6 @@
 
 package org.dogtagpki.server.ocsp;
 
-import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 
 import com.netscape.certsrv.base.IConfigStore;
@@ -30,7 +29,7 @@ import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.ocsp.OCSPAuthority;
 
 @WebListener
-public class OCSPEngine extends CMSEngine implements ServletContextListener {
+public class OCSPEngine extends CMSEngine {
 
     public OCSPEngine() throws Exception {
         super("OCSP");

--- a/base/server/src/main/java/com/netscape/cms/authentication/AgentCertAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/AgentCertAuthentication.java
@@ -60,8 +60,7 @@ import com.netscape.cmscore.usrgrp.User;
  *
  * @version $Revision$, $Date$
  */
-public class AgentCertAuthentication implements AuthManager,
-        ProfileAuthenticator {
+public class AgentCertAuthentication implements ProfileAuthenticator {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AgentCertAuthentication.class);
 

--- a/base/server/src/main/java/com/netscape/cms/authentication/CMCAuth.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/CMCAuth.java
@@ -114,8 +114,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  *
  * @version $Revision$, $Date$
  */
-public class CMCAuth implements AuthManager, IExtendedPluginInfo,
-        ProfileAuthenticator {
+public class CMCAuth implements IExtendedPluginInfo, ProfileAuthenticator {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CMCAuth.class);
     private static Logger signedAuditLogger = SignedAuditLogger.getLogger();

--- a/base/server/src/main/java/com/netscape/cms/authentication/SSLclientCertAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/SSLclientCertAuthentication.java
@@ -24,9 +24,9 @@ import java.util.Enumeration;
 import java.util.Locale;
 import java.util.StringTokenizer;
 
+import org.dogtagpki.server.authentication.AuthManager;
 import org.dogtagpki.server.authentication.AuthManagerConfig;
 import org.dogtagpki.server.authentication.AuthToken;
-import org.dogtagpki.server.authentication.AuthManager;
 import org.mozilla.jss.netscape.security.x509.BasicConstraintsExtension;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
@@ -54,8 +54,7 @@ import com.netscape.cmscore.apps.CMSEngine;
  *         <P>
  *
  */
-public class SSLclientCertAuthentication implements AuthManager,
-        ProfileAuthenticator {
+public class SSLclientCertAuthentication implements ProfileAuthenticator {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SSLclientCertAuthentication.class);
 

--- a/base/server/src/main/java/com/netscape/cms/authentication/TokenAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/TokenAuthentication.java
@@ -55,8 +55,7 @@ import com.netscape.cmsutil.xml.XMLObject;
  *
  * @version $Revision$, $Date$
  */
-public class TokenAuthentication implements AuthManager,
-        ProfileAuthenticator {
+public class TokenAuthentication implements ProfileAuthenticator {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TokenAuthentication.class);
 

--- a/base/server/src/main/java/com/netscape/cms/authentication/UidPwdPinDirAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/UidPwdPinDirAuthentication.java
@@ -64,7 +64,7 @@ import netscape.ldap.LDAPv2;
  * @version $Revision$, $Date$
  */
 public class UidPwdPinDirAuthentication extends DirBasedAuthentication
-        implements IExtendedPluginInfo, ProfileAuthenticator {
+        implements ProfileAuthenticator {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UidPwdPinDirAuthentication.class);
 

--- a/base/server/src/main/java/com/netscape/cms/authorization/BasicAclAuthz.java
+++ b/base/server/src/main/java/com/netscape/cms/authorization/BasicAclAuthz.java
@@ -18,7 +18,6 @@
 package com.netscape.cms.authorization;
 
 import org.dogtagpki.server.authorization.AuthzManagerConfig;
-import org.dogtagpki.server.authorization.IAuthzManager;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.IExtendedPluginInfo;
@@ -29,7 +28,7 @@ import com.netscape.certsrv.base.IExtendedPluginInfo;
  * @version $Revision$, $Date$
  */
 public class BasicAclAuthz extends AAclAuthz
-        implements IAuthzManager, IExtendedPluginInfo {
+        implements IExtendedPluginInfo {
 
     static {
         mExtendedPluginInfo.add("nothing for now");

--- a/base/server/src/main/java/com/netscape/cms/authorization/DirAclAuthz.java
+++ b/base/server/src/main/java/com/netscape/cms/authorization/DirAclAuthz.java
@@ -20,7 +20,6 @@ package com.netscape.cms.authorization;
 import java.util.Enumeration;
 
 import org.dogtagpki.server.authorization.AuthzManagerConfig;
-import org.dogtagpki.server.authorization.IAuthzManager;
 
 import com.netscape.certsrv.acls.EACLsException;
 import com.netscape.certsrv.acls.IACL;
@@ -51,7 +50,7 @@ import netscape.ldap.LDAPv2;
  * @version $Revision$, $Date$
  */
 public class DirAclAuthz extends AAclAuthz
-        implements IAuthzManager, IExtendedPluginInfo {
+        implements IExtendedPluginInfo {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(DirAclAuthz.class);
 

--- a/base/server/src/main/java/com/netscape/cms/jobs/RequestInQueueJob.java
+++ b/base/server/src/main/java/com/netscape/cms/jobs/RequestInQueueJob.java
@@ -26,7 +26,6 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.IConfigStore;
 import com.netscape.certsrv.base.IExtendedPluginInfo;
 import com.netscape.certsrv.base.ISubsystem;
-import com.netscape.certsrv.jobs.IJob;
 import com.netscape.certsrv.jobs.IJobCron;
 import com.netscape.certsrv.notification.IEmailFormProcessor;
 import com.netscape.certsrv.request.IRequestList;
@@ -52,7 +51,7 @@ import com.netscape.cmscore.request.ARequestQueue;
  * @see com.netscape.cms.jobs.AJobBase
  */
 public class RequestInQueueJob extends AJobBase
-        implements IJob, Runnable, IExtendedPluginInfo {
+        implements IExtendedPluginInfo {
     protected static final String PROP_SUBSYSTEM_ID = "subsystemId";
 
     IAuthority mSub = null;

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/CRLIssuingPointRecord.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/CRLIssuingPointRecord.java
@@ -26,7 +26,6 @@ import java.util.Vector;
 import org.mozilla.jss.netscape.security.x509.RevokedCertificate;
 
 import com.netscape.certsrv.base.EBaseException;
-import com.netscape.certsrv.dbs.IDBObj;
 import com.netscape.certsrv.dbs.crldb.ICRLIssuingPointRecord;
 import com.netscape.cmscore.apps.CMS;
 
@@ -37,7 +36,7 @@ import com.netscape.cmscore.apps.CMS;
  * @author thomask
  * @version $Revision$, $Date$
  */
-public class CRLIssuingPointRecord implements ICRLIssuingPointRecord, IDBObj {
+public class CRLIssuingPointRecord implements ICRLIssuingPointRecord {
 
     /**
      *

--- a/base/server/src/test/java/com/netscape/cmscore/dbs/RequestRecordDefaultStub.java
+++ b/base/server/src/test/java/com/netscape/cmscore/dbs/RequestRecordDefaultStub.java
@@ -3,14 +3,13 @@ package com.netscape.cmscore.dbs;
 import java.util.Enumeration;
 
 import com.netscape.certsrv.base.EBaseException;
-import com.netscape.certsrv.dbs.IDBObj;
 import com.netscape.certsrv.request.RequestId;
 import com.netscape.cmscore.request.RequestRecord;
 
 /**
  * Default stub for RequestRecord tests.
  */
-public class RequestRecordDefaultStub extends RequestRecord implements IDBObj {
+public class RequestRecordDefaultStub extends RequestRecord {
 
     public RequestId getRequestId() {
         return null;

--- a/base/tks/src/main/java/com/netscape/tks/TKSAuthority.java
+++ b/base/tks/src/main/java/com/netscape/tks/TKSAuthority.java
@@ -24,10 +24,9 @@ import org.dogtagpki.server.tks.TKSEngineConfig;
 import com.netscape.certsrv.authority.IAuthority;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.IConfigStore;
-import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.certsrv.request.IRequestListener;
 
-public class TKSAuthority implements IAuthority, ISubsystem {
+public class TKSAuthority implements IAuthority {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TKSAuthority.class);
 

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/TKSEngine.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/TKSEngine.java
@@ -18,7 +18,6 @@
 
 package org.dogtagpki.server.tks;
 
-import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 
 import com.netscape.certsrv.base.IConfigStore;
@@ -30,7 +29,7 @@ import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.tks.TKSAuthority;
 
 @WebListener
-public class TKSEngine extends CMSEngine implements ServletContextListener {
+public class TKSEngine extends CMSEngine {
 
     public TKSEngine() throws Exception {
         super("TKS");

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSEngine.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSEngine.java
@@ -18,7 +18,6 @@
 
 package org.dogtagpki.server.tps;
 
-import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 
 import com.netscape.cmscore.apps.CMS;
@@ -27,7 +26,7 @@ import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStorage;
 
 @WebListener
-public class TPSEngine extends CMSEngine implements ServletContextListener {
+public class TPSEngine extends CMSEngine {
 
     public TPSEngine() throws Exception {
         super("TPS");

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSSubsystem.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSSubsystem.java
@@ -61,7 +61,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
 /**
  * @author Endi S. Dewata <edewata@redhat.com>
  */
-public class TPSSubsystem implements IAuthority, ISubsystem {
+public class TPSSubsystem implements IAuthority {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CMSEngine.class);
 


### PR DESCRIPTION
These interfaces are already implemented by superclasses, so implementing them in the derived classes just makes the inheritance hierarchy hard to read.