### PR TITLE
Update KRA tests to use RSNv3

### DIFF
--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -159,6 +159,57 @@ jobs:
           echo pki.example.com > kra.hostname
           diff kra.hostname kraconnector.host
 
+      - name: Switch to RSNv3
+        run: |
+          docker exec pki pki-server stop --wait
+
+          # switch cert request ID generator to RSNv3
+          docker exec pki pki-server ca-config-unset dbs.beginRequestNumber
+          docker exec pki pki-server ca-config-unset dbs.endRequestNumber
+          docker exec pki pki-server ca-config-unset dbs.requestIncrement
+          docker exec pki pki-server ca-config-unset dbs.requestLowWaterMark
+          docker exec pki pki-server ca-config-unset dbs.requestCloneTransferNumber
+          docker exec pki pki-server ca-config-unset dbs.requestRangeDN
+
+          docker exec pki pki-server ca-config-set dbs.request.id.generator random
+          docker exec pki pki-server ca-config-set dbs.request.id.length 128
+
+          # switch cert ID generator to RSNv3
+          docker exec pki pki-server ca-config-unset dbs.beginSerialNumber
+          docker exec pki pki-server ca-config-unset dbs.endSerialNumber
+          docker exec pki pki-server ca-config-unset dbs.serialIncrement
+          docker exec pki pki-server ca-config-unset dbs.serialLowWaterMark
+          docker exec pki pki-server ca-config-unset dbs.serialCloneTransferNumber
+          docker exec pki pki-server ca-config-unset dbs.serialRangeDN
+
+          docker exec pki pki-server ca-config-set dbs.cert.id.generator random
+          docker exec pki pki-server ca-config-set dbs.cert.id.length 128
+
+          # switch key request ID generator to RSNv3
+          docker exec pki pki-server kra-config-unset dbs.beginRequestNumber
+          docker exec pki pki-server kra-config-unset dbs.endRequestNumber
+          docker exec pki pki-server kra-config-unset dbs.requestIncrement
+          docker exec pki pki-server kra-config-unset dbs.requestLowWaterMark
+          docker exec pki pki-server kra-config-unset dbs.requestCloneTransferNumber
+          docker exec pki pki-server kra-config-unset dbs.requestRangeDN
+
+          docker exec pki pki-server kra-config-set dbs.request.id.generator random
+          docker exec pki pki-server kra-config-set dbs.request.id.length 128
+
+          # switch key ID generator to RSNv3
+          docker exec pki pki-server kra-config-unset dbs.beginSerialNumber
+          docker exec pki pki-server kra-config-unset dbs.endSerialNumber
+          docker exec pki pki-server kra-config-unset dbs.serialIncrement
+          docker exec pki pki-server kra-config-unset dbs.serialLowWaterMark
+          docker exec pki pki-server kra-config-unset dbs.serialCloneTransferNumber
+          docker exec pki pki-server kra-config-unset dbs.serialRangeDN
+
+          docker exec pki pki-server kra-config-set dbs.key.id.generator random
+          docker exec pki pki-server kra-config-set dbs.key.id.length 128
+
+          # restart PKI server
+          docker exec pki pki-server start --wait
+
       - name: Verify cert key archival
         run: |
           docker exec pki /usr/share/pki/tests/kra/bin/test-cert-key-archival.sh
@@ -236,6 +287,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=cads.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find
@@ -273,6 +326,8 @@ jobs:
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
               -D pki_ds_hostname=krads.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec kra pki-server cert-find
@@ -388,6 +443,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=cads.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find
@@ -434,6 +491,8 @@ jobs:
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
               -D pki_audit_signing_csr_path=${SHARED}/kra_audit_signing.csr \
               -D pki_admin_csr_path=${SHARED}/kra_admin.csr \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       - name: Issue KRA storage cert
@@ -504,6 +563,8 @@ jobs:
               -D pki_sslserver_cert_path=${SHARED}/sslserver.crt \
               -D pki_audit_signing_cert_path=${SHARED}/kra_audit_signing.crt \
               -D pki_admin_cert_path=${SHARED}/kra_admin.crt \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec kra pki-server cert-find
@@ -614,6 +675,8 @@ jobs:
               -s CA \
               -D pki_ds_hostname=cads.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find
@@ -660,6 +723,8 @@ jobs:
               -D pki_sslserver_csr_path=$SHARED/sslserver.csr \
               -D pki_audit_signing_csr_path=$SHARED/kra_audit_signing.csr \
               -D pki_admin_csr_path=$SHARED/kra_admin.csr \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       # https://github.com/dogtagpki/pki/wiki/Issuing-KRA-Storage-Certificate-with-CMC
@@ -835,6 +900,8 @@ jobs:
               -D pki_sslserver_cert_path=$SHARED/sslserver.p7b \
               -D pki_audit_signing_cert_path=$SHARED/kra_audit_signing.p7b \
               -D pki_admin_cert_path=$SHARED/kra_admin.crt \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec kra pki-server cert-find
@@ -1219,6 +1286,8 @@ jobs:
               -s KRA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
       - name: Issue KRA storage cert
@@ -1288,6 +1357,8 @@ jobs:
               -s KRA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
+              -D pki_key_id_generator=random \
+              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find


### PR DESCRIPTION
The basic KRA test has been modified to switch to RSNv3 after installing using sequential ID generator. The remaining KRA tests have been modified to install using RSNv3.

https://github.com/dogtagpki/pki/wiki/Configuring-KRA-with-Random-Serial-Numbers-v3