### PR TITLE
Use "if connector is None" instead of "if not connector"

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -266,7 +266,7 @@ class PKIServer(object):
         server_config = self.get_server_config()
         connector = server_config.get_connector('Secure')
 
-        if not connector:
+        if connector is None:
             # HTTPS connector not configured, skip
             return
 


### PR DESCRIPTION
Restarting tomcat I noticed a FutureWarning around the use of the "if not <object>" syntax - so it would appear that behaviour is to change in a future version of Python. I couldn't find a PEP that documents it though, or anything from searching around.

Even if there is no such change to the language planned, it is still better to explicitly check for `None` rather than rely on the falsy-ness of the object.