### PR TITLE
Bug2012349-pkispawn-TKS-TPS-2step-install

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -817,7 +817,7 @@ class NSSDatabase(object):
         finally:
             shutil.rmtree(tmpdir)
 
-    def create_request_with_wrap_key(
+    def create_request_with_wrapping_key(
             self,
             subject_dn,
             request_file,
@@ -1351,13 +1351,13 @@ class NSSDatabase(object):
             p = subprocess.Popen(cmd,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
-
             cert_data, std_err = p.communicate()
 
             if std_err:
                 # certutil returned an error
                 # raise exception unless its not cert not found
                 if std_err.startswith(b'certutil: Could not find cert: '):
+                    logger.info('-- cert not found --')
                     return None
 
                 raise Exception('Could not find cert: %s: %s' % (fullname, std_err.strip()))

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -433,8 +433,8 @@ class ConfigurationFile:
     def confirm_external(self):
         # ALWAYS defined via 'pkiparser.py'
         if self.external:
-            # Only allowed for External CA/KRA/OCSP.
-            if self.subsystem not in ['CA', 'KRA', 'OCSP']:
+            # Only allowed for External CA/KRA/OCSP/TKS/TPS.
+            if self.subsystem not in ['CA', 'KRA', 'OCSP', 'TKS', 'TPS']:
                 logger.error(
                     log.PKI_EXTERNAL_UNSUPPORTED_1,
                     self.subsystem)
@@ -475,7 +475,7 @@ class ConfigurationFile:
         # ALWAYS defined via 'pkiparser.py'
         if self.external_step_two:
             # Only allowed for External CA/KRA/OCSP, or Stand-alone PKI
-            if (self.subsystem not in ['CA', 'KRA', 'OCSP'] and
+            if (self.subsystem not in ['CA', 'KRA', 'OCSP', 'TKS', 'TPS'] and
                     not self.standalone):
                 logger.error(
                     log.PKI_EXTERNAL_STEP_TWO_UNSUPPORTED_1,

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -1027,7 +1027,7 @@ class PKIConfigParser:
 
             if config.str2bool(self.mdict['pki_standalone']) \
                     or config.str2bool(self.mdict['pki_external']) \
-                    and self.mdict['pki_subsystem'] in ['KRA', 'OCSP']:
+                    and self.mdict['pki_subsystem'] in ['KRA', 'OCSP', 'TKS', 'TPS']:
 
                 if not config.str2bool(self.mdict['pki_external_step_two']):
                     self.mdict['pki_import_admin_cert'] = 'False'

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -406,6 +406,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 deployer.import_system_certs(nssdb, subsystem)
 
                 deployer.configure_system_certs(subsystem)
+
                 deployer.update_system_certs(nssdb, subsystem)
                 subsystem.save()
 

--- a/base/server/python/pki/server/deployment/scriptlets/initialization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/initialization.py
@@ -146,11 +146,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             logger.info('Initialization')
 
             # Verify that the subsystem already exists for the following cases:
-            # - External CA/KRA/OCSP (Step 2)
+            # - External CA/KRA/OCSP/TKS/TPS (Step 2)
             # - Stand-alone PKI (Step 2)
             # - Two-step installation (Step 2)
 
-            if (deployer.subsystem_name in ['CA', 'KRA', 'OCSP'] or
+            if (deployer.subsystem_name in ['CA', 'KRA', 'OCSP', 'TKS', 'TPS'] or
                 config.str2bool(deployer.mdict['pki_standalone'])) and \
                     config.str2bool(deployer.mdict['pki_external_step_two']) or \
                config.str2bool(deployer.mdict['pki_skip_installation']):

--- a/base/server/python/pki/server/deployment/scriptlets/keygen.py
+++ b/base/server/python/pki/server/deployment/scriptlets/keygen.py
@@ -120,7 +120,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             config.str2bool(deployer.mdict['pki_use_pss_rsa_signing_algorithm']) and
                 (cert_id in ['storage', 'transport'])):
             print('generate_csr: calling PKCS10Client for', cert_id)
-            b64_csr = nssdb.create_request_with_wrap_key(
+            b64_csr = nssdb.create_request_with_wrapping_key(
                 subject_dn=subject_dn,
                 request_file=csr_path,
                 key_size=key_size)
@@ -462,7 +462,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if subsystem.name == 'ca':
             self.generate_ca_signing_csr(deployer, subsystem)
 
-        if subsystem.name in ['kra', 'ocsp']:
+        if subsystem.name in ['kra', 'ocsp', 'tks', 'tps']:
             self.generate_sslserver_csr(deployer, subsystem)
             self.generate_subsystem_csr(deployer, subsystem)
             self.generate_audit_signing_csr(deployer, subsystem)

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -654,8 +654,14 @@ def main(argv):
         elif deployer.subsystem_name == 'KRA':
             print_kra_step_one_information(parser.mdict)
 
-        else:  # OCSP
+        elif deployer.subsystem_name == 'OCSP':
             print_ocsp_step_one_information(parser.mdict)
+
+        elif deployer.subsystem_name == 'TKS':
+            print_tks_step_one_information(parser.mdict)
+
+        elif deployer.subsystem_name == 'TPS':
+            print_tps_step_one_information(parser.mdict)
 
     else:
         print_final_install_information(parser.mdict)
@@ -840,6 +846,70 @@ def print_ocsp_step_one_information(mdict):
 
     if signing_csr:
         print("          OCSP signing:  %s" % signing_csr)
+    if subsystem_csr:
+        print("          subsystem:     %s" % subsystem_csr)
+    if sslserver_csr:
+        print("          SSL server:    %s" % sslserver_csr)
+    if audit_csr:
+        print("          audit signing: %s" % audit_csr)
+    if admin_csr:
+        print("          admin:         %s" % admin_csr)
+
+    print(log.PKI_RUN_INSTALLATION_STEP_TWO)
+    print(log.PKI_SPAWN_INFORMATION_FOOTER)
+
+
+def print_tks_step_one_information(mdict):
+
+    print(log.PKI_SPAWN_INFORMATION_HEADER)
+    print("      The %s subsystem of the '%s' instance is still incomplete." %
+          (deployer.subsystem_name, mdict['pki_instance_name']))
+    print()
+    print("      NSS database: %s" % mdict['pki_server_database_path'])
+    print()
+
+    subsystem_csr = mdict['pki_subsystem_csr_path']
+    sslserver_csr = mdict['pki_sslserver_csr_path']
+    audit_csr = mdict['pki_audit_signing_csr_path']
+    admin_csr = mdict['pki_admin_csr_path']
+
+    if subsystem_csr or sslserver_csr or audit_csr or admin_csr:
+        print("      The CSRs for TKS certificates have been generated in:")
+    else:
+        print("      No CSRs have been generated for TKS certificates.")
+
+    if subsystem_csr:
+        print("          subsystem:     %s" % subsystem_csr)
+    if sslserver_csr:
+        print("          SSL server:    %s" % sslserver_csr)
+    if audit_csr:
+        print("          audit signing: %s" % audit_csr)
+    if admin_csr:
+        print("          admin:         %s" % admin_csr)
+
+    print(log.PKI_RUN_INSTALLATION_STEP_TWO)
+    print(log.PKI_SPAWN_INFORMATION_FOOTER)
+
+
+def print_tps_step_one_information(mdict):
+
+    print(log.PKI_SPAWN_INFORMATION_HEADER)
+    print("      The %s subsystem of the '%s' instance is still incomplete." %
+          (deployer.subsystem_name, mdict['pki_instance_name']))
+    print()
+    print("      NSS database: %s" % mdict['pki_server_database_path'])
+    print()
+
+    subsystem_csr = mdict['pki_subsystem_csr_path']
+    sslserver_csr = mdict['pki_sslserver_csr_path']
+    audit_csr = mdict['pki_audit_signing_csr_path']
+    admin_csr = mdict['pki_admin_csr_path']
+
+    if subsystem_csr or sslserver_csr or audit_csr or admin_csr:
+        print("      The CSRs for TPS certificates have been generated in:")
+    else:
+        print("      No CSRs have been generated for TpS certificates.")
+
     if subsystem_csr:
         print("          subsystem:     %s" % subsystem_csr)
     if sslserver_csr:


### PR DESCRIPTION
The goal of this patch is to allows TKS/TPS to be installed using pkispawn
two-step installation.  There will certainly be more work needed to allow
TMS to function properly in FIPS/(new)HSM.  This patch will provide the
basic platform for the continued work.
There is also possibility that some needed additional work could be worked
around manually.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2012349