### PR TITLE
Disable access to external entities when parsing XML

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/account/Account.java
+++ b/base/common/src/main/java/com/netscape/certsrv/account/Account.java
@@ -23,6 +23,7 @@ import java.io.StringWriter;
 import java.util.Collection;
 import java.util.TreeSet;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -215,6 +216,8 @@ public class Account extends RESTMessage {
         document.appendChild(accountElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -230,6 +233,7 @@ public class Account extends RESTMessage {
     public static Account fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/base/PKIException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/PKIException.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 
 import javax.ws.rs.core.Response;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -160,6 +161,8 @@ public class PKIException extends RuntimeException {
             document.appendChild(element);
 
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -175,6 +178,7 @@ public class PKIException extends RuntimeException {
         public static Data fromXML(String xml) throws Exception {
 
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/base/RESTMessage.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/RESTMessage.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -317,6 +318,8 @@ public class RESTMessage implements JSONSerializer {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -332,6 +335,7 @@ public class RESTMessage implements JSONSerializer {
     public static RESTMessage fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertData.java
@@ -23,6 +23,7 @@ import java.security.Principal;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -450,6 +451,8 @@ public class CertData implements JSONSerializer {
         document.appendChild(infoElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -465,6 +468,7 @@ public class CertData implements JSONSerializer {
     public static CertData fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfo.java
@@ -24,6 +24,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Date;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -482,6 +483,8 @@ public class CertDataInfo implements JSONSerializer {
         document.appendChild(infoElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -497,6 +500,7 @@ public class CertDataInfo implements JSONSerializer {
     public static CertDataInfo fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfos.java
@@ -20,6 +20,7 @@ package com.netscape.certsrv.cert;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -68,6 +69,8 @@ public class CertDataInfos extends DataCollection<CertDataInfo> {
         toDOM(document);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -104,6 +107,7 @@ public class CertDataInfos extends DataCollection<CertDataInfo> {
     public static CertDataInfos fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertEnrollmentRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertEnrollmentRequest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.HashMap;
 
 import javax.ws.rs.core.MultivaluedMap;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -514,6 +515,8 @@ public class CertEnrollmentRequest extends RESTMessage {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -527,6 +530,7 @@ public class CertEnrollmentRequest extends RESTMessage {
 
     public static CertEnrollmentRequest fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfo.java
@@ -21,6 +21,7 @@ package com.netscape.certsrv.cert;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -259,6 +260,8 @@ public class CertRequestInfo extends CMSRequestInfo {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -274,6 +277,7 @@ public class CertRequestInfo extends CMSRequestInfo {
     public static CertRequestInfo fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestInfos.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Collection;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -84,6 +85,8 @@ public class CertRequestInfos extends DataCollection<CertRequestInfo> implements
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -120,6 +123,7 @@ public class CertRequestInfos extends DataCollection<CertRequestInfo> implements
     public static CertRequestInfos fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRetrievalRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRetrievalRequest.java
@@ -25,6 +25,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Objects;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -126,6 +127,8 @@ public class CertRetrievalRequest implements JSONSerializer {
         document.appendChild(requestElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -141,6 +144,7 @@ public class CertRetrievalRequest implements JSONSerializer {
     public static CertRetrievalRequest fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Date;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -226,6 +227,8 @@ public class CertRevokeRequest implements JSONSerializer {
         document.appendChild(requestElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -241,6 +244,7 @@ public class CertRevokeRequest implements JSONSerializer {
     public static CertRevokeRequest fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertSearchRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertSearchRequest.java
@@ -25,6 +25,7 @@ import java.io.StringWriter;
 import java.util.Objects;
 
 import javax.ws.rs.core.MultivaluedMap;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -1079,6 +1080,8 @@ public class CertSearchRequest implements JSONSerializer {
         document.appendChild(rootElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -1094,6 +1097,7 @@ public class CertSearchRequest implements JSONSerializer {
     public static CertSearchRequest fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/key/AsymKeyGenerationRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/AsymKeyGenerationRequest.java
@@ -115,6 +115,7 @@ public class AsymKeyGenerationRequest extends KeyGenerationRequest  {
     public static AsymKeyGenerationRequest fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyArchivalRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyArchivalRequest.java
@@ -257,6 +257,7 @@ public class KeyArchivalRequest extends RESTMessage {
     public static KeyArchivalRequest fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfo.java
@@ -21,6 +21,7 @@ package com.netscape.certsrv.key;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -139,6 +140,8 @@ public class KeyRequestInfo extends CMSRequestInfo {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -154,6 +157,7 @@ public class KeyRequestInfo extends CMSRequestInfo {
     public static KeyRequestInfo fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfoCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestInfoCollection.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Collection;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -74,6 +75,8 @@ public class KeyRequestInfoCollection extends DataCollection<KeyRequestInfo> imp
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -110,6 +113,7 @@ public class KeyRequestInfoCollection extends DataCollection<KeyRequestInfo> imp
     public static KeyRequestInfoCollection fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/key/SymKeyGenerationRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/SymKeyGenerationRequest.java
@@ -104,6 +104,7 @@ public class SymKeyGenerationRequest extends KeyGenerationRequest {
     public static SymKeyGenerationRequest fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/PolicyConstraint.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/PolicyConstraint.java
@@ -22,6 +22,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -228,6 +229,8 @@ public class PolicyConstraint implements JSONSerializer {
             document.appendChild(accountElement);
 
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -242,6 +245,7 @@ public class PolicyConstraint implements JSONSerializer {
 
         public static PolicyConstraint fromXML(String xml) throws Exception {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/PolicyConstraintValue.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/PolicyConstraintValue.java
@@ -20,6 +20,7 @@ package com.netscape.certsrv.profile;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -169,6 +170,8 @@ public class PolicyConstraintValue implements JSONSerializer {
         document.appendChild(pcvElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -183,6 +186,7 @@ public class PolicyConstraintValue implements JSONSerializer {
 
     public static PolicyConstraintValue fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/PolicyDefault.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/PolicyDefault.java
@@ -22,6 +22,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -231,6 +232,8 @@ public class PolicyDefault implements JSONSerializer {
         document.appendChild(pdElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -245,6 +248,7 @@ public class PolicyDefault implements JSONSerializer {
 
     public static PolicyDefault fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileAttribute.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileAttribute.java
@@ -20,6 +20,7 @@ package com.netscape.certsrv.profile;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -180,6 +181,8 @@ public class ProfileAttribute implements JSONSerializer {
         document.appendChild(accountElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -193,6 +196,7 @@ public class ProfileAttribute implements JSONSerializer {
 
     public static ProfileAttribute fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileData.java
@@ -31,6 +31,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Vector;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -532,6 +533,8 @@ public class ProfileData implements JSONSerializer {
         document.appendChild(pdElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -546,6 +549,7 @@ public class ProfileData implements JSONSerializer {
 
     public static ProfileData fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileDataInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileDataInfo.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Objects;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -177,6 +178,8 @@ public class ProfileDataInfo implements JSONSerializer {
         document.appendChild(profileParameterElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -191,6 +194,7 @@ public class ProfileDataInfo implements JSONSerializer {
 
     public static ProfileDataInfo fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileDataInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileDataInfos.java
@@ -20,6 +20,7 @@ package com.netscape.certsrv.profile;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -68,6 +69,8 @@ public class ProfileDataInfos extends DataCollection<ProfileDataInfo> {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -103,6 +106,7 @@ public class ProfileDataInfos extends DataCollection<ProfileDataInfo> {
     public static ProfileDataInfos fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileInput.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileInput.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -354,6 +355,8 @@ public class ProfileInput implements JSONSerializer {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -367,6 +370,7 @@ public class ProfileInput implements JSONSerializer {
 
     public static ProfileInput fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileOutput.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileOutput.java
@@ -22,6 +22,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -234,6 +235,8 @@ public class ProfileOutput implements JSONSerializer {
         document.appendChild(pdElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -248,6 +251,7 @@ public class ProfileOutput implements JSONSerializer {
 
     public static ProfileOutput fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileParameter.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileParameter.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Objects;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -128,6 +129,8 @@ public class ProfileParameter implements JSONSerializer {
         document.appendChild(profileParameterElement);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -142,6 +145,7 @@ public class ProfileParameter implements JSONSerializer {
 
     public static ProfileParameter fromXML(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/com/netscape/certsrv/request/CMSRequestInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/request/CMSRequestInfo.java
@@ -20,6 +20,7 @@ package com.netscape.certsrv.request;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -258,6 +259,8 @@ public class CMSRequestInfo implements JSONSerializer {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -273,6 +276,7 @@ public class CMSRequestInfo implements JSONSerializer {
     public static CMSRequestInfo fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/common/src/main/java/org/dogtagpki/common/Info.java
+++ b/base/common/src/main/java/org/dogtagpki/common/Info.java
@@ -21,6 +21,7 @@ package org.dogtagpki.common;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -185,6 +186,8 @@ public class Info extends RESTMessage {
         document.appendChild(element);
 
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
@@ -200,6 +203,7 @@ public class Info extends RESTMessage {
     public static Info fromXML(String xml) throws Exception {
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(new InputSource(new StringReader(xml)));
 

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/SecurityDomainProcessor.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/SecurityDomainProcessor.java
@@ -24,6 +24,7 @@ import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Vector;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -750,7 +751,10 @@ public class SecurityDomainProcessor extends Processor {
         XMLObject xmlObject = convertDomainInfoToXMLObject(before);
         Document document = xmlObject.getDocument();
 
-        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
 

--- a/base/server/src/main/java/com/netscape/cmscore/apps/ServerXml.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/ServerXml.java
@@ -41,6 +41,7 @@ public class ServerXml {
         ServerXml serverXml = new ServerXml();
 
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document document = builder.parse(filename);
 

--- a/base/util/src/main/java/com/netscape/cmsutil/xml/XMLObject.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/xml/XMLObject.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.io.StringWriter;
 import java.util.Vector;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -58,6 +59,7 @@ public class XMLObject {
     public XMLObject(InputStream s)
             throws SAXException, IOException, ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder docBuilder = factory.newDocumentBuilder();
         mDoc = docBuilder.parse(s);
     }
@@ -65,6 +67,7 @@ public class XMLObject {
     public XMLObject(File f)
             throws SAXException, IOException, ParserConfigurationException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder docBuilder = factory.newDocumentBuilder();
         mDoc = docBuilder.parse(f);
     }
@@ -161,6 +164,8 @@ public class XMLObject {
     public byte[] toByteArray() throws TransformerConfigurationException, TransformerException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         TransformerFactory tranFactory = TransformerFactory.newInstance();
+        tranFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        tranFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer aTransformer = tranFactory.newTransformer();
         Source src = new DOMSource(mDoc);
         Result dest = new StreamResult(bos);
@@ -171,6 +176,8 @@ public class XMLObject {
     public void output(OutputStream os)
             throws TransformerConfigurationException, TransformerException {
         TransformerFactory tranFactory = TransformerFactory.newInstance();
+        tranFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        tranFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer aTransformer = tranFactory.newTransformer();
         Source src = new DOMSource(mDoc);
         Result dest = new StreamResult(os);
@@ -179,6 +186,8 @@ public class XMLObject {
 
     public String toXMLString() throws TransformerConfigurationException, TransformerException {
         TransformerFactory tranFactory = TransformerFactory.newInstance();
+        tranFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        tranFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
         Transformer transformer = tranFactory.newTransformer();
         Source src = new DOMSource(mDoc);
         StreamResult dest = new StreamResult(new StringWriter());


### PR DESCRIPTION
This reduces the vulnerability of XML parsers to XXE (XML external
entity) injection.

The best way to prevent XXE is to stop using XML altogether, which we do
plan to do. Until that happens I consider it worthwhile to tighten the
security here though.