### PR TITLE
Update Java.cmake to use Java 11 source and target

### DIFF
--- a/cmake/Modules/Java.cmake
+++ b/cmake/Modules/Java.cmake
@@ -84,8 +84,8 @@ function(javac target)
             -encoding UTF-8
             -cp ${native_classpath}
             -d ${output_dir}
-            -source 1.8
-            -target 1.8
+            -source 11
+            -target 11
             @${file_list}
         WORKING_DIRECTORY
             ${source_dir}


### PR DESCRIPTION
Resolves #3537.

Currently we're using 1.8, and compiling against OpenJDK 11, so any features/code added in Java 9/10/11 causes spurious compilation failures when running the build script. IT also causes the CI to fail erroneously.