### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 
@@ -119,6 +121,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -303,6 +306,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 
@@ -101,6 +103,8 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          COPR_REPO: ${{ needs.init.outputs.repo }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -213,6 +217,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -312,6 +317,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh rootds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: rootds.example.com
           PASSWORD: Secret.123
 
@@ -340,6 +346,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh subds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: subds.example.com
           PASSWORD: Secret.123
 
@@ -442,6 +449,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -550,6 +558,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -711,6 +720,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -749,6 +759,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -791,6 +802,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tertiaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: tertiaryds.example.com
           PASSWORD: Secret.123
 
@@ -920,6 +932,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1068,6 +1081,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -1173,6 +1187,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -1361,6 +1376,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 
@@ -101,6 +103,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -202,6 +205,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -230,6 +234,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh krads
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: krads.example.com
           PASSWORD: Secret.123
 
@@ -347,6 +352,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -383,6 +389,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh krads
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: krads.example.com
           PASSWORD: Secret.123
 
@@ -548,6 +555,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -585,6 +593,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -638,6 +647,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tertiaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: tertiaryds.example.com
           PASSWORD: Secret.123
 
@@ -776,6 +786,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 
@@ -101,6 +103,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -196,6 +199,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -232,6 +236,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ocspds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ocspds.example.com
           PASSWORD: Secret.123
 
@@ -382,6 +387,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -419,6 +425,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -472,6 +479,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tertiaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: tertiaryds.example.com
           PASSWORD: Secret.123
 
@@ -610,6 +618,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 
@@ -101,6 +103,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -198,6 +201,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -235,6 +239,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -288,6 +293,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tertiaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: tertiaryds.example.com
           PASSWORD: Secret.123
 

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -9,6 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.init.outputs.matrix }}
       repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -18,6 +19,7 @@ jobs:
         env:
           BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |
           tests/bin/init-workflow.sh
 
@@ -101,6 +103,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -278,6 +281,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -335,6 +339,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 

--- a/tests/bin/ds-container-certs-import.sh
+++ b/tests/bin/ds-container-certs-import.sh
@@ -23,41 +23,46 @@ then
     PASSWORD=Secret.123
 fi
 
-echo "Importing DS certs"
+import_certs() {
 
-# Import input file into container
+    echo "Importing DS certs"
 
-docker cp $INPUT $NAME:/tmp/certs.p12
+    # Import input file into container
 
-# Fix file ownership
+    docker cp $INPUT $NAME:/tmp/certs.p12
 
-docker exec -u 0 $NAME chown dirsrv.dirsrv /tmp/certs.p12
+    # Fix file ownership
 
-# Export server cert into /data/tls/server.crt
+    docker exec -u 0 $NAME chown dirsrv.dirsrv /tmp/certs.p12
 
-docker exec $NAME openssl pkcs12 \
-    -in /tmp/certs.p12 \
-    -passin pass:$PASSWORD \
-    -out /data/tls/server.crt \
-    -clcerts \
-    -nokeys
+    # Export server cert into /data/tls/server.crt
 
-# Export server key into /data/tls/server.key
+    docker exec $NAME openssl pkcs12 \
+        -in /tmp/certs.p12 \
+        -passin pass:$PASSWORD \
+        -out /data/tls/server.crt \
+        -clcerts \
+        -nokeys
 
-docker exec $NAME openssl pkcs12 \
-    -in /tmp/certs.p12 \
-    -passin pass:$PASSWORD \
-    -out /data/tls/server.key \
-    -nodes \
-    -nocerts
+    # Export server key into /data/tls/server.key
 
-# Export CA cert into /data/tls/ca/ca.crt
+    docker exec $NAME openssl pkcs12 \
+        -in /tmp/certs.p12 \
+        -passin pass:$PASSWORD \
+        -out /data/tls/server.key \
+        -nodes \
+        -nocerts
 
-docker exec $NAME openssl pkcs12 \
-    -in /tmp/certs.p12 \
-    -passin pass:$PASSWORD \
-    -out /data/tls/ca/ca.crt \
-    -cacerts \
-    -nokeys
+    # Export CA cert into /data/tls/ca/ca.crt
+
+    docker exec $NAME openssl pkcs12 \
+        -in /tmp/certs.p12 \
+        -passin pass:$PASSWORD \
+        -out /data/tls/ca/ca.crt \
+        -cacerts \
+        -nokeys
+}
+
+import_certs
 
 echo "DS certs imported"

--- a/tests/bin/ds-container-start.sh
+++ b/tests/bin/ds-container-start.sh
@@ -23,7 +23,12 @@ fi
 echo "Starting DS container"
 start_time=$(date +%s)
 
-docker start $NAME > /dev/null
+if [ "$IMAGE" == "" ]
+then
+    docker exec $NAME dsctl localhost start
+else
+    docker start $NAME > /dev/null
+fi
 
 if [ $? -ne 0 ]
 then

--- a/tests/bin/ds-container-stop.sh
+++ b/tests/bin/ds-container-stop.sh
@@ -11,6 +11,12 @@ then
 fi
 
 echo "Stopping DS container"
-docker stop $NAME > /dev/null
+
+if [ "$IMAGE" == "" ]
+then
+    docker exec $NAME dsctl localhost stop
+else
+    docker stop $NAME > /dev/null
+fi
 
 echo "DS container is stopped"

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -19,3 +19,12 @@ fi
 
 echo "REPO: $REPO"
 echo "::set-output name=repo::$REPO"
+
+if [ "$BASE64_DATABASE" != "" ]
+then
+    DATABASE=$(echo "$BASE64_DATABASE" | base64 -d)
+    DB_IMAGE=$(echo "$DATABASE" | jq -r .image)
+fi
+
+echo "DB_IMAGE: $DB_IMAGE"
+echo "::set-output name=db-image::$DB_IMAGE"


### PR DESCRIPTION
Recently the DS container used in PKI CI no longer worked so almost all tests were failing. The CI has been modified to use a regular DS server installed from RPM packages by default instead of a DS container. The CI has also been modified such that the type of DS service can be configured using a GH secret:
https://github.com/dogtagpki/pki/wiki/Configuring-Test-Database
