### PR TITLE
Fix recent issue with using pkiconsole with a client auth certificate.

### DIFF
--- a/base/console/src/main/java/com/netscape/admin/certsrv/Console.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/Console.java
@@ -1584,6 +1584,7 @@ public class Console implements CommClient {
         String default_nssdb_path = FilePreferenceManager.getHomePath();
         System.out.println(" -d <nssdb path>   path to nssdb (default: " +
                 default_nssdb_path + ")");
+	System.out.println(" -n <client_cert_nick> nickname of optional client auth cert");
         System.out.println(" -x <options>   Extra options (javalaf, nowinpos, nologo).");
         System.out.println(" -v,--verbose   Run in verbose mode.");
         System.out.println(" -h,--help      Show help message.");
@@ -1613,6 +1614,10 @@ public class Console implements CommClient {
         option = new Option("d", true, "path to nssdb.");
         option.setArgName("options");
         options.addOption(option);
+
+	option = new Option("n",true,"client cert nickname");
+	option.setArgName("options");
+	options.addOption(option);
 
         option = new Option("x", true, "Extra options (javalaf, nowinpos, nologo).");
         option.setArgName("options");
@@ -1776,6 +1781,7 @@ public class Console implements CommClient {
         CryptoManager manager = null;
         String default_nssdb_path = FilePreferenceManager.getHomePath();
 	String nssdb_path = cmd.getOptionValue("d", default_nssdb_path);
+	String client_cert_nick = cmd.getOptionValue("n", null);
 	logger.info("NSS database: " + nssdb_path);
         try {
             CryptoManager.initialize(nssdb_path);
@@ -1790,6 +1796,9 @@ public class Console implements CommClient {
 
         ClientConfig config = new ClientConfig();
         config.setServerURL(protocol, hostName, portNumber);
+        if(client_cert_nick != null) {
+            config.setCertNickname(client_cert_nick);
+        }
 
         PKIClient client = new PKIClient(config);
 


### PR DESCRIPTION
The purpose of this fix is to allow a "-n cert-nickname" option, which
gives the user the ability to pick the nickname of the client auth cert
to use when connecting to the server.

Here is an exmple on how to use this new simpl feature:

 pkiconsole -v https://test.host.com:18443/ca -d ~/.redhat-idm-console -n SubCA_AdminV

Note the -n options specifies the name of of the desired SSL client auth certificate to present
to the server.

If the option is not present , no server cert nickname will be presented to the server.
The tool will work as it did previously in this case.