### PR TITLE
Remove unused Tomcat systemd link

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -305,7 +305,6 @@ CATALINA_HOME=/usr/share/tomcat
 pki_tomcat_bin_path=%(CATALINA_HOME)s/bin
 pki_tomcat_lib_path=%(CATALINA_HOME)s/lib
 
-pki_tomcat_systemd=/usr/sbin/tomcat
 pki_source_server_xml=%(pki_source_server_path)s/server.xml
 pki_source_context_xml=%(pki_source_server_path)s/context.xml
 pki_source_tomcat_conf=%(pki_source_server_path)s/tomcat.conf
@@ -320,7 +319,6 @@ pki_tomcat_work_catalina_host_subsystem_path=%(pki_tomcat_work_catalina_host_pat
 pki_instance_registry_path=%(pki_registry_path)s/tomcat/%(pki_instance_name)s
 pki_subsystem_registry_path=%(pki_instance_registry_path)s/%(pki_subsystem_type)s
 pki_tomcat_bin_link=%(pki_instance_path)s/bin
-pki_instance_systemd_link=%(pki_instance_path)s/%(pki_instance_name)s
 pki_subsystem_signed_audit_log_path=%(pki_subsystem_log_path)s/signedAudit
 
 

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -219,12 +219,6 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             deployer.mdict['pki_tomcat_bin_path'],
             deployer.mdict['pki_tomcat_bin_link'])
 
-        # create systemd links
-        deployer.symlink.create(
-            deployer.mdict['pki_tomcat_systemd'],
-            deployer.mdict['pki_instance_systemd_link'],
-            uid=0, gid=0)
-
         user = deployer.mdict['pki_user']
         group = deployer.mdict['pki_group']
         if user != 'pkiuser' or group != 'pkiuser':

--- a/base/server/upgrade/11.1.0/04-RemoveTomcatSystemdLink.py
+++ b/base/server/upgrade/11.1.0/04-RemoveTomcatSystemdLink.py
@@ -1,0 +1,30 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+from __future__ import absolute_import
+import logging
+import os
+
+import pki.server.upgrade
+
+logger = logging.getLogger(__name__)
+
+
+class RemoveTomcatSystemdLink(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Remove systemd link'
+
+    def upgrade_instance(self, instance):
+
+        systemd_link = os.path.join(instance.base_dir, instance.name)
+        if not os.path.islink(systemd_link):
+            return
+
+        logger.info('Removing %s', systemd_link)
+
+        self.backup(systemd_link)
+        pki.util.unlink(systemd_link)


### PR DESCRIPTION
The Tomcat systemd link at `/var/lib/pki/<instance>/<instance>` is not used so it has been removed.

An upgrade script has been added to remove the link from existing instances.