### PR TITLE
Bug 2069813-Up default CA and OCSP signing cert key size to 3072

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -346,7 +346,7 @@ pki_tomcat_webapps_subsystem_webinf_lib_path=%(pki_tomcat_webapps_subsystem_path
 ###############################################################################
 [CA]
 pki_ca_signing_key_algorithm=SHA256withRSA
-pki_ca_signing_key_size=2048
+pki_ca_signing_key_size=3072
 pki_ca_signing_key_type=rsa
 pki_ca_signing_record_create=True
 pki_ca_signing_serial_number=1
@@ -382,7 +382,7 @@ pki_external_pkcs12_password=%(pki_pkcs12_password)s
 pki_import_admin_cert=False
 
 pki_ocsp_signing_key_algorithm=SHA256withRSA
-pki_ocsp_signing_key_size=2048
+pki_ocsp_signing_key_size=3072
 pki_ocsp_signing_key_type=rsa
 pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s CA
 pki_ocsp_signing_signing_algorithm=SHA256withRSA


### PR DESCRIPTION
Up the default values for the following two pkispawn parameters to 3072
for RSA:
 pki_ca_signing_key_size=3072
 pki_ocsp_signing_key_size=3072

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2069813