### PR TITLE
Fix pki-healthcheck for clones

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -177,7 +177,7 @@ jobs:
           docker exec pki pki-server acme-deploy --wait
 
       - name: Run PKI healthcheck in PKI container
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify admin user in PKI container
         run: |

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -165,7 +165,7 @@ jobs:
           docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Initialize PKI client
         run: |
@@ -326,7 +326,7 @@ jobs:
           diff expected actual
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify CA admin
         run: |
@@ -476,7 +476,7 @@ jobs:
           docker exec subordinate openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
       - name: Run PKI healthcheck
-        run: docker exec subordinate pki-healthcheck
+        run: docker exec subordinate pki-healthcheck --failures-only
 
       - name: Verify CA admin
         run: |
@@ -700,7 +700,7 @@ jobs:
           docker exec subordinate openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
       - name: Run PKI healthcheck
-        run: docker exec subordinate pki-healthcheck
+        run: docker exec subordinate pki-healthcheck --failures-only
 
       - name: Verify subordinate CA admin cert
         run: |
@@ -852,7 +852,7 @@ jobs:
           docker exec pki /usr/share/pki/tests/ca/bin/test-subca-signing-cert-ext.sh ca_signing.crt
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify CA admin
         run: |
@@ -1009,7 +1009,7 @@ jobs:
           docker exec pki pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify CA keys
         run: |
@@ -1388,7 +1388,7 @@ jobs:
           docker exec pki pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify DS connection
         run: |
@@ -1542,9 +1542,6 @@ jobs:
 
           docker exec primary pki-server cert-find
 
-      - name: Run PKI healthcheck in primary PKI container
-        run: docker exec primary pki-healthcheck
-
       - name: Verify DS connection in primary PKI container
         run: |
           docker exec primary pki-server ca-db-config-show > output
@@ -1656,8 +1653,11 @@ jobs:
 
           docker exec secondary pki-server cert-find
 
+      - name: Run PKI healthcheck in primary PKI container
+        run: docker exec primary pki-healthcheck --failures-only
+
       - name: Run PKI healthcheck in secondary PKI container
-        run: docker exec secondary pki-healthcheck
+        run: docker exec secondary pki-healthcheck --failures-only
 
       - name: Verify DS connection in secondary PKI container
         run: |
@@ -1802,7 +1802,7 @@ jobs:
               -v
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Initialize PKI client
         run: |
@@ -1960,7 +1960,7 @@ jobs:
           docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Initialize PKI client
         run: |

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -122,6 +122,9 @@ jobs:
           docker exec ipa bash -c "echo Secret.123 | kinit admin"
           docker exec ipa ipa ping
 
+      - name: Run PKI healthcheck
+        run: docker exec ipa pki-healthcheck --failures-only
+
       - name: Configure test environment
         run: |
           docker exec ipa bash -c "cp -r /etc/ipa/* ~/.ipa"
@@ -424,6 +427,15 @@ jobs:
               --no-host-dns \
               --setup-ca \
               --setup-kra
+
+      # TODO: Enable the following tests after the following issue is fixed:
+      # https://pagure.io/freeipa/issue/9099
+      #
+      # - name: Run PKI healthcheck in primary container
+      #   run: docker exec primary pki-healthcheck --failures-only
+      #
+      # - name: Run PKI healthcheck in secondary container
+      #   run: docker exec secondary pki-healthcheck --failures-only
 
       - name: Verify CA admin
         run: |

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -142,7 +142,7 @@ jobs:
           docker exec pki pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify KRA admin
         run: |
@@ -279,7 +279,7 @@ jobs:
 
       # TODO: Fix DogtagKRAConnectivityCheck to work without CA
       # - name: Run PKI healthcheck
-      #   run: docker exec kra pki-healthcheck
+      #   run: docker exec kra pki-healthcheck --failures-only
 
       - name: Verify KRA admin
         run: |
@@ -510,7 +510,7 @@ jobs:
 
       # TODO: Fix DogtagKRAConnectivityCheck to work without CA
       # - name: Run PKI healthcheck
-      #   run: docker exec kra pki-healthcheck
+      #   run: docker exec kra pki-healthcheck --failures-only
 
       - name: Verify KRA admin
         run: |
@@ -841,7 +841,7 @@ jobs:
 
       # TODO: Fix DogtagKRAConnectivityCheck to work without CA
       # - name: Run PKI healthcheck
-      #   run: docker exec kra pki-healthcheck
+      #   run: docker exec kra pki-healthcheck --failures-only
 
       - name: Verify KRA admin
         run: |
@@ -1069,6 +1069,15 @@ jobs:
               --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin kra-user-show kraadmin
 
+      - name: Run PKI healthcheck in primary container
+        run: docker exec primary pki-healthcheck --failures-only
+
+      - name: Run PKI healthcheck in secondary container
+        run: docker exec secondary pki-healthcheck --failures-only
+
+      - name: Run PKI healthcheck in tertiary container
+        run: docker exec tertiary pki-healthcheck --failures-only
+
       - name: Gather artifacts from primary containers
         if: always()
         run: |
@@ -1273,7 +1282,7 @@ jobs:
 
       # TODO: Fix DogtagKRAConnectivityCheck to work without CA
       # - name: Run PKI healthcheck
-      #   run: docker exec pki pki-healthcheck
+      #   run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify admin user
         run: |

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -142,7 +142,7 @@ jobs:
           docker exec pki pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify OCSP admin
         run: |
@@ -267,7 +267,7 @@ jobs:
           docker exec ocsp pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec ocsp pki-healthcheck
+        run: docker exec ocsp pki-healthcheck --failures-only
 
       - name: Verify OCSP admin
         run: |
@@ -476,7 +476,7 @@ jobs:
           docker exec ocsp pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec ocsp pki-healthcheck
+        run: docker exec ocsp pki-healthcheck --failures-only
 
       - name: Verify OCSP admin
         run: |
@@ -773,7 +773,7 @@ jobs:
           docker exec ocsp pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec ocsp pki-healthcheck
+        run: docker exec ocsp pki-healthcheck --failures-only
 
       - name: Verify OCSP admin
         run: |
@@ -993,6 +993,15 @@ jobs:
 
           docker exec tertiary pki-server cert-find
 
+      - name: Run PKI healthcheck in primary container
+        run: docker exec primary pki-healthcheck --failures-only
+
+      - name: Run PKI healthcheck in secondary container
+        run: docker exec secondary pki-healthcheck --failures-only
+
+      - name: Run PKI healthcheck in tertiary container
+        run: docker exec tertiary pki-healthcheck --failures-only
+
       - name: Verify OCSP admin in tertiary PKI container
         run: |
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
@@ -1195,7 +1204,7 @@ jobs:
 
       # TODO: Fix DogtagOCSPConnectivityCheck to work without CA
       # - name: Run PKI healthcheck
-      #   run: docker exec pki pki-healthcheck
+      #   run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify admin user
         run: |

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -142,7 +142,7 @@ jobs:
           docker exec pki pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify TKS admin
         run: |
@@ -267,7 +267,7 @@ jobs:
           docker exec tks pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec tks pki-healthcheck
+        run: docker exec tks pki-healthcheck --failures-only
 
       - name: Verify TKS admin
         run: |
@@ -472,7 +472,7 @@ jobs:
           docker exec tks pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec tks pki-healthcheck
+        run: docker exec tks pki-healthcheck --failures-only
 
       - name: Verify TKS admin
         run: |
@@ -693,6 +693,15 @@ jobs:
               -v
 
           docker exec tertiary pki-server cert-find
+
+      - name: Run PKI healthcheck in primary container
+        run: docker exec primary pki-healthcheck --failures-only
+
+      - name: Run PKI healthcheck in secondary container
+        run: docker exec secondary pki-healthcheck --failures-only
+
+      - name: Run PKI healthcheck in tertiary container
+        run: docker exec tertiary pki-healthcheck --failures-only
 
       - name: Verify TKS admin in tertiary PKI container
         run: |

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -166,7 +166,7 @@ jobs:
           docker exec pki pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec pki pki-healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
 
       - name: Verify TPS admin
         run: |
@@ -426,7 +426,7 @@ jobs:
           docker exec tps pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec tps pki-healthcheck
+        run: docker exec tps pki-healthcheck --failures-only
 
       - name: Verify TPS admin
         run: |
@@ -748,7 +748,7 @@ jobs:
           docker exec tps pki-server cert-find
 
       - name: Run PKI healthcheck
-        run: docker exec tps pki-healthcheck
+        run: docker exec tps pki-healthcheck --failures-only
 
       - name: Verify TPS admin
         run: |
@@ -1001,6 +1001,12 @@ jobs:
               -v
 
           docker exec secondary pki-server cert-find
+
+      - name: Run PKI healthcheck in primary container
+        run: docker exec primary pki-healthcheck --failures-only
+
+      - name: Run PKI healthcheck in secondary container
+        run: docker exec secondary pki-healthcheck --failures-only
 
       - name: Verify admin user
         run: |

--- a/base/server/healthcheck/pki/server/healthcheck/clones/connectivity_and_data.py
+++ b/base/server/healthcheck/pki/server/healthcheck/clones/connectivity_and_data.py
@@ -46,93 +46,83 @@ class ClonesConnectivyAndDataCheck(ClonesPlugin):
 
     def check_kra_clones(self):
         for host in self.clone_kras:
-            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
-            # Reach out and get some keys or requests , to serve as a data and connectivity check
+
+            url = 'https://' + host.Hostname + ':' + host.SecurePort
+
             try:
-                client_nick = self.security_domain.config.get('ca.connector.KRA.nickName')
+                status = self.get_status(
+                    host.Hostname,
+                    host.SecurePort,
+                    '/kra/admin/kra/getStatus')
 
-                output = self.contact_subsystem_using_pki(
-                    host.SecurePort, host.Hostname, client_nick,
-                    self.passwd, self.db_dir, 'kra-key-show', ['0x01'])
+                logger.info('KRA at %s is %s', url, status)
 
-                # check to see if we either got a key or a key not found exception
-                # of which either will imply a successful connection
-                if output is not None:
-                    key_found = output.find('Key ID:')
-                    key_not_found = output.find('KeyNotFoundException:')
-                    if key_found >= 0:
-                        logger.info('Key material found from kra clone.')
+                if status != 'running':
+                    raise Exception('KRA at %s is %s' % (url, status))
 
-                    if key_not_found >= 0:
-                        logger.info('key not found, possibly empty kra')
-
-                    if key_not_found == -1 and key_found == -1:
-                        logger.info('Failure to get key material from kra')
-                        raise BaseException('KRA clone problem detected ' + cur_clone_msg)
-                else:
-                    raise BaseException('No data obtained from KRA clone.' + cur_clone_msg)
-
-            except BaseException as e:
-                logger.error("Internal error testing KRA clone. %s", e)
-                raise BaseException('Internal error testing KRA clone.' + cur_clone_msg)
-
-        return
+            except Exception as e:
+                logger.error('Unable to reach KRA at %s: %s', url, e)
+                raise Exception('Unable to reach KRA at %s: %s' % (url, e))
 
     def check_ocsp_clones(self):
         for host in self.clone_ocsps:
-            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
-            # Reach out to the ocsp clones
+
+            url = 'https://' + host.Hostname + ':' + host.SecurePort
+
             try:
-                output = self.contact_subsystem_using_sslget(
-                    host.SecurePort, host.Hostname, None,
-                    self.passwd, self.db_dir, None, '/ocsp/admin/ocsp/getStatus')
+                status = self.get_status(
+                    host.Hostname,
+                    host.SecurePort,
+                    '/ocsp/admin/ocsp/getStatus')
 
-                good_status = output.find('<State>1</State>')
-                if good_status == -1:
-                    raise BaseException('OCSP clone problem detected.' + cur_clone_msg)
-                logger.info('good_status %s ', good_status)
-            except BaseException as e:
-                logger.error("Internal error testing OCSP clone.  %s", e)
-                raise BaseException('Internal error testing OCSP clone.' + cur_clone_msg)
+                logger.info('OCSP at %s is %s', url, status)
 
-        return
+                if status != 'running':
+                    raise Exception('OCSP at %s is %s' % (url, status))
+
+            except Exception as e:
+                logger.error('Unable to reach OCSP at %s: %s', url, e)
+                raise Exception('Unable to reach OCSP at %s: %s' % (url, e))
 
     def check_tks_clones(self):
         for host in self.clone_tkss:
-            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
-            # Reach out to the tks clones
+
+            url = 'https://' + host.Hostname + ':' + host.SecurePort
+
             try:
-                output = self.contact_subsystem_using_sslget(
-                    host.SecurePort, host.Hostname, None,
-                    self.passwd, self.db_dir, None, '/tks/admin/tks/getStatus')
+                status = self.get_status(
+                    host.Hostname,
+                    host.SecurePort,
+                    '/tks/admin/tks/getStatus')
 
-                good_status = output.find('<State>1</State>')
-                if good_status == -1:
-                    raise BaseException('TKS clone problem detected.' + cur_clone_msg)
-                logger.info('good_status %s ', good_status)
-            except BaseException as e:
-                logger.error("Internal error testing TKS clone. %s", e)
-                raise BaseException('Internal error testing TKS clone.' + cur_clone_msg)
+                logger.info('TKS at %s is %s', url, status)
 
-        return
+                if status != 'running':
+                    raise Exception('TKS at %s is %s' % (url, status))
+
+            except Exception as e:
+                logger.error('Unable to reach TKS at %s: %s', url, e)
+                raise Exception('Unable to reach TKS at %s: %s' % (url, e))
 
     def check_tps_clones(self):
         for host in self.clone_tpss:
-            cur_clone_msg = ' Host: ' + host.Hostname + ' Port: ' + host.SecurePort
-            # Reach out to the tps clones
-            try:
-                output = self.contact_subsystem_using_sslget(
-                    host.SecurePort, host.Hostname, None,
-                    self.passwd, self.db_dir, None, '/tps/admin/tps/getStatus')
 
-                good_status = output.find('<State>1</State>')
-                if good_status == -1:
-                    raise BaseException('TPS clone problem detected.' + cur_clone_msg)
-                logger.info('good_status  %s ', good_status)
-            except BaseException as e:
-                logger.error("Internal error testing TPS clone. %s", e)
-                raise BaseException('Internal error testing TPS clone.' + cur_clone_msg)
-        return
+            url = 'https://' + host.Hostname + ':' + host.SecurePort
+
+            try:
+                status = self.get_status(
+                    host.Hostname,
+                    host.SecurePort,
+                    '/tps/admin/tps/getStatus')
+
+                logger.info('TPS at %s is %s', url, status)
+
+                if status != 'running':
+                    raise Exception('TPS at %s is %s' % (url, status))
+
+            except Exception as e:
+                logger.error('Unable to reach TPS at %s: %s', url, e)
+                raise Exception('Unable to reach TPS at %s: %s' % (url, e))
 
     @duration
     def check(self):

--- a/base/server/healthcheck/pki/server/healthcheck/clones/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/clones/plugin.py
@@ -6,15 +6,16 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
+import json
+import logging
+import xml.etree.ElementTree as ET
+
 from ipahealthcheck.core.plugin import Plugin, Registry
 from pki.server.instance import PKIInstance
 from pki.client import PKIConnection
 from pki.system import SecurityDomainClient
 
 from pki.server.healthcheck.core.main import merge_dogtag_config
-
-import logging
-import subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -46,60 +47,36 @@ class ClonesPlugin(Plugin):
 
         self.instance = PKIInstance(self.config.instance_name)
 
-    def contact_subsystem_using_pki(
-            self, subport, subhost, subsystemnick,
-            token_pwd, db_path, cmd, exts=None):
-        command = ["/usr/bin/pki",
-                   "-p", str(subport),
-                   "-h", subhost,
-                   "-n", subsystemnick,
-                   "-P", "https",
-                   "-d", db_path,
-                   "-c", token_pwd,
-                   cmd]
+    def get_status(self, host, port, path):
 
-        if exts is not None:
-            command.extend(exts)
+        self.instance.export_ca_cert()
 
-        output = None
-        try:
-            output = subprocess.check_output(command, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            output = e.output.decode('utf-8')
-            return output
+        connection = PKIConnection(
+            protocol='https',
+            hostname=host,
+            port=port,
+            cert_paths=self.instance.ca_cert)
 
-        output = output.decode('utf-8')
+        response = connection.get(path)
 
-        return output
+        content_type = response.headers['Content-Type']
+        content = response.text
+        logger.info('Content:\n%s', content)
 
-    def contact_subsystem_using_sslget(
-            self, port, host, subsystemnick,
-            token_pwd, db_path, params, url):
+        # https://github.com/dogtagpki/pki/wiki/GetStatus-Service
+        if content_type == 'application/json':
+            json_response = json.loads(content)
+            status = json_response['Response']['Status']
 
-        command = ["/usr/bin/sslget"]
+        elif content_type == 'application/xml':
+            root = ET.fromstring(response)
+            status = root.findtext('Status')
 
-        if subsystemnick is not None:
-            command.extend(["-n", subsystemnick])
+        else:
+            raise Exception('Unsupported content-type: %s' % content_type)
 
-        command.extend(["-p", token_pwd, "-d", db_path])
-
-        if params is not None:
-            command.extend(["-e", params])
-
-        command.extend([
-            "-r", url, host + ":" + port])
-
-        logger.info(' command : %s ', command)
-        output = None
-        try:
-            output = subprocess.check_output(command, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            output = e.output.decode('utf-8')
-            return output
-
-        output = output.decode('utf-8')
-
-        return output
+        logger.info('Status: %s', status)
+        return status
 
     def get_security_domain_data(self, host, port):
         domain_data = None

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -241,6 +241,10 @@ class PKIServer(object):
     def jss_conf(self):
         return os.path.join(self.conf_dir, 'jss.conf')
 
+    @property
+    def ca_cert(self):
+        return os.path.join(self.nssdb_dir, 'ca.crt')
+
     def is_valid(self):
         return self.exists()
 
@@ -259,8 +263,6 @@ class PKIServer(object):
 
     def export_ca_cert(self):
 
-        ca_path = os.path.join(self.nssdb_dir, 'ca.crt')
-
         token = pki.nssdb.INTERNAL_TOKEN_NAME
         nickname = self.get_sslserver_cert_nickname()
 
@@ -275,7 +277,7 @@ class PKIServer(object):
         nssdb = self.open_nssdb(token=token)
 
         try:
-            nssdb.extract_ca_cert(ca_path, nickname)
+            nssdb.extract_ca_cert(self.ca_cert, nickname)
         finally:
             nssdb.close()
 


### PR DESCRIPTION
Previously the `ClonesConnectivyAndDataCheck.check_kra_clones()` was trying to check KRA clone status by retrieving a key using the subsystem cert. This operation did not work since the user associated with the cert did not have access to the keys. The code has been changed to get the status from `GetStatus` service instead. The original code might be moved into IPA later so it could run with IPA's RA agent credentials which would allow access to the keys.

Previously the `ClonesPlugin.contact_subsystem_using_sslget()` used `sslget` to call `GetStatus` service and returned the entire output which was then incorrectly processed in XML format. The method has been renamed to `get_status()` and changed to use `PKIConnection` and process the response in either JSON or XML format, then only return the subsystem status. All callers have been updated accordingly.

The `ClonesPlugin.contact_subsystem_using_pki()` is no longer used so it has been removed.

The clone tests have been modified to run `pki-healthcheck`. All `pki-healtcheck` invocations have been modified to show only the failures.
