### PR TITLE
Move emails and profiles to config folder

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -430,8 +430,8 @@ pki_source_cacert_profile=%(pki_source_conf_path)s/caCert.profile
 pki_source_caocspcert_profile=%(pki_source_conf_path)s/caOCSPCert.profile
 pki_source_servercert_profile=%(pki_source_conf_path)s/%(pki_sslserver_key_type)sServerCert.profile
 pki_source_subsystemcert_profile=%(pki_source_conf_path)s/%(pki_subsystem_key_type)sSubsystemCert.profile
-pki_subsystem_emails_path=%(pki_subsystem_path)s/emails
-pki_subsystem_profiles_path=%(pki_subsystem_path)s/profiles
+pki_subsystem_emails_path=%(pki_subsystem_configuration_path)s/emails
+pki_subsystem_profiles_path=%(pki_subsystem_configuration_path)s/profiles
 
 pki_serial_number_range_start=
 pki_serial_number_range_end=

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 import logging
+import os
 import random
 import string
 
@@ -109,18 +110,32 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if deployer.mdict['pki_subsystem'] == "CA":
 
             # Copy /usr/share/pki/ca/emails
-            # to /var/lib/pki/<instance>/<subsystem>/emails
+            # to /etc/pki/<instance>/ca/emails
             logger.info('Creating %s', deployer.mdict['pki_subsystem_emails_path'])
             instance.copy(
                 deployer.mdict['pki_source_emails'],
                 deployer.mdict['pki_subsystem_emails_path'])
 
+            # Link /var/lib/pki/<instance>/ca/emails
+            # to /etc/pki/<instance>/ca/emails
+            emails_path = os.path.join(instance.conf_dir, 'ca', 'emails')
+            emails_link = os.path.join(instance.base_dir, 'ca', 'emails')
+            logger.info('Creating %s', emails_link)
+            instance.symlink(emails_path, emails_link)
+
             # Copy /usr/share/pki/ca/profiles
-            # to /var/lib/pki/<instance>/<subsystem>/profiles
+            # to /etc/pki/<instance>/ca/profiles
             logger.info('Creating %s', deployer.mdict['pki_subsystem_profiles_path'])
             instance.copy(
                 deployer.mdict['pki_source_profiles'],
                 deployer.mdict['pki_subsystem_profiles_path'])
+
+            # Link /var/lib/pki/<instance>/ca/profiles
+            # to /etc/pki/<instance>/ca/profiles
+            profiles_path = os.path.join(instance.conf_dir, 'ca', 'profiles')
+            profiles_link = os.path.join(instance.base_dir, 'ca', 'profiles')
+            logger.info('Creating %s', profiles_link)
+            instance.symlink(profiles_path, profiles_link)
 
             # Copy /usr/share/pki/<subsystem>/conf/flatfile.txt
             # to /etc/pki/<instance>/<subsystem>/flatfile.txt

--- a/base/server/upgrade/11.1.0/01-MoveEmailsAndProfiles.py
+++ b/base/server/upgrade/11.1.0/01-MoveEmailsAndProfiles.py
@@ -1,0 +1,50 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+from __future__ import absolute_import
+import logging
+import os
+import shutil
+
+import pki.server.upgrade
+
+logger = logging.getLogger(__name__)
+
+
+class MoveEmailsAndProfiles(
+        pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super(MoveEmailsAndProfiles, self).__init__()
+        self.message = 'Move emails and profiles'
+
+    def upgrade_subsystem(self, instance, subsystem):
+
+        if subsystem.name != 'ca':
+            return
+
+        old_emails = os.path.join(instance.base_dir, 'ca', 'emails')
+        new_emails = os.path.join(instance.conf_dir, 'ca', 'emails')
+
+        if not os.path.islink(old_emails):
+
+            logger.info('Moving %s to %s', old_emails, new_emails)
+
+            self.backup(old_emails)
+
+            shutil.move(old_emails, new_emails)
+            instance.symlink(new_emails, old_emails)
+
+        old_profiles = os.path.join(instance.base_dir, 'ca', 'profiles')
+        new_profiles = os.path.join(instance.conf_dir, 'ca', 'profiles')
+
+        if not os.path.islink(old_profiles):
+
+            logger.info('Moving %s to %s', old_profiles, new_profiles)
+
+            self.backup(old_profiles)
+
+            shutil.move(old_profiles, new_profiles)
+            instance.symlink(new_profiles, old_profiles)

--- a/docs/changes/v11.1.0/Server-Changes.adoc
+++ b/docs/changes/v11.1.0/Server-Changes.adoc
@@ -1,0 +1,8 @@
+= Server Changes =
+
+== Directory Structure Changes ==
+
+The following folders have been relocated:
+
+* `/var/lib/pki/<instance>/ca/emails` -> `/etc/pki/<instance>/ca/emails`
+* `/var/lib/pki/<instance>/ca/profiles` -> `/etc/pki/<instance>/ca/profiles`


### PR DESCRIPTION
`pkispawn` has been modified to install the emails and profiles in the instance's config folder instead of base folder since
they are a part of CA configuration.

For backward compatibility the old folders have been replaced with links to the new locations.

An upgrade script has been added to relocate the emails and profiles in existing instances.

https://github.com/edewata/pki/blob/upgrade/docs/changes/v11.1.0/Server-Changes.adoc
