### PR TITLE
cli: handle t.getCause() == null in exception handler

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -678,9 +678,10 @@ public class MainCLI extends CLI {
             System.err.println(t.getMessage());
 
         } else if (t instanceof ProcessingException) {
-            // display the cause of the exception
-            t = t.getCause();
-            System.err.println(t.getClass().getSimpleName() + ": " + t.getMessage());
+            // display the cause of the exception (if available)
+            Throwable e = t.getCause();
+            if (e == null) e = t;
+            System.err.println(e.getClass().getSimpleName() + ": " + e.getMessage());
 
         } else if (t instanceof PKIException) {
             System.err.println(t.getClass().getSimpleName() + ": " + t.getMessage());


### PR DESCRIPTION
It is possible that the cause of a ProcessingException is not set.
In that case, t.getCause() returns null.  As a consequence,
handleException() throws an unhandled NullPointerException.

Check that the cause Throwable is non-null before "drilling down" to
it.

## Commentary

This came up in CI for the EST feature: https://github.com/dogtagpki/pki/runs/7205954443
The NPE was obscuring information about the cause, so we need to fix this.
(The actual bug that caused the ProcessingException is now fixed in the EST branch).