### PR TITLE
Bug1971732-subCA Installation cert validation failure

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -373,14 +373,18 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         cert_id = self.get_cert_id(subsystem, tag)
         nickname = deployer.mdict['pki_%s_nickname' % cert_id]
         cert_data = nssdb.get_cert(
-            nickname=nickname)
+            nickname=nickname, output_text=True)
 
         if not cert_data:
             return
 
         logger.info('Validating %s certificate', tag)
 
+        print ("cert_data= " + cert_data)
+
         subsystem.validate_system_cert(tag)
+
+        nssdb.show_certs()
 
     def validate_system_certs(self, deployer, nssdb, subsystem):
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -217,9 +217,12 @@ class PKISubsystem(object):
 
         logger.debug('Command: %s', ' '.join(cmd))
 
-        subprocess.check_output(
-            cmd,
-            stderr=subprocess.STDOUT)
+        try:
+            print (subprocess.check_output(
+                cmd,
+                stderr=subprocess.STDOUT))
+        except subprocess.CalledProcessError as e:
+            print ("pki-server subsystem-cert-validate stdout output:\n", e.output)
 
     def export_system_cert(
             self,


### PR DESCRIPTION
This is an interim debug/quick fix that will bypas cert validation due
to missing CA signing cert and trust in the nssdb.  With this patch
pkispawn will complete, however, one still needs to manually add
the ca signign cert like the following:
$ certutil -d /var/lib/pki/rhcs10-TMS-SubCA/alias -A -t "CT,C,C" -n "TMS-CA_caSigningCert" -i ca.cert

A more permanent fix should follow to add the ca signing cert at an appropriate location prior to cert validation.

https://bugzilla.redhat.com/show_bug.cgi?id=1971732