### PR TITLE
Cherry-pick fix for BZ 1955633 to v10.11

### DIFF
--- a/base/server/src/main/java/com/netscape/cmscore/dbs/KeyRecord.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/KeyRecord.java
@@ -526,6 +526,9 @@ public class KeyRecord implements IKeyRecord {
 
     @Override
     public Boolean isEncrypted() throws EBaseException {
+        if (mMetaInfo == null) {
+            return null;
+        }
         String encrypted = (String) mMetaInfo.get(KeyRecordParser.OUT_PL_ENCRYPTED);
         if (encrypted == null)
             return null;


### PR DESCRIPTION
Trivial cherry-pick was not possible as file has moved, but was a small
change so just re-created it.

I have copied the patch from 7.9z verbatim. The intention of the patch is to prevent a NPE but we're returning null from a method of return type `Boolean`, which could itself cause a NPE. I looked at the code that calls `KeyRecord.isEncrypted()` and there is always an explicit check for null in the calling code so that's fine. There are hints in the code saying that old records return null, so I guess we just don't touch this and accept that NPE is possible if new calls of `isEncrypted()` are not made defensively.