### PR TITLE
Fix Invalid Date error in TPS UI

### DIFF
--- a/base/tps/shared/webapps/tps/js/cert.js
+++ b/base/tps/shared/webapps/tps/js/cert.js
@@ -22,7 +22,6 @@
 var CertificateModel = Model.extend({
     urlRoot: "/tps/rest/certs",
     parseResponse: function(response) {
-        var respModifyTimestamp = (response.ModifyTime === null) ? "N/A" : new Date(response.ModifyTime)
         return {
             id: response.id,
             serialNumber: response.SerialNumber,
@@ -34,7 +33,7 @@ var CertificateModel = Model.extend({
             keyType: response.KeyType,
             status: response.Status,
             createTime: new Date(response.CreateTime),
-            modifyTime: respModifyTimestamp
+            modifyTime: new Date(response.ModifyTime)
         };
     },
     createRequest: function(attributes) {
@@ -63,7 +62,6 @@ var CertificateCollection = Collection.extend({
         return response.Link;
     },
     parseEntry: function(entry) {
-        var custModifyTimestamp = (entry.ModifyTime === null) ? "N/A" : new Date(entry.ModifyTime)
         return new CertificateModel({
             id: entry.id,
             serialNumber: entry.SerialNumber,
@@ -75,7 +73,7 @@ var CertificateCollection = Collection.extend({
             keyType: entry.KeyType,
             status: entry.Status,
             createTime: new Date(entry.CreateTime),
-            modifyTime: custModifyTimestamp
+            modifyTime: new Date(entry.ModifyTime)
         });
     }
 });

--- a/base/tps/shared/webapps/tps/js/token.js
+++ b/base/tps/shared/webapps/tps/js/token.js
@@ -38,7 +38,6 @@ var TOKEN_REUSE_MESSAGE = "When reusing a token that was previously " +
 var TokenModel = Model.extend({
     urlRoot: "/tps/rest/tokens",
     parseResponse: function(response) {
-        var respModifyTimestamp = (response.ModifyTime === null) ? "N/A" : new Date(response.ModifyTime)
         return {
             id: response.id,
             tokenID: response.TokenID,
@@ -50,7 +49,7 @@ var TokenModel = Model.extend({
             keyInfo: response.KeyInfo,
             policy: response.Policy,
             createTimestamp: new Date(response.CreateTimestamp),
-            modifyTimestamp: respModifyTimestamp
+            modifyTimestamp: new Date(response.ModifyTime)
         };
     },
     createRequest: function(attributes) {
@@ -91,7 +90,6 @@ var TokenCollection = Collection.extend({
         return response.Link;
     },
     parseEntry: function(entry) {
-        var custModifyTimestamp = (entry.ModifyTime === null) ? "N/A" : new Date(entry.ModifyTime)
         return new TokenModel({
             id: entry.id,
             tokenID: entry.TokenID,
@@ -103,7 +101,7 @@ var TokenCollection = Collection.extend({
             keyInfo: entry.KeyInfo,
             policy: entry.Policy,
             createTimestamp: new Date(entry.CreateTimestamp),
-            modifyTimestamp: custModifyTimestamp
+            modifyTimestamp: new Date(entry.ModifyTime)
         });
     }
 });


### PR DESCRIPTION
Will make unmodified dates show Thu Jan 01 1970 01:00:00 GMT+0100. A
previous attempt tried to show N/A instead but the date is parsed for
some other purpose and this caused an error - so I have modified it to
return a legitimate Date object