### PR TITLE
Add pki nss-cert-find

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertCLI.java
@@ -16,6 +16,7 @@ public class NSSCertCLI extends CLI {
     public NSSCertCLI(NSSCLI nssCLI) {
         super("cert", "NSS certificate management commands", nssCLI);
 
+        addModule(new NSSCertFindCLI(this));
         addModule(new NSSCertExportCLI(this));
         addModule(new NSSCertImportCLI(this));
         addModule(new NSSCertIssueCLI(this));

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertFindCLI.java
@@ -1,0 +1,54 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CommandCLI;
+import org.mozilla.jss.crypto.CryptoStore;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.X509Certificate;
+
+import com.netscape.cmstools.cli.MainCLI;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class NSSCertFindCLI extends CommandCLI {
+
+    public NSSCertFindCLI(NSSCertCLI certCLI) {
+        super("find", "Find certificates", certCLI);
+    }
+
+    @Override
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...]", options);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        String tokenName = getConfig().getTokenName();
+        CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
+        CryptoStore store = token.getCryptoStore();
+        X509Certificate[] certs = store.getCertificates();
+        boolean first = true;
+
+        for (X509Certificate cert : certs) {
+
+            if (first) {
+                first = false;
+            } else {
+                System.out.println();
+            }
+
+            NSSCertCLI.printCertInfo(cert);
+        }
+    }
+}

--- a/docs/changes/v11.1.0/Tools-Changes.adoc
+++ b/docs/changes/v11.1.0/Tools-Changes.adoc
@@ -21,3 +21,7 @@ The `pki-server <subsystem>-db-access` commands have been added to manage the ac
 == pkidaemon Changes ==
 
 The `pkidaemon status` command has been removed. Use `pki-server status` instead.
+
+== New pki nss-cert-find CLI ==
+
+The `pki nss-cert-find` command has been added to list certificates in NSS database.


### PR DESCRIPTION
The `pki nss-cert-find` has been added to list certificates in NSS database.

https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-CLI
https://github.com/edewata/pki/blob/cli-nss/docs/changes/v11.1.0/Tools-Changes.adoc
