### PR TITLE
Update CA tests to use RSNv3

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -128,10 +128,35 @@ jobs:
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
               -v
+
           # set buffer size to 0 so that revocation takes effect immediately
           docker exec pki pki-server ca-config-set auths.revocationChecking.bufferSize 0
+
           # enable signed audit log
           docker exec pki pki-server ca-config-set log.instance.SignedAudit.logSigning true
+
+          # switch cert request ID generator to RSNv3
+          docker exec pki pki-server ca-config-unset dbs.beginRequestNumber
+          docker exec pki pki-server ca-config-unset dbs.endRequestNumber
+          docker exec pki pki-server ca-config-unset dbs.requestIncrement
+          docker exec pki pki-server ca-config-unset dbs.requestLowWaterMark
+          docker exec pki pki-server ca-config-unset dbs.requestCloneTransferNumber
+          docker exec pki pki-server ca-config-unset dbs.requestRangeDN
+
+          docker exec pki pki-server ca-config-set dbs.request.id.generator random
+          docker exec pki pki-server ca-config-set dbs.request.id.length 128
+
+          # switch cert ID generator to RSNv3
+          docker exec pki pki-server ca-config-unset dbs.beginSerialNumber
+          docker exec pki pki-server ca-config-unset dbs.endSerialNumber
+          docker exec pki pki-server ca-config-unset dbs.serialIncrement
+          docker exec pki pki-server ca-config-unset dbs.serialLowWaterMark
+          docker exec pki pki-server ca-config-unset dbs.serialCloneTransferNumber
+          docker exec pki pki-server ca-config-unset dbs.serialRangeDN
+
+          docker exec pki pki-server ca-config-set dbs.cert.id.generator random
+          docker exec pki pki-server ca-config-set dbs.cert.id.length 128
+
           # restart PKI server
           docker exec pki pki-server restart --wait
 
@@ -283,6 +308,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       - name: Check CA signing cert
@@ -421,6 +448,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=rootds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec root pki-server cert-find
@@ -454,6 +483,8 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/root-ca_signing.crt \
               -D pki_ds_hostname=subds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       - name: Check CA signing cert
@@ -589,6 +620,8 @@ jobs:
               -D pki_ds_hostname=rootds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_security_domain_name=ROOT \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       - name: Update caCMCcaCert profile
@@ -642,6 +675,8 @@ jobs:
               -D pki_ds_hostname=subds.example.com \
               -D pki_ds_ldap_port=3389 \
               -D pki_ca_signing_csr_path=$SHARED/ca_signing.csr \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       # https://github.com/dogtagpki/pki/wiki/Issuing-CA-Signing-Certificate-with-CMC
@@ -678,6 +713,8 @@ jobs:
               -D pki_cert_chain_path=$SHARED/root-ca_signing.crt \
               -D pki_ca_signing_csr_path=$SHARED/ca_signing.csr \
               -D pki_ca_signing_cert_path=$SHARED/ca_signing.p7b \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       - name: Check subordinate CA signing cert
@@ -831,6 +868,8 @@ jobs:
               -D pki_req_ext_add=True \
               -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
               -D pki_req_ext_data=1E0A00530075006200430041 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec pki /usr/share/pki/tests/ca/bin/test-subca-signing-csr-ext.sh ca_signing.csr
@@ -854,6 +893,8 @@ jobs:
               -D pki_req_ext_add=True \
               -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
               -D pki_req_ext_data=1E0A00530075006200430041 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find
@@ -1007,6 +1048,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
           sleep 1  # avoid pkispawn log conflict due to identical timestamps
           docker exec pki pkispawn \
@@ -1014,6 +1057,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find
@@ -1399,6 +1444,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldaps_port=3636 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find
@@ -1554,6 +1601,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=primaryds.example.com \
               -D pki_ds_ldaps_port=3636 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -1665,6 +1714,8 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_hostname=secondaryds.example.com \
               -D pki_ds_ldaps_port=3636 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -1717,6 +1768,8 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_hostname=secondaryds.example.com \
               -D pki_ds_ldaps_port=3636 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       - name: Gather artifacts from primary containers
@@ -2000,6 +2053,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       # https://github.com/dogtagpki/pki/wiki/Configuring-File-based-CRL-Publishing
@@ -2222,6 +2277,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find


### PR DESCRIPTION
The basic CA test has been modified to switch to RSNv3 after installing using sequential ID generator. The remaining CA
tests have been modified to install using RSNv3 except for the RSNv1 test.

https://github.com/dogtagpki/pki/wiki/Configuring-CA-with-Random-Serial-Numbers-v3