### PR TITLE
Fix pkidestroy for OCSP with external certs

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/ca/CAClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/ca/CAClient.java
@@ -132,12 +132,13 @@ public class CAClient extends SubsystemClient {
         }
     }
 
-    public void addOCSPPublisher(URL url, String sessionID) throws Exception {
+    public void addOCSPPublisher(URL url, String subsystemCert, String sessionID) throws Exception {
 
         MultivaluedMap<String, String> content = new MultivaluedHashMap<>();
         content.putSingle("xmlOutput", "true");
         content.putSingle("ocsp_host", url.getHost());
         content.putSingle("ocsp_port", url.getPort() + "");
+        content.putSingle("subsystemCert", subsystemCert);
         content.putSingle("sessionID", sessionID);
         logger.debug("CAClient: content: " + content);
 

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1428,7 +1428,7 @@ class PKIDeployer:
         finally:
             shutil.rmtree(tmpdir)
 
-    def add_ocsp_publisher(self, instance):
+    def add_ocsp_publisher(self, instance, subsystem):
 
         server_config = instance.get_server_config()
         hostname = self.mdict['pki_hostname']
@@ -1437,8 +1437,14 @@ class PKIDeployer:
         ca_url = self.mdict['pki_issuing_ca']
         ocsp_url = 'https://%s:%s' % (hostname, securePort)
 
+        subsystem_cert = subsystem.get_subsystem_cert('subsystem').get('data')
+
         tmpdir = tempfile.mkdtemp()
         try:
+            subsystem_cert_file = os.path.join(tmpdir, 'subsystem.crt')
+            with open(subsystem_cert_file, 'w') as f:
+                f.write(subsystem_cert)
+
             install_token = os.path.join(tmpdir, 'install-token')
             with open(install_token, 'w') as f:
                 f.write(self.install_token.token)
@@ -1450,6 +1456,7 @@ class PKIDeployer:
                 '-U', ca_url,
                 'ca-publisher-ocsp-add',
                 '--url', ocsp_url,
+                '--subsystem-cert', subsystem_cert_file,
                 '--install-token', install_token
             ]
 
@@ -1876,7 +1883,7 @@ class PKIDeployer:
                 # preserving existing functionality.
                 # Next we need to treat the publishing of clones as a group,
                 # and fail over amongst them.
-                self.add_ocsp_publisher(instance)
+                self.add_ocsp_publisher(instance, subsystem)
 
         if subsystem.type == 'TPS':
 

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/PublisherOCSPAddCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/PublisherOCSPAddCLI.java
@@ -38,6 +38,10 @@ public class PublisherOCSPAddCLI extends CommandCLI {
         option.setArgName("URL");
         options.addOption(option);
 
+        option = new Option(null, "subsystem-cert", true, "Subsystem certificate path");
+        option.setArgName("path");
+        options.addOption(option);
+
         option = new Option(null, "session", true, "Session ID");
         option.setArgName("ID");
         options.addOption(option);
@@ -59,6 +63,13 @@ public class PublisherOCSPAddCLI extends CommandCLI {
 
         URL url = new URL(publisherURL);
 
+        String subsystemCertPath = cmd.getOptionValue("subsystem-cert");
+        if (subsystemCertPath == null) {
+            throw new Exception("Missing subsystem certificate");
+        }
+
+        String subsystemCert = new String(Files.readAllBytes(Paths.get(subsystemCertPath)));
+
         String installToken = cmd.getOptionValue("install-token");
         String sessionID;
 
@@ -78,6 +89,6 @@ public class PublisherOCSPAddCLI extends CommandCLI {
         PKIClient client = mainCLI.getClient();
         CAClient caClient = new CAClient(client);
 
-        caClient.addOCSPPublisher(url, sessionID);
+        caClient.addOCSPPublisher(url, subsystemCert, sessionID);
     }
 }


### PR DESCRIPTION
This is similar to PR #3904.

Generally, when installing OCSP `pkispawn` will create a subsystem cert in the CA using a profile that will also create a subsystem user for the OCSP in the CA (see `SubsystemGroupUpdater`), then `pkispawn` will create an OCSP publisher in the CA as well (see `UpdateOCSPConfig`). In case the OCSP is removed later `pkidestroy` can use this user to remove the OCSP publisher from the CA.

If the OCSP was installed with external certs (including CMC case), `pkispawn` would create the subsystem cert using a different profile which would not create the subsystem user, but it would still create the OCSP publisher. However, that means `pkidestroy` would not be able to remove the OCSP publisher.

To fix the problem, some of the code in `SubsystemGroupUpdater` has been copied into `UpdateOCSPConfig` such that the subsystem user will be created when the OCSP publisher is added if it does not already exist.

Right now the `SubsystemGroupUpdater` might still be needed for other things, but potentially it could be removed in the future.