### PR TITLE
Refactor CAInstallerService.createCert()

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/system/SystemCertData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/system/SystemCertData.java
@@ -18,7 +18,6 @@
 
 package com.netscape.certsrv.system;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -36,56 +35,17 @@ import com.netscape.certsrv.util.JSONSerializer;
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class SystemCertData implements JSONSerializer {
 
-    protected String nickname;
     protected String token;
-
     protected String keyID;
-    protected String keyType;
-    protected String keySize;
-    protected boolean keyWrap;
-
-    protected String keyCurveName;
-    protected boolean sslECDH;
-
     protected String keyAlgorithm;
-
     protected RequestId requestID;
-    protected String requestType;
-    protected String request;
-
-    protected String subjectDN;
-
-    protected String req_ext_oid;
-    protected String req_ext_critical;
-    protected String req_ext_data;
-
-    protected String[] dnsNames;
-    protected boolean adjustValidity;
-
     protected String signingAlgorithm;
-
     protected String type;
-
     protected String profile;
-
     protected CertId certID;
     protected String cert;
 
     public SystemCertData() {
-    }
-
-    /**
-     * @return the nickname
-     */
-    public String getNickname() {
-        return nickname;
-    }
-
-    /**
-     * @param nickname the nickname to set
-     */
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
     }
 
     /**
@@ -126,58 +86,6 @@ public class SystemCertData implements JSONSerializer {
         this.keyID = keyID;
     }
 
-    public String getKeyType() {
-        return keyType;
-    }
-
-    public void setKeyType(String keyType) {
-        this.keyType = keyType;
-    }
-
-    /**
-     * @return the keySize
-     */
-    public String getKeySize() {
-        return keySize;
-    }
-
-    /**
-     * @param keySize the keySize to set
-     */
-    public void setKeySize(String keySize) {
-        this.keySize = keySize;
-    }
-
-    public boolean getKeyWrap() {
-        return keyWrap;
-    }
-
-    public void setKeyWrap(boolean keyWrap) {
-        this.keyWrap = keyWrap;
-    }
-
-    /**
-     * @return the keyCurveName
-     */
-    public String getKeyCurveName() {
-        return keyCurveName;
-    }
-
-    /**
-     * @param keyCurveName the keyCurveName to set
-     */
-    public void setKeyCurveName(String keyCurveName) {
-        this.keyCurveName = keyCurveName;
-    }
-
-    public boolean getSslECDH() {
-        return sslECDH;
-    }
-
-    public void setSslECDH(boolean sslECDH) {
-        this.sslECDH = sslECDH;
-    }
-
     public String getKeyAlgorithm() {
         return keyAlgorithm;
     }
@@ -186,48 +94,12 @@ public class SystemCertData implements JSONSerializer {
         this.keyAlgorithm = keyAlgorithm;
     }
 
-    public String getRequestType() {
-        return requestType;
-    }
-
-    public void setRequestType(String requestType) {
-        this.requestType = requestType;
-    }
-
-    /**
-     * @return the request
-     */
-    public String getRequest() {
-        return request;
-    }
-
-    /**
-     * @param request the request to set
-     */
-    public void setRequest(String request) {
-        this.request = request;
-    }
-
     public RequestId getRequestID() {
         return requestID;
     }
 
     public void setRequestID(RequestId requestID) {
         this.requestID = requestID;
-    }
-
-    /**
-     * @return the subjectDN
-     */
-    public String getSubjectDN() {
-        return subjectDN;
-    }
-
-    /**
-     * @param subjectDN the subjectDN to set
-     */
-    public void setSubjectDN(String subjectDN) {
-        this.subjectDN = subjectDN;
     }
 
     public CertId getCertID() {
@@ -252,43 +124,6 @@ public class SystemCertData implements JSONSerializer {
         this.cert = cert;
     }
 
-    /**
-     * @return the req_ext_oid
-     */
-    public String getReqExtOID() {
-        return req_ext_oid;
-    }
-
-    /**
-     * @return the req_ext_data
-     */
-    public String getReqExtData() {
-        return req_ext_data;
-    }
-
-    /**
-     * @return the req_ext_critical
-     */
-    public boolean getReqExtCritical() {
-        return "true".equals(req_ext_critical);
-    }
-
-    public String[] getDNSNames() {
-        return dnsNames;
-    }
-
-    public void setDNSNames(String[] dnsNames) {
-        this.dnsNames = dnsNames;
-    }
-
-    public boolean getAdjustValidity() {
-        return adjustValidity;
-    }
-
-    public void setAdjustValidity(boolean adjustValidity) {
-        this.adjustValidity = adjustValidity;
-    }
-
     public String getSigningAlgorithm() {
         return signingAlgorithm;
     }
@@ -300,28 +135,14 @@ public class SystemCertData implements JSONSerializer {
     @Override
     public String toString() {
         return "SystemCertData["
-            + "nickname=" + nickname
-            + ", token=" + token
+            + "token=" + token
             + ", profile=" + profile
             + ", type=" + type
             + ", keyID=" + keyID
-            + ", keyType=" + keyType
-            + ", keySize=" + keySize
-            + ", keyWrap=" + keyWrap
-            + ", keyCurveName=" + keyCurveName
-            + ", sslECDH=" + sslECDH
             + ", keyAlgorithm=" + keyAlgorithm
-            + ", requestType=" + requestType
-            + ", request=" + request
             + ", requestID=" + requestID
-            + ", subjectDN=" + subjectDN
             + ", certID=" + certID
             + ", cert=" + cert
-            + ", req_ext_oid=" + req_ext_oid
-            + ", req_ext_critical=" + req_ext_critical
-            + ", req_ext_data=" + req_ext_data
-            + ", dnsNames=" + (dnsNames == null ? null : Arrays.asList(dnsNames))
-            + ", adjustValidity=" + adjustValidity
             + ", signingAlgorithm=" + signingAlgorithm
             + "]";
     }
@@ -330,29 +151,15 @@ public class SystemCertData implements JSONSerializer {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + Arrays.hashCode(dnsNames);
         result = prime * result + Objects.hash(
                 certID,
                 cert,
                 keyID,
-                keyType,
-                keySize,
-                keyWrap,
-                keyCurveName,
-                sslECDH,
                 keyAlgorithm,
-                nickname,
                 profile,
-                req_ext_critical,
-                req_ext_data,
-                req_ext_oid,
-                requestType,
-                request,
                 requestID,
-                subjectDN,
                 token,
                 type,
-                adjustValidity,
                 signingAlgorithm);
         return result;
     }
@@ -368,26 +175,12 @@ public class SystemCertData implements JSONSerializer {
         SystemCertData other = (SystemCertData) obj;
         return Objects.equals(certID, other.certID)
                 && Objects.equals(cert, other.cert)
-                && Arrays.equals(dnsNames, other.dnsNames)
                 && Objects.equals(keyID, other.keyID)
-                && Objects.equals(keyType, other.keyType)
-                && Objects.equals(keySize, other.keySize)
-                && Objects.equals(keyWrap, other.keyWrap)
-                && Objects.equals(keyCurveName, other.keyCurveName)
-                && Objects.equals(sslECDH, other.sslECDH)
                 && Objects.equals(keyAlgorithm, other.keyAlgorithm)
-                && Objects.equals(nickname, other.nickname)
                 && Objects.equals(profile, other.profile)
-                && Objects.equals(req_ext_critical, other.req_ext_critical)
-                && Objects.equals(req_ext_data, other.req_ext_data)
-                && Objects.equals(req_ext_oid, other.req_ext_oid)
-                && Objects.equals(requestType, other.requestType)
-                && Objects.equals(request, other.request)
                 && Objects.equals(requestID, other.requestID)
-                && Objects.equals(subjectDN, other.subjectDN)
                 && Objects.equals(token, other.token)
                 && Objects.equals(type, other.type)
-                && Objects.equals(adjustValidity, other.adjustValidity)
                 && Objects.equals(signingAlgorithm, other.signingAlgorithm);
     }
 

--- a/base/common/src/test/java/com/netscape/certsrv/system/SystemCertDataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/system/SystemCertDataTest.java
@@ -15,13 +15,7 @@ public class SystemCertDataTest {
     @Before
     public void setUpBefore() {
         before.setCert("foo");
-        before.setDNSNames(dnsNames);
-        before.setKeyCurveName("bar");
-        before.setKeySize("1024");
-        before.setNickname("dolor");
         before.setProfile("sit");
-        before.setRequest("amet");
-        before.setSubjectDN("consectetur");
         before.setToken("elit");
         before.setType("sed");
     }

--- a/base/common/src/test/java/com/netscape/cms/servlet/test/ConfigurationTest.java
+++ b/base/common/src/test/java/com/netscape/cms/servlet/test/ConfigurationTest.java
@@ -170,38 +170,23 @@ public class ConfigurationTest {
         // create system certs
         List<SystemCertData> systemCerts = new ArrayList<>();
         SystemCertData cert1 = new SystemCertData();
-        cert1.setKeySize("2048");
-        cert1.setNickname("signingCert testca");
-        cert1.setSubjectDN("CN=CA Signing Certificate");
         cert1.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
 
         systemCerts.add(cert1);
 
         SystemCertData cert2 = new SystemCertData();
-        cert2.setKeySize("2048");
-        cert2.setNickname("ocspSigningCert testca");
-        cert2.setSubjectDN("CN= CA OCSP Signing Certificate");
         cert2.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert2);
 
         SystemCertData cert3 = new SystemCertData();
-        cert3.setKeySize("2048");
-        cert3.setNickname("sslServerCert testca");
-        cert3.setSubjectDN("CN=" + host);
         cert3.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert3);
 
         SystemCertData cert4 = new SystemCertData();
-        cert4.setKeySize("2048");
-        cert4.setNickname("subsystemCert testca");
-        cert4.setSubjectDN("CN=CA Subsystem Certificate");
         cert4.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert4);
 
         SystemCertData cert5 = new SystemCertData();
-        cert5.setKeySize("2048");
-        cert5.setNickname("auditSigningCert testca");
-        cert5.setSubjectDN("CN=CA Audit Signing Certificate");
         cert5.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert5);
     }
@@ -211,38 +196,23 @@ public class ConfigurationTest {
         // create system certs
         List<SystemCertData> systemCerts = new ArrayList<>();
         SystemCertData cert1 = new SystemCertData();
-        cert1.setKeySize("2048");
-        cert1.setNickname("signingCert testsubca");
-        cert1.setSubjectDN("CN=SubCA Signing Certificate");
         cert1.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
 
         systemCerts.add(cert1);
 
         SystemCertData cert2 = new SystemCertData();
-        cert2.setKeySize("2048");
-        cert2.setNickname("ocspSigningCert testsubca");
-        cert2.setSubjectDN("CN= SubCA OCSP Signing Certificate");
         cert2.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert2);
 
         SystemCertData cert3 = new SystemCertData();
-        cert3.setKeySize("2048");
-        cert3.setNickname("sslServerCert testsubca");
-        cert3.setSubjectDN("CN=" + host);
         cert3.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert3);
 
         SystemCertData cert4 = new SystemCertData();
-        cert4.setKeySize("2048");
-        cert4.setNickname("subsystemCert testsubca");
-        cert4.setSubjectDN("CN=SubCA Subsystem Certificate");
         cert4.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert4);
 
         SystemCertData cert5 = new SystemCertData();
-        cert5.setKeySize("2048");
-        cert5.setNickname("auditSigningCert testsubca");
-        cert5.setSubjectDN("CN=SubCA Audit Signing Certificate");
         cert5.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert5);
     }
@@ -252,38 +222,23 @@ public class ConfigurationTest {
         // create system certs
         List<SystemCertData> systemCerts = new ArrayList<>();
         SystemCertData cert1 = new SystemCertData();
-        cert1.setKeySize("2048");
-        cert1.setNickname("signingCert testexternalca");
-        cert1.setSubjectDN("CN=External CA Signing Certificate");
         cert1.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
 
         systemCerts.add(cert1);
 
         SystemCertData cert2 = new SystemCertData();
-        cert2.setKeySize("2048");
-        cert2.setNickname("ocspSigningCert testexternalca");
-        cert2.setSubjectDN("CN= External CA OCSP Signing Certificate");
         cert2.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert2);
 
         SystemCertData cert3 = new SystemCertData();
-        cert3.setKeySize("2048");
-        cert3.setNickname("sslServerCert testexternalca");
-        cert3.setSubjectDN("CN=" + host);
         cert3.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert3);
 
         SystemCertData cert4 = new SystemCertData();
-        cert4.setKeySize("2048");
-        cert4.setNickname("subsystemCert testexternalca");
-        cert4.setSubjectDN("CN=External CA Subsystem Certificate");
         cert4.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert4);
 
         SystemCertData cert5 = new SystemCertData();
-        cert5.setKeySize("2048");
-        cert5.setNickname("auditSigningCert testexternalca");
-        cert5.setSubjectDN("CN=SubCA Audit Signing Certificate");
         cert5.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert5);
     }
@@ -293,9 +248,6 @@ public class ConfigurationTest {
         // create system certs
         List<SystemCertData> systemCerts = new ArrayList<>();
         SystemCertData cert1 = new SystemCertData();
-        cert1.setKeySize("2048");
-        cert1.setNickname("signingCert testexternalca");
-        cert1.setSubjectDN("CN=External CA Signing Certificate");
         cert1.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
 
         String extCert = "";
@@ -309,30 +261,18 @@ public class ConfigurationTest {
         systemCerts.add(cert1);
 
         SystemCertData cert2 = new SystemCertData();
-        cert2.setKeySize("2048");
-        cert2.setNickname("ocspSigningCert testexternalca");
-        cert2.setSubjectDN("CN= External CA OCSP Signing Certificate");
         cert2.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert2);
 
         SystemCertData cert3 = new SystemCertData();
-        cert3.setKeySize("2048");
-        cert3.setNickname("sslServerCert testexternalca");
-        cert3.setSubjectDN("CN=" + host);
         cert3.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert3);
 
         SystemCertData cert4 = new SystemCertData();
-        cert4.setKeySize("2048");
-        cert4.setNickname("subsystemCert testexternalca");
-        cert4.setSubjectDN("CN=External CA Subsystem Certificate");
         cert4.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert4);
 
         SystemCertData cert5 = new SystemCertData();
-        cert5.setKeySize("2048");
-        cert5.setNickname("auditSigningCert testexternalca");
-        cert5.setSubjectDN("CN=SubCA Audit Signing Certificate");
         cert5.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert5);
     }
@@ -342,9 +282,6 @@ public class ConfigurationTest {
         // create system certs
         List<SystemCertData> systemCerts = new ArrayList<>();
         SystemCertData cert3 = new SystemCertData();
-        cert3.setKeySize("2048");
-        cert3.setNickname("sslServerCert testca");
-        cert3.setSubjectDN("CN=" + host);
         cert3.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert3);
     }
@@ -354,38 +291,23 @@ public class ConfigurationTest {
         // create system certs
         List<SystemCertData> systemCerts = new ArrayList<>();
         SystemCertData cert1 = new SystemCertData();
-        cert1.setKeySize("2048");
-        cert1.setNickname("transportCert testkra");
-        cert1.setSubjectDN("CN=KRA Transport Certificate");
         cert1.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
 
         systemCerts.add(cert1);
 
         SystemCertData cert2 = new SystemCertData();
-        cert2.setKeySize("2048");
-        cert2.setNickname("storageCert testkra");
-        cert2.setSubjectDN("CN= KRA Storage Certificate");
         cert2.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert2);
 
         SystemCertData cert3 = new SystemCertData();
-        cert3.setKeySize("2048");
-        cert3.setNickname("sslServerCert testkra");
-        cert3.setSubjectDN("CN=" + host);
         cert3.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert3);
 
         SystemCertData cert4 = new SystemCertData();
-        cert4.setKeySize("2048");
-        cert4.setNickname("subsystemCert testkra");
-        cert4.setSubjectDN("CN=KRA Subsystem Certificate");
         cert4.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert4);
 
         SystemCertData cert5 = new SystemCertData();
-        cert5.setKeySize("2048");
-        cert5.setNickname("auditSigningCert testkra");
-        cert5.setSubjectDN("CN=KRA Audit Signing Certificate");
         cert5.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert5);
     }
@@ -395,31 +317,19 @@ public class ConfigurationTest {
         // create system certs
         List<SystemCertData> systemCerts = new ArrayList<>();
         SystemCertData cert1 = new SystemCertData();
-        cert1.setKeySize("2048");
-        cert1.setNickname("ocspSigningCert testocsp");
-        cert1.setSubjectDN("CN=OCSP Signing Certificate");
         cert1.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
 
         systemCerts.add(cert1);
 
         SystemCertData cert3 = new SystemCertData();
-        cert3.setKeySize("2048");
-        cert3.setNickname("sslServerCert testocsp");
-        cert3.setSubjectDN("CN=" + host);
         cert3.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert3);
 
         SystemCertData cert4 = new SystemCertData();
-        cert4.setKeySize("2048");
-        cert4.setNickname("subsystemCert testocsp");
-        cert4.setSubjectDN("CN=OCSP Subsystem Certificate");
         cert4.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert4);
 
         SystemCertData cert5 = new SystemCertData();
-        cert5.setKeySize("2048");
-        cert5.setNickname("auditSigningCert testocsp");
-        cert5.setSubjectDN("CN=OCSP Audit Signing Certificate");
         cert5.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert5);
     }
@@ -430,23 +340,14 @@ public class ConfigurationTest {
         List<SystemCertData> systemCerts = new ArrayList<>();
 
         SystemCertData cert3 = new SystemCertData();
-        cert3.setKeySize("2048");
-        cert3.setNickname("sslServerCert testtks");
-        cert3.setSubjectDN("CN=" + host);
         cert3.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert3);
 
         SystemCertData cert4 = new SystemCertData();
-        cert4.setKeySize("2048");
-        cert4.setNickname("subsystemCert testtks");
-        cert4.setSubjectDN("CN=TKS Subsystem Certificate");
         cert4.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert4);
 
         SystemCertData cert5 = new SystemCertData();
-        cert5.setKeySize("2048");
-        cert5.setNickname("auditSigningCert testtks");
-        cert5.setSubjectDN("CN=TKS Audit Signing Certificate");
         cert5.setToken(CryptoUtil.INTERNAL_TOKEN_FULL_NAME);
         systemCerts.add(cert5);
     }


### PR DESCRIPTION
Previously the `CAInstallerService.createCert()` would get the request type and CSR from the REST API parameters. Since these values are actually already stored in the request record in the CA database, the code has been modified to get the values from the database instead.

Unused fields in SystemCertData have been removed as well.
