### PR TITLE
Run RPMInspect against new builds

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -42,7 +42,15 @@ jobs:
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
 
       - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,tests --with-timestamp --work-dir=build rpm
+        run: ./build.sh --with-timestamp --work-dir=build rpm
+
+      - name: Upload PKI packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: |
+            build/RPMS/
+            build/SRPMS/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -1411,3 +1419,30 @@ jobs:
           docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
           sed -n 's/^<.*>\s\+\S\+\s\+\(\S\+\).*/\1/p' output | sort > expected
           diff actual expected
+
+  rpminspect-test:
+    name: Run RPMInspect on RPMs
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download PKI packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: |
+            build/
+
+      - name: Install RPMInspect
+        run: |
+          dnf install -y dnf-plugins-core rpm-build findutils
+          dnf copr enable -y copr.fedorainfracloud.org/dcantrell/rpminspect
+          dnf install -y rpminspect rpminspect-data-fedora
+      - name: Run RPMInspect on SRPM and RPMs
+        run: |
+          tests/bin/rpminspect.sh

--- a/tests/bin/rpminspect.sh
+++ b/tests/bin/rpminspect.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+# Don't run metadata check as we can't know the build host subdomain
+# of CI runners in advance to add to an allow list
+
+echo "Running RPMInspect on SRPM"
+rpminspect-fedora -E metadata build/SRPMS/*.rpm
+
+# Run RPMInspect on RPMs
+for f in build/RPMS/*rpm; do
+
+  echo "::group::Running RPMInspect on $f"
+  if [[ "$f" == *"dogtag-pki-tools-"[0-9]* ]]
+  then
+    # "Don't run runpath test for dogtag-pki-tools as expect it to fail."
+    # "dogtag-pki-tools utilizes internal libraries located under '%{_libdir}/tps'"
+    rpminspect-fedora -E runpath,metadata,javabytecode "$f"
+  else
+    rpminspect-fedora -E metadata,javabytecode "$f"
+  fi
+  echo "::endgroup::"
+  done


### PR DESCRIPTION
Run only once in `tools-tests`, no need for multiple runs.

Currently the metadata check is failing, this is consistent with what I see locally. I can't compare this with the most recent Fedora build because it is too old and the logs are gone, but `RPMInspect` did fail for that build. `RPMDepLint` also failed, so perhaps a job can be created for that too.

Currently I put this in `tools-tests` rather than make a new pipeline but if we end up doing additional linting/security validation/etc we could spin those things out into their own pipeline.