### PR TITLE
Split SonarCloud in two workflows

### DIFF
--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -1,0 +1,129 @@
+name: Sonarcloud-Pull
+on:
+  workflow_run:
+    workflows: ["Sonarcloud"]
+    types:
+      - completed
+
+jobs:
+  retrieve-pr:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.pr-artifact-script.outputs.result }}
+    steps:
+      - name: 'Download PR artifact'
+        uses: actions/github-script@v3.1.0
+        id: download-pr
+        with:
+          result-encoding: string
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            if (matchArtifact == null){
+              core.setFailed("No PR artifact");
+              return "False";
+            }
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+            return "True";
+            
+      - name: Unzip the pr
+        if: steps.download-pr.outputs.result == 'True'
+        run: unzip pr.zip
+
+      - name: Retrieve the pr number
+        if: success()
+        id: pr-artifact-script
+        uses: actions/github-script@v3.1.0
+        with:
+          result-encoding: string
+          script: |
+            var fs = require('fs');
+            var pr_number = Number(fs.readFileSync('./NR'));
+            return pr_number; 
+
+        
+  sonarcloud:
+    name: Sonar Cloud code analysis
+    needs: retrieve-pr
+    if: needs.retrieve-pr.outputs.pr-number != ''
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Retrieve runner image
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pki-build"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pki-build.zip', Buffer.from(download.data));
+
+      - name: Unzip the build container
+        run: unzip pki-build.zip
+
+      - name: Load runner image
+        run: docker load --input pki-sonar-runner.tar
+
+      - name: Checkout pulled branch
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+#      - name: Get the PR
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          echo "Checking out from PR #${{ needs.retrieve-pr.outputs.pr-number }}"
+#          hub pr checkout ${{ needs.retrieve-pr.outputs.pr-number }}
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+  
+      - name: Copy build in current folder
+        run: docker cp pki:/usr/share/java/pki ./build
+      
+      - name: Remove maven related file
+        run: rm -f pom.xml
+
+      - name: Start Sonar analysis
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ needs.retrieve-pr.outputs.pr-number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -126,8 +126,8 @@ jobs:
       - name: Store runner image
         uses: actions/cache@v3
         with:
-          key: pki-sonar-runner-${{ matrix.os }}-${{ context.payload.workflow_run.id }}
-          path: pki-soanr-runner.tar
+          key: pki-sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
+          path: pki-sonar-runner.tar
         
   sonarcloud:
     name: Sonar Cloud code analysis
@@ -142,7 +142,7 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-sonar-runner-${{ matrix.os }}-${{ context.payload.workflow_run.id }}
+          key: pki-sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
           path: pki-sonar-runner.tar
 
       - name: Load runner image
@@ -154,13 +154,6 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
-
-#      - name: Get the PR
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          echo "Checking out from PR #${{ needs.retrieve-pr.outputs.pr-number }}"
-#          hub pr checkout ${{ needs.retrieve-pr.outputs.pr-number }}
 
       - name: Set up PKI container
         run: |

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -55,38 +55,95 @@ jobs:
             var pr_number = Number(fs.readFileSync('./NR'));
             return pr_number; 
 
+  init:
+    name: Initializing workflow
+    runs-on: ubuntu-latest
+    needs: retrieve-pr
+    outputs:
+      matrix: ${{ steps.init.outputs.matrix }}
+      repo: ${{ steps.init.outputs.repo }}
+      db-image: ${{ steps.init.outputs.db-image }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Initialize workflow
+        id: init
+        env:
+          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_REPO: ${{ secrets.BASE64_REPO }}
+          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
+        run: |
+          tests/bin/init-workflow.sh
+  build:
+    name: Building PKI
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: /var/cache/dnf
+          key: fedora:${{ matrix.os }}-sonar-${{ hashFiles('pki.spec') }}
+
+      - name: Install dependencies
+        run: |
+          # keep packages after installation
+          echo "keepcache=True" >> /etc/dnf/dnf.conf
+          dnf install -y dnf-plugins-core rpm-build moby-engine
+          dnf copr enable -y ${{ needs.init.outputs.repo }}
+          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
+          # don't cache COPR packages
+          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
+
+      - name: Build PKI packages
+        run: ./build.sh --with-timestamp --work-dir=build rpm
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build runner image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-runner
+          target: pki-runner
+          outputs: type=docker,dest=pki-sonar-runner.tar
+
+      - name: Store runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-sonar-runner-${{ matrix.os }}-${{ context.payload.workflow_run.id }}
+          path: pki-soanr-runner.tar
         
   sonarcloud:
     name: Sonar Cloud code analysis
-    needs: retrieve-pr
+    needs: [retrieve-pr, init, build]
     if: needs.retrieve-pr.outputs.pr-number != ''
     runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     env:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Retrieve runner image
-        uses: actions/github-script@v3.1.0
+        uses: actions/cache@v3
         with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id,
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pki-build"
-            })[0];
-            var download = await github.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: matchArtifact.id,
-              archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pki-build.zip', Buffer.from(download.data));
-
-      - name: Unzip the build container
-        run: unzip pki-build.zip
+          key: pki-sonar-runner-${{ matrix.os }}-${{ context.payload.workflow_run.id }}
+          path: pki-sonar-runner.tar
 
       - name: Load runner image
         run: docker load --input pki-sonar-runner.tar

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,5 +1,5 @@
 name: Sonarcloud
-on: [push,pull_request]
+on: [push, pull_request]
 
 jobs:
   call-build-workflow:
@@ -10,6 +10,7 @@ jobs:
 
 
   sonarcloud:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     name: Sonar Cloud code analysis
     needs: call-build-workflow
     runs-on: ubuntu-latest
@@ -45,3 +46,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  get-pr-ref:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    name: Sonar cloud PR fork analyses deferring
+    needs: call-build-workflow
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
+    steps:
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
+      - name: Upload pr as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-sonar-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-sonar-runner.tar
+
+      - name: Upload build as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-build
+          path: pki-sonar-runner.tar  

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   call-build-workflow:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build.yml
     with:
       key_container: sonar
@@ -52,10 +53,6 @@ jobs:
     name: Sonar cloud PR fork analyses deferring
     needs: call-build-workflow
     runs-on: ubuntu-latest
-    env:
-      SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Save PR number
         run: |
@@ -67,15 +64,3 @@ jobs:
         with:
           name: pr
           path: pr/
-
-      - name: Retrieve runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-sonar-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-sonar-runner.tar
-
-      - name: Upload build as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: pki-build
-          path: pki-sonar-runner.tar  

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -51,7 +51,6 @@ jobs:
   get-pr-ref:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     name: Sonar cloud PR fork analyses deferring
-    needs: call-build-workflow
     runs-on: ubuntu-latest
     steps:
       - name: Save PR number


### PR DESCRIPTION
The pull request fork run in a separate workflow triggered by the main
solarcloud workflow.

NOTE: additional tests for pull requests to secondary branch should be
done but these are less frequent