### PR TITLE
Add RSNv3 for KRA

### DIFF
--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -1309,3 +1309,135 @@ jobs:
           name: kra-standalone-${{ matrix.os }}
           path: |
             /tmp/artifacts/pki
+
+  # https://github.com/dogtagpki/pki/wiki/Installing-KRA-with-Random-Serial-Numbers-v3
+  kra-random-v3-test:
+    name: Testing KRA with Random Serial Number v3
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-runner-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_cert_id_length=159 \
+              -D pki_request_id_generator=random \
+              -v
+
+          docker exec pki pki-server cert-find
+
+      - name: Install KRA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra.cfg \
+              -s KRA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+          docker exec pki pki-server cert-find
+
+      - name: Run PKI healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Verify KRA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec pki pki -n caadmin kra-user-show kraadmin
+
+      - name: Verify KRA connector in CA
+        run: |
+          docker exec pki pki -n caadmin ca-kraconnector-show | tee output
+          sed -n 's/\s*Host:\s\+\(\S\+\):.*/\1/p' output > actual
+          echo pki.example.com > expected
+          diff expected actual
+
+      - name: Verify cert key archival
+        run: |
+          docker exec pki /usr/share/pki/tests/kra/bin/test-cert-key-archival.sh
+
+      - name: Check cert requests in CA
+        run: |
+          docker exec pki pki -n caadmin ca-cert-request-find
+
+      - name: Check certs in CA
+        run: |
+          docker exec pki pki ca-cert-find
+
+      - name: Check key requests in KRA
+        run: |
+          docker exec pki pki -n caadmin kra-key-request-find
+
+      - name: Check keys in KRA
+        run: |
+          docker exec pki pki -n caadmin kra-key-find
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove KRA
+        run: docker exec pki pkidestroy -i pki-tomcat -s KRA -v
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: kra-random-v3-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -173,6 +173,8 @@ cmc.sharedSecret.class=com.netscape.cms.authentication.SharedSecret
 cms.version=@APPLICATION_VERSION_MAJOR@.@APPLICATION_VERSION_MINOR@
 cms.passwordlist=internaldb,replicationdb
 dbs.enableSerialManagement=false
+dbs.request.id.generator=[pki_request_id_generator]
+dbs.request.id.length=[pki_request_id_length]
 dbs.beginRequestNumber=1
 dbs.endRequestNumber=10000000
 dbs.requestIncrement=10000000
@@ -180,6 +182,8 @@ dbs.requestLowWaterMark=2000000
 dbs.requestCloneTransferNumber=10000
 dbs.requestDN=ou=kra, ou=requests
 dbs.requestRangeDN=ou=requests, ou=ranges
+dbs.key.id.generator=[pki_key_id_generator]
+dbs.key.id.length=[pki_key_id_length]
 dbs.beginSerialNumber=1
 dbs.endSerialNumber=10000000
 dbs.serialIncrement=10000000

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -529,6 +529,18 @@ pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
 
+# Key ID generator: legacy, random
+pki_key_id_generator=legacy
+
+# Key ID length in bits
+pki_key_id_length=160
+
+# Key request ID generator: legacy, random
+pki_request_id_generator=legacy
+
+# Key request ID length in bits
+pki_request_id_length=160
+
 ###############################################################################
 ##  OCSP Configuration:                                                      ##
 ##                                                                           ##


### PR DESCRIPTION
The `KeyRepository` class has been modified to support the new RSNv3 and the legacy sequential ID generators (it doesn't support RSNv1) for keys in KRA. `pkispawn`'s `default.cfg` has been modified to provide parameters to configure the ID generator type and ID length.

Results:
* https://github.com/dogtagpki/pki/runs/5309491656?check_suite_focus=true#step:18:9
* https://github.com/dogtagpki/pki/runs/5309491656?check_suite_focus=true#step:19:9

Doc:
https://github.com/dogtagpki/pki/wiki/Installing-KRA-with-Random-Serial-Numbers-v3
