### PR TITLE
Remove unused method parameter from ProfileCLI.printProfile()

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileAddCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileAddCLI.java
@@ -70,7 +70,7 @@ public class ProfileAddCLI extends CommandCLI {
 
             MainCLI.printMessage("Added profile " + data.getId());
 
-            ProfileCLI.printProfile(data, profileCLI.getConfig().getServerURL().toURI());
+            ProfileCLI.printProfile(data);
         }
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileCLI.java
@@ -3,7 +3,6 @@ package com.netscape.cmstools.profile;
 import java.io.ByteArrayInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,12 +46,8 @@ public class ProfileCLI extends CLI {
 
     @Override
     public String getFullName() {
-        if (parent instanceof MainCLI) {
-            // do not include MainCLI's name
-            return name;
-        } else {
-            return parent.getFullName() + "-" + name;
-        }
+        // do not include MainCLI's name
+        return (parent instanceof MainCLI) ? name : (parent.getFullName() + "-" + name);
     }
 
     @Override
@@ -84,7 +79,7 @@ public class ProfileCLI extends CLI {
         System.out.println("  Description: " + info.getProfileDescription());
     }
 
-    public static void printProfile(ProfileData data, URI baseUri) {
+    public static void printProfile(ProfileData data) {
         System.out.println("  Profile ID: " + data.getId());
         logger.info("URL: " + data.getLink().getHref().toString());
 

--- a/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileModifyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileModifyCLI.java
@@ -70,7 +70,7 @@ public class ProfileModifyCLI extends CommandCLI {
 
             MainCLI.printMessage("Modified profile " + data.getId());
 
-            ProfileCLI.printProfile(data, profileCLI.getConfig().getServerURL().toURI());
+            ProfileCLI.printProfile(data);
         }
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileShowCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileShowCLI.java
@@ -79,7 +79,7 @@ public class ProfileShowCLI extends CommandCLI {
             if (filename != null) {
                 ProfileCLI.saveProfileToFile(filename, profileData);
             } else {
-                ProfileCLI.printProfile(profileData, profileCLI.getConfig().getServerURL().toURI());
+                ProfileCLI.printProfile(profileData);
             }
         }
     }


### PR DESCRIPTION
* Also tidy up getFullName() by using ternary operator