### PR TITLE
Drop JAXB from CertSearchRequest

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertService.java
@@ -48,7 +48,6 @@ import org.mozilla.jss.netscape.security.x509.CRLExtensions;
 import org.mozilla.jss.netscape.security.x509.CRLReasonExtension;
 import org.mozilla.jss.netscape.security.x509.RevocationReason;
 import org.mozilla.jss.netscape.security.x509.X500Name;
-
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.mozilla.jss.netscape.security.x509.X509ExtensionException;
 import org.mozilla.jss.netscape.security.x509.X509Key;
@@ -478,9 +477,11 @@ public class CertService extends PKIService implements CertResource {
     }
 
     @Override
-    public Response searchCerts(CertSearchRequest data, Integer start, Integer size) {
+    public Response searchCerts(String searchRequest, Integer start, Integer size) {
 
         logger.info("Searching for certificates");
+
+        CertSearchRequest data = unmarshall(searchRequest, CertSearchRequest.class);
 
         if (data == null) {
             throw new BadRequestException("Search request is null");

--- a/base/common/src/main/java/com/netscape/certsrv/ca/CACertClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/ca/CACertClient.java
@@ -89,7 +89,8 @@ public class CACertClient extends Client {
     }
 
     public CertDataInfos findCerts(CertSearchRequest data, Integer start, Integer size) throws Exception {
-        Response response = certClient.searchCerts(data, start, size);
+        String searchRequest = (String) client.marshall(data);
+        Response response = certClient.searchCerts(searchRequest, start, size);
         return client.getEntity(response, CertDataInfos.class);
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertResource.java
@@ -26,7 +26,7 @@ public interface CertResource {
     @POST
     @Path("certs/search")
     public Response searchCerts(
-            CertSearchRequest data,
+            String searchRequest,
             @QueryParam("start") Integer start,
             @QueryParam("size") Integer size);
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertSearchRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertSearchRequest.java
@@ -25,10 +25,6 @@ import java.io.StringWriter;
 import java.util.Objects;
 
 import javax.ws.rs.core.MultivaluedMap;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -51,162 +47,94 @@ import com.netscape.certsrv.util.JSONSerializer;
  * @author jmagne
  *
  */
-@XmlRootElement(name = "CertSearchRequest")
-@XmlAccessorType(XmlAccessType.FIELD)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class CertSearchRequest implements JSONSerializer {
 
-    @XmlElement
     protected String issuerDN;
 
     //Serial Number
-    @XmlElement
+
     protected boolean serialNumberRangeInUse;
-
-    @XmlElement
     protected String serialTo;
-
-    @XmlElement
     protected String serialFrom;
 
     //Subject Name
-    @XmlElement
+
     protected boolean subjectInUse;
-
-    @XmlElement
     protected String eMail;
-
-    @XmlElement
     protected String commonName;
-
-    @XmlElement
     protected String userID;
-
-    @XmlElement
     protected String orgUnit;
-
-    @XmlElement
     protected String org;
-
-    @XmlElement
     protected String locality;
-
-    @XmlElement
     protected String state;
-
-    @XmlElement
     protected String country;
-
-    @XmlElement
     protected boolean matchExactly;
 
     //Status
-    @XmlElement
+
     protected String status;
 
     //Revoked By
 
-    @XmlElement
     protected String revokedBy;
 
     //Revoked On
 
-    @XmlElement
     protected String revokedOnFrom;
-
-    @XmlElement
     protected String revokedOnTo;
 
     //Revocation Reason
 
-    @XmlElement
     protected String revocationReason;
 
     //Issued By
 
-    @XmlElement
     protected String issuedBy;
 
     //Issued On
 
-    @XmlElement
     protected String issuedOnFrom;
-
-    @XmlElement
     protected String issuedOnTo;
 
     //Valid Not Before
 
-    @XmlElement
     protected String validNotBeforeFrom;
-
-    @XmlElement
     protected String validNotBeforeTo;
 
     //Valid Not After
 
-    @XmlElement
     protected String validNotAfterFrom;
-
-    @XmlElement
     protected String validNotAfterTo;
 
     //Validity Length
 
-    @XmlElement
     protected String validityOperation;
-
-    @XmlElement
     protected Integer validityCount;
-
-    @XmlElement
     protected Long validityUnit;
 
     // Cert Type
 
-    @XmlElement
     protected String certTypeSubEmailCA;
-
-    @XmlElement
     protected String certTypeSubSSLCA;
-
-    @XmlElement
     protected String certTypeSecureEmail;
-
-    @XmlElement
     protected String certTypeSSLClient;
-
-    @XmlElement
     protected String certTypeSSLServer;
 
     //Revoked By
-    @XmlElement
+
     protected boolean revokedByInUse;
 
     //Revoked On
-    @XmlElement
+
     protected boolean revokedOnInUse;
-
-    @XmlElement
     protected boolean revocationReasonInUse;
-
-    @XmlElement
     protected boolean issuedByInUse;
-
-    @XmlElement
     protected boolean issuedOnInUse;
-
-    @XmlElement
     protected boolean validNotBeforeInUse;
-
-    @XmlElement
     protected boolean validNotAfterInUse;
-
-    @XmlElement
     protected boolean validityLengthInUse;
-
-    @XmlElement
     protected boolean certTypeInUse;
 
     public String getIssuerDN() {


### PR DESCRIPTION
The `PKIClient.marshall()` and `PKIService.unmarshall()` have been added to suport custom mapping of request objects.
The `CACertClient.findCerts()` has been modified to marshall the `CertSearchRequest` into a `String`.
The `CertService.searchCerts()` has been modified to unmarshall the `String` back into `CertSearchRequest`.