### PR TITLE
Update Maven project

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,16 +17,113 @@ jobs:
   container: $[variables['image']]
   steps:
   - script: |
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf install -y dnf-plugins-core rpm-build
+      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf install -y dnf-plugins-core rpm-build maven
       docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf copr enable -y @pki/master
       docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf builddep -y --spec pki.spec
     displayName: Install PKI dependencies
 
   - script: |
+      ./build.sh \
+          --work-dir=build \
+          --python-dir=/usr/lib/python3.10/site-packages \
+          dist
+    displayName: Build PKI with CMake
+
+  - script: |
+      mvn install:install-file \
+          -Dfile=/usr/lib/java/jss.jar \
+          -DgroupId=org.dogtagpki \
+          -DartifactId=jss \
+          -Dversion=5.3.0-SNAPSHOT \
+          -Dpackaging=jar \
+          -DgeneratePom=true
+
+      mvn install:install-file \
+          -Dfile=/usr/lib/java/jss-symkey.jar \
+          -DgroupId=org.dogtagpki \
+          -DartifactId=jss-symkey \
+          -Dversion=5.3.0-SNAPSHOT \
+          -Dpackaging=jar \
+          -DgeneratePom=true
+    displayName: Install JSS into Maven repo
+
+  - script: |
+      mvn install:install-file \
+          -Dfile=/usr/share/java/tomcatjss.jar \
+          -DgroupId=org.dogtagpki \
+          -DartifactId=tomcatjss \
+          -Dversion=8.3.0-SNAPSHOT \
+          -Dpackaging=jar \
+          -DgeneratePom=true
+    displayName: Install Tomcat JSS into Maven repo
+
+  - script: |
+      mvn install:install-file \
+          -Dfile=/usr/share/java/ldapjdk.jar \
+          -DgroupId=org.dogtagpki \
+          -DartifactId=ldapjdk \
+          -Dversion=5.3.0-SNAPSHOT \
+          -Dpackaging=jar \
+          -DgeneratePom=true
+    displayName: Install LDAP JDK into Maven repo
+
+  - script: |
+      mvn package -DskipTests
+    displayName: Build PKI with Maven
+
+  - script: |
+      jar tvf build/dist/pki-cmsutil.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      jar tvf base/util/target/pki-util-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      diff cmake.out maven.out
+    displayName: Compare pki-util.jar
+
+  - script: |
+      jar tvf build/dist/pki-tools.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      jar tvf base/tools/target/pki-tools-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      diff cmake.out maven.out
+    displayName: Compare pki-tools.jar
+
+  - script: |
+      jar tvf build/dist/pki-ca.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      jar tvf base/ca/target/pki-ca-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      diff cmake.out maven.out
+    displayName: Compare pki-ca.jar
+
+  - script: |
+      jar tvf build/dist/pki-kra.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      jar tvf base/kra/target/pki-kra-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      diff cmake.out maven.out
+    displayName: Compare pki-kra.jar
+
+  - script: |
+      jar tvf build/dist/pki-ocsp.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      jar tvf base/ocsp/target/pki-ocsp-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      diff cmake.out maven.out
+    displayName: Compare pki-ocsp.jar
+
+  - script: |
+      jar tvf build/dist/pki-tks.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      jar tvf base/tks/target/pki-tks-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      diff cmake.out maven.out
+    displayName: Compare pki-tks.jar
+
+  - script: |
+      jar tvf build/dist/pki-tps.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      jar tvf base/tps/target/pki-tps-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      diff cmake.out maven.out
+    displayName: Compare pki-tps.jar
+
+  - script: |
+      jar tvf build/dist/pki-acme.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      jar tvf base/acme/target/pki-acme-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      diff cmake.out maven.out
+    displayName: Compare pki-acme.jar
+
+  - script: |
       docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner ./build.sh \
-          --python-dir=/usr/lib/python3.10/site-packages dist
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner ./build.sh install
-    displayName: Build and install PKI
+          --work-dir=build \
+          install
+    displayName: Install PKI
 
   - script: |
       # generate CSR

--- a/base/acme/pom.xml
+++ b/base/acme/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-acme</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/ca/pom.xml
+++ b/base/ca/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-ca</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/common/pom.xml
+++ b/base/common/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-common</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/kra/pom.xml
+++ b/base/kra/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-kra</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/ocsp/pom.xml
+++ b/base/ocsp/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-ocsp</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-base</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>util</module>
+        <module>common</module>
+        <module>tools</module>
+        <module>tomcat</module>
+        <module>tomcat-9.0</module>
+        <module>server</module>
+        <module>ca</module>
+        <module>kra</module>
+        <module>ocsp</module>
+        <module>tks</module>
+        <module>tps</module>
+        <module>acme</module>
+    </modules>
+
+</project>

--- a/base/server/pom.xml
+++ b/base/server/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-server</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-tomcat-9.0</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/tks/pom.xml
+++ b/base/tks/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-tks</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/tomcat-9.0/pom.xml
+++ b/base/tomcat-9.0/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-tomcat-9.0</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-tomcat</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/tomcat/pom.xml
+++ b/base/tomcat/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-tomcat</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/tools/pom.xml
+++ b/base/tools/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-tools</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>KRATool.cfg</exclude>
+                </excludes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+    </build>
+
+</project>

--- a/base/tps/pom.xml
+++ b/base/tps/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-tps</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/base/util/pom.xml
+++ b/base/util/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki</groupId>
+        <artifactId>pki-base</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-util</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,63 +6,101 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki</groupId>
     <artifactId>pki</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <revision>11.3.0-SNAPSHOT</revision>
+    </properties>
+
+    <modules>
+        <module>base</module>
+    </modules>
 
     <dependencies>
 
         <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.11</version>
-            <scope>runtime</scope>
+            <version>1.15</version>
         </dependency>
 
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
-            <scope>runtime</scope>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>
-            <groupId>commons-lang3</groupId>
+            <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.11</version>
-            <scope>runtime</scope>
+            <version>3.12.0</version>
         </dependency>
 
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>
-            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
-            <scope>runtime</scope>
+            <version>1.7.32</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
-            <scope>runtime</scope>
+            <version>1.7.32</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.10</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-servlet-api</artifactId>
+            <version>9.0.50</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>9.0.50</version>
         </dependency>
 
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.2.12</version>
+            <version>2.3.0</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -70,93 +108,124 @@
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
             <version>1.0.0.Final</version>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.3.0.Final</version>
-            <scope>runtime</scope>
+            <version>3.4.1.Final</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.1</version>
-            <scope>runtime</scope>
+            <version>2.11.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.1</version>
-            <scope>runtime</scope>
+            <version>2.11.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
-            <scope>runtime</scope>
+            <version>2.11.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
-            <version>2.10.1</version>
-            <scope>runtime</scope>
+            <version>2.11.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.10.1</version>
-            <scope>runtime</scope>
+            <version>2.11.4</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
-            <version>2.10.1</version>
-            <scope>runtime</scope>
+            <version>2.11.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.0.19.Final</version>
-            <scope>runtime</scope>
+            <version>3.0.26.Final</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.0.19.Final</version>
-            <scope>runtime</scope>
+            <version>3.0.26.Final</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.19.Final</version>
-            <scope>runtime</scope>
+            <version>3.0.26.Final</version>
         </dependency>
 
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
             <version>1.4.01</version>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>xml-resolver</groupId>
             <artifactId>xml-resolver</artifactId>
             <version>1.2</version>
-            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jss</artifactId>
+            <version>5.3.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jss-symkey</artifactId>
+            <version>5.3.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tomcatjss</artifactId>
+            <version>8.3.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>ldapjdk</artifactId>
+            <version>5.3.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
New `pom.xml` files have been added to define Maven modules for PKI. The dependencies have also been updated to match the available packages on Fedora.

The build test has been updated to build PKI with Maven and compare the build artifacts with the original CMake build artifacts.

**Note:** Some of Maven build artifacts (e.g. `pki-server.jar`) do not have matching CMake build artifacts (e.g. `pki-cms.jar`, `pki-cmsbundle.jar`) so they cannot be compared directly. This will be addressed in the future.

Azure pipeline:
https://dev.azure.com/dogtagpki/pki/_build?definitionId=2