### PR TITLE
Refactor ACMEEngine

### DIFF
--- a/base/util/src/main/java/org/dogtag/util/cert/CertUtil.java
+++ b/base/util/src/main/java/org/dogtag/util/cert/CertUtil.java
@@ -40,6 +40,7 @@ import org.mozilla.jss.netscape.security.x509.GeneralName;
 import org.mozilla.jss.netscape.security.x509.GeneralNameInterface;
 import org.mozilla.jss.netscape.security.x509.GeneralNames;
 import org.mozilla.jss.netscape.security.x509.SubjectAlternativeNameExtension;
+import org.mozilla.jss.netscape.security.x509.X500Name;
 import org.mozilla.jss.pkcs11.PK11Store;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -208,6 +209,41 @@ public class CertUtil {
             //    identifiers as the initial newOrder request.
             //
             throw new Exception("Unsupported identifier: " + generalName);
+        }
+
+        return dnsNames;
+    }
+
+    /**
+     * Get DNS names from PKCS #10 request.
+     */
+    public static Set<String> getDNSNames(PKCS10 pkcs10) throws Exception {
+
+        Set<String> dnsNames = new HashSet<>();
+
+        X500Name subjectDN = pkcs10.getSubjectName();
+        logger.info("Getting DNS name from subject DN: " + subjectDN);
+
+        String cn;
+        try {
+            cn = subjectDN.getCommonName();
+
+        } catch (NullPointerException e) {
+            // X500Name.getCommonName() throws NPE if subject DN is blank
+            // TODO: fix X500Name.getCommonName() to return null
+            cn = null;
+        }
+
+        if (cn != null) {
+            dnsNames.add(cn.toLowerCase());
+        }
+
+        logger.info("Getting SAN extension from CSR");
+        SubjectAlternativeNameExtension sanExtension = CertUtil.getSANExtension(pkcs10);
+
+        if (sanExtension != null) {
+            logger.info("Getting DNS names from SAN extension");
+            dnsNames.addAll(CertUtil.getDNSNames(sanExtension));
         }
 
         return dnsNames;


### PR DESCRIPTION
The methods that parse DNS names from CSR have been moved from `ACMEEngine` to `CertUtil` such that they can be reused outside of ACME (e.g. in CLI). See each commit description for explanation.