### PR TITLE
Fix Bug 2001169 - Audit event 'ACCESS_SESSION_ESTABLISH' is not gener…

### DIFF
--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
@@ -2388,6 +2388,7 @@ public class TPSProcessor {
             try {
                 tps.tdb.tdbAddTokenEntry(tokenRecord, TokenStatus.UNFORMATTED);
                 tps.tdb.tdbActivity(ActivityDatabase.OP_ADD, tokenRecord, session.getIpAddress(), logMsg, "success");
+                fillTokenRecordDefaultPolicy(tokenRecord);
                 logger.debug("TPSProcessor.format: token added");
             } catch (Exception e) {
                 logMsg = logMsg + ":" + e.toString();


### PR DESCRIPTION
…ating for PKI instances acting as Server [10.2.1] (#3745)

This fix allows us to actually see ssl connection events in the audit log from the pki /server perspective.
This fill will also require support bug fixes for both jss and tomcatjss.

Added fix for stray alerts showing up after a server is going down.

Sample audit log messages:

0.https-jsse-nio-18443-exec-6 - [29/Sep/2021:21:09:31 EDT] [14] [6] [AuditEvent=ACCESS_SESSION_ESTABLISH][ClientIP=--][ServerIP=--][SubjectID=CN=PKI Administrator,E=example@testdomain.com,OU=rhcs94-CA-cfu_rsa-nocp11,O=Example-rhcs94-CA_cfu-rsa][Outcome=Success] access session establish success
0.https-jsse-nio-18443-exec-16 - [29/Sep/2021:21:09:32 EDT] [14] [6] [AuditEvent=AUTHZ][SubjectID=$NonRoleUser$][Outcome=Success][aclResource=certServer.ee.profiles][Op=list] authorization success

0.https-jsse-nio-18443-exec-16 - [29/Sep/2021:21:11:34 EDT] [14] [6] [AuditEvent=ACCESS_SESSION_TERMINATED][ClientIP=--][ServerIP=--][SubjectID=CN=PKI Administrator,E=example@testdomain.com,OU=rhcs94-CA-cfu_rsa-nocp11,O=Example-rhcs94-CA_cfu-rsa][Outcome=Success][Info=serverAlertReceived: CLOSE_NOTIFY] access session terminated
0.https-jsse-nio-18443-exec-16 - [29/Sep/2021:21:11:34 EDT] [14] [6] [AuditEvent=ACCESS_SESSION_TERMINATED][ClientIP=--][ServerIP=--][SubjectID=CN=PKI Administrator,E=example@testdomain.com,OU=rhcs94-CA-cfu_rsa-nocp11,O=Example-rhcs94-CA_cfu-rsa][Outcome=Success][Info=serverAlertSent: CLOSE_NOTIFY] access session terminated