### PR TITLE
Troubleshooting improvement for ExternalProcessKeyRetriever

### DIFF
--- a/base/util/src/main/java/com/netscape/cmsutil/json/JSONObject.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/json/JSONObject.java
@@ -38,6 +38,11 @@ public class JSONObject extends ObjectMapper {
         jsonNode = mapper.readTree(s);
     }
 
+    public JSONObject(String s) throws IOException {
+        this();
+        jsonNode = mapper.readTree(s);
+    }
+
     public ObjectMapper getMapper() {
         return mapper;
     }


### PR DESCRIPTION
The `ExternalProcessKeyRetriever` has been updated to provide more detailed log messages and to perform proper `JsonNode` validations of the result to help troubleshooting. See https://fasterxml.github.io/jackson-databind/javadoc/2.7/com/fasterxml/jackson/databind/JsonNode.html

A new constructor has been added to create a `JSONObject` from a `String`.

https://github.com/dogtagpki/pki/issues/4032