### PR TITLE
Add WebListener classes

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -29,9 +29,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.annotation.WebListener;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -73,8 +70,7 @@ import com.netscape.cms.tomcat.ProxyRealm;
 /**
  * @author Endi S. Dewata
  */
-@WebListener
-public class ACMEEngine implements ServletContextListener {
+public class ACMEEngine {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEEngine.class);
 
@@ -1091,36 +1087,5 @@ public class ACMEEngine implements ServletContextListener {
         }
 
         return identifiers;
-    }
-
-    @Override
-    public void contextInitialized(ServletContextEvent event) {
-
-        String path = event.getServletContext().getContextPath();
-        if ("".equals(path)) {
-            id = "ROOT";
-        } else {
-            id = path.substring(1);
-        }
-
-        try {
-            start();
-
-        } catch (Exception e) {
-            logger.error("Unable to start ACME engine: " + e.getMessage(), e);
-            throw new RuntimeException("Unable to start ACME engine: " + e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public void contextDestroyed(ServletContextEvent event) {
-
-        try {
-            stop();
-
-        } catch (Exception e) {
-            logger.error("Unable to stop ACME engine: " + e.getMessage(), e);
-            throw new RuntimeException("Unable to stop ACME engine: " + e.getMessage(), e);
-        }
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEWebListener.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEWebListener.java
@@ -1,0 +1,60 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.acme.server;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import com.netscape.certsrv.base.PKIException;
+
+@WebListener
+public class ACMEWebListener implements ServletContextListener {
+
+    public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEWebListener.class);
+
+    public ACMEEngine createEngine() {
+        return new ACMEEngine();
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+
+        String path = event.getServletContext().getContextPath();
+        String id;
+
+        if ("".equals(path)) {
+            id = "ROOT";
+        } else {
+            id = path.substring(1);
+        }
+
+        ACMEEngine engine = createEngine();
+        engine.setID(id);
+
+        try {
+            engine.start();
+
+        } catch (Exception e) {
+            logger.error("Unable to start ACME engine: " + e.getMessage(), e);
+            throw new PKIException("Unable to start ACME engine: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+
+        ACMEEngine engine = ACMEEngine.getInstance();
+
+        try {
+            engine.stop();
+
+        } catch (Exception e) {
+            logger.error("Unable to stop ACME engine: " + e.getMessage(), e);
+            throw new PKIException("Unable to stop ACME engine: " + e.getMessage(), e);
+        }
+    }
+}

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -34,8 +34,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import javax.servlet.annotation.WebListener;
-
 import org.apache.commons.lang3.StringUtils;
 import org.dogtagpki.legacy.ca.CAPolicy;
 import org.dogtagpki.server.authentication.AuthToken;
@@ -105,7 +103,6 @@ import netscape.ldap.LDAPModification;
 import netscape.ldap.LDAPModificationSet;
 import netscape.ldap.LDAPSearchResults;
 
-@WebListener
 public class CAEngine extends CMSEngine {
 
     protected CertificateRepository certificateRepository;
@@ -168,7 +165,7 @@ public class CAEngine extends CMSEngine {
     protected boolean foundHostCA;
     protected AuthorityMonitor authorityMonitor;
 
-    public CAEngine() throws Exception {
+    public CAEngine() {
         super("CA");
     }
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAWebListener.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAWebListener.java
@@ -1,0 +1,18 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ca;
+
+import javax.servlet.annotation.WebListener;
+
+import com.netscape.cmscore.apps.PKIWebListener;
+
+@WebListener
+public class CAWebListener extends PKIWebListener {
+
+    public CAEngine createEngine() {
+        return new CAEngine();
+    }
+}

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/KRAEngine.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/KRAEngine.java
@@ -18,8 +18,6 @@
 
 package org.dogtagpki.server.kra;
 
-import javax.servlet.annotation.WebListener;
-
 import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
@@ -29,10 +27,9 @@ import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.request.KeyRequestRepository;
 import com.netscape.kra.KeyRecoveryAuthority;
 
-@WebListener
 public class KRAEngine extends CMSEngine {
 
-    public KRAEngine() throws Exception {
+    public KRAEngine() {
         super("KRA");
     }
 

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/KRAWebListener.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/KRAWebListener.java
@@ -1,0 +1,18 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.kra;
+
+import javax.servlet.annotation.WebListener;
+
+import com.netscape.cmscore.apps.PKIWebListener;
+
+@WebListener
+public class KRAWebListener extends PKIWebListener {
+
+    public KRAEngine createEngine() {
+        return new KRAEngine();
+    }
+}

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
@@ -18,8 +18,6 @@
 
 package org.dogtagpki.server.ocsp;
 
-import javax.servlet.annotation.WebListener;
-
 import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
@@ -28,10 +26,9 @@ import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.ocsp.OCSPAuthority;
 
-@WebListener
 public class OCSPEngine extends CMSEngine {
 
-    public OCSPEngine() throws Exception {
+    public OCSPEngine() {
         super("OCSP");
     }
 

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPWebListener.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPWebListener.java
@@ -1,0 +1,18 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ocsp;
+
+import javax.servlet.annotation.WebListener;
+
+import com.netscape.cmscore.apps.PKIWebListener;
+
+@WebListener
+public class OCSPWebListener extends PKIWebListener {
+
+    public OCSPEngine createEngine() {
+        return new OCSPEngine();
+    }
+}

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -35,8 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
 import javax.servlet.http.HttpServlet;
 
 import org.apache.commons.lang3.StringUtils;
@@ -60,9 +58,7 @@ import com.netscape.certsrv.notification.IMailNotification;
 import com.netscape.certsrv.password.IPasswordCheck;
 import com.netscape.certsrv.request.IRequestListener;
 import com.netscape.certsrv.request.RequestStatus;
-import com.netscape.cms.realm.PKIRealm;
 import com.netscape.cms.servlet.common.CMSRequest;
-import com.netscape.cms.tomcat.ProxyRealm;
 import com.netscape.cmscore.authentication.AuthSubsystem;
 import com.netscape.cmscore.authentication.VerifiedCert;
 import com.netscape.cmscore.authentication.VerifiedCerts;
@@ -105,7 +101,7 @@ import com.netscape.cmsutil.util.NuxwdogUtil;
 import netscape.ldap.LDAPConnection;
 import netscape.ldap.LDAPException;
 
-public class CMSEngine implements ServletContextListener {
+public class CMSEngine {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CMSEngine.class);
 
@@ -178,12 +174,13 @@ public class CMSEngine implements ServletContextListener {
     private static final int PW_CANNOT_CONNECT = 3;
     private static final int PW_MAX_ATTEMPTS = 3;
 
-
     public CMSEngine(String name) {
         this.id = name.toLowerCase();
         this.name = name;
 
         logger.info("Creating " + name + " engine");
+
+        CMS.setCMSEngine(this);
     }
 
     public String getID() {
@@ -1720,40 +1717,5 @@ public class CMSEngine implements ServletContextListener {
                 logger.warn("debugSleep: sleep out:" + e.toString());
             }
         }
-    }
-
-    @Override
-    public void contextInitialized(ServletContextEvent event) {
-
-        logger.info("CMSEngine: Servlet context initialized");
-
-        String path = event.getServletContext().getContextPath();
-        if ("".equals(path)) {
-            id = "ROOT";
-        } else {
-            id = path.substring(1);
-        }
-
-        CMS.setCMSEngine(this);
-
-        try {
-            start();
-
-        } catch (Exception e) {
-            logger.error("Unable to start " + name + " engine: " + e.getMessage(), e);
-            shutdown();
-            throw new RuntimeException("Unable to start " + name + " engine: " + e.getMessage(), e);
-        }
-
-        // Register realm for this subsystem
-        ProxyRealm.registerRealm(id, new PKIRealm());
-    }
-
-    @Override
-    public void contextDestroyed(ServletContextEvent event) {
-
-        logger.info("CMSEngine: Servlet context destroyed");
-
-        shutdown();
     }
 }

--- a/base/server/src/main/java/com/netscape/cmscore/apps/PKIWebListener.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/PKIWebListener.java
@@ -1,0 +1,57 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmscore.apps;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import com.netscape.certsrv.base.PKIException;
+import com.netscape.cms.realm.PKIRealm;
+import com.netscape.cms.tomcat.ProxyRealm;
+
+public abstract class PKIWebListener implements ServletContextListener {
+
+    public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIWebListener.class);
+
+    public abstract CMSEngine createEngine();
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+
+        String path = event.getServletContext().getContextPath();
+        String id;
+
+        if ("".equals(path)) {
+            id = "ROOT";
+        } else {
+            id = path.substring(1);
+        }
+
+        CMSEngine engine = createEngine();
+        engine.setID(id);
+
+        String name = engine.getName();
+
+        try {
+            engine.start();
+
+        } catch (Exception e) {
+            logger.error("Unable to start " + name + " engine: " + e.getMessage(), e);
+            engine.shutdown();
+            throw new PKIException("Unable to start " + name + " engine: " + e.getMessage(), e);
+        }
+
+        // Register realm for this subsystem
+        ProxyRealm.registerRealm(id, new PKIRealm());
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+
+        CMSEngine engine = CMS.getCMSEngine();
+        engine.shutdown();
+    }
+}

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/TKSEngine.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/TKSEngine.java
@@ -18,8 +18,6 @@
 
 package org.dogtagpki.server.tks;
 
-import javax.servlet.annotation.WebListener;
-
 import com.netscape.certsrv.base.ISubsystem;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
@@ -28,10 +26,9 @@ import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.tks.TKSAuthority;
 
-@WebListener
 public class TKSEngine extends CMSEngine {
 
-    public TKSEngine() throws Exception {
+    public TKSEngine() {
         super("TKS");
     }
 

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/TKSWebListener.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/TKSWebListener.java
@@ -1,0 +1,18 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.tks;
+
+import javax.servlet.annotation.WebListener;
+
+import com.netscape.cmscore.apps.PKIWebListener;
+
+@WebListener
+public class TKSWebListener extends PKIWebListener {
+
+    public TKSEngine createEngine() {
+        return new TKSEngine();
+    }
+}

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSEngine.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSEngine.java
@@ -18,17 +18,14 @@
 
 package org.dogtagpki.server.tps;
 
-import javax.servlet.annotation.WebListener;
-
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStorage;
 
-@WebListener
 public class TPSEngine extends CMSEngine {
 
-    public TPSEngine() throws Exception {
+    public TPSEngine() {
         super("TPS");
     }
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSWebListener.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSWebListener.java
@@ -1,0 +1,18 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.tps;
+
+import javax.servlet.annotation.WebListener;
+
+import com.netscape.cmscore.apps.PKIWebListener;
+
+@WebListener
+public class TPSWebListener extends PKIWebListener {
+
+    public TPSEngine createEngine() {
+        return new TPSEngine();
+    }
+}


### PR DESCRIPTION
Previously the engine classes were marked as `WebListeners` so the the engine instances would be created and destroyed automatically by Tomcat. However, this also means that it's not possible to customize the engine using a custom class.

To avoid the problem, new `WebListener` classes have been added which will explicitly create and destroy the engine instances. This way it will be possible to add a config parameter that will specify the custom engine class in the future.

**Note:** Currently the `ACMEEngine` does not inherit from `CMSEngine` so the `ACMEWebListener` cannot inherit from `PKIWebListener` either. In the future it might be possible to merge these classes.