### PR TITLE
Drop JAXB from CertRevokeRequest

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/PKIIssuer.java
@@ -287,7 +287,7 @@ public class PKIIssuer extends ACMEIssuer {
             }
 
             CertRevokeRequest request = new CertRevokeRequest();
-            request.setReason(RevocationReason.valueOf(reason));
+            request.setReason(RevocationReason.valueOf(reason).getLabel());
             request.setNonce(certData.getNonce());
 
             logger.info("Revoking certificate");

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertService.java
@@ -180,7 +180,7 @@ public class CertService extends PKIService implements CertResource {
         @SuppressWarnings("unused")
         CertData data = getCertData(id);
 
-        RevocationReason revReason = request.getReason();
+        RevocationReason revReason = RevocationReason.valueOf(request.getReason());
         if (revReason == RevocationReason.REMOVE_FROM_CRL) {
             return unrevokeCert(id);
         }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
@@ -30,9 +30,6 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.mozilla.jss.netscape.security.x509.RevocationReason;
-import org.mozilla.jss.netscape.security.x509.RevocationReasonAdapter;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -48,7 +45,7 @@ import com.netscape.certsrv.util.JSONSerializer;
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class CertRevokeRequest implements JSONSerializer {
 
-    RevocationReason reason;
+    String reason;
     Date invalidityDate;
     String comments;
     String encoded;
@@ -57,12 +54,11 @@ public class CertRevokeRequest implements JSONSerializer {
 
     @XmlElement(name="Reason")
     @FormParam("revocationReason")
-    @XmlJavaTypeAdapter(RevocationReasonAdapter.class)
-    public RevocationReason getReason() {
+    public String getReason() {
         return reason;
     }
 
-    public void setReason(RevocationReason reason) {
+    public void setReason(String reason) {
         this.reason = reason;
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
@@ -30,6 +30,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -150,6 +154,80 @@ public class CertRevokeRequest implements JSONSerializer {
         } else if (!reason.equals(other.reason))
             return false;
         return true;
+    }
+
+    public Element toDOM(Document document) {
+
+        Element requestElement = document.createElement("CertRevokeRequest");
+
+        if (reason != null) {
+            Element reasonElement = document.createElement("Reason");
+            reasonElement.appendChild(document.createTextNode(reason));
+            requestElement.appendChild(reasonElement);
+        }
+
+        if (invalidityDate != null) {
+            Element invalidityDateElement = document.createElement("InvalidityDate");
+            invalidityDateElement.appendChild(document.createTextNode(Long.toString(invalidityDate.getTime())));
+            requestElement.appendChild(invalidityDateElement);
+        }
+
+        if (comments != null) {
+            Element commentsElement = document.createElement("Comments");
+            commentsElement.appendChild(document.createTextNode(comments));
+            requestElement.appendChild(commentsElement);
+        }
+
+        if (encoded != null) {
+            Element encodedElement = document.createElement("Encoded");
+            encodedElement.appendChild(document.createTextNode(encoded));
+            requestElement.appendChild(encodedElement);
+        }
+
+        if (nonce != null) {
+            Element nonceElement = document.createElement("Nonce");
+            nonceElement.appendChild(document.createTextNode(Long.toString(nonce)));
+            requestElement.appendChild(nonceElement);
+        }
+
+        return requestElement;
+    }
+
+    public static CertRevokeRequest fromDOM(Element dataElement) {
+
+        CertRevokeRequest request = new CertRevokeRequest();
+
+        NodeList reasonList = dataElement.getElementsByTagName("Reason");
+        if (reasonList.getLength() > 0) {
+            String value = reasonList.item(0).getTextContent();
+            request.setReason(value);
+        }
+
+        NodeList invalidityDateList = dataElement.getElementsByTagName("InvalidityDate");
+        if (invalidityDateList.getLength() > 0) {
+            String value = invalidityDateList.item(0).getTextContent();
+            request.setInvalidityDate(new Date(Long.parseLong(value)));
+        }
+
+        NodeList commentsList = dataElement.getElementsByTagName("Comments");
+        if (commentsList.getLength() > 0) {
+            String value = commentsList.item(0).getTextContent();
+            request.setComments(value);
+        }
+
+        NodeList encodedList = dataElement.getElementsByTagName("Encoded");
+        if (encodedList.getLength() > 0) {
+            String value = encodedList.item(0).getTextContent();
+            request.setEncoded(value);
+        }
+
+        NodeList nonceList = dataElement.getElementsByTagName("Nonce");
+        if (nonceList.getLength() > 0) {
+            String value = nonceList.item(0).getTextContent();
+            request.setNonce(Long.parseLong(value));
+        }
+
+        return request;
     }
 
     public String toXML() throws Exception {

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRevokeRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRevokeRequestTest.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mozilla.jss.netscape.security.x509.RevocationReason;
 
 import com.netscape.certsrv.util.JSONSerializer;
 
@@ -14,7 +15,7 @@ public class CertRevokeRequestTest {
 
     @Before
     public void setUpBefore() {
-    //  before.setReason(RevocationReason.CERTIFICATE_HOLD);
+        before.setReason(RevocationReason.CERTIFICATE_HOLD.getLabel());
         before.setInvalidityDate(new Date());
         before.setComments("test");
         before.setEncoded("test");

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACertHoldCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACertHoldCLI.java
@@ -97,7 +97,7 @@ public class CACertHoldCLI extends CommandCLI {
         }
 
         CertRevokeRequest request = new CertRevokeRequest();
-        request.setReason(RevocationReason.CERTIFICATE_HOLD);
+        request.setReason(RevocationReason.CERTIFICATE_HOLD.getLabel());
         request.setComments(cmd.getOptionValue("comments"));
         request.setNonce(certData.getNonce());
 

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACertRevokeCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACertRevokeCLI.java
@@ -127,7 +127,7 @@ public class CACertRevokeCLI extends CommandCLI {
         }
 
         CertRevokeRequest request = new CertRevokeRequest();
-        request.setReason(reason);
+        request.setReason(reason.getLabel());
         request.setComments(cmd.getOptionValue("comments"));
         request.setNonce(certData.getNonce());
 


### PR DESCRIPTION
The `CertRevokeRequest.reason` has been converted into `String` to remove dependency on `RevocationReasonAdapter` which is also dependent on JAXB.

The `@FormParam` is also removed since forms are not supported with REST API.