### PR TITLE
Remove unused subsystem webapp folders

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -322,10 +322,6 @@ pki_subsystem_registry_path=%(pki_instance_registry_path)s/%(pki_subsystem_type)
 pki_tomcat_bin_link=%(pki_instance_path)s/bin
 pki_instance_systemd_link=%(pki_instance_path)s/%(pki_instance_name)s
 pki_subsystem_signed_audit_log_path=%(pki_subsystem_log_path)s/signedAudit
-pki_tomcat_subsystem_webapps_path=%(pki_subsystem_path)s/webapps
-pki_tomcat_webapps_subsystem_path=%(pki_tomcat_subsystem_webapps_path)s/%(pki_subsystem_type)s
-pki_tomcat_webapps_subsystem_webinf_classes_path=%(pki_tomcat_webapps_subsystem_path)s/WEB-INF/classes
-pki_tomcat_webapps_subsystem_webinf_lib_path=%(pki_tomcat_webapps_subsystem_path)s/WEB-INF/lib
 
 
 ###############################################################################

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -729,38 +729,6 @@ class ConfigurationFile:
                         self.mdict['pki_instance_name']))
         return
 
-# PKI Deployment XML File Class
-# class xml_file:
-#    def remove_filter_section_from_web_xml(self,
-#                                           web_xml_source,
-#                                           web_xml_target):
-#        logger.info(
-#            log.PKIHELPER_REMOVE_FILTER_SECTION_1,
-#            self.mdict['pki_target_subsystem_web_xml'])
-#        begin_filters_section = False
-#        begin_servlet_section = False
-#        FILE = open(web_xml_target, "w")
-#        for line in fileinput.FileInput(web_xml_source):
-#            if not begin_filters_section:
-#                # Read and write lines until first "<filter>" tag
-#                if line.count("<filter>") >= 1:
-#                    # Mark filters section
-#                    begin_filters_section = True
-#                else:
-#                    FILE.write(line)
-#            elif not begin_servlet_section:
-#                # Skip lines until first "<servlet>" tag
-#                if line.count("<servlet>") >= 1:
-#                    # Mark servlets section and write out the opening tag
-#                    begin_servlet_section = True
-#                    FILE.write(line)
-#                else:
-#                    continue
-#            else:
-#                # Read and write lines all lines after "<servlet>" tag
-#                FILE.write(line)
-#        FILE.close()
-
 
 class Instance:
     """PKI Deployment Instance Class"""

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -632,17 +632,6 @@ class PKIConfigParser:
                 os.path.join(
                     self.mdict['pki_instance_configuration_path'],
                     "tomcat.conf")
-            # in-place slot substitution name/value pairs
-            self.mdict['pki_target_subsystem_web_xml'] = \
-                os.path.join(
-                    self.mdict['pki_tomcat_webapps_subsystem_path'],
-                    "WEB-INF",
-                    "web.xml")
-            self.mdict['pki_target_subsystem_web_xml_orig'] = \
-                os.path.join(
-                    self.mdict['pki_tomcat_webapps_subsystem_path'],
-                    "WEB-INF",
-                    "web.xml.orig")
 
             self.mdict['pki_target_registry_cfg'] = \
                 os.path.join(

--- a/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
+++ b/base/server/python/pki/server/deployment/scriptlets/webapp_deployment.py
@@ -28,7 +28,6 @@ import pki.server.instance
 import pki.util
 
 # PKI Deployment Imports
-from .. import pkiconfig as config
 from .. import pkiscriptlet
 
 logger = logging.getLogger(__name__)
@@ -38,23 +37,7 @@ logger = logging.getLogger(__name__)
 class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
     def spawn(self, deployer):
-        if config.str2bool(deployer.mdict['pki_skip_installation']):
-            logger.info('Skipping webapp creation')
-            return
-
-        logger.info('Deploying /%s web application', deployer.mdict['pki_subsystem'].lower())
-
-        instance = self.instance
-        instance.load()
-
-        # Create subsystem webapps folder to store custom webapps:
-        # <instance>/<subsystem>/webapps.
-        deployer.directory.create(
-            deployer.mdict['pki_tomcat_subsystem_webapps_path'])
-
-        # set ownerships, permissions, and acls
-        deployer.directory.set_mode(
-            deployer.mdict['pki_tomcat_subsystem_webapps_path'])
+        pass
 
     def destroy(self, deployer):
 

--- a/base/server/upgrade/11.1.0/02-RemoveSubsystemWebappsFolders.py
+++ b/base/server/upgrade/11.1.0/02-RemoveSubsystemWebappsFolders.py
@@ -1,0 +1,34 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+from __future__ import absolute_import
+import logging
+import os
+import shutil
+
+import pki.server.upgrade
+
+logger = logging.getLogger(__name__)
+
+
+class RemoveSubsystemWebappsFolders(
+        pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super(RemoveSubsystemWebappsFolders, self).__init__()
+        self.message = 'Remove subsystem webapps folders'
+
+    def upgrade_subsystem(self, instance, subsystem):
+
+        webapps_dir = os.path.join(instance.base_dir, subsystem.name, 'webapps')
+
+        if not os.path.isdir(webapps_dir):
+            return
+
+        logger.info('Removing %s', webapps_dir)
+
+        self.backup(webapps_dir)
+
+        shutil.rmtree(webapps_dir)

--- a/docs/changes/v11.1.0/Server-Changes.adoc
+++ b/docs/changes/v11.1.0/Server-Changes.adoc
@@ -6,3 +6,7 @@ The following folders have been relocated:
 
 * `/var/lib/pki/<instance>/ca/emails` -> `/etc/pki/<instance>/ca/emails`
 * `/var/lib/pki/<instance>/ca/profiles` -> `/etc/pki/<instance>/ca/profiles`
+
+The following folders have been removed:
+
+* `/var/lib/pki/<instance>/<subsystem>/webapps`


### PR DESCRIPTION
`pkispawn` has been modified to no longer create the subsystem `webapps` folders.

An upgrade script has been added to remove the folders from existing instances.

https://github.com/edewata/pki/blob/upgrade/docs/changes/v11.1.0/Server-Changes.adoc