### PR TITLE
Fix replica reinstallation

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1278,6 +1278,19 @@ jobs:
           docker exec secondary pki -n caadmin ca-user-find
           docker exec secondary pki securitydomain-host-find
 
+      - name: Remove CA from secondary PKI container
+        run: |
+          docker exec secondary pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Re-install CA in secondary PKI container
+        run: |
+          docker exec secondary pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg \
+              -s CA \
+              -D pki_ds_hostname=secondaryds.example.com \
+              -D pki_ds_ldaps_port=3636 \
+              -v
+
       - name: Gather artifacts from primary containers
         if: always()
         run: |

--- a/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
+++ b/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
@@ -60,12 +60,13 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         logger.info('Undeploying /%s web application', deployer.mdict['pki_subsystem'].lower())
 
-        # Delete <instance>/Catalina/localhost/<subsystem>.xml
-        pki.util.remove(
-            path=os.path.join(
-                deployer.mdict['pki_instance_configuration_path'],
-                "Catalina",
-                "localhost",
-                deployer.mdict['pki_subsystem'].lower() + ".xml"),
-            force=deployer.mdict['pki_force_destroy']
-        )
+        # Delete <instance>/Catalina/localhost/<subsystem>.xml if exists
+
+        context_xml = os.path.join(
+            deployer.mdict['pki_instance_configuration_path'],
+            'Catalina',
+            'localhost',
+            deployer.mdict['pki_subsystem'].lower() + '.xml')
+
+        if os.path.exists(context_xml):
+            pki.util.remove(context_xml)

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
@@ -678,26 +678,35 @@ public class LDAPConfigurator {
 
         try {
             connection.add(entry);
+            // replication manager added -> done
+            return;
 
         } catch (LDAPException e) {
-            if (e.getLDAPResultCode() == LDAPException.ENTRY_ALREADY_EXISTS) {
-                logger.warn("Entry already exists: " + dn);
-
-                try {
-                    logger.info("Deleting " + dn);
-                    connection.delete(dn);
-
-                    logger.info("Re-adding " + dn);
-                    connection.add(entry);
-
-                } catch (LDAPException ee) {
-                    logger.warn("Unable to recreate " + dn + ": " + ee.getMessage());
-                }
-
-            } else {
+            if (e.getLDAPResultCode() != LDAPException.ENTRY_ALREADY_EXISTS) {
                 logger.error("Unable to add " + dn + ": " + e.getMessage(), e);
                 throw e;
             }
+            logger.warn("Replication manager already exists: " + dn);
+        }
+
+        logger.warn("Deleting existing replication manager: " + dn);
+
+        try {
+            connection.delete(dn);
+
+        } catch (LDAPException e) {
+            logger.error("Unable to delete " + dn + ": " + e.getMessage());
+            throw e;
+        }
+
+        logger.warn("Adding new replication manager: " + dn);
+
+        try {
+            connection.add(entry);
+
+        } catch (LDAPException e) {
+            logger.error("Unable to add " + dn + ": " + e.getMessage());
+            throw e;
         }
     }
 
@@ -816,28 +825,41 @@ public class LDAPConfigurator {
 
         try {
             connection.add(entry);
+            // replica object added -> done
+            return true;
 
         } catch (LDAPException e) {
-
             if (e.getLDAPResultCode() != LDAPException.ENTRY_ALREADY_EXISTS) {
+                logger.error("Unable to add " + replicaDN + ": " + e.getMessage(), e);
                 throw e;
             }
-
-            // BZ 470918: We can't just add the new dn.
-            // We need to do a replace until the bug is fixed.
-            logger.warn("Entry already exists, adding bind DN");
-
-            entry = connection.read(replicaDN);
-            LDAPAttribute attr = entry.getAttribute("nsDS5ReplicaBindDN");
-            attr.addValue(bindDN);
-
-            LDAPModification mod = new LDAPModification(LDAPModification.REPLACE, attr);
-            connection.modify(replicaDN, mod);
-
-            return false;
+            logger.warn("Replica object already exists: " + replicaDN);
         }
 
-        return true;
+        logger.info("Adding replica bind DN");
+
+        // BZ 470918: We can't just add the new dn.
+        // We need to do a replace until the bug is fixed.
+
+        entry = connection.read(replicaDN);
+        LDAPAttribute attr = entry.getAttribute("nsDS5ReplicaBindDN");
+        attr.addValue(bindDN);
+
+        LDAPModification mod = new LDAPModification(LDAPModification.REPLACE, attr);
+
+        try {
+            connection.modify(replicaDN, mod);
+            // replica bind DN added -> done
+
+        } catch (LDAPException e) {
+            if (e.getLDAPResultCode() != LDAPException.ATTRIBUTE_OR_VALUE_EXISTS) {
+                logger.error("Unable to add " + bindDN + ": " + e.getMessage(), e);
+                throw e;
+            }
+            logger.warn("Replica bind DN already exists: " + bindDN);
+        }
+
+        return false;
     }
 
     public void createReplicationAgreement(
@@ -881,29 +903,33 @@ public class LDAPConfigurator {
 
         try {
             connection.add(entry);
+            // replication agreement added -> done
+            return;
 
         } catch (LDAPException e) {
-            if (e.getLDAPResultCode() == LDAPException.ENTRY_ALREADY_EXISTS) {
-                logger.warn("Entry already exists: " + dn);
-
-                try {
-                    connection.delete(dn);
-                } catch (LDAPException ee) {
-                    logger.error("Unable to delete " + dn + ": " + ee.getMessage(), ee);
-                    throw ee;
-                }
-
-                try {
-                    connection.add(entry);
-                } catch (LDAPException ee) {
-                    logger.error("Unable to add " + dn + ": " + ee.getMessage(), ee);
-                    throw ee;
-                }
-
-            } else {
+            if (e.getLDAPResultCode() != LDAPException.ENTRY_ALREADY_EXISTS) {
                 logger.error("Unable to add " + dn + ": " + e.getMessage(), e);
                 throw e;
             }
+            logger.warn("Replication agreement already exists: " + dn);
+        }
+
+        logger.warn("Removing existing replication agreement: " + dn);
+
+        try {
+            connection.delete(dn);
+        } catch (LDAPException e) {
+            logger.error("Unable to delete " + dn + ": " + e.getMessage(), e);
+            throw e;
+        }
+
+        logger.warn("Adding new replication agreement: " + dn);
+
+        try {
+            connection.add(entry);
+        } catch (LDAPException e) {
+            logger.error("Unable to add " + dn + ": " + e.getMessage(), e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
The `pkispawn` and `pkidestroy` have been modified to ignore failures caused by adding an entry or attribute that is already exists and to check whether a file exists before removing it during replica removal and reinstallation.

One of the CA clone tests has been modified to test removing and reinstalling a replica.

Resolves: https://github.com/dogtagpki/pki/issues/3544