### PR TITLE
Drop JAXB from CMSRequestInfo

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfo.java
@@ -18,6 +18,23 @@
 
 package com.netscape.certsrv.cert;
 
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.apache.commons.lang3.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -33,13 +50,9 @@ public class CertRequestInfo extends CMSRequestInfo {
     public static final String RES_ERROR = "error";
 
     protected CertId certId;
-
     protected String certURL;
-
     protected String certRequestType;
-
     protected String operationResult;
-
     protected String errorMessage;
 
     public CertRequestInfo() {
@@ -149,4 +162,108 @@ public class CertRequestInfo extends CMSRequestInfo {
         }
     }
 
+    public Element toDOM(Document document) {
+
+        Element infoElement = document.createElement("CertDataInfo");
+
+        toDOM(document, infoElement);
+
+        if (certId != null) {
+            infoElement.setAttribute("id", certId.toHexString());
+        }
+
+        if (certURL != null) {
+            Element subjectDNElement = document.createElement("certURL");
+            subjectDNElement.appendChild(document.createTextNode(certURL));
+            infoElement.appendChild(subjectDNElement);
+        }
+
+        if (certRequestType != null) {
+            Element issuerDNElement = document.createElement("certRequestType");
+            issuerDNElement.appendChild(document.createTextNode(certRequestType));
+            infoElement.appendChild(issuerDNElement);
+        }
+
+        if (operationResult != null) {
+            Element statusElement = document.createElement("operationResult");
+            statusElement.appendChild(document.createTextNode(operationResult));
+            infoElement.appendChild(statusElement);
+        }
+
+        if (errorMessage != null) {
+            Element typeElement = document.createElement("errorMessage");
+            typeElement.appendChild(document.createTextNode(errorMessage));
+            infoElement.appendChild(typeElement);
+        }
+
+        return infoElement;
+    }
+
+    public static CertRequestInfo fromDOM(Element infoElement) {
+
+        CertRequestInfo info = new CertRequestInfo();
+
+        CMSRequestInfo.fromDOM(infoElement, info);
+
+        String id = infoElement.getAttribute("id");
+        info.setCertId(StringUtils.isEmpty(id) ? null : new CertId(id));
+
+        NodeList certURLList = infoElement.getElementsByTagName("certURL");
+        if (certURLList.getLength() > 0) {
+            String value = certURLList.item(0).getTextContent();
+            info.setCertURL(value);
+        }
+
+        NodeList certRequestTypeList = infoElement.getElementsByTagName("certRequestType");
+        if (certRequestTypeList.getLength() > 0) {
+            String value = certRequestTypeList.item(0).getTextContent();
+            info.setCertRequestType(value);
+        }
+
+        NodeList operationResultList = infoElement.getElementsByTagName("operationResult");
+        if (operationResultList.getLength() > 0) {
+            String value = operationResultList.item(0).getTextContent();
+            info.setOperationResult(value);
+        }
+
+        NodeList typeList = infoElement.getElementsByTagName("errorMessage");
+        if (typeList.getLength() > 0) {
+            String value = typeList.item(0).getTextContent();
+            info.setErrorMessage(value);
+        }
+
+        return info;
+    }
+
+    public String toXML() throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.newDocument();
+
+        Element element = toDOM(document);
+        document.appendChild(element);
+
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+
+        DOMSource domSource = new DOMSource(document);
+        StringWriter sw = new StringWriter();
+        StreamResult streamResult = new StreamResult(sw);
+        transformer.transform(domSource, streamResult);
+
+        return sw.toString();
+    }
+
+    public static CertRequestInfo fromXML(String xml) throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(xml)));
+
+        Element element = document.getDocumentElement();
+        return fromDOM(element);
+    }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfos.java
@@ -17,7 +17,22 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.cert;
 
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.Collection;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -62,4 +77,86 @@ public class CertRequestInfos extends DataCollection<CertRequestInfo> implements
         }
     }
 
+    public Element toDOM(Document document) {
+
+        Element infosElement = document.createElement("CertDataInfos");
+        document.appendChild(infosElement);
+
+        Element totalElement = document.createElement("total");
+        totalElement.appendChild(document.createTextNode(Integer.toString(total)));
+        infosElement.appendChild(totalElement);
+
+        for (CertRequestInfo certRequestInfo : getEntries()) {
+            Element infoElement = certRequestInfo.toDOM(document);
+            infosElement.appendChild(infoElement);
+        }
+
+        for (Link link : getLinks()) {
+            Element infoElement = link.toDOM(document);
+            infosElement.appendChild(infoElement);
+        }
+
+        return infosElement;
+    }
+
+    public String toXML() throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.newDocument();
+
+        Element element = toDOM(document);
+        document.appendChild(element);
+
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+
+        DOMSource domSource = new DOMSource(document);
+        StringWriter sw = new StringWriter();
+        StreamResult streamResult = new StreamResult(sw);
+        transformer.transform(domSource, streamResult);
+
+        return sw.toString();
+    }
+
+    public static CertRequestInfos fromDOM(Element infosElement) {
+
+        CertRequestInfos infos = new CertRequestInfos();
+
+        NodeList totalList = infosElement.getElementsByTagName("total");
+        if (totalList.getLength() > 0) {
+            String value = totalList.item(0).getTextContent();
+            infos.setTotal(Integer.parseInt(value));
+        }
+
+        NodeList infoList = infosElement.getElementsByTagName("CertRequestInfo");
+        int infoCount = infoList.getLength();
+        for (int i=0; i<infoCount; i++) {
+           Element infoElement = (Element) infoList.item(i);
+           CertRequestInfo info = CertRequestInfo.fromDOM(infoElement);
+           infos.addEntry(info);
+        }
+
+        NodeList linkList = infosElement.getElementsByTagName("Link");
+        int linkCount = linkList.getLength();
+        for (int i=0; i<linkCount; i++) {
+           Element linkElement = (Element) linkList.item(i);
+           Link link = Link.fromDOM(linkElement);
+           infos.addLink(link);
+        }
+
+        return infos;
+    }
+
+    public static CertRequestInfos fromXML(String xml) throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(xml)));
+
+        Element element = document.getDocumentElement();
+        return fromDOM(element);
+    }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfoCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfoCollection.java
@@ -17,7 +17,22 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.key;
 
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.Collection;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -53,4 +68,86 @@ public class KeyRequestInfoCollection extends DataCollection<KeyRequestInfo> imp
         return null;
     }
 
+    public Element toDOM(Document document) {
+
+        Element infosElement = document.createElement("KeyRequestInfoCollection");
+        document.appendChild(infosElement);
+
+        Element totalElement = document.createElement("total");
+        totalElement.appendChild(document.createTextNode(Integer.toString(total)));
+        infosElement.appendChild(totalElement);
+
+        for (KeyRequestInfo keyRequestInfo : getEntries()) {
+            Element infoElement = keyRequestInfo.toDOM(document);
+            infosElement.appendChild(infoElement);
+        }
+
+        for (Link link : getLinks()) {
+            Element infoElement = link.toDOM(document);
+            infosElement.appendChild(infoElement);
+        }
+
+        return infosElement;
+    }
+
+    public String toXML() throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.newDocument();
+
+        Element element = toDOM(document);
+        document.appendChild(element);
+
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+
+        DOMSource domSource = new DOMSource(document);
+        StringWriter sw = new StringWriter();
+        StreamResult streamResult = new StreamResult(sw);
+        transformer.transform(domSource, streamResult);
+
+        return sw.toString();
+    }
+
+    public static KeyRequestInfoCollection fromDOM(Element infosElement) {
+
+        KeyRequestInfoCollection infos = new KeyRequestInfoCollection();
+
+        NodeList totalList = infosElement.getElementsByTagName("total");
+        if (totalList.getLength() > 0) {
+            String value = totalList.item(0).getTextContent();
+            infos.setTotal(Integer.parseInt(value));
+        }
+
+        NodeList infoList = infosElement.getElementsByTagName("KeyRequestInfo");
+        int infoCount = infoList.getLength();
+        for (int i=0; i<infoCount; i++) {
+           Element infoElement = (Element) infoList.item(i);
+           KeyRequestInfo info = KeyRequestInfo.fromDOM(infoElement);
+           infos.addEntry(info);
+        }
+
+        NodeList linkList = infosElement.getElementsByTagName("Link");
+        int linkCount = linkList.getLength();
+        for (int i=0; i<linkCount; i++) {
+           Element linkElement = (Element) linkList.item(i);
+           Link link = Link.fromDOM(linkElement);
+           infos.addLink(link);
+        }
+
+        return infos;
+    }
+
+    public static KeyRequestInfoCollection fromXML(String xml) throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(xml)));
+
+        Element element = document.getDocumentElement();
+        return fromDOM(element);
+    }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/request/CMSRequestInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/request/CMSRequestInfo.java
@@ -20,11 +20,6 @@ package com.netscape.certsrv.request;
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -43,23 +38,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.util.JSONSerializer;
 
-@XmlRootElement(name="CMSRequestInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class CMSRequestInfo implements JSONSerializer {
 
-    @XmlElement
     protected String requestType;
-
-    @XmlElement
-    @XmlJavaTypeAdapter(RequestStatusAdapter.class)
     protected RequestStatus requestStatus;
-
-    @XmlElement
     protected String requestURL;
-
-    @XmlElement
     protected String realm;
 
     /**

--- a/base/common/src/main/java/com/netscape/certsrv/request/RequestStatus.java
+++ b/base/common/src/main/java/com/netscape/certsrv/request/RequestStatus.java
@@ -24,6 +24,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * The RequestStatus class represents the current state of a request
@@ -41,6 +43,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
  *
  * @version $Revision$ $Date$
  */
+@JsonSerialize(using=RequestStatusSerializer.class)
+@JsonDeserialize(using=RequestStatusDeserializer.class)
 public final class RequestStatus implements Serializable {
 
     private static final long serialVersionUID = -8176052970922133411L;

--- a/base/common/src/main/java/com/netscape/certsrv/request/RequestStatusDeserializer.java
+++ b/base/common/src/main/java/com/netscape/certsrv/request/RequestStatusDeserializer.java
@@ -1,0 +1,30 @@
+package com.netscape.certsrv.request;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+public class RequestStatusDeserializer extends StdDeserializer<RequestStatus> {
+
+    public RequestStatusDeserializer() {
+        this(null);
+    }
+
+    public RequestStatusDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public RequestStatus deserialize(
+            JsonParser parser,
+            DeserializationContext context
+            ) throws IOException, JsonProcessingException {
+
+        JsonNode node = parser.getCodec().readTree(parser);
+        return RequestStatus.valueOf(node.asText());
+    }
+}

--- a/base/common/src/main/java/com/netscape/certsrv/request/RequestStatusSerializer.java
+++ b/base/common/src/main/java/com/netscape/certsrv/request/RequestStatusSerializer.java
@@ -1,0 +1,29 @@
+package com.netscape.certsrv.request;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class RequestStatusSerializer extends StdSerializer<RequestStatus> {
+
+    public RequestStatusSerializer() {
+        this(null);
+    }
+
+    public RequestStatusSerializer(Class<RequestStatus> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(
+            RequestStatus requestStatus,
+            JsonGenerator generator,
+            SerializerProvider provider
+            ) throws IOException, JsonProcessingException {
+
+        generator.writeString(requestStatus.toString());
+    }
+}


### PR DESCRIPTION
JAXB has been replaced with DOM in the following classes:
* `CMSRequestInfo`
* `CertRequestInfo`
* `CertRequestInfos`
* `KeyRequestInfo`
* `KeyRequestInfoCollection`

A JSON serializer/deserializer has been added for `RequestStatus`.
