### PR TITLE
Fixes for classpath on F35+

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -21,6 +21,11 @@
 	<classpathentry kind="src" path="base/acme/src/main/java"/>
 	<classpathentry kind="src" path="base/console/src/main/java"/>
 	<classpathentry excluding="**/CMakeLists.txt" kind="src" path="tests/dogtag/dev_java_tests/src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="lib" path="/usr/share/java/apache-commons-cli.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/apache-commons-logging.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/commons-codec.jar"/>
@@ -47,9 +52,7 @@
 	<classpathentry kind="lib" path="/usr/share/java/tomcat/tomcat-util-scan.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/slf4j/slf4j-api.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/tomcat/tomcat-coyote.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/hamcrest/core.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/jboss-logging/jboss-logging.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/tomcat/tomcat-juli.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/tomcat/jaspic-api.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/jackson-databind.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/jackson-core.jar"/>
@@ -58,10 +61,6 @@
 	<classpathentry kind="lib" path="/usr/share/java/jackson-annotations.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/jackson-modules/jackson-module-jaxb-annotations.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/apache-commons-net.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="lib" path="/usr/share/java/hamcrest/hamcrest.jar"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/base/server/src/test/java/com/netscape/cmscore/password/PlainPasswordFileTest.java
+++ b/base/server/src/test/java/com/netscape/cmscore/password/PlainPasswordFileTest.java
@@ -17,16 +17,17 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cmscore.password;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import com.netscape.cmsutil.password.PlainPasswordFile;
@@ -66,9 +67,6 @@ public class PlainPasswordFileTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testInitNormal() throws IOException {
@@ -112,20 +110,17 @@ public class PlainPasswordFileTest {
 
     @Test
     public void testNoValue() throws IOException {
-        expectedException.expect(IOException.class);
-        testHelper(8, false);
+        assertThrows(IOException.class, () -> testHelper(8, false));
     }
 
     @Test
     public void testWrongDelimiter() throws IOException {
-        expectedException.expect(IOException.class);
-        testHelper(9, false);
+        assertThrows(IOException.class, () -> testHelper(9, false));
     }
 
     @Test
     public void testSpaceDelimiter() throws IOException {
-        expectedException.expect(IOException.class);
-        testHelper(10, false);
+        assertThrows(IOException.class, () -> testHelper(10, false));
     }
 
     private void writeToFileAndInit(File file, String string) throws IOException {
@@ -136,9 +131,9 @@ public class PlainPasswordFileTest {
     private void testHelper(int testCaseId, boolean isEmpty) throws IOException {
         writeToFileAndInit(createdFile, testCases[testCaseId][TESTCASE_ENTRY]);
         if (isEmpty) {
-            Assert.assertEquals(0, pwdFile.getSize());
+            assertEquals(0, pwdFile.getSize());
         } else {
-            Assert.assertEquals(testCases[testCaseId][TESTCASE_VALUE],
+            assertEquals(testCases[testCaseId][TESTCASE_VALUE],
                     pwdFile.getPassword(testCases[testCaseId][TESTCASE_KEY], 0));
         }
     }


### PR DESCRIPTION
* Remove JARs that are no longer needed from classpath
* Replace Matcher `expectedException.expect()` with JUnit's `assertThrows()`