### PR TITLE
Update default RSNv3 length

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -145,7 +145,6 @@ jobs:
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -333,7 +332,6 @@ jobs:
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1115,7 +1115,6 @@ jobs:
               -D pki_ds_hostname=primaryds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -1166,7 +1165,6 @@ jobs:
               -D pki_ds_hostname=secondaryds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -1218,7 +1216,6 @@ jobs:
               -D pki_ds_hostname=tertiaryds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -1911,7 +1908,6 @@ jobs:
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -940,7 +940,6 @@ jobs:
               -D pki_ds_hostname=primaryds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -991,7 +990,6 @@ jobs:
               -D pki_ds_hostname=secondaryds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -1054,7 +1052,6 @@ jobs:
               -D pki_ds_hostname=tertiaryds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -1378,7 +1375,6 @@ jobs:
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -127,7 +127,6 @@ jobs:
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -315,7 +314,6 @@ jobs:
               -D pki_ds_hostname=cads.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -571,7 +569,6 @@ jobs:
               -D pki_ds_hostname=cads.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -900,7 +897,6 @@ jobs:
               -D pki_ds_hostname=primaryds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 
@@ -975,7 +971,6 @@ jobs:
               -D pki_ds_hostname=secondaryds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_cert_id_generator=random \
-              -D pki_cert_id_length=159 \
               -D pki_request_id_generator=random \
               -v
 

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -437,13 +437,13 @@ pki_replica_number_range_end=
 pki_cert_id_generator=legacy
 
 # Cert cert ID length in bits
-pki_cert_id_length=160
+pki_cert_id_length=128
 
 # Cert request ID generator: legacy, random
 pki_request_id_generator=legacy
 
 # Cert request ID length in bits
-pki_request_id_length=160
+pki_request_id_length=128
 
 ###############################################################################
 ##  KRA Configuration:                                                       ##
@@ -533,13 +533,13 @@ pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
 pki_key_id_generator=legacy
 
 # Key ID length in bits
-pki_key_id_length=160
+pki_key_id_length=128
 
 # Key request ID generator: legacy, random
 pki_request_id_generator=legacy
 
 # Key request ID length in bits
-pki_request_id_length=160
+pki_request_id_length=128
 
 ###############################################################################
 ##  OCSP Configuration:                                                      ##

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/Repository.java
@@ -297,9 +297,10 @@ public abstract class Repository implements IRepository {
 
             logger.debug("Repository: Generating random serial number");
 
-            // JSS BigInt does not allow negative value
-            // so use the absolute (i.e. positive) value.
-            BigInteger id = new BigInteger(idLength, secureRandom).abs();
+            // JSS BigInt does not allow negative value.
+            // The following BigInteger constructor will
+            // always create a non-negative number.
+            BigInteger id = new BigInteger(idLength, secureRandom);
             logger.info("Repository: id: 0x" + id.toString(16));
 
             return id;


### PR DESCRIPTION
`pkispawn`'s `default.cfg` has been modified to generate 128-bit numbers for RSNv3 by default as described in the design:
https://github.com/dogtagpki/pki/wiki/Random-Certificate-Serial-Numbers-v3

All RSNv3 tests have been modified to use the default length.

The `Repository.getNextSerialNumber()` has been updated to no longer call `BigInteger.abs()` since the `BigInteger` constructor will always create a non-negative number.
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/math/BigInteger.html#%3Cinit%3E(int,java.util.Random)