### PR TITLE
Remove hard-coded temp SSL server cert params

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1080,7 +1080,7 @@ class NSSDatabase(object):
             self,
             request_file,
             cert_file,
-            serial,
+            serial=None,
             issuer=None,
             key_usage_ext=None,
             basic_constraints_ext=None,
@@ -1095,7 +1095,7 @@ class NSSDatabase(object):
             self.__create_cert(
                 request_file,
                 cert_file,
-                serial,
+                serial=serial,
                 validity=validity)
             return
 
@@ -1276,7 +1276,7 @@ class NSSDatabase(object):
             self,
             request_file,
             cert_file,
-            serial,
+            serial=None,
             validity=None):
         '''
         Issue certificate using pki nss-cert-issue command.
@@ -1296,8 +1296,10 @@ class NSSDatabase(object):
 
         cmd.extend(['nss-cert-issue'])
         cmd.extend(['--csr', request_file])
-        cmd.extend(['--serial', str(serial)])
         cmd.extend(['--cert', cert_file])
+
+        if serial:
+            cmd.extend(['--serial', serial])
 
         if validity:
             cmd.extend(['--months-valid', str(validity)])

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -895,9 +895,6 @@ class PKIConfigParser:
             self.mdict['pki_self_signed_subject'] = \
                 "cn=" + self.mdict['pki_hostname'] + "," + \
                 "o=" + self.mdict['pki_certificate_timestamp']
-            self.mdict['pki_self_signed_serial_number'] = 0
-            self.mdict['pki_self_signed_validity_period'] = 12
-            self.mdict['pki_self_signed_trustargs'] = "CTu,CTu,CTu"
 
             # Tomcat NSS security database convenience
             # symbolic links

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -101,8 +101,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             nssdb.create_cert(
                 request_file=csr_file,
                 cert_file=cert_file,
-                serial=deployer.mdict['pki_self_signed_serial_number'],
-                validity=deployer.mdict['pki_self_signed_validity_period'],
+                serial=deployer.mdict.get('pki_self_signed_serial_number'),
+                validity=deployer.mdict.get('pki_self_signed_validity_period'),
                 use_jss=True
             )
 
@@ -110,7 +110,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 nickname=nickname,
                 cert_file=cert_file,
                 token=deployer.mdict['pki_self_signed_token'],
-                trust_attributes=deployer.mdict['pki_self_signed_trustargs'],
+                trust_attributes=deployer.mdict.get('pki_self_signed_trustargs'),
                 use_jss=True
             )
 


### PR DESCRIPTION
Previously the parameters for the temp SSL server cert were hard-coded as follows:

- `pki_self_signed_serial_number`: `0`
- `pki_self_signed_validity_period`: `12` months
- `pki_self_signed_trustargs`: `CTu,CTu,CTu`

The hard-coded values have been removed so it will use the default values provided by the `pki nss-cert` commands:

- serial number: 128-bit random integer
- validity: 3 months
- trust attribute: none

The new default values should be fine since the cert will only exists temporarily during installation.

This change also allows the admin to override the default values if necessary by specifying these parameters in the `pkispawn` configuration.