### PR TITLE
Bug1999146-TPS-install-Python-error-text

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1372,7 +1372,7 @@ class PKIDeployer:
             subprocess.run(
                 cmd,
                 input=cert,
-                text=True,
+                universal_newlines=True,
                 check=True)
 
         finally:
@@ -1554,7 +1554,7 @@ class PKIDeployer:
         subprocess.run(
             cmd,
             input=json.dumps(shared_secret),
-            text=True,
+            universal_newlines=True,
             check=True)
 
     def setup_shared_secret(self, instance, subsystem):


### PR DESCRIPTION
This patch is an attempt to fix the TPS installation issue regarding:
   TypeError: __init__() got an unexpected keyword argument 'text'

My research shows that it's likely having to do with Python version
differences.  In Python 3.6.8, "text" is possibly not yet introduced
so I"m trying out "universal_newlines".

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1999146