### PR TITLE
Replace Assert.assert* methods with assert* static imports

### DIFF
--- a/base/common/src/test/java/com/netscape/certsrv/account/AccountTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/account/AccountTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.account;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,7 +32,7 @@ public class AccountTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -44,6 +45,6 @@ public class AccountTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 }

--- a/base/common/src/test/java/com/netscape/certsrv/authority/AuthorityDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/authority/AuthorityDataTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.authority;
 
+import static org.junit.Assert.assertEquals;
+
 import java.math.BigInteger;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +36,7 @@ public class AuthorityDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/base/DataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/base/DataTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.base;
 
+import static org.junit.Assert.assertEquals;
+
 import javax.ws.rs.core.Response;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class DataTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -45,7 +46,7 @@ public class DataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/base/RESTMessageTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/base/RESTMessageTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.base;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ public class RESTMessageTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -40,7 +41,7 @@ public class RESTMessageTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfoTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.cert;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Date;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,7 +42,7 @@ public class CertDataInfoTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -54,7 +55,7 @@ public class CertDataInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfosTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertDataInfosTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.cert;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Date;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,6 +47,6 @@ public class CertDataInfosTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertDataTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.cert;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mozilla.jss.netscape.security.util.Cert;
@@ -50,7 +51,7 @@ public class CertDataTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -63,7 +64,7 @@ public class CertDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertEnrollmentRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertEnrollmentRequestTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.cert;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -67,7 +68,7 @@ public class CertEnrollmentRequestTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -80,7 +81,7 @@ public class CertEnrollmentRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRequestInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRequestInfoTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.cert;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class CertRequestInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRequestInfosTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRequestInfosTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.cert;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class CertRequestInfosTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRetrievalRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRetrievalRequestTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.cert;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,7 +32,7 @@ public class CertRetrievalRequestTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -44,7 +45,7 @@ public class CertRetrievalRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertReviewResponseTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertReviewResponseTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.cert;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -81,7 +82,7 @@ public class CertReviewResponseTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertRevokeRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertRevokeRequestTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.cert;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Date;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mozilla.jss.netscape.security.x509.RevocationReason;
@@ -32,7 +33,7 @@ public class CertRevokeRequestTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -45,7 +46,7 @@ public class CertRevokeRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/cert/CertSearchRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/cert/CertSearchRequestTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.cert;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import com.netscape.certsrv.util.JSONSerializer;
@@ -19,7 +20,7 @@ public class CertSearchRequestTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -32,7 +33,7 @@ public class CertSearchRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 

--- a/base/common/src/test/java/com/netscape/certsrv/client/ClientConfigTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/client/ClientConfigTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.client;
 
+import static org.junit.Assert.assertEquals;
+
 import java.net.MalformedURLException;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class ClientConfigTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/dbs/keydb/KeyIdTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/dbs/keydb/KeyIdTest.java
@@ -1,6 +1,8 @@
 package com.netscape.certsrv.dbs.keydb;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import com.netscape.certsrv.util.JSONSerializer;
@@ -68,23 +70,23 @@ public class KeyIdTest {
             KeyId keyID = new KeyId(hex);
 
             // convert KeyId into hex string
-            Assert.assertEquals(hex, keyID.toHexString());
+            assertEquals(hex, keyID.toHexString());
 
             // convert KeyId into JSON
             String json = (String) TEST_DATA[i][1];
-            Assert.assertEquals(json, keyID.toJSON());
+            assertEquals(json, keyID.toJSON());
 
             // convert JSON into KeyId
             KeyId afterJSON = JSONSerializer.fromJSON(json, KeyId.class);
-            Assert.assertEquals(keyID, afterJSON);
+            assertEquals(keyID, afterJSON);
 
             // convert KeyId into bytes
             byte[] bytes = (byte[]) TEST_DATA[i][2];
-            Assert.assertArrayEquals(bytes, keyID.toByteArray());
+            assertArrayEquals(bytes, keyID.toByteArray());
 
             // convert bytes into KeyId
             KeyId afterBytes = new KeyId(bytes);
-            Assert.assertEquals(keyID, afterBytes);
+            assertEquals(keyID, afterBytes);
         }
     }
 }

--- a/base/common/src/test/java/com/netscape/certsrv/group/GroupDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/group/GroupDataTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.group;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ public class GroupDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/group/GroupMemberCollectionTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/group/GroupMemberCollectionTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.group;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,7 +37,7 @@ public class GroupMemberCollectionTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/group/GroupMemberDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/group/GroupMemberDataTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.group;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class GroupMemberDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 

--- a/base/common/src/test/java/com/netscape/certsrv/key/AsymKeyGenerationRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/AsymKeyGenerationRequestTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.key;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +36,7 @@ public class AsymKeyGenerationRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyArchivalRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyArchivalRequestTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,7 +32,7 @@ public class KeyArchivalRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyDataTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ public class KeyDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyInfoCollectionTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyInfoCollectionTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class KeyInfoCollectionTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyInfoTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ public class KeyInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyRecoveryRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyRecoveryRequestTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class KeyRecoveryRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestInfoCollectionTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestInfoCollectionTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class KeyRequestInfoCollectionTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestInfoTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class KeyRequestInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestResponseTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyRequestResponseTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class KeyRequestResponseTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ public class KeyTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/key/SymKeyGenerationRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/SymKeyGenerationRequestTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.key;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class SymKeyGenerationRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/logging/ActivityDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/logging/ActivityDataTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.logging;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Date;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class ActivityDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/logging/AuditConfigTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/logging/AuditConfigTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.logging;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,7 +39,7 @@ public class AuditConfigTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/logging/AuditFileTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/logging/AuditFileTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.logging;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class AuditFileTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/PolicyConstraintTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/PolicyConstraintTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.profile;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -49,7 +50,7 @@ public class PolicyConstraintTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -62,7 +63,7 @@ public class PolicyConstraintTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/PolicyConstraintValueTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/PolicyConstraintValueTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.profile;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class PolicyConstraintValueTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -48,7 +49,7 @@ public class PolicyConstraintValueTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/PolicyDefaultTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/PolicyDefaultTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.profile;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -62,7 +63,7 @@ public class PolicyDefaultTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -75,7 +76,7 @@ public class PolicyDefaultTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/ProfileAttributeTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/ProfileAttributeTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.profile;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class ProfileAttributeTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -47,7 +48,7 @@ public class ProfileAttributeTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/ProfileDataInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/ProfileDataInfoTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.profile;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class ProfileDataInfoTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -41,7 +42,7 @@ public class ProfileDataInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/ProfileDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/ProfileDataTest.java
@@ -1,10 +1,11 @@
 package com.netscape.certsrv.profile;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -134,7 +135,7 @@ public class ProfileDataTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -147,7 +148,7 @@ public class ProfileDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/ProfileInputTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/ProfileInputTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.profile;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ public class ProfileInputTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -50,7 +51,7 @@ public class ProfileInputTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/ProfileOutputTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/ProfileOutputTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.profile;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ public class ProfileOutputTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -50,7 +51,7 @@ public class ProfileOutputTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/ProfileParameterTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/ProfileParameterTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.profile;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class ProfileParameterTest {
         System.out.println("XML (after): " + afterXML.toXML());
 
         // Assert
-        Assert.assertEquals(before, afterXML);
+        assertEquals(before, afterXML);
     }
 
     @Test
@@ -39,7 +40,7 @@ public class ProfileParameterTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/profile/ProfilePolicyTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/profile/ProfilePolicyTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.profile;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -83,7 +84,7 @@ public class ProfilePolicyTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/property/DescriptorTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/property/DescriptorTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.property;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import com.netscape.certsrv.util.JSONSerializer;
@@ -23,6 +24,6 @@ public class DescriptorTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 }

--- a/base/common/src/test/java/com/netscape/certsrv/request/CMSRequestInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/request/CMSRequestInfoTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.request;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class CMSRequestInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/request/RequestIdTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/request/RequestIdTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.request;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import com.netscape.certsrv.util.JSONSerializer;
@@ -19,7 +20,7 @@ public class RequestIdTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/selftests/SelfTestDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/selftests/SelfTestDataTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.selftests;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ public class SelfTestDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/selftests/SelfTestResultTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/selftests/SelfTestResultTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.selftests;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ public class SelfTestResultTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/CertificateSetupRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/CertificateSetupRequestTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.system;
 
+import static org.junit.Assert.assertEquals;
+
 import java.net.MalformedURLException;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class CertificateSetupRequestTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/DomainInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/DomainInfoTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.system;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class DomainInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/FeatureTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/FeatureTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.system;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class FeatureTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/InstallTokenTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/InstallTokenTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.system;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,7 +26,7 @@ public class InstallTokenTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/KRAConnectorInfoTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/KRAConnectorInfoTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.system;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,7 +53,7 @@ public class KRAConnectorInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/SecurityDomainHostTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/SecurityDomainHostTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.system;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class SecurityDomainHostTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/SecurityDomainSubsystemTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/SecurityDomainSubsystemTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.system;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class SecurityDomainSubsystemTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/SystemCertDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/SystemCertDataTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.system;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +36,7 @@ public class SystemCertDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/system/TPSConnectorDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/TPSConnectorDataTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.system;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class TPSConnectorDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/tps/authenticator/AuthenticatorDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/tps/authenticator/AuthenticatorDataTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.tps.authenticator;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class AuthenticatorDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/tps/cert/TPSCertDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/tps/cert/TPSCertDataTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.tps.cert;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Date;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class TPSCertDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/tps/connector/ConnectorDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/tps/connector/ConnectorDataTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.tps.connector;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class ConnectorDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/tps/profile/ProfileDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/tps/profile/ProfileDataTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.tps.profile;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class ProfileDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/tps/profile/ProfileMappingDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/tps/profile/ProfileMappingDataTest.java
@@ -1,9 +1,10 @@
 package com.netscape.certsrv.tps.profile;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class ProfileMappingDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/tps/token/TokenDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/tps/token/TokenDataTest.java
@@ -1,8 +1,9 @@
 package com.netscape.certsrv.tps.token;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Date;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ public class TokenDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/user/UserCertDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/user/UserCertDataTest.java
@@ -5,10 +5,11 @@
 //
 package com.netscape.certsrv.user;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.jss.netscape.security.util.Cert;
 
@@ -54,6 +55,6 @@ public class UserCertDataTest {
         UserCertData after = UserCertData.fromJSON(json);
         System.out.println("After: " + after.toJSON());
 
-        Assert.assertEquals(userCertData, after);
+        assertEquals(userCertData, after);
     }
 }

--- a/base/common/src/test/java/com/netscape/certsrv/user/UserCollectionTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/user/UserCollectionTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.user;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class UserCollectionTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/user/UserDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/user/UserDataTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.user;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class UserDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/user/UserMembershipCollectionTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/user/UserMembershipCollectionTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.user;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class UserMembershipCollectionTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/com/netscape/certsrv/user/UserMembershipDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/user/UserMembershipDataTest.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.user;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class UserMembershipDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/org/dogtagpki/common/CAInfoTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/CAInfoTest.java
@@ -1,6 +1,7 @@
 package org.dogtagpki.common;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,6 +29,6 @@ public class CAInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 }

--- a/base/common/src/test/java/org/dogtagpki/common/ConfigDataTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/ConfigDataTest.java
@@ -1,9 +1,10 @@
 package org.dogtagpki.common;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class ConfigDataTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/org/dogtagpki/common/InfoTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/InfoTest.java
@@ -1,6 +1,7 @@
 package org.dogtagpki.common;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class InfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/common/src/test/java/org/dogtagpki/common/KRAInfoTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/KRAInfoTest.java
@@ -1,6 +1,7 @@
 package org.dogtagpki.common;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class KRAInfoTest {
         System.out.println("JSON (after): " + afterJSON.toJSON());
 
         // Assert
-        Assert.assertEquals(before, afterJSON);
+        assertEquals(before, afterJSON);
     }
 
 }

--- a/base/server/src/test/java/com/netscape/cmscore/authentication/AuthTokenTest.java
+++ b/base/server/src/test/java/com/netscape/cmscore/authentication/AuthTokenTest.java
@@ -1,5 +1,7 @@
 package com.netscape.cmscore.authentication;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.CertificateException;
@@ -7,7 +9,6 @@ import java.security.cert.X509Certificate;
 import java.util.Date;
 
 import org.dogtagpki.server.authentication.AuthToken;
-import org.junit.Assert;
 import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.x509.BasicConstraintsExtension;
 import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
@@ -54,7 +55,7 @@ public class AuthTokenTest extends CMSBaseTestCase {
         authToken.set("key", data);
 
         byte[] retval = authToken.getInByteArray("key");
-        Assert.assertArrayEquals(data, retval);
+        assertArrayEquals(data, retval);
 
         assertFalse(authToken.set("key2", (byte[]) null));
     }
@@ -83,7 +84,7 @@ public class AuthTokenTest extends CMSBaseTestCase {
                 authToken.get("key"));
 
         BigInteger[] retval = authToken.getInBigIntegerArray("key");
-        Assert.assertArrayEquals(data, retval);
+        assertArrayEquals(data, retval);
 
         authToken.set("key2", "123456");
         retval = authToken.getInBigIntegerArray("key2");
@@ -132,7 +133,7 @@ public class AuthTokenTest extends CMSBaseTestCase {
         if (retval == null) {
             throw new IOException("Unable to get key as String Array");
         }
-        Assert.assertArrayEquals(value, retval);
+        assertArrayEquals(value, retval);
 
         // illegal value parsing
         authToken.set("key2", new byte[] { 1, 2, 3, 4 });
@@ -194,7 +195,7 @@ public class AuthTokenTest extends CMSBaseTestCase {
         assertNotNull(retval);
 
         X509Certificate[] retCerts = retval.getCertificates();
-        Assert.assertArrayEquals(certArray, retCerts);
+        assertArrayEquals(certArray, retCerts);
 
         assertFalse(authToken.set("key2", (Certificates) null));
     }
@@ -210,7 +211,7 @@ public class AuthTokenTest extends CMSBaseTestCase {
 
         byte[][] retval = authToken.getInByteArrayArray("key");
         assertNotNull(retval);
-        Assert.assertArrayEquals(value, retval);
+        assertArrayEquals(value, retval);
 
         assertFalse(authToken.set("key2", (byte[][]) null));
     }

--- a/base/server/src/test/java/com/netscape/cmscore/request/RequestTest.java
+++ b/base/server/src/test/java/com/netscape/cmscore/request/RequestTest.java
@@ -1,5 +1,7 @@
 package com.netscape.cmscore.request;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.math.BigInteger;
 import java.security.cert.CRLException;
 import java.security.cert.CertificateEncodingException;
@@ -8,7 +10,6 @@ import java.util.Hashtable;
 import java.util.Vector;
 
 import org.dogtagpki.server.authentication.AuthToken;
-import org.junit.Assert;
 import org.mozilla.jss.netscape.security.x509.BasicConstraintsExtension;
 import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
 import org.mozilla.jss.netscape.security.x509.CertificateSubjectName;
@@ -311,7 +312,7 @@ public class RequestTest extends CMSBaseTestCase {
         request.setExtData("key", data);
 
         byte[] out = request.getExtDataInByteArray("key");
-        Assert.assertArrayEquals(data, out);
+        assertArrayEquals(data, out);
 
         assertFalse(request.setExtData("key", (byte[]) null));
     }
@@ -341,7 +342,7 @@ public class RequestTest extends CMSBaseTestCase {
         X509CertImpl[] retval = request.getExtDataInCertArray("key");
         assertNotNull(retval);
 
-        Assert.assertArrayEquals(vals, retval);
+        assertArrayEquals(vals, retval);
 
         assertFalse(request.setExtData("key", (X509CertImpl[]) null));
     }

--- a/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -689,9 +689,6 @@ public class CRSPKIMessage {
      */
 
     public byte[] getEncoded() {
-        //Assert.assert(messageType != null);
-        //Assert.assert(pkiStatus != null);
-
         return new byte[1]; // blagh
     }
 
@@ -898,7 +895,6 @@ public class CRSPKIMessage {
             return "GetCRL";
         }
         // messageType should match one of the above
-        //Assert.assert(false);
         return null;
     }
 }

--- a/base/util/src/test/java/com/netscape/cmsutil/crypto/KeyIDCodecTest.java
+++ b/base/util/src/test/java/com/netscape/cmsutil/crypto/KeyIDCodecTest.java
@@ -17,6 +17,10 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cmsutil.crypto;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -157,7 +161,7 @@ public class KeyIDCodecTest {
             String hex = (String)TEST_DATA[i][1];
 
             String result = CryptoUtil.encodeKeyID(bytes);
-            Assert.assertEquals(hex, result);
+            assertEquals(hex, result);
         }
 
         System.out.println("Testing Key ID encoder with invalid data:");
@@ -167,7 +171,7 @@ public class KeyIDCodecTest {
             CryptoUtil.encodeKeyID(null);
             Assert.fail("should throw NullPointerException");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof NullPointerException);
+            assertTrue(e instanceof NullPointerException);
         }
 
         try {
@@ -175,7 +179,7 @@ public class KeyIDCodecTest {
             CryptoUtil.encodeKeyID(new byte[] {});
             Assert.fail("should throw IllegalArgumentException");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof IllegalArgumentException);
+            assertTrue(e instanceof IllegalArgumentException);
         }
 
         try {
@@ -183,7 +187,7 @@ public class KeyIDCodecTest {
             CryptoUtil.encodeKeyID(new byte[] { (byte)0x24, (byte)0xac });
             Assert.fail("should throw IllegalArgumentException");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof IllegalArgumentException);
+            assertTrue(e instanceof IllegalArgumentException);
         }
     }
 
@@ -199,7 +203,7 @@ public class KeyIDCodecTest {
             String hex = (String)TEST_DATA[i][1];
 
             byte[] result = CryptoUtil.decodeKeyID(hex);
-            Assert.assertArrayEquals(bytes, result);
+            assertArrayEquals(bytes, result);
         }
 
         System.out.println("Testing Key ID decoder with invalid data:");
@@ -209,7 +213,7 @@ public class KeyIDCodecTest {
             CryptoUtil.decodeKeyID(null);
             Assert.fail("should throw NullPointerException");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof NullPointerException);
+            assertTrue(e instanceof NullPointerException);
         }
 
         try {
@@ -217,7 +221,7 @@ public class KeyIDCodecTest {
             CryptoUtil.decodeKeyID("");
             Assert.fail("should throw IllegalArgumentException");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof IllegalArgumentException);
+            assertTrue(e instanceof IllegalArgumentException);
         }
 
         try {
@@ -225,7 +229,7 @@ public class KeyIDCodecTest {
             CryptoUtil.decodeKeyID("ffffffffffffffffffffffffffffffffffffffffff");
             Assert.fail("should throw IllegalArgumentException");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof IllegalArgumentException);
+            assertTrue(e instanceof IllegalArgumentException);
         }
 
         try {
@@ -233,7 +237,7 @@ public class KeyIDCodecTest {
             CryptoUtil.decodeKeyID("garbage");
             Assert.fail("should throw NumberFormatException");
         } catch (Exception e) {
-            Assert.assertTrue(e instanceof NumberFormatException);
+            assertTrue(e instanceof NumberFormatException);
         }
     }
 }


### PR DESCRIPTION
In JUnit 5 org.junit.Assert is replaced with
org.junit.jupiter.api.Assertions. Migrating seems like it could be a big
diff but we can make it a bit smaller by using static imports now. That
way when we migrate the method signature in the calling code is the
same, it is only the import which needs to change.