### PR TITLE
Use human-readable date format on TPS Agent page

### DIFF
--- a/base/tps/shared/webapps/tps/js/cert.js
+++ b/base/tps/shared/webapps/tps/js/cert.js
@@ -22,6 +22,7 @@
 var CertificateModel = Model.extend({
     urlRoot: "/tps/rest/certs",
     parseResponse: function(response) {
+        var respModifyTimestamp = (response.ModifyTime === null) ? "N/A" : new Date(response.ModifyTime)
         return {
             id: response.id,
             serialNumber: response.SerialNumber,
@@ -32,8 +33,8 @@ var CertificateModel = Model.extend({
             type: response.Type,
             keyType: response.KeyType,
             status: response.Status,
-            createTime: response.CreateTime,
-            modifyTime: response.ModifyTime
+            createTime: new Date(response.CreateTime),
+            modifyTime: respModifyTimestamp
         };
     },
     createRequest: function(attributes) {
@@ -62,6 +63,7 @@ var CertificateCollection = Collection.extend({
         return response.Link;
     },
     parseEntry: function(entry) {
+        var custModifyTimestamp = (entry.ModifyTime === null) ? "N/A" : new Date(entry.ModifyTime)
         return new CertificateModel({
             id: entry.id,
             serialNumber: entry.SerialNumber,
@@ -72,8 +74,8 @@ var CertificateCollection = Collection.extend({
             type: entry.Type,
             keyType: entry.KeyType,
             status: entry.Status,
-            createTime: entry.CreateTime,
-            modifyTime: entry.ModifyTime
+            createTime: new Date(entry.CreateTime),
+            modifyTime: custModifyTimestamp
         });
     }
 });

--- a/base/tps/shared/webapps/tps/js/token.js
+++ b/base/tps/shared/webapps/tps/js/token.js
@@ -38,6 +38,7 @@ var TOKEN_REUSE_MESSAGE = "When reusing a token that was previously " +
 var TokenModel = Model.extend({
     urlRoot: "/tps/rest/tokens",
     parseResponse: function(response) {
+        var respModifyTimestamp = (response.ModifyTime === null) ? "N/A" : new Date(response.ModifyTime)
         return {
             id: response.id,
             tokenID: response.TokenID,
@@ -48,8 +49,8 @@ var TokenModel = Model.extend({
             appletID: response.AppletID,
             keyInfo: response.KeyInfo,
             policy: response.Policy,
-            createTimestamp: response.CreateTimestamp,
-            modifyTimestamp: response.ModifyTimestamp
+            createTimestamp: new Date(response.CreateTimestamp),
+            modifyTimestamp: respModifyTimestamp
         };
     },
     createRequest: function(attributes) {
@@ -90,6 +91,7 @@ var TokenCollection = Collection.extend({
         return response.Link;
     },
     parseEntry: function(entry) {
+        var custModifyTimestamp = (entry.ModifyTime === null) ? "N/A" : new Date(entry.ModifyTime)
         return new TokenModel({
             id: entry.id,
             tokenID: entry.TokenID,
@@ -100,8 +102,8 @@ var TokenCollection = Collection.extend({
             appletID: entry.AppletID,
             keyInfo: entry.KeyInfo,
             policy: entry.Policy,
-            createTimestamp: entry.CreateTimestamp,
-            modifyTimestamp: entry.ModifyTimestamp
+            createTimestamp: new Date(entry.CreateTimestamp),
+            modifyTimestamp: custModifyTimestamp
         });
     }
 });


### PR DESCRIPTION
Based on patch by czinda, changes made to patch include:

* Use of ternary operator to simplify logic
* Use N/A instead of Date(null), which would confusingly print 1st Jan 1970
* Use === instead of ==
* Explicitly define variables