### PR TITLE
Fix navigation buttons in CA EE list certs page

### DIFF
--- a/base/ca/shared/webapps/ca/ee/ca/queryCert.template
+++ b/base/ca/shared/webapps/ca/ee/ca/queryCert.template
@@ -407,7 +407,7 @@ function renderNextButtonElement(name, label, disabled)
     result.innerText = label;
     result.width = 72;
     result.disabled = disabled ? true : false;
-    result.onClick = () => doNext(result);
+    result.onclick = () => doNext(result);
     return result;
 }
 


### PR DESCRIPTION
The `renderNextButtonElement()` has been modified to fix a typo in commit 13f4c7fe7d71d42b46b25f3e8472ef7f35da5dd6.

The `mReverse`, `mHardJumpTo`, and `mDirection` fields in `ListCerts` servlet has been converted into regular variables to avoid potential concurrency issues.

https://bugzilla.redhat.com/show_bug.cgi?id=1978345