### PR TITLE
Add JSON wrappers for classes org.dogtagpki.common

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
@@ -68,15 +68,12 @@ public class CAInfoService extends PKIService implements CAInfoResource {
 
     private static Logger logger = LoggerFactory.getLogger(CAInfoService.class);
 
-    public final static String ENCRYPT_MECHANISM = "encrypt";
-    public final static String KEYWRAP_MECHANISM = "keywrap";
-
     // is the current KRA-related info authoritative?
     private static boolean kraInfoAuthoritative = false;
 
     // KRA-related fields (the initial values are only used if we
     // did not yet receive authoritative info from KRA)
-    private static String archivalMechanism = KEYWRAP_MECHANISM;
+    private static String archivalMechanism = CAInfo.KEYWRAP_MECHANISM;
     private static String encryptAlgorithm;
     private static String keyWrapAlgorithm;
 
@@ -160,7 +157,7 @@ public class CAInfoService extends PKIService implements CAInfoResource {
                 } catch (EBaseException e1) {
                     encrypt_archival = false;
                 }
-                archivalMechanism = encrypt_archival ? ENCRYPT_MECHANISM : KEYWRAP_MECHANISM;
+                archivalMechanism = encrypt_archival ? CAInfo.ENCRYPT_MECHANISM : CAInfo.KEYWRAP_MECHANISM;
 
                 // mark info as authoritative
                 kraInfoAuthoritative = true;

--- a/base/common/src/main/java/org/dogtagpki/common/CAInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/common/CAInfo.java
@@ -27,31 +27,22 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.ResourceMessage;
 
 /**
  * @author Ade Lee
  */
 @XmlRootElement(name="CAInfo")
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CAInfo extends ResourceMessage {
 
-    private static Logger logger = LoggerFactory.getLogger(CAInfo.class);
-
-    public static Marshaller marshaller;
-    public static Unmarshaller unmarshaller;
-
-    static {
-        try {
-            marshaller = JAXBContext.newInstance(CAInfo.class).createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            unmarshaller = JAXBContext.newInstance(CAInfo.class).createUnmarshaller();
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
-    }
+    public static final String ENCRYPT_MECHANISM = "encrypt";
+    public static final String KEYWRAP_MECHANISM = "keywrap";
 
     String archivalMechanism;
     String encryptAlgorithm;
@@ -121,32 +112,28 @@ public class CAInfo extends ResourceMessage {
         return true;
     }
 
-    @Override
-    public String toString() {
-        try {
-            StringWriter sw = new StringWriter();
-            marshaller.marshal(this, sw);
-            return sw.toString();
-
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public String toXML() throws Exception {
+        Marshaller marshaller = JAXBContext.newInstance(CAInfo.class).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(this, sw);
+        return sw.toString();
     }
 
-    public static CAInfo valueOf(String string) throws Exception {
+    public static CAInfo fromXML(String string) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(CAInfo.class).createUnmarshaller();
         return (CAInfo)unmarshaller.unmarshal(new StringReader(string));
     }
 
-    public static void main(String args[]) throws Exception {
-
-        CAInfo before = new CAInfo();
-        before.setArchivalMechanism("encrypt");
-
-        String string = before.toString();
-        System.out.println(string);
-
-        CAInfo after = CAInfo.valueOf(string);
-        System.out.println(before.equals(after));
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
     }
+
+    public static CAInfo fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CAInfo.class);
+    }
+
 }
 

--- a/base/common/src/main/java/org/dogtagpki/common/ConfigData.java
+++ b/base/common/src/main/java/org/dogtagpki/common/ConfigData.java
@@ -1,3 +1,4 @@
+
 // --- BEGIN COPYRIGHT BLOCK ---
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -24,7 +25,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
@@ -52,19 +52,6 @@ import com.netscape.certsrv.base.Link;
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class ConfigData {
-
-    public static Marshaller marshaller;
-    public static Unmarshaller unmarshaller;
-
-    static {
-        try {
-            marshaller = JAXBContext.newInstance(ConfigData.class).createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            unmarshaller = JAXBContext.newInstance(ConfigData.class).createUnmarshaller();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
 
     String status;
     Map<String, String> properties;
@@ -175,13 +162,16 @@ public class ConfigData {
     }
 
     public String toXML() throws Exception {
+        Marshaller marshaller = JAXBContext.newInstance(ConfigData.class).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
         StringWriter sw = new StringWriter();
         marshaller.marshal(this, sw);
         return sw.toString();
     }
 
-    public static ConfigData fromXML(String xml) throws Exception {
-        return (ConfigData) unmarshaller.unmarshal(new StringReader(xml));
+    public static ConfigData fromXML(String string) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(ConfigData.class).createUnmarshaller();
+        return (ConfigData)unmarshaller.unmarshal(new StringReader(string));
     }
 
     public String toJSON() throws Exception {
@@ -194,35 +184,4 @@ public class ConfigData {
         return mapper.readValue(json, ConfigData.class);
     }
 
-    @Override
-    public String toString() {
-        try {
-            return toJSON();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static void main(String args[]) throws Exception {
-
-        ConfigData before = new ConfigData();
-        before.setStatus("ENABLED");
-
-        Map<String, String> properties = new TreeMap<>();
-        properties.put("param1", "value1");
-        properties.put("param2", "value2");
-        before.setProperties(properties);
-
-        String xml = before.toXML();
-        System.out.println(xml);
-
-        ConfigData afterXML = ConfigData.fromXML(xml);
-        System.out.println(before.equals(afterXML));
-
-        String json = before.toJSON();
-        System.out.println(json);
-
-        ConfigData afterJSON = ConfigData.fromJSON(json);
-        System.out.println(before.equals(afterJSON));
-    }
 }

--- a/base/common/src/main/java/org/dogtagpki/common/Info.java
+++ b/base/common/src/main/java/org/dogtagpki/common/Info.java
@@ -137,35 +137,4 @@ public class Info extends ResourceMessage {
         return (Info)unmarshaller.unmarshal(new StringReader(string));
     }
 
-    @Override
-    public String toString() {
-        try {
-            return toXML();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static void main(String args[]) throws Exception {
-
-        Info info = new Info();
-        info.setName("PKI");
-        info.setVersion("10.8.0");
-        info.setBanner(
-                "WARNING!\n" +
-                "Access to this service is restricted to those individuals with " +
-                "specific permissions.");
-
-        String json = info.toJSON();
-        System.out.println(json);
-
-        Info afterJSON = Info.fromJSON(json);
-        System.out.println(info.equals(afterJSON));
-
-        String xml = info.toXML();
-        System.out.println(xml);
-
-        Info afterXML = Info.fromXML(xml);
-        System.out.println(info.equals(afterXML));
-    }
 }

--- a/base/common/src/main/java/org/dogtagpki/common/KRAInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/common/KRAInfo.java
@@ -27,31 +27,19 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.ResourceMessage;
 
 /**
  * @author Ade Lee
  */
 @XmlRootElement(name="KRAInfo")
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class KRAInfo extends ResourceMessage {
-
-    private static Logger logger = LoggerFactory.getLogger(KRAInfo.class);
-
-    public static Marshaller marshaller;
-    public static Unmarshaller unmarshaller;
-
-    static {
-        try {
-            marshaller = JAXBContext.newInstance(KRAInfo.class).createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            unmarshaller = JAXBContext.newInstance(KRAInfo.class).createUnmarshaller();
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
-    }
 
     String archivalMechanism;
     String recoveryMechanism;
@@ -137,35 +125,28 @@ public class KRAInfo extends ResourceMessage {
         return true;
     }
 
-    @Override
-    public String toString() {
-        try {
-            StringWriter sw = new StringWriter();
-            marshaller.marshal(this, sw);
-            return sw.toString();
-
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
     }
 
-    public static KRAInfo valueOf(String string) throws Exception {
+    public static KRAInfo fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, KRAInfo.class);
+    }
+
+    public String toXML() throws Exception {
+        StringWriter sw = new StringWriter();
+        Marshaller marshaller = JAXBContext.newInstance(KRAInfo.class).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        marshaller.marshal(this, sw);
+        return sw.toString();
+    }
+
+    public static KRAInfo fromXML(String string) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(KRAInfo.class).createUnmarshaller();
         return (KRAInfo)unmarshaller.unmarshal(new StringReader(string));
     }
 
-    public static void main(String args[]) throws Exception {
-
-        KRAInfo before = new KRAInfo();
-        before.setArchivalMechanism("encrypt");
-        before.setRecoveryMechanism("keywrap");
-        before.setEncryptAlgorithm("AES/CBC/Pad");
-        before.setWrapAlgorithm("AES KeyWrap/Padding");
-
-        String string = before.toString();
-        System.out.println(string);
-
-        KRAInfo after = KRAInfo.valueOf(string);
-        System.out.println(before.equals(after));
-    }
 }
 

--- a/base/common/src/test/java/org/dogtagpki/common/CAInfoTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/CAInfoTest.java
@@ -1,0 +1,44 @@
+package org.dogtagpki.common;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class CAInfoTest {
+
+    private static CAInfo before = new CAInfo();
+
+    @Before
+    public void setUpBefore() {
+        before.setArchivalMechanism(CAInfo.KEYWRAP_MECHANISM);
+        before.setEncryptAlgorithm(CAInfo.ENCRYPT_MECHANISM);
+        before.setKeyWrapAlgorithm(CAInfo.KEYWRAP_MECHANISM);
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CAInfo afterXML = CAInfo.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CAInfo afterJSON = CAInfo.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+}

--- a/base/common/src/test/java/org/dogtagpki/common/ConfigDataTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/ConfigDataTest.java
@@ -1,0 +1,55 @@
+package org.dogtagpki.common;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netscape.certsrv.base.Link;
+
+public class ConfigDataTest {
+
+    private static ConfigData before = new ConfigData();
+    private static Map<String, String> properties = new TreeMap<>();
+
+    @Before
+    public void setUpBefore() throws URISyntaxException {
+        properties.put("param1", "value1");
+        properties.put("param2", "value2");
+
+        before.setLink(new Link("self", new URI("https://www.example.com")));
+        before.setProperties(properties);
+        before.setStatus("ENABLED");
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        ConfigData afterXML = ConfigData.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        ConfigData afterJSON = ConfigData.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/org/dogtagpki/common/InfoTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/InfoTest.java
@@ -1,0 +1,47 @@
+package org.dogtagpki.common;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InfoTest {
+
+    private static Info before = new Info();
+
+    @Before
+    public void setUpBefore() {
+        before.setName("PKI");
+        before.setVersion("10.8.0");
+        before.setBanner(
+                "WARNING!\n" +
+                "Access to this service is restricted to those individuals with " +
+                "specific permissions.");
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        Info afterXML = Info.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        Info afterJSON = Info.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/org/dogtagpki/common/KRAInfoTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/KRAInfoTest.java
@@ -1,0 +1,45 @@
+package org.dogtagpki.common;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KRAInfoTest {
+
+    private static KRAInfo before = new KRAInfo();
+
+    @Before
+    public void setUpBefore() {
+        before.setArchivalMechanism("encrypt");
+        before.setRecoveryMechanism("keywrap");
+        before.setEncryptAlgorithm("AES/CBC/Pad");
+        before.setWrapAlgorithm("AES KeyWrap/Padding");
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        KRAInfo afterXML = KRAInfo.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        KRAInfo afterJSON = KRAInfo.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}


### PR DESCRIPTION
Requires overriding `equals()` and `hashCode()` in `Link` class, otherwise the
equals check for `ConfigData` fails on object equivalence for the Links.