### PR TITLE
Don't allow SHA-1 by default

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CAService.java
+++ b/base/ca/src/main/java/com/netscape/ca/CAService.java
@@ -1628,7 +1628,7 @@ class serviceCheckChallenge implements IServant {
 
     public serviceCheckChallenge(CAService service) {
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
         } catch (NoSuchAlgorithmException e) {
             logger.warn(CMS.getLogMessage("OPERATION_ERROR", e.toString()), e);
         }

--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -1496,14 +1496,14 @@ public class CertificateAuthority
     public ResponderID getResponderIDByHash() {
 
         /*
-         KeyHash ::= OCTET STRING --SHA-1 hash of responder's public key
+         KeyHash ::= OCTET STRING --SHA-256 hash of responder's public key
          --(excluding the tag and length fields)
          */
         PublicKey publicKey = getOCSPSigningUnit().getPublicKey();
         MessageDigest md = null;
 
         try {
-            md = MessageDigest.getInstance("SHA1");
+            md = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
         } catch (NoSuchAlgorithmException e) {
             return null;
         }

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -174,7 +174,7 @@ public class CRSEnrollment extends HttpServlet {
     private boolean mUseCA = true;
     private String mNickname = null;
     private String mTokenName = "";
-    private String mHashAlgorithm = "SHA1";
+    private String mHashAlgorithm = CryptoUtil.getDefaultHashAlgName();
     private String mHashAlgorithmList = null;
     private String[] mAllowedHashAlgorithm;
     private String mConfiguredEncryptionAlgorithm = "DES3";
@@ -265,7 +265,7 @@ public class CRSEnrollment extends HttpServlet {
                 mIsDynamicProfileId = true;
                 logger.debug("CRSEnrollment: init: expecting dynamic ProfileId in URL");
             }
-            mHashAlgorithm = scepConfig.getString("hashAlgorithm", "SHA1");
+            mHashAlgorithm = scepConfig.getString("hashAlgorithm", CryptoUtil.getDefaultHashAlgName());
             mConfiguredEncryptionAlgorithm = scepConfig.getString("encryptionAlgorithm", "DES3");
             mNonceSizeLimit = scepConfig.getInteger("nonceSizeLimit", 0);
             mHashAlgorithmList = scepConfig.getString("allowedHashAlgorithms", "SHA1,SHA256,SHA512");
@@ -357,7 +357,7 @@ public class CRSEnrollment extends HttpServlet {
         OID_SERIALNUMBER = X500NameAttrMap.getDefault().getOid("SERIALNUMBER");
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
         } catch (NoSuchAlgorithmException e) {
         }
 

--- a/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
+++ b/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
@@ -232,14 +232,14 @@ public class OCSPAuthority implements IOCSPAuthority, IOCSPService, IAuthority {
     public ResponderID getResponderIDByHash() {
 
         /*
-         KeyHash ::= OCTET STRING --SHA-1 hash of responder's public key
+         KeyHash ::= OCTET STRING --SHA-256 hash of responder's public key
          --(excluding the tag and length fields)
          */
         PublicKey publicKey = getSigningUnit().getPublicKey();
         MessageDigest md = null;
 
         try {
-            md = MessageDigest.getInstance("SHA1");
+            md = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
         } catch (NoSuchAlgorithmException e) {
             return null;
         }

--- a/base/server/src/main/java/com/netscape/cms/authentication/HashAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/HashAuthentication.java
@@ -26,9 +26,9 @@ import java.util.Hashtable;
 import java.util.Locale;
 import java.util.Vector;
 
+import org.dogtagpki.server.authentication.AuthManager;
 import org.dogtagpki.server.authentication.AuthManagerConfig;
 import org.dogtagpki.server.authentication.AuthToken;
-import org.dogtagpki.server.authentication.AuthManager;
 import org.mozilla.jss.netscape.security.util.Utils;
 
 import com.netscape.certsrv.authentication.EAuthException;
@@ -38,6 +38,7 @@ import com.netscape.certsrv.authentication.IAuthToken;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.IExtendedPluginInfo;
 import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
  * Hash uid/pwd directory based authentication manager
@@ -95,7 +96,7 @@ public class HashAuthentication implements AuthManager, IExtendedPluginInfo {
         mHosts = new HashAuthData();
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
         } catch (NoSuchAlgorithmException e) {
             throw new EAuthException(CMS.getUserMessage("CMS_AUTHENTICATION_INTERNAL_ERROR", e.getMessage()));
         }

--- a/base/server/src/main/java/com/netscape/cms/servlet/base/CMSServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/base/CMSServlet.java
@@ -109,6 +109,7 @@ import com.netscape.cmscore.request.RequestRepository;
 import com.netscape.cmscore.security.JssSubsystem;
 import com.netscape.cmscore.usrgrp.Group;
 import com.netscape.cmscore.usrgrp.UGSubsystem;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 import com.netscape.cmsutil.xml.XMLObject;
 
 /**
@@ -376,7 +377,7 @@ public abstract class CMSServlet extends HttpServlet {
         }
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
         } catch (NoSuchAlgorithmException e) {
             logger.error(CMS.getLogMessage("CMSGW_ERR_CONF_TEMP_PARAMS", e.toString()), e);
             throw new ServletException(e);

--- a/base/server/src/main/java/com/netscape/cms/servlet/processors/CMCProcessor.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/processors/CMCProcessor.java
@@ -68,6 +68,7 @@ import com.netscape.certsrv.request.IRequest;
 import com.netscape.cms.servlet.base.CMSServlet;
 import com.netscape.cms.servlet.common.ECMSGWException;
 import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
  * Process CMC messages according to RFC 2797
@@ -299,7 +300,7 @@ public class CMCProcessor extends PKIProcessor {
                         X509Key subjectKeyInfo =
                                 (X509Key) ((CertificateX509Key) certInfoArray[j].get(X509CertInfo.KEY))
                                         .get(CertificateX509Key.KEY);
-                        MessageDigest md = MessageDigest.getInstance("SHA-1");
+                        MessageDigest md = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
 
                         md.update(subjectKeyInfo.getEncoded());
                         byte[] skib = md.digest();

--- a/base/server/src/main/java/com/netscape/cmscore/authentication/ChallengePhraseAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cmscore/authentication/ChallengePhraseAuthentication.java
@@ -44,6 +44,7 @@ import com.netscape.cmscore.dbs.CertRecord;
 import com.netscape.cmscore.dbs.CertificateRepository;
 import com.netscape.cmscore.request.RequestQueue;
 import com.netscape.cmscore.request.RequestRepository;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
  * Challenge phrase based authentication.
@@ -113,7 +114,7 @@ public class ChallengePhraseAuthentication implements AuthManager {
         mConfig = config;
 
         try {
-            mSHADigest = MessageDigest.getInstance("SHA1");
+            mSHADigest = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
 
         } catch (NoSuchAlgorithmException e) {
             throw new EAuthException(CMS.getUserMessage("CMS_AUTHENTICATION_INTERNAL_ERROR", e.getMessage()), e);

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
@@ -66,6 +66,7 @@ import com.netscape.certsrv.tps.token.TokenStatus;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.security.JssSubsystem;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 
 public class TPSEnrollProcessor extends TPSProcessor {
 
@@ -3748,8 +3749,6 @@ public class TPSEnrollProcessor extends TPSProcessor {
 
     private TPSBuffer makeKeyIDFromPublicKeyInfo(byte[] publicKeyInfo) throws TPSException {
 
-        final String alg = "SHA1";
-
         if (publicKeyInfo == null) {
             throw new TPSException("TPSEnrollProcessor.makeKeyIDFromPublicKeyInfo: invalid input data",
                     TPSStatus.STATUS_ERROR_MAC_ENROLL_PDU);
@@ -3761,7 +3760,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
 
         java.security.MessageDigest mozillaDigest;
         try {
-            mozillaDigest = java.security.MessageDigest.getInstance(alg);
+            mozillaDigest = java.security.MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
         } catch (NoSuchAlgorithmException e) {
             throw new TPSException("TPSEnrollProcessor.makeKeyIDFromPublicKeyInfo: " + e,
                     TPSStatus.STATUS_ERROR_MAC_ENROLL_PDU);

--- a/base/util/src/main/java/com/netscape/cmsutil/ocsp/OCSPProcessor.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/ocsp/OCSPProcessor.java
@@ -44,6 +44,8 @@ import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.mozilla.jss.netscape.security.x509.X509Key;
 import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
 /**
  * This class implements an OCSP utility.
  *
@@ -98,7 +100,7 @@ public class OCSPProcessor {
     public OCSPRequest createRequest(X500Name issuerName, X509Key issuerKey, BigInteger serialNumber)
             throws Exception {
 
-        MessageDigest md = MessageDigest.getInstance("SHA");
+        MessageDigest md = MessageDigest.getInstance(CryptoUtil.getDefaultHashAlgName());
 
         // calculate hashes
         byte issuerNameHash[] = md.digest(issuerName.getEncoded());


### PR DESCRIPTION
Instances where `SHA-1` is hardcoded/the default algorithm have been replaced with `CryptoUtil.getDefaultHashAlgName()`, which is currently `SHA-256`. This will also allow us to easily test a new default in the future.

There are some exceptions:

- Methods relating to Subject Key Identifier and Authority Key Identifier fields have been left at `SHA-1`, as this is _de facto_ expected behaviour according to RFC 5280
- `CheckRequest` - I was unsure of a replacement for `signAlg = SignatureAlgorithm.DSASignatureWithSHA1Digest;`, advice welcome
-  I was unsure of a replacement for `PBEAlgorithm.PBE_SHA1_DES3_CBC` in KRA classes