### PR TITLE
Cherry-pick fix for BZ 1942687 to v10.11

### DIFF
--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSTokenPolicy.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSTokenPolicy.java
@@ -42,18 +42,29 @@ public class TPSTokenPolicy {
     private boolean force_format = false;
     private boolean pin_reset = true;
     private boolean reset_pin_reset_to_no = false;
+    private String cuid = null;
 
-    public TPSTokenPolicy (TPSSubsystem tps) throws TPSException {
+    // Construct with a single token in mind. Load the token's config from
+    // the db after the default. All operations will then be on this token.
+    public TPSTokenPolicy (TPSSubsystem tps, String cuid) throws TPSException {
         if (tps == null) {
             String msg = "TPSTokenPolicy.TPSTokenPolicy: tps cannnot be null";
             logger.error(msg);
             throw new TPSException(msg);
         }
+        if (cuid == null) {
+            String msg = "TPSTokenPolicy.TPSTokenPolicy: cuid cannnot be null";
+            logger.error(msg);
+            throw new TPSException(msg);
+        }
         this.tps = tps;
-        // init from config first
+        // Get the CS.cfg defaults first
         String policySetString = getDefaultPolicySetString();
         parsePolicySetString(policySetString);
 
+        this.cuid = cuid;
+        //Read from the token db once and write at the end if needed
+        getUpdatedPolicy();
     }
 
     public String getDefaultPolicySetString() {
@@ -95,6 +106,40 @@ public class TPSTokenPolicy {
         }
     }
 
+    /* Take the current state of the policyt variables, create a new policy string,
+     * and write the new value for the provided token cuid.
+     */
+    public void updatePolicySet()  throws TPSException {
+
+        String method = "TPSTokenPolicy.updatePolicySet: ";
+        String msg = method +  "Can't update token policy string to database.";
+
+        TokenRecord tokenRecord = null;
+        try {
+            tokenRecord = tps.tdb.tdbGetTokenEntry(this.cuid);
+        } catch (Exception e) {
+            throw new TPSException(e.toString() + " " + msg);
+        }
+
+        String newPolicy = "";
+
+        newPolicy += "RE_ENROLL=" + getFromBool(re_enroll);
+        newPolicy += ";RENEW=" + getFromBool(renew);
+        newPolicy += ";FORCE_FORMAT=" + getFromBool(force_format);
+        newPolicy += ";PIN_RESET=" + getFromBool(pin_reset);
+        newPolicy += ";RESET_PIN_RESET_TO_NO=" + getFromBool(reset_pin_reset_to_no);
+        newPolicy += ";RENEW_KEEP_OLD_ENC_CERTS=" + getFromBool(renew_keep_old_enc_certs);
+
+        logger.debug("{}newPolicy: {}", method, newPolicy);
+        tokenRecord.setPolicy(newPolicy);
+        try {
+            tps.tdb.tdbUpdateTokenEntry(tokenRecord);
+        } catch(Exception e) {
+            throw new TPSException(e.toString() + " " + msg);
+        }
+
+    }
+
 /*
  * getBool translates string to boolean:
  * true: "YES", "yes", "TRUE", "true"
@@ -117,12 +162,16 @@ public class TPSTokenPolicy {
         return defaultBool;
     }
 
-    private void getUpdatedPolicy(String cuid) {
+    private String getFromBool(boolean value) {
+        return value ? "YES" : "NO";
+    }
+
+    private void getUpdatedPolicy() {
         // note: default policy already initialized in the constructor
         TokenRecord tokenRecord = null;
         String policySetString = null;
         try {
-            tokenRecord = tps.tdb.tdbGetTokenEntry(cuid);
+            tokenRecord = tps.tdb.tdbGetTokenEntry(this.cuid);
         } catch (Exception e) {
             // just take the default;
             return;
@@ -132,38 +181,67 @@ public class TPSTokenPolicy {
         parsePolicySetString(policySetString);
     }
 
-    public boolean isAllowedTokenPinReset(String cuid) {
-        getUpdatedPolicy(cuid);
+    // Note we only want to allow one cuid to be operated upon
+    // by this class, since we are going to allow values to be changed
+    // as well as written.
 
+    public boolean isAllowedTokenPinReset() {
         return reset_pin_reset_to_no;
     }
 
-    public boolean isAllowedPinReset(String cuid) {
-        getUpdatedPolicy(cuid);
+    // Add better named version to get the value
+    // reset_pin_reset_to_no
 
+    public boolean isAllowedResetPinResetToNo() {
+        return reset_pin_reset_to_no;
+    }
+
+    public boolean isAllowedPinReset() {
         return pin_reset;
     }
 
-    public boolean isForceTokenFormat(String cuid) {
-        getUpdatedPolicy(cuid);
-
+    public boolean isForceTokenFormat() {
         return force_format;
     }
 
-    public boolean isAllowdTokenReenroll(String cuid) {
-        getUpdatedPolicy(cuid);
-
+    public boolean isAllowdTokenReenroll() {
         return re_enroll;
     }
 
-    public boolean isAllowdRenewSaveOldEncCerts(String cuid) {
-        getUpdatedPolicy(cuid);
+    public boolean isAllowdRenewSaveOldEncCerts() {
         return renew_keep_old_enc_certs;
     }
 
-    public boolean isAllowdTokenRenew(String cuid) {
-        getUpdatedPolicy(cuid);
-
+    public boolean isAllowdTokenRenew() {
         return renew;
     }
+
+    public void setAllowedTokenPinReset(boolean value) {
+        reset_pin_reset_to_no = value;
+    }
+
+    public void setAllowedResetPinResetToNo(boolean value) {
+        reset_pin_reset_to_no = value;
+    }
+
+    public void setAllowedPinReset(boolean value) {
+        pin_reset = value;
+    }
+
+    public void setForceTokenFormat(boolean value) {
+        force_format = value;
+    }
+
+    public void setAllowdTokenReenroll(boolean value) {
+        re_enroll = value;
+    }
+
+    public void setAllowdRenewSaveOldEncCerts(boolean value) {
+        renew_keep_old_enc_certs = value;
+    }
+
+    public void setAllowdTokenRenew(boolean value) {
+        renew = value;
+    }
+
 }

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSTokendb.java
@@ -200,9 +200,12 @@ public class TPSTokendb {
 
     public void tdbAddTokenEntry(TokenRecord tokenRecord, TokenStatus status)
             throws Exception {
+
+        String method = "TPSTokendb.tdbAddTokenEntry: ";
         tokenRecord.setTokenStatus(status);
 
         tps.tokenDatabase.addRecord(tokenRecord.getId(), tokenRecord);
+        logger.debug("{}Added tokenRecord.", method);
     }
 
     public void tdbUpdateTokenEntry(TokenRecord tokenRecord)

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
@@ -95,6 +95,7 @@ import com.netscape.certsrv.authentication.IAuthCredentials;
 import com.netscape.certsrv.authentication.IAuthToken;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.EPropertyNotFound;
+import com.netscape.certsrv.base.IConfigStore;
 import com.netscape.certsrv.common.Constants;
 import com.netscape.certsrv.dbs.EDBRecordNotFoundException;
 import com.netscape.certsrv.logging.AuditEvent;
@@ -1532,6 +1533,28 @@ public class TPSProcessor {
         }
 
         logger.debug(method + ": ends");
+
+    }
+
+    protected void fillTokenRecordDefaultPolicy(TokenRecord tokenRecord) throws TPSException {
+
+        String method = "TPSProcessor.fillTokenRecordDefaultPolicy: ";
+
+        try {
+            org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
+            TPSSubsystem subsystem = (TPSSubsystem) engine.getSubsystem(TPSSubsystem.ID);
+            IConfigStore configStore = subsystem.getConfigStore();
+
+            String config = "tokendb.defaultPolicy";
+            String defaultPolicy = configStore.getString(config);
+
+            logger.debug("{} default token policy: {}", method, defaultPolicy);
+
+            tokenRecord.setPolicy(defaultPolicy);
+        } catch (Exception e) {
+            logger.debug("{}Problem with adding the default policy to the token.", method);
+            throw new TPSException(e.toString(), TPSStatus.STATUS_ERROR_MISCONFIGURATION);
+        }
 
     }
 


### PR DESCRIPTION
Original commit message below.


Fix: Bug 1942687 - TPS not populating Token Policy, or switching
PIN_RESET=YES to NO . (#3510)

Now the behavior will be the following:

    When a new token entry gets created in the token db, due to a token
operation such
    as format or enrollment, the db entry will get populated with the
contents of the
    CS.cfg value:
    ex:
    tokendb.defaultPolicy=RE_ENROLL=YES;RENEW=NO;FORCE_FORMAT=NO;PIN_RESET=NO;RESET_PIN_RESET_TO_NO=NO

    Now the value of RESET_PIN_RESET_TO_NO is actually observed.
    If this value is set to YES and pin reset is allowed, after a
successful pin reset,
    the value of PIN_RESET will be set to NO, thus not allowing further
pin resets on this
    token, until the value is manually changed in the token db entry.

    Also, the class itself has been simplified to allow the cuid token
number at constructor
    time. Now if another token is desired , we must instantiate a new
TPSTokenPolicy object for
    that additional token.

Co-authored-by: Jack Magne <jmagne@test.host.com>