### PR TITLE
Add SonarCloud analysis action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build PKI
 on:
   workflow_call:
+    inputs:
+      key_container:
+        required: true
+        type: string
     secrets:
       BASE64_MATRIX:
         required: false
@@ -66,7 +70,7 @@ jobs:
           rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,tests --with-timestamp --work-dir=build rpm
+        run: ./build.sh --with-timestamp --work-dir=build rpm
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -80,10 +84,10 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-ca-runner.tar
+          outputs: type=docker,dest=pki-${{ inputs.key_container}}-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-${{ inputs.key_container }}-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-${{ inputs.key_container }}-runner.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,89 @@
+name: Build PKI
+on:
+  workflow_call:
+    secrets:
+      BASE64_MATRIX:
+        required: false
+      BASE64_REPO:
+        required: false
+      BASE64_DATABASE:
+        required: false
+    outputs:
+      matrix:
+        value: ${{ jobs.init.outputs.matrix}}
+      repo:
+        value: ${{ jobs.init.outputs.repo}}
+      db-image:
+        value: ${{ jobs.init.outputs.db-image}}
+
+jobs:
+  init:
+    name: Initializing workflow
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.init.outputs.matrix }}
+      repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Initialize workflow
+        id: init
+        env:
+          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
+        run: |
+          tests/bin/init-workflow.sh
+
+  # docs/development/Building_PKI.md
+  build:
+    name: Building PKI
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: /var/cache/dnf
+          key: fedora:${{ matrix.os }}-ca-${{ hashFiles('pki.spec') }}
+
+      - name: Install dependencies
+        run: |
+          # keep packages after installation
+          echo "keepcache=True" >> /etc/dnf/dnf.conf
+          dnf install -y dnf-plugins-core rpm-build moby-engine
+          dnf copr enable -y ${{ needs.init.outputs.repo }}
+          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
+          # don't cache COPR packages
+          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
+
+      - name: Build PKI packages
+        run: ./build.sh --with-pkgs=base,server,ca,tests --with-timestamp --work-dir=build rpm
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build runner image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-runner
+          target: pki-runner
+          outputs: type=docker,dest=pki-ca-runner.tar
+
+      - name: Store runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,45 @@
+name: Sonarcloud
+on: [push,pull_request]
+
+jobs:
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+
+  sonarcloud:
+    name: Sonar Cloud code analysis
+    needs: call-build-workflow
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-ca-runner.tar
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+       
+      - name: Copy build in current folder
+        run: docker cp pki:/usr/share/java/pki ./build
+      
+      - name: Remove maven related file
+        run: rm -f pom.xml
+
+      - name: Start Sonar analysis
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,6 +4,8 @@ on: [push,pull_request]
 jobs:
   call-build-workflow:
     uses: ./.github/workflows/build.yml
+    with:
+      key_container: sonar
     secrets: inherit
 
 
@@ -22,11 +24,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-sonar-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-sonar-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-sonar-runner.tar
 
       - name: Set up PKI container
         run: |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=dogtagpki_pki
+sonar.organization=dogtagpki
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=pki
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=base/acme/src/main/java,base/ca/src/main/java,base/ca/src/test/java,base/common/examples/java,base/common/src/main/java,base/common/src/test/java,base/console/src/main/java,base/kra/src/main/java,base/kra/src/test/java,base/ocsp/src/main/java,base/server/src/main/java,base/server/src/test/java,base/tks/src/main/java,base/tomcat-9.0/src/main/java,base/tomcat/src/main/java,base/tools/src/main/java,base/tps/src/main/java,base/util/src/main/java,base/util/src/test/java,tests/dogtag/shared/java
+
+sonar.java.binaries=build/
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Added the action to perform SonarCloud code analysis. In order to work properly the SonarCloud token for the project must be added among the secrets.

Additionally, the build steps are isolated in callable work-flow. It seems the steps are almost identical for the other work-flows so they could be modified to call the same build steps and avoid to repeat the same steps everywhere.