### PR TITLE
Fix serial type in nss-cert-issue request in nssdb.py

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1668,7 +1668,7 @@ class NSSDatabase(object):
                 cmd.extend(['--ext', ext_conf])
 
             if serial:
-                cmd.extend(['--serial', serial])
+                cmd.extend(['--serial', str(serial)])
 
             if issuer:
                 cmd.extend(['--issuer', issuer])


### PR DESCRIPTION
The command expects a `str` input but we were providing numerical input.
We didn't notice before as this code path had no coverage but now we use
JSS instead of NSS for issuing temporary certs we now have coverage of
this method, unearthing this issue.

Resolves #4012 