### PR TITLE
Make more classes implement JSONSerializer to reduce boilerplate code

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/request/RequestStatus.java
+++ b/base/common/src/main/java/com/netscape/certsrv/request/RequestStatus.java
@@ -111,7 +111,7 @@ public final class RequestStatus implements Serializable {
      */
     public static RequestStatus COMPLETE = new RequestStatus("complete");
 
-    private String label;
+    public String label;
 
     private RequestStatus() {
     }

--- a/base/common/src/main/java/com/netscape/certsrv/util/JSONSerializer.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/JSONSerializer.java
@@ -1,7 +1,5 @@
 package com.netscape.certsrv.util;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
@@ -15,14 +13,12 @@ public interface JSONSerializer {
         return new ObjectMapper()
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .setAnnotationIntrospector(new JacksonAnnotationIntrospector())
-                .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
                 .writeValueAsString(this);
     }
 
     static <T> T fromJSON(String json, Class<T> clazz) throws Exception {
         return new ObjectMapper()
                 .setAnnotationIntrospector(new JacksonAnnotationIntrospector())
-                .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
                 .readValue(json, clazz);
     }
 


### PR DESCRIPTION
In following packages:

com.netscape.certsrv.account
com.netscape.certsrv.authority
com.netscape.certsrv.cert
com.netscape.certsrv.base