### PR TITLE
Bug1979560-subCA installation ECC cert validation failure

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -450,9 +450,12 @@ class PKISubsystem(object):
 
         logger.debug('Command: %s', ' '.join(cmd))
 
-        subprocess.check_output(
-            cmd,
-            stderr=subprocess.STDOUT)
+        try:
+            print subprocess.check_output(
+                cmd,
+                stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError, e:
+            print "pki-server subsystem-cert-validate stdout output:\n", e.output
 
     def export_system_cert(
             self,

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -821,6 +821,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             "validating %s certificate", tag,
             extra=config.PKI_INDENTATION_LEVEL_2)
 
+        print "validate_system_cert on: " +tag + "; cert_data= " + cert_data
+
         subsystem.validate_system_cert(tag)
 
     def validate_system_certs(self, deployer, nssdb, subsystem):
@@ -1091,6 +1093,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 self.configure_system_certs(deployer, subsystem)
                 self.update_system_certs(deployer, nssdb, subsystem)
                 subsystem.save()
+                print "cfu: sleep for 30 seconds before validate_system_certs() call"
+                time.sleep(30);
 
                 self.validate_system_certs(deployer, nssdb, subsystem)
 
@@ -1105,6 +1109,10 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pass
 
         finally:
+            nssdb.close()
+            print "cfu: self.validate_system_certs() again after nssdb.close()"
+            nssdb = instance.open_nssdb(token)
+            self.validate_system_certs(deployer, nssdb, subsystem)
             nssdb.close()
 
         create_temp_sslserver_cert = self.create_temp_sslserver_cert(deployer, instance)


### PR DESCRIPTION
    Bug1979560-subCA installation ECC cert validation failure
    
    This is an interim debug/quick fix patch that will
     -  bypass the pki-server subsystem-cert-validate
        failure within pkispawn, so that the installation will complete.
     -  sleep for 30 seconds after system.save(), to see if it's some kind
        of delay on sync
     -  calls cert validation again AFTER nssdb.close() to see if that's
        the silver bullet
    
    upon pkispawn completion, the pki-server subsystem-cert-validate call
    would actually succeed.  That's an indication that the cert validation
    call might need to be moved down further.
    
    The ECC subCA installation would otherwise fail without such bypass
    at this time.
    
    https://bugzilla.redhat.com/show_bug.cgi?id=1979560