### PR TITLE
Add tests for HTTPS connector

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -131,7 +131,20 @@ jobs:
 
       - name: Start PKI server
         run: |
-          docker exec pki pki-server start --wait -v
+          docker exec pki pki-server start
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Wait for PKI server to start
+        run: |
+          tests/bin/pki-start-wait.sh client http://pki.example.com:8080
 
       - name: Stop PKI server
         run: |
@@ -152,6 +165,120 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: pki-server-test-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki
+
+  # docs/admin/server/Configuring-HTTPS-Connector.adoc
+  pki-server-https-test:
+    name: Testing PKI server with HTTPS connector
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-runner-image-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up server container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect server container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Create PKI server
+        run: |
+          docker exec pki pki-server create -v
+
+      - name: Create NSS database in PKI server
+        run: |
+          docker exec pki pki-server nss-create --no-password
+
+      - name: Create SSL server cert
+        run: |
+          docker exec pki pki -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-request \
+              --subject "CN=$HOSTNAME" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr sslserver.csr
+          docker exec pki pki -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-issue \
+              --csr sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --cert sslserver.crt
+          docker exec pki pki -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-import \
+              --cert sslserver.crt \
+              sslserver
+
+      - name: Create HTTPS connector
+        run: |
+          docker exec pki pki-server jss-enable
+          docker exec pki pki-server http-connector-add \
+              --port 8443 \
+              --scheme https \
+              --secure true \
+              --sslEnabled true \
+              --sslProtocol SSL \
+              --sslImpl org.dogtagpki.tomcat.JSSImplementation \
+              Secure
+          docker exec pki pki-server http-connector-cert-add \
+              --keyAlias sslserver \
+              --keystoreType pkcs11 \
+              --keystoreProvider Mozilla-JSS
+
+      - name: Start PKI server
+        run: |
+          docker exec pki pki-server start
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Wait for PKI server to start
+        run: |
+          tests/bin/pki-start-wait.sh client https://pki.example.com:8443
+
+      - name: Stop PKI server
+        run: |
+          docker exec pki pki-server stop --wait -v
+
+      - name: Remove PKI server
+        run: |
+          docker exec pki pki-server remove -v
+
+      - name: Gather artifacts from server container
+        if: always()
+        run: |
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts from server container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-server-https-test-${{ matrix.os }}
           path: |
             /tmp/artifacts/pki
 
@@ -206,7 +333,7 @@ jobs:
 
       - name: Wait for server container to start
         run: |
-          tests/bin/pki-start-wait.sh client http://pki.example.com:8080
+          tests/bin/pki-start-wait.sh client https://pki.example.com:8443
 
       - name: Gather artifacts from server container
         if: always()

--- a/tests/bin/pki-start-wait.sh
+++ b/tests/bin/pki-start-wait.sh
@@ -20,7 +20,7 @@ while :
 do
     sleep 1
 
-    docker exec $NAME curl -ISs $URL
+    docker exec $NAME curl -IkSs $URL
 
     if [ $? -eq 0 ]
     then


### PR DESCRIPTION
The basic server test has been modified to create a client container to verify that the server is running.

A new job has been added to test HTTPS connector using NSS database. Tests for HTTPS connector using other methods can
be added later.

The container test has been modified to use HTTPS protocol to verify that the server is running.

The `pki-start-wait.sh` script has been modified to ignore self-signed cert.