### PR TITLE
Add pki nss-cert-request options

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
@@ -478,17 +478,23 @@ public class CRMFPopClient {
 
             if (verbose) System.out.println("Generating key pair: temporary: " + temporary);
             KeyPair keyPair;
+
             if (algorithm.equals("rsa")) {
+
                 boolean sens = false;
                 boolean extract = true;
+
+                Usage[] usages = CryptoUtil.RSA_KEYPAIR_USAGES;
+                Usage[] usagesMask = CryptoUtil.RSA_KEYPAIR_USAGES_MASK;
+
                 keyPair = CryptoUtil.generateRSAKeyPair(
                         token,
                         keySize,
                         temporary,
                         sens,
                         extract,
-                        CryptoUtil.RSA_KEYPAIR_USAGES,
-                        CryptoUtil.RSA_KEYPAIR_USAGES_MASK);
+                        usages,
+                        usagesMask);
 
             } else if (algorithm.equals("ec")) {
                 keyPair = client.generateECCKeyPair(token, curve, sslECDH, temporary, sensitive, extractable);

--- a/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
@@ -109,24 +109,6 @@ public class CRMFPopClient {
     public boolean verbose;
     private boolean useOAEP = false;
 
-    private static org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage rsa_keypair_usages[] = {
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.ENCRYPT,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.DECRYPT,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.WRAP,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.UNWRAP,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN_RECOVER
-    };
-
-    private static org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage rsa_keypair_usages_mask[] = {
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.ENCRYPT,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.DECRYPT,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.WRAP,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.UNWRAP,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN,
-        org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage.SIGN_RECOVER
-    };
-
     public static Options createOptions() {
 
         Options options = new Options();
@@ -499,7 +481,15 @@ public class CRMFPopClient {
             if (algorithm.equals("rsa")) {
                 boolean sens = false;
                 boolean extract = true;
-                keyPair = CryptoUtil.generateRSAKeyPair(token, keySize, temporary,sens, extract, rsa_keypair_usages, rsa_keypair_usages_mask);
+                keyPair = CryptoUtil.generateRSAKeyPair(
+                        token,
+                        keySize,
+                        temporary,
+                        sens,
+                        extract,
+                        CryptoUtil.RSA_KEYPAIR_USAGES,
+                        CryptoUtil.RSA_KEYPAIR_USAGES_MASK);
+
             } else if (algorithm.equals("ec")) {
                 keyPair = client.generateECCKeyPair(token, curve, sslECDH, temporary, sensitive, extractable);
 

--- a/base/tools/src/main/java/com/netscape/cmstools/PKCS10Client.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/PKCS10Client.java
@@ -21,15 +21,14 @@ import java.io.BufferedReader;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.security.KeyPair;
 
 import org.dogtag.util.cert.CertUtil;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.InitializationValues;
-import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage;
 import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.netscape.security.pkcs.PKCS10;
 import org.mozilla.jss.netscape.security.x509.Extensions;
@@ -286,14 +285,27 @@ public class PKCS10Client {
 
             }  else if (alg.equals("ec")) {
 
+                Usage[] usages;
+                Usage[] usagesMask;
+
+                if (ec_ssl_ecdh) {
+                    usages = null;
+                    usagesMask = CryptoUtil.ECDH_USAGES_MASK;
+
+                } else {
+                    usages = null;
+                    usagesMask = CryptoUtil.ECDHE_USAGES_MASK;
+                }
+
                 pair = CryptoUtil.generateECCKeyPair(
                         token,
                         ecc_curve,
                         ec_temporary,
                         ec_sensitive,
                         ec_extractable,
-                        null,
-                        ec_ssl_ecdh ? CryptoUtil.ECDH_USAGES_MASK : CryptoUtil.ECDHE_USAGES_MASK);
+                        usages,
+                        usagesMask);
+
                 if (pair == null) {
                     System.out.println("PKCS10Client: pair null.");
                     System.exit(1);

--- a/base/tools/src/main/java/com/netscape/cmstools/PKCS10Client.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/PKCS10Client.java
@@ -261,15 +261,28 @@ public class PKCS10Client {
             KeyPair pair = null;
 
             if (alg.equals("rsa")) {
-                if (!rsa_keygen_wrap_unwrap_ops) {
-                    pair = CryptoUtil.generateRSAKeyPair(token, rsa_keylen);
-                } else {
+
+                Usage[] usages;
+                Usage[] usagesMask;
+
+                if (rsa_keygen_wrap_unwrap_ops) {
+
                     if (verbose)
                         System.out.println("PKCS10Client: rsa_keygen_wrap_unwrap_ops is true");
-                    pair = CryptoUtil.generateRSAKeyPair(token, rsa_keylen,
-                            CryptoUtil.RSA_KEYPAIR_USAGES,
-                            CryptoUtil.RSA_KEYPAIR_USAGES_MASK);
+
+                    usages = CryptoUtil.RSA_KEYPAIR_USAGES;
+                    usagesMask = CryptoUtil.RSA_KEYPAIR_USAGES_MASK;
+
+                } else {
+                    usages = null;
+                    usagesMask = null;
                 }
+
+                pair = CryptoUtil.generateRSAKeyPair(
+                        token,
+                        rsa_keylen,
+                        usages,
+                        usagesMask);
 
             }  else if (alg.equals("ec")) {
 

--- a/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertRequestCLI.java
@@ -38,6 +38,7 @@ import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.nss.NSSDatabase;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage;
 import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.Signature;
 import org.mozilla.jss.crypto.X509Certificate;
@@ -470,7 +471,27 @@ public class ClientCertRequestCLI extends CommandCLI {
                     usagesMask);
 
         } else if (algorithm.equals("ec")) {
-            keyPair = client.generateECCKeyPair(token, curve, sslECDH, temporary, sensitive, extractable);
+
+            Usage[] usages;
+            Usage[] usagesMask;
+
+            if (sslECDH) {
+                usages = null;
+                usagesMask = CryptoUtil.ECDH_USAGES_MASK;
+
+            } else {
+                usages = null;
+                usagesMask = CryptoUtil.ECDHE_USAGES_MASK;
+            }
+
+            keyPair = CryptoUtil.generateECCKeyPair(
+                    token,
+                    curve,
+                    temporary,
+                    sensitive,
+                    extractable,
+                    usages,
+                    usagesMask);
 
         } else {
             throw new Exception("Unknown algorithm: " + algorithm);

--- a/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertRequestCLI.java
@@ -459,7 +459,15 @@ public class ClientCertRequestCLI extends CommandCLI {
 
         KeyPair keyPair;
         if (algorithm.equals("rsa")) {
-            keyPair = CryptoUtil.generateRSAKeyPair(token, length);
+
+            Usage[] usages = null;
+            Usage[] usagesMask = null;
+
+            keyPair = CryptoUtil.generateRSAKeyPair(
+                    token,
+                    length,
+                    usages,
+                    usagesMask);
 
         } else if (algorithm.equals("ec")) {
             keyPair = client.generateECCKeyPair(token, curve, sslECDH, temporary, sensitive, extractable);

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -62,6 +62,8 @@ public class NSSCertRequestCLI extends CommandCLI {
         option.setArgName("name");
         options.addOption(option);
 
+        options.addOption(null, "ssl-ecdh", false, "Generate EC key for SSL with ECDH ECDSA.");
+
         option = new Option(null, "hash", true, "Hash algorithm (default: SHA256)");
         option.setArgName("name");
         options.addOption(option);
@@ -99,6 +101,7 @@ public class NSSCertRequestCLI extends CommandCLI {
         String keySize = cmd.getOptionValue("key-size", "2048");
         boolean keyWrap = cmd.hasOption("key-wrap");
         String curve = cmd.getOptionValue("curve");
+        boolean sslECDH = cmd.hasOption("ssl-ecdh");
         String hash = cmd.getOptionValue("hash", "SHA256");
         String extConf = cmd.getOptionValue("ext");
 
@@ -144,7 +147,24 @@ public class NSSCertRequestCLI extends CommandCLI {
                     usagesMask);
 
         } else if ("ec".equalsIgnoreCase(keyType)) {
-            keyPair = nssdb.createECKeyPair(token, curve);
+
+            Usage[] usages;
+            Usage[] usagesMask;
+
+            if (sslECDH) {
+                usages = null;
+                usagesMask = CryptoUtil.ECDH_USAGES_MASK;
+
+            } else {
+                usages = null;
+                usagesMask = CryptoUtil.ECDHE_USAGES_MASK;
+            }
+
+            keyPair = nssdb.createECKeyPair(
+                    token,
+                    curve,
+                    usages,
+                    usagesMask);
 
         } else {
             throw new Exception("Unsupported key type: " + keyType);


### PR DESCRIPTION
The `pki nss-cert-request --ssl-ecdh` option has been added to generate an EC key for SSL with ECDH ECDSA. This is similar to `PKCS10Client -x`, `CRMFPopClient -x`, and `pki client-cert-request --ssl-ecdh` options.

The `pki nss-cert-request --key-wrap` option has been added to generate an RSA key for wrapping/unwrapping. This is similar to `PKCS10Client -w` option. There are no corresponding options in `CRMFPopClient` and `pki client-cert-request`.

In the future these tools could be consolidated for simplicity & consistency.
