### PR TITLE
Build a single package

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -348,7 +348,7 @@ add_subdirectory(util)
 add_subdirectory(common)
 add_subdirectory(tools)
 
-if(WITH_SERVER)
+if(WITH_SERVER OR WITH_CA OR WITH_KRA OR WITH_OCSP OR WITH_TKS OR WITH_TPS OR WITH_ACME)
 
     add_subdirectory(${APP_SERVER})
     add_subdirectory(server)
@@ -396,7 +396,7 @@ if(WITH_SERVER)
         add_subdirectory(acme)
     endif(WITH_ACME)
 
-endif(WITH_SERVER)
+endif(WITH_SERVER OR WITH_CA OR WITH_KRA OR WITH_OCSP OR WITH_TKS OR WITH_TPS OR WITH_ACME)
 
 if(WITH_JAVADOC)
     add_subdirectory(javadoc)

--- a/pki.spec
+++ b/pki.spec
@@ -795,7 +795,6 @@ This package provides test suite for %{product_name}.
 %set_build_flags
 
 pkgs=base\
-#%{?with_server:,server}\
 %if (%{with server}) || (%{with ca} || %{with kra} || %{with ocsp} || %{with tks} || %{with tps} || %{with acme})
 ,server\
 %endif

--- a/pki.spec
+++ b/pki.spec
@@ -795,7 +795,10 @@ This package provides test suite for %{product_name}.
 %set_build_flags
 
 pkgs=base\
-%{?with_server:,server}\
+#%{?with_server:,server}\
+%if (%{with server}) || (!%{with server} && (%{with ca} || %{with kra} || %{with ocsp} || %{with tks} || %{with tps} || %{with acme}))
+,server\
+%endif
 %{?with_ca:,ca}\
 %{?with_kra:,kra}\
 %{?with_ocsp:,ocsp}\

--- a/pki.spec
+++ b/pki.spec
@@ -796,7 +796,7 @@ This package provides test suite for %{product_name}.
 
 pkgs=base\
 #%{?with_server:,server}\
-%if (%{with server}) || (!%{with server} && (%{with ca} || %{with kra} || %{with ocsp} || %{with tks} || %{with tps} || %{with acme}))
+%if (%{with server}) || (%{with ca} || %{with kra} || %{with ocsp} || %{with tks} || %{with tps} || %{with acme})
 ,server\
 %endif
 %{?with_ca:,ca}\

--- a/pki.spec
+++ b/pki.spec
@@ -795,9 +795,7 @@ This package provides test suite for %{product_name}.
 %set_build_flags
 
 pkgs=base\
-%if (%{with server}) || (%{with ca} || %{with kra} || %{with ocsp} || %{with tks} || %{with tps} || %{with acme})
-,server\
-%endif
+%{?with_server:,server}\
 %{?with_ca:,ca}\
 %{?with_kra:,kra}\
 %{?with_ocsp:,ocsp}\


### PR DESCRIPTION
The build option --with-pkgs does not work for sub-systems if not the
`server` package is specified. This will build the server in case it is
needed although only the rpm for the specified packages are generated.

Fix #4039