### PR TITLE
Fix pki ca-cert-request-unassign

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/RequestProcessor.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/RequestProcessor.java
@@ -190,7 +190,7 @@ public class RequestProcessor extends CertProcessor {
                     } else if (op.equals("validate")) {
                         updateValues(data, req, profile, locale);
                     } else if (op.equals("unassign")) {
-                        req.setRequestOwner("");
+                        req.setRequestOwner(null);
                     }
                 } else {
                     logger.error("RequestProcessor: Permission not granted to approve/reject/cancel/update/validate/unassign request.");


### PR DESCRIPTION
The `pki ca-cert-request-unassign` command is supposed to remove the owner of a cert request. Previously the server would call the `RequestProcessor.processRequest()` to set the request owner attribute to an empty string. However, this value would violate the LDAP schema so the command failed. The code has been fixed to set the owner to `null` instead such that the attribute will be removed from LDAP.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1858702