### PR TITLE
Bug2082717 - SCEP manual approval failure

### DIFF
--- a/base/server/cms/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1633,6 +1633,9 @@ public class CRSEnrollment extends HttpServlet {
             reqs[0].setExtData("profileRemoteAddr", httpReq.getRemoteAddr());
             reqs[0].setExtData("profileApprovedBy", profile.getApprovedBy());
 
+	    String setId = profile.getPolicySetId(reqs[0]);
+	    reqs[0].setExtData("profileSetId" /*CAProcessor.ARG_PROFILE_SET_ID*/, setId);
+
             CMS.debug("CRSEnrollment: Populating inputs");
             profile.populateInput(ctx, reqs[0]);
             CMS.debug("CRSEnrollment: Populating requests");


### PR DESCRIPTION
This patch fixes the set id not found null pointer exception.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2082717