### PR TITLE
Clean up installation examples

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -185,7 +185,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Verify ACME in PKI container

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Test CA agent
@@ -267,7 +267,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Gather artifacts
@@ -381,7 +381,7 @@ jobs:
           docker exec subordinate pki client-cert-import ca_signing --ca-cert root-ca_signing.crt
           docker exec subordinate pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec subordinate pki -n caadmin ca-user-show caadmin
 
       - name: Gather artifacts from root containers
@@ -508,7 +508,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert root-ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Gather artifacts
@@ -670,7 +670,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Gather artifacts
@@ -751,7 +751,7 @@ jobs:
           docker exec primary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
           docker exec primary pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec primary pki -n caadmin ca-user-find
           docker exec primary pki securitydomain-host-find
 
@@ -790,11 +790,10 @@ jobs:
       - name: Verify users and SD hosts in secondary PKI container
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
-          docker exec primary cp /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf ${SHARED}/pkcs12_password.conf
           docker exec secondary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec secondary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin ca-user-find
           docker exec secondary pki securitydomain-host-find
 
@@ -836,7 +835,7 @@ jobs:
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec tertiary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin ca-user-find
           docker exec tertiary pki securitydomain-host-find
 
@@ -1030,7 +1029,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Gather artifacts
@@ -1179,7 +1178,7 @@ jobs:
           docker exec primary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec primary pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec primary pki -n caadmin ca-user-find
           docker exec primary pki securitydomain-host-find
 
@@ -1284,12 +1283,11 @@ jobs:
       - name: Verify users and SD hosts in secondary PKI container
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
-          docker exec primary cp /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf ${SHARED}/pkcs12_password.conf
           docker exec secondary pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec secondary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec secondary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin ca-user-find
           docker exec secondary pki securitydomain-host-find
 

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -146,7 +146,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin kra-user-show kraadmin
 
       - name: Verify KRA connector in CA
@@ -270,11 +270,10 @@ jobs:
       - name: Verify KRA admin
         run: |
           docker exec ca cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
-          docker exec ca cp /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf ${SHARED}/pkcs12_password.conf
           docker exec kra pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec kra pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec kra pki -n caadmin kra-user-show kraadmin
 
       - name: Verify KRA connector in CA
@@ -282,7 +281,7 @@ jobs:
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec ca bash -c "pki -n caadmin ca-kraconnector-show | sed -n 's/\s*Host:\s\+\(\S\+\):.*/\1/p' > ${SHARED}/kraconnector.host"
           echo kra.example.com > kra.hostname
           diff kra.hostname kraconnector.host
@@ -383,7 +382,7 @@ jobs:
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
 
       - name: Set up KRA DS container
         run: |
@@ -481,7 +480,7 @@ jobs:
           docker exec kra pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec kra pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/kra_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/kra/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec kra pki -n kraadmin kra-user-show kraadmin
 
       - name: Verify KRA connector in CA
@@ -636,11 +635,10 @@ jobs:
       - name: Verify KRA admin in secondary PKI container
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
-          docker exec primary cp /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf ${SHARED}/pkcs12_password.conf
           docker exec secondary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec secondary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin kra-user-show kraadmin
 
       - name: Set up tertiary DS container
@@ -692,7 +690,7 @@ jobs:
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec tertiary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin kra-user-show kraadmin
 
       - name: Gather artifacts from primary containers
@@ -899,7 +897,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/kra_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/kra/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n kraadmin kra-user-show kraadmin
 
       - name: Gather artifacts

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -146,7 +146,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ocsp-user-show ocspadmin
 
       - name: Gather artifacts
@@ -230,7 +230,7 @@ jobs:
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
 
       - name: Set up OCSP DS container
         run: |
@@ -319,7 +319,7 @@ jobs:
           docker exec ocsp pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec ocsp pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ocsp/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec ocsp pki -n ocspadmin ocsp-user-show ocspadmin
 
       - name: Gather artifacts from CA containers
@@ -468,11 +468,10 @@ jobs:
       - name: Verify OCSP admin in secondary PKI container
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
-          docker exec primary cp /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf ${SHARED}/pkcs12_password.conf
           docker exec secondary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec secondary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin ocsp-user-show ocspadmin
 
       - name: Set up tertiary DS container
@@ -524,7 +523,7 @@ jobs:
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec tertiary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin ocsp-user-show ocspadmin
 
       - name: Gather artifacts from primary containers
@@ -722,7 +721,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ocsp/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n ocspadmin ocsp-user-show ocspadmin
 
       - name: Gather artifacts

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -146,7 +146,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin tks-user-show tksadmin
 
       - name: Gather artifacts
@@ -282,11 +282,10 @@ jobs:
       - name: Verify TKS admin in secondary PKI container
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
-          docker exec primary cp /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf ${SHARED}/pkcs12_password.conf
           docker exec secondary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec secondary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin tks-user-show tksadmin
 
       - name: Set up tertiary DS container
@@ -338,7 +337,7 @@ jobs:
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec tertiary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin tks-user-show tksadmin
 
       - name: Gather artifacts from primary containers

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -166,7 +166,7 @@ jobs:
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec pki pki client-cert-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec pki pki -n caadmin tps-user-show tpsadmin
 
       - name: Set up TPS authentication
@@ -406,11 +406,10 @@ jobs:
       - name: Verify admin user
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
-          docker exec primary cp /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf ${SHARED}/pkcs12_password.conf
           docker exec secondary pki client-cert-import ca_signing --ca-cert ca_signing.crt
           docker exec secondary pki client-cert-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
-              --pkcs12-password-file ${SHARED}/pkcs12_password.conf
+              --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin tps-user-show tpsadmin
 
       - name: Gather artifacts from primary containers

--- a/base/server/examples/installation/ca-clone-of-clone.cfg
+++ b/base/server/examples/installation/ca-clone-of-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-clone-of-clone.cfg
+++ b/base/server/examples/installation/ca-clone-of-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-clone.cfg
+++ b/base/server/examples/installation/ca-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-clone.cfg
+++ b/base/server/examples/installation/ca-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-ecc.cfg
+++ b/base/server/examples/installation/ca-ecc.cfg
@@ -12,7 +12,6 @@ pki_admin_key_size=nistp521
 pki_admin_key_algorithm=SHA512withEC
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-ecc.cfg
+++ b/base/server/examples/installation/ca-ecc.cfg
@@ -11,7 +11,6 @@ pki_admin_key_type=ecc
 pki_admin_key_size=nistp521
 pki_admin_key_algorithm=SHA512withEC
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-existing-certs-step1.cfg
+++ b/base/server/examples/installation/ca-existing-certs-step1.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-existing-certs-step1.cfg
+++ b/base/server/examples/installation/ca-existing-certs-step1.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-existing-certs-step2.cfg
+++ b/base/server/examples/installation/ca-existing-certs-step2.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-existing-certs-step2.cfg
+++ b/base/server/examples/installation/ca-existing-certs-step2.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-external-cert-step1.cfg
+++ b/base/server/examples/installation/ca-external-cert-step1.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-external-cert-step1.cfg
+++ b/base/server/examples/installation/ca-external-cert-step1.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-external-cert-step2.cfg
+++ b/base/server/examples/installation/ca-external-cert-step2.cfg
@@ -11,7 +11,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-external-cert-step2.cfg
+++ b/base/server/examples/installation/ca-external-cert-step2.cfg
@@ -10,7 +10,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca-secure-ds-primary.cfg
+++ b/base/server/examples/installation/ca-secure-ds-primary.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_hostname=primary.example.com

--- a/base/server/examples/installation/ca-secure-ds-primary.cfg
+++ b/base/server/examples/installation/ca-secure-ds-primary.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_hostname=primary.example.com

--- a/base/server/examples/installation/ca-secure-ds-secondary.cfg
+++ b/base/server/examples/installation/ca-secure-ds-secondary.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_hostname=secondary.example.com

--- a/base/server/examples/installation/ca-secure-ds-secondary.cfg
+++ b/base/server/examples/installation/ca-secure-ds-secondary.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_hostname=secondary.example.com

--- a/base/server/examples/installation/ca-secure-ds.cfg
+++ b/base/server/examples/installation/ca-secure-ds.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_hostname=pki.example.com

--- a/base/server/examples/installation/ca-secure-ds.cfg
+++ b/base/server/examples/installation/ca-secure-ds.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_hostname=pki.example.com

--- a/base/server/examples/installation/ca.cfg
+++ b/base/server/examples/installation/ca.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ca.cfg
+++ b/base/server/examples/installation/ca.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-clone-of-clone.cfg
+++ b/base/server/examples/installation/kra-clone-of-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-clone-of-clone.cfg
+++ b/base/server/examples/installation/kra-clone-of-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-clone.cfg
+++ b/base/server/examples/installation/kra-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-clone.cfg
+++ b/base/server/examples/installation/kra-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-external-certs-step1.cfg
+++ b/base/server/examples/installation/kra-external-certs-step1.cfg
@@ -12,7 +12,6 @@ pki_admin_subject_dn=uid=kraadmin
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-external-certs-step2.cfg
+++ b/base/server/examples/installation/kra-external-certs-step2.cfg
@@ -12,7 +12,6 @@ pki_admin_subject_dn=uid=kraadmin
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-separate.cfg
+++ b/base/server/examples/installation/kra-separate.cfg
@@ -13,7 +13,6 @@ pki_admin_uid=kraadmin
 pki_admin_cert_file=ca_admin.cert
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-separate.cfg
+++ b/base/server/examples/installation/kra-separate.cfg
@@ -12,7 +12,6 @@ pki_admin_uid=kraadmin
 
 pki_admin_cert_file=ca_admin.cert
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-standalone-step1.cfg
+++ b/base/server/examples/installation/kra-standalone-step1.cfg
@@ -10,7 +10,6 @@ pki_admin_subject_dn=uid=kraadmin
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra-standalone-step2.cfg
+++ b/base/server/examples/installation/kra-standalone-step2.cfg
@@ -12,7 +12,6 @@ pki_admin_subject_dn=uid=kraadmin
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra.cfg
+++ b/base/server/examples/installation/kra.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/kra.cfg
+++ b/base/server/examples/installation/kra.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp-clone-of-clone.cfg
+++ b/base/server/examples/installation/ocsp-clone-of-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp-clone-of-clone.cfg
+++ b/base/server/examples/installation/ocsp-clone-of-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp-clone.cfg
+++ b/base/server/examples/installation/ocsp-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp-clone.cfg
+++ b/base/server/examples/installation/ocsp-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp-external-certs-step1.cfg
+++ b/base/server/examples/installation/ocsp-external-certs-step1.cfg
@@ -12,7 +12,6 @@ pki_admin_subject_dn=uid=ocspadmin
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp-external-certs-step2.cfg
+++ b/base/server/examples/installation/ocsp-external-certs-step2.cfg
@@ -12,7 +12,6 @@ pki_admin_subject_dn=uid=ocspadmin
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp-standalone-step1.cfg
+++ b/base/server/examples/installation/ocsp-standalone-step1.cfg
@@ -10,7 +10,6 @@ pki_admin_subject_dn=uid=ocspadmin
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp-standalone-step2.cfg
+++ b/base/server/examples/installation/ocsp-standalone-step2.cfg
@@ -12,7 +12,6 @@ pki_admin_subject_dn=uid=ocspadmin
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp.cfg
+++ b/base/server/examples/installation/ocsp.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/ocsp.cfg
+++ b/base/server/examples/installation/ocsp.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/subca.cfg
+++ b/base/server/examples/installation/subca.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/subca.cfg
+++ b/base/server/examples/installation/subca.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tks-clone-of-clone.cfg
+++ b/base/server/examples/installation/tks-clone-of-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=tksadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tks-clone-of-clone.cfg
+++ b/base/server/examples/installation/tks-clone-of-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tks-clone.cfg
+++ b/base/server/examples/installation/tks-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=tksadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tks-clone.cfg
+++ b/base/server/examples/installation/tks-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tks.cfg
+++ b/base/server/examples/installation/tks.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=tksadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tks.cfg
+++ b/base/server/examples/installation/tks.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tps-clone.cfg
+++ b/base/server/examples/installation/tps-clone.cfg
@@ -9,7 +9,6 @@ pki_admin_nickname=tpsadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tpsadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tps,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tps-clone.cfg
+++ b/base/server/examples/installation/tps-clone.cfg
@@ -10,7 +10,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tpsadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tps,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tps.cfg
+++ b/base/server/examples/installation/tps.cfg
@@ -8,7 +8,6 @@ pki_admin_nickname=tpsadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tpsadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tps,dc=pki,dc=example,dc=com

--- a/base/server/examples/installation/tps.cfg
+++ b/base/server/examples/installation/tps.cfg
@@ -9,7 +9,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tpsadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tps,dc=pki,dc=example,dc=com

--- a/docs/development/Testing-CA-Performance.adoc
+++ b/docs/development/Testing-CA-Performance.adoc
@@ -13,7 +13,7 @@ Then export the CA admin certificate and key:
 ----
 $ openssl pkcs12 \
     -in $HOME/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-    -passin file:$HOME/.dogtag/pki-tomcat/ca/pkcs12_password.conf \
+    -passin pass:<password> \
     -out caadmin.pem \
     -nodes
 ----

--- a/docs/installation/ca/Installing_CA.md
+++ b/docs/installation/ca/Installing_CA.md
@@ -66,7 +66,7 @@ Admin Certificate
 
 After installation the admin certificate and key will be stored
 in `~/.dogtag/pki-tomcat/ca_admin_cert.p12`.
-The password for this file will be stored in `~/.dogtag/pki-tomcat/ca/pkcs12_password.conf`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 
 To use the admin certificate, prepare a client NSS database (default is `~/.dogtag/nssdb`):
 
@@ -90,8 +90,8 @@ Finally, import admin certificate and key with the following command:
 
 ```
 $ pki client-cert-import \
-   --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-   --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the CA subsystem, execute the following command:

--- a/docs/installation/ca/Installing_CA_Clone.md
+++ b/docs/installation/ca/Installing_CA_Clone.md
@@ -74,8 +74,8 @@ By default the subsystem will be deployed into a Tomcat instance called `pki-tom
 A sample deployment configuration is available at [/usr/share/pki/server/examples/installation/ca-clone.cfg](../../../base/server/examples/installation/ca-clone.cfg).
 It assumes that the primary CA subsystem is running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
-the admin certificate and key have been exported into `ca_admin_cert.p12`,
-and the password for this file has been exported into `pkcs12_password.conf`.
+and the admin certificate and key have been exported into `ca_admin_cert.p12`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 See [Installing CA](Installing_CA.md) for details.
 
 To start the installation execute the following command:
@@ -140,7 +140,7 @@ Finally, import admin certificate and key with the following command:
 ```
 $ pki client-cert-import \
     --pkcs12 ca_admin_cert.p12 \
-    --pkcs12-password-file pkcs12_password.conf
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the CA subsystem clone, execute the following command:

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.md
@@ -32,7 +32,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.md
@@ -115,8 +115,8 @@ Import the master's admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the CA clone by executing the following command:

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.md
@@ -33,7 +33,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.md
@@ -96,8 +96,8 @@ By default the subsystem will be deployed into a Tomcat instance called `pki-tom
 A sample deployment configuration is available at [/usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg](../../../base/server/examples/installation/ca-secure-ds-secondary.cfg).
 It assumes that the existing CA and DS instances are running on primary.example.com, and the new CA and DS clones are being installed on secondary.example.com,
 the CA signing certificate has been exported into `ca_signing.crt`,
-the admin certificate and key have been exported into `ca_admin_cert.p12`,
-and the password for this file has been exported into `pkcs12_password.conf`.
+and the admin certificate and key have been exported into `ca_admin_cert.p12`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 
 To start the installation execute the following command:
 
@@ -162,7 +162,7 @@ Finally, import admin certificate and key with the following command:
 ```
 $ pki client-cert-import \
     --pkcs12 ca_admin_cert.p12 \
-    --pkcs12-password-file pkcs12_password.conf
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the CA subsystem clone, execute the following command:

--- a/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
+++ b/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
@@ -22,7 +22,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
+++ b/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
@@ -23,7 +23,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
+++ b/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
@@ -150,8 +150,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the CA subsystem by executing the following command:

--- a/docs/installation/ca/Installing_CA_with_ECC.md
+++ b/docs/installation/ca/Installing_CA_with_ECC.md
@@ -78,7 +78,7 @@ Admin Certificate
 
 After installation the admin certificate and key will be stored
 in `~/.dogtag/pki-tomcat/ca_admin_cert.p12`.
-The password for this file will be stored in `~/.dogtag/pki-tomcat/ca/pkcs12_password.conf`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 
 To use the admin certificate, prepare a client NSS database (default is `~/.dogtag/nssdb`):
 
@@ -102,8 +102,8 @@ Finally, import admin certificate and key with the following command:
 
 ```
 $ pki client-cert-import \
-   --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-   --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the CA subsystem, execute the following command:

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
@@ -32,7 +32,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
@@ -33,7 +33,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
@@ -180,8 +180,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the CA subsystem by executing the following command:

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.md
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.md
@@ -134,8 +134,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the CA subsystem by executing the following command:

--- a/docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
+++ b/docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
@@ -118,8 +118,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the CA subsystem by executing the following command:

--- a/docs/installation/ca/Installing_CA_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_HSM.md
@@ -105,8 +105,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the CA subsystem by executing the following command:

--- a/docs/installation/ca/Installing_CA_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_HSM.md
@@ -29,7 +29,6 @@ pki_admin_nickname=caadmin
 pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/docs/installation/ca/Installing_CA_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_HSM.md
@@ -30,7 +30,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com

--- a/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
+++ b/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
@@ -93,7 +93,7 @@ Admin Certificate
 
 After installation the admin certificate and key will be stored
 in `~/.dogtag/pki-tomcat/ca_admin_cert.p12`.
-The password for this file will be stored in `~/.dogtag/pki-tomcat/ca/pkcs12_password.conf`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 
 To use the admin certificate, prepare a client NSS database (default is `~/.dogtag/nssdb`):
 
@@ -117,8 +117,8 @@ Finally, import admin certificate and key with the following command:
 
 ```
 $ pki client-cert-import \
-   --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-   --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the CA subsystem, execute the following command:

--- a/docs/installation/ca/Installing_Subordinate_CA.md
+++ b/docs/installation/ca/Installing_Subordinate_CA.md
@@ -71,7 +71,7 @@ Import admin key and certificate:
 ```
 $ pki client-cert-import \
     --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-    --pkcs12-password-file /root/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the subordinate CA subsystem by executing the following command:

--- a/docs/installation/kra/Installing_KRA.md
+++ b/docs/installation/kra/Installing_KRA.md
@@ -67,8 +67,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:

--- a/docs/installation/kra/Installing_KRA_Clone.md
+++ b/docs/installation/kra/Installing_KRA_Clone.md
@@ -51,8 +51,8 @@ By default the subsystem will be deployed into a Tomcat instance called `pki-tom
 A sample deployment configuration is available at [/usr/share/pki/server/examples/installation/kra-clone.cfg](../../../base/server/examples/installation/kra-clone.cfg).
 It assumes that the primary CA and KRA subsystems are running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
-the admin certificate and key have been exported into `ca_admin_cert.p12`,
-and the password for this file has been exported into `pkcs12_password.conf`.
+and the admin certificate and key have been exported into `ca_admin_cert.p12`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 See [Installing CA](../ca/Installing_CA.md) for details.
 
 To start the installation execute the following command:
@@ -118,7 +118,7 @@ Finally, import admin certificate and key with the following command:
 ```
 $ pki client-cert-import \
     --pkcs12 ca_admin_cert.p12 \
-    --pkcs12-password-file pkcs12_password.conf
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the KRA subsystem clone, execute the following command:

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
@@ -32,7 +32,6 @@ pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
@@ -33,7 +33,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
@@ -115,8 +115,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:

--- a/docs/installation/kra/Installing_KRA_on_Separate_Instance.md
+++ b/docs/installation/kra/Installing_KRA_on_Separate_Instance.md
@@ -72,7 +72,7 @@ Import CA admin key and certificate:
 ```
 $ pki -c Secret.123 client-cert-import \
     --pkcs12 ca_admin_cert.p12 \
-    --pkcs12-password-file pkcs12_password.conf
+    --pkcs12-password Secret.123
 ```
 
 Verify that the CA admin certificate can be used to access the KRA subsystem by executing the following command:

--- a/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
+++ b/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
@@ -22,7 +22,6 @@ pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
+++ b/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
@@ -23,7 +23,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
+++ b/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
@@ -171,8 +171,8 @@ Import the admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/kra_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/kra_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access KRA by executing the following command:

--- a/docs/installation/kra/Installing_KRA_with_ECC.md
+++ b/docs/installation/kra/Installing_KRA_with_ECC.md
@@ -35,7 +35,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/docs/installation/kra/Installing_KRA_with_ECC.md
+++ b/docs/installation/kra/Installing_KRA_with_ECC.md
@@ -34,7 +34,6 @@ pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/docs/installation/kra/Installing_KRA_with_ECC.md
+++ b/docs/installation/kra/Installing_KRA_with_ECC.md
@@ -123,8 +123,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:

--- a/docs/installation/kra/Installing_KRA_with_External_Certificates.md
+++ b/docs/installation/kra/Installing_KRA_with_External_Certificates.md
@@ -116,8 +116,8 @@ Import the admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/kra_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/kra_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access KRA by executing the following command:

--- a/docs/installation/kra/Installing_KRA_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_with_HSM.md
@@ -31,7 +31,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/docs/installation/kra/Installing_KRA_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_with_HSM.md
@@ -108,8 +108,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:

--- a/docs/installation/kra/Installing_KRA_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_with_HSM.md
@@ -30,7 +30,6 @@ pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
@@ -27,7 +27,6 @@ pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_ldaps_port=636

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
@@ -120,8 +120,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
@@ -28,7 +28,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_ldaps_port=636

--- a/docs/installation/kra/Installing_Standalone_KRA.adoc
+++ b/docs/installation/kra/Installing_Standalone_KRA.adoc
@@ -88,8 +88,8 @@ Import admin key and certificate:
 
 ----
 $ pki client-cert-import \
-   --pkcs12 kra_admin_cert.p12 \
-   --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 kra_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ----
 
 Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:

--- a/docs/installation/ocsp/Installing_OCSP.md
+++ b/docs/installation/ocsp/Installing_OCSP.md
@@ -66,8 +66,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:

--- a/docs/installation/ocsp/Installing_OCSP_Clone.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone.md
@@ -50,8 +50,8 @@ By default the subsystem will be deployed into a Tomcat instance called `pki-tom
 A sample deployment configuration is available at [/usr/share/pki/server/examples/installation/ocsp-clone.cfg](../../../base/server/examples/installation/ocsp-clone.cfg).
 It assumes that the primary CA and OCSP subsystems are running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
-the admin certificate and key have been exported into `ca_admin_cert.p12`,
-and the password for this file has been exported into `pkcs12_password.conf`.
+and the admin certificate and key have been exported into `ca_admin_cert.p12`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 See [Installing CA](../ca/Installing_CA.md) for details.
 
 To start the installation execute the following command:
@@ -115,7 +115,7 @@ Finally, import admin certificate and key with the following command:
 ```
 $ pki client-cert-import \
     --pkcs12 ca_admin_cert.p12 \
-    --pkcs12-password-file pkcs12_password.conf
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the OCSP subsystem clone, execute the following command:

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
@@ -32,7 +32,6 @@ pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
@@ -112,8 +112,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
@@ -33,7 +33,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
@@ -23,7 +23,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
@@ -164,8 +164,8 @@ Import the admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:

--- a/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
@@ -22,7 +22,6 @@ pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/docs/installation/ocsp/Installing_OCSP_with_ECC.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_ECC.md
@@ -36,7 +36,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/docs/installation/ocsp/Installing_OCSP_with_ECC.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_ECC.md
@@ -115,8 +115,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:

--- a/docs/installation/ocsp/Installing_OCSP_with_ECC.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_ECC.md
@@ -35,7 +35,6 @@ pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
@@ -113,8 +113,8 @@ Import the admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ~/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
- --pkcs12-password-file ~/.dogtag/pki-tomcat/ca/pkcs12_password.conf
+    --pkcs12 ~/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.md
@@ -106,8 +106,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.md
@@ -30,7 +30,6 @@ pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.md
@@ -31,7 +31,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
@@ -118,8 +118,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
@@ -27,7 +27,6 @@ pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_ldaps_port=636

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
@@ -28,7 +28,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_ldaps_port=636

--- a/docs/installation/ocsp/Installing_Standalone_OCSP.adoc
+++ b/docs/installation/ocsp/Installing_Standalone_OCSP.adoc
@@ -86,8 +86,8 @@ Import admin key and certificate:
 
 ----
 $ pki client-cert-import \
-   --pkcs12 ocsp_admin_cert.p12 \
-   --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ocsp_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ----
 
 Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:

--- a/docs/installation/tks/Installing_TKS.md
+++ b/docs/installation/tks/Installing_TKS.md
@@ -65,8 +65,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the TKS subsystem by executing the following command:

--- a/docs/installation/tks/Installing_TKS_Clone.md
+++ b/docs/installation/tks/Installing_TKS_Clone.md
@@ -49,8 +49,8 @@ By default the subsystem will be deployed into a Tomcat instance called `pki-tom
 A sample deployment configuration is available at [/usr/share/pki/server/examples/installation/tks-clone.cfg](../../../base/server/examples/installation/tks-clone.cfg).
 It assumes that the primary CA and TKS are running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
-the admin certificate and key have been exported into `ca_admin_cert.p12`,
-and the password for this file has been exported into `pkcs12_password.conf`.
+and the admin certificate and key have been exported into `ca_admin_cert.p12`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 See [Installing CA](../ca/Installing_CA.md) for details.
 
 To start the installation execute the following command:
@@ -112,7 +112,7 @@ Finally, import admin certificate and key with the following command:
 ```
 $ pki client-cert-import \
     --pkcs12 ca_admin_cert.p12 \
-    --pkcs12-password-file pkcs12_password.conf
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the TKS subsystem clone, execute the following command:

--- a/docs/installation/tks/Installing_TKS_with_ECC.md
+++ b/docs/installation/tks/Installing_TKS_with_ECC.md
@@ -35,7 +35,6 @@ pki_admin_nickname=tksadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/docs/installation/tks/Installing_TKS_with_ECC.md
+++ b/docs/installation/tks/Installing_TKS_with_ECC.md
@@ -111,8 +111,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the TKS subsystem by executing the following command:

--- a/docs/installation/tks/Installing_TKS_with_ECC.md
+++ b/docs/installation/tks/Installing_TKS_with_ECC.md
@@ -36,7 +36,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/docs/installation/tks/Installing_TKS_with_HSM.md
+++ b/docs/installation/tks/Installing_TKS_with_HSM.md
@@ -30,7 +30,6 @@ pki_admin_nickname=tksadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/docs/installation/tks/Installing_TKS_with_HSM.md
+++ b/docs/installation/tks/Installing_TKS_with_HSM.md
@@ -31,7 +31,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com

--- a/docs/installation/tks/Installing_TKS_with_HSM.md
+++ b/docs/installation/tks/Installing_TKS_with_HSM.md
@@ -104,8 +104,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the TKS subsystem by executing the following command:

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
@@ -28,7 +28,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_ldaps_port=636

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
@@ -116,8 +116,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the TKS subsystem by executing the following command:

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
@@ -27,7 +27,6 @@ pki_admin_nickname=tksadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tksadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_ldaps_port=636

--- a/docs/installation/tps/Installing_TPS.md
+++ b/docs/installation/tps/Installing_TPS.md
@@ -65,8 +65,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the TPS subsystem by executing the following command:

--- a/docs/installation/tps/Installing_TPS_Clone.md
+++ b/docs/installation/tps/Installing_TPS_Clone.md
@@ -50,8 +50,8 @@ By default the subsystem will be deployed into a Tomcat instance called `pki-tom
 A sample deployment configuration is available at [/usr/share/pki/server/examples/installation/tps-clone.cfg](../../../base/server/examples/installation/tps-clone.cfg).
 It assumes that the primary CA, KRA, TKS, and TPS subsystems are running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
-the admin certificate and key have been exported into `ca_admin_cert.p12`,
-and the password for this file has been exported into `pkcs12_password.conf`.
+and the admin certificate and key have been exported into `ca_admin_cert.p12`.
+The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 See [Installing CA](../ca/Installing_CA.md) for details.
 
 To start the installation execute the following command:
@@ -112,8 +112,8 @@ Finally, import admin certificate and key with the following command:
 
 ```
 $ pki client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 To verify that the admin certificate can be used to access the TPS subsystem clone, execute the following command:

--- a/docs/installation/tps/Installing_TPS_with_HSM.md
+++ b/docs/installation/tps/Installing_TPS_with_HSM.md
@@ -104,8 +104,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the TPS subsystem by executing the following command:

--- a/docs/installation/tps/Installing_TPS_with_HSM.md
+++ b/docs/installation/tps/Installing_TPS_with_HSM.md
@@ -31,7 +31,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tpsadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tps,dc=pki,dc=example,dc=com

--- a/docs/installation/tps/Installing_TPS_with_HSM.md
+++ b/docs/installation/tps/Installing_TPS_with_HSM.md
@@ -30,7 +30,6 @@ pki_admin_nickname=tpsadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tpsadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_base_dn=dc=tps,dc=pki,dc=example,dc=com

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
@@ -116,8 +116,8 @@ Import admin key and certificate:
 
 ```
 $ pki -c Secret.123 client-cert-import \
- --pkcs12 ca_admin_cert.p12 \
- --pkcs12-password-file pkcs12_password.conf
+    --pkcs12 ca_admin_cert.p12 \
+    --pkcs12-password Secret.123
 ```
 
 Verify that the admin certificate can be used to access the TPS subsystem by executing the following command:

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
@@ -28,7 +28,6 @@ pki_admin_password=Secret.123
 pki_admin_uid=tpsadmin
 
 pki_client_database_password=Secret.123
-pki_client_database_purge=False
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_ldaps_port=636

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
@@ -27,7 +27,6 @@ pki_admin_nickname=tpsadmin
 pki_admin_password=Secret.123
 pki_admin_uid=tpsadmin
 
-pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
 pki_ds_ldaps_port=636

--- a/docs/manuals/man8/pkispawn.8.md
+++ b/docs/manuals/man8/pkispawn.8.md
@@ -385,8 +385,6 @@ where **myconfig.txt** contains the following text:
 pki_admin_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 pki_ds_password=Secret.123
-# Optionally keep client databases
-pki_client_database_purge=False
 ```
 
 To install a shared KRA in the same instance used by the CA execute the following command:
@@ -522,8 +520,6 @@ where **myconfig.txt** contains the following text:
 pki_admin_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 pki_ds_password=Secret.123
-# Optionally keep client databases
-pki_client_database_purge=False
 # Separated CA instance name and ports
 pki_instance_name=pki-ca
 pki_http_port=18080
@@ -552,8 +548,6 @@ pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 pki_ds_password=Secret.123
 pki_security_domain_password=Secret.123
-# Optionally keep client databases
-pki_client_database_purge=False
 # Separated KRA instance name and ports
 pki_instance_name=pki-kra
 pki_http_port=28080
@@ -590,8 +584,6 @@ pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 pki_ds_password=Secret.123
 pki_security_domain_password=Secret.123
-# Optionally keep client databases
-pki_client_database_purge=False
 # Separated OCSP instance name and ports
 pki_instance_name=pki-ocsp
 pki_http_port=29080
@@ -628,8 +620,6 @@ pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 pki_ds_password=Secret.123
 pki_security_domain_password=Secret.123
-# Optionally keep client databases
-pki_client_database_purge=False
 # Separated TKS instance name and ports
 pki_instance_name=pki-tks
 pki_http_port=30080
@@ -666,8 +656,6 @@ pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 pki_ds_password=Secret.123
 pki_security_domain_password=Secret.123
-# Optionally keep client databases
-pki_client_database_purge=False
 # Separated TPS instance name and ports
 pki_instance_name=pki-tps
 pki_http_port=31080
@@ -787,8 +775,6 @@ where **myconfig.txt** contains the following text:
 pki_admin_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 pki_ds_password=Secret.123
-# Optionally keep client databases
-pki_client_database_purge=False
 # Provide HSM parameters
 pki_hsm_enable=True
 pki_hsm_libfile=<hsm_libfile>


### PR DESCRIPTION
Previously the `pki_client_database_purge` param was used in the examples to retain the temporary NSS database used to generate the admin certificate so it can be reused after installation. The param has been removed from the examples since it's recommended to import the admin PKCS12 file instead of reusing the temporary NSS database.

The `pki_client_database_password` param has been removed from examples since it's not used except for installation with existing certs and standalone installation where the installation is done in two steps and pkispawn needs to use the same NSS database password in both steps.

The admin PKCS12 password file is only created if the `pki_client_database_purge` is set to `False`, which is not the default, so the examples have been updated to use the password directly.
