### PR TITLE
Add test for CA profiles

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -133,6 +133,16 @@ jobs:
           docker exec pki /usr/share/pki/tests/ca/bin/test-ca-auditor-cert.sh
           docker exec pki /usr/share/pki/tests/ca/bin/test-ca-auditor-logs.sh
 
+      - name: Check CA profiles
+        run: |
+          docker exec pki pki -n caadmin ca-profile-find
+
+          # create custom profile
+          docker exec pki pki -n caadmin ca-profile-show caUserCert --output ${PKIDIR}/profile.xml
+          sed -i "s/caUserCert/caCustomUser/g" profile.xml
+          docker exec pki pki --debug -n caadmin ca-profile-add ${PKIDIR}/profile.xml
+          docker exec pki pki -n caadmin ca-profile-show caCustomUser
+
       - name: Gather artifacts
         if: always()
         run: |


### PR DESCRIPTION
This PR is adding a test for retrieving a profile, renaming the profile, and readding it as a new profile.

The test ran successfully:
https://github.com/dogtagpki/pki/runs/5281555052?check_suite_focus=true#step:15:907

However, I did see it failed once, so I'm guessing this is also affected by the intermittent authentication issue that is also affecting other tests. It's also possible that the issue is happening more frequently in certain environments.

Once merged, this PR will be cherry-picked into `v11.1` branch and `master` branch.