### PR TITLE
Update pkidestroy log messages

### DIFF
--- a/base/server/python/pki/server/deployment/pkimessages.py
+++ b/base/server/python/pki/server/deployment/pkimessages.py
@@ -281,8 +281,6 @@ PKIHELPER_SECURITY_DOMAIN_UNDEFINED = \
     "Otherwise, manually delete the entry from the security domain master."
 PKIHELPER_SECURITY_DOMAIN_UNREACHABLE_1 = \
     "security domain '%s' may be offline or unreachable!"
-PKIHELPER_SECURITY_DOMAIN_UNREGISTERED_2 = \
-    "this '%s' entry may not be registered with security domain '%s'!"
 PKIHELPER_SECURITY_DOMAIN_UPDATE_FAILURE_2 = \
     "this '%s' entry will NOT be deleted from security domain '%s'!"
 PKIHELPER_SECURITY_DOMAIN_UPDATE_FAILURE_3 = \
@@ -290,12 +288,6 @@ PKIHELPER_SECURITY_DOMAIN_UPDATE_FAILURE_3 = \
     "security domain '%s': '%s'"
 PKIHELPER_SELINUX_DISABLED = "Selinux is disabled.  Not checking port contexts"
 PKIHELPER_SET_MODE_1 = "Setting up ownerships, permissions, and ACLs on %s"
-PKIHELPER_SSLGET_OUTPUT_1 = '''
-    Dump of 'sslget' output:
-    =====================================================
-    %s
-    =====================================================
-'''
 PKIHELPER_SYSTEMD_COMMAND_1 = "executing '%s'"
 PKIHELPER_TOMCAT_INSTANCE_SUBSYSTEMS_2 = \
     "instance '%s' contains '%d' Tomcat PKI subsystems"

--- a/base/server/python/pki/server/deployment/pkimessages.py
+++ b/base/server/python/pki/server/deployment/pkimessages.py
@@ -225,8 +225,6 @@ PKIHELPER_JAR_XF_C_2 = "jar -xf %s -C %s"
 PKIHELPER_KRACONNECTOR_UPDATE_FAILURE = "Failed to update KRA connector on CA"
 PKIHELPER_KRACONNECTOR_UPDATE_FAILURE_2 = \
     "Failed to update KRA connector for %s:%s"
-PKIHELPER_KRACONNECTOR_DEREGISTER_FAILURE_4 = \
-    "Failed to deregister KRA connector %s:%s from CA %s:%s"
 PKIHELPER_LINK_S_2 = "ln -s %s %s"
 PKIHELPER_MKDIR_1 = "mkdir -p %s"
 PKIHELPER_MODUTIL_MISSING_LIBFILE = \

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/UpdateDomainXML.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/UpdateDomainXML.java
@@ -89,12 +89,12 @@ public class UpdateDomainXML extends CMSServlet {
             authToken = authenticate(cmsReq);
         } catch (Exception e) {
             logger.error(CMS.getLogMessage("CMSGW_ERR_BAD_SERV_OUT_STREAM", "", e.toString()), e);
-            outputError(httpResp, AUTH_FAILURE, "Error: Not authenticated", null);
+            outputError(httpResp, AUTH_FAILURE, "Not authenticated", null);
             return;
         }
         if (authToken == null) {
             logger.error("UpdateDomainXML process: authToken is null");
-            outputError(httpResp, AUTH_FAILURE, "Error: not authenticated", null);
+            outputError(httpResp, AUTH_FAILURE, "Not authenticated", null);
             return;
         }
         logger.debug("UpdateDomainXML process: authentication done");
@@ -106,16 +106,16 @@ public class UpdateDomainXML extends CMSServlet {
                     "modify");
         } catch (EAuthzAccessDenied e) {
             logger.error(CMS.getLogMessage("ADMIN_SRVLT_AUTH_FAILURE", e.toString()), e);
-            outputError(httpResp, "Error: Not authorized");
+            outputError(httpResp, "Not authorized");
             return;
         } catch (Exception e) {
             logger.error(CMS.getLogMessage("ADMIN_SRVLT_AUTH_FAILURE", e.toString()), e);
-            outputError(httpResp, "Error: Encountered problem during authorization.");
+            outputError(httpResp, "Encountered problem during authorization.");
             return;
         }
         if (authzToken == null) {
             logger.error("UpdateDomainXML process: authorization error");
-            outputError(httpResp, "Error: Not authorized");
+            outputError(httpResp, "Not authorized");
             return;
         }
 
@@ -152,10 +152,8 @@ public class UpdateDomainXML extends CMSServlet {
         }
 
         if (!missing.equals("")) {
-            logger.error("UpdateDomainXML process: required parameters:" + missing +
-                      "not provided in request");
-            outputError(httpResp, "Error: required parameters: " + missing +
-                        "not provided in request");
+            logger.error("UpdateDomainXML: Missing required parameters: " + missing);
+            outputError(httpResp, "Missing required parameters: " + missing);
             return;
         }
 

--- a/cmake/Modules/DefinePythonSitePackages.cmake
+++ b/cmake/Modules/DefinePythonSitePackages.cmake
@@ -4,7 +4,7 @@ function(find_site_packages pythonexecutable targetname)
     execute_process(
         COMMAND
             ${pythonexecutable} -c
-            "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+            "import sysconfig; print(sysconfig.get_path('purelib'))"
         OUTPUT_VARIABLE
             out
         ERROR_VARIABLE

--- a/tests/bin/pki-lint
+++ b/tests/bin/pki-lint
@@ -58,7 +58,7 @@ while getopts v-: arg ; do
     esac
 done
 
-PYTHONPATH=`python3 -Ic "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
+PYTHONPATH=`python3 -Ic "import sysconfig; print(sysconfig.get_path('purelib'))"`
 
 SOURCES="`find $PYTHONPATH/pki -name "*.py"`"
 SOURCES="$SOURCES `find /usr/share/pki/upgrade -name "*.py"`"


### PR DESCRIPTION
The `KRAConnector.deregister()` and `SecurityDomain.deregister()` has been modified to show the commands to manually remove the KRA connector and unregister from the security domain in case `pkidestroy` cannot execute them.