### PR TITLE
Update pki nss-key-create/find to support AES

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -478,6 +478,62 @@ jobs:
           diff sslserver_key_id new_sslserver_key_id
 
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
+  pki-nss-aes-test:
+    name: Testing PKI NSS CLI with AES
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-tools-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-tools-runner.tar
+
+      - name: Set up runner container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Check pki nss-key-create
+        run: |
+          docker exec pki pki nss-key-create --key-type AES test | tee output
+
+          echo "Nickname: test" > expected
+          echo "Type: AES" >> expected
+          echo "Algorithm: AES" >> expected
+
+          sed -n 's/^\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          # verify with tkstool
+          docker exec pki tkstool -L -d /root/.dogtag/nssdb | tee output
+          echo "test" > expected
+          sed -n 's/^\s*<.\+>\s\+\(\S\+\)\s*$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check pki nss-key-find
+        run: |
+          docker exec pki pki nss-key-find | tee output
+
+          echo "Nickname: test" > expected
+          echo "Type: AES" >> expected
+          echo "Algorithm: AES" >> expected
+
+          sed -n 's/^\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+  # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-hsm-test:
     name: Testing PKI NSS CLI with HSM
     needs: [init, build]

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyInfo.java
@@ -41,8 +41,9 @@ public class KeyInfo implements JSONSerializer {
 
     protected String clientKeyID;
 
+    protected String nickname;
     protected String status;
-
+    protected String type;
     protected String algorithm;
 
     protected Integer size;
@@ -95,12 +96,28 @@ public class KeyInfo implements JSONSerializer {
         this.clientKeyID = clientKeyID;
     }
 
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
     public String getStatus() {
         return status;
     }
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     public String getAlgorithm() {
@@ -170,11 +187,13 @@ public class KeyInfo implements JSONSerializer {
         result = prime * result + ((clientKeyID == null) ? 0 : clientKeyID.hashCode());
         result = prime * result + ((keyId == null) ? 0 : keyId.hashCode());
         result = prime * result + ((keyURL == null) ? 0 : keyURL.hashCode());
+        result = prime * result + ((nickname == null) ? 0 : nickname.hashCode());
         result = prime * result + ((ownerName == null) ? 0 : ownerName.hashCode());
         result = prime * result + ((publicKey == null) ? 0 : publicKey.hashCode());
         result = prime * result + ((realm == null) ? 0 : realm.hashCode());
         result = prime * result + ((size == null) ? 0 : size.hashCode());
         result = prime * result + ((status == null) ? 0 : status.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
         return result;
     }
 
@@ -207,6 +226,11 @@ public class KeyInfo implements JSONSerializer {
                 return false;
         } else if (!keyURL.equals(other.keyURL))
             return false;
+        if (nickname == null) {
+            if (other.nickname != null)
+                return false;
+        } else if (!nickname.equals(other.nickname))
+            return false;
         if (ownerName == null) {
             if (other.ownerName != null)
                 return false;
@@ -231,6 +255,11 @@ public class KeyInfo implements JSONSerializer {
             if (other.status != null)
                 return false;
         } else if (!status.equals(other.status))
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
             return false;
         return true;
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCLI.java
@@ -24,7 +24,16 @@ public class NSSKeyCLI extends CLI {
     public static void printKeyInfo(KeyInfo keyInfo) throws Exception {
 
         KeyId keyID = keyInfo.getKeyId();
-        System.out.println("  Key ID: " + keyID.toHexString());
+        if (keyID != null) {
+            System.out.println("  Key ID: " + keyID.toHexString());
+        }
+
+        String nickname = keyInfo.getNickname();
+        if (nickname != null) {
+            System.out.println("  Nickname: " + nickname);
+        }
+
+        System.out.println("  Type: " + keyInfo.getType());
         System.out.println("  Algorithm: " + keyInfo.getAlgorithm());
     }
 }


### PR DESCRIPTION
The `pki nss-key-create` command has been updated to support creating AES key. The `pki nss-key-find` command has been updated to include symmetric keys in the result. A new test has been added to validate these changes.

This PR depends on JSS PR [#871](https://github.com/dogtagpki/jss/pull/871).