### PR TITLE
Simplify getSW{1,2}() methods in APDUResponse

### DIFF
--- a/base/common/src/main/java/org/dogtagpki/tps/apdu/APDUResponse.java
+++ b/base/common/src/main/java/org/dogtagpki/tps/apdu/APDUResponse.java
@@ -43,29 +43,11 @@ public class APDUResponse extends APDU {
     }
 
     public byte getSW1() {
-        if (data == null) {
-            return 0x0;
-        } else {
-            if (data.size() < 2) {
-                return 0x0;
-            } else {
-                return data.at(data.size() - 2);
-            }
-        }
-
+        return data == null || data.size() < 2 ? 0x0 : data.at(data.size() - 2);
     }
 
     public byte getSW2() {
-        if (data == null) {
-            return 0x0;
-        } else {
-            if (data.size() < 2) {
-                return 0x0;
-            } else {
-                return data.at(data.size() - 1);
-            }
-        }
-
+        return data == null || data.size() < 2 ? 0x0 : data.at(data.size() - 1);
     }
 
     //Not every non 0x90 0x00 is considered fatal, return result


### PR DESCRIPTION
These complicated if-else blocks contain 3 return statements, two of
which are the same. It can be drastically simplified by using the
ternary operator and taking advantage of the short-circuit evaluation of
the || operator to reduce them to one-liners.