### PR TITLE
Bug1984431- pkispawn:SEC_ERROR_ADDING_CERT for KRA admin cert

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1622,7 +1622,7 @@ class NSSDatabase(object):
                 'pki',
                 '-d', self.directory,
                 'pkcs7-cert-export',
-                '--pkcs7-file', pkcs7_file,
+                '--pkcs7', pkcs7_file,
                 '--output-prefix', prefix,
                 '--output-suffix', suffix
             ]

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2598,6 +2598,7 @@ class ConfigClient:
 
     def process_admin_cert(self, admin_cert):
 
+        logger.info('process_admin_cert')
         admin_cert_file = self.mdict['pki_client_admin_cert']
         logger.info('Storing admin certificate into %s', admin_cert_file)
 
@@ -2620,7 +2621,8 @@ class ConfigClient:
         finally:
             client_nssdb.close()
 
-        logger.info('Exporting admin certificate into %s',
+    def process_admin_p12(self):
+        logger.info('process_admin_p12: Exporting admin certificate into %s',
                     self.mdict['pki_client_admin_cert_p12'])
 
         # create directory for p12 file if it does not exist


### PR DESCRIPTION
The issue reported in Bug1984431 was with pkispawn two-step installation
for KRA where if pki_import_admin_cert is specified in the pkispawn config
file, installation would fail with the following error:
  INFO: Importing admin certificate into /opt/topology-cc-KRA/kra/alias
  DEBUG: Command: certutil -A -d /opt/topology-cc-KRA/kra/alias -f /opt/topology-cc-KRA/kra/password.conf -n PKI KRA Administrator for Example.Org -a -i /opt/topology-cc-KRA/kra_admin.cert -t ,,
  certutil: could not add certificate to token or database: SEC_ERROR_ADDING_CERT: Error adding certificate to database.
  CalledProcessError: Command '['certutil', '-A', '-d', '/opt/topology-cc-KRA/kra/alias', '-f', '/opt/topology-cc-KRA/kra/password.conf', '-n', 'PKI KRA Administrator for Example.Org', '-a', '-i', '/opt/topology-cc-KRA/kra_admin.cert', '-t', ',,']' returned non-zero exit status 255.

My investigation reveals the following:
The code didn't put into account that the KRA admin cert was already being
manually issued (after pkispawn step 1) and imported into the kra admin nssdb.
It errornously generates a 2nd CSR and sent directly to the CA and received
a new cert.  It was at the time when it attempts to import the 2nd admin cert,
using the same nickname where certutil blows up and breaks the installation.

While it was observed that if it were the exact same cert, certutil would
function without issue, but this is a different cert.  Also, the format of
the 2nd csr is not CMC, which is the requirement that's breached.

This patch detects the "step 2" status of a non-CA and skips over the
re-generation of the 2nd csr for KRA admin.

My test of the patch is able to get past the reported SEC_ERROR_ADDING_CERT issue.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1984431