### PR TITLE
Bug1694417-TLS Session audit events establish/terminate when CS actin…

### DIFF
--- a/base/server/src/main/java/com/netscape/cmscore/ldapconn/LdapBoundConnFactory.java
+++ b/base/server/src/main/java/com/netscape/cmscore/ldapconn/LdapBoundConnFactory.java
@@ -355,13 +355,18 @@ public class LdapBoundConnFactory implements ILdapConnFactory {
      * makes the minumum number of connections
      */
     private void makeMinimum() throws ELdapException {
-        if (mMasterConn == null || mMasterConn.isConnected() == false)
+        String method = "LdapBoundConnFactory.makeMinimum: ";
+        if (mMasterConn == null || mMasterConn.isConnected() == false) {
+            logger.debug(method + "master conn not available; returning");
             return;
+        }
         int increment;
+        logger.debug(method + "begins: total connections: " + mTotal);
+        logger.debug(method + "begins: available connections: " + mNumConns);
 
         if (mNumConns < mMinConns && mTotal <= mMaxConns) {
             increment = Math.min(mMinConns - mNumConns, mMaxConns - mTotal);
-            logger.debug("LdapBoundConnFactory: increasing minimum connections by " + increment);
+            logger.debug(method + "increasing minimum connections by " + increment);
 
             for (int i = increment - 1; i >= 0; i--) {
 
@@ -376,8 +381,8 @@ public class LdapBoundConnFactory implements ILdapConnFactory {
             mTotal += increment;
             mNumConns += increment;
 
-            logger.debug("LdapBoundConnFactory: total connections: " + mTotal);
-            logger.debug("LdapBoundConnFactory: number of connections: " + mNumConns);
+            logger.debug(method + "ends: total connections: " + mTotal);
+            logger.debug(method + "ends: number of connections: " + mNumConns);
         }
     }
 

--- a/base/server/src/main/java/org/dogtagpki/server/PKIClientSocketListener.java
+++ b/base/server/src/main/java/org/dogtagpki/server/PKIClientSocketListener.java
@@ -69,17 +69,10 @@ public class PKIClientSocketListener implements SSLSocketListener {
             Principal subjectDN = peerCertificate == null ? null : peerCertificate.getSubjectDN();
             String subjectID = subjectDN == null ? "" : subjectDN.toString();
 */
-String subjectID = "SYSTEM";
+            String subjectID = "SYSTEM";
 
             int description = event.getDescription();
-            String reason = SSLAlertDescription.valueOf(description).toString();
-
-            logger.debug("SSL alert received:");
-            logger.debug("- reason: " + reason);
-            logger.debug("- client: " + clientIP);
-            logger.debug("- server: " + serverIP);
-            logger.debug("- subject: " + subjectID);
-
+            String reason = "clientAlertReceived: " + SSLAlertDescription.valueOf(description).toString();
 
             signedAuditLogger.log(ClientAccessSessionTerminatedEvent.createEvent(
                     clientIP,
@@ -88,11 +81,17 @@ String subjectID = "SYSTEM";
                     subjectID,
                     reason));
 
-            logger.debug(method + "CS_CLIENT_ACCESS_SESSION_TERMINATED");
-            logger.debug(method + "clientIP=" + clientIP + " serverIP=" + serverIP + " serverPort=" + serverPort + " reason=" + reason);
+            //logger.debug(method + "CS_CLIENT_ACCESS_SESSION_TERMINATED");
+
+            logger.debug("PKIClientSocketListener: SSL alert received:");
+            logger.debug("- reason: " + reason);
+            logger.debug("- client: " + clientIP);
+            logger.debug("- server: " + serverIP);
+            logger.debug("- server port: " + serverPort);
+            logger.debug("- subject: " + subjectID);
 
         } catch (Exception e) {
-            logger.warn(e.getMessage(), e);
+            logger.warn("PKIClientSocketListener: " + e.getMessage(), e);
         }
     }
 
@@ -105,7 +104,7 @@ String subjectID = "SYSTEM";
 
             int description = event.getDescription();
             logger.debug(method + "got description:"+ description);
-            String reason = SSLAlertDescription.valueOf(description).toString();
+            String reason = "clientAlertSent: " + SSLAlertDescription.valueOf(description).toString();
             logger.debug(method + "got reason:"+ reason);
 
             SignedAuditEvent auditEvent;
@@ -130,9 +129,6 @@ String subjectID = "SYSTEM";
                         subjectID,
                         reason);
 
-                logger.debug(method + "CS_CLIENT_ACCESS_SESSION_TERMINATED");
-                logger.debug(method + "clientIP=" + clientIP + " serverIP=" + serverIP+ " serverPort=" + serverPort + " reason=" + reason);
-
             } else {
 
                 // get socket info from the socket itself
@@ -149,7 +145,7 @@ String subjectID = "SYSTEM";
                 Principal subjectDN = peerCertificate == null ? null : peerCertificate.getSubjectDN();
                 subjectID = subjectDN == null ? "" : subjectDN.toString();
 */
-subjectID = "SYSTEM";
+                subjectID = "SYSTEM";
 
                 auditEvent = ClientAccessSessionEstablishEvent.createFailureEvent(
                         clientIP,
@@ -160,19 +156,17 @@ subjectID = "SYSTEM";
 
             }
 
-            logger.debug("SSL alert sent:");
+            signedAuditLogger.log(auditEvent);
+
+            logger.debug("PKIClientSocketListener: SSL alert sent:");
             logger.debug("- reason: " + reason);
             logger.debug("- client: " + clientIP);
             logger.debug("- server: " + serverIP);
             logger.debug("- subject: " + subjectID);
-
-            signedAuditLogger.log(auditEvent);
-
-            logger.debug(method + "CS_CLIENT_ACCESS_SESSION_ESTABLISH_FAILURE");
-            logger.debug(method + "clientIP=" + clientIP + " serverIP=" + serverIP + " serverPort=" + serverPort + " reason=" + reason);
+            logger.debug("- server port: " + serverPort);
 
         } catch (Exception e) {
-            logger.warn(e.getMessage(), e);
+            logger.warn("PKIClientSocketListener: " + e.getMessage(), e);
         }
     }
 
@@ -195,11 +189,12 @@ subjectID = "SYSTEM";
             Principal subjectDN = peerCertificate == null ? null : peerCertificate.getSubjectDN();
             String subjectID = subjectDN == null ? "" : subjectDN.toString();
 */
-String subjectID = "SYSTEM";
+            String subjectID = "SYSTEM";
 
-            logger.debug("Handshake completed:");
+            logger.debug("PKIClientSocketListener: Handshake completed:");
             logger.debug("- client: " + clientIP);
             logger.debug("- server: " + serverIP);
+            logger.debug("- server port: " + serverPort);
             logger.debug("- subject: " + subjectID);
 
             // store socket info in socketInfos map
@@ -216,11 +211,8 @@ String subjectID = "SYSTEM";
                     serverPort,
                     subjectID));
 
-            logger.debug(method + "CS_CLIENT_ACCESS_SESSION_ESTABLISH_SUCCESS");
-            logger.debug(method + "clientIP=" + clientIP + " serverIP=" + serverIP + " serverPort=" + serverPort);
-
         } catch (Exception e) {
-            logger.warn(e.getMessage(), e);
+            logger.warn("PKIClientSocketListener: " + e.getMessage(), e);
         }
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/PKIServerSocketListener.java
+++ b/base/server/src/main/java/org/dogtagpki/server/PKIServerSocketListener.java
@@ -68,9 +68,9 @@ public class PKIServerSocketListener implements SSLSocketListener {
             String subjectID = subjectDN == null ? "" : subjectDN.toString();
 
             int description = event.getDescription();
-            String reason = SSLAlertDescription.valueOf(description).toString();
+            String reason = "serverAlertReceived: " + SSLAlertDescription.valueOf(description).toString();
 
-            logger.debug("SSL alert received:");
+            logger.debug("PKIServerSocketListener: SSL alert received:");
             logger.debug("- reason: " + reason);
             logger.debug("- client: " + clientIP);
             logger.debug("- server: " + serverIP);
@@ -83,7 +83,7 @@ public class PKIServerSocketListener implements SSLSocketListener {
                     reason));
 
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            logger.error("PKIServerSocketListener: " + e.getMessage(), e);
         }
     }
 
@@ -93,7 +93,7 @@ public class PKIServerSocketListener implements SSLSocketListener {
             SSLSocket socket = event.getSocket();
 
             int description = event.getDescription();
-            String reason = SSLAlertDescription.valueOf(description).toString();
+            String reason = "serverAlertSent: " + SSLAlertDescription.valueOf(description).toString();
 
             SignedAuditEvent auditEvent;
             String clientIP;
@@ -134,7 +134,7 @@ public class PKIServerSocketListener implements SSLSocketListener {
                         reason);
             }
 
-            logger.debug("SSL alert sent:");
+            logger.debug("PKIServerSocketListener: SSL alert sent:");
             logger.debug("- reason: " + reason);
             logger.debug("- client: " + clientIP);
             logger.debug("- server: " + serverIP);
@@ -143,7 +143,7 @@ public class PKIServerSocketListener implements SSLSocketListener {
             signedAuditLogger.log(auditEvent);
 
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            logger.error("PKIServerSocketListener: " + e.getMessage(), e);
         }
     }
 
@@ -162,7 +162,7 @@ public class PKIServerSocketListener implements SSLSocketListener {
             Principal subjectDN = peerCertificate == null ? null : peerCertificate.getSubjectDN();
             String subjectID = subjectDN == null ? "" : subjectDN.toString();
 
-            logger.debug("Handshake completed:");
+            logger.debug("PKIServerSocketListener: Handshake completed:");
             logger.debug("- client: " + clientIP);
             logger.debug("- server: " + serverIP);
             logger.debug("- subject: " + subjectID);
@@ -180,7 +180,7 @@ public class PKIServerSocketListener implements SSLSocketListener {
                     subjectID));
 
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            logger.error("PKIServerSocketListener: " + e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
…g as a client

The description of this bug could be a litte off so I'll try to explain
when CLIENT_ACCESS_SESSION_ESTABLISH and CLIENT_ACCESS_SESSION_ERMINATED
are supposed to happen first before explaining the patch.

CLIENT_ACCESS_SESSION_ESTABLISH is supposed to happen when a CS instance
tries to connect to its TLS server (for a CA, that'd be a DS server or
KRA).  And CLIENT_ACCESS_SESSION_ERMINATED is supposed to happen when
a connection closes, be it initiated by the CS instance itself, or the
TLS server.

In the case when the TLS server is the DS server, CS actually tries to
create a minimum # of connections at system startup for every "module"
of CS.  This minimum number is specified in the CS.cfg parameter
internaldb.minConns, which is defaulted to 3. It is because of this
mechanism, you will not see these establish/terminated events triggered
per action.
The "modules" I spoke of can be found by search for the following string
in the debug log (if debug.level=0) :
  "Creating LdapBoundConnFactor"
e.g.
  "Creating LdapBoundConnFactor(DBSubsystem)"

In my observation, DS seems to send a CLOSE_NOTIFY alert to CS after one
hour of inactivity.  In other words, you'd see 3 "sets" of the
TERMINATED after one hour of inactivity (see example later on what my patch
does). I also notice how CS is reacting to such "receiveAlert" with a
"sendAlert", so we essentially see two terminated events when DS times
out on CS.  Another thing I observe is that after a connection is
"terminated", further actions don't trigger any more "establish" events.
I think the connections just go back to the connection pool to be reused
at "terminate".

KRA is different from DS. For every key archival action, CA->KRA
connection is established and then terminated when done.  It is
therefore easier to see these audit events more clearly.

Now about the this patch.  I actually am not sure if there's anything
not working as expected as far as the two audit events go.
However, I find the events to be not as descriptive as it's hard to tell
when an CLIENT_ACCESS_SESSION_ERMINATED alert was triggered by the
server(DS or KRA) or by the client (CS). For this reason, I prepend
"alertSent:" or "alertReceived:" before the CLOSE_NOTIFY in the audit
Info.

Here are a couple examples:
CA->KRA when crmf is submitted for key archival
0.ConnectAsync - [25/Aug/2021:19:31:05 EDT] [14] [6] [AuditEvent=CLIENT_ACCESS_SESSION_ESTABLISH][ClientHost=a.b.c.d][ServerHost=a.b.c.d][ServerPort=8443][SubjectID=SYSTEM][Outcome=Success] access session establish successfully when Certificate System acts as client
0.https-jsse-nio-8443-exec-17 - [25/Aug/2021:19:31:06 EDT] [14] [6] [AuditEvent=CLIENT_ACCESS_SESSION_TERMINATED][ClientHost=a.b.c.d][ServerHost=a.b.c.d][ServerPort=8443][SubjectID=SYSTEM][Outcome=Success][Info=clientAlertSent:CLOSE_NOTIFY] access session terminated when Certificate System acts as client

CA->DS
At system (CS) startup:
0.main - [25/Aug/2021:12:49:17 EDT] [14] [6] [AuditEvent=CLIENT_ACCESS_SESSION_ESTABLISH][ClientHost=a.b.c.d][ServerHost=a.b.c.d][ServerPort=636][SubjectID=SYSTEM][Outcome=Success] access session establish successfully when Certificate System acts as client
...
Do something such as
  pki -d . -c pAssword.123 -P https -p 8443 -n "PKI Administrator for example.com" ca-user-find
Notice how neither of the establish/terminated events get triggered.
...

After one hour (imposed by DS by default):
0.LDAPConnThread-9 ldaps://pki1.example.com:636 - [25/Aug/2021:13:49:17 EDT] [14] [6] [AuditEvent=CLIENT_ACCESS_SESSION_TERMINATED][ClientHost=a.b.c.d][ServerHost=a.b.c.d][ServerPort=636][SubjectID=SYSTEM][Outcome=Success][Info=clientAlertSent:CLOSE_NOTIFY] access session terminated when Certificate System acts as client

I also adjusted some of the debug messages to make them easier to debug.

addresses https://bugzilla.redhat.com/show_bug.cgi?id=1694417