### PR TITLE
Add RSNv3 for CA

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1755,7 +1755,7 @@ jobs:
           path: |
             /tmp/artifacts/secondary
 
-  # https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Random-Certificate-Serial-Numbers
+  # https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Random-Serial-Numbers-v1
   ca-random-v1-test:
     name: Testing CA with Random Serial Number v1
     needs: [init, build]
@@ -1845,6 +1845,101 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ca-random-v1-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki
+
+  # https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Random-Serial-Numbers-v3
+  ca-random-v3-test:
+    name: Testing CA with Random Serial Number v3
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-runner-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          COPR_REPO: ${{ needs.init.outputs.repo }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_cert_id_length=159 \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Run PKI healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Initialize PKI client
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Check cert requests in CA
+        run: |
+          docker exec pki pki -n caadmin ca-cert-request-find
+
+      - name: Check certs in CA
+        run: |
+          docker exec pki pki ca-cert-find
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ca-random-v3-${{ matrix.os }}
           path: |
             /tmp/artifacts/pki
 

--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -768,6 +768,8 @@ http.port=[PKI_UNSECURE_PORT]
 dbs.enableSerialManagement=[PKI_ENABLE_RANDOM_SERIAL_NUMBERS]
 dbs.enableRandomSerialNumbers=[PKI_ENABLE_RANDOM_SERIAL_NUMBERS]
 dbs.randomSerialNumberCounter=0
+dbs.request.id.generator=[pki_request_id_generator]
+dbs.request.id.length=[pki_request_id_length]
 dbs.beginRequestNumber=1
 dbs.endRequestNumber=10000000
 dbs.requestIncrement=10000000
@@ -775,6 +777,8 @@ dbs.requestLowWaterMark=2000000
 dbs.requestCloneTransferNumber=10000
 dbs.requestDN=ou=ca, ou=requests
 dbs.requestRangeDN=ou=requests, ou=ranges
+dbs.cert.id.generator=[pki_cert_id_generator]
+dbs.cert.id.length=[pki_cert_id_length]
 dbs.beginSerialNumber=1
 dbs.endSerialNumber=10000000
 dbs.serialIncrement=10000000

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -433,6 +433,17 @@ pki_request_number_range_end=
 pki_replica_number_range_start=
 pki_replica_number_range_end=
 
+# Cert cert ID generator: legacy, random
+pki_cert_id_generator=legacy
+
+# Cert cert ID length in bits
+pki_cert_id_length=160
+
+# Cert request ID generator: legacy, random
+pki_request_id_generator=legacy
+
+# Cert request ID length in bits
+pki_request_id_length=160
 
 ###############################################################################
 ##  KRA Configuration:                                                       ##


### PR DESCRIPTION
The `CertificateRepository`, `RequestRepository`, and `Repository` classes have been modified to support the new RSNv3 and the legacy ID generators. `pkispawn`'s `default.cfg` has been modified to provide the configuration parameters.

Results:
https://github.com/dogtagpki/pki/runs/5296272839?check_suite_focus=true#step:13:9
https://github.com/dogtagpki/pki/runs/5296272839?check_suite_focus=true#step:14:9

Doc:
https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Random-Serial-Numbers-v3
