### PR TITLE
Update OCSPClient to support hex serial numbers

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
@@ -33,6 +33,7 @@ import org.apache.commons.cli.Options;
 import org.dogtagpki.util.logging.PKILogger;
 import org.mozilla.jss.CryptoManager;
 
+import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.cmsutil.ocsp.BasicOCSPResponse;
 import com.netscape.cmsutil.ocsp.CertStatus;
 import com.netscape.cmsutil.ocsp.GoodInfo;
@@ -167,7 +168,8 @@ public class OCSPClient {
             if (serial != null) {
                 logger.info("Creating request for serial number " + serial);
 
-                BigInteger serialNumber = new BigInteger(serial);
+                CertId certID = new CertId(serial);
+                BigInteger serialNumber = certID.toBigInteger();
                 request = processor.createRequest(caNickname, serialNumber);
 
             } else if (input != null) {
@@ -201,8 +203,9 @@ public class OCSPClient {
                         throw new Exception("No OCSP Response data.");
                     }
 
-                    System.out.println("CertID.serialNumber=" +
-                            sr.getCertID().getSerialNumber());
+                    BigInteger serialNumber = sr.getCertID().getSerialNumber();
+                    CertId certID = new CertId(serialNumber);
+                    System.out.println("CertID.serialNumber=" + certID.toHexString());
 
                     CertStatus status = sr.getCertStatus();
                     if (status instanceof GoodInfo) {

--- a/docs/changes/v11.2.0/Tools-Changes.adoc
+++ b/docs/changes/v11.2.0/Tools-Changes.adoc
@@ -1,0 +1,13 @@
+= Tools Changes =
+
+== OCSPClient Changes ==
+
+
+The `OCSPClient` now accepts a serial number in decimal or hexadecimal (with `0x` prefix)
+but always displays the returned serial number in hexadecimal. For example:
+
+----
+$ OCSPClient ... --serial 35525
+CertID.serialNumber=0x8ac5
+CertStatus=Revoked
+----


### PR DESCRIPTION
The `OCSPClient` has been modified to accept hex serial numbers but always display the returned serial number in hex.

https://github.com/edewata/pki/blob/ocsp-client/docs/changes/v11.2.0/Tools-Changes.adoc