### PR TITLE
Remove non-functional cache for build dependencies

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-acme-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,ca,acme --with-timestamp --work-dir=build rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,21 +53,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-ca-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-timestamp --work-dir=build rpm

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-ca-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,ca,tests --with-timestamp --work-dir=build rpm

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-ca-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,ca,tests --with-timestamp --work-dir=build rpm

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-ipa-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,ca,kra,acme --with-timestamp --work-dir=build rpm

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-kra-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,ca,kra,tests --with-timestamp --work-dir=build rpm

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-ocsp-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,ca,ocsp,tests --with-timestamp --work-dir=build rpm

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-python-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,tests --with-timestamp --work-dir=build rpm

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-qe-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-timestamp --work-dir=build rpm

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-server-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server --with-timestamp --work-dir=build rpm

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -90,21 +90,11 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-sonar-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-timestamp --work-dir=build rpm

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-tks-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,ca,tks --with-timestamp --work-dir=build rpm

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-tools-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,tests --with-timestamp --work-dir=build rpm

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -35,21 +35,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/dnf
-          key: fedora:${{ matrix.os }}-tps-${{ hashFiles('pki.spec') }}
-
       - name: Install dependencies
         run: |
-          # keep packages after installation
-          echo "keepcache=True" >> /etc/dnf/dnf.conf
           dnf install -y dnf-plugins-core rpm-build moby-engine
           dnf copr enable -y ${{ needs.init.outputs.repo }}
           dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-          # don't cache COPR packages
-          rm -f `find /var/cache/dnf -name '*.rpm' | grep '/var/cache/dnf/copr:'`
 
       - name: Build PKI packages
         run: ./build.sh --with-pkgs=base,server,ca,kra,tks,tps --with-timestamp --work-dir=build rpm


### PR DESCRIPTION
The cache for build dependencies in the CI was originally added in 66a6e594ae0e89e0d0411f78d2ac7c716f7cc9e7 to reduce build time but it never worked properly so it has been removed.