### PR TITLE
Bug1889434 Unable to start HSM configured CA with after enabling Nuxwdog

### DIFF
--- a/base/util/src/main/java/com/netscape/cmsutil/password/NuxwdogPasswordStore.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/password/NuxwdogPasswordStore.java
@@ -81,6 +81,10 @@ public class NuxwdogPasswordStore implements IPasswordStore {
 
         String keyringTag = id + "/" + tag;
         pwd = Keyring.getPassword(keyringTag, "raw");
+        if ((pwd != null) & pwd.startsWith("keyctl_read_alloc:")) {
+            // System.out.println("NuxwdogPasswordStore.getPassword: resetting pwd to null because  Keyring.getPassword returned :" + pwd);
+            pwd = null;
+        }
 
         if (pwd != null) {
             addTag(tag);


### PR DESCRIPTION
The bug itself was actually a "not a bug" according to Chandan's latest
finding how it was working again when setup on a different vm.
However, I found a possible issue that could only be seen on the vm
where he initially had issue with.  I don't know how to reproduce other
than being able to see the correct message if my debugging was enabled
in this patch.
The nature of the issue that this patch tries to fix is that in case
when pwd is returned with "keyctl_read_alloc:..." regarding password not
found, and it treated the result as thought it was a password to be
saved.

relating to https://bugzilla.redhat.com/show_bug.cgi?id=1889434