### PR TITLE
Update pkispawn and pkidestroy logging

### DIFF
--- a/base/server/python/pki/server/deployment/pkilogging.py
+++ b/base/server/python/pki/server/deployment/pkilogging.py
@@ -50,10 +50,17 @@ def log_format(given_dict):
 # PKI Deployment Logging Functions
 def enable_pki_logger(filename):
 
+    logger = logging.getLogger('pki')
+
     # Configure console handler
     console = logging.StreamHandler()
     console_format = logging.Formatter('%(levelname)s: %(message)s')
     console.setFormatter(console_format)
+
+    logger.addHandler(console)
+
+    if not filename:
+        return
 
     # Create an empty file with the proper permission
     pathlib.Path(filename).touch()
@@ -65,6 +72,4 @@ def enable_pki_logger(filename):
                                     '%Y-%m-%d %H:%M:%S')
     log_file.setFormatter(file_format)
 
-    logger = logging.getLogger('pki')
-    logger.addHandler(console)
     logger.addHandler(log_file)

--- a/base/server/python/pki/server/pkidestroy.py
+++ b/base/server/python/pki/server/pkidestroy.py
@@ -230,18 +230,9 @@ def main(argv):
         group=deployer.mdict['pki_group'])
 
     if args.log_file:
-        log_file = args.log_file
-    else:
-        log_dir = config.PKI_DEPLOYMENT_LOG_ROOT
-        log_name = "pki" + "-" +\
-                   deployer.subsystem_name.lower() +\
-                   "-" + "destroy" + "." +\
-                   deployer.log_timestamp + "." + "log"
-        log_file = os.path.join(log_dir, log_name)
+        print('Uninstallation log: %s' % args.log_file)
 
-    print('Uninstallation log: %s' % log_file)
-
-    pkilogging.enable_pki_logger(log_file)
+    pkilogging.enable_pki_logger(args.log_file)
 
     # Add force_destroy to master dictionary
     parser.mdict['pki_force_destroy'] = force_destroy

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -541,18 +541,9 @@ def main(argv):
         group=deployer.mdict['pki_group'])
 
     if args.log_file:
-        log_file = args.log_file
-    else:
-        log_dir = config.PKI_DEPLOYMENT_LOG_ROOT
-        log_name = "pki" + "-" + \
-                   deployer.subsystem_name.lower() + \
-                   "-" + "spawn" + "." + \
-                   deployer.log_timestamp + "." + "log"
-        log_file = os.path.join(log_dir, log_name)
+        print('Installation log: %s' % args.log_file)
 
-    print('Installation log: %s' % log_file)
-
-    pkilogging.enable_pki_logger(log_file)
+    pkilogging.enable_pki_logger(args.log_file)
 
     if not interactive and \
             not config.str2bool(parser.mdict['pki_skip_configuration']):
@@ -590,8 +581,11 @@ def main(argv):
         print("Installation failed: Command failed: %s" % ' '.join(e.cmd))
         if e.output:
             print(e.output)
-        print()
-        print('Please check pkispawn logs in %s' % log_file)
+
+        if args.log_file:
+            print()
+            print('Please check pkispawn logs in %s' % args.log_file)
+
         sys.exit(1)
 
     except requests.HTTPError as e:

--- a/docs/changes/v11.1.0/Tools-Changes.adoc
+++ b/docs/changes/v11.1.0/Tools-Changes.adoc
@@ -1,0 +1,11 @@
+= Tools Changes =
+
+== pkispawn and pkidestroy Changes ==
+
+Previously `pkispawn` and `pkidestroy` generated the logs on the console and also stored the logs into a file.
+The tools have been modified to only generate the logs on the console by default.
+To store the logs into a file as well, specify the file path using the `--log-file` option:
+
+----
+$ pkispawn ... --log-file <path>
+----


### PR DESCRIPTION
`pkispawn` and `pkidestroy` have been modified to only generate the logs on the console. It can additionally store the logs
into a file using the `--log-file` option.

https://github.com/edewata/pki/blob/logging/docs/changes/v11.1.0/Tools-Changes.adoc

Note: There shouldn't be any impact on IPA since it's already using the `--log-file` option.