### PR TITLE
Add PKIDeployer.configure_id_generators()

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -768,24 +768,8 @@ http.port=[PKI_UNSECURE_PORT]
 dbs.enableSerialManagement=[PKI_ENABLE_RANDOM_SERIAL_NUMBERS]
 dbs.enableRandomSerialNumbers=[PKI_ENABLE_RANDOM_SERIAL_NUMBERS]
 dbs.randomSerialNumberCounter=0
-dbs.request.id.generator=[pki_request_id_generator]
-dbs.request.id.length=[pki_request_id_length]
-dbs.beginRequestNumber=1
-dbs.endRequestNumber=10000000
-dbs.requestIncrement=10000000
-dbs.requestLowWaterMark=2000000
-dbs.requestCloneTransferNumber=10000
 dbs.requestDN=ou=ca, ou=requests
-dbs.requestRangeDN=ou=requests, ou=ranges
-dbs.cert.id.generator=[pki_cert_id_generator]
-dbs.cert.id.length=[pki_cert_id_length]
-dbs.beginSerialNumber=1
-dbs.endSerialNumber=10000000
-dbs.serialIncrement=10000000
-dbs.serialLowWaterMark=2000000
-dbs.serialCloneTransferNumber=10000
 dbs.serialDN=ou=certificateRepository, ou=ca
-dbs.serialRangeDN=ou=certificateRepository, ou=ranges
 dbs.beginReplicaNumber=1
 dbs.endReplicaNumber=100
 dbs.replicaIncrement=100

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -173,24 +173,8 @@ cmc.sharedSecret.class=com.netscape.cms.authentication.SharedSecret
 cms.version=@APPLICATION_VERSION_MAJOR@.@APPLICATION_VERSION_MINOR@
 cms.passwordlist=internaldb,replicationdb
 dbs.enableSerialManagement=false
-dbs.request.id.generator=[pki_request_id_generator]
-dbs.request.id.length=[pki_request_id_length]
-dbs.beginRequestNumber=1
-dbs.endRequestNumber=10000000
-dbs.requestIncrement=10000000
-dbs.requestLowWaterMark=2000000
-dbs.requestCloneTransferNumber=10000
 dbs.requestDN=ou=kra, ou=requests
-dbs.requestRangeDN=ou=requests, ou=ranges
-dbs.key.id.generator=[pki_key_id_generator]
-dbs.key.id.length=[pki_key_id_length]
-dbs.beginSerialNumber=1
-dbs.endSerialNumber=10000000
-dbs.serialIncrement=10000000
-dbs.serialLowWaterMark=2000000
-dbs.serialCloneTransferNumber=10000
 dbs.serialDN=ou=keyRepository, ou=kra
-dbs.serialRangeDN=ou=keyRepository, ou=ranges
 dbs.beginReplicaNumber=1
 dbs.endReplicaNumber=100
 dbs.replicaIncrement=100

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -231,6 +231,56 @@ class PKIDeployer:
             subsystem_dict[0] = None
             self.mdict.update(subsystem_dict)
 
+    def configure_id_generators(self, subsystem):
+
+        if subsystem.type in ['CA', 'KRA']:
+
+            request_id_generator = self.mdict['pki_request_id_generator']
+
+            if request_id_generator == 'random':
+                subsystem.config['dbs.request.id.generator'] = request_id_generator
+                subsystem.config['dbs.request.id.length'] = self.mdict['pki_request_id_length']
+
+            else:  # legacy
+                subsystem.config['dbs.beginRequestNumber'] = '1'
+                subsystem.config['dbs.endRequestNumber'] = '10000000'
+                subsystem.config['dbs.requestIncrement'] = '10000000'
+                subsystem.config['dbs.requestLowWaterMark'] = '2000000'
+                subsystem.config['dbs.requestCloneTransferNumber'] = '10000'
+                subsystem.config['dbs.requestRangeDN'] = 'ou=requests,ou=ranges'
+
+        if subsystem.type == 'CA':
+
+            cert_id_generator = self.mdict['pki_cert_id_generator']
+
+            if cert_id_generator == 'random':
+                subsystem.config['dbs.cert.id.generator'] = cert_id_generator
+                subsystem.config['dbs.cert.id.length'] = self.mdict['pki_cert_id_length']
+
+            else:  # legacy
+                subsystem.config['dbs.beginSerialNumber'] = '1'
+                subsystem.config['dbs.endSerialNumber'] = '10000000'
+                subsystem.config['dbs.serialIncrement'] = '10000000'
+                subsystem.config['dbs.serialLowWaterMark'] = '2000000'
+                subsystem.config['dbs.serialCloneTransferNumber'] = '10000'
+                subsystem.config['dbs.serialRangeDN'] = 'ou=certificateRepository,ou=ranges'
+
+        if subsystem.type == 'KRA':
+
+            key_id_generator = self.mdict['pki_key_id_generator']
+
+            if key_id_generator == 'random':
+                subsystem.config['dbs.key.id.generator'] = key_id_generator
+                subsystem.config['dbs.key.id.length'] = self.mdict['pki_key_id_length']
+
+            else:  # legacy
+                subsystem.config['dbs.beginSerialNumber'] = '1'
+                subsystem.config['dbs.endSerialNumber'] = '10000000'
+                subsystem.config['dbs.serialIncrement'] = '10000000'
+                subsystem.config['dbs.serialLowWaterMark'] = '2000000'
+                subsystem.config['dbs.serialCloneTransferNumber'] = '10000'
+                subsystem.config['dbs.serialRangeDN'] = 'ou=keyRepository,ou=ranges'
+
     def get_cert_id(self, subsystem, tag):
 
         if tag == 'signing':

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -231,6 +231,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if ocsp_uri:
             subsystem.config['ca.defaultOcspUri'] = ocsp_uri
 
+        deployer.configure_id_generators(subsystem)
+
         if subsystem.name == 'ca':
             serial_number_range_start = deployer.mdict.get('pki_serial_number_range_start')
             if serial_number_range_start:


### PR DESCRIPTION
The `PKIDeployer.configure_id_generators()` has been added to configure the ID generator parameters in `CS.cfg` based on the selected type. This will ensure that the ID generator code does depend on parameters belonging to another ID generator.