### PR TITLE
Remove jakarta-activation from .classpath

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -35,7 +35,6 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="/usr/share/java/jakarta-activation/jakarta.activation.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/httpcomponents/httpclient.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/httpcomponents/httpcore.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/jboss-jaxrs-2.0-api.jar"/>

--- a/pki.spec
+++ b/pki.spec
@@ -435,7 +435,6 @@ Requires:         resteasy-jackson2-provider >= 3.0.17-1
 
 %if 0%{?fedora} >= 33 || 0%{?rhel} > 8
 Requires:         jaxb-impl >= 2.3.3
-Requires:         jakarta-activation >= 1.2.2
 %endif
 
 Requires:         xalan-j2

--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,6 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-            <version>1.2.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
             <artifactId>jboss-annotations-api_1.2_spec</artifactId>
             <version>1.0.0.Final</version>


### PR DESCRIPTION
This dependency is satisfied through `resteasy-client -> resteasy-core`,
so no need to explicitly depend on it like this.

The package `jakarta-activation` is orphaned in Fedora, by removing this explicit dependency we make it clear that our dependency is indirect and by inference other maintainers for the orphaned package may be more appropriate than us.