### PR TITLE
Add test for SCEP responder

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1196,3 +1196,124 @@ jobs:
           name: ca-secure-ds-secondary-${{ matrix.os }}
           path: |
             /tmp/artifacts/secondary
+
+  scep-test:
+    name: Testing SCEP Responder
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      PKIDIR: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-runner-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Run PKI container
+        run: |
+          IMAGE=pki-runner \
+          NAME=pki \
+          HOSTNAME=pki.example.com \
+          tests/bin/runner-init.sh
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Run client container
+        run: |
+          IMAGE=pki-runner \
+          NAME=client \
+          HOSTNAME=client.example.com \
+          tests/bin/runner-init.sh
+
+      - name: Connect client container to network
+        run: |
+          docker network connect example client --alias client.example.com
+          docker inspect -f '{{ .NetworkSettings.Networks.example.IPAddress }}' client > client.ip
+          echo "Client's IP: `cat client.ip`"
+
+      - name: Install dependencies in PKI container
+        run: docker exec pki dnf install -y 389-ds-base
+
+      - name: Install DS in PKI container
+        run: docker exec pki ${PKIDIR}/tests/bin/ds-create.sh
+
+      - name: Install CA in PKI container
+        run: docker exec pki pkispawn -f /usr/share/pki/server/examples/installation/ca.cfg -s CA -v
+
+      # https://github.com/dogtagpki/pki/wiki/Configuring-SCEP-Responder
+      - name: Configure SCEP in CA
+        run: |
+          docker exec pki pki-server ca-config-set ca.scep.enable true
+          docker exec pki bash -c "echo UID:$(cat client.ip) > /etc/pki/pki-tomcat/ca/flatfile.txt"
+          docker exec pki bash -c "echo PWD:Secret.123 >> /etc/pki/pki-tomcat/ca/flatfile.txt"
+          docker exec pki pki-server restart --wait
+
+      # https://github.com/dogtagpki/pki/wiki/Building-SSCEP
+      - name: Build SSCEP in client container
+        run: |
+          docker exec client dnf install -y autoconf automake libtool openssl-devel rpm-build
+          docker exec client bash -c "mkdir -p ~/rpmbuild/SOURCES"
+          docker exec client curl -JLOSs https://github.com/certnanny/sscep/archive/v0.9.0/tags/sscep-0.9.0.tar.gz
+          docker exec client bash -c "mv sscep-0.9.0.tar.gz ~/rpmbuild/SOURCES"
+          docker exec client curl -JLOSs https://raw.githubusercontent.com/certnanny/sscep/v0.9.0/scripts/sscep.spec
+          docker exec client sed -i '/%build/ a ./bootstrap.sh' sscep.spec
+          docker exec client rpmbuild -ba sscep.spec
+          docker exec client bash -c "find ~/rpmbuild/RPMS -name *.rpm" > files
+          docker exec client dnf localinstall -y $(cat files)
+          docker exec client curl -JLOSs https://raw.githubusercontent.com/certnanny/sscep/v0.9.0/mkrequest
+          docker exec client chmod +x mkrequest
+
+      # https://github.com/dogtagpki/pki/wiki/Certificate-Enrollment-with-SSCEP
+      - name: Get CA certificate using SSCEP
+        run: |
+          docker exec client sscep getca \
+              -u http://pki.example.com:8080/ca/cgi-bin/pkiclient.exe \
+              -c ca.crt
+          docker exec client openssl x509 -text -noout -in ca.crt
+
+      - name: Enroll certificate with IP address using SSCEP
+        run: |
+          docker exec client ./mkrequest -ip $(cat client.ip) Secret.123
+          docker exec client openssl req -text -noout -in local.csr
+          docker exec client sscep enroll \
+              -u http://pki.example.com:8080/ca/cgi-bin/pkiclient.exe \
+              -c ca.crt \
+              -k local.key \
+              -r local.csr \
+              -l local.crt \
+              -E 3des \
+              -S sha256
+          docker exec client openssl x509 -text -noout -in local.crt
+
+      - name: Gather artifacts from PKI container
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh pki
+          tests/bin/pki-artifacts-save.sh pki
+
+      - name: Remove CA from PKI container
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Remove DS from PKI container
+        run: docker exec pki ${PKIDIR}/tests/bin/ds-remove.sh
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: scep-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki


### PR DESCRIPTION
A CI test has been added to set up SCEP responder,
build SSCEP client, then run an enrollment test.

Docs:
* https://github.com/dogtagpki/pki/wiki/SCEP-Responder
* https://github.com/dogtagpki/pki/wiki/Configuring-SCEP-Responder
* https://github.com/dogtagpki/pki/wiki/Building-SSCEP
* https://github.com/dogtagpki/pki/wiki/Certificate-Enrollment-with-SSCEP
