### PR TITLE
Make CertificateAuthority implement IAuthority directly

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -91,6 +91,7 @@ import org.mozilla.jss.pkix.cert.Extension;
 import org.mozilla.jss.pkix.primitive.Name;
 
 import com.netscape.certsrv.authentication.IAuthToken;
+import com.netscape.certsrv.authority.IAuthority;
 import com.netscape.certsrv.base.BadRequestDataException;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.Nonces;
@@ -161,7 +162,7 @@ import com.netscape.cmsutil.ocsp.UnknownInfo;
  * @author lhsiao
  * @version $Revision$, $Date$
  */
-public class CertificateAuthority implements ICertificateAuthority, IOCSPService {
+public class CertificateAuthority implements IAuthority, ICertificateAuthority, IOCSPService {
 
     public final static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CertificateAuthority.class);
 

--- a/base/ca/src/main/java/com/netscape/cms/listeners/RequestInQListener.java
+++ b/base/ca/src/main/java/com/netscape/cms/listeners/RequestInQListener.java
@@ -20,8 +20,7 @@ package com.netscape.cms.listeners;
 import java.io.IOException;
 import java.util.Hashtable;
 
-import org.dogtagpki.server.ca.ICertificateAuthority;
-
+import com.netscape.ca.CertificateAuthority;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.EPropertyNotFound;
 import com.netscape.certsrv.base.ISubsystem;
@@ -78,7 +77,7 @@ public class RequestInQListener implements IRequestListener {
     private ConfigStore mConfig;
     private Hashtable<String, Object> mContentParams = new Hashtable<>();
     private String mId = "RequestInQListener";
-    private ICertificateAuthority mSubsystem = null;
+    private CertificateAuthority mSubsystem = null;
     private String mHttpHost = null;
     private String mAgentPort = null;
 
@@ -97,7 +96,7 @@ public class RequestInQListener implements IRequestListener {
 
         CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
-        mSubsystem = (ICertificateAuthority) sub;
+        mSubsystem = (CertificateAuthority) sub;
         mConfig = mSubsystem.getConfigStore();
 
         ConfigStore nc = mConfig.getSubStore(PROP_NOTIFY_SUBSTORE, ConfigStore.class);

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -38,7 +38,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.dogtagpki.server.authentication.AuthToken;
 import org.dogtagpki.server.ca.CAEngine;
-import org.dogtagpki.server.ca.ICertificateAuthority;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NoSuchTokenException;
 import org.mozilla.jss.NotInitializedException;
@@ -94,6 +93,7 @@ import org.mozilla.jss.pkix.cert.Certificate;
 import org.mozilla.jss.util.IncorrectPasswordException;
 import org.mozilla.jss.util.PasswordCallback;
 
+import com.netscape.ca.CertificateAuthority;
 import com.netscape.certsrv.authentication.AuthCredentials;
 import com.netscape.certsrv.authentication.EInvalidCredentials;
 import com.netscape.certsrv.authentication.EMissingCredential;
@@ -159,7 +159,7 @@ public class CRSEnrollment extends HttpServlet {
 
     protected ProfileSubsystem mProfileSubsystem;
     protected String mProfileId = null;
-    protected ICertificateAuthority mAuthority;
+    protected CertificateAuthority mAuthority;
     protected ConfigStore mConfig;
     protected AuthSubsystem mAuthSubsystem;
     protected String mAppendDN = null;
@@ -182,7 +182,7 @@ public class CRSEnrollment extends HttpServlet {
     private String[] mAllowedEncryptionAlgorithm;
     private SecureRandom mRandom = null;
     private int mNonceSizeLimit = 0;
-    private ICertificateAuthority ca;
+    private CertificateAuthority ca;
     private boolean mIsDynamicProfileId = false;
     private String mAllowedDynamicProfileIdList = null;
     private String[] mAllowedDynamicProfileId;
@@ -248,7 +248,7 @@ public class CRSEnrollment extends HttpServlet {
         CAEngine engine = CAEngine.getInstance();
         JssSubsystem jssSubsystem = engine.getJSSSubsystem();
 
-        mAuthority = (ICertificateAuthority) engine.getSubsystem(crsCA);
+        mAuthority = (CertificateAuthority) engine.getSubsystem(crsCA);
         ca = mAuthority;
 
         if (mAuthority == null) {

--- a/base/ca/src/main/java/com/netscape/cmscore/ldap/LdapPublishModule.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/ldap/LdapPublishModule.java
@@ -25,11 +25,11 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 
 import org.dogtagpki.server.ca.CAEngine;
-import org.dogtagpki.server.ca.ICertificateAuthority;
 import org.mozilla.jss.netscape.security.x509.X500Name;
 import org.mozilla.jss.netscape.security.x509.X509CRLImpl;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
+import com.netscape.ca.CertificateAuthority;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.certsrv.base.MetaInfo;
@@ -63,7 +63,7 @@ public class LdapPublishModule implements IRequestListener {
     protected ConfigStore mConfig;
     protected LdapBoundConnFactory mLdapConnFactory = null;
     private boolean mInited = false;
-    protected ICertificateAuthority mAuthority = null;
+    protected CertificateAuthority mAuthority = null;
 
     /**
      * hashtable of cert types to cert mappers and publishers.
@@ -119,10 +119,7 @@ public class LdapPublishModule implements IRequestListener {
 
     protected CAPublisherProcessor mPubProcessor;
 
-    public void init(
-            ICertificateAuthority authority,
-            CAPublisherProcessor p,
-            ConfigStore config)
+    public void init(CertificateAuthority authority, CAPublisherProcessor p, ConfigStore config)
             throws EBaseException {
         if (mInited)
             return;
@@ -145,7 +142,7 @@ public class LdapPublishModule implements IRequestListener {
         mAuthority.registerRequestListener(this);
     }
 
-    public void init(ICertificateAuthority authority, ConfigStore config) throws EBaseException {
+    public void init(CertificateAuthority authority, ConfigStore config) throws EBaseException {
         if (mInited)
             return;
 

--- a/base/ca/src/main/java/org/dogtagpki/legacy/ca/CAPolicy.java
+++ b/base/ca/src/main/java/org/dogtagpki/legacy/ca/CAPolicy.java
@@ -20,7 +20,6 @@ package org.dogtagpki.legacy.ca;
 import org.dogtagpki.legacy.core.policy.GenericPolicyProcessor;
 import org.dogtagpki.legacy.policy.IPolicyProcessor;
 import org.dogtagpki.server.ca.CAEngine;
-import org.dogtagpki.server.ca.ICertificateAuthority;
 
 import com.netscape.ca.CertificateAuthority;
 import com.netscape.certsrv.base.EBaseException;
@@ -46,7 +45,7 @@ public class CAPolicy implements IPolicy {
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CAPolicy.class);
 
     ConfigStore mConfig;
-    ICertificateAuthority mCA = null;
+    CertificateAuthority mCA = null;
 
     public static String PROP_PROCESSOR =
             "processor";

--- a/base/server/src/main/java/org/dogtagpki/server/ca/ICertificateAuthority.java
+++ b/base/server/src/main/java/org/dogtagpki/server/ca/ICertificateAuthority.java
@@ -32,8 +32,8 @@ import org.mozilla.jss.netscape.security.x509.X509CRLImpl;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.mozilla.jss.netscape.security.x509.X509CertInfo;
 
-import com.netscape.certsrv.authority.IAuthority;
 import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.certsrv.ca.AuthorityID;
 import com.netscape.certsrv.ca.ECAException;
 import com.netscape.certsrv.request.IRequestListener;
@@ -51,7 +51,7 @@ import com.netscape.cmscore.dbs.ReplicaIDRepository;
  *
  * @version $Revision$, $Date$
  */
-public interface ICertificateAuthority extends IAuthority {
+public interface ICertificateAuthority extends ISubsystem {
 
 
     public static final String ID = "ca";


### PR DESCRIPTION
* This gives `CertificateAuthority` a similar inheritance hierarchy to the
other subsystem authorities