### PR TITLE
Force Date(null) for unmodified token timestamps

### DIFF
--- a/base/tps/shared/webapps/tps/js/cert.js
+++ b/base/tps/shared/webapps/tps/js/cert.js
@@ -22,6 +22,7 @@
 var CertificateModel = Model.extend({
     urlRoot: "/tps/rest/certs",
     parseResponse: function(response) {
+    var respModifyTimestamp = (response.ModifyTime === null) ? new Date(null) : new Date(response.ModifyTime)
         return {
             id: response.id,
             serialNumber: response.SerialNumber,
@@ -33,7 +34,7 @@ var CertificateModel = Model.extend({
             keyType: response.KeyType,
             status: response.Status,
             createTime: new Date(response.CreateTime),
-            modifyTime: new Date(response.ModifyTime)
+            modifyTime: respModifyTimestamp
         };
     },
     createRequest: function(attributes) {
@@ -62,6 +63,7 @@ var CertificateCollection = Collection.extend({
         return response.Link;
     },
     parseEntry: function(entry) {
+        var custModifyTimestamp = (entry.ModifyTime === null) ? new Date(null) : new Date(entry.ModifyTime)
         return new CertificateModel({
             id: entry.id,
             serialNumber: entry.SerialNumber,
@@ -73,7 +75,7 @@ var CertificateCollection = Collection.extend({
             keyType: entry.KeyType,
             status: entry.Status,
             createTime: new Date(entry.CreateTime),
-            modifyTime: new Date(entry.ModifyTime)
+            modifyTime: custModifyTimestamp
         });
     }
 });

--- a/base/tps/shared/webapps/tps/js/token.js
+++ b/base/tps/shared/webapps/tps/js/token.js
@@ -38,6 +38,7 @@ var TOKEN_REUSE_MESSAGE = "When reusing a token that was previously " +
 var TokenModel = Model.extend({
     urlRoot: "/tps/rest/tokens",
     parseResponse: function(response) {
+    var respModifyTimestamp = (response.ModifyTime === null) ? new Date(null) : new Date(response.ModifyTime)
         return {
             id: response.id,
             tokenID: response.TokenID,
@@ -49,7 +50,7 @@ var TokenModel = Model.extend({
             keyInfo: response.KeyInfo,
             policy: response.Policy,
             createTimestamp: new Date(response.CreateTimestamp),
-            modifyTimestamp: new Date(response.ModifyTime)
+            modifyTimestamp: respModifyTimestamp
         };
     },
     createRequest: function(attributes) {
@@ -90,6 +91,7 @@ var TokenCollection = Collection.extend({
         return response.Link;
     },
     parseEntry: function(entry) {
+        var custModifyTimestamp = (entry.ModifyTime === null) ? new Date(null) : new Date(entry.ModifyTime)
         return new TokenModel({
             id: entry.id,
             tokenID: entry.TokenID,
@@ -101,7 +103,7 @@ var TokenCollection = Collection.extend({
             keyInfo: entry.KeyInfo,
             policy: entry.Policy,
             createTimestamp: new Date(entry.CreateTimestamp),
-            modifyTimestamp: new Date(entry.ModifyTime)
+            modifyTimestamp: custModifyTimestamp
         });
     }
 });


### PR DESCRIPTION
* Passing the argument directly into the constructor results in Invalid
Date, so for whatever reason it can't be parsed. Get around this by
using Date(null) explictly, which definitely gives a valid Date