### PR TITLE
Drop httpcomponents dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,20 +60,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.10</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.12</version>


### PR DESCRIPTION
The direct dependency on `httpcomponents` has been dropped
from `pom.xml` since it is already provided by `resteasy`.
There is no such dependency in `pki.spec`.