### PR TITLE
Add CA test scripts

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -42,7 +42,7 @@ jobs:
           build-args: |
             OS_VERSION=${{ matrix.os }}
             COPR_REPO=${{ env.COPR_REPO }}
-            BUILD_OPTS=--with-pkgs=base,server,ca --with-timestamp --with-commit-id
+            BUILD_OPTS=--with-pkgs=base,server,ca,tests --with-timestamp --with-commit-id
           tags: pki-runner
           target: pki-runner
           outputs: type=docker,dest=/tmp/pki-runner.tar
@@ -111,12 +111,7 @@ jobs:
 
       - name: Verify creating CA agent
         run: |
-          # create a user
-          docker exec pki pki -n caadmin ca-user-add caagent --fullName "CA Agent" --password Secret.123
-          # add the user to agent group
-          docker exec pki pki -n caadmin ca-user-membership-add caagent "Certificate Manager Agents"
-          # test the username and password
-          docker exec pki pki -u caagent -w Secret.123 ca-cert-request-find
+          docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-create.sh
 
       - name: Verify creating and revoking CA agent cert
         run: |

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -113,30 +113,11 @@ jobs:
         run: |
           docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-create.sh
 
-      - name: Verify creating and revoking CA agent cert
+      - name: Verify creating, revoking, and unrevoking CA agent cert
         run: |
-          # submit a cert request and capture the request ID
-          docker exec pki pki client-cert-request uid=caagent | sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" > request_id
-          # approve the cert request and capture the cert ID
-          docker exec pki pki -n caadmin ca-cert-request-approve `cat request_id` --force | sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" > cert_id
-          # assign the cert to the user
-          docker exec pki pki -n caadmin ca-user-cert-add caagent --serial `cat cert_id`
-          # import the cert into client
-          docker exec pki pki client-cert-import caagent --serial `cat cert_id`
-          # test the client certificate
-          docker exec pki pki -n caagent ca-cert-request-find
-
-          # revoke the cert
-          docker exec pki pki -n caadmin ca-cert-hold `cat cert_id` --force
-          # revoked cert should not work
-          docker exec pki pki -n caagent ca-cert-request-find || echo $? > actual
-          echo 255 > expected
-          diff actual expected
-
-          # unrevoke the cert
-          docker exec pki pki -n caadmin ca-cert-release-hold `cat cert_id` --force
-          # unrevoked cert should work again
-          docker exec pki pki -n caagent ca-cert-request-find
+          docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-create.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-revoke.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-unrevoke.sh
 
       - name: Gather artifacts
         if: always()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,17 @@ install(
 
 install(
     DIRECTORY
+        ca/bin/
+    DESTINATION
+        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/tests/ca/bin
+    FILE_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)
+
+install(
+    DIRECTORY
         dogtag/pytest-ansible/pytest/performance_test/
     DESTINATION
         ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/tests/python/performance/

--- a/tests/ca/bin/ca-agent-cert-create.sh
+++ b/tests/ca/bin/ca-agent-cert-create.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+# submit a cert request and capture the request ID
+pki client-cert-request uid=caagent | sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" > /tmp/request_id
+
+# approve the cert request and capture the cert ID
+pki -n caadmin ca-cert-request-approve `cat /tmp/request_id` --force | sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" > /tmp/cert_id
+
+# assign the cert to the user
+pki -n caadmin ca-user-cert-add caagent --serial `cat /tmp/cert_id`
+
+# import the cert into client
+pki client-cert-import caagent --serial `cat /tmp/cert_id`
+
+# test the client certificate
+pki -n caagent ca-cert-request-find

--- a/tests/ca/bin/ca-agent-cert-revoke.sh
+++ b/tests/ca/bin/ca-agent-cert-revoke.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -ex
+
+# revoke the cert
+pki -n caadmin ca-cert-hold `cat /tmp/cert_id` --force
+
+set +e
+
+# revoked cert should not work
+pki -n caagent ca-cert-request-find || echo $? > /tmp/actual
+
+set -e
+
+echo 255 > /tmp/expected
+diff /tmp/actual /tmp/expected

--- a/tests/ca/bin/ca-agent-cert-unrevoke.sh
+++ b/tests/ca/bin/ca-agent-cert-unrevoke.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+# unrevoke the cert
+pki -n caadmin ca-cert-release-hold `cat /tmp/cert_id` --force
+
+# unrevoked cert should work again
+pki -n caagent ca-cert-request-find

--- a/tests/ca/bin/ca-agent-create.sh
+++ b/tests/ca/bin/ca-agent-create.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+# create a user
+pki -n caadmin ca-user-add caagent --fullName "CA Agent" --password Secret.123
+
+# add the user to agent group
+pki -n caadmin ca-user-membership-add caagent "Certificate Manager Agents"
+
+# test the username and password
+pki -u caagent -w Secret.123 ca-cert-request-find


### PR DESCRIPTION
Some test code in CA workflow has been converted into shell scripts in order to simplify the workflow and make the test code more reusable.