### PR TITLE
Fix cert/key ID handling in pki pkcs12 CLIs

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12CertExportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12CertExportCLI.java
@@ -99,7 +99,8 @@ public class PKCS12CertExportCLI extends CommandCLI {
         if (cmdArgs.length >= 1) {
             nickname = cmdArgs[0];
         } else {
-            certID = Hex.decodeHex(id.toCharArray());
+            if (id.startsWith("0x")) id = id.substring(2);
+            certID = Hex.decodeHex(id);
         }
 
         String pkcs12File = cmd.getOptionValue("pkcs12-file");

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12CertModCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12CertModCLI.java
@@ -139,7 +139,9 @@ public class PKCS12CertModCLI extends CommandCLI {
 
         byte[] certID;
         try {
-            certID = Hex.decodeHex(nickname.toCharArray());
+            String id = nickname;
+            if (id.startsWith("0x")) id = id.substring(2);
+            certID = Hex.decodeHex(id);
         } catch (DecoderException e) {
             // nickname is not an ID
             certID = null;

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12KeyRemoveCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12KeyRemoveCLI.java
@@ -23,12 +23,12 @@ import java.io.FileReader;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
-import org.apache.commons.codec.binary.Hex;
 import org.dogtagpki.cli.CommandCLI;
 import org.mozilla.jss.netscape.security.pkcs.PKCS12;
 import org.mozilla.jss.netscape.security.pkcs.PKCS12Util;
 import org.mozilla.jss.util.Password;
 
+import com.netscape.certsrv.dbs.keydb.KeyId;
 import com.netscape.cmstools.cli.MainCLI;
 
 /**
@@ -72,8 +72,7 @@ public class PKCS12KeyRemoveCLI extends CommandCLI {
             throw new Exception("Missing key ID.");
         }
 
-        String keyID = cmdArgs[0];
-        byte[] id = Hex.decodeHex(keyID.toCharArray());
+        KeyId keyID = new KeyId(cmdArgs[0]);
 
         String filename = cmd.getOptionValue("pkcs12-file");
 
@@ -106,7 +105,7 @@ public class PKCS12KeyRemoveCLI extends CommandCLI {
             PKCS12Util util = new PKCS12Util();
 
             PKCS12 pkcs12 = util.loadFromFile(filename, password);
-            pkcs12.removeKeyInfoByID(id);
+            pkcs12.removeKeyInfoByID(keyID.toByteArray());
             util.storeIntoFile(pkcs12, filename, password);
 
         } finally {


### PR DESCRIPTION
The `pki pkcs12-key-remove` has been modified to use the `KeyId` class which can handle hexadecimal key IDs with `0x` prefix.

The `pki pkcs12-cert-export/mod` have been modified to strip the `0x` prefix from cert IDs. In the future this code may be replaced with `CertId` class that can handle hexadecimal cert IDs properly.

Resolves: https://github.com/dogtagpki/pki/issues/3974