### PR TITLE
Add pki nss-cert-export --output-file option

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1683,8 +1683,8 @@ jobs:
               --pkcs12-password Secret.123
           docker exec secondary pki \
               nss-cert-export \
-              Self-Signed-CA \
-              ds_signing.crt
+              --output-file ds_signing.crt \
+              Self-Signed-CA
           docker exec secondary certutil -L -d /root/.dogtag/nssdb
 
       - name: Create DS server cert in secondary PKI container

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1622,7 +1622,10 @@ class NSSDatabase(object):
         else:
             fullname = nickname
 
-        cmd.extend(['nss-cert-export'])
+        cmd.extend([
+            'nss-cert-export',
+            '--output-file', output_file
+        ])
 
         if include_chain:
             cmd.extend(['--with-chain'])
@@ -1636,7 +1639,7 @@ class NSSDatabase(object):
         elif logger.isEnabledFor(logging.INFO):
             cmd.append('--verbose')
 
-        cmd.extend([fullname, output_file])
+        cmd.append(fullname)
 
         self.run(cmd, check=True)
 

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertExportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertExportCLI.java
@@ -30,12 +30,16 @@ public class NSSCertExportCLI extends CommandCLI {
 
     @Override
     public void printHelp() {
-        formatter.printHelp(getFullName() + " [OPTIONS...] nickname [path]", options);
+        formatter.printHelp(getFullName() + " [OPTIONS...] <nickname> [path]", options);
     }
 
     @Override
     public void createOptions() {
-        Option option = new Option(null, "format", true, "Certificate format: PEM (default), DER, RAW");
+        Option option = new Option(null, "output-file", true, "Output file path");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "format", true, "Certificate format: PEM (default), DER, RAW");
         option.setArgName("format");
         options.addOption(option);
 
@@ -57,7 +61,13 @@ public class NSSCertExportCLI extends CommandCLI {
         nickname = cmdArgs[0];
 
         if (cmdArgs.length >= 2) {
+            logger.warn("The optional positional path argument has been deprecated. Use the --output-file option instead.");
             path = cmdArgs[1];
+        }
+
+        String outputFile = cmd.getOptionValue("output-file");
+        if (outputFile != null) {
+            path = outputFile;
         }
 
         String format = cmd.getOptionValue("format", "PEM").toUpperCase();

--- a/docs/changes/v11.2.0/Tools-Changes.adoc
+++ b/docs/changes/v11.2.0/Tools-Changes.adoc
@@ -11,3 +11,8 @@ $ OCSPClient ... --serial 35525
 CertID.serialNumber=0x8ac5
 CertStatus=Revoked
 ----
+
+== pki nss-cert-export Changes ==
+
+The optional positional `path` argument for `pki nss-cert-export` has been deprecated.
+Use the `--output-file` option instead.


### PR DESCRIPTION
The `pki nss-cert-export` CLI has been modified to provide a `--output-file` option for consistency with other CLIs. The optional positional `path` argument has been deprecated.

https://github.com/edewata/pki/blob/cli/docs/changes/v11.2.0/Tools-Changes.adoc
