### PR TITLE
Prevent NullPointerException in DirBasedAuthentication

### DIFF
--- a/base/server/src/main/java/com/netscape/cms/authentication/DirBasedAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/DirBasedAuthentication.java
@@ -607,9 +607,13 @@ public abstract class DirBasedAuthentication
                 logger.info("DirBasedAuthentication: Searching for " + userdn);
 
                 String[] attrs = getLdapAttrs();
-                logger.info("DirBasedAuthentication: - attributes:");
-                for (String attr : attrs) {
-                    logger.info("DirBasedAuthentication:   - " + attr);
+                if (attrs == null) {
+                    logger.info("DirBasedAuthentication: - no attributes found");
+                } else {
+                    logger.info("DirBasedAuthentication: - attributes:");
+                    for (String attr : attrs) {
+                        logger.info("DirBasedAuthentication:   - " + attr);
+                    }
                 }
 
                 LDAPSearchResults results = conn.search(


### PR DESCRIPTION
* It is acceptable for `getLdapAttrs()` to return `null`, so check before
dereference.