### PR TITLE
Drop JAXB annotations from CertEnrollmentRequest

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertRequestService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertRequestService.java
@@ -114,9 +114,11 @@ public class CertRequestService extends PKIService implements CertRequestResourc
     }
 
     @Override
-    public Response enrollCert(CertEnrollmentRequest data, String aidString, String adnString) {
+    public Response enrollCert(String enrollmentRequest, String aidString, String adnString) {
 
         logger.info("CertRequestService: Receiving certificate request");
+
+        CertEnrollmentRequest data = unmarshall(enrollmentRequest, CertEnrollmentRequest.class);
 
         if (data == null) {
             String message = "Unable to create enrollment request: Missing input data";

--- a/base/common/src/main/java/com/netscape/certsrv/ca/CACertClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/ca/CACertClient.java
@@ -119,7 +119,8 @@ public class CACertClient extends Client {
             } catch (IOException e) {
             }
         }
-        Response response = certRequestClient.enrollCert(data, aidString, adnString);
+        String enrollmentRequest = (String) client.marshall(data);
+        Response response = certRequestClient.enrollCert(enrollmentRequest, aidString, adnString);
         return client.getEntity(response, CertRequestInfos.class);
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertEnrollmentRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertEnrollmentRequest.java
@@ -28,11 +28,6 @@ import java.util.Collection;
 import java.util.HashMap;
 
 import javax.ws.rs.core.MultivaluedMap;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -49,9 +44,9 @@ import org.xml.sax.InputSource;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.base.ResourceMessage;
 import com.netscape.certsrv.dbs.certdb.CertId;
-import com.netscape.certsrv.dbs.certdb.CertIdAdapter;
 import com.netscape.certsrv.profile.ProfileAttribute;
 import com.netscape.certsrv.profile.ProfileInput;
 import com.netscape.certsrv.profile.ProfileOutput;
@@ -62,8 +57,6 @@ import com.netscape.certsrv.property.Descriptor;
  *
  */
 
-@XmlRootElement(name = "CertEnrollmentRequest")
-@XmlAccessorType(XmlAccessType.FIELD)
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class CertEnrollmentRequest extends ResourceMessage {
@@ -73,33 +66,31 @@ public class CertEnrollmentRequest extends ResourceMessage {
     private static final String SERIAL_NUM = "serial_num";
     private static final String SERVERSIDE_KEYGEN_P12_PASSWD = "serverSideKeygenP12Passwd";
 
-    @XmlElement(name="ProfileID")
+    @JsonProperty("ProfileID")
     protected String profileId;
 
-    @XmlElement(name="ServerSideKeygenP12Passwd")
+    @JsonProperty("ServerSideKeygenP12Passwd")
     protected String serverSideKeygenP12Passwd;
 
-    @XmlElement(name="Renewal")
+    @JsonProperty("Renewal")
     protected boolean renewal;
 
-    @XmlElement(name="SerialNumber")
-    @XmlJavaTypeAdapter(CertIdAdapter.class)
+    @JsonProperty("SerialNumber")
     protected CertId serialNum;   // used for one type of renewal
 
-    @XmlElement(name="RemoteHost")
+    @JsonProperty("RemoteHost")
     protected String remoteHost;
 
-    @XmlElement(name="RemoteAddress")
+    @JsonProperty("RemoteAddress")
     protected String remoteAddr;
 
-    @XmlElement(name = "Input")
+    @JsonProperty("Input")
     protected Collection<ProfileInput> inputs = new ArrayList<>();
 
-    @XmlElement(name = "Output")
+    @JsonProperty("Output")
     protected Collection<ProfileOutput> outputs = new ArrayList<>();
 
     public CertEnrollmentRequest() {
-        // required for jaxb
     }
 
     public CertEnrollmentRequest(MultivaluedMap<String, String> form) {

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestResource.java
@@ -34,7 +34,7 @@ public interface CertRequestResource {
     @POST
     @Path("certrequests")
     public Response enrollCert(
-        CertEnrollmentRequest data,
+        String enrollmentRequest,
         @QueryParam("issuer-id") String caIDString,
         @QueryParam("issuer-dn") String caDNString);
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertReviewResponse.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertReviewResponse.java
@@ -40,6 +40,7 @@ import org.xml.sax.InputSource;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.profile.PolicyDefault;
 import com.netscape.certsrv.profile.ProfileAttribute;
 import com.netscape.certsrv.profile.ProfilePolicy;
@@ -50,21 +51,52 @@ import com.netscape.certsrv.request.RequestId;
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class CertReviewResponse extends CertEnrollmentRequest {
 
+    @JsonProperty("ProfilePolicySet")
     protected List<ProfilePolicySet> policySets = new ArrayList<>();
+
+    @JsonProperty
     protected String nonce;
+
+    @JsonProperty
     protected RequestId requestId;
+
+    @JsonProperty
     protected String requestType;
+
+    @JsonProperty
     protected String requestStatus;
+
+    @JsonProperty
     protected String requestOwner;
+
+    @JsonProperty
     protected String requestCreationTime;
+
+    @JsonProperty
     protected String requestModificationTime;
+
+    @JsonProperty
     protected String requestNotes;
+
+    @JsonProperty
     protected String profileApprovedBy;
+
+    @JsonProperty
     protected String profileSetId;
+
+    @JsonProperty
     protected String profileIsVisible;
+
+    @JsonProperty
     protected String profileName;
+
+    @JsonProperty
     protected String profileDescription;
+
+    @JsonProperty
     protected String profileRemoteHost;
+
+    @JsonProperty
     protected String profileRemoteAddr;
 
     public String getNonce() {

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileAttribute.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileAttribute.java
@@ -42,6 +42,7 @@ import org.xml.sax.InputSource;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.property.Descriptor;
 import com.netscape.certsrv.util.JSONSerializer;
 
@@ -70,6 +71,7 @@ public class ProfileAttribute implements JSONSerializer {
         this.descriptor = descriptor;
     }
 
+    @JsonProperty
     public String getName() {
         return name;
     }
@@ -78,6 +80,7 @@ public class ProfileAttribute implements JSONSerializer {
         this.name = name;
     }
 
+    @JsonProperty("Value")
     public String getValue() {
         return value;
     }
@@ -86,6 +89,7 @@ public class ProfileAttribute implements JSONSerializer {
         this.value = value;
     }
 
+    @JsonProperty("Descriptor")
     public Descriptor getDescriptor() {
         return descriptor;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileDataInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileDataInfos.java
@@ -17,7 +17,21 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.profile;
 
-import java.util.Collection;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -29,26 +43,85 @@ import com.netscape.certsrv.base.Link;
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class ProfileDataInfos extends DataCollection<ProfileDataInfo> {
 
-    @Override
-    public Collection<ProfileDataInfo> getEntries() {
-        return super.getEntries();
+    public Element toDOM(Document document) {
+
+        Element element = document.createElement("ProfileDataInfos");
+
+        Element totalElement = document.createElement("total");
+        totalElement.appendChild(document.createTextNode(Integer.toString(total)));
+        element.appendChild(totalElement);
+
+        for (ProfileDataInfo profileDataInfo : getEntries()) {
+            Element infoElement = profileDataInfo.toDOM(document);
+            element.appendChild(infoElement);
+        }
+
+        for (Link link : getLinks()) {
+            Element linkElement = link.toDOM(document);
+            element.appendChild(linkElement);
+        }
+
+        return element;
     }
 
-    public String getNext() {
-        for (Link link : getLinks()) {
-            if ("next".equals(link. getRelationship())) {
-                return link.getHref().toString();
-            }
-        }
-        return null;
+    public String toXML() throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.newDocument();
+
+        Element element = toDOM(document);
+        document.appendChild(element);
+
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+
+        DOMSource domSource = new DOMSource(document);
+        StringWriter sw = new StringWriter();
+        StreamResult streamResult = new StreamResult(sw);
+        transformer.transform(domSource, streamResult);
+
+        return sw.toString();
     }
 
-    public String getPrevious() {
-        for (Link link : getLinks()) {
-            if ("previous".equals(link.getRelationship())) {
-                return link.getHref().toString();
-            }
+    public static ProfileDataInfos fromDOM(Element infosElement) {
+
+        ProfileDataInfos infos = new ProfileDataInfos();
+
+        NodeList totalList = infosElement.getElementsByTagName("total");
+        if (totalList.getLength() > 0) {
+            String value = totalList.item(0).getTextContent();
+            infos.setTotal(Integer.parseInt(value));
         }
-        return null;
+
+        NodeList infoList = infosElement.getElementsByTagName("ProfileDataInfo");
+        int infoCount = infoList.getLength();
+        for (int i=0; i<infoCount; i++) {
+           Element infoElement = (Element) infoList.item(i);
+           ProfileDataInfo info = ProfileDataInfo.fromDOM(infoElement);
+           infos.addEntry(info);
+        }
+
+        NodeList linkList = infosElement.getElementsByTagName("Link");
+        int linkCount = linkList.getLength();
+        for (int i=0; i<linkCount; i++) {
+           Element linkElement = (Element) linkList.item(i);
+           Link link = Link.fromDOM(linkElement);
+           infos.addLink(link);
+        }
+
+        return infos;
+    }
+
+    public static ProfileDataInfos fromXML(String xml) throws Exception {
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(xml)));
+
+        Element element = document.getDocumentElement();
+        return fromDOM(element);
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileInput.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileInput.java
@@ -45,6 +45,7 @@ import org.xml.sax.InputSource;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.property.Descriptor;
 import com.netscape.certsrv.util.JSONSerializer;
 
@@ -82,14 +83,17 @@ public class ProfileInput implements JSONSerializer {
         this.classId = classId;
     }
 
+    @JsonProperty("ClassID")
     public String getClassId() {
         return classId;
     }
 
+    @JsonProperty("Name")
     public String getName() {
         return name;
     }
 
+    @JsonProperty("Text")
     public String getText() {
         return text;
     }
@@ -98,6 +102,7 @@ public class ProfileInput implements JSONSerializer {
         this.classId = classId;
     }
 
+    @JsonProperty("id")
     public String getId() {
         return id;
     }
@@ -114,6 +119,7 @@ public class ProfileInput implements JSONSerializer {
         this.text = text;
     }
 
+    @JsonProperty("Attribute")
     public Collection<ProfileAttribute> getAttributes() {
         return attrs;
     }
@@ -142,6 +148,7 @@ public class ProfileInput implements JSONSerializer {
         attrs.clear();
     }
 
+    @JsonProperty("ConfigAttribute")
     public List<ProfileAttribute> getConfigAttrs() {
         return configAttrs;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileOutput.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileOutput.java
@@ -43,6 +43,7 @@ import org.xml.sax.InputSource;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.util.JSONSerializer;
 
 @XmlRootElement
@@ -60,6 +61,7 @@ public class ProfileOutput implements JSONSerializer {
     @XmlElement
     private String text;
 
+    @JsonProperty
     public String getId() {
         return id;
     }
@@ -85,6 +87,7 @@ public class ProfileOutput implements JSONSerializer {
         this.classId = classId;
     }
 
+    @JsonProperty
     public String getClassId() {
         return classId;
     }
@@ -93,6 +96,7 @@ public class ProfileOutput implements JSONSerializer {
         this.classId = classId;
     }
 
+    @JsonProperty("attributes")
     public List<ProfileAttribute> getAttrs() {
         return attrs;
     }
@@ -101,6 +105,7 @@ public class ProfileOutput implements JSONSerializer {
         this.attrs = attrs;
     }
 
+    @JsonProperty
     public String getName() {
         return name;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/property/Descriptor.java
+++ b/base/common/src/main/java/com/netscape/certsrv/property/Descriptor.java
@@ -19,9 +19,11 @@ package com.netscape.certsrv.property;
 
 import java.util.Locale;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.util.JSONSerializer;
 
 
@@ -35,12 +37,16 @@ import com.netscape.certsrv.util.JSONSerializer;
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class Descriptor implements IDescriptor, JSONSerializer {
 
+    @JsonProperty("Syntax")
     public String mSyntax = null;
 
+    @JsonProperty("Constraint")
     public String mConstraint = null;
 
+    @JsonProperty("Description")
     public String mDescription = null;
 
+    @JsonProperty("DefaultValue")
     public String mDef = null;
 
     public Descriptor() {
@@ -68,6 +74,7 @@ public class Descriptor implements IDescriptor, JSONSerializer {
      * @return syntax
      */
     @Override
+    @JsonIgnore
     public String getSyntax() {
         return mSyntax;
     }
@@ -78,6 +85,7 @@ public class Descriptor implements IDescriptor, JSONSerializer {
      * @return default value
      */
     @Override
+    @JsonIgnore
     public String getDefaultValue() {
         return mDef;
     }
@@ -95,6 +103,7 @@ public class Descriptor implements IDescriptor, JSONSerializer {
      * @return constraint
      */
     @Override
+    @JsonIgnore
     public String getConstraint() {
         return mConstraint;
     }
@@ -106,6 +115,7 @@ public class Descriptor implements IDescriptor, JSONSerializer {
      * @return description
      */
     @Override
+    @JsonIgnore
     public String getDescription(Locale locale) {
         return mDescription;
     }


### PR DESCRIPTION
Some JSON and XML mappings have been fixed to match PKI 10.11.

The `ResourceMessage` class has been modified to provide a JSON serializer/deserializer for the `attributes` to match the original JAXB mapping.

The `CACertClient.enrollRequest()` has been modified to marshall the `CertEnrollmentRequest` into a `String`. The `CertRequestService.enrollCert()` has been modified to unmarshall the `String` back into `CertEnrollmentRequest`.
