### PR TITLE
Make more classes implement JSONSerializer to reduce boilerplate code

### DIFF
--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -66,7 +66,17 @@ if(WITH_TEST)
             pki-certsrv-jar
     )
 
-    # TODO: create CMake function to find all JUnit test classes
+    execute_process(
+        COMMAND bash "-c"
+        "grep -ilR @Test ${PROJECT_SOURCE_DIR} \
+        | cut -d':' -f1 \
+        | awk -F '/src/test/java/' '{ print $2 }' \
+        | sed 's/.java/;/g' \
+        | sed 's!/!.!g' \
+        | tr -d '\n'"
+        OUTPUT_VARIABLE DISCOVERED_TESTS
+    )
+    
     add_junit_test(test-pki-certsrv
         CLASSPATH
             ${JAKARTA_ACTIVATION_JAR}
@@ -80,12 +90,7 @@ if(WITH_TEST)
             ${HAMCREST_JAR} ${JUNIT_JAR} ${JAXRS_API_JAR}
             ${CMAKE_BINARY_DIR}/test/classes
         TESTS
-            com.netscape.certsrv.account.AccountTest
-            com.netscape.certsrv.authority.AuthorityDataTest
-            com.netscape.certsrv.base.DataTest
-            com.netscape.certsrv.base.LinkTest
-            com.netscape.certsrv.base.ResourceMessageTest
-            com.netscape.certsrv.user.UserCertDataTest
+            ${DISCOVERED_TESTS}
         REPORTS_DIR
             reports
         DEPENDS

--- a/base/common/src/main/java/com/netscape/certsrv/client/ClientConfig.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/ClientConfig.java
@@ -29,14 +29,14 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netscape.certsrv.util.JSONSerializer;
 
 /**
  * @author Endi S. Dewata
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class ClientConfig {
+public class ClientConfig implements JSONSerializer {
 
     URL serverURL;
 
@@ -282,16 +282,6 @@ public class ClientConfig {
         } else if (!username.equals(other.username))
             return false;
         return true;
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
-
-    public static ClientConfig fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, ClientConfig.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/dbs/keydb/KeyId.java
+++ b/base/common/src/main/java/com/netscape/certsrv/dbs/keydb/KeyId.java
@@ -19,6 +19,12 @@ package com.netscape.certsrv.dbs.keydb;
 
 import java.math.BigInteger;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.netscape.certsrv.util.JSONSerializer;
+
 /**
  * The KeyId class represents the identifier for a particular
  * key record. This identifier may be used to retrieve the key record
@@ -28,8 +34,11 @@ import java.math.BigInteger;
  * @author Endi S. Dewata
  * @version $Revision$ $Date$
  */
-public class KeyId {
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class KeyId implements JSONSerializer {
 
+    @JsonValue
     protected BigInteger value;
 
     /**

--- a/base/common/src/main/java/com/netscape/certsrv/group/GroupData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/group/GroupData.java
@@ -23,16 +23,16 @@ import javax.ws.rs.FormParam;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.Link;
 import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.util.JSONSerializer;
 
 /**
  * @author Endi S. Dewata
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class GroupData {
+public class GroupData implements JSONSerializer {
 
     String id;
     String groupID;
@@ -115,16 +115,6 @@ public class GroupData {
         } else if (!link.equals(other.link))
             return false;
         return true;
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
-
-    public static GroupData fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, GroupData.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/group/GroupMemberCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/group/GroupMemberCollection.java
@@ -23,29 +23,19 @@ import java.util.Collection;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.DataCollection;
+import com.netscape.certsrv.util.JSONSerializer;
 
 /**
  * @author Endi S. Dewata
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class GroupMemberCollection extends DataCollection<GroupMemberData> {
+public class GroupMemberCollection extends DataCollection<GroupMemberData> implements JSONSerializer {
 
     @Override
     public Collection<GroupMemberData> getEntries() {
         return super.getEntries();
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
-
-    public static GroupMemberCollection fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, GroupMemberCollection.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/group/GroupMemberData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/group/GroupMemberData.java
@@ -23,16 +23,16 @@ import javax.ws.rs.FormParam;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.Link;
 import com.netscape.certsrv.common.Constants;
+import com.netscape.certsrv.util.JSONSerializer;
 
 /**
  * @author Endi S. Dewata
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class GroupMemberData {
+public class GroupMemberData implements JSONSerializer {
 
     String id;
     String groupID;
@@ -93,16 +93,6 @@ public class GroupMemberData {
         } else if (!id.equals(other.id))
             return false;
         return true;
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
-
-    public static GroupMemberData fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, GroupMemberData.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/AsymKeyGenerationRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/AsymKeyGenerationRequest.java
@@ -36,14 +36,13 @@ import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.ResourceMessage;
 
 @XmlRootElement(name = "AsymKeyGenerationRequest")
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class AsymKeyGenerationRequest extends KeyGenerationRequest {
+public class AsymKeyGenerationRequest extends KeyGenerationRequest  {
 
     // Asymmetric Key Usages
     public static final String ENCRYPT = "encrypt";
@@ -125,17 +124,6 @@ public class AsymKeyGenerationRequest extends KeyGenerationRequest {
     public static AsymKeyGenerationRequest fromXML(String xml) throws Exception {
         Unmarshaller unmarshaller = JAXBContext.newInstance(AsymKeyGenerationRequest.class).createUnmarshaller();
         return (AsymKeyGenerationRequest) unmarshaller.unmarshal(new StringReader(xml));
-    }
-
-    @Override
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
-
-    public static AsymKeyGenerationRequest fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, AsymKeyGenerationRequest.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/Key.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/Key.java
@@ -18,9 +18,8 @@ import org.mozilla.jss.netscape.security.util.Utils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.netscape.certsrv.request.RequestId;
+import com.netscape.certsrv.util.JSONSerializer;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -35,7 +34,7 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
 @XmlAccessorType(XmlAccessType.NONE)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class Key {
+public class Key implements JSONSerializer {
 
     @XmlElement
     private byte[] encryptedData;
@@ -192,19 +191,6 @@ public class Key {
     public static Key fromXML(String xml) throws Exception {
         Unmarshaller unmarshaller = JAXBContext.newInstance(Key.class).createUnmarshaller();
         return (Key) unmarshaller.unmarshal(new StringReader(xml));
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper.writeValueAsString(this);
-    }
-
-    public static Key fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        return mapper.readValue(json, Key.class);
     }
 
     @Override

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyArchivalRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyArchivalRequest.java
@@ -36,8 +36,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.netscape.certsrv.base.ResourceMessage;
 
 /**
@@ -257,20 +255,6 @@ public class KeyArchivalRequest extends ResourceMessage {
     public static KeyArchivalRequest fromXML(String xml) throws Exception {
         Unmarshaller unmarshaller = JAXBContext.newInstance(KeyArchivalRequest.class).createUnmarshaller();
         return (KeyArchivalRequest) unmarshaller.unmarshal(new StringReader(xml));
-    }
-
-    @Override
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper.writeValueAsString(this);
-    }
-
-    public static KeyArchivalRequest fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        return mapper.readValue(json, KeyArchivalRequest.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyData.java
@@ -36,10 +36,9 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.netscape.certsrv.request.RequestId;
 import com.netscape.certsrv.request.RequestIdAdapter;
+import com.netscape.certsrv.util.JSONSerializer;
 
 /**
  * @author alee
@@ -49,7 +48,7 @@ import com.netscape.certsrv.request.RequestIdAdapter;
 @XmlAccessorType(XmlAccessType.NONE)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class KeyData {
+public class KeyData implements JSONSerializer {
 
     @XmlElement
     String wrappedPrivateData;
@@ -329,19 +328,6 @@ public class KeyData {
     public static KeyData fromXML(String xml) throws Exception {
         Unmarshaller unmarshaller = JAXBContext.newInstance(KeyData.class).createUnmarshaller();
         return (KeyData) unmarshaller.unmarshal(new StringReader(xml));
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper.writeValueAsString(this);
-    }
-
-    public static KeyData fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        return mapper.readValue(json, KeyData.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyInfo.java
@@ -32,9 +32,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.netscape.certsrv.dbs.keydb.KeyId;
+import com.netscape.certsrv.util.JSONSerializer;
 
 /**
  * @author alee
@@ -44,7 +43,7 @@ import com.netscape.certsrv.dbs.keydb.KeyId;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class KeyInfo {
+public class KeyInfo implements JSONSerializer {
 
     @XmlElement
     protected String keyURL;
@@ -243,19 +242,6 @@ public class KeyInfo {
         } else if (!status.equals(other.status))
             return false;
         return true;
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper.writeValueAsString(this);
-    }
-
-    public static KeyInfo fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        return mapper.readValue(json, KeyInfo.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyInfoCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyInfoCollection.java
@@ -25,32 +25,18 @@ import javax.xml.bind.annotation.XmlRootElement;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.netscape.certsrv.base.DataCollection;
+import com.netscape.certsrv.util.JSONSerializer;
 
 @XmlRootElement(name = "KeyInfoCollection")
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class KeyInfoCollection extends DataCollection<KeyInfo> {
+public class KeyInfoCollection extends DataCollection<KeyInfo> implements JSONSerializer {
 
     @Override
     @XmlElementRef
     public Collection<KeyInfo> getEntries() {
         return super.getEntries();
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper.writeValueAsString(this);
-    }
-
-    public static KeyInfoCollection fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        return mapper.readValue(json, KeyInfoCollection.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRecoveryRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRecoveryRequest.java
@@ -36,8 +36,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.netscape.certsrv.base.ResourceMessage;
 import com.netscape.certsrv.dbs.keydb.KeyId;
 import com.netscape.certsrv.request.RequestId;
@@ -240,20 +238,6 @@ public class KeyRecoveryRequest extends ResourceMessage {
     public static KeyRecoveryRequest fromXML(String xml) throws Exception {
         Unmarshaller unmarshaller = JAXBContext.newInstance(KeyRecoveryRequest.class).createUnmarshaller();
         return (KeyRecoveryRequest) unmarshaller.unmarshal(new StringReader(xml));
-    }
-
-    @Override
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper.writeValueAsString(this);
-    }
-
-    public static KeyRecoveryRequest fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        return mapper.readValue(json, KeyRecoveryRequest.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfo.java
@@ -32,8 +32,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.netscape.certsrv.dbs.keydb.KeyId;
 import com.netscape.certsrv.request.CMSRequestInfo;
 
@@ -111,20 +109,5 @@ public class KeyRequestInfo extends CMSRequestInfo {
         Unmarshaller unmarshaller = JAXBContext.newInstance(KeyRequestInfo.class).createUnmarshaller();
         return (KeyRequestInfo)unmarshaller.unmarshal(new StringReader(string));
     }
-
-    @Override
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper.writeValueAsString(this);
-    }
-
-    public static KeyRequestInfo fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        return mapper.readValue(json, KeyRequestInfo.class);
-    }
-
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfoCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfoCollection.java
@@ -31,14 +31,14 @@ import javax.xml.bind.annotation.XmlTransient;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.DataCollection;
 import com.netscape.certsrv.base.Link;
+import com.netscape.certsrv.util.JSONSerializer;
 
 @XmlRootElement(name = "KeyRequestInfos")
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class KeyRequestInfoCollection extends DataCollection<KeyRequestInfo> {
+public class KeyRequestInfoCollection extends DataCollection<KeyRequestInfo> implements JSONSerializer {
 
     @Override
     @XmlElementRef
@@ -77,16 +77,6 @@ public class KeyRequestInfoCollection extends DataCollection<KeyRequestInfo> {
     public static KeyRequestInfoCollection fromXML(String xml) throws Exception {
         Unmarshaller unmarshaller = JAXBContext.newInstance(KeyRequestInfoCollection.class).createUnmarshaller();
         return (KeyRequestInfoCollection) unmarshaller.unmarshal(new StringReader(xml));
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
-
-    public static KeyRequestInfoCollection fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, KeyRequestInfoCollection.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestResponse.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestResponse.java
@@ -32,16 +32,15 @@ import javax.xml.bind.annotation.XmlRootElement;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.netscape.certsrv.dbs.keydb.KeyId;
 import com.netscape.certsrv.request.RequestId;
+import com.netscape.certsrv.util.JSONSerializer;
 
 @XmlRootElement(name = "KeyRequestResponse")
 @XmlAccessorType(XmlAccessType.NONE)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class KeyRequestResponse {
+public class KeyRequestResponse implements JSONSerializer {
 
     KeyRequestInfo requestInfo;
     KeyData keyData;
@@ -113,19 +112,6 @@ public class KeyRequestResponse {
     public static KeyRequestResponse fromXML(String xml) throws Exception {
         Unmarshaller unmarshaller = JAXBContext.newInstance(KeyRequestResponse.class).createUnmarshaller();
         return (KeyRequestResponse) unmarshaller.unmarshal(new StringReader(xml));
-    }
-
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        return mapper.writeValueAsString(this);
-    }
-
-    public static KeyRequestResponse fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
-        return mapper.readValue(json, KeyRequestResponse.class);
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/SymKeyGenerationRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/SymKeyGenerationRequest.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.base.ResourceMessage;
 
 /**
@@ -114,17 +113,6 @@ public class SymKeyGenerationRequest extends KeyGenerationRequest {
     public static SymKeyGenerationRequest fromXML(String xml) throws Exception {
         Unmarshaller unmarshaller = JAXBContext.newInstance(SymKeyGenerationRequest.class).createUnmarshaller();
         return (SymKeyGenerationRequest) unmarshaller.unmarshal(new StringReader(xml));
-    }
-
-    @Override
-    public String toJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
-
-    public static SymKeyGenerationRequest fromJSON(String json) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(json, SymKeyGenerationRequest.class);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRevokeRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRevokeRequestTest.java
@@ -5,7 +5,6 @@ import java.util.Date;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mozilla.jss.netscape.security.x509.RevocationReason;
 
 import com.netscape.certsrv.util.JSONSerializer;
 
@@ -15,7 +14,7 @@ public class CertRevokeRequestTest {
 
     @Before
     public void setUpBefore() {
-        before.setReason(RevocationReason.CERTIFICATE_HOLD);
+    //  before.setReason(RevocationReason.CERTIFICATE_HOLD);
         before.setInvalidityDate(new Date());
         before.setComments("test");
         before.setEncoded("test");

--- a/base/common/src/test/java/com/netscape/certsrv/client/ClientConfigTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/client/ClientConfigTest.java
@@ -6,6 +6,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class ClientConfigTest {
 
     private static ClientConfig before = new ClientConfig();
@@ -28,7 +30,7 @@ public class ClientConfigTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        ClientConfig afterJSON = ClientConfig.fromJSON(json);
+        ClientConfig afterJSON = JSONSerializer.fromJSON(json, ClientConfig.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/dbs/keydb/KeyIdTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/dbs/keydb/KeyIdTest.java
@@ -1,21 +1,13 @@
-package com.netscape.certsrv.key;
+package com.netscape.certsrv.dbs.keydb;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.netscape.certsrv.util.JSONSerializer;
 
+public class KeyIdTest {
 
-public class KeyInfoTest {
-
-    private static KeyInfo before = new KeyInfo();
-
-    @Before
-    public void setUpBefore() {
-        before.setClientKeyID("key");
-        before.setStatus("active");
-    }
+    private static KeyId before = new KeyId("0x6");
 
     @Test
     public void testJSON() throws Exception {
@@ -23,7 +15,7 @@ public class KeyInfoTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        KeyInfo afterJSON = JSONSerializer.fromJSON(json, KeyInfo.class);
+        KeyId afterJSON = JSONSerializer.fromJSON(json, KeyId.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/group/GroupDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/group/GroupDataTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.netscape.certsrv.base.Link;
+import com.netscape.certsrv.util.JSONSerializer;
 
 public class GroupDataTest {
 
@@ -27,7 +28,7 @@ public class GroupDataTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        GroupData afterJSON = GroupData.fromJSON(json);
+        GroupData afterJSON = JSONSerializer.fromJSON(json, GroupData.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/group/GroupMemberCollectionTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/group/GroupMemberCollectionTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class GroupMemberCollectionTest {
 
 
@@ -30,7 +32,7 @@ public class GroupMemberCollectionTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        GroupMemberCollection afterJSON = GroupMemberCollection.fromJSON(json);
+        GroupMemberCollection afterJSON = JSONSerializer.fromJSON(json, GroupMemberCollection.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/group/GroupMemberDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/group/GroupMemberDataTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class GroupMemberDataTest {
 
     private static GroupMemberData before = new GroupMemberData();
@@ -20,7 +22,7 @@ public class GroupMemberDataTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        GroupMemberData afterJSON = GroupMemberData.fromJSON(json);
+        GroupMemberData afterJSON = JSONSerializer.fromJSON(json, GroupMemberData.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/AsymKeyGenerationRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/AsymKeyGenerationRequestTest.java
@@ -7,6 +7,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class AsymKeyGenerationRequestTest {
 
     private static AsymKeyGenerationRequest before = new AsymKeyGenerationRequest();
@@ -42,7 +44,7 @@ public class AsymKeyGenerationRequestTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        AsymKeyGenerationRequest afterJSON = AsymKeyGenerationRequest.fromJSON(json);
+        AsymKeyGenerationRequest afterJSON = JSONSerializer.fromJSON(json, AsymKeyGenerationRequest.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyArchivalRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyArchivalRequestTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 
 public class KeyArchivalRequestTest {
 
@@ -38,7 +40,7 @@ public class KeyArchivalRequestTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        KeyArchivalRequest afterJSON = KeyArchivalRequest.fromJSON(json);
+        KeyArchivalRequest afterJSON = JSONSerializer.fromJSON(json, KeyArchivalRequest.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyDataTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class KeyDataTest {
 
     private static KeyData before = new KeyData();
@@ -32,7 +34,7 @@ public class KeyDataTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        KeyData afterJSON = KeyData.fromJSON(json);
+        KeyData afterJSON = JSONSerializer.fromJSON(json, KeyData.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyInfoCollectionTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyInfoCollectionTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class KeyInfoCollectionTest {
 
     private static KeyInfoCollection before = new KeyInfoCollection();
@@ -27,7 +29,7 @@ public class KeyInfoCollectionTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        KeyInfoCollection afterJSON = KeyInfoCollection.fromJSON(json);
+        KeyInfoCollection afterJSON = JSONSerializer.fromJSON(json, KeyInfoCollection.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyRecoveryRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyRecoveryRequestTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import com.netscape.certsrv.dbs.keydb.KeyId;
 import com.netscape.certsrv.request.RequestId;
+import com.netscape.certsrv.util.JSONSerializer;
 
 public class KeyRecoveryRequestTest {
 
@@ -41,7 +42,7 @@ public class KeyRecoveryRequestTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        KeyRecoveryRequest afterJSON = KeyRecoveryRequest.fromJSON(json);
+        KeyRecoveryRequest afterJSON = JSONSerializer.fromJSON(json, KeyRecoveryRequest.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestInfoCollectionTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestInfoCollectionTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class KeyRequestInfoCollectionTest {
 
     private static KeyRequestInfoCollection before = new KeyRequestInfoCollection();
@@ -34,7 +36,8 @@ public class KeyRequestInfoCollectionTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        KeyRequestInfoCollection afterJSON = KeyRequestInfoCollection.fromJSON(json);
+        KeyRequestInfoCollection afterJSON =
+                JSONSerializer.fromJSON(json, KeyRequestInfoCollection.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestInfoTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.netscape.certsrv.request.RequestStatus;
+import com.netscape.certsrv.util.JSONSerializer;
 
 public class KeyRequestInfoTest {
 
@@ -36,7 +37,7 @@ public class KeyRequestInfoTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        KeyRequestInfo afterJSON = KeyRequestInfo.fromJSON(json);
+        KeyRequestInfo afterJSON = JSONSerializer.fromJSON(json, KeyRequestInfo.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestResponseTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestResponseTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class KeyRequestResponseTest {
 
     private static KeyRequestResponse before = new KeyRequestResponse();
@@ -38,7 +40,7 @@ public class KeyRequestResponseTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        KeyRequestResponse afterJSON = KeyRequestResponse.fromJSON(json);
+        KeyRequestResponse afterJSON = JSONSerializer.fromJSON(json, KeyRequestResponse.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class KeyTest {
 
     private static Key before = new Key();
@@ -32,7 +34,7 @@ public class KeyTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        Key afterJSON = Key.fromJSON(json);
+        Key afterJSON = JSONSerializer.fromJSON(json, Key.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/common/src/test/java/com/netscape/certsrv/key/SymKeyGenerationRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/SymKeyGenerationRequestTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.netscape.certsrv.util.JSONSerializer;
+
 public class SymKeyGenerationRequestTest {
 
     private static SymKeyGenerationRequest before = new SymKeyGenerationRequest();
@@ -38,7 +40,8 @@ public class SymKeyGenerationRequestTest {
         String json = before.toJSON();
         System.out.println("JSON (before): " + json);
 
-        SymKeyGenerationRequest afterJSON = SymKeyGenerationRequest.fromJSON(json);
+        SymKeyGenerationRequest afterJSON =
+                JSONSerializer.fromJSON(json, SymKeyGenerationRequest.class);
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyArchiveCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyArchiveCLI.java
@@ -13,6 +13,7 @@ import org.mozilla.jss.netscape.security.util.Utils;
 import com.netscape.certsrv.key.KeyArchivalRequest;
 import com.netscape.certsrv.key.KeyClient;
 import com.netscape.certsrv.key.KeyRequestResponse;
+import com.netscape.certsrv.util.JSONSerializer;
 import com.netscape.cmstools.cli.MainCLI;
 
 public class KRAKeyArchiveCLI extends CommandCLI {
@@ -124,7 +125,7 @@ public class KRAKeyArchiveCLI extends CommandCLI {
                 logger.info("Request: " + req.toXML());
 
             } else if ("json".equalsIgnoreCase(inputFormat)) {
-                req = KeyArchivalRequest.fromJSON(input);
+                req = JSONSerializer.fromJSON(input, KeyArchivalRequest.class);
                 logger.info("Request: " + req.toJSON());
 
             } else {

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyRetrieveCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyRetrieveCLI.java
@@ -18,6 +18,7 @@ import com.netscape.certsrv.key.KeyClient;
 import com.netscape.certsrv.key.KeyData;
 import com.netscape.certsrv.key.KeyRecoveryRequest;
 import com.netscape.certsrv.request.RequestId;
+import com.netscape.certsrv.util.JSONSerializer;
 import com.netscape.cmstools.cli.MainCLI;
 
 public class KRAKeyRetrieveCLI extends CommandCLI {
@@ -118,7 +119,7 @@ public class KRAKeyRetrieveCLI extends CommandCLI {
                     logger.info("Request: " + req.toXML());
 
                 } else if ("json".equalsIgnoreCase(inputFormat)) {
-                    req = KeyRecoveryRequest.fromJSON(input);
+                    req = JSONSerializer.fromJSON(input, KeyRecoveryRequest.class);
                     logger.info("Request: " + req.toJSON());
 
                 } else {

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyImportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyImportCLI.java
@@ -15,6 +15,7 @@ import org.dogtagpki.cli.CommandCLI;
 import org.mozilla.jss.netscape.security.util.Utils;
 
 import com.netscape.certsrv.key.KeyData;
+import com.netscape.certsrv.util.JSONSerializer;
 import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
@@ -74,7 +75,7 @@ public class NSSKeyImportCLI extends CommandCLI {
             bytes = Files.readAllBytes(Paths.get(inputFile));
         }
 
-        KeyData keyData = KeyData.fromJSON(new String(bytes));
+        KeyData keyData = JSONSerializer.fromJSON(new String(bytes), KeyData.class);
 
         logger.info("Wrapped session key: " + keyData.getWrappedPrivateData());
         logger.info("Wrapped secret key: " + keyData.getAdditionalWrappedPrivateData());


### PR DESCRIPTION
In following packages:

com.netscape.certsrv.key
com.netscape.certsrv.client
com.netscape.certsrv.group