### PR TITLE
Bug1911262- cloning KRA with HSM failed with invalid auditSigningCert

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -491,11 +491,20 @@ class NSSDatabase(object):
             # If HSM is not used, or cert has trust attributes,
             # import cert into internal token.
             if not token or trust_attributes != ',,':
-                cmd = [
-                    'certutil',
-                    '-A',
-                    '-d', self.directory
-                ]
+                if token and trust_attributes != ',,':
+                  cmd = [
+                      'certutil',
+                      '-M',
+                      '-d', self.directory
+                  ]
+
+                  nickname = token + ":" + nickname
+                else:
+                  cmd = [
+                      'certutil',
+                      '-A',
+                      '-d', self.directory
+                  ]
 
                 if self.internal_password_file:
                     cmd.extend(['-f', self.internal_password_file])


### PR DESCRIPTION
This path attempts to address the issue where when a KRA is being cloned,
the cloned KRA is missing the ',,P' trust setting for its auditSigningCert
in its nssdb.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1911262