### PR TITLE
Add more tests for HTTPS connector

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -168,6 +168,111 @@ jobs:
           path: |
             /tmp/artifacts/pki
 
+  # docs/admin/server/Configuring-HTTPS-Connector-with-PEM-Files.adoc
+  pki-server-https-pem-test:
+    name: Testing HTTPS connector with PEM files
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-runner-image-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up server container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect server container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Create PKI server
+        run: |
+          docker exec pki pki-server create -v
+
+      - name: Create SSL server cert
+        run: |
+          docker exec pki openssl req \
+              -newkey rsa:2048 \
+              -x509 \
+              -nodes \
+              -days 365 \
+              -subj "/CN=$HOSTNAME" \
+              -keyout /var/lib/pki/pki-tomcat/conf/sslserver.key \
+              -out /var/lib/pki/pki-tomcat/conf/sslserver.crt
+          docker exec pki chown pkiuser.pkiuser /var/lib/pki/pki-tomcat/conf/sslserver.crt
+          docker exec pki chmod 660 /var/lib/pki/pki-tomcat/conf/sslserver.crt
+          docker exec pki chown pkiuser.pkiuser /var/lib/pki/pki-tomcat/conf/sslserver.key
+          docker exec pki chmod 660 /var/lib/pki/pki-tomcat/conf/sslserver.key
+
+      - name: Create HTTPS connector with PEM files
+        run: |
+          docker exec pki pki-server http-connector-add \
+              --port 8443 \
+              --scheme https \
+              --secure true \
+              --sslEnabled true \
+              --sslProtocol SSL \
+              Secure
+          docker exec pki pki-server http-connector-cert-add \
+              --certFile /var/lib/pki/pki-tomcat/conf/sslserver.crt \
+              --keyFile /var/lib/pki/pki-tomcat/conf/sslserver.key
+
+      - name: Start PKI server
+        run: |
+          docker exec pki pki-server start
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Wait for PKI server to start
+        run: |
+          tests/bin/pki-start-wait.sh client https://pki.example.com:8443
+
+      - name: Stop PKI server
+        run: |
+          docker exec pki pki-server stop --wait -v
+
+      - name: Remove PKI server
+        run: |
+          docker exec pki pki-server remove -v
+
+      - name: Gather artifacts from server container
+        if: always()
+        run: |
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts from server container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-server-https-pem-test-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki
+
   # docs/admin/server/Configuring-HTTPS-Connector-with-JKS-File.adoc
   pki-server-https-jks-test:
     name: Testing HTTPS connector with JKS file

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -168,6 +168,109 @@ jobs:
           path: |
             /tmp/artifacts/pki
 
+  # docs/admin/server/Configuring-HTTPS-Connector-with-JKS-File.adoc
+  pki-server-https-jks-test:
+    name: Testing HTTPS connector with JKS file
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-runner-image-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up server container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect server container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Create PKI server
+        run: |
+          docker exec pki pki-server create -v
+
+      - name: Create SSL server cert
+        run: |
+          docker exec pki keytool -genkeypair \
+              -keystore /var/lib/pki/pki-tomcat/conf/keystore.jks \
+              -storepass Secret.123 \
+              -alias "sslserver" \
+              -dname "CN=$HOSTNAME" \
+              -keyalg RSA \
+              -keypass Secret.123
+          docker exec pki chown pkiuser.pkiuser /var/lib/pki/pki-tomcat/conf/keystore.jks
+          docker exec pki chmod 660 /var/lib/pki/pki-tomcat/conf/keystore.jks
+
+      - name: Create HTTPS connector with JKS file
+        run: |
+          docker exec pki pki-server http-connector-add \
+              --port 8443 \
+              --scheme https \
+              --secure true \
+              --sslEnabled true \
+              --sslProtocol SSL \
+              Secure
+          docker exec pki pki-server http-connector-cert-add \
+              --keyAlias sslserver \
+              --keystoreFile /var/lib/pki/pki-tomcat/conf/keystore.jks \
+              --keystorePassword Secret.123
+
+      - name: Start PKI server
+        run: |
+          docker exec pki pki-server start
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Wait for PKI server to start
+        run: |
+          tests/bin/pki-start-wait.sh client https://pki.example.com:8443
+
+      - name: Stop PKI server
+        run: |
+          docker exec pki pki-server stop --wait -v
+
+      - name: Remove PKI server
+        run: |
+          docker exec pki pki-server remove -v
+
+      - name: Gather artifacts from server container
+        if: always()
+        run: |
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts from server container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-server-https-jks-test-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki
+
   # docs/admin/server/Configuring-HTTPS-Connector-with-PKCS12-File.adoc
   pki-server-https-pkcs12-test:
     name: "Testing HTTPS connector with PKCS #12 file"

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -168,9 +168,114 @@ jobs:
           path: |
             /tmp/artifacts/pki
 
-  # docs/admin/server/Configuring-HTTPS-Connector.adoc
-  pki-server-https-test:
-    name: Testing PKI server with HTTPS connector
+  # docs/admin/server/Configuring-HTTPS-Connector-with-PKCS12-File.adoc
+  pki-server-https-pkcs12-test:
+    name: "Testing HTTPS connector with PKCS #12 file"
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download runner image
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-runner-image-${{ matrix.os }}
+          path: /tmp
+
+      - name: Load runner image
+        run: docker load --input /tmp/pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up server container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect server container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Create PKI server
+        run: |
+          docker exec pki pki-server create -v
+
+      - name: Create SSL server cert
+        run: |
+          docker exec pki keytool -genkeypair \
+              -keystore /var/lib/pki/pki-tomcat/conf/keystore.p12 \
+              -storetype pkcs12 \
+              -storepass Secret.123 \
+              -alias "sslserver" \
+              -dname "CN=$HOSTNAME" \
+              -keyalg RSA \
+              -keypass Secret.123
+          docker exec pki chown pkiuser.pkiuser /var/lib/pki/pki-tomcat/conf/keystore.p12
+          docker exec pki chmod 660 /var/lib/pki/pki-tomcat/conf/keystore.p12
+
+      - name: "Create HTTPS connector with PKCS #12 file"
+        run: |
+          docker exec pki pki-server http-connector-add \
+              --port 8443 \
+              --scheme https \
+              --secure true \
+              --sslEnabled true \
+              --sslProtocol SSL \
+              Secure
+          docker exec pki pki-server http-connector-cert-add \
+              --keyAlias sslserver \
+              --keystoreType pkcs12 \
+              --keystoreFile /var/lib/pki/pki-tomcat/conf/keystore.p12 \
+              --keystorePassword Secret.123
+
+      - name: Start PKI server
+        run: |
+          docker exec pki pki-server start
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Wait for PKI server to start
+        run: |
+          tests/bin/pki-start-wait.sh client https://pki.example.com:8443
+
+      - name: Stop PKI server
+        run: |
+          docker exec pki pki-server stop --wait -v
+
+      - name: Remove PKI server
+        run: |
+          docker exec pki pki-server remove -v
+
+      - name: Gather artifacts from server container
+        if: always()
+        run: |
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts from server container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-server-https-pkcs12-test-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki
+
+  # docs/admin/server/Configuring-HTTPS-Connector-with-NSS-Database.adoc
+  pki-server-https-nss-test:
+    name: Testing HTTPS connector with NSS database
     needs: [init, build]
     runs-on: ubuntu-latest
     env:
@@ -227,7 +332,7 @@ jobs:
               --cert sslserver.crt \
               sslserver
 
-      - name: Create HTTPS connector
+      - name: Create HTTPS connector with NSS database
         run: |
           docker exec pki pki-server jss-enable
           docker exec pki pki-server http-connector-add \
@@ -278,7 +383,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: pki-server-https-test-${{ matrix.os }}
+          name: pki-server-https-nss-test-${{ matrix.os }}
           path: |
             /tmp/artifacts/pki
 


### PR DESCRIPTION
New tests have been added to test HTTPS connector with PEM files, JKS file, and PKCS #12 file.

Previously the `PKIServer.export_ca_cert()` would always export the CA cert from NSS database in all cases. The code has been modified to do the export only if the server has an HTTPS connector with NSS database. The support for other types of HTTPS connector will be added later.