### PR TITLE
Fix installation with RSA/PSS

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -411,6 +411,182 @@ jobs:
           path: |
             /tmp/artifacts/pki
 
+  # docs/installation/ca/Installing-CA-with-RSA-PSS.adoc
+  ca-rsa-pss-test:
+    name: Testing CA with RSA/PSS
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-ca-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_use_pss_rsa_signing_algorithm=True \
+              -D pki_ca_signing_key_algorithm=SHA512withRSA/PSS \
+              -D pki_ca_signing_signing_algorithm=SHA512withRSA/PSS \
+              -D pki_ocsp_signing_key_algorithm=SHA512withRSA/PSS \
+              -D pki_ocsp_signing_signing_algorithm=SHA512withRSA/PSS \
+              -D pki_audit_signing_key_algorithm=SHA512withRSA/PSS \
+              -D pki_audit_signing_signing_algorithm=SHA512withRSA/PSS \
+              -D pki_subsystem_key_algorithm=SHA512withRSA/PSS \
+              -D pki_subsystem_signing_algorithm=SHA512withRSA/PSS \
+              -D pki_sslserver_key_algorithm=SHA512withRSA/PSS \
+              -D pki_sslserver_signing_algorithm=SHA512withRSA/PSS \
+              -D pki_admin_key_algorithm=SHA512withRSA/PSS \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Check CA signing cert
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki openssl x509 -text -noout -in ca_signing.crt | tee output
+
+          echo "rsassaPss" > expected
+          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          diff expected actual
+
+      - name: Check CA OCSP signing cert
+        run: |
+          docker exec pki pki-server cert-export ca_ocsp_signing --cert-file ca_ocsp_signing.crt
+          docker exec pki openssl x509 -text -noout -in ca_ocsp_signing.crt | tee output
+
+          echo "rsassaPss" > expected
+          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          diff expected actual
+
+      - name: Check CA audit signing cert
+        run: |
+          docker exec pki pki-server cert-export ca_audit_signing --cert-file ca_audit_signing.crt
+          docker exec pki openssl x509 -text -noout -in ca_audit_signing.crt | tee output
+
+          echo "rsassaPss" > expected
+          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          diff expected actual
+
+      - name: Check subsystem cert
+        run: |
+          docker exec pki pki-server cert-export subsystem --cert-file subsystem.crt
+          docker exec pki openssl x509 -text -noout -in subsystem.crt | tee output
+
+          echo "rsassaPss" > expected
+          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          diff expected actual
+
+      - name: Check SSL server cert
+        run: |
+          docker exec pki pki-server cert-export sslserver --cert-file sslserver.crt
+          docker exec pki openssl x509 -text -noout -in sslserver.crt | tee output
+
+          echo "rsassaPss" > expected
+          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          diff expected actual
+
+      - name: Check CA admin cert
+        run: |
+          docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert | tee output
+
+          echo "rsassaPss" > expected
+          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          diff expected actual
+
+      - name: Verify that system certs have RSA keys
+        run: |
+          echo Secret.123 > password.txt
+          docker exec pki certutil -K -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt | tee output
+          echo "rsa" > expected
+
+          grep ca_signing output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
+          diff expected actual
+
+          grep ca_ocsp_signing output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
+          diff expected actual
+
+          grep ca_audit_signing output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
+          diff expected actual
+
+          grep subsystem output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
+          diff expected actual
+
+          grep sslserver output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
+          diff expected actual
+
+      - name: Run PKI healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Verify CA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Check cert requests in CA
+        run: |
+          docker exec pki pki -n caadmin ca-cert-request-find
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ca-rsa-pss-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki
+
   # docs/installation/ca/Installing_Subordinate_CA.md
   subca-test:
     name: Testing subordinate CA

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertImportCLI.java
@@ -92,6 +92,24 @@ public class CACertImportCLI extends CommandCLI {
         String certPath = cmd.getOptionValue("cert");
         String certFormat = cmd.getOptionValue("format");
 
+        if (!cmd.hasOption("request")) {
+            throw new Exception("Missing request ID");
+        }
+
+        RequestId requestID = new RequestId(cmd.getOptionValue("request"));
+
+        if (!cmd.hasOption("profile")) {
+            throw new Exception("Missing profile ID");
+        }
+
+        String profileID = cmd.getOptionValue("profile");
+
+        // initialize JSS in pki-server CLI
+        TomcatJSS tomcatjss = TomcatJSS.getInstance();
+        tomcatjss.loadConfig();
+        tomcatjss.init();
+
+        // load input certificate
         byte[] bytes;
         if (certPath == null) {
             // read from standard input
@@ -112,25 +130,10 @@ public class CACertImportCLI extends CommandCLI {
             throw new Exception("Unsupported format: " + certFormat);
         }
 
+        // must be done after JSS initialization for RSA/PSS
         X509CertImpl cert = new X509CertImpl(bytes);
 
-        if (!cmd.hasOption("request")) {
-            throw new Exception("Missing request ID");
-        }
-
-        RequestId requestID = new RequestId(cmd.getOptionValue("request"));
-
-        if (!cmd.hasOption("profile")) {
-            throw new Exception("Missing profile ID");
-        }
-
-        String profileID = cmd.getOptionValue("profile");
-
         String catalinaBase = System.getProperty("catalina.base");
-
-        TomcatJSS tomcatjss = TomcatJSS.getInstance();
-        tomcatjss.loadConfig();
-        tomcatjss.init();
 
         String subsystem = parent.getParent().getName();
         String confDir = catalinaBase + File.separator + subsystem + File.separator + "conf";

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertImportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertImportCLI.java
@@ -64,6 +64,11 @@ public class NSSCertImportCLI extends CommandCLI {
         if (trustFlags == null)
             trustFlags = ",,";
 
+        // initialize CLI in pki CLI
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        // load input certificate
         byte[] bytes;
         if (filename == null) {
             // read from standard input
@@ -84,10 +89,8 @@ public class NSSCertImportCLI extends CommandCLI {
             throw new Exception("Unsupported format: " + format);
         }
 
+        // must be done after JSS initialization for RSA/PSS
         X509CertImpl cert = new X509CertImpl(bytes);
-
-        MainCLI mainCLI = (MainCLI) getRoot();
-        mainCLI.init();
 
         ClientConfig clientConfig = mainCLI.getConfig();
         NSSDatabase nssdb = mainCLI.getNSSDatabase();

--- a/docs/installation/ca/Installing-CA-with-RSA-PSS.adoc
+++ b/docs/installation/ca/Installing-CA-with-RSA-PSS.adoc
@@ -1,0 +1,42 @@
+= Overview =
+
+This page describes the process to install a CA subsystem with RSA/PSS.
+
+= Installation Procedure =
+
+To install CA subsystem with RSA/PSS, follow the normal link:Installing_CA.md[CA installation] procedure, then specify the parameters below.
+
+----
+[DEFAULT]
+pki_use_pss_rsa_signing_algorithm=True
+
+pki_audit_signing_key_algorithm=SHA512withRSA/PSS
+pki_audit_signing_signing_algorithm=SHA512withRSA/PSS
+
+pki_subsystem_key_algorithm=SHA512withRSA/PSS
+pki_subsystem_signing_algorithm=SHA512withRSA/PSS
+
+pki_sslserver_key_algorithm=SHA512withRSA/PSS
+pki_sslserver_signing_algorithm=SHA512withRSA/PSS
+
+pki_admin_key_algorithm=SHA512withRSA/PSS
+
+[CA]
+pki_ca_signing_key_algorithm=SHA512withRSA/PSS
+pki_ca_signing_signing_algorithm=SHA512withRSA/PSS
+
+pki_ocsp_signing_key_algorithm=SHA512withRSA/PSS
+pki_ocsp_signing_signing_algorithm=SHA512withRSA/PSS
+----
+
+= Verification =
+
+To verify that the CA signing certificate was created with RSA/PSS, execute the following command:
+
+----
+$ pki-server cert-export ca_signing --cert-file ca_signing.crt
+$ openssl x509 -text -noout -in ca_signing.crt
+...
+        Signature Algorithm: rsassaPss
+...
+----


### PR DESCRIPTION
The `pki ca-cert-import` and `pki nss-cert-import` CLIs have been modified to parse the cert data after initializing JSS to ensure that it works with RSA/PSS.

Doc: https://github.com/edewata/pki/blob/rsa-pss/docs/installation/ca/Installing-CA-with-RSA-PSS.adoc

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2083575
