### PR TITLE
Redirect banner prompt to standard error

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -600,10 +600,12 @@ public class MainCLI extends CLI {
 
             if (banner != null && !ignoreBanner) {
 
-                System.out.println(banner);
-                System.out.println();
-                System.out.print("Do you want to proceed (y/N)? ");
-                System.out.flush();
+                System.err.print("""
+                    %s
+
+                    Do you want to proceed (y/N)?\s""".formatted(banner)
+                );
+                System.err.flush();
 
                 BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
                 String line = reader.readLine().trim();


### PR DESCRIPTION
Previously if PKI server was configured with access banner `pki` CLI would display the access banner on the standard output. This could cause a problem if `pki` CLI is used in automation because the output might change.

To fix the problem `pki` CLI has been modified to dispaly the access banner on the standard error instead.

Verification steps:

1. Install CA
2. Configure [Access Banner](https://github.com/dogtagpki/pki/wiki/Access-Banner)
3. Run `pki` CLI to access the server and redirect the output to a file, e.g. `pki info > output.txt`

Expected result: The file should contain only the output of the command. Warnings that occur during the execution should appear on the standard error.

Test result:
```
$ pki info > output.txt
WARNING: UNTRUSTED ISSUER encountered on 'CN=fedora,OU=pki-tomcat,O=EXAMPLE' indicates a non-trusted CA cert 'CN=CA Signing Certificate,OU=pki-tomcat,O=EXAMPLE'
Trust this certificate (y/N)? y
WARNING!
Access to this service is restricted to those individuals with
specific permissions. If you are not an authorized user, disconnect
now. Any attempts to gain unauthorized access will be prosecuted to
the fullest extent of the law.

Do you want to proceed (y/N)? y
$ cat output.txt 
  Server URL: https://fedora:8443
  Server Name: Dogtag Certificate System
  Server Version: 11.2.0
```
So the warnings about untrusted issuer and banner prompt go to standard error which is displayed on the screen, and the actual output goes into the standard output which is redirected into a file.