### PR TITLE
"Fix Bug 2001169 - Audit event 'ACCESS_SESSION_ESTABLISH' is not gener…

### DIFF
--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -147,9 +147,11 @@ public class CMSEngine implements ServletContextListener {
 
     private Debug debug = new Debug();
     private PluginRegistry pluginRegistry = new PluginRegistry();
+    private PKIServerSocketListener serverSocketListener = null;
     protected LogSubsystem logSubsystem = LogSubsystem.getInstance();
     protected JssSubsystem jssSubsystem = JssSubsystem.getInstance();
     protected DBSubsystem dbSubsystem = new DBSubsystem();
+
 
     protected RequestRepository requestRepository;
     protected RequestQueue requestQueue;
@@ -1128,16 +1130,19 @@ public class CMSEngine implements ServletContextListener {
         // Register realm for this subsystem
         ProxyRealm.registerRealm(id, new PKIRealm());
 
-        // Register TomcatJSS socket listener
-        TomcatJSS tomcatJss = TomcatJSS.getInstance();
-        tomcatJss.addSocketListener(new PKIServerSocketListener());
-
         ready = true;
         isStarted = true;
 
         mStartupTime = System.currentTimeMillis();
 
         logger.info(name + " engine started");
+        // Register TomcatJSS socket listener
+        TomcatJSS tomcatJss = TomcatJSS.getInstance();
+        if(serverSocketListener == null) {
+            serverSocketListener = new PKIServerSocketListener();
+        }
+        tomcatJss.addSocketListener(serverSocketListener);
+
         notifySubsystemStarted();
     }
 
@@ -1327,6 +1332,12 @@ public class CMSEngine implements ServletContextListener {
      */
     public void shutdown() {
 
+        isStarted = false;
+        if(serverSocketListener != null) {
+            // De-Register TomcatJSS socket listener
+            TomcatJSS tomcatJss = TomcatJSS.getInstance();
+            tomcatJss.removeSocketListener(serverSocketListener);
+        }
         logger.info("Shutting down " + name + " subsystem");
 
         /*

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
@@ -2387,6 +2387,7 @@ public class TPSProcessor {
             try {
                 tps.tdb.tdbAddTokenEntry(tokenRecord, TokenStatus.UNFORMATTED);
                 tps.tdb.tdbActivity(ActivityDatabase.OP_ADD, tokenRecord, session.getIpAddress(), logMsg, "success");
+                fillTokenRecordDefaultPolicy(tokenRecord);
                 logger.debug("TPSProcessor.format: token added");
             } catch (Exception e) {
                 logMsg = logMsg + ":" + e.toString();


### PR DESCRIPTION
…ating for PKI instances acting as Server [10.2.1] (#3745) (#3763)

This fix allows us to actually see ssl connection events in the audit log from the pki /server perspective.
This fill will also require support bug fixes for both jss and tomcatjss.

Added fix for stray alerts showing up after a server is going down.

Sample audit log messages:

0.https-jsse-nio-18443-exec-6 - [29/Sep/2021:21:09:31 EDT] [14] [6] [AuditEvent=ACCESS_SESSION_ESTABLISH][ClientIP=--][ServerIP=--][SubjectID=CN=PKI Administrator,E=example@testdomain.com,OU=rhcs94-CA-cfu_rsa-nocp11,O=Example-rhcs94-CA_cfu-rsa][Outcome=Success] access session establish success
0.https-jsse-nio-18443-exec-16 - [29/Sep/2021:21:09:32 EDT] [14] [6] [AuditEvent=AUTHZ][SubjectID=$NonRoleUser$][Outcome=Success][aclResource=certServer.ee.profiles][Op=list] authorization success

0.https-jsse-nio-18443-exec-16 - [29/Sep/2021:21:11:34 EDT] [14] [6] [AuditEvent=ACCESS_SESSION_TERMINATED][ClientIP=--][ServerIP=--][SubjectID=CN=PKI Administrator,E=example@testdomain.com,OU=rhcs94-CA-cfu_rsa-nocp11,O=Example-rhcs94-CA_cfu-rsa][Outcome=Success][Info=serverAlertReceived: CLOSE_NOTIFY] access session terminated
0.https-jsse-nio-18443-exec-16 - [29/Sep/2021:21:11:34 EDT] [14] [6] [AuditEvent=ACCESS_SESSION_TERMINATED][ClientIP=--][ServerIP=--][SubjectID=CN=PKI Administrator,E=example@testdomain.com,OU=rhcs94-CA-cfu_rsa-nocp11,O=Example-rhcs94-CA_cfu-rsa][Outcome=Success][Info=serverAlertSent: CLOSE_NOTIFY] access session terminated"


This was a change made by @jmagne to fix bug: 2001169 for RHCS 10.2.1, Originally he only made the change on the `v10.11` branch but it needs to go to `master` and `v10.12` as well. 

Tested locally by building and installing JSS, tomcatjss, and pki and observed the AUDIT logs:
```
0.https-jsse-nio-8443-exec-15 - [05/Nov/2021:15:31:17 GMT] [14] [6] [AuditEvent=ACCESS_SESSION_ESTABLISH][ClientIP=--][ServerIP=--][SubjectID=--][Outcome=Success] access session establish success
0.https-jsse-nio-8443-exec-16 - [05/Nov/2021:15:31:17 GMT] [14] [6] [AuditEvent=ACCESS_SESSION_TERMINATED][ClientIP=--][ServerIP=--][SubjectID=--][Outcome=Success][Info=serverAlertReceived: CLOSE_NOTIFY] access session terminated
```

This PR is dependent on JSS PR: https://github.com/dogtagpki/jss/pull/822 