### PR TITLE
Allow automatic determination of Fedora versions to test against

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -6,15 +6,19 @@ jobs:
   init:
     name: Initializing Workflow
     runs-on: ubuntu-latest
+    container: fedora:latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set up test matrix
         id: set-matrix
         run: |
+          export latest=$(cat /etc/fedora-release | awk '{ print $3 }')
+          export previous=$(cat /etc/fedora-release | awk '{ print $3 - 1}')
+          echo "Running CI against Fedora $previous and $latest"
           if [ "${{ secrets.MATRIX }}" == "" ]
           then
-              echo "::set-output name=matrix::{\"os\":[\"33\", \"34\"]}"
+              echo "::set-output name=matrix::{\"os\":[\"$previous\", \"$latest\"]}"
           else
               echo "::set-output name=matrix::${{ secrets.MATRIX }}"
           fi


### PR DESCRIPTION
Currently the Fedora versions to test against are hardcoded into matrices in every workflow, so we have to modify many different files every time there is a new release of Fedora (plus we have to actually remember to do it). This PR solves that problem by performing the workflow setup tasks inside a `fedora:latest` container, which allows us to determine what the latest version of Fedora is and populate all the matrices to use the latest version, and the version prior. The matrices can still be overridden for testing purposes. 