### PR TITLE
Rename PKI packages

### DIFF
--- a/docs/changes/v11.0.0/Packaging-Changes.adoc
+++ b/docs/changes/v11.0.0/Packaging-Changes.adoc
@@ -1,0 +1,26 @@
+= Packaging Changes =
+
+== Package Name Changes ==
+
+In PKI 11 the following packages have been renamed:
+
+* `pki-base` -> `dogtag-pki-base`
+* `pki-base-java` -> `dogtag-pki-base-java`
+* `pki-javadoc` -> `dogtag-pki-javadoc`
+* `python3-pki` -> `python3-dogtag-pki`
+* `pki-tools` -> `dogtag-pki-tools`
+* `pki-symkey` -> `dogtag-pki-symkey`
+* `pki-server` -> `dogtag-pki-server`
+* `pki-ca` -> `dogtag-pki-ca`
+* `pki-kra` -> `dogtag-pki-kra`
+* `pki-ocsp` -> `dogtag-pki-ocsp`
+* `pki-tks` -> `dogtag-pki-tks`
+* `pki-tps` -> `dogtag-pki-tps`
+* `pki-acme` -> `dogtag-pki-acme`
+* `pki-server-theme` -> `dogtag-pki-server-theme`
+* `pki-tests` -> `dogtag-pki-tests`
+
+== PKI Console Changes ==
+
+PKI Console is no longer supported in PKI 11, so the `pki-console` and `pki-console-theme` packages have been dropped.
+Use link:https://github.com/dogtagpki/pki/wiki/PKI-CLI[PKI CLI] instead.

--- a/pki.spec
+++ b/pki.spec
@@ -2,10 +2,11 @@
 Name:             pki
 ################################################################################
 
-%global           vendor_id dogtag
-%global           brand Dogtag
+%global           product_name Dogtag PKI
+%global           product_id dogtag-pki
+%global           theme dogtag
 
-Summary:          %{brand} PKI Package
+Summary:          %{product_name} Package
 URL:              https://www.dogtagpki.org
 # The entire source code is GPLv2 except for 'pki-tps' which is LGPLv2
 License:          GPLv2 and LGPLv2
@@ -240,13 +241,13 @@ BuildRequires:    nss-tools
 BuildRequires:    openssl
 
 # description for top-level package (if there is a separate meta package)
-%if "%{name}" != "%{vendor_id}-pki"
+%if "%{name}" != "%{product_id}"
 %description
 
-%{brand} PKI is an enterprise software system designed
+%{product_name} is an enterprise software system designed
 to manage enterprise Public Key Infrastructure deployments.
 
-PKI consists of the following components:
+%{product_name} consists of the following components:
 
   * Automatic Certificate Management Environment (ACME) Responder
   * Certificate Authority (CA)
@@ -258,12 +259,12 @@ PKI consists of the following components:
 %endif
 
 %if %{with meta}
-%if "%{name}" != "%{vendor_id}-pki"
+%if "%{name}" != "%{product_id}"
 ################################################################################
-%package -n       %{vendor_id}-pki
+%package -n       %{product_id}
 ################################################################################
 
-Summary:          %{brand} PKI Package
+Summary:          %{product_name} Package
 %endif
 
 Obsoletes:        pki-console < %{version}
@@ -272,18 +273,18 @@ Obsoletes:        idm-console-framework < 2.0
 
 # Make certain that this 'meta' package requires the latest version(s)
 # of ALL PKI theme packages
-Requires:         %{vendor_id}-pki-server-theme = %{version}-%{release}
+Requires:         %{product_id}-server-theme = %{version}-%{release}
 
 # Make certain that this 'meta' package requires the latest version(s)
 # of ALL PKI core packages
-Requires:         pki-acme = %{version}-%{release}
-Requires:         pki-ca = %{version}-%{release}
-Requires:         pki-kra = %{version}-%{release}
-Requires:         pki-ocsp = %{version}-%{release}
-Requires:         pki-tks = %{version}-%{release}
-Requires:         pki-tps = %{version}-%{release}
+Requires:         %{product_id}-acme = %{version}-%{release}
+Requires:         %{product_id}-ca = %{version}-%{release}
+Requires:         %{product_id}-kra = %{version}-%{release}
+Requires:         %{product_id}-ocsp = %{version}-%{release}
+Requires:         %{product_id}-tks = %{version}-%{release}
+Requires:         %{product_id}-tps = %{version}-%{release}
 
-Requires:         pki-javadoc = %{version}-%{release}
+Requires:         %{product_id}-javadoc = %{version}-%{release}
 
 # Make certain that this 'meta' package requires the latest version(s)
 # of ALL PKI clients -- except for s390/s390x where 'esc' is not built
@@ -292,16 +293,16 @@ Requires:         esc >= 1.1.1
 %endif
 
 # description for top-level package (unless there is a separate meta package)
-%if "%{name}" == "%{vendor_id}-pki"
+%if "%{name}" == "%{product_id}"
 %description
 %else
-%description -n   %{vendor_id}-pki
+%description -n   %{product_id}
 %endif
 
-%{brand} PKI is an enterprise software system designed
+%{product_name} is an enterprise software system designed
 to manage enterprise Public Key Infrastructure deployments.
 
-PKI consists of the following components:
+%{product_name} consists of the following components:
 
   * Automatic Certificate Management Environment (ACME) Responder
   * Certificate Authority (CA)
@@ -315,10 +316,13 @@ PKI consists of the following components:
 
 %if %{with base}
 ################################################################################
-%package -n       pki-symkey
+%package -n       %{product_id}-symkey
 ################################################################################
 
-Summary:          PKI Symmetric Key Package
+Summary:          %{product_name} Symmetric Key Package
+
+Obsoletes:        pki-symkey < %{version}-%{release}
+Provides:         pki-symkey = %{version}-%{release}
 
 Requires:         %{java_headless}
 Requires:         jpackage-utils >= 0:1.7.5-10
@@ -330,16 +334,18 @@ Conflicts:        pki-symkey < %{version}
 Conflicts:        pki-javadoc < %{version}
 Conflicts:        pki-server-theme < %{version}
 
-%description -n   pki-symkey
-The PKI Symmetric Key Java Package supplies various native
-symmetric key operations to Java programs.
+%description -n   %{product_id}-symkey
+This package provides library for symmetric key operations.
 
 ################################################################################
-%package -n       pki-base
+%package -n       %{product_id}-base
 ################################################################################
 
-Summary:          PKI Base Package
+Summary:          %{product_name} Base Package
 BuildArch:        noarch
+
+Obsoletes:        pki-base < %{version}-%{release}
+Provides:         pki-base = %{version}-%{release}
 
 Requires:         nss >= 3.36.1
 
@@ -351,24 +357,27 @@ Conflicts:        pki-symkey < %{version}
 Conflicts:        pki-javadoc < %{version}
 Conflicts:        pki-server-theme < %{version}
 
-%description -n   pki-base
-The PKI Base Package contains the common and client libraries and utilities
-written in Python.
+%description -n   %{product_id}-base
+This package provides default configuration files for %{product_name} client.
 
 ################################################################################
-%package -n       python3-pki
+%package -n       python3-%{product_id}
 ################################################################################
 
-Summary:          PKI Python 3 Package
+Summary:          %{product_name} Python 3 Package
 BuildArch:        noarch
 
-Obsoletes:        pki-base-python3 < %{version}
+Obsoletes:        python3-pki < %{version}-%{release}
+Provides:         python3-pki = %{version}-%{release}
+
+Obsoletes:        pki-base-python3 < %{version}-%{release}
 Provides:         pki-base-python3 = %{version}-%{release}
+
 %if 0%{?fedora} || 0%{?rhel} > 8
 %{?python_provide:%python_provide python3-pki}
 %endif
 
-Requires:         pki-base = %{version}-%{release}
+Requires:         %{product_id}-base = %{version}-%{release}
 Requires:         python3 >= 3.5
 Requires:         python3-cryptography
 Requires:         python3-ldap
@@ -379,15 +388,18 @@ Requires:         python3-six
 Recommends:       python3-nss
 %endif
 
-%description -n   python3-pki
-This package contains PKI client library for Python 3.
+%description -n   python3-%{product_id}
+This package provides common and client library for Python 3.
 
 ################################################################################
-%package -n       pki-base-java
+%package -n       %{product_id}-base-java
 ################################################################################
 
-Summary:          PKI Base Java Package
+Summary:          %{product_name} Base Java Package
 BuildArch:        noarch
+
+Obsoletes:        pki-base-java < %{version}-%{release}
+Provides:         pki-base-java = %{version}-%{release}
 
 Requires:         %{java_headless}
 Requires:         apache-commons-cli
@@ -402,7 +414,7 @@ Requires:         slf4j-jdk14
 Requires:         jpackage-utils >= 0:1.7.5-10
 Requires:         jss >= 5.0.0
 Requires:         ldapjdk >= 5.0.0
-Requires:         pki-base = %{version}-%{release}
+Requires:         %{product_id}-base = %{version}-%{release}
 
 %if 0%{?rhel} && 0%{?rhel} <= 8
 Requires:         resteasy >= 3.0.26
@@ -421,39 +433,44 @@ Requires:         xalan-j2
 Requires:         xerces-j2
 Requires:         xml-commons-resolver
 
-%description -n   pki-base-java
-The PKI Base Java Package contains the common and client libraries and utilities
-written in Java.
+%description -n   %{product_id}-base-java
+This package provides common and client libraries for Java.
 
 ################################################################################
-%package -n       pki-tools
+%package -n       %{product_id}-tools
 ################################################################################
 
-Summary:          PKI Tools Package
+Summary:          %{product_name} Tools Package
+
+Obsoletes:        pki-tools < %{version}-%{release}
+Provides:         pki-tools = %{version}-%{release}
 
 Requires:         openldap-clients
 Requires:         nss-tools >= 3.36.1
-Requires:         pki-base-java = %{version}-%{release}
+Requires:         %{product_id}-base-java = %{version}-%{release}
 Requires:         p11-kit-trust
 
 # PKICertImport depends on certutil and openssl
 Requires:         nss-tools
 Requires:         openssl
 
-%description -n   pki-tools
-This package contains PKI executables that can be used to help make
-Certificate System into a more complete and robust PKI solution.
+%description -n   %{product_id}-tools
+This package provides tools that can be used to help make
+%{product_name} into a more complete and robust PKI solution.
 
 # with base
 %endif
 
 %if %{with server}
 ################################################################################
-%package -n       pki-server
+%package -n       %{product_id}-server
 ################################################################################
 
-Summary:          PKI Server Package
+Summary:          %{product_name} Server Package
 BuildArch:        noarch
+
+Obsoletes:        pki-server < %{version}-%{release}
+Provides:         pki-server = %{version}-%{release}
 
 Requires:         hostname
 
@@ -461,8 +478,8 @@ Requires:         policycoreutils
 Requires:         procps-ng
 Requires:         openldap-clients
 Requires:         openssl
-Requires:         pki-symkey = %{version}-%{release}
-Requires:         pki-tools = %{version}-%{release}
+Requires:         %{product_id}-symkey = %{version}-%{release}
+Requires:         %{product_id}-tools = %{version}-%{release}
 
 Requires:         keyutils
 
@@ -507,25 +524,27 @@ Provides:         bundled(js-jquery-i18n-properties) = 1.2.7
 Provides:         bundled(js-patternfly) = 3.59.2
 Provides:         bundled(js-underscore) = 1.9.2
 
-%description -n   pki-server
-The PKI Server Package contains libraries and utilities needed by other
-PKI subsystems.
+%description -n   %{product_id}-server
+This package provides libraries and utilities needed by %{product_name} services.
 
 # with server
 %endif
 
 %if %{with acme}
 ################################################################################
-%package -n       pki-acme
+%package -n       %{product_id}-acme
 ################################################################################
 
-Summary:          PKI ACME Package
+Summary:          %{product_name} ACME Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Obsoletes:        pki-acme < %{version}-%{release}
+Provides:         pki-acme = %{version}-%{release}
 
-%description -n   pki-acme
-The PKI ACME responder is a service that provides an automatic certificate
+Requires:         %{product_id}-server = %{version}-%{release}
+
+%description -n   %{product_id}-acme
+%{product_name} ACME responder is a service that provides an automatic certificate
 management via ACME v2 protocol defined in RFC 8555.
 
 # with acme
@@ -533,18 +552,21 @@ management via ACME v2 protocol defined in RFC 8555.
 
 %if %{with ca}
 ################################################################################
-%package -n       pki-ca
+%package -n       %{product_id}-ca
 ################################################################################
 
-Summary:          PKI CA Package
+Summary:          %{product_name} CA Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Obsoletes:        pki-ca < %{version}-%{release}
+Provides:         pki-ca = %{version}-%{release}
+
+Requires:         %{product_id}-server = %{version}-%{release}
 Requires(post):   systemd-units
 Requires(postun): systemd-units
 
-%description -n   pki-ca
-The Certificate Authority (CA) is a required PKI subsystem which issues,
+%description -n   %{product_id}-ca
+%{product_name} Certificate Authority (CA) is a required subsystem which issues,
 renews, revokes, and publishes certificates as well as compiling and
 publishing Certificate Revocation Lists (CRLs).
 
@@ -557,18 +579,21 @@ where it obtains its own signing certificate from a public CA.
 
 %if %{with kra}
 ################################################################################
-%package -n       pki-kra
+%package -n       %{product_id}-kra
 ################################################################################
 
-Summary:          PKI KRA Package
+Summary:          %{product_name} KRA Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Obsoletes:        pki-kra < %{version}-%{release}
+Provides:         pki-kra = %{version}-%{release}
+
+Requires:         %{product_id}-server = %{version}-%{release}
 Requires(post):   systemd-units
 Requires(postun): systemd-units
 
-%description -n   pki-kra
-The Key Recovery Authority (KRA) is an optional PKI subsystem that can act
+%description -n   %{product_id}-kra
+%{product_name} Key Recovery Authority (KRA) is an optional subsystem that can act
 as a key archival facility.  When configured in conjunction with the
 Certificate Authority (CA), the KRA stores private encryption keys as part of
 the certificate enrollment process.  The key archival mechanism is triggered
@@ -587,18 +612,21 @@ since such archival would undermine non-repudiation properties of signing keys.
 
 %if %{with ocsp}
 ################################################################################
-%package -n       pki-ocsp
+%package -n       %{product_id}-ocsp
 ################################################################################
 
-Summary:          PKI OCSP Package
+Summary:          %{product_name} OCSP Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Obsoletes:        pki-ocsp < %{version}-%{release}
+Provides:         pki-ocsp = %{version}-%{release}
+
+Requires:         %{product_id}-server = %{version}-%{release}
 Requires(post):   systemd-units
 Requires(postun): systemd-units
 
-%description -n   pki-ocsp
-The Online Certificate Status Protocol (OCSP) Manager is an optional PKI
+%description -n   %{product_id}-ocsp
+%{product_name} Online Certificate Status Protocol (OCSP) Manager is an optional
 subsystem that can act as a stand-alone OCSP service.  The OCSP Manager
 performs the task of an online certificate validation authority by enabling
 OCSP-compliant clients to do real-time verification of certificates.  Note
@@ -624,18 +652,21 @@ whenever they are issued or updated.
 
 %if %{with tks}
 ################################################################################
-%package -n       pki-tks
+%package -n       %{product_id}-tks
 ################################################################################
 
-Summary:          PKI TKS Package
+Summary:          %{product_name} TKS Package
 BuildArch:        noarch
 
-Requires:         pki-server = %{version}-%{release}
+Obsoletes:        pki-tks < %{version}-%{release}
+Provides:         pki-tks = %{version}-%{release}
+
+Requires:         %{product_id}-server = %{version}-%{release}
 Requires(post):   systemd-units
 Requires(postun): systemd-units
 
-%description -n   pki-tks
-The Token Key Service (TKS) is an optional PKI subsystem that manages the
+%description -n   %{product_id}-tks
+%{product_name} Token Key Service (TKS) is an optional subsystem that manages the
 master key(s) and the transport key(s) required to generate and distribute
 keys for hardware tokens.  TKS provides the security between tokens and an
 instance of Token Processing System (TPS), where the security relies upon the
@@ -655,12 +686,15 @@ behind the firewall with restricted access.
 
 %if %{with tps}
 ################################################################################
-%package -n       pki-tps
+%package -n       %{product_id}-tps
 ################################################################################
 
-Summary:          PKI TPS Package
+Summary:          %{product_name} TPS Package
 
-Requires:         pki-server = %{version}-%{release}
+Obsoletes:        pki-tps < %{version}-%{release}
+Provides:         pki-tps = %{version}-%{release}
+
+Requires:         %{product_id}-server = %{version}-%{release}
 Requires(post):   systemd-units
 Requires(postun): systemd-units
 
@@ -670,8 +704,8 @@ Requires(postun): systemd-units
 Requires:         nss-tools >= 3.36.1
 Requires:         openldap-clients
 
-%description -n   pki-tps
-The Token Processing System (TPS) is an optional PKI subsystem that acts
+%description -n   %{product_id}-tps
+%{product_name} Token Processing System (TPS) is an optional subsystem that acts
 as a Registration Authority (RA) for authenticating and processing
 enrollment requests, PIN reset requests, and formatting requests from
 the Enterprise Security Client (ESC).
@@ -695,51 +729,58 @@ smart card.
 
 %if %{with javadoc}
 ################################################################################
-%package -n       pki-javadoc
+%package -n       %{product_id}-javadoc
 ################################################################################
 
-Summary:          PKI Javadoc Package
+Summary:          %{product_name} Javadoc Package
 BuildArch:        noarch
+
+Obsoletes:        pki-javadoc < %{version}-%{release}
+Provides:         pki-javadoc = %{version}-%{release}
 
 # Ensure we end up with a useful installation
 Conflicts:        pki-base < %{version}
 Conflicts:        pki-symkey < %{version}
 Conflicts:        pki-server-theme < %{version}
 
-%description -n   pki-javadoc
-This package contains PKI API documentation.
+%description -n   %{product_id}-javadoc
+This package provides %{product_name} API documentation.
 
 # with javadoc
 %endif
 
 %if %{with console}
 ################################################################################
-%package -n       pki-console
+%package -n       %{product_id}-console
 ################################################################################
 
-Summary:          PKI Console Package
+Summary:          %{product_name} Console Package
 BuildArch:        noarch
 
 BuildRequires:    idm-console-framework >= 2.0
 
-Requires:         idm-console-framework >= 2.0
-Requires:         pki-base-java = %{version}-%{release}
-Requires:         pki-console-theme = %{version}-%{release}
+Obsoletes:        pki-console < %{version}-%{release}
+Provides:         pki-console = %{version}-%{release}
 
-%description -n   pki-console
-The PKI Console is a Java application used to administer PKI server.
+Requires:         idm-console-framework >= 2.0
+Requires:         %{product_id}-base-java = %{version}-%{release}
+Requires:         %{product_id}-console-theme = %{version}-%{release}
+
+%description -n   %{product_id}-console
+%{product_name} Console is a Java application used to administer %{product_name} Server.
 
 # with console
 %endif
 
 %if %{with theme}
 ################################################################################
-%package -n       %{vendor_id}-pki-server-theme
+%package -n       %{product_id}-server-theme
 ################################################################################
 
-Summary:          %{brand} PKI Server Theme Package
+Summary:          %{product_name} Server Theme Package
 BuildArch:        noarch
 
+Obsoletes:        pki-server-theme < %{version}-%{release}
 Provides:         pki-server-theme = %{version}-%{release}
 
 # Ensure we end up with a useful installation
@@ -747,18 +788,18 @@ Conflicts:        pki-base < %{version}
 Conflicts:        pki-symkey < %{version}
 Conflicts:        pki-javadoc < %{version}
 
-%description -n   %{vendor_id}-pki-server-theme
-This PKI Server Theme Package contains
-%{brand} textual and graphical user interface for PKI Server.
+%description -n   %{product_id}-server-theme
+This package provides theme files for %{product_name} Server.
 
 %if %{with console}
 ################################################################################
-%package -n       %{vendor_id}-pki-console-theme
+%package -n       %{product_id}-console-theme
 ################################################################################
 
-Summary:          %{brand} PKI Console Theme Package
+Summary:          %{product_name} Console Theme Package
 BuildArch:        noarch
 
+Obsoletes:        pki-console-theme < %{version}-%{release}
 Provides:         pki-console-theme = %{version}-%{release}
 
 # Ensure we end up with a useful installation
@@ -767,9 +808,8 @@ Conflicts:        pki-symkey < %{version}
 Conflicts:        pki-server-theme < %{version}
 Conflicts:        pki-javadoc < %{version}
 
-%description -n   %{vendor_id}-pki-console-theme
-This PKI Console Theme Package contains
-%{brand} textual and graphical user interface for PKI Console.
+%description -n   %{product_id}-console-theme
+This package provides theme files for %{product_name} Console.
 
 # with console
 %endif
@@ -779,17 +819,20 @@ This PKI Console Theme Package contains
 
 %if %{with tests}
 ################################################################################
-%package -n       pki-tests
+%package -n       %{product_id}-tests
 ################################################################################
 
-Summary:          PKI Tests
+Summary:          %{product_name} Tests
 BuildArch:        noarch
+
+Obsoletes:        pki-tests < %{version}-%{release}
+Provides:         pki-tests = %{version}-%{release}
 
 Requires:         python3-pylint
 Requires:         python3-flake8
 
-%description -n   pki-tests
-This package contains PKI test suite.
+%description -n   %{product_id}-tests
+This package provides test suite for %{product_name}.
 
 # with tests
 %endif
@@ -847,7 +890,7 @@ cd build
     -DWITH_JAVADOC:BOOL=%{?with_javadoc:ON}%{!?with_javadoc:OFF} \
     -DWITH_TEST:BOOL=%{?with_test:ON}%{!?with_test:OFF} \
     -DBUILD_PKI_CONSOLE:BOOL=%{?with_console:ON}%{!?with_console:OFF} \
-    -DTHEME=%{?with_theme:%{vendor_id}} \
+    -DTHEME=%{?with_theme:%{theme}} \
 %if 0%{?rhel} && 0%{?rhel} <= 8
     ..
 %else
@@ -894,7 +937,7 @@ ctest --output-on-failure
 
 cat > %{buildroot}%{_datadir}/doc/pki/README << EOF
 This package is a "meta-package" whose dependencies pull in all of the
-packages comprising the %{brand} Public Key Infrastructure (PKI) Suite.
+packages comprising the %{product_name} Suite.
 EOF
 
 # with meta
@@ -924,7 +967,7 @@ ln -sf /usr/share/java/jakarta-annotations/jakarta.annotation-api.jar %{buildroo
 
 %if %{with server}
 
-%pre -n pki-server
+%pre -n %{product_id}-server
 getent group %{pki_groupname} >/dev/null || groupadd -f -g %{pki_gid} -r %{pki_groupname}
 if ! getent passwd %{pki_username} >/dev/null ; then
     useradd -r -u %{pki_uid} -g %{pki_groupname} -d %{pki_homedir} -s /sbin/nologin -c "Certificate System" %{pki_username}
@@ -936,7 +979,7 @@ exit 0
 
 %if %{with base}
 
-%post -n pki-base
+%post -n %{product_id}-base
 
 if [ $1 -eq 1 ]
 then
@@ -950,7 +993,7 @@ else
     echo >> /var/log/pki/pki-upgrade-%{version}.log
 fi
 
-%postun -n pki-base
+%postun -n %{product_id}-base
 
 if [ $1 -eq 0 ]
 then
@@ -963,7 +1006,7 @@ fi
 
 %if %{with server}
 
-%post -n pki-server
+%post -n %{product_id}-server
 # CVE-2021-3551
 # Remove world access from existing installation logs
 find /var/log/pki -maxdepth 1 -type f -exec chmod o-rwx {} \;
@@ -978,9 +1021,9 @@ fi
 %endif
 
 %if %{with meta}
-%if "%{name}" != "%{vendor_id}-pki"
+%if "%{name}" != "%{product_id}"
 ################################################################################
-%files -n %{vendor_id}-pki
+%files -n %{product_id}
 ################################################################################
 %else
 %files
@@ -993,7 +1036,7 @@ fi
 
 %if %{with base}
 ################################################################################
-%files -n pki-symkey
+%files -n %{product_id}-symkey
 ################################################################################
 
 %license base/symkey/LICENSE
@@ -1001,7 +1044,7 @@ fi
 %{_libdir}/symkey/
 
 ################################################################################
-%files -n pki-base
+%files -n %{product_id}-base
 ################################################################################
 
 %license base/common/LICENSE
@@ -1027,7 +1070,7 @@ fi
 %{_mandir}/man8/pki-upgrade.8.gz
 
 ################################################################################
-%files -n pki-base-java
+%files -n %{product_id}-base-java
 ################################################################################
 
 %license base/common/LICENSE
@@ -1039,7 +1082,7 @@ fi
 %{_javadir}/pki/pki-certsrv.jar
 
 ################################################################################
-%files -n python3-pki
+%files -n python3-%{product_id}
 ################################################################################
 
 %license base/common/LICENSE
@@ -1050,7 +1093,7 @@ fi
 %{python3_sitelib}/pki
 
 ################################################################################
-%files -n pki-tools
+%files -n %{product_id}-tools
 ################################################################################
 
 %license base/tools/LICENSE
@@ -1124,7 +1167,7 @@ fi
 
 %if %{with server}
 ################################################################################
-%files -n pki-server
+%files -n %{product_id}-server
 ################################################################################
 
 %license base/common/THIRD_PARTY_LICENSES
@@ -1185,7 +1228,7 @@ fi
 
 %if %{with acme}
 ################################################################################
-%files -n pki-acme
+%files -n %{product_id}-acme
 ################################################################################
 
 %{_javadir}/pki/pki-acme.jar
@@ -1196,7 +1239,7 @@ fi
 
 %if %{with ca}
 ################################################################################
-%files -n pki-ca
+%files -n %{product_id}-ca
 ################################################################################
 
 %license base/ca/LICENSE
@@ -1208,7 +1251,7 @@ fi
 
 %if %{with kra}
 ################################################################################
-%files -n pki-kra
+%files -n %{product_id}-kra
 ################################################################################
 
 %license base/kra/LICENSE
@@ -1220,7 +1263,7 @@ fi
 
 %if %{with ocsp}
 ################################################################################
-%files -n pki-ocsp
+%files -n %{product_id}-ocsp
 ################################################################################
 
 %license base/ocsp/LICENSE
@@ -1232,7 +1275,7 @@ fi
 
 %if %{with tks}
 ################################################################################
-%files -n pki-tks
+%files -n %{product_id}-tks
 ################################################################################
 
 %license base/tks/LICENSE
@@ -1244,7 +1287,7 @@ fi
 
 %if %{with tps}
 ################################################################################
-%files -n pki-tps
+%files -n %{product_id}-tps
 ################################################################################
 
 %license base/tps/LICENSE
@@ -1266,7 +1309,7 @@ fi
 
 %if %{with javadoc}
 ################################################################################
-%files -n pki-javadoc
+%files -n %{product_id}-javadoc
 ################################################################################
 
 %{_javadocdir}/pki-%{version}/
@@ -1276,7 +1319,7 @@ fi
 
 %if %{with console}
 ################################################################################
-%files -n pki-console
+%files -n %{product_id}-console
 ################################################################################
 
 %license base/console/LICENSE
@@ -1288,10 +1331,10 @@ fi
 
 %if %{with theme}
 ################################################################################
-%files -n %{vendor_id}-pki-server-theme
+%files -n %{product_id}-server-theme
 ################################################################################
 
-%license themes/%{vendor_id}/common-ui/LICENSE
+%license themes/%{theme}/common-ui/LICENSE
 %dir %{_datadir}/pki
 %{_datadir}/pki/CS_SERVER_VERSION
 %{_datadir}/pki/common-ui/
@@ -1307,10 +1350,10 @@ fi
 
 %if %{with console}
 ################################################################################
-%files -n %{vendor_id}-pki-console-theme
+%files -n %{product_id}-console-theme
 ################################################################################
 
-%license themes/%{vendor_id}/console-ui/LICENSE
+%license themes/%{theme}/console-ui/LICENSE
 %{_javadir}/pki/pki-console-theme.jar
 
 # with console
@@ -1321,7 +1364,7 @@ fi
 
 %if %{with tests}
 ################################################################################
-%files -n pki-tests
+%files -n %{product_id}-tests
 ################################################################################
 
 %{_datadir}/pki/tests/


### PR DESCRIPTION
The `pki-*` packages have been renamed into `dogtag-pki-*`. The `Obsoletes:` directives have been added to replace
installed `pki-*` packages. The `Provides:` directives have been added for backward compatibility.

The `vendor_id` and `brand` macros have been replaced with`product_name`, `product_id`, and `theme` macros.

https://github.com/edewata/pki/blob/packaging/docs/changes/v11.0.0/Packaging-Changes.adoc
