### PR TITLE
Replace deprecated distutils.sysconfig.get_python_lib()

### DIFF
--- a/cmake/Modules/DefinePythonSitePackages.cmake
+++ b/cmake/Modules/DefinePythonSitePackages.cmake
@@ -4,7 +4,7 @@ function(find_site_packages pythonexecutable targetname)
     execute_process(
         COMMAND
             ${pythonexecutable} -c
-            "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+            "import sysconfig; print(sysconfig.get_path('purelib'))"
         OUTPUT_VARIABLE
             out
         ERROR_VARIABLE

--- a/tests/bin/pki-lint
+++ b/tests/bin/pki-lint
@@ -58,7 +58,7 @@ while getopts v-: arg ; do
     esac
 done
 
-PYTHONPATH=`python3 -Ic "from distutils.sysconfig import get_python_lib; print(get_python_lib())"`
+PYTHONPATH=`python3 -Ic "import sysconfig; print(sysconfig.get_path('purelib'))"`
 
 SOURCES="`find $PYTHONPATH/pki -name "*.py"`"
 SOURCES="$SOURCES `find /usr/share/pki/upgrade -name "*.py"`"


### PR DESCRIPTION
The `distutils.sysconfig.get_python_lib()` has been deprecated so it has been replaced with `sysconfig.get_path('purelib')`.

https://bugs.python.org/issue41282
https://www.python.org/dev/peps/pep-0632/