### PR TITLE
Add test for PKI CLI in Azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,31 @@ jobs:
     displayName: Install PKI dependencies
 
   - script: |
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner ./build.sh dist
+      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner ./build.sh \
+          --python-dir=/usr/lib/python3.10/site-packages dist
       docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner ./build.sh install
     displayName: Build and install PKI
+
+  - script: |
+      # generate CSR
+      pki nss-cert-request \
+          --key-type RSA \
+          --subject "CN=Certificate Authority" \
+          --ext /usr/share/pki/server/certs/ca_signing.conf \
+          --csr ca_signing.csr
+
+      # issue self-signed cert
+      pki nss-cert-issue \
+          --csr ca_signing.csr \
+          --ext /usr/share/pki/server/certs/ca_signing.conf \
+          --cert ca_signing.crt
+
+      # import cert
+      pki nss-cert-import \
+          --cert ca_signing.crt \
+          --trust CT,C,C \
+          ca_signing
+
+      # display cert
+      pki nss-cert-show ca_signing
+    displayName: Test PKI CLI

--- a/cmake/Modules/DefinePythonSitePackages.cmake
+++ b/cmake/Modules/DefinePythonSitePackages.cmake
@@ -31,6 +31,7 @@ if (PYTHON_VERSION_STRING VERSION_LESS "3.5.0")
 endif()
 message(STATUS "Building pki.server for ${PYTHON_VERSION_STRING}")
 
-# Find site-packages for Python 3
-find_site_packages("python3" PYTHON3_SITE_PACKAGES)
-message(STATUS "Building Python 3 pki client package")
+if (NOT DEFINED PYTHON3_SITE_PACKAGES)
+    # Find default site-packages for Python 3
+    find_site_packages("python3" PYTHON3_SITE_PACKAGES)
+endif(NOT DEFINED PYTHON3_SITE_PACKAGES)

--- a/pki.spec
+++ b/pki.spec
@@ -823,6 +823,7 @@ pkgs=base\
     --java-home=%{java_home} \
     --jni-dir=%{_jnidir} \
     --unit-dir=%{_unitdir} \
+    --python=%{python_executable} \
     --with-pkgs=$pkgs \
     %{!?with_test:--without-test} \
     dist


### PR DESCRIPTION
The Azure pipeline has been updated to perform basic tests using PKI CLI (which is partially Python) without building an
RPM. However, for this to work the Python module installation directory needs to be hard-coded due to changes in F36:
https://docs.fedoraproject.org/en-US/fedora/f36/release-notes/developers/Development_Python/
    
Currently PKI modules are installed into `purelib` directory. Inside RPM build environment this directory translates into `/usr/lib/python3.10/site-packages` which works just fine.
    
Outside RPM build environment this directory translates into `/usr/local/lib/python3.10/site-packages`, but for some reason Python could not load modules from this directory.

As a workaround the build command was updated to install the modules into the same directory used in RPM build environment. Further investigation might be needed to see if there's a better solution that works consistently in any environment.

New `build.sh` options have been added to specify the Python executable and modules locations.