### PR TITLE
Automatically detect JUnit tests when running build.sh

### DIFF
--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -66,7 +66,17 @@ if(WITH_TEST)
     )
 
     # create test target
-    # TODO: create CMake function to find all JUnit test classes
+    execute_process(
+        COMMAND bash "-c"
+        "grep -ilR @Test ${PROJECT_SOURCE_DIR} \
+        | cut -d':' -f1 \
+        | awk -F '/src/test/java/' '{ print $2 }' \
+        | sed 's/.java/;/g' \
+        | sed 's!/!.!g' \
+        | tr -d '\n'"
+        OUTPUT_VARIABLE DISCOVERED_TESTS
+    )
+
     add_junit_test(test-pki-server
         DEPENDS
             pki-server-test-classes
@@ -80,16 +90,7 @@ if(WITH_TEST)
             ${HAMCREST_JAR} ${JUNIT_JAR} ${COMMONS_IO_JAR}
             ${CMAKE_BINARY_DIR}/test/classes
         TESTS
-            com.netscape.cmscore.authentication.AuthTokenTest
-            com.netscape.cmscore.dbs.CertRecordListTest
-            com.netscape.cmscore.dbs.DBRegistryTest
-            com.netscape.cmscore.request.AgentApprovalsTest
-            com.netscape.cmscore.request.ExtAttrDynMapperTest
-            com.netscape.cmscore.request.ExtDataHashtableTest
-            com.netscape.cmscore.request.RequestQueueTest
-            com.netscape.cmscore.request.RequestRecordTest
-            com.netscape.cmscore.request.RequestTest
-            com.netscape.cmscore.password.PlainPasswordFileTest
+            ${DISCOVERED_TESTS}
         REPORTS_DIR
             reports
     )

--- a/base/util/CMakeLists.txt
+++ b/base/util/CMakeLists.txt
@@ -59,7 +59,17 @@ if(WITH_TEST)
             pki-cmsutil-jar
     )
 
-    # TODO: create CMake function to find all JUnit test classes
+    execute_process(
+        COMMAND bash "-c"
+        "grep -ilR @Test ${PROJECT_SOURCE_DIR} \
+        | cut -d':' -f1 \
+        | awk -F '/src/test/java/' '{ print $2 }' \
+        | sed 's/.java/;/g' \
+        | sed 's!/!.!g' \
+        | tr -d '\n'"
+        OUTPUT_VARIABLE DISCOVERED_TESTS
+    )
+
     add_junit_test(test-pki-util
         CLASSPATH
             ${SLF4J_API_JAR} ${SLF4J_JDK14_JAR}
@@ -69,7 +79,7 @@ if(WITH_TEST)
             ${HAMCREST_JAR} ${JUNIT_JAR}
             ${CMAKE_BINARY_DIR}/test/classes
         TESTS
-            com.netscape.cmsutil.crypto.KeyIDCodecTest
+            ${DISCOVERED_TESTS}
         REPORTS_DIR
             reports
         DEPENDS


### PR DESCRIPTION
Currently you have to remember to add new unit tests manually, but now
they will be picked up automatically.

I did something similar in #3639 and noticed today that there were 2 other places where it could be improved like this. An even better improvement would be to refactor out the test discovery process so there are not 3 copies. I shall investigate doing so, but I still think there is value in this intermediate step.