### PR TITLE
Add tests for PKI server

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,0 +1,187 @@
+name: Server Tests
+
+on: [push, pull_request]
+
+jobs:
+  init:
+    name: Initializing workflow
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.init.outputs.matrix }}
+      repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Initialize workflow
+        id: init
+        env:
+          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
+        run: |
+          tests/bin/init-workflow.sh
+
+  # docs/development/Building_PKI.md
+  build:
+    name: Building PKI
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: /var/cache/dnf
+          key: fedora:${{ matrix.os }}-server-${{ hashFiles('pki.spec') }}
+
+      - name: Install dependencies
+        run: |
+          # keep packages after installation
+          echo "keepcache=True" >> /etc/dnf/dnf.conf
+          dnf install -y dnf-plugins-core rpm-build moby-engine
+          dnf copr enable -y ${{ needs.init.outputs.repo }}
+          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
+          # don't cache COPR packages
+          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
+
+      - name: Build PKI packages
+        run: ./build.sh --with-pkgs=base,server --with-timestamp --work-dir=build rpm
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build runner image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-runner
+          target: pki-runner
+          outputs: type=docker,dest=/tmp/pki-runner.tar
+
+      - name: Upload runner image
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-runner-${{ matrix.os }}
+          path: /tmp/pki-runner.tar
+
+      - name: Build server image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-server
+          target: pki-server
+          outputs: type=docker,dest=/tmp/pki-server.tar
+
+      - name: Upload server image
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-server-${{ matrix.os }}
+          path: /tmp/pki-server.tar
+
+  # docs/installation/server/Installing_Basic_PKI_Server.md
+  pki-server-test:
+    name: Testing PKI server
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-runner-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Create PKI server
+        run: |
+          docker exec pki pki-server create -v
+
+      - name: Start PKI server
+        run: |
+          docker exec pki pki-server start --wait -v
+
+      - name: Stop PKI server
+        run: |
+          docker exec pki pki-server stop --wait -v
+
+      - name: Remove PKI server
+        run: |
+          docker exec pki pki-server remove -v
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-server-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki
+
+  pki-container-test:
+    name: Testing PKI container
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download PKI server image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-server-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load PKI server image
+        run: docker load --input /tmp/pki-server.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up PKI container
+        run: |
+          docker run --name pki --detach pki-server
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com


### PR DESCRIPTION
A new GH workflow has been added to test basic PKI server functionalities (e.g. create, start, stop, remove) without any PKI subsystems. It will also test running the server as a container. The container image later can be used to create other PKI subsystem containers.