### PR TITLE
Fix pki <subsystem>-audit CLIs

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/logging/AuditModifyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/logging/AuditModifyCLI.java
@@ -121,7 +121,7 @@ public class AuditModifyCLI extends CommandCLI {
 
         } else {
             try (PrintWriter out = new PrintWriter(new FileWriter(output))) {
-                out.println(auditConfig);
+                out.println(auditConfig.toJSON());
             }
         }
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/logging/AuditShowCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/logging/AuditShowCLI.java
@@ -78,7 +78,7 @@ public class AuditShowCLI extends CommandCLI {
 
         } else {
             try (PrintWriter out = new PrintWriter(new FileWriter(output))) {
-                out.println(auditConfig);
+                out.println(auditConfig.toJSON());
             }
             MainCLI.printMessage("Stored audit configuration into " + output);
         }

--- a/docs/changes/v11.0.0/Switching-from-XML-to-JSON-REST-API.adoc
+++ b/docs/changes/v11.0.0/Switching-from-XML-to-JSON-REST-API.adoc
@@ -7,6 +7,22 @@ Starting from version 11 PKI will only support REST API in JSON format.
 In most cases users using the REST API indirectly via CLI or Web UI should not be affected.
 However, PKI tools that used to take or produce an XML file will now take or produce a JSON file instead.
 
+= PKI Audit CLI Changes =
+
+The `--output` parameter for `pki <subsystem>-audit-show` command will now produce a JSON file:
+
+----
+$ pki -n caadmin <subsystem>-audit-show --output audit.json
+----
+
+The `--input` parameter for `pki <subsystem>-audit-mod` will now take a JSON file:
+
+----
+$ pki -n caadmin <subsystem>-audit-mod --input audit.json
+----
+
+See link:../../user/tools/Using-PKI-Audit-CLI.adoc[Using PKI Audit CLI].
+
 = PKI TPS Configuration CLI Changes =
 
 The `--output` parameter for `pki tps-config-show` command will now produce a JSON file:

--- a/docs/user/tools/Using-PKI-Audit-CLI.adoc
+++ b/docs/user/tools/Using-PKI-Audit-CLI.adoc
@@ -55,61 +55,63 @@ Audit configuration
 To download audit configuration into a file:
 
 ----
-$ pki -n caadmin tps-audit-show --output audit.xml
------------------------------------------
-Stored audit configuration into audit.xml
------------------------------------------
+$ pki -n caadmin tps-audit-show --output audit.json
+------------------------------------------
+Stored audit configuration into audit.json
+------------------------------------------
 ----
 
-The audit configuration is stored in XML format:
+The audit configuration is stored in JSON format:
 
 ----
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Audit xmlns:ns2="http://www.w3.org/2005/Atom">
-    <BufferSize>512</BufferSize>
-    <Events>
-        <Event name="AUDIT_LOG_SHUTDOWN">mandatory</Event>
-        <Event name="AUDIT_LOG_STARTUP">mandatory</Event>
-        <Event name="AUTHZ_FAIL">enabled</Event>
-        <Event name="AUTHZ_SUCCESS">enabled</Event>
-        <Event name="AUTH_FAIL">enabled</Event>
-        <Event name="AUTH_SUCCESS">enabled</Event>
-        <Event name="CIMC_CERT_VERIFICATION">enabled</Event>
-        <Event name="CONFIG_AUTH">enabled</Event>
-        <Event name="CONFIG_ROLE">enabled</Event>
-        <Event name="CONFIG_SIGNED_AUDIT">enabled</Event>
-        <Event name="CONFIG_TOKEN_AUTHENTICATOR">enabled</Event>
-        <Event name="CONFIG_TOKEN_CONNECTOR">enabled</Event>
-        <Event name="CONFIG_TOKEN_GENERAL">enabled</Event>
-        <Event name="CONFIG_TOKEN_MAPPING_RESOLVER">enabled</Event>
-        <Event name="CONFIG_TOKEN_PROFILE">enabled</Event>
-        <Event name="CONFIG_TOKEN_RECORD">enabled</Event>
-        <Event name="LOGGING_SIGNED_AUDIT_SIGNING">mandatory</Event>
-        <Event name="ROLE_ASSUME">enabled</Event>
-        <Event name="SELFTESTS_EXECUTION">enabled</Event>
-        <Event name="TOKEN_APPLET_UPGRADE_FAILURE">enabled</Event>
-        <Event name="TOKEN_APPLET_UPGRADE_SUCCESS">enabled</Event>
-        <Event name="TOKEN_AUTH_FAILURE">enabled</Event>
-        <Event name="TOKEN_AUTH_SUCCESS">enabled</Event>
-        <Event name="TOKEN_CERT_ENROLLMENT">enabled</Event>
-        <Event name="TOKEN_CERT_RENEWAL">enabled</Event>
-        <Event name="TOKEN_CERT_RETRIEVAL">enabled</Event>
-        <Event name="TOKEN_FORMAT_FAILURE">enabled</Event>
-        <Event name="TOKEN_FORMAT_SUCCESS">enabled</Event>
-        <Event name="TOKEN_KEY_CHANGEOVER_FAILURE">enabled</Event>
-        <Event name="TOKEN_KEY_CHANGEOVER_REQUIRED">enabled</Event>
-        <Event name="TOKEN_KEY_CHANGEOVER_SUCCESS">enabled</Event>
-        <Event name="TOKEN_KEY_RECOVERY">enabled</Event>
-        <Event name="TOKEN_OP_REQUEST">enabled</Event>
-        <Event name="TOKEN_PIN_RESET_FAILURE">enabled</Event>
-        <Event name="TOKEN_PIN_RESET_SUCCESS">enabled</Event>
-        <Event name="TOKEN_STATE_CHANGE">enabled</Event>
-    </Events>
-    <Interval>5</Interval>
-    <Link href="https://server.example.com:8443/tps/rest/audit" rel="self"/>
-    <Signed>false</Signed>
-    <Status>Enabled</Status>
-</Audit>
+{
+  "status" : "Enabled",
+  "signed" : false,
+  "interval" : 5,
+  "bufferSize" : 512,
+  "eventConfigs" : {
+    "AUDIT_LOG_SHUTDOWN" : "mandatory",
+    "AUDIT_LOG_STARTUP" : "mandatory",
+    "AUTHZ_FAIL" : "enabled",
+    "AUTHZ_SUCCESS" : "enabled",
+    "AUTH_FAIL" : "enabled",
+    "AUTH_SUCCESS" : "enabled",
+    "CIMC_CERT_VERIFICATION" : "enabled",
+    "CONFIG_AUTH" : "enabled",
+    "CONFIG_ROLE" : "enabled",
+    "CONFIG_SIGNED_AUDIT" : "enabled",
+    "CONFIG_TOKEN_AUTHENTICATOR" : "enabled",
+    "CONFIG_TOKEN_CONNECTOR" : "enabled",
+    "CONFIG_TOKEN_GENERAL" : "enabled",
+    "CONFIG_TOKEN_MAPPING_RESOLVER" : "enabled",
+    "CONFIG_TOKEN_PROFILE" : "enabled",
+    "CONFIG_TOKEN_RECORD" : "enabled",
+    "LOGGING_SIGNED_AUDIT_SIGNING" : "mandatory",
+    "ROLE_ASSUME" : "enabled",
+    "SELFTESTS_EXECUTION" : "enabled",
+    "TOKEN_APPLET_UPGRADE_FAILURE" : "enabled",
+    "TOKEN_APPLET_UPGRADE_SUCCESS" : "enabled",
+    "TOKEN_AUTH_FAILURE" : "enabled",
+    "TOKEN_AUTH_SUCCESS" : "enabled",
+    "TOKEN_CERT_ENROLLMENT" : "enabled",
+    "TOKEN_CERT_RENEWAL" : "enabled",
+    "TOKEN_CERT_RETRIEVAL" : "enabled",
+    "TOKEN_FORMAT_FAILURE" : "enabled",
+    "TOKEN_FORMAT_SUCCESS" : "enabled",
+    "TOKEN_KEY_CHANGEOVER_FAILURE" : "enabled",
+    "TOKEN_KEY_CHANGEOVER_REQUIRED" : "enabled",
+    "TOKEN_KEY_CHANGEOVER_SUCCESS" : "enabled",
+    "TOKEN_KEY_RECOVERY" : "enabled",
+    "TOKEN_OP_REQUEST" : "enabled",
+    "TOKEN_PIN_RESET_FAILURE" : "enabled",
+    "TOKEN_PIN_RESET_SUCCESS" : "enabled",
+    "TOKEN_STATE_CHANGE" : "enabled"
+  },
+  "link" : {
+    "relationship" : "self",
+    "href" : "https://server.example.com:8443/tps/rest/audit"
+  }
+}
 ----
 
 == Modifying Audit Configuration ==
@@ -118,27 +120,26 @@ To modify the audit configuration, download the current audit configuration into
 Edit the file as needed:
 
 ----
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Audit xmlns:ns2="http://www.w3.org/2005/Atom">
-    <BufferSize>1024</BufferSize>
-    <Events>
-        ...
-        <Event name="AUTHZ_SUCCESS">disabled</Event>
-        ...
-        <Event name="AUTH_SUCCESS">disabled</Event>
-        ...
-    </Events>
-    <Interval>10</Interval>
+{
+  ...
+  "signed" : true,
+  "interval" : 10,
+  "bufferSize" : 1024,
+  "eventConfigs" : {
     ...
-    <Signed>true</Signed>
+    "AUTHZ_SUCCESS" : "disabled",
     ...
-</Audit>
+    "AUTH_SUCCESS" : "disabled",
+    ...
+  },
+  ...
+}
 ----
 
 Then upload the new configuration with the following command:
 
 ----
-$ pki -n caadmin tps-audit-mod --input audit.xml
+$ pki -n caadmin tps-audit-mod --input audit.json
 ----------------------------
 Modified audit configuration
 ----------------------------


### PR DESCRIPTION
The `pki <subsystem>-audit-show` and `-mod` commands have been modified to store the output file in JSON format.

The doc for these commands has been updated as well:
https://github.com/edewata/pki/blob/docs/docs/changes/v11.0.0/Switching-from-XML-to-JSON-REST-API.adoc
https://github.com/edewata/pki/blob/docs/docs/user/tools/Using-PKI-Audit-CLI.adoc

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1980368

**Note:** This PR should be merged together with PR #3613.
