### PR TITLE
PKCS#12 export: encrypt private key with AES

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -1997,6 +1997,11 @@ class PK12util:
                 logger.error(log.PKIHELPER_PK12UTIL_MISSING_DBPWFILE)
                 raise Exception(log.PKIHELPER_PK12UTIL_MISSING_DBPWFILE)
 
+            # encrypt private keys with PKCS#5 PBES2
+            command.extend(["-c", "AES-128-CBC"])
+            # don't encrypt public certs
+            command.extend(["-C", "NONE"])
+
             logger.debug('Command: %s', ' '.join(command))
             with open(os.devnull, "w") as fnull:
                 subprocess.check_call(command, stdout=fnull, stderr=fnull)


### PR DESCRIPTION
pk12util export defaults to "PKCS #12 V2 PBE With SHA-1 And 40 Bit RC2
CBC". The algorithm is no longer supported by OpenSSL 3.0.0. Use modern
PBES2 with AES-128-CBC to encrypt private key and leave public certs
unencrypted.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1975406
Signed-off-by: Christian Heimes <cheimes@redhat.com>