### PR TITLE
Update NSSDatabase.create_request(), create_cert(), add_cert()

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -94,21 +94,24 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 request_file=csr_file,
                 token=deployer.mdict['pki_self_signed_token'],
                 key_type=deployer.mdict['pki_sslserver_key_type'],
-                key_size=deployer.mdict['pki_sslserver_key_size']
+                key_size=deployer.mdict['pki_sslserver_key_size'],
+                use_jss=True
             )
 
             nssdb.create_cert(
                 request_file=csr_file,
                 cert_file=cert_file,
                 serial=deployer.mdict['pki_self_signed_serial_number'],
-                validity=deployer.mdict['pki_self_signed_validity_period']
+                validity=deployer.mdict['pki_self_signed_validity_period'],
+                use_jss=True
             )
 
             nssdb.add_cert(
                 nickname=nickname,
                 cert_file=cert_file,
                 token=deployer.mdict['pki_self_signed_token'],
-                trust_attributes=deployer.mdict['pki_self_signed_trustargs']
+                trust_attributes=deployer.mdict['pki_self_signed_trustargs'],
+                use_jss=True
             )
 
             return True


### PR DESCRIPTION
The `NSSDatabase.create_request()`, `create_cert()`, and `add_cert()` have been modified to provide an option to use JSS-based PKI CLIs instead of NSS-based certutil to generate a CSR, issue a cert, and import the cert. In the future the methods will only use the PKI CLIs since they can support long serial numbers.

The `pkispawn` has been modified to use the PKI CLIs to generate the temporary SSL server certificate during installation.