### PR TITLE
Fix pki-server cert-fix for RSNv3

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1246,6 +1246,21 @@ class NSSDatabase(object):
 
         exts['subjectKeyIdentifier'] = ', '.join(values)
 
+    def __create_aki_ext(self, exts, aki_ext):
+        '''
+        Create authority key ID extension config for pki nss-cert-request/issue.
+        '''
+
+        values = []
+
+        if aki_ext.get('critical'):
+            values.append('critical')
+
+        # generate authority key ID from hash
+        values.append('keyid')
+
+        exts['authorityKeyIdentifier'] = ', '.join(values)
+
     def __create_request(
             self,
             subject_dn,
@@ -1392,6 +1407,7 @@ class NSSDatabase(object):
                 issuer=issuer,
                 key_usage_ext=key_usage_ext,
                 basic_constraints_ext=basic_constraints_ext,
+                aki_ext=aki_ext,
                 ski_ext=ski_ext,
                 ext_key_usage_ext=ext_key_usage_ext,
                 validity=validity)
@@ -1569,6 +1585,7 @@ class NSSDatabase(object):
             issuer=None,
             key_usage_ext=None,
             basic_constraints_ext=None,
+            aki_ext=None,
             ski_ext=None,
             ext_key_usage_ext=None,
             validity=None):
@@ -1590,6 +1607,9 @@ class NSSDatabase(object):
 
         if ski_ext:
             self.__create_ski_ext(exts, ski_ext)
+
+        if aki_ext:
+            self.__create_aki_ext(exts, aki_ext)
 
         tmpdir = tempfile.mkdtemp()
 

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1261,6 +1261,32 @@ class NSSDatabase(object):
 
         exts['authorityKeyIdentifier'] = ', '.join(values)
 
+    def __create_aia_ext(self, exts, aia_ext):
+        '''
+        Create authority info access extension config for pki nss-cert-request/issue.
+        '''
+
+        values = []
+
+        if aia_ext.get('critical'):
+            values.append('critical')
+
+        ca_issuers = aia_ext.get('ca_issuers')
+        if ca_issuers:
+            uris = ca_issuers.get('uri')
+            if uris:
+                for uri in uris:
+                    values.append('caIssuers;' + uri)
+
+        ocsp = aia_ext.get('ocsp')
+        if ocsp:
+            uris = ocsp.get('uri')
+            if uris:
+                for uri in uris:
+                    values.append('OCSP;' + uri)
+
+        exts['authorityInfoAccess'] = ', '.join(values)
+
     def __create_request(
             self,
             subject_dn,
@@ -1409,6 +1435,7 @@ class NSSDatabase(object):
                 basic_constraints_ext=basic_constraints_ext,
                 aki_ext=aki_ext,
                 ski_ext=ski_ext,
+                aia_ext=aia_ext,
                 ext_key_usage_ext=ext_key_usage_ext,
                 validity=validity)
             return
@@ -1587,6 +1614,7 @@ class NSSDatabase(object):
             basic_constraints_ext=None,
             aki_ext=None,
             ski_ext=None,
+            aia_ext=None,
             ext_key_usage_ext=None,
             validity=None):
         '''
@@ -1610,6 +1638,9 @@ class NSSDatabase(object):
 
         if aki_ext:
             self.__create_aki_ext(exts, aki_ext)
+
+        if aia_ext:
+            self.__create_aia_ext(exts, aia_ext)
 
         tmpdir = tempfile.mkdtemp()
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -890,7 +890,9 @@ class PKISubsystem(object):
             serial=serial,
             key_usage_ext=key_usage_ext,
             aki_ext=aki_ext,
-            ext_key_usage_ext=ext_key_usage_ext)
+            ext_key_usage_ext=ext_key_usage_ext,
+            use_jss=True)
+
         if rc:
             raise pki.server.PKIServerException(
                 'Failed to generate CA-signed temp SSL certificate. RC: %d' % rc)


### PR DESCRIPTION
This is a continuation of PR #4002.

The `pki-server cert-fix` has been modified to use JSS (i.e. `pki nss-cert-create`) instead of NSS (i.e. `certutil`) to generate a temporary SSL server cert since `certutil` is unable to handle large serial numbers.

Some methods have been added into Python `NSSDatabase` to generate cert extension configs for `pki nss-cert-create`. See also: https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-Extensions.

Resolves: https://github.com/dogtagpki/pki/issues/3996
