### PR TITLE
Bug2007405-pkispawn bails out too easily in validate_system_cert

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -450,9 +450,12 @@ class PKISubsystem(object):
 
         logger.debug('Command: %s', ' '.join(cmd))
 
-        subprocess.check_output(
-            cmd,
-            stderr=subprocess.STDOUT)
+        try:
+            print(subprocess.check_output(
+                cmd,
+                stderr=subprocess.STDOUT))
+        except subprocess.CalledProcessError as v:
+            print("pki-server subsystem-cert-validate stdout output:\n", v.output)
 
     def export_system_cert(
             self,


### PR DESCRIPTION
For pkispawn, in def validate_system_cert, it appears some unexpected
conditions could happen that would trigger failur to
  pki-server subsystem-cert-validate

Some of these conditions probably could have been resolved manually
if installation were allowed to complete.

This patch is to print out the result as information then allow the
installation to continue. It doesn't necessarily mean that the
installation will succeed, but it will at least go further to allow
for better investigation.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2007405