### PR TITLE
Fix Bug 2001576 - pki instance creation fails for IPA server in FIPS …

### DIFF
--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -98,6 +98,7 @@ class PKICLI(pki.cli.CLI):
 
         java_path = os.getenv('PKI_JAVA_PATH')
         java_home = os.getenv('JAVA_HOME')
+        java_fips_cmd = os.getenv('JAVA_FIPS_ENABLED')
         pki_lib = os.getenv('PKI_LIB')
         logging_config = os.getenv('PKI_LOGGING_CONFIG')
 
@@ -113,7 +114,15 @@ class PKICLI(pki.cli.CLI):
             cmd.extend(['/usr/bin/env', 'java'])
 
         cmd.extend([
-            '-cp', pki_lib + '/*',
+            '-cp', pki_lib + '/*'
+        ])
+
+        if java_fips_cmd is not None:
+            cmd.extend([
+                java_fips_cmd
+            ])
+
+        cmd.extend([
             '-Djava.util.logging.config.file=' + logging_config,
             'com.netscape.cmstools.cli.MainCLI'
         ])

--- a/base/common/share/etc/pki.conf
+++ b/base/common/share/etc/pki.conf
@@ -14,6 +14,16 @@ export JAVA_HOME
 PKI_JAVA_PATH=${PKI_JAVA_PATH}
 export PKI_JAVA_PATH
 
+# JVM options
+#
+# Command switch we want to tell java to observer fips mode
+# For the moment we want this to be false even if we really are
+# in fips mode, because we want the jss prover instead of the sun
+# fips provider to be selected.
+JAVA_FIPS_ENABLED="-Dcom.redhat.fips=false" # Disable FIPS mode
+
+export JAVA_FIPS_ENABLED
+
 # JNI jar file location
 JNI_JAR_DIR=/usr/lib/java
 export JNI_JAR_DIR


### PR DESCRIPTION
…mode (RHEL-8.5)

It looks like this is an issue in FIPS mode because when we restart the subsystem, there is a pki command
that runs before the server runs. In order for this command to succeed, we must alter the python script that
runs pki commands to add the following switch to turn off fips mode in java: "-Dcom.redhat.fips=false".

This allows the JSS proivder to be selected instead of a differnt one which doesn't work for us, when we are in
fips mode.