### PR TITLE
Update CA and KRA clone tests to use RSNv3

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1114,6 +1114,9 @@ jobs:
               -s CA \
               -D pki_ds_hostname=primaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_cert_id_length=159 \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -1162,6 +1165,9 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_hostname=secondaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_cert_id_length=159 \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -1211,6 +1217,9 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_hostname=tertiaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_cert_id_length=159 \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec tertiary pki-server cert-find

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -939,6 +939,9 @@ jobs:
               -s CA \
               -D pki_ds_hostname=primaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_cert_id_length=159 \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -950,6 +953,8 @@ jobs:
               -s KRA \
               -D pki_ds_hostname=primaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -985,6 +990,9 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_hostname=secondaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_cert_id_length=159 \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -999,6 +1007,8 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_ds_hostname=secondaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -1043,6 +1053,9 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_hostname=tertiaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_cert_id_length=159 \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec tertiary pki-server cert-find
@@ -1057,6 +1070,8 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_ds_hostname=tertiaryds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec tertiary pki-server cert-find

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1173,20 +1173,33 @@ class PKISubsystem(object):
 
     def request_ranges(self, master_url, session_id=None, install_token=None):
 
-        logger.info('Requesting request ID range')
+        # request cert/key request ID range if it uses legacy generator
+        if self.type in ['CA', 'KRA'] and \
+                self.config.get('dbs.request.id.generator', 'legacy') == 'legacy':
 
-        request_range = self.request_range(
-            master_url, 'request', session_id=session_id, install_token=install_token)
-        self.config['dbs.beginRequestNumber'] = request_range['begin']
-        self.config['dbs.endRequestNumber'] = request_range['end']
+            logger.info('Requesting request ID range')
 
-        logger.info('Requesting serial number range')
+            request_range = self.request_range(
+                master_url, 'request', session_id=session_id, install_token=install_token)
 
-        serial_range = self.request_range(
-            master_url, 'serialNo', session_id=session_id, install_token=install_token)
-        self.config['dbs.beginSerialNumber'] = serial_range['begin']
-        self.config['dbs.endSerialNumber'] = serial_range['end']
+            self.config['dbs.beginRequestNumber'] = request_range['begin']
+            self.config['dbs.endRequestNumber'] = request_range['end']
 
+        # request cert/key ID range if it uses legacy generator
+        if self.type == 'CA' and \
+                self.config.get('dbs.cert.id.generator', 'legacy') == 'legacy' or \
+                self.type == 'KRA' \
+                and self.config.get('dbs.key.id.generator', 'legacy') == 'legacy':
+
+            logger.info('Requesting serial number range')
+
+            serial_range = self.request_range(
+                master_url, 'serialNo', session_id=session_id, install_token=install_token)
+
+            self.config['dbs.beginSerialNumber'] = serial_range['begin']
+            self.config['dbs.endSerialNumber'] = serial_range['end']
+
+        # always request replica ID range since it doesn't support random generator
         logger.info('Requesting replica ID range')
 
         replica_range = self.request_range(


### PR DESCRIPTION
The `PKISubsystem.request_ranges()` has been modified to request ID ranges from the master only for legacy ID generators and replica ID.