### PR TITLE
BZ-1981850 Check directory for files on load subsystems

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1098,6 +1098,11 @@ grant codeBase "file:%s" {
 
             subsystem_dir = os.path.join(self.base_dir, subsystem_name)
             if not os.path.exists(subsystem_dir):
+                # Directory does not exist
+                continue
+
+            if not os.listdir(subsystem_dir):
+                # Directory exists but it is empty
                 continue
 
             subsystem = pki.server.subsystem.PKISubsystemFactory.create(self, subsystem_name)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1981850 


I didn't see the behaviour described in the original issue #3397 / BZ issue

What I saw when trying to reproduce the issue was these log lines in the `journalctl` and the service would succeed in restarting. 
These log lines occur when using `systemctl restart pki-tomcatd@pki-tomcat` while the `/var/lib/pki/pki-tomcat/kra` exists and is empty.  
```
localhost-live server[41113]: SEVERE: One or more listeners failed to start. Full details will be found in the appropriate container>
localhost-live server[41113]: SEVERE: Context [/kra] startup failed due to previous errors
```

After some digging I found the line that was causing the issue. I changed the logic a little bit to try and list the contents of the directory. If an exception is raised, there is no directory continue and if there is a directory but it is empty continue. This bug specifically mentions the `kra` directory but would probably happen if other empty subsystem directories appeared. 

With these change these `SEVERE` level log lines do not appear on `restart` with the presence of the the empty `kra` directory

PS: I spoke with Chris about what branch to merge this into. We settled on `master` but let me know if that needs to change