### PR TITLE
Add JSON wrappers for classes in com.netscape.certsrv.cert

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfo.java
@@ -32,6 +32,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.Link;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.dbs.certdb.CertIdAdapter;
@@ -42,21 +46,9 @@ import com.netscape.certsrv.util.DateAdapter;
  *
  */
 @XmlRootElement(name = "CertDataInfo")
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CertDataInfo {
-
-    public static Marshaller marshaller;
-    public static Unmarshaller unmarshaller;
-
-    static {
-        try {
-            JAXBContext context = JAXBContext.newInstance(CertDataInfo.class);
-            marshaller = context.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            unmarshaller = context.createUnmarshaller();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
 
     CertId id;
     String subjectDN;
@@ -324,38 +316,28 @@ public class CertDataInfo {
         return true;
     }
 
-    @Override
-    public String toString() {
-        try {
-            StringWriter sw = new StringWriter();
-            marshaller.marshal(this, sw);
-            return sw.toString();
+    public String toXML() throws Exception {
+        Marshaller marshaller = JAXBContext.newInstance(CertDataInfo.class).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
-        } catch (Exception e) {
-            return super.toString();
-        }
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(this, sw);
+        return sw.toString();
     }
 
-    public static CertDataInfo valueOf(String string) throws Exception {
-        try {
-            return (CertDataInfo)unmarshaller.unmarshal(new StringReader(string));
-        } catch (Exception e) {
-            return null;
-        }
+    public static CertDataInfo fromXML(String xml) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(CertDataInfo.class).createUnmarshaller();
+        return (CertDataInfo) unmarshaller.unmarshal(new StringReader(xml));
     }
 
-    public static void main(String args[]) throws Exception {
-
-        CertDataInfo before = new CertDataInfo();
-        before.setID(new CertId("12512514865863765114"));
-        before.setSubjectDN("CN=Test User,UID=testuser,O=EXAMPLE-COM");
-        before.setStatus("VALID");
-
-        String string = before.toString();
-        System.out.println(string);
-
-        CertDataInfo after = CertDataInfo.valueOf(string);
-
-        System.out.println(before.equals(after));
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
     }
+
+    public static CertDataInfo fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CertDataInfo.class);
+    }
+
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfos.java
@@ -22,9 +22,14 @@ import java.util.Collection;
 import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.base.DataCollection;
 
 @XmlRootElement(name = "CertDataInfos")
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CertDataInfos extends DataCollection<CertDataInfo> {
 
     @Override

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertEnrollmentRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertEnrollmentRequest.java
@@ -37,6 +37,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.ResourceMessage;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.dbs.certdb.CertIdAdapter;
@@ -51,6 +55,8 @@ import com.netscape.certsrv.profile.ProfileOutput;
 
 @XmlRootElement(name = "CertEnrollmentRequest")
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CertEnrollmentRequest extends ResourceMessage {
 
     private static final String PROFILE_ID = "profileId";
@@ -345,66 +351,28 @@ public class CertEnrollmentRequest extends ResourceMessage {
     }
 
     public String toXML() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(CertEnrollmentRequest.class);
-        Marshaller marshaller = context.createMarshaller();
+        Marshaller marshaller = JAXBContext.newInstance(CertEnrollmentRequest.class).createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
         StringWriter sw = new StringWriter();
         marshaller.marshal(this, sw);
         return sw.toString();
     }
 
-    public static CertEnrollmentRequest fromXML(String string) throws Exception {
-        JAXBContext context = JAXBContext.newInstance(CertEnrollmentRequest.class);
-        Unmarshaller unmarshaller = context.createUnmarshaller();
-        return (CertEnrollmentRequest) unmarshaller.unmarshal(new StringReader(string));
+    public static CertEnrollmentRequest fromXML(String xml) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(CertEnrollmentRequest.class).createUnmarshaller();
+        return (CertEnrollmentRequest) unmarshaller.unmarshal(new StringReader(xml));
     }
 
     @Override
-    public String toString() {
-        try {
-            return toXML();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
     }
 
-    public static void main(String args[]) throws Exception {
-        CertEnrollmentRequest before = new CertEnrollmentRequest();
-        before.setProfileId("caUserCert");
-        before.setRenewal(false);
-
-        ProfileInput certReq = before.createInput("KeyGenInput");
-        certReq.addAttribute(new ProfileAttribute("cert_request_type", "crmf", null));
-        certReq.addAttribute(new ProfileAttribute(
-                "cert_request",
-                "MIIBozCCAZ8wggEFAgQBMQp8MIHHgAECpQ4wDDEKMAgGA1UEAxMBeKaBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA2NgaPHp0jiohcP4M+ufrJOZEqH8GV+liu5JLbT8nWpkfhC+8EUBqT6g+n3qroSxIcNVGNdcsBEqs1utvpItzyslAbpdyat3WwQep1dWMzo6RHrPDuIoxNA0Yka1n3qEX4U//08cLQtUv2bYglYgN/hOCNQemLV6vZWAv0n7zelkCAwEAAakQMA4GA1UdDwEB/wQEAwIF4DAzMBUGCSsGAQUFBwUBAQwIcmVnVG9rZW4wGgYJKwYBBQUHBQECDA1hdXRoZW50aWNhdG9yoYGTMA0GCSqGSIb3DQEBBQUAA4GBAJ1VOQcaSEhdHa94s8kifVbSZ2WZeYE5//qxL6wVlEst20vq4ybj13CetnbN3+WT49Zkwp7Fg+6lALKgSk47suTg3EbbQDm+8yOrC0nc/q4PTRoHl0alMmUxIhirYc1t3xoCMqJewmjX1bNP8lpVIZAYFZo4eZCpZaiSkM5BeHhz",
-                null));
-
-        ProfileInput subjectName = before.createInput("SubjectNameInput");
-        subjectName.addAttribute(new ProfileAttribute("sn_uid", "jmagne", null));
-        subjectName.addAttribute(new ProfileAttribute("sn_e", "jmagne@redhat.com", null));
-        subjectName.addAttribute(new ProfileAttribute("sn_c", "US", null));
-        subjectName.addAttribute(new ProfileAttribute("sn_ou", "Development", null));
-        subjectName.addAttribute(new ProfileAttribute("sn_ou1", "IPA", null));
-        subjectName.addAttribute(new ProfileAttribute("sn_ou2", "Dogtag", null));
-        subjectName.addAttribute(new ProfileAttribute("sn_ou3", "CA", null));
-        subjectName.addAttribute(new ProfileAttribute("sn_cn", "Common", null));
-        subjectName.addAttribute(new ProfileAttribute("sn_o", "RedHat", null));
-
-        ProfileInput submitter = before.createInput("SubmitterInfoInput");
-        submitter.addAttribute(new ProfileAttribute("requestor_name", "admin", null));
-        submitter.addAttribute(new ProfileAttribute("requestor_email", "admin@redhat.com", null));
-        submitter.addAttribute(new ProfileAttribute("requestor_phone", "650-555-5555", null));
-
-        before.setAttribute("uid", "testuser");
-        before.setAttribute("pwd", "password");
-
-        String xml = before.toXML();
-        System.out.println(xml);
-
-        CertEnrollmentRequest after = CertEnrollmentRequest.fromXML(xml);
-        System.out.println(after.toXML());
-
-        System.out.println(before.equals(after));
+    public static CertEnrollmentRequest fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CertEnrollmentRequest.class);
     }
+
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfo.java
@@ -30,13 +30,18 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.dbs.certdb.CertIdAdapter;
 import com.netscape.certsrv.request.CMSRequestInfo;
-import com.netscape.certsrv.request.RequestStatus;
 
 @XmlRootElement(name = "CertRequestInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CertRequestInfo extends CMSRequestInfo {
 
     public static final String REQ_COMPLETE = "complete";
@@ -158,42 +163,29 @@ public class CertRequestInfo extends CMSRequestInfo {
     }
 
     @Override
-    public String toString() {
-        try {
-            StringWriter sw = new StringWriter();
-            Marshaller marshaller = JAXBContext.newInstance(CertRequestInfo.class).createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            marshaller.marshal(this, sw);
-            return sw.toString();
+    public String toXML() throws Exception {
+        Marshaller marshaller = JAXBContext.newInstance(CertRequestInfo.class).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
-        } catch (Exception e) {
-            return super.toString();
-        }
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(this, sw);
+        return sw.toString();
     }
 
-    public static CertRequestInfo valueOf(String string) throws Exception {
-        try {
-            Unmarshaller unmarshaller = JAXBContext.newInstance(CertRequestInfo.class).createUnmarshaller();
-            return (CertRequestInfo)unmarshaller.unmarshal(new StringReader(string));
-        } catch (Exception e) {
-            return null;
-        }
+    public static CertRequestInfo fromXML(String xml) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(CertRequestInfo.class).createUnmarshaller();
+        return (CertRequestInfo) unmarshaller.unmarshal(new StringReader(xml));
     }
 
-    public static void main(String args[]) throws Exception {
-
-        CertRequestInfo before = new CertRequestInfo();
-        before.setRequestType("enrollment");
-        before.setRequestStatus(RequestStatus.COMPLETE);
-        before.setCertRequestType("pkcs10");
-        before.setCertId(new CertId("5"));
-
-        String string = before.toString();
-        System.out.println(string);
-
-        CertRequestInfo after = CertRequestInfo.valueOf(string);
-        System.out.println(after);
-
-        System.out.println(before.equals(after));
+    @Override
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
     }
+
+    public static CertRequestInfo fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CertRequestInfo.class);
+    }
+
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfos.java
@@ -36,7 +36,6 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.DataCollection;
 import com.netscape.certsrv.base.Link;
-import com.netscape.certsrv.request.RequestStatus;
 
 @XmlRootElement(name = "CertRequestInfos")
 @JsonInclude(Include.NON_NULL)
@@ -96,40 +95,4 @@ public class CertRequestInfos extends DataCollection<CertRequestInfo> {
         return (CertRequestInfos)unmarshaller.unmarshal(new StringReader(string));
     }
 
-    @Override
-    public String toString() {
-        try {
-            return toXML();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static void main(String args[]) throws Exception {
-
-        CertRequestInfo request = new CertRequestInfo();
-        request.setRequestType("enrollment");
-        request.setRequestStatus(RequestStatus.COMPLETE);
-        request.setCertRequestType("pkcs10");
-
-        CertRequestInfos before = new CertRequestInfos();
-        before.addEntry(request);
-        before.setTotal(1);
-
-        String xml = before.toXML();
-        System.out.println("Before (XML): " + xml);
-
-        CertRequestInfos afterXML = CertRequestInfos.fromXML(xml);
-        System.out.println("After (XML): " + afterXML.toXML());
-
-        System.out.println(before.equals(afterXML));
-
-        String json = before.toJSON();
-        System.out.println("Before (JSON): " + json);
-
-        CertRequestInfos afterJSON = CertRequestInfos.fromJSON(json);
-        System.out.println("After (JSON): " + afterJSON.toJSON());
-
-        System.out.println(before.equals(afterJSON));
-    }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRetrievalRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRetrievalRequest.java
@@ -21,12 +21,23 @@
  */
 package com.netscape.certsrv.cert;
 
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Objects;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.dbs.certdb.CertIdAdapter;
 import com.netscape.certsrv.request.RequestId;
@@ -38,6 +49,8 @@ import com.netscape.certsrv.request.RequestIdAdapter;
  */
 @XmlRootElement(name = "CertRetrievalRequest")
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CertRetrievalRequest {
 
     @XmlElement
@@ -46,7 +59,7 @@ public class CertRetrievalRequest {
 
     @XmlElement
     @XmlJavaTypeAdapter(RequestIdAdapter.class)
-    protected RequestId requestId;
+    public RequestId requestId;
 
     public CertRetrievalRequest() {
         // required for JAXB (defaults)
@@ -61,6 +74,55 @@ public class CertRetrievalRequest {
      */
     public CertId getCertId() {
         return certId;
+    }
+
+    protected void setCertId(CertId certId) {
+        this.certId = certId;
+    }
+
+    protected void setRequestId(RequestId requestId) {
+        this.requestId = requestId;
+    }
+
+    public String toXML() throws Exception {
+        Marshaller marshaller = JAXBContext.newInstance(CertRetrievalRequest.class).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(this, sw);
+        return sw.toString();
+    }
+
+    public static CertRetrievalRequest fromXML(String xml) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(CertRetrievalRequest.class).createUnmarshaller();
+        return (CertRetrievalRequest) unmarshaller.unmarshal(new StringReader(xml));
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static CertRetrievalRequest fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CertRetrievalRequest.class);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(certId, requestId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CertRetrievalRequest other = (CertRetrievalRequest) obj;
+        return Objects.equals(certId, other.certId) && Objects.equals(requestId, other.requestId);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertReviewResponse.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertReviewResponse.java
@@ -22,6 +22,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
@@ -32,6 +33,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.profile.PolicyDefault;
 import com.netscape.certsrv.profile.ProfileAttribute;
 import com.netscape.certsrv.profile.ProfilePolicy;
@@ -41,6 +46,8 @@ import com.netscape.certsrv.request.RequestIdAdapter;
 
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CertReviewResponse extends CertEnrollmentRequest {
 
     @XmlElement(name="ProfilePolicySet")
@@ -237,17 +244,62 @@ public class CertReviewResponse extends CertEnrollmentRequest {
 
     @Override
     public String toXML() throws Exception {
-        JAXBContext context = JAXBContext.newInstance(CertReviewResponse.class);
-        Marshaller marshaller = context.createMarshaller();
+        Marshaller marshaller = JAXBContext.newInstance(CertReviewResponse.class).createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
         StringWriter sw = new StringWriter();
         marshaller.marshal(this, sw);
         return sw.toString();
     }
 
     public static CertReviewResponse fromXML(String xml) throws Exception {
-        JAXBContext context = JAXBContext.newInstance(CertReviewResponse.class);
-        Unmarshaller unmarshaller = context.createUnmarshaller();
+        Unmarshaller unmarshaller = JAXBContext.newInstance(CertReviewResponse.class).createUnmarshaller();
         return (CertReviewResponse) unmarshaller.unmarshal(new StringReader(xml));
     }
+
+    @Override
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static CertReviewResponse fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CertReviewResponse.class);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(nonce, policySets, profileApprovedBy, profileDescription,
+                profileIsVisible, profileName, profileRemoteAddr, profileRemoteHost, profileSetId, requestCreationTime,
+                requestId, requestModificationTime, requestNotes, requestOwner, requestStatus, requestType);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CertReviewResponse other = (CertReviewResponse) obj;
+        return Objects.equals(nonce, other.nonce) && Objects.equals(policySets, other.policySets)
+                && Objects.equals(profileApprovedBy, other.profileApprovedBy)
+                && Objects.equals(profileDescription, other.profileDescription)
+                && Objects.equals(profileIsVisible, other.profileIsVisible)
+                && Objects.equals(profileName, other.profileName)
+                && Objects.equals(profileRemoteAddr, other.profileRemoteAddr)
+                && Objects.equals(profileRemoteHost, other.profileRemoteHost)
+                && Objects.equals(profileSetId, other.profileSetId)
+                && Objects.equals(requestCreationTime, other.requestCreationTime)
+                && Objects.equals(requestId, other.requestId)
+                && Objects.equals(requestModificationTime, other.requestModificationTime)
+                && Objects.equals(requestNotes, other.requestNotes) && Objects.equals(requestOwner, other.requestOwner)
+                && Objects.equals(requestStatus, other.requestStatus) && Objects.equals(requestType, other.requestType);
+    }
+
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
@@ -33,6 +33,10 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.mozilla.jss.netscape.security.x509.RevocationReason;
 import org.mozilla.jss.netscape.security.x509.RevocationReasonAdapter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.request.IRequest;
 import com.netscape.certsrv.util.DateAdapter;
 
@@ -40,21 +44,9 @@ import com.netscape.certsrv.util.DateAdapter;
  * @author Endi S. Dewata
  */
 @XmlRootElement(name="CertRevokeRequest")
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CertRevokeRequest {
-
-    public static Marshaller marshaller;
-    public static Unmarshaller unmarshaller;
-
-    static {
-        try {
-            JAXBContext context = JAXBContext.newInstance(CertRevokeRequest.class);
-            marshaller = context.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            unmarshaller = context.createUnmarshaller();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
 
     RevocationReason reason;
     Date invalidityDate;
@@ -164,40 +156,28 @@ public class CertRevokeRequest {
         return true;
     }
 
-    @Override
-    public String toString() {
-        try {
-            StringWriter sw = new StringWriter();
-            marshaller.marshal(this, sw);
-            return sw.toString();
+    public String toXML() throws Exception {
+        Marshaller marshaller = JAXBContext.newInstance(CertRevokeRequest.class).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
-        } catch (Exception e) {
-            return super.toString();
-        }
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(this, sw);
+        return sw.toString();
     }
 
-    public static CertRevokeRequest valueOf(String string) throws Exception {
-        try {
-            return (CertRevokeRequest)unmarshaller.unmarshal(new StringReader(string));
-        } catch (Exception e) {
-            return null;
-        }
+    public static CertRevokeRequest fromXML(String xml) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(CertRevokeRequest.class).createUnmarshaller();
+        return (CertRevokeRequest) unmarshaller.unmarshal(new StringReader(xml));
     }
 
-    public static void main(String args[]) throws Exception {
-
-        CertRevokeRequest before = new CertRevokeRequest();
-        before.setReason(RevocationReason.CERTIFICATE_HOLD);
-        before.setInvalidityDate(new Date());
-        before.setComments("test");
-        before.setEncoded("test");
-        before.setNonce(12345l);
-
-        String string = before.toString();
-        System.out.println(string);
-
-        CertRevokeRequest after = CertRevokeRequest.valueOf(string);
-
-        System.out.println(before.equals(after));
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
     }
+
+    public static CertRevokeRequest fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CertRevokeRequest.class);
+    }
+
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertSearchRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertSearchRequest.java
@@ -21,15 +21,24 @@
 package com.netscape.certsrv.cert;
 
 import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Objects;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author jmagne
@@ -37,6 +46,8 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @XmlRootElement(name = "CertSearchRequest")
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class CertSearchRequest {
 
     @XmlElement
@@ -567,9 +578,84 @@ public class CertSearchRequest {
     public CertSearchRequest(MultivaluedMap<String, String> form) {
     }
 
-    public static CertSearchRequest valueOf(Reader reader) throws JAXBException {
+    public String toXML() throws Exception {
+        Marshaller marshaller = JAXBContext.newInstance(CertSearchRequest.class).createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+        StringWriter sw = new StringWriter();
+        marshaller.marshal(this, sw);
+        return sw.toString();
+    }
+
+    public static CertSearchRequest fromXML(String xml) throws Exception {
+        Unmarshaller unmarshaller = JAXBContext.newInstance(CertSearchRequest.class).createUnmarshaller();
+        return (CertSearchRequest) unmarshaller.unmarshal(new StringReader(xml));
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static CertSearchRequest fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, CertSearchRequest.class);
+    }
+
+    public static CertSearchRequest fromXML(Reader reader) throws JAXBException {
         JAXBContext context = JAXBContext.newInstance(CertSearchRequest.class);
         Unmarshaller unmarshaller = context.createUnmarshaller();
         return (CertSearchRequest) unmarshaller.unmarshal(reader);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(certTypeInUse, certTypeSSLClient, certTypeSSLServer, certTypeSecureEmail,
+                certTypeSubEmailCA, certTypeSubSSLCA, commonName, country, eMail, issuedBy, issuedByInUse, issuedOnFrom,
+                issuedOnInUse, issuedOnTo, issuerDN, locality, matchExactly, org, orgUnit, revocationReason,
+                revocationReasonInUse, revokedBy, revokedByInUse, revokedOnFrom, revokedOnInUse, revokedOnTo,
+                serialFrom, serialNumberRangeInUse, serialTo, state, status, subjectInUse, userID, validNotAfterFrom,
+                validNotAfterInUse, validNotAfterTo, validNotBeforeFrom, validNotBeforeInUse, validNotBeforeTo,
+                validityCount, validityLengthInUse, validityOperation, validityUnit);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CertSearchRequest other = (CertSearchRequest) obj;
+        return certTypeInUse == other.certTypeInUse && Objects.equals(certTypeSSLClient, other.certTypeSSLClient)
+                && Objects.equals(certTypeSSLServer, other.certTypeSSLServer)
+                && Objects.equals(certTypeSecureEmail, other.certTypeSecureEmail)
+                && Objects.equals(certTypeSubEmailCA, other.certTypeSubEmailCA)
+                && Objects.equals(certTypeSubSSLCA, other.certTypeSubSSLCA)
+                && Objects.equals(commonName, other.commonName) && Objects.equals(country, other.country)
+                && Objects.equals(eMail, other.eMail) && Objects.equals(issuedBy, other.issuedBy)
+                && issuedByInUse == other.issuedByInUse && Objects.equals(issuedOnFrom, other.issuedOnFrom)
+                && issuedOnInUse == other.issuedOnInUse && Objects.equals(issuedOnTo, other.issuedOnTo)
+                && Objects.equals(issuerDN, other.issuerDN) && Objects.equals(locality, other.locality)
+                && matchExactly == other.matchExactly && Objects.equals(org, other.org)
+                && Objects.equals(orgUnit, other.orgUnit) && Objects.equals(revocationReason, other.revocationReason)
+                && revocationReasonInUse == other.revocationReasonInUse && Objects.equals(revokedBy, other.revokedBy)
+                && revokedByInUse == other.revokedByInUse && Objects.equals(revokedOnFrom, other.revokedOnFrom)
+                && revokedOnInUse == other.revokedOnInUse && Objects.equals(revokedOnTo, other.revokedOnTo)
+                && Objects.equals(serialFrom, other.serialFrom)
+                && serialNumberRangeInUse == other.serialNumberRangeInUse && Objects.equals(serialTo, other.serialTo)
+                && Objects.equals(state, other.state) && Objects.equals(status, other.status)
+                && subjectInUse == other.subjectInUse && Objects.equals(userID, other.userID)
+                && Objects.equals(validNotAfterFrom, other.validNotAfterFrom)
+                && validNotAfterInUse == other.validNotAfterInUse
+                && Objects.equals(validNotAfterTo, other.validNotAfterTo)
+                && Objects.equals(validNotBeforeFrom, other.validNotBeforeFrom)
+                && validNotBeforeInUse == other.validNotBeforeInUse
+                && Objects.equals(validNotBeforeTo, other.validNotBeforeTo)
+                && Objects.equals(validityCount, other.validityCount)
+                && validityLengthInUse == other.validityLengthInUse
+                && Objects.equals(validityOperation, other.validityOperation)
+                && Objects.equals(validityUnit, other.validityUnit);
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/request/RequestId.java
+++ b/base/common/src/main/java/com/netscape/certsrv/request/RequestId.java
@@ -20,6 +20,8 @@ package com.netscape.certsrv.request;
 import java.io.Serializable;
 import java.math.BigInteger;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * The RequestId class represents the identifier for a particular
  * request within a request queue. This identifier may be used to
@@ -112,6 +114,7 @@ public class RequestId implements Serializable {
      * @return
      *         a string containing the hex (base 16) value for the identifier.
      */
+    @JsonValue
     public String toHexString() {
         return "0x"+value.toString(16);
     }

--- a/base/common/src/main/java/com/netscape/certsrv/request/RequestStatus.java
+++ b/base/common/src/main/java/com/netscape/certsrv/request/RequestStatus.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * The RequestStatus class represents the current state of a request
  * in a request queue. The state of the request changes as actions
@@ -147,6 +149,7 @@ public final class RequestStatus implements Serializable {
      * @return request status
      */
     @Override
+    @JsonValue
     public String toString() {
         return label;
     }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfoTest.java
@@ -1,0 +1,46 @@
+package com.netscape.certsrv.cert;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netscape.certsrv.dbs.certdb.CertId;
+
+public class CertDataInfoTest {
+
+    private static CertDataInfo before = new CertDataInfo();
+
+    @Before
+    public void setUpBefore() {
+        before.setID(new CertId("12512514865863765114"));
+        before.setSubjectDN("CN=Test User,UID=testuser,O=EXAMPLE-COM");
+        before.setStatus("VALID");
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertDataInfo afterXML = CertDataInfo.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertDataInfo afterJSON = CertDataInfo.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertDataTest.java
@@ -1,0 +1,68 @@
+package com.netscape.certsrv.cert;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mozilla.jss.netscape.security.util.Cert;
+
+import com.netscape.certsrv.dbs.certdb.CertId;
+
+public class CertDataTest {
+
+    private static CertData before = new CertData();
+    private static StringWriter sw = new StringWriter();
+    private static PrintWriter out = new PrintWriter(sw, true);
+
+    @BeforeClass
+    public static void setUpBefore() {
+        out.println(Cert.HEADER);
+        out.println("MIIB/zCCAWgCCQCtpWH58pqsejANBgkqhkiG9w0BAQUFADBEMRQwEgYDVQQKDAtF");
+        out.println("WEFNUExFLUNPTTEYMBYGCgmSJomT8ixkAQEMCHRlc3R1c2VyMRIwEAYDVQQDDAlU");
+        out.println("ZXN0IFVzZXIwHhcNMTIwNTE0MTcxNzI3WhcNMTMwNTE0MTcxNzI3WjBEMRQwEgYD");
+        out.println("VQQKDAtFWEFNUExFLUNPTTEYMBYGCgmSJomT8ixkAQEMCHRlc3R1c2VyMRIwEAYD");
+        out.println("VQQDDAlUZXN0IFVzZXIwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKmmiPJp");
+        out.println("Agh/gPUAZjfgJ3a8QiHvpMzZ/hZy1FVP3+2sNhCkMv+D/I8Y7AsrbJGxxvD7bTDm");
+        out.println("zQYtYx2ryGyOgY7KBRxEj/IrNVHIkJMYq5G/aIU4FAzpc6ntNSwUQBYUAamfK8U6");
+        out.println("Wo4Cp6rLePXIDE6sfGn3VX6IeSJ8U2V+vwtzAgMBAAEwDQYJKoZIhvcNAQEFBQAD");
+        out.println("gYEAY9bjcD/7Z+oX6gsJtX6Rd79E7X5IBdOdArYzHNE4vjdaQrZw6oCxrY8ffpKC");
+        out.println("0T0q5PX9I7er+hx/sQjGPMrJDEN+vFBSNrZE7sTeLRgkyiqGvChSyuG05GtGzXO4");
+        out.println("bFBr+Gwk2VF2wJvOhTXU2hN8sfkkd9clzIXuL8WCDhWk1bY=");
+        out.println(Cert.FOOTER);
+
+        before.setSerialNumber(new CertId("12512514865863765114"));
+        before.setIssuerDN("CN=Test User,UID=testuser,O=EXAMPLE-COM");
+        before.setSubjectDN("CN=Test User,UID=testuser,O=EXAMPLE-COM");
+        before.setEncoded(sw.toString());
+        before.setNonce(12345l);
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertData afterXML = CertData.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertData afterJSON = CertData.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertEnrollmentRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertEnrollmentRequestTest.java
@@ -1,0 +1,75 @@
+package com.netscape.certsrv.cert;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netscape.certsrv.profile.ProfileAttribute;
+import com.netscape.certsrv.profile.ProfileInput;
+
+public class CertEnrollmentRequestTest {
+
+    private static CertEnrollmentRequest before = new CertEnrollmentRequest();
+    private static ProfileInput certReq = new ProfileInput();
+    private static ProfileInput subjectName = new ProfileInput();
+    private static ProfileInput submitter = new ProfileInput();
+
+    @Before
+    public void setUpBefore() {
+        before.setProfileId("caUserCert");
+        before.setRenewal(false);
+
+        certReq = before.createInput("KeyGenInput");
+        certReq.addAttribute(new ProfileAttribute("cert_request_type", "crmf", null));
+        certReq.addAttribute(new ProfileAttribute(
+                "cert_request",
+                "MIIBozCCAZ8wggEFAgQBMQp8MIHHgAECpQ4wDDEKMAgGA1UEAxMBeKaBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA2NgaPHp0jiohcP4M+ufrJOZEqH8GV+liu5JLbT8nWpkfhC+8EUBqT6g+n3qroSxIcNVGNdcsBEqs1utvpItzyslAbpdyat3WwQep1dWMzo6RHrPDuIoxNA0Yka1n3qEX4U//08cLQtUv2bYglYgN/hOCNQemLV6vZWAv0n7zelkCAwEAAakQMA4GA1UdDwEB/wQEAwIF4DAzMBUGCSsGAQUFBwUBAQwIcmVnVG9rZW4wGgYJKwYBBQUHBQECDA1hdXRoZW50aWNhdG9yoYGTMA0GCSqGSIb3DQEBBQUAA4GBAJ1VOQcaSEhdHa94s8kifVbSZ2WZeYE5//qxL6wVlEst20vq4ybj13CetnbN3+WT49Zkwp7Fg+6lALKgSk47suTg3EbbQDm+8yOrC0nc/q4PTRoHl0alMmUxIhirYc1t3xoCMqJewmjX1bNP8lpVIZAYFZo4eZCpZaiSkM5BeHhz",
+                null));
+
+        subjectName = before.createInput("SubjectNameInput");
+        subjectName.addAttribute(new ProfileAttribute("sn_uid", "name", null));
+        subjectName.addAttribute(new ProfileAttribute("sn_e", "name@example.com", null));
+        subjectName.addAttribute(new ProfileAttribute("sn_c", "US", null));
+        subjectName.addAttribute(new ProfileAttribute("sn_ou", "Development", null));
+        subjectName.addAttribute(new ProfileAttribute("sn_ou1", "IPA", null));
+        subjectName.addAttribute(new ProfileAttribute("sn_ou2", "Dogtag", null));
+        subjectName.addAttribute(new ProfileAttribute("sn_ou3", "CA", null));
+        subjectName.addAttribute(new ProfileAttribute("sn_cn", "Common", null));
+        subjectName.addAttribute(new ProfileAttribute("sn_o", "RedHat", null));
+
+        submitter = before.createInput("SubmitterInfoInput");
+        submitter.addAttribute(new ProfileAttribute("requestor_name", "admin", null));
+        submitter.addAttribute(new ProfileAttribute("requestor_email", "admin@example.com", null));
+        submitter.addAttribute(new ProfileAttribute("requestor_phone", "650-555-5555", null));
+
+        before.setAttribute("uid", "testuser");
+        before.setAttribute("pwd", "password");
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertEnrollmentRequest afterXML = CertEnrollmentRequest.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertEnrollmentRequest afterJSON = CertEnrollmentRequest.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRequestInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRequestInfoTest.java
@@ -1,0 +1,48 @@
+package com.netscape.certsrv.cert;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netscape.certsrv.dbs.certdb.CertId;
+import com.netscape.certsrv.request.RequestStatus;
+
+public class CertRequestInfoTest {
+
+    private static CertRequestInfo before = new CertRequestInfo();
+
+    @Before
+    public void setUpBefore() {
+        before.setRequestType("enrollment");
+        before.setRequestStatus(RequestStatus.COMPLETE);
+        before.setCertRequestType("pkcs10");
+        before.setCertId(new CertId("5"));
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertRequestInfo afterXML = CertRequestInfo.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertRequestInfo afterJSON = CertRequestInfo.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRequestInfosTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRequestInfosTest.java
@@ -1,0 +1,50 @@
+package com.netscape.certsrv.cert;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netscape.certsrv.request.RequestStatus;
+
+public class CertRequestInfosTest {
+
+    private static CertRequestInfo request = new CertRequestInfo();
+    private static CertRequestInfos before = new CertRequestInfos();
+
+    @Before
+    public void setUpBefore() {
+        request.setRequestType("enrollment");
+        request.setRequestStatus(RequestStatus.COMPLETE);
+        request.setCertRequestType("pkcs10");
+
+        before.addEntry(request);
+        before.setTotal(1);
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertRequestInfos afterXML = CertRequestInfos.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertRequestInfos afterJSON = CertRequestInfos.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRetrievalRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRetrievalRequestTest.java
@@ -1,0 +1,49 @@
+package com.netscape.certsrv.cert;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netscape.certsrv.dbs.certdb.CertId;
+import com.netscape.certsrv.request.RequestId;
+
+public class CertRetrievalRequestTest {
+
+    private static CertRetrievalRequest before = new CertRetrievalRequest();
+    private static CertId cId = new CertId(0x3);
+    private static RequestId rId = new RequestId(0x3);
+
+
+    @Before
+    public void setUpBefore() {
+        before.setCertId(cId);
+        before.setRequestId(rId);
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertRetrievalRequest afterXML = CertRetrievalRequest.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertRetrievalRequest afterJSON = CertRetrievalRequest.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertReviewResponseTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertReviewResponseTest.java
@@ -1,0 +1,37 @@
+package com.netscape.certsrv.cert;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CertReviewResponseTest {
+
+    private CertReviewResponse before = new CertReviewResponse();
+
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertReviewResponse afterXML = CertReviewResponse.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertReviewResponse afterJSON = CertReviewResponse.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRevokeRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRevokeRequestTest.java
@@ -1,0 +1,49 @@
+package com.netscape.certsrv.cert;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.jss.netscape.security.x509.RevocationReason;
+
+public class CertRevokeRequestTest {
+
+    private static CertRevokeRequest before = new CertRevokeRequest();
+
+    @Before
+    public void setUpBefore() {
+        before.setReason(RevocationReason.CERTIFICATE_HOLD);
+        before.setInvalidityDate(new Date());
+        before.setComments("test");
+        before.setEncoded("test");
+        before.setNonce(12345l);
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertRevokeRequest afterXML = CertRevokeRequest.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertRevokeRequest afterJSON = CertRevokeRequest.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+}

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertSearchRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertSearchRequestTest.java
@@ -1,0 +1,37 @@
+package com.netscape.certsrv.cert;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CertSearchRequestTest {
+
+    private static CertSearchRequest before = new CertSearchRequest();
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertSearchRequest afterXML = CertSearchRequest.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+
+    @Test
+    public void testJSON() throws Exception {
+        // Act
+        String json = before.toJSON();
+        System.out.println("JSON (before): " + json);
+
+        CertSearchRequest afterJSON = CertSearchRequest.fromJSON(json);
+        System.out.println("JSON (after): " + afterJSON.toJSON());
+
+        // Assert
+        Assert.assertEquals(before, afterJSON);
+    }
+
+
+}

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACertFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACertFindCLI.java
@@ -216,7 +216,7 @@ public class CACertFindCLI extends CommandCLI {
             FileReader reader = null;
             try {
                 reader = new FileReader(fileName);
-                searchData = CertSearchRequest.valueOf(reader);
+                searchData = CertSearchRequest.fromXML(reader);
 
             } finally {
                 if (reader != null)


### PR DESCRIPTION
Currently one broken test `CertRevokeRequestTest`, caused I think by `RevocationReason` not being marshalled correctly in JSON but correct in XML. 