### PR TITLE
Add Dockerfile for IPA runner

### DIFF
--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -61,11 +61,12 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: tests/ipa/Dockerfile
           build-args: |
             OS_VERSION=${{ matrix.os }}
             COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
+          tags: ipa-runner
+          target: ipa-runner
           outputs: type=docker,dest=/tmp/ipa-runner.tar
 
       - name: Upload runner image
@@ -99,13 +100,8 @@ jobs:
         run: |
           tests/bin/runner-init.sh ipa
         env:
+          IMAGE: ipa-runner
           HOSTNAME: ipa.example.com
-
-      - name: Install IPA packages
-        run: |
-          docker exec ipa dnf copr enable -y @freeipa/freeipa-master-nightly
-          docker exec ipa dnf install -y freeipa-server freeipa-server-dns \
-              python3-ipatests freeipa-healthcheck
 
       - name: Install IPA server
         run: |
@@ -208,15 +204,11 @@ jobs:
         run: |
           tests/bin/runner-init.sh ipa
         env:
+          IMAGE: ipa-runner
           HOSTNAME: ipa.example.com
 
       - name: Connect IPA container to network
         run: docker network connect example ipa --alias ipa.example.com --alias ipa-ca.example.com
-
-      - name: Install IPA packages in IPA container
-        run: |
-          docker exec ipa dnf copr enable -y @freeipa/freeipa-master-nightly
-          docker exec ipa dnf install -y freeipa-server freeipa-server-dns
 
       - name: Install IPA server in IPA container
         run: |
@@ -259,16 +251,11 @@ jobs:
               --privileged \
               --tmpfs /tmp \
               --tmpfs /run \
-              pki-runner \
+              ipa-runner \
               /usr/sbin/init
 
       - name: Connect client container to network
         run: docker network connect example client --alias client.example.com
-
-      - name: Install dependencies in client container
-        run: |
-          docker exec client dnf copr enable -y @freeipa/freeipa-master-nightly
-          docker exec client dnf install -y freeipa-client certbot
 
       - name: Install IPA client in client container
         run: |
@@ -368,15 +355,11 @@ jobs:
         run: |
           tests/bin/runner-init.sh primary
         env:
+          IMAGE: ipa-runner
           HOSTNAME: primary.example.com
 
       - name: Connect primary container to network
         run: docker network connect example primary --alias primary.example.com
-
-      - name: Install IPA packages in primary container
-        run: |
-          docker exec primary dnf copr enable -y @freeipa/freeipa-master-nightly
-          docker exec primary dnf install -y freeipa-server freeipa-server-dns
 
       - name: Install IPA server in primary container
         run: |
@@ -397,15 +380,11 @@ jobs:
         run: |
           tests/bin/runner-init.sh secondary
         env:
+          IMAGE: ipa-runner
           HOSTNAME: secondary.example.com
 
       - name: Connect secondary container to network
         run: docker network connect example secondary --alias secondary.example.com
-
-      - name: Install IPA packages in secondary container
-        run: |
-          docker exec secondary dnf copr enable -y @freeipa/freeipa-master-nightly
-          docker exec secondary dnf install -y freeipa-server freeipa-server-dns
 
       - name: Install IPA client in secondary container
         run: |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,13 @@ install(
 
 install(
     DIRECTORY
+        ipa/
+    DESTINATION
+        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/tests/ipa
+)
+
+install(
+    DIRECTORY
         dogtag/pytest-ansible/pytest/performance_test/
     DESTINATION
         ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/tests/python/performance/

--- a/tests/ipa/Dockerfile
+++ b/tests/ipa/Dockerfile
@@ -1,0 +1,33 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# https://docs.fedoraproject.org/en-US/containers/guidelines/guidelines/
+
+ARG VENDOR="Dogtag"
+ARG MAINTAINER="Dogtag PKI Team <devel@lists.dogtagpki.org>"
+ARG COMPONENT="dogtag-pki"
+ARG LICENSE="GPLv2 and LGPLv2"
+ARG ARCH="x86_64"
+ARG VERSION="0"
+ARG OS_VERSION="latest"
+ARG COPR_REPO="@pki/master"
+
+FROM registry.fedoraproject.org/fedora:$OS_VERSION AS ipa-runner
+
+ARG COPR_REPO
+
+# Enable COPR repo if specified
+RUN if [ -n "$COPR_REPO" ]; then dnf install -y dnf-plugins-core; dnf copr enable -y $COPR_REPO; fi
+
+# Import PKI packages
+COPY build/RPMS /tmp/RPMS/
+
+# Install PKI packages
+RUN dnf localinstall -y /tmp/RPMS/*; rm -rf /tmp/RPMS
+
+# Install IPA packages
+RUN dnf copr enable -y @freeipa/freeipa-master-nightly
+RUN dnf install -y freeipa-server freeipa-server-dns freeipa-healthcheck freeipa-client \
+    certbot python3-ipatests


### PR DESCRIPTION
The IPA tests have been modified to use a new `Dockerfile` which will include IPA packages in the image so the tests do not need to install the packages.