### PR TITLE
Drop JAXB from CertDataInfo

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/base/DataCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/DataCollection.java
@@ -28,9 +28,9 @@ import javax.xml.bind.annotation.XmlElement;
  */
 public class DataCollection<E> {
 
-    int total;
-    Collection<E> entries = new ArrayList<>();
-    Collection<Link> links = new ArrayList<>();
+    protected int total;
+    protected Collection<E> entries = new ArrayList<>();
+    protected Collection<Link> links = new ArrayList<>();
 
     public int getTotal() {
         return total;

--- a/base/common/src/main/java/com/netscape/certsrv/base/Link.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/Link.java
@@ -20,6 +20,10 @@ package com.netscape.certsrv.base;
 import java.net.URI;
 import java.util.Objects;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -112,4 +116,53 @@ public class Link implements JSONSerializer {
                 Objects.equals(type, other.type);
     }
 
+    public Element toDOM(Document document) {
+
+        Element linkElement = document.createElement("Link");
+
+        if (relationship != null) {
+            Element relationshipElement = document.createElement("relationship");
+            relationshipElement.appendChild(document.createTextNode(relationship));
+            linkElement.appendChild(relationshipElement);
+        }
+
+        if (href != null) {
+            Element hrefElement = document.createElement("href");
+            hrefElement.appendChild(document.createTextNode(href));
+            linkElement.appendChild(hrefElement);
+        }
+
+        if (type != null) {
+            Element typeElement = document.createElement("type");
+            typeElement.appendChild(document.createTextNode(type));
+            linkElement.appendChild(typeElement);
+        }
+
+        return linkElement;
+    }
+
+    public static Link fromDOM(Element linkElement) {
+
+        Link link = new Link();
+
+        NodeList relationshipList = linkElement.getElementsByTagName("relationship");
+        if (relationshipList.getLength() > 0) {
+            String value = relationshipList.item(0).getTextContent();
+            link.setRelationship(value);
+        }
+
+        NodeList hrefList = linkElement.getElementsByTagName("href");
+        if (hrefList.getLength() > 0) {
+            String value = hrefList.item(0).getTextContent();
+            link.setHref(value);
+        }
+
+        NodeList typeList = linkElement.getElementsByTagName("type");
+        if (typeList.getLength() > 0) {
+            String value = typeList.item(0).getTextContent();
+            link.setType(value);
+        }
+
+        return link;
+    }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfo.java
@@ -24,10 +24,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Date;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -47,15 +43,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.base.Link;
 import com.netscape.certsrv.dbs.certdb.CertId;
-import com.netscape.certsrv.dbs.certdb.CertIdAdapter;
-import com.netscape.certsrv.util.DateAdapter;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
  * @author alee
  *
  */
-@XmlRootElement(name = "CertDataInfo")
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class CertDataInfo implements JSONSerializer {
@@ -77,8 +70,6 @@ public class CertDataInfo implements JSONSerializer {
 
     Link link;
 
-    @XmlAttribute(name="id")
-    @XmlJavaTypeAdapter(CertIdAdapter.class)
     public CertId getID() {
         return id;
     }
@@ -87,7 +78,6 @@ public class CertDataInfo implements JSONSerializer {
         this.id = id;
     }
 
-    @XmlElement(name="SubjectDN")
     public String getSubjectDN() {
         return subjectDN;
     }
@@ -96,7 +86,6 @@ public class CertDataInfo implements JSONSerializer {
         this.subjectDN = subjectDN;
     }
 
-    @XmlElement(name="IssuerDN")
     public String getIssuerDN() {
         return issuerDN;
     }
@@ -105,7 +94,6 @@ public class CertDataInfo implements JSONSerializer {
         this.issuerDN = issuerDN;
     }
 
-    @XmlElement(name="Status")
     public String getStatus() {
         return status;
     }
@@ -114,7 +102,6 @@ public class CertDataInfo implements JSONSerializer {
         this.status = status;
     }
 
-    @XmlElement(name="Type")
     public String getType() {
         return type;
     }
@@ -123,7 +110,6 @@ public class CertDataInfo implements JSONSerializer {
         this.type = type;
     }
 
-    @XmlElement(name="Version")
     public Integer getVersion() {
         return version;
     }
@@ -132,7 +118,6 @@ public class CertDataInfo implements JSONSerializer {
         this.version = version;
     }
 
-    @XmlElement(name="KeyAlgorithmOID")
     public String getKeyAlgorithmOID() {
         return keyAlgorithmOID;
     }
@@ -141,7 +126,6 @@ public class CertDataInfo implements JSONSerializer {
         this.keyAlgorithmOID = keyAlgorithmOID;
     }
 
-    @XmlElement(name="KeyLength")
     public Integer getKeyLength() {
         return keyLength;
     }
@@ -150,8 +134,6 @@ public class CertDataInfo implements JSONSerializer {
         this.keyLength = keyLength;
     }
 
-    @XmlElement(name="NotValidBefore")
-    @XmlJavaTypeAdapter(DateAdapter.class)
     public Date getNotValidBefore() {
         return notValidBefore;
     }
@@ -160,8 +142,6 @@ public class CertDataInfo implements JSONSerializer {
         this.notValidBefore = notValidBefore;
     }
 
-    @XmlElement(name="NotValidAfter")
-    @XmlJavaTypeAdapter(DateAdapter.class)
     public Date getNotValidAfter() {
         return notValidAfter;
     }
@@ -170,8 +150,6 @@ public class CertDataInfo implements JSONSerializer {
         this.notValidAfter = notValidAfter;
     }
 
-    @XmlElement(name="IssuedOn")
-    @XmlJavaTypeAdapter(DateAdapter.class)
     public Date getIssuedOn() {
         return issuedOn;
     }
@@ -180,7 +158,6 @@ public class CertDataInfo implements JSONSerializer {
         this.issuedOn = issuedOn;
     }
 
-    @XmlElement(name="IssuedBy")
     public String getIssuedBy() {
         return issuedBy;
     }
@@ -189,8 +166,6 @@ public class CertDataInfo implements JSONSerializer {
         this.issuedBy = issuedBy;
     }
 
-    @XmlElement(name="RevokedOn")
-    @XmlJavaTypeAdapter(DateAdapter.class)
     public Date getRevokedOn() {
         return revokedOn;
     }
@@ -199,7 +174,6 @@ public class CertDataInfo implements JSONSerializer {
         this.revokedOn = revokedOn;
     }
 
-    @XmlElement(name="RevokedBy")
     public String getRevokedBy() {
         return revokedBy;
     }
@@ -208,7 +182,6 @@ public class CertDataInfo implements JSONSerializer {
         this.revokedBy = revokedBy;
     }
 
-    @XmlElement(name="Link")
     public Link getLink() {
         return link;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfo.java
@@ -24,13 +24,23 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Date;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.apache.commons.lang3.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -316,18 +326,224 @@ public class CertDataInfo implements JSONSerializer {
         return true;
     }
 
-    public String toXML() throws Exception {
-        Marshaller marshaller = JAXBContext.newInstance(CertDataInfo.class).createMarshaller();
-        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+    public Element toDOM(Document document) {
 
+        Element infoElement = document.createElement("CertDataInfo");
+
+        if (id != null) {
+            infoElement.setAttribute("id", id.toHexString());
+        }
+
+        if (subjectDN != null) {
+            Element subjectDNElement = document.createElement("SubjectDN");
+            subjectDNElement.appendChild(document.createTextNode(subjectDN));
+            infoElement.appendChild(subjectDNElement);
+        }
+
+        if (issuerDN != null) {
+            Element issuerDNElement = document.createElement("IssuerDN");
+            issuerDNElement.appendChild(document.createTextNode(issuerDN));
+            infoElement.appendChild(issuerDNElement);
+        }
+
+        if (status != null) {
+            Element statusElement = document.createElement("Status");
+            statusElement.appendChild(document.createTextNode(status));
+            infoElement.appendChild(statusElement);
+        }
+
+        if (type != null) {
+            Element typeElement = document.createElement("Type");
+            typeElement.appendChild(document.createTextNode(type));
+            infoElement.appendChild(typeElement);
+        }
+
+        if (version != null) {
+            Element versionElement = document.createElement("Version");
+            versionElement.appendChild(document.createTextNode(Integer.toString(version)));
+            infoElement.appendChild(versionElement);
+        }
+
+        if (keyAlgorithmOID != null) {
+            Element keyAlgorithmOIDElement = document.createElement("KeyAlgorithmOID");
+            keyAlgorithmOIDElement.appendChild(document.createTextNode(keyAlgorithmOID));
+            infoElement.appendChild(keyAlgorithmOIDElement);
+        }
+
+        if (keyLength != null) {
+            Element keyLengthElement = document.createElement("KeyLength");
+            keyLengthElement.appendChild(document.createTextNode(Integer.toString(keyLength)));
+            infoElement.appendChild(keyLengthElement);
+        }
+
+        if (notValidBefore != null) {
+            Element notValidBeforeElement = document.createElement("NotValidBefore");
+            notValidBeforeElement.appendChild(document.createTextNode(Long.toString(notValidBefore.getTime())));
+            infoElement.appendChild(notValidBeforeElement);
+        }
+
+        if (notValidAfter != null) {
+            Element notValidAfterElement = document.createElement("NotValidAfter");
+            notValidAfterElement.appendChild(document.createTextNode(Long.toString(notValidAfter.getTime())));
+            infoElement.appendChild(notValidAfterElement);
+        }
+
+        if (issuedOn != null) {
+            Element issuedOnElement = document.createElement("IssuedOn");
+            issuedOnElement.appendChild(document.createTextNode(Long.toString(issuedOn.getTime())));
+            infoElement.appendChild(issuedOnElement);
+        }
+
+        if (issuedBy != null) {
+            Element issuedByElement = document.createElement("IssuedBy");
+            issuedByElement.appendChild(document.createTextNode(issuedBy));
+            infoElement.appendChild(issuedByElement);
+        }
+
+        if (revokedOn != null) {
+            Element revokedOnElement = document.createElement("RevokedOn");
+            revokedOnElement.appendChild(document.createTextNode(Long.toString(revokedOn.getTime())));
+            infoElement.appendChild(revokedOnElement);
+        }
+
+        if (revokedBy != null) {
+            Element revokedByElement = document.createElement("RevokedBy");
+            revokedByElement.appendChild(document.createTextNode(revokedBy));
+            infoElement.appendChild(revokedByElement);
+        }
+
+        if (link != null) {
+            Element linkElement = link.toDOM(document);
+            infoElement.appendChild(linkElement);
+        }
+
+        return infoElement;
+    }
+
+    public static CertDataInfo fromDOM(Element infoElement) {
+
+        CertDataInfo info = new CertDataInfo();
+
+        String id = infoElement.getAttribute("id");
+        info.setID(StringUtils.isEmpty(id) ? null : new CertId(id));
+
+        NodeList subjectDNList = infoElement.getElementsByTagName("SubjectDN");
+        if (subjectDNList.getLength() > 0) {
+            String value = subjectDNList.item(0).getTextContent();
+            info.setSubjectDN(value);
+        }
+
+        NodeList issuerDNList = infoElement.getElementsByTagName("IssuerDN");
+        if (issuerDNList.getLength() > 0) {
+            String value = issuerDNList.item(0).getTextContent();
+            info.setIssuerDN(value);
+        }
+
+        NodeList statusList = infoElement.getElementsByTagName("Status");
+        if (statusList.getLength() > 0) {
+            String value = statusList.item(0).getTextContent();
+            info.setStatus(value);
+        }
+
+        NodeList typeList = infoElement.getElementsByTagName("Type");
+        if (typeList.getLength() > 0) {
+            String value = typeList.item(0).getTextContent();
+            info.setType(value);
+        }
+
+        NodeList versionList = infoElement.getElementsByTagName("Version");
+        if (versionList.getLength() > 0) {
+            String value = versionList.item(0).getTextContent();
+            info.setVersion(Integer.parseInt(value));
+        }
+
+        NodeList keyAlgorithmOIDList = infoElement.getElementsByTagName("KeyAlgorithmOID");
+        if (keyAlgorithmOIDList.getLength() > 0) {
+            String value = keyAlgorithmOIDList.item(0).getTextContent();
+            info.setKeyAlgorithmOID(value);
+        }
+
+        NodeList keyLengthList = infoElement.getElementsByTagName("KeyLength");
+        if (keyLengthList.getLength() > 0) {
+            String value = keyLengthList.item(0).getTextContent();
+            info.setKeyLength(Integer.parseInt(value));
+        }
+
+        NodeList notValidBeforeList = infoElement.getElementsByTagName("NotValidBefore");
+        if (notValidBeforeList.getLength() > 0) {
+            String value = notValidBeforeList.item(0).getTextContent();
+            info.setNotValidBefore(new Date(Long.parseLong(value)));
+        }
+
+        NodeList notValidAfterList = infoElement.getElementsByTagName("NotValidAfter");
+        if (notValidAfterList.getLength() > 0) {
+            String value = notValidAfterList.item(0).getTextContent();
+            info.setNotValidAfter(new Date(Long.parseLong(value)));
+        }
+
+        NodeList issuedOnList = infoElement.getElementsByTagName("IssuedOn");
+        if (issuedOnList.getLength() > 0) {
+            String value = issuedOnList.item(0).getTextContent();
+            info.setIssuedOn(new Date(Long.parseLong(value)));
+        }
+
+        NodeList issuedByList = infoElement.getElementsByTagName("IssuedBy");
+        if (issuedByList.getLength() > 0) {
+            String value = issuedByList.item(0).getTextContent();
+            info.setIssuedBy(value);
+        }
+
+        NodeList revokedOnList = infoElement.getElementsByTagName("RevokedOn");
+        if (revokedOnList.getLength() > 0) {
+            String value = revokedOnList.item(0).getTextContent();
+            info.setRevokedOn(new Date(Long.parseLong(value)));
+        }
+
+        NodeList revokedByList = infoElement.getElementsByTagName("RevokedBy");
+        if (revokedByList.getLength() > 0) {
+            String value = revokedByList.item(0).getTextContent();
+            info.setRevokedBy(value);
+        }
+
+        NodeList linkList = infoElement.getElementsByTagName("Link");
+        if (linkList.getLength() > 0) {
+            Element linkElement = (Element) linkList.item(0);
+            Link link = Link.fromDOM(linkElement);
+            info.setLink(link);
+        }
+
+        return info;
+    }
+
+    public String toXML() throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.newDocument();
+
+        Element infoElement = toDOM(document);
+        document.appendChild(infoElement);
+
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+
+        DOMSource domSource = new DOMSource(document);
         StringWriter sw = new StringWriter();
-        marshaller.marshal(this, sw);
+        StreamResult streamResult = new StreamResult(sw);
+        transformer.transform(domSource, streamResult);
+
         return sw.toString();
     }
 
     public static CertDataInfo fromXML(String xml) throws Exception {
-        Unmarshaller unmarshaller = JAXBContext.newInstance(CertDataInfo.class).createUnmarshaller();
-        return (CertDataInfo) unmarshaller.unmarshal(new StringReader(xml));
-    }
 
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(xml)));
+
+        Element infoElement = document.getDocumentElement();
+        return fromDOM(infoElement);
+    }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfos.java
@@ -22,10 +22,15 @@ import java.util.Collection;
 import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.base.DataCollection;
+import com.netscape.certsrv.base.Link;
 
 @XmlRootElement(name = "CertDataInfos")
 @JsonInclude(Include.NON_NULL)
@@ -36,5 +41,56 @@ public class CertDataInfos extends DataCollection<CertDataInfo> {
     @XmlElementRef
     public Collection<CertDataInfo> getEntries() {
         return super.getEntries();
+    }
+
+    public Element toDOM(Document document) {
+
+        Element infosElement = document.createElement("CertDataInfos");
+        document.appendChild(infosElement);
+
+        Element totalElement = document.createElement("total");
+        totalElement.appendChild(document.createTextNode(Integer.toString(total)));
+        infosElement.appendChild(totalElement);
+
+        for (CertDataInfo certDataInfo : getEntries()) {
+            Element infoElement = certDataInfo.toDOM(document);
+            infosElement.appendChild(infoElement);
+        }
+
+        for (Link link : getLinks()) {
+            Element infoElement = link.toDOM(document);
+            infosElement.appendChild(infoElement);
+        }
+
+        return infosElement;
+    }
+
+    public static CertDataInfos fromDOM(Element infosElement) {
+
+        CertDataInfos infos = new CertDataInfos();
+
+        NodeList totalList = infosElement.getElementsByTagName("total");
+        if (totalList.getLength() > 0) {
+            String value = totalList.item(0).getTextContent();
+            infos.setTotal(Integer.parseInt(value));
+        }
+
+        NodeList infoList = infosElement.getElementsByTagName("CertDataInfo");
+        int infoCount = infoList.getLength();
+        for (int i=0; i<infoCount; i++) {
+           Element infoElement = (Element) infoList.item(i);
+           CertDataInfo info = CertDataInfo.fromDOM(infoElement);
+           infos.addEntry(info);
+        }
+
+        NodeList linkList = infosElement.getElementsByTagName("Link");
+        int linkCount = linkList.getLength();
+        for (int i=0; i<linkCount; i++) {
+           Element linkElement = (Element) linkList.item(i);
+           Link link = Link.fromDOM(linkElement);
+           infos.addLink(link);
+        }
+
+        return infos;
     }
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfoTest.java
@@ -1,5 +1,7 @@
 package com.netscape.certsrv.cert;
 
+import java.util.Date;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,7 +17,18 @@ public class CertDataInfoTest {
     public void setUpBefore() {
         before.setID(new CertId("12512514865863765114"));
         before.setSubjectDN("CN=Test User,UID=testuser,O=EXAMPLE-COM");
+        before.setIssuerDN("CN=Certificate Authority,O=EXAMPLE-COM");
         before.setStatus("VALID");
+        before.setType("X.509");
+        before.setVersion(2);
+        before.setKeyAlgorithmOID("1.2.840.113549.1.1.1");
+        before.setKeyLength(2048);
+        before.setNotValidBefore(new Date());
+        before.setNotValidAfter(new Date());
+        before.setIssuedOn(new Date());
+        before.setIssuedBy("admin");
+        before.setRevokedOn(new Date());
+        before.setRevokedBy("admin");
     }
 
     @Test

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfosTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfosTest.java
@@ -1,0 +1,51 @@
+package com.netscape.certsrv.cert;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netscape.certsrv.dbs.certdb.CertId;
+
+public class CertDataInfosTest {
+
+    private static CertDataInfo info;
+    private static CertDataInfos before;
+
+    @Before
+    public void setUpBefore() {
+        info = new CertDataInfo();
+        info.setID(new CertId("12512514865863765114"));
+        info.setSubjectDN("CN=Test User,UID=testuser,O=EXAMPLE-COM");
+        info.setIssuerDN("CN=Certificate Authority,O=EXAMPLE-COM");
+        info.setStatus("VALID");
+        info.setType("X.509");
+        info.setVersion(2);
+        info.setKeyAlgorithmOID("1.2.840.113549.1.1.1");
+        info.setKeyLength(2048);
+        info.setNotValidBefore(new Date());
+        info.setNotValidAfter(new Date());
+        info.setIssuedOn(new Date());
+        info.setIssuedBy("admin");
+        info.setRevokedOn(new Date());
+        info.setRevokedBy("admin");
+
+        before = new CertDataInfos();
+        before.addEntry(info);
+        before.setTotal(1);
+    }
+
+    @Test
+    public void testXML() throws Exception {
+        // Act
+        String xml = before.toXML();
+        System.out.println("XML (before): " + xml);
+
+        CertDataInfos afterXML = CertDataInfos.fromXML(xml);
+        System.out.println("XML (after): " + afterXML.toXML());
+
+        // Assert
+        Assert.assertEquals(before, afterXML);
+    }
+}


### PR DESCRIPTION
The `PKIClient` and `PKIService` classes have been modified to support optional XML mapping using `fromXML()` and `toXML()`. This can be used to implement an alternative XML mapping using DOM instead of JAXB.

The `Link`, `CertDataInfo`, and `CertDataInfos` classes have been modified to use DOM so the JAXB can be dropped from `CertDataInfo`.

Note: it might be easier to review this PR by reviewing individual commits.