### PR TITLE
Update OCSP test

### DIFF
--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -235,8 +235,14 @@ jobs:
               -serial $CERT_ID \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
+          # remove the random parts of stderr so it can be compared
+          sed -i "s/^[^:]*:error:/error:/g" stderr
+
           # the responder should fail
           echo "Error querying OCSP responder" > expected
+          echo "error:1E800076:HTTP routines:OSSL_HTTP_REQ_CTX_nbio:unexpected content type:crypto/http/http_client.c:676:expected=application/ocsp-response, actual=text/html" >> expected
+          echo "error:1E800067:HTTP routines:OSSL_HTTP_REQ_CTX_exchange:error receiving:crypto/http/http_client.c:874:server=http://pki.example.com:8080" >> expected
+
           diff expected stderr
 
       - name: Check OCSP responder with revoked cert


### PR DESCRIPTION
The latest OpenSSL OCSP client generates additional error messages when it talks to an OCSP responder that does not have any CRLs. The OCSP test has been updated to expect the extra messages.