### PR TITLE
Update pki tps-config doc

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/base/Link.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/Link.java
@@ -58,7 +58,6 @@ public class Link implements JSONSerializer {
     public Link(String relationship, URI uri) {
         this.relationship = relationship;
         this.href = uri.toString();
-        this.type = "application/xml";
     }
 
     /**

--- a/docs/changes/v11.0.0/Switching-from-XML-to-JSON-REST-API.adoc
+++ b/docs/changes/v11.0.0/Switching-from-XML-to-JSON-REST-API.adoc
@@ -1,0 +1,24 @@
+= Overview =
+
+Prior to version 11 PKI mostly supported REST API in XML format,
+although there were endpoints that supported JSON as well.
+Starting from version 11 PKI will only support REST API in JSON format.
+
+In most cases users using the REST API indirectly via CLI or Web UI should not be affected.
+However, PKI tools that used to take or produce an XML file will now take or produce a JSON file instead.
+
+= PKI TPS Configuration CLI Changes =
+
+The `--output` parameter for `pki tps-config-show` command will now produce a JSON file:
+
+----
+$ pki -n caadmin tps-config-show --output tps.json
+----
+
+The `--input` parameter for `pki tps-config-mod` will now take a JSON file:
+
+----
+$ pki -n caadmin tps-config-mod --input tps.json
+----
+
+See link:../../user/tools/Using-PKI-TPS-Configuration-CLI.adoc[Using PKI TPS Configuration CLI].

--- a/docs/user/tools/Using-PKI-TPS-Configuration-CLI.adoc
+++ b/docs/user/tools/Using-PKI-TPS-Configuration-CLI.adoc
@@ -58,64 +58,66 @@ Configuration
 To download the TPS configuration into a file:
 
 ----
-$ pki -n caadmin tps-config-show --output tps.xml
----------------------------------
-Stored configuration into tps.xml
----------------------------------
+$ pki -n caadmin tps-config-show --output tps.json
+----------------------------------
+Stored configuration into tps.json
+----------------------------------
 ----
 
-The configuration will be stored in XML format:
+The configuration will be stored in JSON format:
 
 ----
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Configuration xmlns:ns2="http://www.w3.org/2005/Atom">
-    <Link href="https://server.example.com:8443/tps/rest/config" rel="self"/>
-    <Properties>
-        <Property name="applet._000">#########################################</Property>
-        <Property name="applet._001"># applet information</Property>
-        <Property name="applet._002"># SAF Key:</Property>
-        <Property name="applet._003"># applet.aid.cardmgr_instance=A0000001510000</Property>
-        <Property name="applet._004"># Stock RSA,KeyRecover applet : 1.4.54de790f.ijc</Property>
-        <Property name="applet._005"># Beta RSA/KeyRecovery/GP211/SCP02 applet : 1.5.558cdcff.ijc</Property>
-        <Property name="applet._006"># Use GP211 applet only with SCP02 card</Property>
-        <Property name="applet._007">#########################################</Property>
-        <Property name="applet.aid.cardmgr_instance">A0000000030000</Property>
-        <Property name="applet.aid.netkey_file">627601FF0000</Property>
-        <Property name="applet.aid.netkey_instance">627601FF000000</Property>
-        <Property name="applet.aid.netkey_old_file">A000000001</Property>
-        <Property name="applet.aid.netkey_old_instance">A00000000101</Property>
-        <Property name="applet.delete_old">true</Property>
-        <Property name="applet.so_pin">000000000000</Property>
-        <Property name="channel._000">#########################################</Property>
-        <Property name="channel._001"># channel.encryption:</Property>
-        <Property name="channel._002">#</Property>
-        <Property name="channel._003">#   - enable encryption for all operation commands to token</Property>
-        <Property name="channel._004">#   - default is true</Property>
-        <Property name="channel._005">#  channel.blocksize=224</Property>
-        <Property name="channel._006">#  channel.defKeyVersion=0</Property>
-        <Property name="channel._007">#  channel.defKeyIndex=0</Property>
-        <Property name="channel._008">#</Property>
-        <Property name="channel._009">#  Config the size of memory managed memory in the applet</Property>
-        <Property name="channel._010">#  Default is 5000, try not go get close to the instanceSize</Property>
-        <Property name="channel._011">#  which defaults to 18000:</Property>
-        <Property name="channel._012">#</Property>
-        <Property name="channel._013">#  * channel.instanceSize=18000</Property>
-        <Property name="channel._014">#  * channel.appletMemorySize=5000</Property>
-        <Property name="channel._015">#########################################</Property>
-        <Property name="channel.blocksize">224</Property>
-        <Property name="channel.defKeyIndex">0</Property>
-        <Property name="channel.defKeyVersion">0</Property>
-        <Property name="channel.encryption">true</Property>
-        <Property name="failover.pod.enable">false</Property>
-        <Property name="general.applet_ext">ijc</Property>
-        <Property name="general.pwlength.min">16</Property>
-        <Property name="general.search.sizelimit.default">100</Property>
-        <Property name="general.search.sizelimit.max">2000</Property>
-        <Property name="general.search.timelimit.default">10</Property>
-        <Property name="general.search.timelimit.max">10</Property>
-        <Property name="general.verifyProof">1</Property>
-    </Properties>
-</Configuration>
+{
+  "properties" : {
+    "applet._000" : "#########################################",
+    "applet._001" : "# applet information",
+    "applet._002" : "# SAF Key:",
+    "applet._003" : "# applet.aid.cardmgr_instance=A0000001510000",
+    "applet._004" : "# Stock RSA,KeyRecover applet : 1.4.54de790f.ijc",
+    "applet._005" : "# Beta RSA/KeyRecovery/GP211/SCP02 applet : 1.5.558cdcff.ijc",
+    "applet._006" : "# Use GP211 applet only with SCP02 card",
+    "applet._007" : "#########################################",
+    "applet.aid.cardmgr_instance" : "A0000000030000",
+    "applet.aid.netkey_file" : "627601FF0000",
+    "applet.aid.netkey_instance" : "627601FF000000",
+    "applet.aid.netkey_old_file" : "A000000001",
+    "applet.aid.netkey_old_instance" : "A00000000101",
+    "applet.delete_old" : "true",
+    "applet.so_pin" : "000000000000",
+    "channel._000" : "#########################################",
+    "channel._001" : "# channel.encryption:",
+    "channel._002" : "#",
+    "channel._003" : "#   - enable encryption for all operation commands to token",
+    "channel._004" : "#   - default is true",
+    "channel._005" : "#  channel.blocksize=224",
+    "channel._006" : "#  channel.defKeyVersion=0",
+    "channel._007" : "#  channel.defKeyIndex=0",
+    "channel._008" : "#",
+    "channel._009" : "#  Config the size of memory managed memory in the applet",
+    "channel._010" : "#  Default is 5000, try not go get close to the instanceSize",
+    "channel._011" : "#  which defaults to 18000:",
+    "channel._012" : "#",
+    "channel._013" : "#  * channel.instanceSize=18000",
+    "channel._014" : "#  * channel.appletMemorySize=5000",
+    "channel._015" : "#########################################",
+    "channel.blocksize" : "224",
+    "channel.defKeyIndex" : "0",
+    "channel.defKeyVersion" : "0",
+    "channel.encryption" : "true",
+    "failover.pod.enable" : "false",
+    "general.applet_ext" : "ijc",
+    "general.pwlength.min" : "16",
+    "general.search.sizelimit.default" : "100",
+    "general.search.sizelimit.max" : "2000",
+    "general.search.timelimit.default" : "10",
+    "general.search.timelimit.max" : "10",
+    "general.verifyProof" : "1"
+  },
+  "link" : {
+    "relationship" : "self",
+    "href" : "https://server.example.com:8443/tps/rest/config"
+  }
+}
 ----
 
 == Modifying TPS Configuration ==
@@ -124,7 +126,7 @@ To update the TPS configuration, download the existing configuration into a file
 Edit the file, then execute the following command:
 
 ----
-$ pki -n caadmin tps-config-mod --input tps.xml
+$ pki -n caadmin tps-config-mod --input tps.json
 ----
 
 To save the updated configuration into a file, specify the `--output` parameter.


### PR DESCRIPTION
The doc for `pki tps-config` has been updated to use JSON instead of XML file format:
https://github.com/edewata/pki/blob/json/docs/changes/v11.0.0/Switching-from-XML-to-JSON-REST-API.adoc
https://github.com/edewata/pki/blob/json/docs/user/tools/Using-PKI-TPS-Configuration-CLI.adoc

The `Link` constructor has been modified not to set the type if it's not specified to match RESTEasy's `Link` constructor:
https://github.com/resteasy/Resteasy/blob/3.0.26.Final/providers/resteasy-atom/src/main/java/org/jboss/resteasy/plugins/providers/atom/Link.java#L54-L58

**Note:** This PR should be merged together with PR #3610.