### PR TITLE
Tidy up logic in SecureChannelProtocol classes

### DIFF
--- a/base/tks/src/main/java/org/dogtagpki/server/tks/servlet/SecureChannelProtocol.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/servlet/SecureChannelProtocol.java
@@ -1113,10 +1113,7 @@ public class SecureChannelProtocol {
         //logger.debug(method + "Returning symkey: " + unwrapped);
         logger.debug(method + "Returning symkey...");
 
-        if (finalUnwrapped != null)
-            return finalUnwrapped;
-        else
-            return unwrapped;
+        return finalUnwrapped == null ? unwrapped : finalUnwrapped;
     }
 
     public SymmetricKey unwrapSymKeyOnToken(CryptoToken token, byte[] inputKeyArray, boolean isPerm)

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/channel/SecureChannelProtocol.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/channel/SecureChannelProtocol.java
@@ -598,10 +598,7 @@ public class SecureChannelProtocol {
         //logger.debug(method + "Returning symkey: " + unwrapped);
         logger.debug(method + "Returning symkey...");
 
-        if (finalUnwrapped != null)
-            return finalUnwrapped;
-        else
-            return unwrapped;
+        return finalUnwrapped == null ? unwrapped : finalUnwrapped;
     }
 
     public SymmetricKey unwrapSymKeyOnToken(CryptoToken token, byte[] inputKeyArray, boolean isPerm)


### PR DESCRIPTION
* Use ternary operator and invert logic