### PR TITLE
Refactor NSSDatabase.__create_request()

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1174,6 +1174,39 @@ class NSSDatabase(object):
 
         exts['basicConstraints'] = ', '.join(values)
 
+    def __create_key_usage_ext(self, exts, key_usage_ext):
+        '''
+        Create key usage extension config for pki nss-cert-request/issue.
+        '''
+
+        values = []
+
+        if key_usage_ext.get('critical'):
+            values.append('critical')
+
+        if key_usage_ext.get('digitalSignature'):
+            values.append('digitalSignature')
+
+        if key_usage_ext.get('nonRepudiation'):
+            values.append('nonRepudiation')
+
+        if key_usage_ext.get('keyEncipherment'):
+            values.append('keyEncipherment')
+
+        if key_usage_ext.get('dataEncipherment'):
+            values.append('dataEncipherment')
+
+        if key_usage_ext.get('keyAgreement'):
+            values.append('keyAgreement')
+
+        if key_usage_ext.get('certSigning'):
+            values.append('keyCertSign')
+
+        if key_usage_ext.get('crlSigning'):
+            values.append('cRLSign')
+
+        exts['keyUsage'] = ', '.join(values)
+
     def __create_request(
             self,
             subject_dn,
@@ -1201,34 +1234,7 @@ class NSSDatabase(object):
             self.__create_basic_constraints_ext(exts, basic_constraints_ext)
 
         if key_usage_ext:
-
-            values = []
-
-            if key_usage_ext.get('critical'):
-                values.append('critical')
-
-            if key_usage_ext.get('digitalSignature'):
-                values.append('digitalSignature')
-
-            if key_usage_ext.get('nonRepudiation'):
-                values.append('nonRepudiation')
-
-            if key_usage_ext.get('keyEncipherment'):
-                values.append('keyEncipherment')
-
-            if key_usage_ext.get('dataEncipherment'):
-                values.append('dataEncipherment')
-
-            if key_usage_ext.get('keyAgreement'):
-                values.append('keyAgreement')
-
-            if key_usage_ext.get('certSigning'):
-                values.append('keyCertSign')
-
-            if key_usage_ext.get('crlSigning'):
-                values.append('cRLSign')
-
-            exts['keyUsage'] = ', '.join(values)
+            self.__create_key_usage_ext(exts, key_usage_ext)
 
         if extended_key_usage_ext:
 
@@ -1361,6 +1367,7 @@ class NSSDatabase(object):
                 cert_file,
                 serial=serial,
                 issuer=issuer,
+                key_usage_ext=key_usage_ext,
                 basic_constraints_ext=basic_constraints_ext,
                 validity=validity)
             return
@@ -1535,6 +1542,7 @@ class NSSDatabase(object):
             cert_file,
             serial=None,
             issuer=None,
+            key_usage_ext=None,
             basic_constraints_ext=None,
             validity=None):
         '''
@@ -1546,6 +1554,9 @@ class NSSDatabase(object):
 
         if basic_constraints_ext:
             self.__create_basic_constraints_ext(exts, basic_constraints_ext)
+
+        if key_usage_ext:
+            self.__create_key_usage_ext(exts, key_usage_ext)
 
         tmpdir = tempfile.mkdtemp()
 

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1207,6 +1207,30 @@ class NSSDatabase(object):
 
         exts['keyUsage'] = ', '.join(values)
 
+    def __create_extended_key_usage_ext(self, exts, extended_key_usage_ext):
+        '''
+        Create extended key usage extension config for pki nss-cert-request/issue.
+        '''
+
+        values = []
+
+        if extended_key_usage_ext.get('critical'):
+            values.append('critical')
+
+        if extended_key_usage_ext.get('serverAuth'):
+            values.append('serverAuth')
+
+        if extended_key_usage_ext.get('clientAuth'):
+            values.append('clientAuth')
+
+        if extended_key_usage_ext.get('emailProtection'):
+            values.append('emailProtection')
+
+        if extended_key_usage_ext.get('ocspResponder'):
+            values.append('OCSPSigning')
+
+        exts['extendedKeyUsage'] = ', '.join(values)
+
     def __create_request(
             self,
             subject_dn,
@@ -1237,25 +1261,7 @@ class NSSDatabase(object):
             self.__create_key_usage_ext(exts, key_usage_ext)
 
         if extended_key_usage_ext:
-
-            values = []
-
-            if extended_key_usage_ext.get('critical'):
-                values.append('critical')
-
-            if extended_key_usage_ext.get('serverAuth'):
-                values.append('serverAuth')
-
-            if extended_key_usage_ext.get('clientAuth'):
-                values.append('clientAuth')
-
-            if extended_key_usage_ext.get('emailProtection'):
-                values.append('emailProtection')
-
-            if extended_key_usage_ext.get('ocspResponder'):
-                values.append('OCSPSigning')
-
-            exts['extendedKeyUsage'] = ', '.join(values)
+            self.__create_extended_key_usage_ext(exts, extended_key_usage_ext)
 
         if subject_key_id:
             # always generate SKID from hash
@@ -1369,6 +1375,7 @@ class NSSDatabase(object):
                 issuer=issuer,
                 key_usage_ext=key_usage_ext,
                 basic_constraints_ext=basic_constraints_ext,
+                ext_key_usage_ext=ext_key_usage_ext,
                 validity=validity)
             return
 
@@ -1544,6 +1551,7 @@ class NSSDatabase(object):
             issuer=None,
             key_usage_ext=None,
             basic_constraints_ext=None,
+            ext_key_usage_ext=None,
             validity=None):
         '''
         Issue certificate using pki nss-cert-issue command.
@@ -1557,6 +1565,9 @@ class NSSDatabase(object):
 
         if key_usage_ext:
             self.__create_key_usage_ext(exts, key_usage_ext)
+
+        if ext_key_usage_ext:
+            self.__create_extended_key_usage_ext(exts, ext_key_usage_ext)
 
         tmpdir = tempfile.mkdtemp()
 


### PR DESCRIPTION
Some of the code that generates cert request extension config in `NSSDatabase.__create_request()` has been moved into new methods such that they can be reused to generate cert extension config in `NSSDatabase.__create_cert()`. There will be another PR to move the remaining code.

This is needed to change `pki-server cert-fix` to use `pki nss-cert` CLI instead of `certutil` (which doesn't support long serial number) in order to fix issue #3396.

Doc: https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-Extensions

Note: It might be easier to review the commits one by one.