### PR TITLE
Fix typo bug in KeyService.auditKeyInfoSuccess()

### DIFF
--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/KeyService.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/KeyService.java
@@ -695,7 +695,7 @@ public class KeyService extends SubsystemService implements KeyResource {
         ));
     }
 
-    public void auditKeyInfoSuccess(KeyId keyid, String clientKeyId) {
+    public void auditKeyInfoSuccess(KeyId keyId, String clientKeyId) {
         auditKeyInfo(keyId, clientKeyId, ILogger.SUCCESS, null);
     }
 


### PR DESCRIPTION
The current implementation ignores the `KeyId` parameter passed in and
uses an internal field of `KeyService` instead. It seems unlikely this was
the intention, it is likely that this is a typo that was missed because
the erroneous variable happened to exist and the code compiled. The
implementation was changed to use the parameter instead.