### PR TITLE
Bug2040525-disableFIPS-pkiconsole-nssdb-path

### DIFF
--- a/base/console/templates/pki_console_wrapper
+++ b/base/console/templates/pki_console_wrapper
@@ -128,6 +128,7 @@ export CP
 
 ${JAVA} ${JAVA_OPTIONS} \
   -cp ${CP} \
+  -Dcom.redhat.fips=false \
   -Djava.util.prefs.systemRoot=/tmp/.java \
   -Djava.util.prefs.userRoot=/tmp/java \
   -Djava.util.logging.config.file=${PKI_LOGGING_CONFIG} \


### PR DESCRIPTION
This patch takes care of the issue that java commands can't work with
FIPS enabled.  The trick is to temporarily disable it so it can load the
crypto provider and then it will take its (FIPS) course after the
initialization.
This particular script was missed at previous effort.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2040525