### PR TITLE
Update Fedora container and COPR repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ARG COMPONENT="pki-core"
 ARG LICENSE="GPLv2 and LGPLv2"
 ARG ARCH="x86_64"
 ARG VERSION="0"
-ARG OS_VERSION="latest"
-ARG COPR_REPO="@pki/10.11"
+ARG OS_VERSION="34"
+ARG COPR_REPO="@pki/10.12"
 
 ################################################################################
 FROM registry.fedoraproject.org/fedora:$OS_VERSION AS pki-builder

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For other types of deployments (Sub-CA, Clones, HSMs, etc) please see under [doc
 sudo dnf install dnf-plugins-core rpm-build git
 
 # NOTE: Use the intendended branch name instead of "master" to pull right dependency version
-sudo dnf copr enable @pki/10.11
+sudo dnf copr enable @pki/10.12
 
 sudo dnf builddep pki.spec
 ````

--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -5,7 +5,7 @@
 #
 # https://docs.fedoraproject.org/en-US/containers/guidelines/guidelines/
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:34
 
 ARG NAME="pki-acme"
 ARG SUMMARY="Dogtag PKI ACME Responder"
@@ -15,7 +15,7 @@ ARG ARCH="x86_64"
 ARG MAINTAINER="Dogtag PKI Team <devel@lists.dogtagpki.org>"
 ARG VENDOR="Dogtag"
 ARG COMPONENT="pki-core"
-ARG COPR_REPO="@pki/10.11"
+ARG COPR_REPO="@pki/10.12"
 
 LABEL name="$NAME" \
       summary="$SUMMARY" \

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -2,7 +2,7 @@
 
 if [ "$BASE64_MATRIX" == "" ]
 then
-    MATRIX="{\"os\":[\"latest\"]}"
+    MATRIX="{\"os\":[\"34\"]}"
 else
     MATRIX=$(echo "$BASE64_MATRIX" | base64 -d)
 fi
@@ -12,7 +12,7 @@ echo "::set-output name=matrix::$MATRIX"
 
 if [ "$BASE64_REPO" == "" ]
 then
-    REPO="@pki/10.11"
+    REPO="@pki/10.12"
 else
     REPO=$(echo "$BASE64_REPO" | base64 -d)
 fi

--- a/tests/dogtag/pytest-ansible/provision/post_provision.yml
+++ b/tests/dogtag/pytest-ansible/provision/post_provision.yml
@@ -11,5 +11,5 @@
       when: ansible_distribution == "Fedora"
 
     - name: set PKI master copr repo
-      shell: dnf copr enable @pki/10.11 -y
+      shell: dnf copr enable @pki/10.12 -y
       when: ansible_distribution == "Fedora"


### PR DESCRIPTION
PKI 10.12 is only supported up to Fedora 34, so the Fedora container has been changed to `fedora:34` and the COPR repository has been changed to `@pki/10.12`.