### PR TITLE
Backport acme-wait.sh to v11.0

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -448,6 +448,7 @@ jobs:
 
       - name: Verify certbot in client container
         run: |
+          tests/acme/bin/acme-wait.sh client http://pki.example.com:8080/acme/directory
           docker exec client certbot register \
               --server http://pki.example.com:8080/acme/directory \
               --email user1@example.com \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,17 @@ install(
 
 install(
     DIRECTORY
+        acme/bin/
+    DESTINATION
+        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/tests/acme/bin
+    FILE_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)
+
+install(
+    DIRECTORY
         ca/bin/
     DESTINATION
         ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/tests/ca/bin

--- a/tests/acme/bin/acme-wait.sh
+++ b/tests/acme/bin/acme-wait.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+NAME=$1
+URL=$2
+
+if [ "$NAME" == "" -o "$URL" == "" ]
+then
+    echo "Usage: acme-wait.sh <name> <URL>"
+    exit 1
+fi
+
+if [ "$MAX_WAIT" == "" ]
+then
+    MAX_WAIT=60 # seconds
+fi
+
+start_time=$(date +%s)
+
+while :
+do
+    sleep 1
+
+    docker exec client curl -ISs $URL
+
+    if [ $? -eq 0 ]
+    then
+        break
+    fi
+
+    current_time=$(date +%s)
+    elapsed_time=$(expr $current_time - $start_time)
+
+    if [ $elapsed_time -ge $MAX_WAIT ]
+    then
+        echo "ACME server did not start after ${MAX_WAIT}s"
+        exit 1
+    fi
+
+    echo "Waiting for ACME server to start (${elapsed_time}s)"
+done
+
+echo "ACME server is started"


### PR DESCRIPTION
It was backported to v10.11+ but not to v11.0, so the CI failure this addresses was still appearing for PKI 11.0 