### PR TITLE
Revert "AuthorityService.getCert/Chain: avoid NPE if CA is not ready"

### DIFF
--- a/base/ca/src/org/dogtagpki/server/ca/rest/AuthorityService.java
+++ b/base/ca/src/org/dogtagpki/server/ca/rest/AuthorityService.java
@@ -140,13 +140,8 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
         if (ca == null)
             throw new ResourceNotFoundException("CA \"" + aidString + "\" not found");
 
-        org.mozilla.jss.crypto.X509Certificate cert = ca.getCaX509Cert();
-        if (cert == null)
-            throw new ResourceNotFoundException(
-                "Certificate for CA \"" + aidString + "\" not available");
-
         try {
-            return Response.ok(cert.getEncoded()).build();
+            return Response.ok(ca.getCaX509Cert().getEncoded()).build();
         } catch (CertificateEncodingException e) {
             // this really is a 500 Internal Server Error
             throw new PKIException("Error encoding certificate: " + e);
@@ -172,14 +167,9 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
         if (ca == null)
             throw new ResourceNotFoundException("CA \"" + aidString + "\" not found");
 
-        org.mozilla.jss.netscape.security.x509.CertificateChain chain = ca.getCACertChain();
-        if (chain == null)
-            throw new ResourceNotFoundException(
-                "Certificate chain for CA \"" + aidString + "\" not available");
-
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
-            chain.encode(out);
+            ca.getCACertChain().encode(out);
         } catch (IOException e) {
             throw new PKIException("Error encoding certificate chain: " + e);
         }


### PR DESCRIPTION
This reverts commit 4a8e5d1c8b5b7eb3edfed6fc82c5c71935958c9e.

This was done to fix a bug but is causing issues: revert until problem is resolved with a new PR