### PR TITLE
Tidy up ACLEntry

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/acls/ACLEntry.java
+++ b/base/common/src/main/java/com/netscape/certsrv/acls/ACLEntry.java
@@ -33,23 +33,23 @@ public class ACLEntry implements IACLEntry, java.io.Serializable {
     */
     private static final long serialVersionUID = 422656406529200393L;
 
-    public enum Type { Allow , Deny };
+    public enum Type { ALLOW , DENY };
 
     protected Hashtable<String, String> mPerms = new Hashtable<>();
     protected String expressions = null;
-    protected Type type = Type.Deny;
+    protected Type type = Type.DENY;
     protected String aclEntryString = null;
 
     /**
      * Class Constructor
      */
-    public ACLEntry() {
+    private ACLEntry() {
     }
 
     /**
      * Get the Type of the ACL entry.
      *
-     * @return Allow or Deny
+     * @return ALLOW or DENY
      */
     public Type getType() {
         return type;
@@ -91,7 +91,7 @@ public class ACLEntry implements IACLEntry, java.io.Serializable {
      *            protected resource in its ACL
      */
     public void addPermission(IACL acl, String permission) {
-        if (acl.checkRight(permission) == true) {
+        if (acl.checkRight(permission)) {
             mPerms.put(permission, permission);
         } else {
             // not a valid right...log it later
@@ -155,11 +155,7 @@ public class ACLEntry implements IACLEntry, java.io.Serializable {
         //           don't grant permission
         if (mPerms.get(permission) == null)
             return false;
-        if (type == Type.Deny) {
-            return false;
-        } else {
-            return true;
-        }
+        return type != Type.DENY;
     }
 
     /**
@@ -190,9 +186,9 @@ public class ACLEntry implements IACLEntry, java.io.Serializable {
         ACLEntry entry = new ACLEntry();
 
         if (prefix.equals("allow")) {
-            entry.type = Type.Allow;
+            entry.type = Type.ALLOW;
         } else if (prefix.equals("deny")) {
-            entry.type = Type.Deny;
+            entry.type = Type.DENY;
         } else {
             return null;
         }
@@ -210,7 +206,7 @@ public class ACLEntry implements IACLEntry, java.io.Serializable {
 
         StringTokenizer st = new StringTokenizer(prefix, ",");
 
-        for (; st.hasMoreTokens();) {
+        while (st.hasMoreTokens()) {
             entry.addPermission(acl, st.nextToken());
         }
         entry.setAttributeExpressions(suffix);
@@ -226,14 +222,14 @@ public class ACLEntry implements IACLEntry, java.io.Serializable {
     public String toString() {
         StringBuffer entry = new StringBuffer();
 
-        if (type == Type.Deny) {
+        if (type == Type.DENY) {
             entry.append("deny (");
         } else {
             entry.append("allow (");
         }
         Enumeration<String> e = permissions();
 
-        for (; e.hasMoreElements();) {
+        while (e.hasMoreElements()) {
             String p = e.nextElement();
 
             entry.append(p);

--- a/base/server/src/main/java/com/netscape/cms/authorization/AAclAuthz.java
+++ b/base/server/src/main/java/com/netscape/cms/authorization/AAclAuthz.java
@@ -384,7 +384,7 @@ public abstract class AAclAuthz implements IAuthzManager {
                         logger.error("AAclAuthz: checkACLs(): permission denied");
                         throw new EACLsException(CMS.getUserMessage("CMS_ACL_PERMISSION_DENIED"));
                     }
-                } else if (entry.getType() == ACLEntry.Type.Allow) {
+                } else if (entry.getType() == ACLEntry.Type.ALLOW) {
                     // didn't meet the access expression for "allow", failed
                     logger.error("AAclAuthz: checkACLs(): permission denied");
                     throw new EACLsException(CMS.getUserMessage("CMS_ACL_PERMISSION_DENIED"));
@@ -541,7 +541,7 @@ public abstract class AAclAuthz implements IAuthzManager {
             IAuthToken authToken,
             Iterable<String> nodes,
             String perm) {
-        for (ACLEntry entry : getEntries(ACLEntry.Type.Allow, nodes, perm)) {
+        for (ACLEntry entry : getEntries(ACLEntry.Type.ALLOW, nodes, perm)) {
             logger.debug("checkAllowEntries(): expressions: " + entry.getAttributeExpressions());
             if (evaluateExpressions(authToken, entry.getAttributeExpressions())) {
                 return true;
@@ -556,7 +556,7 @@ public abstract class AAclAuthz implements IAuthzManager {
             Iterable<String> nodes,
             String perm)
             throws EACLsException {
-        for (ACLEntry entry : getEntries(ACLEntry.Type.Deny, nodes, perm)) {
+        for (ACLEntry entry : getEntries(ACLEntry.Type.DENY, nodes, perm)) {
             logger.debug("checkDenyEntries(): expressions: " + entry.getAttributeExpressions());
             if (evaluateExpressions(authToken, entry.getAttributeExpressions())) {
                 logger.error("AAclAuthz: checkPermission(): permission denied");


### PR DESCRIPTION
* Replace for loops that are actually while loops with while loops
* Remove unnecessary Boolean literal comparison
* Rename Type enum entries to match the JLS
* Make empty class constructor private to prevent instantiation
* Simplify checkPermission by not returning Boolean literals