### PR TITLE
Set deactivateDefaultTyping() on JSONSerializer ObjectMapper objects

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/util/JSONSerializer.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/JSONSerializer.java
@@ -1,6 +1,7 @@
 package com.netscape.certsrv.util;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
@@ -13,17 +14,19 @@ public interface JSONSerializer {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JSONSerializer.class);
 
-    default String toJSON() throws Exception {
+    default String toJSON() throws JsonProcessingException {
         return new ObjectMapper()
                 .enable(SerializationFeature.INDENT_OUTPUT)
+                .deactivateDefaultTyping()
                 .setAnnotationIntrospector(new JacksonAnnotationIntrospector())
                 .writeValueAsString(this);
     }
 
-    static <T> T fromJSON(String json, Class<T> clazz) throws Exception {
+    static <T> T fromJSON(String json, Class<T> clazz) throws JsonProcessingException {
         try {
             return new ObjectMapper()
                     .setAnnotationIntrospector(new JacksonAnnotationIntrospector())
+                    .deactivateDefaultTyping()
                     .readValue(json, clazz);
         } catch (JsonParseException e) {
             String errMsg = "The input file provided could not be parsed as JSON";


### PR DESCRIPTION
With this setting activated it is possible for bad actors to create
objects not of the type clazz - e.g. a class that extends clazz - which
could introduce malicious code into the application. Explicitly
disabling it guarantees that only an object of type clazz can be
produced.

The remaining ObjectMapper objects in the code should me migrated to use
this class.