### PR TITLE
Fixed performance issues#3481: avoiding the session object sharing among threads

### DIFF
--- a/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_revocation.py
+++ b/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_revocation.py
@@ -36,35 +36,35 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 args = parser.parse_args()
 
-# Create a PKIConnection object that stores the details of the CA.
-connection = PKIConnection('https', args.hostname, args.port, cert_paths=args.ca_cert_path)
 
-# The pem file used for authentication. Created from a p12 file using the
-# command -
-# openssl pkcs12 -in <p12_file_path> -out /tmp/auth.pem -nodes
-connection.set_authentication_cert(args.client_cert)
+class TestClient(threading.Thread):
 
-# Instantiate the CertClient
-cert_client = CertClient(connection)
+    def __init__(self, connection, cert_sn, number_of_tests_per_client):
+        super().__init__()
+        self.connection = connection
+        self.number_of_tests_per_client = number_of_tests_per_client
+        self.cert_sn = cert_sn
+        self.cert_client = CertClient(self.connection)
+        return
 
-
-def run_test(cert_sn, number_of_tests_per_thread):
-    # execute the specified number of tests
-    for sn in range(number_of_tests_per_thread):
-        try:
-            start = timer()
-            log.info("Revoking Cert : {}".format(cert_sn[sn]))
-            revoke_data = cert_client.revoke_cert(cert_sn[sn], revocation_reason='Key_Compromise')
-            end = timer()
-            revocation_times.append(int(end - start))
-        except Exception as error:
-            log.error(error)
+    def run(self):
+        # execute the specified number of tests
+        for sn in range(self.number_of_tests_per_client):
+            try:
+                start = timer()
+                log.info("Revoking Cert : {}".format(self.cert_sn[sn]))
+                revoke_data = self.cert_client.revoke_cert(self.cert_sn[sn], revocation_reason='Key_Compromise')
+                end = timer()
+                revocation_times.append(int(end - start))
+            except Exception as error:
+                log.error(error)
+        return
 
 
 if __name__ == "__main__":
     # get test parameters from CLI parameters
-    number_of_threads = args.number_of_clients
-    number_of_tests_per_thread = args.number_of_tests_per_client
+    number_of_clients = args.number_of_clients
+    number_of_tests_per_client = args.number_of_tests_per_client
     # execute the test_cert_enrollement.py script and store Serial Number data into file
     # provide that file path to this script by using --cert_sn_file <file path>
     cert_sn_file = open(args.cert_sn_file, 'r')
@@ -72,28 +72,38 @@ if __name__ == "__main__":
 
     # Dividing the list into small sublist
     sub_list = lambda cert_list, n: [cert_list[x: x + n] for x in range(0, len(cert_list), n)]
-    sub_list = sub_list(cert_list, number_of_tests_per_thread)
+    sub_list = sub_list(cert_list, number_of_tests_per_client)
 
-    # create the specified number of threads
-    threads = []
     revocation_times = []
+    clients = []
+
+    for nth in range(number_of_clients):
+        # Create a PKIConnection object that stores the details of the CA.
+        connection = PKIConnection('https', args.hostname, args.port, cert_paths=args.ca_cert_path)
+
+        # The pem file used for authentication. Created from a p12 file using the
+        # command -
+        # openssl pkcs12 -in <p12_file_path> -out /tmp/auth.pem -nodes
+        connection.set_authentication_cert(args.client_cert)
+        client = TestClient( connection, sub_list[nth], number_of_tests_per_client)
+        clients.append(client)
 
     start = timer()
-    for nth in range(number_of_threads):
-        t1 = threading.Thread(target=run_test, args=(sub_list[nth], number_of_tests_per_thread))
-        t1.start()
-        threads.append(t1)
+
+    for client in clients:
+        client.start()
 
     # wait for all threads to complete
-    for t in threads:
-        t.join()
+    for client in clients:
+        client.join()
+
     end = timer()
 
     with open("revocation_times.json", "w") as cf:
         json.dump(revocation_times, cf)
 
     T = int(end - start)
-    N = number_of_threads * number_of_tests_per_thread
+    N = number_of_clients * number_of_tests_per_client
 
     log.info("Number of certs Revoked (N)={}".format(N))
     log.info("Minimum execution time (T)={}".format(min(revocation_times)))


### PR DESCRIPTION
Session object is not thread safe and was causing segmentation fault. Changes dont to stop sharing of PKIConnection object among threads.

Signed-off-by: Shalini Khandelwal <skhandel@redhat.com>