### PR TITLE
Remove unused static info in server.xml

### DIFF
--- a/base/server/upgrade/11.1.0/03-RemoveStaticInfoInServerXML.py
+++ b/base/server/upgrade/11.1.0/03-RemoveStaticInfoInServerXML.py
@@ -1,0 +1,50 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+from __future__ import absolute_import
+import logging
+
+import pki.server.upgrade
+
+logger = logging.getLogger(__name__)
+
+
+class RemoveStaticInfoInServerXML(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Remove static info in server.xml'
+
+    def upgrade_instance(self, instance):
+
+        logger.info('Updating %s', instance.server_xml)
+        self.backup(instance.server_xml)
+
+        with open(instance.server_xml) as f:
+            lines = f.readlines()
+
+        lines = [line.rstrip() for line in lines]
+        new_lines = []
+        remove = False
+
+        # Remove everything between these lines:
+        # <!-- DO NOT REMOVE - Begin PKI Status Definitions -->
+        # ...
+        # <!-- DO NOT REMOVE - End PKI Status Definitions -->
+
+        for line in lines:
+
+            if line == '<!-- DO NOT REMOVE - Begin PKI Status Definitions -->':
+                remove = True
+
+            elif line == '<!-- DO NOT REMOVE - End PKI Status Definitions -->':
+                remove = False
+
+            elif not remove:
+                new_lines.append(line)
+
+        with open(instance.server_xml, 'w') as f:
+            for line in new_lines:
+                f.write("%s\n" % line)

--- a/base/tomcat-9.0/conf/server.xml
+++ b/base/tomcat-9.0/conf/server.xml
@@ -24,50 +24,6 @@
      define subcomponents such as "Valves" at this level.
      Documentation at /docs/config/server.html
  -->
-
-<!-- DO NOT REMOVE - Begin PKI Status Definitions -->
-<!-- CA Status Definitions -->
-<?pkidaemon
-Unsecure URL        = http://[PKI_HOSTNAME]:[PKI_UNSECURE_PORT]/ca/ee/ca
-Secure Agent URL    = https://[PKI_HOSTNAME]:[PKI_AGENT_SECURE_PORT]/ca/agent/ca
-Secure EE URL       = https://[PKI_HOSTNAME]:[PKI_EE_SECURE_PORT]/ca/ee/ca
-Secure Admin URL    = https://[PKI_HOSTNAME]:[PKI_ADMIN_SECURE_PORT]/ca/services
-PKI Console Command = pkiconsole https://[PKI_HOSTNAME]:[PKI_ADMIN_SECURE_PORT]/ca
-Tomcat Port         = [TOMCAT_SERVER_PORT] (for shutdown)
-?>
-<!-- KRA Status Definitions -->
-<?pkidaemon
-Secure Agent URL    = https://[PKI_HOSTNAME]:[PKI_AGENT_SECURE_PORT]/kra/agent/kra
-Secure Admin URL    = https://[PKI_HOSTNAME]:[PKI_ADMIN_SECURE_PORT]/kra/services
-PKI Console Command = pkiconsole https://[PKI_HOSTNAME]:[PKI_ADMIN_SECURE_PORT]/kra
-Tomcat Port         = [TOMCAT_SERVER_PORT] (for shutdown)
-?>
-<!-- OCSP Status Definitions -->
-<?pkidaemon
-Unsecure URL        = http://[PKI_HOSTNAME]:[PKI_UNSECURE_PORT]/ocsp/ee/ocsp/<ocsp request blob>
-Secure Agent URL    = https://[PKI_HOSTNAME]:[PKI_AGENT_SECURE_PORT]/ocsp/agent/ocsp
-Secure EE URL       = https://[PKI_HOSTNAME]:[PKI_EE_SECURE_PORT]/ocsp/ee/ocsp/<ocsp request blob>
-Secure Admin URL    = https://[PKI_HOSTNAME]:[PKI_ADMIN_SECURE_PORT]/ocsp/services
-PKI Console Command = pkiconsole https://[PKI_HOSTNAME]:[PKI_ADMIN_SECURE_PORT]/ocsp
-Tomcat Port         = [TOMCAT_SERVER_PORT] (for shutdown)
-?>
-<!-- TKS Status Definitions -->
-<?pkidaemon
-Secure Agent URL    = https://[PKI_HOSTNAME]:[PKI_AGENT_SECURE_PORT]/tks/agent/tks
-Secure Admin URL    = https://[PKI_HOSTNAME]:[PKI_ADMIN_SECURE_PORT]/tks/services
-PKI Console Command = pkiconsole https://[PKI_HOSTNAME]:[PKI_ADMIN_SECURE_PORT]/tks
-Tomcat Port         = [TOMCAT_SERVER_PORT] (for shutdown)
-?>
-<!-- TPS Status Definitions -->
-<?pkidaemon
-Unsecure URL        = http://[PKI_HOSTNAME]:[PKI_UNSECURE_PORT]/tps
-Secure URL          = https://[PKI_HOSTNAME]:[PKI_SECURE_PORT]/tps
-Unsecure PHONE HOME = http://[PKI_HOSTNAME]:[PKI_UNSECURE_PORT]/tps/phoneHome
-Secure PHONE HOME   = https://[PKI_HOSTNAME]:[PKI_SECURE_PORT]/tps/phoneHome
-Tomcat Port         = [TOMCAT_SERVER_PORT] (for shutdown)
-?>
-<!-- DO NOT REMOVE - End PKI Status Definitions -->
-
 <Server port="[TOMCAT_SERVER_PORT]" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
   <!-- Security listener. Documentation at /docs/config/listeners.html


### PR DESCRIPTION
The `server.xml` has been modified to no longer include some static info since it can be obtained using `pki-server status`.

A new upgrade script has been added to remove the unused info from existing instances.