### PR TITLE
Return an ACME badSignatureAlgorithm response instead of JWS exception

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -675,7 +675,16 @@ public class ACMEEngine implements ServletContextListener {
             publicKey = keyFactory.generatePublic(keySpec);
 
         } else {
-            throw new Exception("Unsupported JWS algorithm: " + alg);
+            ResponseBuilder builder = Response.status(Response.Status.BAD_REQUEST);
+            builder.type("application/problem+json");
+
+            ACMEError error = new ACMEError();
+            error.setType("urn:ietf:params:acme:error:badSignatureAlgorithm");
+            error.setDetail("Signature of type " + alg + " not supported\n" +
+                    "Try again with RS256.");
+            builder.entity(error);
+
+            throw new WebApplicationException(builder.build());
         }
 
         validateJWS(jws, signer, publicKey);


### PR DESCRIPTION
Issue https://github.com/dogtagpki/pki/issues/3729

This allows rfc8555 compatible ACME clients to correctly fall back to RS256 when enrolling.

Tested successfully using win-acme against pki-acme 10.10.6 on Fedora 34.