### PR TITLE
Update test scripts to use password authentication

### DIFF
--- a/tests/ca/bin/ca-agent-cert-create.sh
+++ b/tests/ca/bin/ca-agent-cert-create.sh
@@ -4,14 +4,14 @@
 pki client-cert-request uid=caagent | sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" > /tmp/request_id
 
 # approve the cert request and capture the cert ID
-pki -n caadmin ca-cert-request-approve `cat /tmp/request_id` --force | sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" > /tmp/cert_id
+pki -u caadmin -w Secret.123 ca-cert-request-approve `cat /tmp/request_id` --force | sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" > /tmp/cert_id
 
 # assign the cert to the user
 # ignore JSS issue (https://github.com/dogtagpki/jss/issues/781)
-pki -n caadmin ca-user-cert-add caagent --serial `cat /tmp/cert_id` || true
+pki -u caadmin -w Secret.123 ca-user-cert-add caagent --serial `cat /tmp/cert_id` || true
 
 # import the cert into client
 pki client-cert-import caagent --serial `cat /tmp/cert_id`
 
 # test the client certificate
-pki -n caagent ca-cert-request-find
+pki -u caagent -w Secret.123 ca-cert-request-find

--- a/tests/ca/bin/ca-agent-cert-revoke.sh
+++ b/tests/ca/bin/ca-agent-cert-revoke.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # revoke the cert
-pki -n caadmin ca-cert-hold `cat /tmp/cert_id` --force
+pki -u caadmin -w Secret.123 ca-cert-hold `cat /tmp/cert_id` --force
 
 set +e
 

--- a/tests/ca/bin/ca-agent-cert-unrevoke.sh
+++ b/tests/ca/bin/ca-agent-cert-unrevoke.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # unrevoke the cert
-pki -n caadmin ca-cert-release-hold `cat /tmp/cert_id` --force
+pki -u caadmin -w Secret.123 ca-cert-release-hold `cat /tmp/cert_id` --force
 
 # unrevoked cert should work again
 pki -n caagent ca-cert-request-find

--- a/tests/ca/bin/ca-agent-create.sh
+++ b/tests/ca/bin/ca-agent-create.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -ex
 
 # create a user
-pki -n caadmin ca-user-add caagent --fullName "CA Agent" --password Secret.123
+pki -u caadmin -w Secret.123 ca-user-add caagent --fullName "CA Agent" --password Secret.123
 
 # add the user to agent group
-pki -n caadmin ca-user-membership-add caagent "Certificate Manager Agents"
+pki -u caadmin -w Secret.123 ca-user-membership-add caagent "Certificate Manager Agents"
 
 # test the username and password
 pki -u caagent -w Secret.123 ca-cert-request-find

--- a/tests/ca/bin/test-ca-auditor-cert.sh
+++ b/tests/ca/bin/test-ca-auditor-cert.sh
@@ -4,14 +4,14 @@
 pki client-cert-request uid=caauditor | sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" > /tmp/request_id
 
 # approve the cert request and capture the cert ID
-pki -n caadmin ca-cert-request-approve `cat /tmp/request_id` --force | sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" > /tmp/cert_id
+pki -u caadmin -w Secret.123 ca-cert-request-approve `cat /tmp/request_id` --force | sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" > /tmp/cert_id
 
 # assign the cert to the user
 # ignore JSS issue (https://github.com/dogtagpki/jss/issues/781)
-pki -n caadmin ca-user-cert-add caauditor --serial `cat /tmp/cert_id` || true
+pki -u caadmin -w Secret.123 ca-user-cert-add caauditor --serial `cat /tmp/cert_id` || true
 
 # import the cert into client
 pki client-cert-import caauditor --serial `cat /tmp/cert_id`
 
 # test client certificate
-pki -n caauditor ca-audit-file-find
+pki -u caauditor -w Secret.123 ca-audit-file-find

--- a/tests/ca/bin/test-ca-auditor-create.sh
+++ b/tests/ca/bin/test-ca-auditor-create.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -ex
 
 # create a user
-pki -n caadmin ca-user-add caauditor --fullName "CA Auditor" --password Secret.123
+pki -u caadmin -w Secret.123 ca-user-add caauditor --fullName "CA Auditor" --password Secret.123
 
 # add the user to Auditors group
-pki -n caadmin ca-user-membership-add caauditor "Auditors"
+pki -u caadmin -w Secret.123 ca-user-membership-add caauditor "Auditors"
 
 # test username and password
 pki -u caauditor -w Secret.123 ca-audit-file-find

--- a/tests/ca/bin/test-ca-auditor-logs.sh
+++ b/tests/ca/bin/test-ca-auditor-logs.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -ex
 
 # list of audit log files
-pki -n caauditor ca-audit-file-find | sed -n "s/^\s*File name: \s*\(\S*\)$/\1/p" > /tmp/audit.filenames
+pki -u caauditor -w Secret.123 ca-audit-file-find | sed -n "s/^\s*File name: \s*\(\S*\)$/\1/p" > /tmp/audit.filenames
 
 # retrieve audit log files
 for filename in `cat /tmp/audit.filenames`
 do
-    pki -n caauditor ca-audit-file-retrieve $filename
+    pki -u caauditor -w Secret.123 ca-audit-file-retrieve $filename
 done

--- a/tests/kra/bin/test-cert-key-archival.sh
+++ b/tests/kra/bin/test-cert-key-archival.sh
@@ -17,7 +17,7 @@ REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)\s*$/\1/p" output)
 echo "Request ID: $REQUEST_ID"
 
 # https://github.com/dogtagpki/pki/wiki/Handling-Certificate-Request
-pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
+pki -u caadmin -w Secret.123 ca-cert-request-approve $REQUEST_ID --force | tee output
 
 CERT_ID=$(sed -n "s/^\s*Certificate ID:\s*\(\S*\)\s*$/\1/p" output)
 echo "Cert ID: $CERT_ID"
@@ -38,7 +38,7 @@ diff expected actual
 # Currently there's no mechanism in KRA to find the key that corresponds to
 # a cert so the test will try to find all keys in KRA instead.
 # TODO: add mechanism to find the cert's exact key
-pki -n caadmin kra-key-find | tee output
+pki -u kraadmin -w Secret.123 kra-key-find | tee output
 
 KEY_ID=$(sed -n "s/^\s*Key ID:\s*\(\S*\)$/\1/p" output)
 echo "Key ID: $KEY_ID"


### PR DESCRIPTION
The test scripts have been modified to use password instead of client certificate to avoid intermittent authentication failures.