### PR TITLE
Bump dependency to Python 3.9

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -452,7 +452,7 @@ class NSSDatabase(object):
 
     def add_cert(self, nickname, cert_file, token=None, trust_attributes=None):
 
-        logger.debug('nssdb.add_cert')
+        logger.debug('NSSDatabase.add_cert(%s)', nickname)
 
         tmpdir = tempfile.mkdtemp()
         try:
@@ -1205,7 +1205,7 @@ class NSSDatabase(object):
         :return: Trust flag
         :rtype: str
         """
-        logger.debug('get_trust')
+        logger.debug('NSSDatabase.get_trust(%s)', nickname)
         cert_trust = None
 
         tmpdir = tempfile.mkdtemp()
@@ -1223,7 +1223,7 @@ class NSSDatabase(object):
                 cmd.extend(['-h', token])
                 fullname = token + ':' + fullname
 
-            logger.debug('fullname = %s', fullname)
+            logger.debug('fullname: %s', fullname)
 
             if password_file:
                 cmd.extend(['-f', password_file])
@@ -1307,7 +1307,7 @@ class NSSDatabase(object):
     def get_cert(self, nickname, token=None, output_format='pem',
                  output_text=False):
 
-        logger.info('nssdb.get_cert')
+        logger.debug('NSSDatabase.get_cert(%s) begins', nickname)
 
         if output_format == 'pem':
             output_format_option = '-a'
@@ -1357,28 +1357,27 @@ class NSSDatabase(object):
                 # certutil returned an error
                 # raise exception unless its not cert not found
                 if std_err.startswith(b'certutil: Could not find cert: '):
-                    logger.info('-- cert not found --')
+                    logger.debug('Cert not found: %s', nickname)
                     return None
 
                 raise Exception('Could not find cert: %s: %s' % (fullname, std_err.strip()))
 
             if not cert_data:
-                # certutil did not return data
-                logger.info('certutil did not return data')
+                logger.debug('certutil did not return cert data')
                 return None
             else:
-                logger.info('certutil returned data for cert')
+                logger.debug('certutil returned cert data')
 
             if p.returncode != 0:
                 logger.warning('certutil returned non-zero exit code (bug #1539996)')
-                logger.info('certutil returned errocode: %s', p.returncode)
+                logger.debug('return code: %s', p.returncode)
 
             if output_format == 'base64':
                 cert_data = base64.b64encode(cert_data).decode('utf-8')
             if output_text and not isinstance(cert_data, six.string_types):
                 cert_data = cert_data.decode('ascii')
 
-            logger.info('nssdb.get_cert ends')
+            logger.debug('NSSDatabase.get_cert(%s) ends', nickname)
 
             return cert_data
 
@@ -1387,7 +1386,7 @@ class NSSDatabase(object):
 
     def get_cert_info(self, nickname, token=None):
 
-        logger.debug('nssdb.get_cert_info begins: %s', nickname)
+        logger.debug('NSSDatabase.get_cert_info(%s) begins', nickname)
         cert_pem = self.get_cert(nickname=nickname, token=token)
 
         if not cert_pem:
@@ -1408,7 +1407,7 @@ class NSSDatabase(object):
         cert['not_after'] = self.convert_time_to_millis(cert_obj.not_valid_after)
         cert['trust_flags'] = self.get_trust(nickname=nickname, token=token)
 
-        logger.debug('nssdb.get_cert_info ends: %s', nickname)
+        logger.debug('NSSDatabase.get_cert_info(%s) ends', nickname)
 
         return cert
 
@@ -1571,15 +1570,15 @@ class NSSDatabase(object):
             token=None,
             trust_attributes=None):
 
-        tmpdir = tempfile.mkdtemp()
+        logger.debug('NSSDatabase.import_cert_chain(%s) begins', nickname)
 
-        logger.debug('nssdb.import_cert_chain begins')
+        tmpdir = tempfile.mkdtemp()
 
         try:
             file_type = get_file_type(cert_chain_file)
 
             if file_type == 'cert':  # import single PEM cert
-                logger.debug('type is cert')
+                logger.debug('Importing a single cert')
                 self.add_cert(
                     nickname=nickname,
                     cert_file=cert_chain_file,
@@ -1594,7 +1593,7 @@ class NSSDatabase(object):
                 )
 
             elif file_type == 'pkcs7':  # import PKCS #7 cert chain
-                logger.debug('type is pkcs7')
+                logger.debug('Importing a PKCS #7 cert chain')
                 self.import_pkcs7(
                     pkcs7_file=cert_chain_file,
                     nickname=nickname,
@@ -1609,7 +1608,7 @@ class NSSDatabase(object):
                 return base64_data, [nickname]
 
             else:  # import PKCS #7 data without header/footer
-                logger.debug('type is pkcs7 without header/footer')
+                logger.debug('Importing a PKCS #7 data without header/footer')
                 with open(cert_chain_file, 'r') as f:
                     base64_data = f.read()
 
@@ -1635,7 +1634,7 @@ class NSSDatabase(object):
 
         finally:
             shutil.rmtree(tmpdir)
-            logger.info('import_cert_chain ends')
+            logger.debug('NSSDatabase.import_cert_chain(%s) ends', nickname)
 
     def import_pkcs7(
             self,
@@ -1645,7 +1644,7 @@ class NSSDatabase(object):
             token=None,
             trust_attributes=None):
 
-        logger.debug('import_pkcs7')
+        logger.debug('NSSDatabase.import_pkcs7()')
 
         if not nickname:
 
@@ -1704,7 +1703,7 @@ class NSSDatabase(object):
                     break
                 n = n + 1
 
-            logger.debug('Number of certs in pkcs#7 to import: %s', n)
+            logger.debug('Number of certs in PKCS #7: %s', n)
             # Import CA certs with default nicknames and trust attributes.
             for i in range(0, n - 1):
                 cert_file = prefix + str(i) + suffix

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1205,7 +1205,7 @@ grant codeBase "file:%s" {
         server_config = self.get_server_config()
         connector = server_config.get_connector('Secure')
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: Secure')
 
         sslhost = server_config.get_sslhost(connector)
@@ -1225,7 +1225,7 @@ grant codeBase "file:%s" {
         server_config = self.get_server_config()
         connector = server_config.get_connector('Secure')
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: Secure')
 
         sslhost = server_config.get_sslhost(connector)
@@ -1668,7 +1668,7 @@ class ServerConfiguration(object):
 
         connector = self.get_connector(name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % name)
 
         service = connector.getparent()

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -211,7 +211,7 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
 
         connector = server_config.get_connector(name)
 
-        if connector:
+        if connector is not None:
             raise Exception('Connector already exists: %s' % name)
 
         connector = server_config.create_connector(name)
@@ -437,7 +437,7 @@ class HTTPConnectorShowCLI(pki.cli.CLI):
         server_config = instance.get_server_config()
         connector = server_config.get_connector(name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % name)
 
         HTTPConnectorCLI.print_connector(connector)
@@ -573,7 +573,7 @@ class HTTPConnectorModCLI(pki.cli.CLI):
         server_config = instance.get_server_config()
         connector = server_config.get_connector(name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % name)
 
         if connector_type == 'JSS':
@@ -743,7 +743,7 @@ class SSLHostAddCLI(pki.cli.CLI):
         server_config = instance.get_server_config()
         connector = server_config.get_connector(connector_name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
 
         try:
@@ -831,7 +831,7 @@ class SSLHostDeleteCLI(pki.cli.CLI):
         server_config = instance.get_server_config()
         connector = server_config.get_connector(connector_name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
 
         server_config.remove_sslhost(connector, hostname)
@@ -902,7 +902,7 @@ class SSLHostFindCLI(pki.cli.CLI):
         server_config = instance.get_server_config()
         connector = server_config.get_connector(connector_name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
 
         sslhosts = server_config.get_sslhosts(connector)
@@ -1062,7 +1062,7 @@ class SSLCertAddCLI(pki.cli.CLI):
         server_config = instance.get_server_config()
         connector = server_config.get_connector(connector_name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
 
         sslhost = server_config.get_sslhost(connector, hostname)
@@ -1163,7 +1163,7 @@ class SSLCertDeleteCLI(pki.cli.CLI):
         server_config = instance.get_server_config()
         connector = server_config.get_connector(connector_name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
 
         sslhost = server_config.get_sslhost(connector, hostname)
@@ -1243,7 +1243,7 @@ class SSLCertFindLI(pki.cli.CLI):
         server_config = instance.get_server_config()
         connector = server_config.get_connector(connector_name)
 
-        if not connector:
+        if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
 
         sslhost = server_config.get_sslhost(connector, hostname)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -350,6 +350,8 @@ class PKIDeployer:
 
     def import_cert_chain(self, nssdb):
 
+        logger.debug('PKIDeployer.import_cert_chain()')
+
         chain_file = self.mdict.get('pki_cert_chain_path')
 
         if not chain_file or not os.path.exists(chain_file):
@@ -357,7 +359,7 @@ class PKIDeployer:
 
         nickname = self.mdict['pki_cert_chain_nickname']
 
-        logger.info('import_cert_chain: Importing certificate chain from %s', chain_file)
+        logger.info('Importing certificate chain from %s', chain_file)
 
         nssdb.import_cert_chain(
             nickname=nickname,
@@ -421,7 +423,7 @@ class PKIDeployer:
 
     def configure_system_certs(self, subsystem):
 
-        logger.debug('configure_system_certs')
+        logger.debug('PKIDeployer.configure_system_certs()')
 
         if subsystem.name == 'ca':
             self.configure_system_cert(subsystem, 'signing')
@@ -553,7 +555,7 @@ class PKIDeployer:
 
     def ds_connect(self):
         if not self.ds_url:
-            logger.info('ds_connect called without corresponding call to ds_init')
+            logger.debug('ds_connect() called without corresponding call to ds_init()')
             self.ds_init()
 
         logger.info('Connecting to LDAP server at %s', self.ds_url)
@@ -681,7 +683,7 @@ class PKIDeployer:
 
     def setup_cert(self, subsystem, client, tag, system_cert):
 
-        logger.info('setup_cert:')
+        logger.debug('PKIDeployer.setup_cert()')
 
         # Process existing CA installation like external CA
         external = config.str2bool(self.mdict['pki_external']) or \
@@ -755,7 +757,7 @@ class PKIDeployer:
 
     def setup_system_certs(self, subsystem, client):
 
-        logger.info("setup_system_certs: ")
+        logger.debug('PKIDeployer.setup_system_certs()')
         system_certs = {}
 
         for system_cert in subsystem.find_system_certs():
@@ -787,7 +789,7 @@ class PKIDeployer:
 
     def load_admin_cert(self, subsystem):
 
-        logger.info('load_admin_cert')
+        logger.debug('PKIDeployer.load_admin_cert()')
 
         standalone = config.str2bool(self.mdict['pki_standalone'])
         external_step_two = config.str2bool(self.mdict['pki_external_step_two'])
@@ -799,7 +801,7 @@ class PKIDeployer:
             # Copy the externally-issued admin certificate into
             # 'ca_admin.cert' under the specified 'pki_client_dir'
             # stripping the certificate HEADER/FOOTER prior to saving it.
-            logger.info('load_admin_cert: external_step_two and not CA')
+            logger.debug('load_admin_cert: external_step_two and not CA')
 
             logger.info('Loading admin cert from %s', self.mdict['pki_admin_cert_path'])
 
@@ -981,13 +983,13 @@ class PKIDeployer:
 
     def get_admin_cert(self, subsystem, client):
 
-        logger.info('get_admin_cert')
+        logger.debug('PKIDeployer.get_admin_cert()')
         external_step_two = config.str2bool(self.mdict['pki_external_step_two'])
         if config.str2bool(self.mdict['pki_import_admin_cert']):
             b64cert = self.load_admin_cert(subsystem)
         else:
             if external_step_two and subsystem.type != 'CA':
-                logger.info('get_admin_cert: pki_external_step_two True')
+                logger.debug('get_admin_cert: pki_external_step_two True')
                 b64cert = self.load_admin_cert(subsystem)
                 self.config_client.process_admin_p12()
                 logger.debug('Admin cert: %s', b64cert)

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -1680,7 +1680,7 @@ class HSM:
             command = [config.PKI_HSM_NCIPHER_EXE, "restart"]
 
             # Display this "nCipher" HSM command
-            logger.info(log.PKIHELPER_NCIPHER_RESTART_1, ' '.join(command))
+            logger.debug(log.PKIHELPER_NCIPHER_RESTART_1, ' '.join(command))
             # Execute this "nCipher" HSM command
             subprocess.check_call(command)
         except subprocess.CalledProcessError as exc:
@@ -1798,7 +1798,7 @@ class Certutil:
                     raise Exception(
                         log.PKI_FILE_MISSING_OR_NOT_A_FILE_1 % password_file)
             # Display this "certutil" command
-            logger.info('Command: %s', ' '.join(command))
+            logger.debug('Command: %s', ' '.join(command))
             # Execute this "certutil" command
             if silent:
                 # By default, execute this command silently
@@ -2603,7 +2603,7 @@ class ConfigClient:
 
     def process_admin_cert(self, admin_cert):
 
-        logger.info('process_admin_cert')
+        logger.debug('ConfigClient.process_admin_cert()')
         admin_cert_file = self.mdict['pki_client_admin_cert']
         logger.info('Storing admin certificate into %s', admin_cert_file)
 
@@ -2627,7 +2627,10 @@ class ConfigClient:
             client_nssdb.close()
 
     def process_admin_p12(self):
-        logger.info('process_admin_p12: Exporting admin certificate into %s',
+
+        logger.debug('ConfigClient.process_admin_p12()')
+
+        logger.info('Exporting admin certificate into %s',
                     self.mdict['pki_client_admin_cert_p12'])
 
         # create directory for p12 file if it does not exist

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -192,7 +192,7 @@ class PKISubsystem(object):
 
     def get_nssdb_cert_info(self, cert_id):
 
-        logger.info('get_nssdb_cert_info')
+        logger.debug('PKISubsystem.get_nssdb_cert_info()')
         logger.info('Getting %s cert info from NSS database', cert_id)
 
         nickname = self.config.get('%s.%s.nickname' % (self.name, cert_id))

--- a/pki.spec
+++ b/pki.spec
@@ -183,7 +183,7 @@ BuildRequires:    python3-sphinx
 
 BuildRequires:    resteasy >= 3.0.26
 
-BuildRequires:    python3 >= 3.5
+BuildRequires:    python3 >= 3.9
 BuildRequires:    python3-devel
 BuildRequires:    python3-setuptools
 BuildRequires:    python3-cryptography
@@ -376,7 +376,7 @@ Provides:         pki-base-python3 = %{version}-%{release}
 %endif
 
 Requires:         %{product_id}-base = %{version}-%{release}
-Requires:         python3 >= 3.5
+Requires:         python3 >= 3.9
 Requires:         python3-cryptography
 Requires:         python3-ldap
 Requires:         python3-lxml


### PR DESCRIPTION
Python 3.9 is available on all platforms supported by PKI 11.1.

Some log messages have been converted into DEBUG since they would be more useful for development/troubleshooting. INFO messages are meant for users so they should be kept simple.

The following warnings have been fixed:
> FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.