### PR TITLE
Override cmake cache

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -667,6 +667,12 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
         OPTIONS+=(-DWITH_$package:BOOL=OFF)
     done
 
+    for package in ${PKGS_TO_BUILD[@]}
+    do
+        package=${package^^}
+        OPTIONS+=(-DWITH_$package:BOOL=ON)
+    done
+
     if [ "$WITH_CONSOLE" = true ] ; then
         OPTIONS+=(-DWITH_CONSOLE:BOOL=ON)
     fi


### PR DESCRIPTION
Building two subpackages in different runs does not work because cmake
will set the list of packages in the first run and cache it for the
following runs. The patch force to update the list of packages at each run.