### PR TITLE
Bug Automation 1963220 revoke with allowExtCASignedAgentCerts parms

### DIFF
--- a/tests/dogtag/pytest-ansible/pytest/ca/externalca/fixtures.py
+++ b/tests/dogtag/pytest-ansible/pytest/ca/externalca/fixtures.py
@@ -89,7 +89,7 @@ def config_setup(request,ansible_module):
         yield("resource")
         log.info("teardown before exit")
         for x in ['rm -rf %s %s' %(instance_creation.nssdb, instance_creation.pass_file),
-                  'pkidestroy -s %s -i %s' % (instance_creation.subsystem, instance_creation.instance_name)]:
+                  'pkidestroy -s %s -i %s --force' % (instance_creation.subsystem, instance_creation.instance_name)]:
             ansible_module.shell(x)
             log.info("Teardown: Remove %s",x)
 
@@ -104,7 +104,9 @@ def config_setup(request,ansible_module):
         ansible_module.copy(src=instance_creation.config_step2, dest=instance_creation.config_step2)
         yield("resource")
         log.info("teardown before exit")
+        for file in "config_step1.cfg", "config_step2.cfg":
+            os.remove("/tmp/" + file)
         for x in ['rm -rf %s %s' %(instance_creation.nssdb, instance_creation.pass_file),
-                  'pkidestroy -s %s -i %s' % (instance_creation.subsystem, instance_creation.instance_name)]:
+                  'pkidestroy -s %s -i %s --force' % (instance_creation.subsystem, instance_creation.instance_name)]:
             ansible_module.shell(x)
             log.info("Teardown: Remove %s",x)

--- a/tests/dogtag/pytest-ansible/pytest/ca/externalca/test_externalca_SKI_bug_1656856_in_signing_request.py
+++ b/tests/dogtag/pytest-ansible/pytest/ca/externalca/test_externalca_SKI_bug_1656856_in_signing_request.py
@@ -157,3 +157,7 @@ def test_bug_1656856_include_SKI_in_ca_signing_certificate_request(ansible_modul
     log.info("User's request id is :%s" %(instance_creation.find(output,"Request ID:")))
     output = instance_creation.approve_usercsr(ansible_module,instance_creation.find(output,"Request ID:"))
     log.info(" Approve csr : %s", output)
+
+    log.info("teardown before exit")
+    ansible_module.shell("yes|cp -f /usr/share/pki/ca/profiles/ca/caCACert.cfg {}".format(profile_path))
+    instance_status(ansible_module, status='restart')

--- a/tests/dogtag/pytest-ansible/pytest/ca/externalca/utils.py
+++ b/tests/dogtag/pytest-ansible/pytest/ca/externalca/utils.py
@@ -179,7 +179,7 @@ class pki_externalca_common(object):
         for values in out.values():
             for items in [x.strip(' ') for x in values[key].splitlines()]:
                 if items.startswith('{}'.format(search)):
-                    req = items.strip('{}'.format(search))
+                    req = items.lstrip('{}'.format(search))
                     return str(req)
 
 class pki_externalca(pki_externalca_common):


### PR DESCRIPTION
1. Install CA and SubCA.
2. Create certificate on external CA for agent with name extCA-agent.
3. Create agent on main CA and import extCA-agent certificate.
4. Test with default value of ca.allowExtCASignedAgentCerts=false without any changes.
5. Test with parameter ca.allowExtCASignedAgentCerts=true in CS.cfg parameter

Signed-off-by: Deepak Punia <dpunia@redhat.com>

Upstream pipeline executed for this test : https://gitlab.com/dpunia/pki/-/pipelines/332762747 