### PR TITLE
Switch to Java 17

### DIFF
--- a/docs/changes/v11.1.0/Packaging-Changes.adoc
+++ b/docs/changes/v11.1.0/Packaging-Changes.adoc
@@ -6,3 +6,7 @@ The following packages have been renamed:
 
 * `dogtag-pki-base-java` -> `dogtag-pki-java`
 * `dogtag-pki-server-theme` -> `dogtag-pki-theme`
+
+== Java Dependency Changes ==
+
+PKI packages will now require OpenJDK 17.

--- a/pki.spec
+++ b/pki.spec
@@ -60,9 +60,9 @@ ExcludeArch: i686
 # Java
 ################################################################################
 
-%define java_devel java-11-openjdk-devel
-%define java_headless java-11-openjdk-headless
-%define java_home /usr/lib/jvm/jre-11-openjdk
+%define java_devel java-17-openjdk-devel
+%define java_headless java-17-openjdk-headless
+%define java_home /usr/lib/jvm/jre-17-openjdk
 
 ################################################################################
 # RESTEasy

--- a/tests/bin/runner-init.sh
+++ b/tests/bin/runner-init.sh
@@ -28,7 +28,6 @@ docker run \
     --privileged \
     --tmpfs /tmp \
     --tmpfs /run \
-    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
     -v ${GITHUB_WORKSPACE}:${SHARED} \
     -e BUILDUSER_UID=$(id -u) \
     -e BUILDUSER_GID=$(id -g) \


### PR DESCRIPTION
The `pki.spec` has been modified to depend on Java 17. The `runner-init.sh` has been modified to no longer mount
`/sys/fs/cgroup` to avoid the following warnings:

>  Warning: warning][os,container] Duplicate cpuset controllers detected. Picking /sys/fs/cgroup/cpuset, skipping /sys/fs/cgroup/cpuset.

https://github.com/edewata/pki/blob/java17/docs/changes/v11.1.0/Packaging-Changes.adoc