### PR TITLE
Check whether server is alive before asking certbot to register

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -479,6 +479,7 @@ jobs:
 
       - name: Verify certbot in client container
         run: |
+          docker exec client bash -c "curl -I http://pki.example.com:8080/acme/directory"
           docker exec client certbot register \
               --server http://pki.example.com:8080/acme/directory \
               --email user1@example.com \


### PR DESCRIPTION
To diagnose an intermittent CI issue with ACME, we can try to narrow
down the issue by making sure the server is responding before trying to
do anything with certbot. This will tell us that the issue is not
certbot, but either something went wrong in the container or the CI env
itself.