### PR TITLE
Update CI tests to cache build artifacts

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -66,15 +66,15 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/pki-runner.tar
+          outputs: type=docker,dest=pki-acme-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp/pki-runner.tar
+          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-acme-runner.tar
 
-      - name: Build ACME image
+      - name: Build server image
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -83,13 +83,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-acme
           target: pki-acme
-          outputs: type=docker,dest=/tmp/pki-acme.tar
+          outputs: type=docker,dest=pki-acme-server.tar
 
-      - name: Upload ACME image
-        uses: actions/upload-artifact@v2
+      - name: Store server image
+        uses: actions/cache@v3
         with:
-          name: pki-acme-${{ matrix.os }}
-          path: /tmp/pki-acme.tar
+          key: pki-acme-server-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-acme-server.tar
 
   # docs/installation/acme/Installing_PKI_ACME_Responder.md
   # docs/user/acme/Using_PKI_ACME_Responder_with_Certbot.md
@@ -105,14 +105,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-acme-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-acme-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -292,14 +292,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-acme-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-acme-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -493,23 +493,23 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-acme-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-acme-runner.tar
 
-      - name: Download ACME image
-        uses: actions/download-artifact@v2
+      - name: Retrieve server image
+        uses: actions/cache@v3
         with:
-          name: pki-acme-${{ matrix.os }}
-          path: /tmp
+          key: pki-acme-server-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-acme-server.tar
 
       - name: Load ACME image
-        run: docker load --input /tmp/pki-acme.tar
+        run: docker load --input pki-acme-server.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -66,13 +66,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/pki-runner.tar
+          outputs: type=docker,dest=pki-ca-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp/pki-runner.tar
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
   # docs/installation/ca/Installing_CA.md
   ca-test:
@@ -87,14 +87,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -284,14 +284,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -424,14 +424,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -601,14 +601,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -831,14 +831,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -969,14 +969,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1141,14 +1141,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1376,14 +1376,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1533,14 +1533,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1848,14 +1848,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1973,14 +1973,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -2066,14 +2066,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -2279,14 +2279,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ca-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -67,13 +67,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: ipa-runner
           target: ipa-runner
-          outputs: type=docker,dest=/tmp/ipa-runner.tar
+          outputs: type=docker,dest=ipa-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: ipa-runner-${{ matrix.os }}
-          path: /tmp/ipa-runner.tar
+          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: ipa-runner.tar
 
   ipa-test:
     name: Testing IPA
@@ -87,14 +87,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: ipa-runner-${{ matrix.os }}
-          path: /tmp
+          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: ipa-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/ipa-runner.tar
+        run: docker load --input ipa-runner.tar
 
       - name: Run IPA container
         run: |
@@ -192,14 +192,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: ipa-runner-${{ matrix.os }}
-          path: /tmp
+          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: ipa-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/ipa-runner.tar
+        run: docker load --input ipa-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -347,14 +347,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: ipa-runner-${{ matrix.os }}
-          path: /tmp
+          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: ipa-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/ipa-runner.tar
+        run: docker load --input ipa-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -66,13 +66,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/pki-runner.tar
+          outputs: type=docker,dest=pki-kra-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp/pki-runner.tar
+          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-kra-runner.tar
 
   # docs/installation/kra/Installing_KRA.md
   kra-test:
@@ -87,14 +87,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-kra-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-kra-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -290,14 +290,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-kra-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-kra-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -454,14 +454,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-kra-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-kra-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -686,14 +686,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-kra-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-kra-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1017,14 +1017,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-kra-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-kra-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1282,14 +1282,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-kra-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-kra-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1456,14 +1456,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-kra-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-kra-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -66,13 +66,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/pki-runner.tar
+          outputs: type=docker,dest=pki-ocsp-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp/pki-runner.tar
+          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ocsp-runner.tar
 
   # docs/installation/ocsp/Installing_OCSP.md
   ocsp-test:
@@ -87,14 +87,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ocsp-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ocsp-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -344,14 +344,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ocsp-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ocsp-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -493,14 +493,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ocsp-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ocsp-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -703,14 +703,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ocsp-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ocsp-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1002,14 +1002,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner images
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ocsp-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ocsp-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1261,14 +1261,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ocsp-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-ocsp-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -66,13 +66,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/pki-runner.tar
+          outputs: type=docker,dest=pki-python-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp/pki-runner.tar
+          key: pki-python-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-python-runner.tar
 
   lint-test:
     name: Running Python lint
@@ -86,14 +86,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-python-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-python-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-python-runner.tar
 
       - name: Run container
         run: |

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -66,13 +66,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/qe-runner.tar
+          outputs: type=docker,dest=qe-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: qe-runner-${{ matrix.os }}
-          path: /tmp/qe-runner.tar
+          key: qe-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: qe-runner.tar
 
   # Tier 0
   installation-sanity-test:
@@ -96,14 +96,14 @@ jobs:
           pip3 install -r tests/dogtag/pytest-ansible/requirements.txt
           pip3 install -e tests/dogtag/pytest-ansible
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: qe-runner-${{ matrix.os }}
-          path: /tmp
+          key: qe-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: qe-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/qe-runner.tar
+        run: docker load --input qe-runner.tar
 
       - name: Run master container
         run: |

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -66,13 +66,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/pki-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-image-${{ matrix.os }}
-          path: /tmp/pki-runner.tar
+          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-runner.tar
 
       - name: Build server image
         uses: docker/build-push-action@v2
@@ -83,13 +83,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-server
           target: pki-server
-          outputs: type=docker,dest=/tmp/pki-server.tar
+          outputs: type=docker,dest=pki-server.tar
 
-      - name: Upload server image
-        uses: actions/upload-artifact@v2
+      - name: Store server image
+        uses: actions/cache@v3
         with:
-          name: pki-server-image-${{ matrix.os }}
-          path: /tmp/pki-server.tar
+          key: pki-server-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-server.tar
 
   # docs/installation/server/Installing_Basic_PKI_Server.md
   pki-server-test:
@@ -104,14 +104,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-image-${{ matrix.os }}
-          path: /tmp
+          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -181,14 +181,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-image-${{ matrix.os }}
-          path: /tmp
+          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -286,14 +286,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-image-${{ matrix.os }}
-          path: /tmp
+          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -389,14 +389,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-image-${{ matrix.os }}
-          path: /tmp
+          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -494,14 +494,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-image-${{ matrix.os }}
-          path: /tmp
+          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -607,23 +607,23 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-image-${{ matrix.os }}
-          path: /tmp
+          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-runner.tar
 
-      - name: Download server image
-        uses: actions/download-artifact@v2
+      - name: Retrieve server image
+        uses: actions/cache@v3
         with:
-          name: pki-server-image-${{ matrix.os }}
-          path: /tmp
+          key: pki-server-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-server.tar
 
       - name: Load server image
-        run: docker load --input /tmp/pki-server.tar
+        run: docker load --input pki-server.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -66,13 +66,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/pki-runner.tar
+          outputs: type=docker,dest=pki-tks-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp/pki-runner.tar
+          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tks-runner.tar
 
   # docs/installation/tks/Installing_TKS.md
   tks-test:
@@ -87,14 +87,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tks-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-tks-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -214,14 +214,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tks-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-tks-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -362,14 +362,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tks-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-tks-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -571,14 +571,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tks-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-tks-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,tests --with-timestamp --work-dir=build rpm
 
-      - name: Upload PKI packages
+      - name: Store PKI packages
         uses: actions/upload-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
@@ -71,7 +71,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download PKI packages
+      - name: Retrieve PKI packages
         uses: actions/download-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Download PKI packages
+      - name: Retrieve PKI packages
         uses: actions/download-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
@@ -279,7 +279,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Download PKI packages
+      - name: Retrieve PKI packages
         uses: actions/download-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
@@ -464,7 +464,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Download PKI packages
+      - name: Retrieve PKI packages
         uses: actions/download-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
@@ -626,7 +626,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Download PKI packages
+      - name: Retrieve PKI packages
         uses: actions/download-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
@@ -711,7 +711,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Download PKI packages
+      - name: Retrieve PKI packages
         uses: actions/download-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
@@ -842,7 +842,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     container: registry.fedoraproject.org/fedora:${{ matrix.os }}
     steps:
-      - name: Download PKI packages
+      - name: Retrieve PKI packages
         uses: actions/download-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}
@@ -989,7 +989,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     container: registry.fedoraproject.org/fedora:${{ matrix.os }}
     steps:
-      - name: Download PKI packages
+      - name: Retrieve PKI packages
         uses: actions/download-artifact@v2
         with:
           name: pki-build-${{ matrix.os }}

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -66,13 +66,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=/tmp/pki-runner.tar
+          outputs: type=docker,dest=pki-tps-runner.tar
 
-      - name: Upload runner image
-        uses: actions/upload-artifact@v2
+      - name: Store runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp/pki-runner.tar
+          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tps-runner.tar
 
   # docs/installation/tps/Installing_TPS.md
   tps-test:
@@ -87,14 +87,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tps-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-tps-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -300,14 +300,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tps-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-tps-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -567,14 +567,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tps-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-tps-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -895,14 +895,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Download runner image
-        uses: actions/download-artifact@v2
+      - name: Retrieve runner image
+        uses: actions/cache@v3
         with:
-          name: pki-runner-${{ matrix.os }}
-          path: /tmp
+          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tps-runner.tar
 
       - name: Load runner image
-        run: docker load --input /tmp/pki-runner.tar
+        run: docker load --input pki-tps-runner.tar
 
       - name: Create network
         run: docker network create example


### PR DESCRIPTION
The CI tests have been modified to use cache action to distribute build artifacts among the jobs which should be faster than using upload/download actions.