### PR TITLE
Fixes for broken parts of TPS UI

### DIFF
--- a/base/ca/shared/webapps/ca/js/cert.js
+++ b/base/ca/shared/webapps/ca/js/cert.js
@@ -56,8 +56,8 @@ var CertificateCollection = Collection.extend({
             keyLength: entry.KeyLength,
             keyAlgorithmOID: entry.KeyAlgorithmOID,
             status: entry.Status,
-            notValidBefore: entry.NotValidBefore,
-            notValidAfter: entry.NotValidAfter
+            notValidBefore: new Date(entry.NotValidBefore),
+            notValidAfter: new Date(entry.NotValidAfter)
         });
     }
 });

--- a/base/common/src/main/java/com/netscape/certsrv/tps/token/TokenData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/token/TokenData.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -58,17 +59,27 @@ public class TokenData {
     }
 
     String id;
+    @JsonProperty("TokenID")
     String tokenID;
+    @JsonProperty("UserID")
     String userID;
+    @JsonProperty("Type")
     String type;
 
+    @JsonProperty("Status")
     TokenStatusData status;
+    @JsonProperty("NextStates")
     Collection<TokenStatusData> nextStates;
 
+    @JsonProperty("AppletID")
     String appletID;
+    @JsonProperty("KeyInfo")
     String keyInfo;
+    @JsonProperty("Policy")
     String policy;
+    @JsonProperty("CreateTimestamp")
     Date createTimestamp;
+    @JsonProperty("ModifyTimestamp")
     Date modifyTimestamp;
 
     public String getID() {

--- a/base/tps/shared/webapps/tps/js/token.js
+++ b/base/tps/shared/webapps/tps/js/token.js
@@ -38,7 +38,7 @@ var TOKEN_REUSE_MESSAGE = "When reusing a token that was previously " +
 var TokenModel = Model.extend({
     urlRoot: "/tps/rest/tokens",
     parseResponse: function(response) {
-    var respModifyTimestamp = (response.ModifyTime === null) ? new Date(null) : new Date(response.ModifyTime)
+    var respModifyTimestamp = (response.ModifyTimestamp == null) ? undefined : new Date(response.ModifyTimestamp)
         return {
             id: response.id,
             tokenID: response.TokenID,
@@ -91,7 +91,7 @@ var TokenCollection = Collection.extend({
         return response.Link;
     },
     parseEntry: function(entry) {
-        var custModifyTimestamp = (entry.ModifyTime === null) ? new Date(null) : new Date(entry.ModifyTime)
+        var custModifyTimestamp = (entry.ModifyTimestamp == null) ? undefined : new Date(entry.ModifyTimestamp)
         return new TokenModel({
             id: entry.id,
             tokenID: entry.TokenID,


### PR DESCRIPTION
The JSON mapping of `TokenData` used different attribute names to the original XML mapping, so the JS code was unable to parse it. This is now fixed. In addition, the token created/modified dates are made human-readable and the not valid before/after dates for the CA certificates are also human-readable.

Not fixed by this PR:

- Changing token status via the UI is broken, both from `/tps/ui/#tokens` and `/tps/ui/#tokens/<token>`. It works from the CLI.
- The dates on `/tps/ui/#activities` are broken.
- No certs appear to be issued when adding tokens.
