### PR TITLE
Bug1959937 - TPS Allowing Token Transactions while the CA is Down

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
@@ -616,7 +616,7 @@ public class TPSTokendb {
     }
 
     private void revokeCert(TokenRecord tokenRecord, TPSCertRecord cert, String tokenReason,
-            String ipAddress, String remoteUser) {
+            String ipAddress, String remoteUser) throws Exception {
 
         String method = "TPSTokendb.revokeCert";
         String logMsg;
@@ -678,12 +678,15 @@ public class TPSTokendb {
             tdbActivity(ActivityDatabase.OP_CERT_REVOCATION, tokenRecord,
                     ipAddress, e.getMessage(), "failure", remoteUser);
 
-            // continue revoking the next certificate
+            // bail out if revocation failed; This will allow the token
+            // status info to be consistent with that of the certs on the
+            // CA
+            throw e;
         }
     }
 
     private void unrevokeCert(TokenRecord tokenRecord, TPSCertRecord cert, String tokenReason,
-            String ipAddress, String remoteUser) {
+            String ipAddress, String remoteUser) throws Exception {
 
         String method = "TPSTokendb.unrevokeCert";
         String logMsg;
@@ -733,7 +736,10 @@ public class TPSTokendb {
             tdbActivity(ActivityDatabase.OP_CERT_RESTORATION, tokenRecord,
                     ipAddress, e.getMessage(), "failure", remoteUser);
 
-            // continue unrevoking the next certificate
+            // bail out if revocation failed; This will allow the token
+            // status info to be consistent with that of the certs on the
+            // CA
+            throw e;
         }
     }
 


### PR DESCRIPTION
This patch propagates the exception thrown when revocation/unrevocation
fails so that the token record is not updated on TPS; This allows
the TPS token to be consistent with the certs on the CA.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1959937