### PR TITLE
AuthorityService.getCert/Chain: avoid NPE if CA is not ready

### DIFF
--- a/base/ca/src/org/dogtagpki/server/ca/rest/AuthorityService.java
+++ b/base/ca/src/org/dogtagpki/server/ca/rest/AuthorityService.java
@@ -140,8 +140,13 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
         if (ca == null)
             throw new ResourceNotFoundException("CA \"" + aidString + "\" not found");
 
+        org.mozilla.jss.crypto.X509Certificate cert = ca.getCaX509Cert();
+        if (cert == null)
+            throw new ResourceNotFoundException(
+                "Certificate for CA \"" + aidString + "\" not available");
+
         try {
-            return Response.ok(ca.getCaX509Cert().getEncoded()).build();
+            return Response.ok(cert.getEncoded()).build();
         } catch (CertificateEncodingException e) {
             // this really is a 500 Internal Server Error
             throw new PKIException("Error encoding certificate: " + e);
@@ -167,9 +172,14 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
         if (ca == null)
             throw new ResourceNotFoundException("CA \"" + aidString + "\" not found");
 
+        netscape.security.x509.CertificateChain chain = ca.getCACertChain();
+        if (chain == null)
+            throw new ResourceNotFoundException(
+                "Certificate chain for CA \"" + aidString + "\" not available");
+
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
-            ca.getCACertChain().encode(out);
+            chain.encode(out);
         } catch (IOException e) {
             throw new PKIException("Error encoding certificate chain: " + e);
         }


### PR DESCRIPTION
Fixed backported commit, original commit message follows:

--
If a LWCA is not ready (i.e. key replication and signing unit
initialisation has not completed), asking for its certificate (or
chain) results in a NullPointerException.  Update
AuthorityService.getCert() and .getChain() to raise
ResourceNotFoundException instead.

Part of: https://pagure.io/dogtagpki/issue/3102