### PR TITLE
Add PKISubsystem.setup_replication()

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBCLI.java
@@ -19,11 +19,12 @@
 package org.dogtagpki.server.ca.cli;
 
 import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemDBAccessCLI;
 import org.dogtagpki.server.cli.SubsystemDBEmptyCLI;
 import org.dogtagpki.server.cli.SubsystemDBInfoCLI;
 import org.dogtagpki.server.cli.SubsystemDBInitCLI;
-import org.dogtagpki.server.cli.SubsystemDBAccessCLI;
 import org.dogtagpki.server.cli.SubsystemDBRemoveCLI;
+import org.dogtagpki.server.cli.SubsystemDBReplicationCLI;
 import org.dogtagpki.server.cli.SubsystemDBVLVCLI;
 
 /**
@@ -41,6 +42,7 @@ public class CADBCLI extends CLI {
         addModule(new CADBUpgradeCLI(this));
 
         addModule(new SubsystemDBAccessCLI(this));
+        addModule(new SubsystemDBReplicationCLI(this));
         addModule(new SubsystemDBVLVCLI(this));
     }
 }

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -954,10 +954,6 @@ class PKISubsystem(object):
             create_base=False,
             create_containers=False,
             rebuild_indexes=False,
-            setup_replication=False,
-            replication_security=None,
-            replication_port=None,
-            master_replication_port=None,
             as_current_user=False):
 
         cmd = [self.name + '-db-init']
@@ -976,18 +972,6 @@ class PKISubsystem(object):
 
         if rebuild_indexes:
             cmd.append('--rebuild-indexes')
-
-        if setup_replication:
-            cmd.append('--setup-replication')
-
-        if replication_security:
-            cmd.extend(['--replication-security', replication_security])
-
-        if replication_port:
-            cmd.extend(['--replication-port', replication_port])
-
-        if master_replication_port:
-            cmd.extend(['--master-replication-port', master_replication_port])
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -1066,6 +1050,32 @@ class PKISubsystem(object):
             cmd,
             as_current_user=as_current_user,
             capture_output=True)
+
+    def setup_replication(
+            self,
+            master_replication_port=None,
+            replica_replication_port=None,
+            replication_security=None,
+            as_current_user=False):
+
+        cmd = [self.name + '-db-replication-setup']
+
+        if master_replication_port:
+            cmd.extend(['--master-replication-port', master_replication_port])
+
+        if replica_replication_port:
+            cmd.extend(['--replica-replication-port', replica_replication_port])
+
+        if replication_security:
+            cmd.extend(['--replication-security', replication_security])
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd, as_current_user=as_current_user)
 
     def find_vlv(self, as_current_user=False):
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBCLI.java
@@ -35,6 +35,7 @@ public class SubsystemDBCLI extends CLI {
         addModule(new SubsystemDBUpgradeCLI(this));
 
         addModule(new SubsystemDBAccessCLI(this));
+        addModule(new SubsystemDBReplicationCLI(this));
         addModule(new SubsystemDBVLVCLI(this));
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
@@ -11,19 +11,12 @@ import org.dogtagpki.cli.CLI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netscape.certsrv.base.IConfigStore;
 import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
-import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.apps.EngineConfig;
-import com.netscape.cmscore.apps.PreOpConfig;
-import com.netscape.cmscore.base.ConfigStorage;
-import com.netscape.cmscore.base.FileConfigStore;
-import com.netscape.cmscore.base.PropConfigStore;
 import com.netscape.cmscore.ldapconn.LDAPAuthenticationConfig;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
 import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
 import com.netscape.cmscore.ldapconn.LdapAuthInfo;
-import com.netscape.cmscore.ldapconn.LdapBoundConnFactory;
 import com.netscape.cmscore.ldapconn.LdapBoundConnection;
 import com.netscape.cmscore.ldapconn.LdapConnInfo;
 import com.netscape.cmscore.ldapconn.PKISocketConfig;
@@ -31,8 +24,6 @@ import com.netscape.cmscore.ldapconn.PKISocketFactory;
 import com.netscape.cmsutil.ldap.LDAPUtil;
 import com.netscape.cmsutil.password.IPasswordStore;
 import com.netscape.cmsutil.password.PasswordStoreConfig;
-
-import netscape.ldap.LDAPConnection;
 
 /**
  * @author Endi S. Dewata
@@ -61,10 +52,6 @@ public class SubsystemDBInitCLI extends SubsystemCLI {
         options.addOption(null, "create-base", false, "Create base entry");
         options.addOption(null, "create-containers", false, "Create container entries");
         options.addOption(null, "rebuild-indexes", false, "Rebuild indexes");
-        options.addOption(null, "setup-replication", false, "Set up replication");
-        options.addOption(null, "replication-security", true, "Replication security");
-        options.addOption(null, "replication-port", true, "Replication port");
-        options.addOption(null, "master-replication-port", true, "Master replication port");
 
         options.addOption("v", "verbose", false, "Run in verbose mode.");
         options.addOption(null, "debug", false, "Run in debug mode.");
@@ -138,187 +125,8 @@ public class SubsystemDBInitCLI extends SubsystemCLI {
                 ldapConfigurator.rebuildIndexes(subsystem);
             }
 
-            if (cmd.hasOption("setup-replication")) {
-                String replicationSecurity = cmd.getOptionValue("replication-security");
-                String replicationPort = cmd.getOptionValue("replication-port");
-                String masterReplicationPort = cmd.getOptionValue("master-replication-port");
-
-                setupReplication(
-                        cs,
-                        passwordStore,
-                        replicationSecurity,
-                        replicationPort,
-                        masterReplicationPort);
-            }
-
-            cs.commit(false);
-
         } finally {
             conn.disconnect();
         }
-    }
-
-    public void setupReplication(
-            EngineConfig cs,
-            IPasswordStore passwordStore,
-            String replicationSecurity,
-            String replicaReplicationPort,
-            String masterReplicationPort) throws Exception {
-
-        String hostname = cs.getHostname();
-        String instanceId = cs.getInstanceID();
-        String subsystem = cs.getType().toLowerCase();
-        PreOpConfig preopConfig = cs.getPreOpConfig();
-
-        PKISocketConfig socketConfig = cs.getSocketConfig();
-
-        LDAPConfig ldapConfig = cs.getInternalDBConfig();
-        LDAPConnectionConfig replicaConnConfig = ldapConfig.getConnectionConfig();
-        String replicaHostname = replicaConnConfig.getString("host", "");
-        String replicaPort = replicaConnConfig.getString("port", "");
-
-        if (replicaReplicationPort == null || replicaReplicationPort.equals("")) {
-            replicaReplicationPort = replicaPort;
-        }
-
-        LdapBoundConnFactory ldapFactory = new LdapBoundConnFactory("LDAPConfigurator");
-        ldapFactory.init(socketConfig, ldapConfig, passwordStore);
-
-        LDAPConnection conn = ldapFactory.getConn();
-        LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, ldapConfig, instanceId);
-
-        try {
-            LDAPConfig masterConfig = preopConfig.getSubStore("internaldb.master", LDAPConfig.class);
-            LDAPConnectionConfig masterConnConfig = masterConfig.getConnectionConfig();
-            String masterHostname = masterConnConfig.getString("host", "");
-            String masterPort = masterConnConfig.getString("port", "");
-
-            if (masterReplicationPort == null || masterReplicationPort.equals("")) {
-                masterReplicationPort = masterPort;
-            }
-
-            String masterReplicationPassword = preopConfig.getString("internaldb.master.replication.password", "");
-            String replicaReplicationPassword = passwordStore.getPassword("replicationdb", 0);
-
-            // set master ldap password (if it exists) temporarily in password store
-            // in case it is needed for replication.  Not stored in password.conf.
-
-            LDAPAuthenticationConfig masterAuthConfig = masterConfig.getAuthenticationConfig();
-            String masterPassword = masterAuthConfig.getString("password", "");
-
-            if (!masterPassword.equals("")) {
-                masterAuthConfig.putString("bindPWPrompt", "master_internaldb");
-                passwordStore.putPassword("master_internaldb", masterPassword);
-                passwordStore.commit();
-            }
-
-            LdapBoundConnFactory masterFactory = new LdapBoundConnFactory("MasterLDAPConfigurator");
-            masterFactory.init(socketConfig, masterConfig, passwordStore);
-
-            LDAPConnection masterConn = masterFactory.getConn();
-            LDAPConfigurator masterConfigurator = new LDAPConfigurator(masterConn, masterConfig);
-
-            try {
-                String masterAgreementName = "masterAgreement1-" + hostname + "-" + instanceId;
-                String replicaAgreementName = "cloneAgreement1-" + hostname + "-" + instanceId;
-
-                DatabaseConfig dbConfig = cs.getDatabaseConfig();
-                int beginReplicaNumber = dbConfig.getInteger("beginReplicaNumber", 1);
-                int endReplicaNumber = dbConfig.getInteger("endReplicaNumber", 100);
-                logger.info("Current replica number range: " + beginReplicaNumber + "-" + endReplicaNumber);
-
-                beginReplicaNumber = setupReplicationAgreements(
-                        masterConfigurator,
-                        ldapConfigurator,
-                        masterAgreementName,
-                        replicaAgreementName,
-                        replicationSecurity,
-                        masterHostname,
-                        replicaHostname,
-                        Integer.parseInt(masterReplicationPort),
-                        Integer.parseInt(replicaReplicationPort),
-                        masterReplicationPassword,
-                        replicaReplicationPassword,
-                        beginReplicaNumber);
-
-                logger.info("New replica number range: " + beginReplicaNumber + "-" + endReplicaNumber);
-                dbConfig.putString("beginReplicaNumber", Integer.toString(beginReplicaNumber));
-
-                logger.info("Initializing replication consumer");
-                masterConfigurator.initializeConsumer(masterAgreementName);
-
-            } finally {
-                if (masterConn != null) masterConn.disconnect();
-            }
-
-            // remove master ldap password from password.conf (if present)
-
-            if (!masterPassword.equals("")) {
-                String passwordFile = cs.getString("passwordFile");
-                ConfigStorage storage = new FileConfigStore(passwordFile);
-                IConfigStore passwords = new PropConfigStore(storage);
-                passwords.load();
-                passwords.remove("master_internaldb");
-                passwords.commit(false);
-            }
-
-        } finally {
-            if (conn != null) conn.disconnect();
-        }
-    }
-
-    public int setupReplicationAgreements(
-            LDAPConfigurator masterConfigurator,
-            LDAPConfigurator replicaConfigurator,
-            String masterAgreementName,
-            String replicaAgreementName,
-            String replicationSecurity,
-            String masterHostname,
-            String replicaHostname,
-            int masterReplicationPort,
-            int replicaReplicationPort,
-            String masterReplicationPassword,
-            String replicaReplicationPassword,
-            int replicaID)
-            throws Exception {
-
-        String masterBindUser = "Replication Manager " + masterAgreementName;
-        String replicaBindUser = "Replication Manager " + replicaAgreementName;
-
-        logger.info("Setting up replication agreement on " + masterHostname);
-
-        boolean created = masterConfigurator.setupReplicationAgreement(
-                masterAgreementName,
-                masterBindUser,
-                masterReplicationPassword,
-                replicaHostname,
-                replicaReplicationPort,
-                replicaBindUser,
-                replicaReplicationPassword,
-                replicationSecurity,
-                replicaID);
-
-        if (created) {
-            replicaID++;
-        }
-
-        logger.info("Setting up replication agreement on " + replicaHostname);
-
-        created = replicaConfigurator.setupReplicationAgreement(
-                replicaAgreementName,
-                replicaBindUser,
-                replicaReplicationPassword,
-                masterHostname,
-                masterReplicationPort,
-                masterBindUser,
-                masterReplicationPassword,
-                replicationSecurity,
-                replicaID);
-
-        if (created) {
-            replicaID++;
-        }
-
-        return replicaID;
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationCLI.java
@@ -1,0 +1,20 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemDBReplicationCLI extends CLI {
+
+    public SubsystemDBReplicationCLI(CLI parent) {
+        super("replication", parent.parent.name.toUpperCase() + " database replication management commands", parent);
+
+        addModule(new SubsystemDBReplicationSetupCLI(this));
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationSetupCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationSetupCLI.java
@@ -1,0 +1,250 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.util.logging.PKILogger;
+import org.dogtagpki.util.logging.PKILogger.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.certsrv.base.IConfigStore;
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
+import com.netscape.cmscore.apps.DatabaseConfig;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.apps.PreOpConfig;
+import com.netscape.cmscore.base.ConfigStorage;
+import com.netscape.cmscore.base.FileConfigStore;
+import com.netscape.cmscore.base.PropConfigStore;
+import com.netscape.cmscore.ldapconn.LDAPAuthenticationConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapBoundConnFactory;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmsutil.password.IPasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+import netscape.ldap.LDAPConnection;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemDBReplicationSetupCLI extends SubsystemCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(SubsystemDBReplicationSetupCLI.class);
+
+    public SubsystemDBReplicationSetupCLI(CLI parent) {
+        super("setup", "Set up " + parent.parent.parent.getName().toUpperCase() + " database replication", parent);
+    }
+
+    @Override
+    public void createOptions() {
+
+        options.addOption(null, "master-replication-port", true, "Master replication port");
+        options.addOption(null, "replica-replication-port", true, "Replica replication port");
+        options.addOption(null, "replication-security", true, "Replication security: SSL, TLS, None");
+
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(Level.DEBUG);
+
+        } else if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(Level.INFO);
+        }
+
+        String masterReplicationPort = cmd.getOptionValue("master-replication-port");
+        String replicaReplicationPort = cmd.getOptionValue("replica-replication-port");
+        String replicationSecurity = cmd.getOptionValue("replication-security");
+
+        initializeTomcatJSS();
+        String subsystem = parent.parent.parent.getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        IPasswordStore passwordStore = IPasswordStore.create(psc);
+
+        setupReplication(
+                cs,
+                passwordStore,
+                masterReplicationPort,
+                replicaReplicationPort,
+                replicationSecurity);
+
+        cs.commit(false);
+    }
+
+    public void setupReplication(
+            EngineConfig cs,
+            IPasswordStore passwordStore,
+            String masterReplicationPort,
+            String replicaReplicationPort,
+            String security) throws Exception {
+
+        String hostname = cs.getHostname();
+        String instanceID = cs.getInstanceID();
+        PreOpConfig preopConfig = cs.getPreOpConfig();
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        LDAPConfig ldapConfig = cs.getInternalDBConfig();
+        LDAPConnectionConfig replicaConnConfig = ldapConfig.getConnectionConfig();
+        String replicaHostname = replicaConnConfig.getString("host", "");
+        String replicaPort = replicaConnConfig.getString("port", "");
+
+        if (replicaReplicationPort == null || replicaReplicationPort.equals("")) {
+            replicaReplicationPort = replicaPort;
+        }
+
+        LdapBoundConnFactory ldapFactory = new LdapBoundConnFactory("LDAPConfigurator");
+        ldapFactory.init(socketConfig, ldapConfig, passwordStore);
+
+        LDAPConnection conn = ldapFactory.getConn();
+        LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, ldapConfig, instanceID);
+
+        try {
+            LDAPConfig masterConfig = preopConfig.getSubStore("internaldb.master", LDAPConfig.class);
+            LDAPConnectionConfig masterConnConfig = masterConfig.getConnectionConfig();
+            String masterHostname = masterConnConfig.getString("host", "");
+            String masterPort = masterConnConfig.getString("port", "");
+
+            if (masterReplicationPort == null || masterReplicationPort.equals("")) {
+                masterReplicationPort = masterPort;
+            }
+
+            String masterReplicationPassword = preopConfig.getString("internaldb.master.replication.password", "");
+            String replicaReplicationPassword = passwordStore.getPassword("replicationdb", 0);
+
+            // Set master LDAP password (if it exists) temporarily in password store
+            // in case it is needed for replication. Not stored in password.conf.
+
+            LDAPAuthenticationConfig masterAuthConfig = masterConfig.getAuthenticationConfig();
+            String masterPassword = masterAuthConfig.getString("password", "");
+
+            if (!masterPassword.equals("")) {
+                masterAuthConfig.putString("bindPWPrompt", "master_internaldb");
+                passwordStore.putPassword("master_internaldb", masterPassword);
+                passwordStore.commit();
+            }
+
+            LdapBoundConnFactory masterFactory = new LdapBoundConnFactory("MasterLDAPConfigurator");
+            masterFactory.init(socketConfig, masterConfig, passwordStore);
+
+            LDAPConnection masterConn = masterFactory.getConn();
+            LDAPConfigurator masterConfigurator = new LDAPConfigurator(masterConn, masterConfig);
+
+            try {
+                String masterAgreementName = "masterAgreement1-" + hostname + "-" + instanceID;
+                String replicaAgreementName = "cloneAgreement1-" + hostname + "-" + instanceID;
+
+                DatabaseConfig dbConfig = cs.getDatabaseConfig();
+                int beginReplicaNumber = dbConfig.getInteger("beginReplicaNumber", 1);
+                int endReplicaNumber = dbConfig.getInteger("endReplicaNumber", 100);
+                logger.info("Current replica number range: " + beginReplicaNumber + "-" + endReplicaNumber);
+
+                beginReplicaNumber = setupReplicationAgreements(
+                        masterConfigurator,
+                        ldapConfigurator,
+                        masterAgreementName,
+                        replicaAgreementName,
+                        security,
+                        masterHostname,
+                        replicaHostname,
+                        Integer.parseInt(masterReplicationPort),
+                        Integer.parseInt(replicaReplicationPort),
+                        masterReplicationPassword,
+                        replicaReplicationPassword,
+                        beginReplicaNumber);
+
+                logger.info("New replica number range: " + beginReplicaNumber + "-" + endReplicaNumber);
+                dbConfig.putString("beginReplicaNumber", Integer.toString(beginReplicaNumber));
+
+                logger.info("Initializing replication consumer");
+                masterConfigurator.initializeConsumer(masterAgreementName);
+
+            } finally {
+                if (masterConn != null) masterConn.disconnect();
+            }
+
+            // remove master ldap password from password.conf (if present)
+
+            if (!masterPassword.equals("")) {
+                String passwordFile = cs.getString("passwordFile");
+                ConfigStorage storage = new FileConfigStore(passwordFile);
+                IConfigStore passwords = new PropConfigStore(storage);
+                passwords.load();
+                passwords.remove("master_internaldb");
+                passwords.commit(false);
+            }
+
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+
+    public int setupReplicationAgreements(
+            LDAPConfigurator masterConfigurator,
+            LDAPConfigurator replicaConfigurator,
+            String masterAgreementName,
+            String replicaAgreementName,
+            String replicationSecurity,
+            String masterHostname,
+            String replicaHostname,
+            int masterReplicationPort,
+            int replicaReplicationPort,
+            String masterReplicationPassword,
+            String replicaReplicationPassword,
+            int replicaID)
+            throws Exception {
+
+        String masterBindUser = "Replication Manager " + masterAgreementName;
+        String replicaBindUser = "Replication Manager " + replicaAgreementName;
+
+        logger.info("Setting up replication agreement on " + masterHostname);
+
+        boolean created = masterConfigurator.setupReplicationAgreement(
+                masterAgreementName,
+                masterBindUser,
+                masterReplicationPassword,
+                replicaHostname,
+                replicaReplicationPort,
+                replicaBindUser,
+                replicaReplicationPassword,
+                replicationSecurity,
+                replicaID);
+
+        if (created) {
+            replicaID++;
+        }
+
+        logger.info("Setting up replication agreement on " + replicaHostname);
+
+        created = replicaConfigurator.setupReplicationAgreement(
+                replicaAgreementName,
+                replicaBindUser,
+                replicaReplicationPassword,
+                masterHostname,
+                masterReplicationPort,
+                masterBindUser,
+                masterReplicationPassword,
+                replicationSecurity,
+                replicaID);
+
+        if (created) {
+            replicaID++;
+        }
+
+        return replicaID;
+    }
+}


### PR DESCRIPTION
The Java code that sets up replication in `SubsystemDBInitCLI` has been moved into `SubsystemDBReplicationSetupCLI` so that
later it can be reused as a separate CLI. The Python code that calls `SubsystemDBInitCLI` with replication params has been moved into `setup_replication()` to call `SubsystemDBReplicationSetupCLI`.