### PR TITLE
Add pki-server <subsystem>-user-del

### DIFF
--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1550,6 +1550,23 @@ class PKISubsystem(object):
             as_current_user=as_current_user,
             capture_output=True)
 
+    def remove_user(self, user_id, as_current_user=False):
+
+        cmd = [self.name + '-user-del']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(user_id)
+
+        self.run(
+            cmd,
+            as_current_user=as_current_user,
+            capture_output=True)
+
     def add_user_cert(self, user_id,
                       cert_data=None,
                       cert_path=None,

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCLI.java
@@ -18,6 +18,7 @@ public class SubsystemUserCLI extends CLI {
         addModule(new SubsystemUserAddCLI(this));
         addModule(new SubsystemUserFindCLI(this));
         addModule(new SubsystemUserModifyCLI(this));
+        addModule(new SubsystemUserRemoveCLI(this));
         addModule(new SubsystemUserShowCLI(this));
 
         addModule(new SubsystemUserCertCLI(this));

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRemoveCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRemoveCLI.java
@@ -1,0 +1,111 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import java.io.File;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.tomcat.util.net.jss.TomcatJSS;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CommandCLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.certsrv.user.UserData;
+import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.base.ConfigStorage;
+import com.netscape.cmscore.base.FileConfigStore;
+import com.netscape.cmscore.ldapconn.LDAPAuthenticationConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapAuthInfo;
+import com.netscape.cmscore.ldapconn.LdapConnInfo;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmscore.usrgrp.UGSubsystem;
+import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
+import com.netscape.cmsutil.password.IPasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemUserRemoveCLI extends CommandCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(SubsystemUserRemoveCLI.class);
+
+    public SubsystemUserRemoveCLI(CLI parent) {
+        super("del", "Remove " + parent.getParent().getName().toUpperCase() + " user", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing user ID");
+        }
+
+        String userID = cmdArgs[0];
+
+        String catalinaBase = System.getProperty("catalina.base");
+
+        TomcatJSS tomcatjss = TomcatJSS.getInstance();
+        tomcatjss.loadConfig();
+        tomcatjss.init();
+
+        String subsystem = parent.getParent().getName();
+        String configDir = catalinaBase + File.separator + subsystem;
+        String configFile = configDir+ File.separator + "conf" + File.separator + CMS.CONFIG_FILE;
+
+        logger.info("Loading " + configFile);
+        ConfigStorage storage = new FileConfigStore(configFile);
+        EngineConfig cs = new EngineConfig(storage);
+        cs.load();
+        LDAPConfig ldapConfig = cs.getInternalDBConfig();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        IPasswordStore passwordStore = IPasswordStore.create(psc);
+
+        LDAPConnectionConfig connConfig = ldapConfig.getConnectionConfig();
+        LDAPAuthenticationConfig authConfig = ldapConfig.getAuthenticationConfig();
+
+        LdapConnInfo connInfo = new LdapConnInfo(connConfig);
+
+        LdapAuthInfo authInfo = new LdapAuthInfo();
+        authInfo.setPasswordStore(passwordStore);
+        authInfo.init(
+                authConfig,
+                connInfo.getHost(),
+                connInfo.getPort(),
+                connInfo.getSecure());
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PKISocketFactory socketFactory;
+        if (authInfo.getAuthType() == LdapAuthInfo.LDAP_AUTHTYPE_SSLCLIENTAUTH) {
+            socketFactory = new PKISocketFactory(authInfo.getClientCertNickname());
+        } else {
+            socketFactory = new PKISocketFactory(connInfo.getSecure());
+        }
+        socketFactory.init(socketConfig);
+
+        UGSubsystemConfig ugConfig = cs.getUGSubsystemConfig();
+        UGSubsystem ugSubsystem = new UGSubsystem();
+
+        UserData userData = new UserData();
+
+        try {
+            ugSubsystem.init(socketConfig, ugConfig, passwordStore);
+            ugSubsystem.removeUser(userID);
+
+        } finally {
+            ugSubsystem.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
The `pki-server <subsystem>-user-del` has been added to provide a way for the admin to remove a user from the database while the server is offline.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Subsystem-User-CLI