### PR TITLE
Replace SHA-1 references with SHA-256

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -1496,14 +1496,14 @@ public class CertificateAuthority
     public ResponderID getResponderIDByHash() {
 
         /*
-         KeyHash ::= OCTET STRING --SHA-1 hash of responder's public key
+         KeyHash ::= OCTET STRING --SHA-256 hash of responder's public key
          --(excluding the tag and length fields)
          */
         PublicKey publicKey = getOCSPSigningUnit().getPublicKey();
         MessageDigest md = null;
 
         try {
-            md = MessageDigest.getInstance("SHA1");
+            md = MessageDigest.getInstance("SHA256");
         } catch (NoSuchAlgorithmException e) {
             return null;
         }

--- a/base/ca/src/main/java/com/netscape/cms/profile/def/SubjectKeyIdentifierExtDefault.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/def/SubjectKeyIdentifierExtDefault.java
@@ -55,7 +55,7 @@ public class SubjectKeyIdentifierExtDefault extends EnrollExtDefault {
     public static final String VAL_KEY_ID = "keyid";
     public static final String CONFIG_MD = "messageDigest";
     public static final String VAL_MD = "messageDigest";
-    public static final String DEF_CONFIG_MDS = "SHA-1,SHA-256,SHA-384,SHA-512";
+    public static final String DEF_CONFIG_MDS = "SHA-256,SHA-384,SHA-512";
     public static final String MD_LABEL="Message digest";
     public static final String USE_SKI_LABEL="Use SKI From Cert Request";
     public static final String VAL_USE_SKI_IF_IN_REQUEST = "useSKIFromCertRequest";
@@ -78,7 +78,7 @@ public class SubjectKeyIdentifierExtDefault extends EnrollExtDefault {
     public IDescriptor getConfigDescriptor(Locale locale, String name) { /* testms */
         if (name.equals(CONFIG_MD)) {
             return new Descriptor(IDescriptor.CHOICE, DEF_CONFIG_MDS,
-                    "SHA-1",
+                    "SHA-256",
                     MD_LABEL);
         } else if (name.equals(CONFIG_USE_SKI_IF_IN_REQUEST)) {
             return new Descriptor(IDescriptor.BOOLEAN,null,"false",USE_SKI_LABEL);
@@ -203,7 +203,7 @@ public class SubjectKeyIdentifierExtDefault extends EnrollExtDefault {
             String alg = getConfig(CONFIG_MD);
 
             if (alg == null || alg.length() == 0) {
-                alg = "SHA-1";
+                alg = "SHA-256";
             }
             return alg;
         } else if (name.equals(VAL_USE_SKI_IF_IN_REQUEST)) {
@@ -303,7 +303,7 @@ public class SubjectKeyIdentifierExtDefault extends EnrollExtDefault {
                     info.get(X509CertInfo.KEY);
             X509Key key = (X509Key) infokey.get(CertificateX509Key.KEY);
 
-            // "SHA-1" is default for CryptoUtil.generateKeyIdentifier.
+            // "SHA-256" is default for CryptoUtil.generateKeyIdentifier.
             // you could specify different algorithm with the alg parameter
             // like this:
             //byte[] hash = CryptoUtil.generateKeyIdentifier(key.getKey(), "SHA-256");
@@ -314,7 +314,7 @@ public class SubjectKeyIdentifierExtDefault extends EnrollExtDefault {
                 logger.debug(method + " generating hash with alg: " + configHashAlg);
                 hash = CryptoUtil.generateKeyIdentifier(key.getKey(), configHashAlg);
             } else {
-                logger.debug(method + " generating hash with default alg: SHA-1");
+                logger.debug(method + " generating hash with default alg: SHA-256");
                 hash = CryptoUtil.generateKeyIdentifier(key.getKey());
             }
 

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -640,7 +640,6 @@ public class CRSEnrollment extends HttpServlet {
              - GetNextCACert (currently not supported by Dogtag)
              - POSTPKIOperation (currently not supported by Dogtag)
              - Renewal (currently not supported by Dogtag)
-             - SHA-1
              - SHA-256
              - SHA-512
              - SCEPStandard (currently not supported by Dogtag due to missing AES support)
@@ -649,9 +648,6 @@ public class CRSEnrollment extends HttpServlet {
                 response.append("DES3\n");
             }
             // response.append("POSTPKIOperation\n");
-            if (isAlgorithmAllowed(mAllowedHashAlgorithm, "SHA1")) {
-                response.append("SHA-1\n");
-            }
             if (isAlgorithmAllowed(mAllowedHashAlgorithm, "SHA256")) {
                 response.append("SHA-256\n");
             }

--- a/base/ca/src/main/java/org/dogtagpki/legacy/server/policy/constraints/SigningAlgorithmConstraints.java
+++ b/base/ca/src/main/java/org/dogtagpki/legacy/server/policy/constraints/SigningAlgorithmConstraints.java
@@ -95,7 +95,7 @@ public class SigningAlgorithmConstraints extends APolicyRule
      * <P>
      *
      * The entries probably are of the form ra.Policy.rule.<ruleName>.implName=SigningAlgorithmConstraints
-     * ra.Policy.rule.<ruleName>.algorithms=SHA-1WithRSA, SHA-1WithDSA ra.Policy.rule.<ruleName>.enable=true
+     * ra.Policy.rule.<ruleName>.algorithms=SHA-256WithRSA, SHA-256WithDSA ra.Policy.rule.<ruleName>.enable=true
      * ra.Policy.rule.<ruleName>.predicate=ou==Sales
      *
      * @param config The config store reference

--- a/base/ca/src/main/java/org/dogtagpki/legacy/server/policy/extensions/SubjectKeyIdentifierExt.java
+++ b/base/ca/src/main/java/org/dogtagpki/legacy/server/policy/extensions/SubjectKeyIdentifierExt.java
@@ -315,7 +315,7 @@ public class SubjectKeyIdentifierExt extends APolicyRule
         }
         try {
             byte[] octetString = new byte[8];
-            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
 
             md.update(key.getKey());
             byte[] hash = md.digest();

--- a/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
+++ b/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
@@ -232,14 +232,14 @@ public class OCSPAuthority implements IOCSPAuthority, IOCSPService, IAuthority {
     public ResponderID getResponderIDByHash() {
 
         /*
-         KeyHash ::= OCTET STRING --SHA-1 hash of responder's public key
+         KeyHash ::= OCTET STRING --SHA-256 hash of responder's public key
          --(excluding the tag and length fields)
          */
         PublicKey publicKey = getSigningUnit().getPublicKey();
         MessageDigest md = null;
 
         try {
-            md = MessageDigest.getInstance("SHA1");
+            md = MessageDigest.getInstance("SHA256");
         } catch (NoSuchAlgorithmException e) {
             return null;
         }

--- a/base/server/src/main/java/com/netscape/cms/servlet/processors/CMCProcessor.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/processors/CMCProcessor.java
@@ -299,7 +299,7 @@ public class CMCProcessor extends PKIProcessor {
                         X509Key subjectKeyInfo =
                                 (X509Key) ((CertificateX509Key) certInfoArray[j].get(X509CertInfo.KEY))
                                         .get(CertificateX509Key.KEY);
-                        MessageDigest md = MessageDigest.getInstance("SHA-1");
+                        MessageDigest md = MessageDigest.getInstance("SHA-256");
 
                         md.update(subjectKeyInfo.getEncoded());
                         byte[] skib = md.digest();

--- a/base/server/src/main/java/org/dogtagpki/legacy/server/policy/APolicyRule.java
+++ b/base/server/src/main/java/org/dogtagpki/legacy/server/policy/APolicyRule.java
@@ -257,7 +257,7 @@ public abstract class APolicyRule implements IPolicyRule {
 
     public static KeyIdentifier createKeyIdentifier(X509Key key)
             throws NoSuchAlgorithmException, InvalidKeyException {
-        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
 
         md.update(key.getEncoded());
         return new KeyIdentifier(md.digest());
@@ -334,7 +334,7 @@ public abstract class APolicyRule implements IPolicyRule {
             }
             byte[] rawKey = key.getKey();
 
-            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
 
             md.update(rawKey);
             keyId = new KeyIdentifier(md.digest());

--- a/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -70,17 +70,17 @@ import org.mozilla.jss.asn1.ANY;
 import org.mozilla.jss.asn1.ASN1Value;
 import org.mozilla.jss.asn1.BIT_STRING;
 import org.mozilla.jss.asn1.BMPString;
-import org.mozilla.jss.asn1.PrintableString;
-import org.mozilla.jss.asn1.TeletexString;
-import org.mozilla.jss.asn1.UTF8String;
-import org.mozilla.jss.asn1.UniversalString;
 import org.mozilla.jss.asn1.INTEGER;
 import org.mozilla.jss.asn1.InvalidBERException;
 import org.mozilla.jss.asn1.NULL;
 import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.asn1.OCTET_STRING;
+import org.mozilla.jss.asn1.PrintableString;
 import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.asn1.SET;
+import org.mozilla.jss.asn1.TeletexString;
+import org.mozilla.jss.asn1.UTF8String;
+import org.mozilla.jss.asn1.UniversalString;
 import org.mozilla.jss.crypto.Algorithm;
 import org.mozilla.jss.crypto.Cipher;
 import org.mozilla.jss.crypto.CryptoStore;
@@ -157,8 +157,8 @@ import org.mozilla.jss.pkix.crmf.CertTemplate;
 import org.mozilla.jss.pkix.crmf.EncryptedKey;
 import org.mozilla.jss.pkix.crmf.EncryptedValue;
 import org.mozilla.jss.pkix.crmf.PKIArchiveOptions;
-import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 import org.mozilla.jss.pkix.primitive.AVA;
+import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 import org.mozilla.jss.pkix.primitive.Name;
 import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
 import org.mozilla.jss.ssl.SSLCipher;
@@ -1546,7 +1546,7 @@ public class CryptoUtil {
         String method = "CryptoUtil: generateKeyIdentifier: ";
         String msg = "";
         if (alg == null) {
-            alg = "SHA-1";
+            alg = "SHA-256";
         }
         try {
             MessageDigest md = MessageDigest.getInstance(alg);

--- a/base/util/src/main/java/com/netscape/cmsutil/ocsp/CertID.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/ocsp/CertID.java
@@ -167,7 +167,6 @@ public class CertID implements ASN1Value {
     static {
         digestNames.put(new OBJECT_IDENTIFIER("1.2.840.113549.2.2"), "MD2");
         digestNames.put(new OBJECT_IDENTIFIER("1.2.840.113549.2.5"), "MD5");
-        digestNames.put(new OBJECT_IDENTIFIER("1.3.14.3.2.26"), "SHA-1");
         digestNames.put(new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.2.4"), "SHA-224");
         digestNames.put(new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.2.1"), "SHA-256");
         digestNames.put(new OBJECT_IDENTIFIER("2.16.840.1.101.3.4.2.2"), "SHA-384");


### PR DESCRIPTION
First part of attempting to remove the `SHA-1` algorithm from use. This change replaces references to `SHA-1` with `SHA-256`, if this is not reasonable then please shout!

Caveats:

- I have not changed any of the native code, just the Java objects.
- I have not changed the `Provider` class, as I will need to change that in `JSS` first.