### PR TITLE
Update Python tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,59 +28,62 @@ jobs:
     name: Building PKI
     needs: init
     runs-on: ubuntu-latest
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
     env:
       COPR_REPO: "@pki/master"
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Install git
-        run: dnf install -y git
-
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build
-          dnf copr enable -y $COPR_REPO
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,tests --with-timestamp --with-commit-id --work-dir=build rpm
+      - name: Build runner image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ env.COPR_REPO }}
+            BUILD_OPTS=--with-pkgs=base,server,tests --with-timestamp --with-commit-id
+          tags: pki-runner
+          target: pki-runner
+          outputs: type=docker,dest=/tmp/pki-runner.tar
 
-      - name: Upload PKI packages
+      - name: Upload runner image
         uses: actions/upload-artifact@v2
         with:
-          name: pki-build-${{ matrix.os }}
-          path: build/RPMS/
+          name: pki-runner-${{ matrix.os }}
+          path: /tmp/pki-runner.tar
 
-  pylint-test:
-    name: pylint
+  lint-test:
+    name: Run Python lint
     needs: [init, build]
     runs-on: ubuntu-latest
     env:
-      COPR_REPO: "@pki/master"
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+      PKIDIR: /tmp/workdir/pki
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Download PKI packages
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
         uses: actions/download-artifact@v2
         with:
-          name: pki-build-${{ matrix.os }}
-          path: build/RPMS
+          name: pki-runner-${{ matrix.os }}
+          path: /tmp
 
-      - name: Update container
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Run container
         run: |
-          dnf install -y python3-pylint python3-flake8 python3-pyflakes findutils dnf-plugins-core
-          dnf copr enable -y ${COPR_REPO}
+          IMAGE=pki-runner \
+          NAME=pki \
+          HOSTNAME=pki.example.com \
+          tests/bin/runner-init.sh
 
-      - name: Install PKI packages
-        run: dnf -y localinstall build/RPMS/*
-
-      - name: Run python lint
-        run: |
-          /usr/share/pki/tests/bin/pki-lint \
-            --rcfile=/usr/share/pki/tests/pylintrc \
-            --config=/usr/share/pki/tests/tox.ini -v
+      - name: Run Python lint
+        run: docker exec pki /usr/share/pki/tests/bin/pki-lint

--- a/pki.spec
+++ b/pki.spec
@@ -807,6 +807,9 @@ This PKI Console Theme Package contains
 Summary:          PKI Tests
 BuildArch:        noarch
 
+Requires:         python3-pylint
+Requires:         python3-flake8
+
 %description -n   pki-tests
 This package contains PKI test suite.
 

--- a/tests/bin/pki-lint
+++ b/tests/bin/pki-lint
@@ -1,10 +1,13 @@
 #! /bin/bash -e
+
 SCRIPT_PATH=`readlink -f "$0"`
 SCRIPT_NAME=`basename "$SCRIPT_PATH"`
-SRC_DIR=`dirname "$SCRIPT_PATH"`
 
-RC_FILE="/usr/share/pki/tests/pylintrc"
-FLAKE8_CONFIG="/usr/share/pki/tests/tox.ini"
+BIN_DIR=`dirname "$SCRIPT_PATH"`
+TESTS_DIR=`dirname "$BIN_DIR"`
+
+RC_FILE="$TESTS_DIR/pylintrc"
+FLAKE8_CONFIG="$TESTS_DIR/tox.ini"
 
 usage() {
     echo "Usage: $SCRIPT_NAME [OPTIONS]"
@@ -16,12 +19,6 @@ usage() {
     echo "    --debug                Run in debug mode."
     echo "    --help                 Show help message."
 }
-# Check if python linters are installed
-rpm -q python3-pylint python3-flake8 python3-pyflakes
-
-# Python files are present in python3-pki and pki-server packages. Get the list of the files
-PYTHON_PKI_FILES=`rpm -ql python3-pki | grep .py$`
-PYTHON_PKI_FILES="$PYTHON_PKI_FILES `rpm -ql pki-server | grep .py$`"
 
 while getopts v-: arg ; do
     case $arg in
@@ -61,12 +58,18 @@ while getopts v-: arg ; do
     esac
 done
 
-# Run pylint
+PYTHONPATH=`python -Ic "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
+
+SOURCES="`find $PYTHONPATH/pki -name "*.py"`"
+SOURCES="$SOURCES `find /usr/share/pki/upgrade -name "*.py"`"
+SOURCES="$SOURCES `find /usr/share/pki/server/upgrade -name "*.py"`"
+
+echo "Running pylint..."
 pylint-3 \
     --rcfile=${RC_FILE} \
-    ${PYTHON_PKI_FILES}
+    $SOURCES
 
-# Run flake8
+echo "Running flake8..."
 python3-flake8 \
     --config ${FLAKE8_CONFIG} \
-    ${PYTHON_PKI_FILES}
+    $SOURCES


### PR DESCRIPTION
The Python tests have been modified to build a test
container and run the tests in the container.

The `pki-lint` script has been modified to use `pylint`
and `flake8` configuration files from the parent folder.

The script has also been modified to get the sources
from Python library path and upgrade folders instead
of from RPM packages.

The script dependencies have been moved into `pki.spec`.
The direct dependency on `python3-pyflakes` has been
removed since it's already required by `python3-flake8`.