### PR TITLE
Drop preop.internaldb.master

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -716,6 +716,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             logger.info('- replication security: %s', replication_security)
 
             subsystem.setup_replication(
+                master_properties,
                 master_replication_port=master_replication_port,
                 replica_replication_port=replica_replication_port,
                 replication_security=replication_security)


### PR DESCRIPTION
Previously pkispawn would retrieve the `internaldb.*` params from the master server and store it under `preop.internaldb.master` in the replica's `CS.cfg` so `SubsystemDBReplicationSetupCLI` can use it. Later these params will be removed from `CS.cfg`.

To minimize changes to the replica's `CS.cfg`, these params will now be stored in a separate temporary file instead.