### PR TITLE
Update test for external CA installation

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -480,25 +480,44 @@ jobs:
               --trust CT,C,C \
               root-ca_signing
 
-      - name: Install subordinate CA
+      - name: Install subordinate CA (step 1)
         run: |
+          # https://github.com/dogtagpki/pki/wiki/Adding-CA-Signing-CSR-Extension
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg \
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_req_ext_add=True \
+              -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
+              -D pki_req_ext_data=1E0A00530075006200430041 \
               -v
+
+          docker exec pki /usr/share/pki/tests/ca/bin/test-subca-signing-csr-ext.sh ca_signing.csr
+
+      - name: Issue subordinate CA signing cert
+        run: |
           docker exec pki pki -d nssdb nss-cert-issue \
               --issuer root-ca_signing \
               --csr ca_signing.csr \
-              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --ext /usr/share/pki/server/certs/subca_signing.conf \
               --cert ca_signing.crt
+
+      - name: Install subordinate CA (step 2)
+        run: |
+          # https://github.com/dogtagpki/pki/wiki/Adding-CA-Signing-CSR-Extension
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-external-cert-step2.cfg \
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_req_ext_add=True \
+              -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
+              -D pki_req_ext_data=1E0A00530075006200430041 \
               -v
+
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki /usr/share/pki/tests/ca/bin/test-subca-signing-cert-ext.sh ca_signing.crt
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --debug

--- a/base/server/certs/subca_signing.conf
+++ b/base/server/certs/subca_signing.conf
@@ -2,5 +2,7 @@ subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid:always
 basicConstraints       = critical, CA:TRUE
 keyUsage               = critical, digitalSignature, nonRepudiation, keyCertSign, cRLSign
+
+# Microsoft's Subordinate CA Extension
 genericExtensions      = 1.3.6.1.4.1.311.20.2
 1.3.6.1.4.1.311.20.2   = DER:1E:0A:00:53:00:75:00:62:00:43:00:41

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -365,10 +365,9 @@ pki_subsystem_cert_path=
 pki_ca_starting_crl_number=0
 pki_external=False
 pki_req_ext_add=False
-# MS subca request ext data
-pki_req_ext_oid=1.3.6.1.4.1.311.20.2
+pki_req_ext_oid=
 pki_req_ext_critical=False
-pki_req_ext_data=1E0A00530075006200430041
+pki_req_ext_data=
 pki_external_step_two=False
 
 pki_external_pkcs12_path=%(pki_pkcs12_path)s


### PR DESCRIPTION
The test for CA installation with external signing cert has been updated to add a Microsoft Subordinate CA extension in the CSR and in the issued cert.

The `pkispawn` default configuration file has been modified to no longer include the extension since it's already provided as an example in the `subca_signing.conf`.