### PR TITLE
PKI NSS CLI improvements

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -451,6 +451,214 @@ jobs:
       - name: Remove HSM token
         run: softhsm2-util --delete-token --token HSM
 
+  # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
+  pki-nss-exts-test:
+    name: Testing PKI NSS CLI with Extensions
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Download PKI packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: build/RPMS
+
+      - name: Install PKI packages
+        run: |
+          dnf install -y dnf-plugins-core
+          dnf copr enable -y ${{ needs.init.outputs.repo }}
+          dnf -y localinstall build/RPMS/*
+
+      - name: Create CA signing cert request
+        run: |
+          pki nss-cert-request \
+              --subject "CN=Certificate Authority" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr ca_signing.csr
+          openssl req -text -noout -in ca_signing.csr | tee output
+
+          # verfiy basic constraints extension
+          echo "X509v3 Basic Constraints: critical" > expected
+          echo "CA:TRUE" >> expected
+          sed -En 'N; s/^ *(X509v3 Basic Constraints: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy key usage extension
+          echo "X509v3 Key Usage: critical" > expected
+          echo "Digital Signature, Non Repudiation, Certificate Sign, CRL Sign" >> expected
+          sed -En 'N; s/^ *(X509v3 Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+      - name: Issue self-signed CA signing cert
+        run: |
+          pki nss-cert-issue \
+              --csr ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert ca_signing.crt
+          openssl x509 -text -noout -in ca_signing.crt | tee output
+
+          # verfiy SKI extension
+          echo "X509v3 Subject Key Identifier: " > expected
+          sed -En 's/^ *(X509v3 Subject Key Identifier: .*)$/\1/p' output | tee actual
+          diff actual expected
+
+          # verfiy basic constraints extension
+          echo "X509v3 Basic Constraints: critical" > expected
+          echo "CA:TRUE" >> expected
+          sed -En 'N; s/^ *(X509v3 Basic Constraints: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy key usage extension
+          echo "X509v3 Key Usage: critical" > expected
+          echo "Digital Signature, Non Repudiation, Certificate Sign, CRL Sign" >> expected
+          sed -En 'N; s/^ *(X509v3 Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+      - name: Import CA signing cert
+        run: |
+          pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+          certutil -L -d /root/.dogtag/nssdb -n ca_signing
+
+      - name: Create subordinate CA signing cert request
+        run: |
+          pki nss-cert-request \
+              --subject "CN=Subordinate CA" \
+              --ext /usr/share/pki/server/certs/subca_signing.conf \
+              --csr subca_signing.csr
+          openssl req -text -noout -in subca_signing.csr | tee output
+
+          # verfiy basic constraints extension
+          echo "X509v3 Basic Constraints: critical" > expected
+          echo "CA:TRUE" >> expected
+          sed -En 'N; s/^ *(X509v3 Basic Constraints: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy key usage extension
+          echo "X509v3 Key Usage: critical" > expected
+          echo "Digital Signature, Non Repudiation, Certificate Sign, CRL Sign" >> expected
+          sed -En 'N; s/^ *(X509v3 Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy subordinate CA extension
+          echo "1.3.6.1.4.1.311.20.2: " > expected
+          echo "." >> expected
+          echo ".S.u.b.C.A" >> expected
+          sed -En '1N;$!N;s/^ *(1.3.6.1.4.1.311.20.2: .*)\n *(.*)\n *(.*)/\1\n\2\n\3/p;D' output | tee actual
+          diff  actual expected
+
+      - name: Issue subordinate CA signing cert
+        run: |
+          pki nss-cert-issue \
+              --issuer ca_signing \
+              --csr subca_signing.csr \
+              --ext /usr/share/pki/server/certs/subca_signing.conf \
+              --cert subca_signing.crt
+          openssl x509 -text -noout -in subca_signing.crt | tee output
+
+          # verfiy SKI extension
+          echo "X509v3 Subject Key Identifier: " > expected
+          sed -En 's/^ *(X509v3 Subject Key Identifier: .*)$/\1/p' output | tee actual
+          diff actual expected
+
+          # verfiy AKI extension
+          echo "X509v3 Authority Key Identifier: " > expected
+          sed -En 's/^ *(X509v3 Authority Key Identifier: .*)$/\1/p' output | tee actual
+          diff actual expected
+
+          # verfiy basic constraints extension
+          echo "X509v3 Basic Constraints: critical" > expected
+          echo "CA:TRUE" >> expected
+          sed -En 'N; s/^ *(X509v3 Basic Constraints: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy key usage extension
+          echo "X509v3 Key Usage: critical" > expected
+          echo "Digital Signature, Non Repudiation, Certificate Sign, CRL Sign" >> expected
+          sed -En 'N; s/^ *(X509v3 Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy subordinate CA extension
+          echo "1.3.6.1.4.1.311.20.2: " > expected
+          echo "." >> expected
+          echo ".S.u.b.C.A" >> expected
+          sed -En '1N;$!N;s/^ *(1.3.6.1.4.1.311.20.2: .*)\n *(.*)\n *(.*)/\1\n\2\n\3/p;D' output | tee actual
+          diff actual expected
+
+      - name: Create SSL server cert request
+        run: |
+          pki nss-cert-request \
+              --subject "CN=pki.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr sslserver.csr
+          openssl req -text -noout -in sslserver.csr | tee output
+
+          # verfiy basic constraints extension
+          echo "X509v3 Basic Constraints: critical" > expected
+          echo "CA:FALSE" >> expected
+          sed -En 'N; s/^ *(X509v3 Basic Constraints: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy key usage extension
+          echo "X509v3 Key Usage: critical" > expected
+          echo "Digital Signature, Key Encipherment" >> expected
+          sed -En 'N; s/^ *(X509v3 Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy extended key usage extension
+          echo "X509v3 Extended Key Usage: " > expected
+          echo "TLS Web Server Authentication, TLS Web Client Authentication" >> expected
+          sed -En 'N; s/^ *(X509v3 Extended Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+      - name: Issue SSL server cert
+        run: |
+          pki nss-cert-issue \
+              --issuer ca_signing \
+              --csr sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --cert sslserver.crt
+          openssl x509 -text -noout -in sslserver.crt | tee output
+
+          # verfiy SKI extension
+          echo "X509v3 Subject Key Identifier: " > expected
+          sed -En 's/^ *(X509v3 Subject Key Identifier: .*)$/\1/p' output | tee actual
+          diff actual expected
+
+          # verfiy AKI extension
+          echo "X509v3 Authority Key Identifier: " > expected
+          sed -En 's/^ *(X509v3 Authority Key Identifier: .*)$/\1/p' output | tee actual
+          diff actual expected
+
+          # verfiy basic constraints extension
+          echo "X509v3 Basic Constraints: critical" > expected
+          echo "CA:FALSE" >> expected
+          sed -En 'N; s/^ *(X509v3 Basic Constraints: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy key usage extension
+          echo "X509v3 Key Usage: critical" > expected
+          echo "Digital Signature, Key Encipherment" >> expected
+          sed -En 'N; s/^ *(X509v3 Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy extended key usage extension
+          echo "X509v3 Extended Key Usage: " > expected
+          echo "TLS Web Server Authentication, TLS Web Client Authentication" >> expected
+          sed -En 'N; s/^ *(X509v3 Extended Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # verfiy SAN extension
+          echo "X509v3 Subject Alternative Name: " > expected
+          echo "DNS:pki.example.com" >> expected
+          sed -En 'N; s/^ *(X509v3 Subject Alternative Name: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
   # docs/user/tools/Using-PKI-PKCS7-CLI.adoc
   pki-pkcs7-test:
     name: Testing PKI PKCS7 CLI

--- a/base/acme/issuer/nss/sslserver.conf
+++ b/base/acme/issuer/nss/sslserver.conf
@@ -1,8 +1,9 @@
-basicConstraints       = critical, CA:FALSE
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid:always
+basicConstraints       = critical, CA:FALSE
 keyUsage               = critical, digitalSignature, keyEncipherment
 extendedKeyUsage       = serverAuth, clientAuth
+subjectAltName         = DNS:request_subject_cn, DNS:request_san_ext
 
 # authorityInfoAccess    = OCSP;URI:http://ocsp.example.com, caIssuers;URI:http://cert.example.com
 

--- a/base/server/certs/sslserver.conf
+++ b/base/server/certs/sslserver.conf
@@ -1,5 +1,6 @@
-basicConstraints       = critical, CA:FALSE
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid:always
+basicConstraints       = critical, CA:FALSE
 keyUsage               = critical, digitalSignature, keyEncipherment
 extendedKeyUsage       = serverAuth, clientAuth
+subjectAltName         = DNS:request_subject_cn, DNS:request_san_ext

--- a/base/server/certs/subca_signing.conf
+++ b/base/server/certs/subca_signing.conf
@@ -1,0 +1,6 @@
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid:always
+basicConstraints       = critical, CA:TRUE
+keyUsage               = critical, digitalSignature, nonRepudiation, keyCertSign, cRLSign
+genericExtensions      = 1.3.6.1.4.1.311.20.2
+1.3.6.1.4.1.311.20.2   = DER:1E:0A:00:53:00:75:00:62:00:43:00:41


### PR DESCRIPTION
Previously the `NSSExtensionGenerator.createSANExtension()` would add a SAN extension to all certs or requests created with it. The code has been modified to add a SAN extension only if the `subjectAltName` param is specified.

The param currently supports two options:

- `DNS:request_subject_cn` which will copy the DNS name from the CN attribute of the request's subject name
- `DNS:request_san_ext` which will copy the DNS names from the request's SAN extension
    
The [sslserver.conf](https://github.com/edewata/pki/blob/cli-nss/base/server/certs/sslserver.conf) has been modified to use the new param.

The `NSSExtensionGenerator.createGenericExtensions()` has been added to support user-provided generic extensions such as Microsoft's SubCA extension. A new [subca_signing.conf](https://github.com/edewata/pki/blob/cli-nss/base/server/certs/subca_signing.conf) has been added as an example.

A new test has been added to verify that the PKI NSS CLI will add the cert and request extensions properly according to:

- [ca_signing.conf](https://github.com/edewata/pki/blob/cli-nss/base/server/certs/ca_signing.conf)
- [subca_signing.conf](https://github.com/edewata/pki/blob/cli-nss/base/server/certs/subca_signing.conf)
- [sslserver.conf](https://github.com/edewata/pki/blob/cli-nss/base/server/certs/sslserver.conf)
