### PR TITLE
Restore support for custom SKI in CSR

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1062,7 +1062,7 @@ jobs:
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
-              -D pki_req_ski=DEFAULT \
+              -D pki_req_ski=AEB2FA7A07115A0AB994FF9B5BDA8E75D536BC77 \
               -D pki_req_ext_add=True \
               -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
               -D pki_req_ext_data=1E0A00530075006200430041 \
@@ -1088,7 +1088,7 @@ jobs:
               -s CA \
               -D pki_ds_hostname=ds.example.com \
               -D pki_ds_ldap_port=3389 \
-              -D pki_req_ski=DEFAULT \
+              -D pki_req_ski=AEB2FA7A07115A0AB994FF9B5BDA8E75D536BC77 \
               -D pki_req_ext_add=True \
               -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
               -D pki_req_ext_data=1E0A00530075006200430041 \

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1241,8 +1241,15 @@ class NSSDatabase(object):
         if ski_ext.get('critical'):
             values.append('critical')
 
-        # generate subject key ID from hash (i.e. ignore the provided ID)
-        values.append('hash')
+        sk_id = ski_ext.get('sk_id')
+
+        if sk_id == 'DEFAULT':
+            # generate subject key ID from hash
+            values.append('hash')
+        else:
+            # convert <hex><hex>...<hex> into <hex>:<hex>:...:<hex>
+            value = binascii.unhexlify(sk_id).hex(':')
+            values.append(value)
 
         exts['subjectKeyIdentifier'] = ', '.join(values)
 


### PR DESCRIPTION
The `NSSExtensionGenerator.createSKIDExtension()` has been updated to support custom (user-provided) SKI.

The Python code has been updated to transform the hex value from `pki_req_ski` into the format required by `NSSExtensionGenerator`. See: https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-Extensions

The CA test has been updated to use `pki_req_ski=<hex>`, but for now the result will need to be validated manually in the CI. QE has an automated test for this.

Test result: The CSR has the correct SKI extension.
https://github.com/dogtagpki/pki/runs/7008900892?check_suite_focus=true#step:11:238

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2099312
