### PR TITLE
Drop JAXB from Account

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/account/Account.java
+++ b/base/common/src/main/java/com/netscape/certsrv/account/Account.java
@@ -20,23 +20,22 @@ package com.netscape.certsrv.account;
 
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.TreeSet;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -46,7 +45,6 @@ import com.netscape.certsrv.base.ResourceMessage;
 /**
  * @author Endi S. Dewata
  */
-@XmlRootElement(name="Account")
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class Account extends ResourceMessage {
@@ -56,7 +54,6 @@ public class Account extends ResourceMessage {
     String email;
     Collection<String> roles = new TreeSet<>();
 
-    @XmlAttribute(name="id")
     public String getID() {
         return id;
     }
@@ -65,7 +62,6 @@ public class Account extends ResourceMessage {
         this.id = id;
     }
 
-    @XmlElement(name="FullName")
     public String getFullName() {
         return fullName;
     }
@@ -74,7 +70,6 @@ public class Account extends ResourceMessage {
         this.fullName = fullName;
     }
 
-    @XmlElement(name="Email")
     public String getEmail() {
         return email;
     }
@@ -83,8 +78,6 @@ public class Account extends ResourceMessage {
         this.email = email;
     }
 
-    @XmlElement(name="Roles")
-    @XmlJavaTypeAdapter(RolesAdapter.class)
     public Collection<String> getRoles() {
         return roles;
     }
@@ -238,17 +231,35 @@ public class Account extends ResourceMessage {
     }
 
     public String toXML() throws Exception {
-        Marshaller marshaller = JAXBContext.newInstance(Account.class).createMarshaller();
-        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.newDocument();
+
+        Element accountElement = toDOM(document);
+        document.appendChild(accountElement);
+
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+
+        DOMSource domSource = new DOMSource(document);
         StringWriter sw = new StringWriter();
-        marshaller.marshal(this, sw);
+        StreamResult streamResult = new StreamResult(sw);
+        transformer.transform(domSource, streamResult);
+
         return sw.toString();
     }
 
     public static Account fromXML(String xml) throws Exception {
-        Unmarshaller unmarshaller = JAXBContext.newInstance(Account.class).createUnmarshaller();
-        return (Account) unmarshaller.unmarshal(new StringReader(xml));
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(xml)));
+
+        Element accountElement = document.getDocumentElement();
+        return fromDOM(accountElement);
     }
 
     @Override
@@ -259,30 +270,4 @@ public class Account extends ResourceMessage {
             throw new RuntimeException(e);
         }
     }
-
-    public static class RolesAdapter extends XmlAdapter<RoleList, Collection<String>> {
-
-        @Override
-        public RoleList marshal(Collection<String> roles) {
-            RoleList list = new RoleList();
-            list.roles = roles.toArray(new String[roles.size()]);
-            return list;
-        }
-
-        @Override
-        public Collection<String> unmarshal(RoleList list) {
-            Collection<String> roles = new TreeSet<>();
-            if (list.roles != null) {
-                roles.addAll(Arrays.asList(list.roles));
-            }
-            return roles;
-        }
-    }
-
-    public static class RoleList {
-
-        @XmlElement(name="Role")
-        public String[] roles;
-    }
-
 }

--- a/base/common/src/main/java/com/netscape/certsrv/base/ResourceMessage.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/ResourceMessage.java
@@ -55,7 +55,7 @@ import com.netscape.certsrv.util.JSONSerializer;
 public class ResourceMessage implements JSONSerializer {
 
     protected Map<String, String> attributes = new LinkedHashMap<>();
-    String className;
+    protected String className;
 
     public ResourceMessage() {
         // required for jax-b


### PR DESCRIPTION
The `Account` class has been modified to use DOM instead of JAXB for XML mapping.
