### PR TITLE
Add tests for CA auditor

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -99,6 +99,9 @@ jobs:
           docker exec pki pkispawn -f /usr/share/pki/server/examples/installation/ca.cfg -s CA -v
           # set buffer size to 0 so that revocation takes effect immediately
           docker exec pki pki-server ca-config-set auths.revocationChecking.bufferSize 0
+          # enable signed audit log
+          docker exec pki pki-server ca-config-set log.instance.SignedAudit.logSigning true
+          # restart PKI server
           docker exec pki pki-server restart --wait
 
       - name: Run PKI healthcheck
@@ -129,6 +132,12 @@ jobs:
           docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-create.sh
           docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-revoke.sh
           docker exec pki /usr/share/pki/tests/ca/bin/ca-agent-cert-unrevoke.sh
+
+      - name: Test CA auditor
+        run: |
+          docker exec pki /usr/share/pki/tests/ca/bin/test-ca-auditor-create.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/test-ca-auditor-cert.sh
+          docker exec pki /usr/share/pki/tests/ca/bin/test-ca-auditor-logs.sh
 
       - name: Gather artifacts
         if: always()

--- a/tests/ca/bin/test-ca-auditor-cert.sh
+++ b/tests/ca/bin/test-ca-auditor-cert.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+# submit a cert request and capture the request ID
+pki client-cert-request uid=caauditor | sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" > /tmp/request_id
+
+# approve the cert request and capture the cert ID
+pki -n caadmin ca-cert-request-approve `cat /tmp/request_id` --force | sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" > /tmp/cert_id
+
+# assign the cert to the user
+pki -n caadmin ca-user-cert-add caauditor --serial `cat /tmp/cert_id`
+
+# import the cert into client
+pki client-cert-import caauditor --serial `cat /tmp/cert_id`
+
+# test client certificate
+pki -n caauditor ca-audit-file-find

--- a/tests/ca/bin/test-ca-auditor-create.sh
+++ b/tests/ca/bin/test-ca-auditor-create.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+# create a user
+pki -n caadmin ca-user-add caauditor --fullName "CA Auditor" --password Secret.123
+
+# add the user to Auditors group
+pki -n caadmin ca-user-membership-add caauditor "Auditors"
+
+# test username and password
+pki -u caauditor -w Secret.123 ca-audit-file-find

--- a/tests/ca/bin/test-ca-auditor-logs.sh
+++ b/tests/ca/bin/test-ca-auditor-logs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+# list of audit log files
+pki -n caauditor ca-audit-file-find | sed -n "s/^\s*File name: \s*\(\S*\)$/\1/p" > /tmp/audit.filenames
+
+# retrieve audit log files
+for filename in `cat /tmp/audit.filenames`
+do
+    pki -n caauditor ca-audit-file-retrieve $filename
+done


### PR DESCRIPTION
New tests have been added to verify creating CA auditor
with basic auth and client cert auth and retrieving
audit logs.