### PR TITLE
Encode cert request as bytes before writing to file

### DIFF
--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -491,7 +491,7 @@ class CACertRequestShowCLI(pki.cli.CLI):
 
         if output_file:
             with io.open(output_file, 'wb') as f:
-                f.write(request['request'])
+                f.write(request['request'].encode())
 
         else:
             CACertRequestCLI.print_request(request, details=True)


### PR DESCRIPTION
From bug:
```
[root@pki1 ~]# pki-server ca-cert-request-show 1 -i pki-tomcat --output-file /tmp/test.req --debug
INFO: Loading instance: pki-tomcat
INFO: Loading global Tomcat config: /etc/tomcat/tomcat.conf
INFO: Loading PKI Tomcat config: /usr/share/pki/etc/tomcat.conf
INFO: Loading instance Tomcat config: /etc/pki/pki-tomcat/tomcat.conf
INFO: Loading password config: /etc/pki/pki-tomcat/password.conf
INFO: Loading instance registry: /etc/sysconfig/pki/tomcat/pki-tomcat/pki-tomcat
INFO: Loading subsystem: ca
INFO: Loading subsystem config: /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
INFO: Loading subsystem: kra
INFO: Loading subsystem config: /var/lib/pki/pki-tomcat/kra/conf/CS.cfg
ERROR: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/pki/server/pkiserver.py", line 40, in <module>
    cli.execute(sys.argv)
  File "/usr/lib/python3.6/site-packages/pki/server/cli/__init__.py", line 143, in execute
    super(PKIServerCLI, self).execute(args)
  File "/usr/lib/python3.6/site-packages/pki/cli/__init__.py", line 197, in execute
    module.execute(module_args)
  File "/usr/lib/python3.6/site-packages/pki/cli/__init__.py", line 197, in execute
    module.execute(module_args)
  File "/usr/lib/python3.6/site-packages/pki/cli/__init__.py", line 197, in execute
    module.execute(module_args)
  [Previous line repeated 1 more time]
  File "/usr/lib/python3.6/site-packages/pki/server/cli/ca.py", line 350, in execute
    f.write(request['request'])
TypeError: a bytes-like object is required, not 'str'
```

After the fix, build and install:
```
cdorney@fedora ~/src/upstream/cdorney/pki (bz_ca_cert_request_show_type_error)$ sudo pki-server ca-cert-request-show 1 -i pki-tomcat --output-file /tmp/test.req --debug
[sudo] password for cdorney: 
INFO: Loading instance type: pki-tomcatd
INFO: Loading instance: pki-tomcat
INFO: Loading global Tomcat config: /etc/tomcat/tomcat.conf
INFO: Loading PKI Tomcat config: /usr/share/pki/etc/tomcat.conf
INFO: Loading instance Tomcat config: /etc/pki/pki-tomcat/tomcat.conf
INFO: Loading password config: /etc/pki/pki-tomcat/password.conf
INFO: Loading subsystem config: /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
INFO: Loading subsystem registry: /var/lib/pki/pki-tomcat/ca/conf/registry.cfg
INFO: Loading instance registry: /etc/sysconfig/pki/tomcat/pki-tomcat/pki-tomcat
DEBUG: - user: pkiuser
DEBUG: - group: pkiuser
cdorney@fedora ~/src/upstream/cdorney/pki (bz_ca_cert_request_show_type_error)$ cat /tmp/test.req
-----BEGIN CERTIFICATE REQUEST-----
*snip*
-----END CERTIFICATE REQUEST-----
```