### PR TITLE
Drop JAXB from PKIException

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/base/PKIException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/PKIException.java
@@ -39,6 +39,8 @@ import org.xml.sax.InputSource;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class PKIException extends RuntimeException {
 
@@ -102,6 +104,8 @@ public class PKIException extends RuntimeException {
     @XmlRootElement(name="PKIException")
     @JsonInclude(Include.NON_NULL)
     @JsonIgnoreProperties(ignoreUnknown=true)
+    @JsonSerialize(using=PKIExceptionSerializer.class)
+    @JsonDeserialize(using=PKIExceptionDeserializer.class)
     public static class Data extends ResourceMessage {
 
         @XmlElement(name="Code")

--- a/base/common/src/main/java/com/netscape/certsrv/base/PKIException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/PKIException.java
@@ -21,8 +21,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 
 import javax.ws.rs.core.Response;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -101,17 +99,13 @@ public class PKIException extends RuntimeException {
         return data;
     }
 
-    @XmlRootElement(name="PKIException")
     @JsonInclude(Include.NON_NULL)
     @JsonIgnoreProperties(ignoreUnknown=true)
     @JsonSerialize(using=PKIExceptionSerializer.class)
     @JsonDeserialize(using=PKIExceptionDeserializer.class)
     public static class Data extends ResourceMessage {
 
-        @XmlElement(name="Code")
         public int code;
-
-        @XmlElement(name="Message")
         public String message;
 
         public Element toDOM(Document document) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/PKIExceptionDeserializer.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/PKIExceptionDeserializer.java
@@ -1,0 +1,47 @@
+package com.netscape.certsrv.base;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.netscape.certsrv.base.PKIException.Data;
+
+public class PKIExceptionDeserializer extends StdDeserializer<Data> {
+
+    public PKIExceptionDeserializer() {
+        this(null);
+    }
+
+    public PKIExceptionDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Data deserialize(
+            JsonParser parser,
+            DeserializationContext context
+            ) throws IOException, JsonProcessingException {
+
+        Data data = new Data();
+
+        JsonNode node = parser.getCodec().readTree(parser);
+
+        JsonNode attributes = node.get("Attributes");
+        JsonNode attribute = attributes.get("Attribute");
+        for (JsonNode attr : attribute) {
+            String name = attr.get("name").asText();
+            String value = attr.get("value").asText();
+            data.attributes.put(name, value);
+        }
+
+        data.className = node.get("ClassName").asText();
+        data.code = (Integer) ((IntNode) node.get("Code")).numberValue();
+        data.message = node.get("Message").asText();
+
+        return data;
+    }
+}

--- a/base/common/src/main/java/com/netscape/certsrv/base/PKIExceptionSerializer.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/PKIExceptionSerializer.java
@@ -1,0 +1,48 @@
+package com.netscape.certsrv.base;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.netscape.certsrv.base.PKIException.Data;
+
+public class PKIExceptionSerializer extends StdSerializer<Data> {
+
+    public PKIExceptionSerializer() {
+        this(null);
+    }
+
+    public PKIExceptionSerializer(Class<Data> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(
+            Data data,
+            JsonGenerator generator,
+            SerializerProvider provider
+            ) throws IOException, JsonProcessingException {
+
+        generator.writeStartObject();
+
+        generator.writeObjectFieldStart("Attributes");
+        generator.writeArrayFieldStart("Attribute");
+        for (Map.Entry<String,String> entry : data.attributes.entrySet()) {
+            generator.writeStartObject();
+            generator.writeStringField("name", entry.getKey());
+            generator.writeStringField("value", entry.getValue());
+            generator.writeEndObject();
+        }
+        generator.writeEndArray();
+        generator.writeEndObject();
+
+        generator.writeStringField("ClassName", data.className);
+        generator.writeNumberField("Code", data.code);
+        generator.writeStringField("Message", data.message);
+
+        generator.writeEndObject();
+    }
+}


### PR DESCRIPTION
A JSON serializer/derserializer has been added for `PKIException` to replace JAXB mapping.