### PR TITLE
Add SigningUnitConfig

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CASigningUnit.java
+++ b/base/ca/src/main/java/com/netscape/ca/CASigningUnit.java
@@ -35,9 +35,9 @@ import com.netscape.certsrv.base.EPropertyNotFound;
 import com.netscape.certsrv.ca.CAMissingCertException;
 import com.netscape.certsrv.ca.CAMissingKeyException;
 import com.netscape.certsrv.ca.ECAException;
+import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.certsrv.security.SigningUnit;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -55,11 +55,11 @@ public final class CASigningUnit extends SigningUnit {
 
     @Override
     public void updateConfig(String nickname, String tokenname) {
-        mConfig.putString(PROP_CA_CERT_NICKNAME, nickname);
-        mConfig.putString(PROP_TOKEN_NAME, tokenname);
+        mConfig.setCACertNickname(nickname);
+        mConfig.setTokenName(tokenname);
     }
 
-    public void init(ConfigStore config, String nickname) throws EBaseException {
+    public void init(SigningUnitConfig config, String nickname) throws EBaseException {
 
         logger.debug("CASigningUnit.init(" + config.getName() + ", " + nickname + ")");
 
@@ -71,15 +71,15 @@ public final class CASigningUnit extends SigningUnit {
 
             if (nickname == null) {
                 try {
-                    mNickname = mConfig.getString(PROP_CERT_NICKNAME);
+                    mNickname = mConfig.getCertNickname();
                 } catch (EPropertyNotFound e) {
-                    mNickname = mConfig.getString(PROP_CA_CERT_NICKNAME);
+                    mNickname = mConfig.getCACertNickname();
                 }
             } else {
                 mNickname = nickname;
             }
 
-            tokenname = config.getString(PROP_TOKEN_NAME);
+            tokenname = config.getTokenName();
             mToken = CryptoUtil.getKeyStorageToken(tokenname);
             if (!CryptoUtil.isInternalToken(tokenname)) {
                 mNickname = tokenname + ":" + mNickname;
@@ -112,7 +112,7 @@ public final class CASigningUnit extends SigningUnit {
             mPubk = mCert.getPublicKey();
 
             // get def alg and check if def sign alg is valid for token.
-            mDefSigningAlgname = config.getString(PROP_DEFAULT_SIGNALG);
+            mDefSigningAlgname = config.getDefaultSigningAlgorithm();
             mDefSigningAlgorithm = checkSigningAlgorithmFromName(mDefSigningAlgname);
             logger.debug("SigningUnit: signing algorithm: " + mDefSigningAlgorithm);
 
@@ -177,7 +177,7 @@ public final class CASigningUnit extends SigningUnit {
 
         logger.info("CASigningUnit: Signing Certificate");
 
-        boolean testSignatureFailure = mConfig.getBoolean("testSignatureFailure", false);
+        boolean testSignatureFailure = mConfig.getTestSignatureFailure();
         if (testSignatureFailure) {
             throw new SignatureException("SignatureException forced for testing");
         }

--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -113,6 +113,7 @@ import com.netscape.certsrv.logging.event.CertSigningInfoEvent;
 import com.netscape.certsrv.logging.event.OCSPSigningInfoEvent;
 import com.netscape.certsrv.ocsp.IOCSPService;
 import com.netscape.certsrv.request.RequestStatus;
+import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.certsrv.util.IStatsSubsystem;
 import com.netscape.cms.logging.Logger;
 import com.netscape.cms.logging.SignedAuditLogger;
@@ -1199,7 +1200,7 @@ public class CertificateAuthority implements IAuthority, ICertificateAuthority, 
 
         logger.info("CertificateAuthority: Initializing cert signing unit");
 
-        ConfigStore caSigningCfg = mConfig.getSubStore(PROP_SIGNING_SUBSTORE, ConfigStore.class);
+        SigningUnitConfig caSigningCfg = mConfig.getSigningUnitConfig();
 
         mSigningUnit = new CASigningUnit();
         mSigningUnit.init(caSigningCfg, mNickname);
@@ -1245,7 +1246,7 @@ public class CertificateAuthority implements IAuthority, ICertificateAuthority, 
 
         logger.info("CertificateAuthority: Initializing CRL signing unit");
 
-        ConfigStore crlSigningConfig = mConfig.getSubStore(PROP_CRL_SIGNING_SUBSTORE, ConfigStore.class);
+        SigningUnitConfig crlSigningConfig = mConfig.getCRLSigningUnitConfig();
 
         if (hostCA && crlSigningConfig != null && crlSigningConfig.size() > 0) {
             mCRLSigningUnit = new CASigningUnit();
@@ -1273,7 +1274,7 @@ public class CertificateAuthority implements IAuthority, ICertificateAuthority, 
 
         logger.info("CertificateAuthority: Initializing OCSP signing unit");
 
-        ConfigStore ocspSigningConfig = mConfig.getSubStore(PROP_OCSP_SIGNING_SUBSTORE, ConfigStore.class);
+        SigningUnitConfig ocspSigningConfig = mConfig.getOCSPSigningUnitConfig();
 
         if (hostCA && ocspSigningConfig != null && ocspSigningConfig.size() > 0) {
             mOCSPSigningUnit = new CASigningUnit();

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAConfig.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAConfig.java
@@ -5,11 +5,15 @@
 //
 package org.dogtagpki.server.ca;
 
+import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.base.SimpleProperties;
 import com.netscape.cmscore.ldap.PublishingConfig;
 
+/**
+ * Provides ca.* parameters.
+ */
 public class CAConfig extends ConfigStore {
 
     public CAConfig(ConfigStorage storage) {
@@ -22,5 +26,26 @@ public class CAConfig extends ConfigStore {
 
     public PublishingConfig getPublishingConfig() {
         return getSubStore("publish", PublishingConfig.class);
+    }
+
+    /**
+     * Returns ca.signing.* parameters.
+     */
+    public SigningUnitConfig getSigningUnitConfig() {
+        return getSubStore("signing", SigningUnitConfig.class);
+    }
+
+    /**
+     * Returns ca.ocsp_signing.* parameters.
+     */
+    public SigningUnitConfig getOCSPSigningUnitConfig() {
+        return getSubStore("ocsp_signing", SigningUnitConfig.class);
+    }
+
+    /**
+     * Returns ca.crl_signing.* parameters.
+     */
+    public SigningUnitConfig getCRLSigningUnitConfig() {
+        return getSubStore("crl_signing", SigningUnitConfig.class);
     }
 }

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CAInstallerService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CAInstallerService.java
@@ -49,6 +49,7 @@ import com.netscape.ca.CertificateAuthority;
 import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.request.RequestId;
+import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.certsrv.system.CertificateSetupRequest;
 import com.netscape.certsrv.system.SystemCertData;
 import com.netscape.cms.servlet.csadmin.BootstrapProfile;
@@ -237,7 +238,7 @@ public class CAInstallerService extends SystemConfigService {
             } else { // certType == local
 
                 CAConfig caConfig = engineConfig.getCAConfig();
-                ConfigStore caSigningCfg = caConfig.getSubStore("signing", ConfigStore.class);
+                SigningUnitConfig caSigningCfg = caConfig.getSigningUnitConfig();
 
                 // create CA signing unit
                 CASigningUnit signingUnit = new CASigningUnit();

--- a/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
+++ b/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
@@ -57,6 +57,7 @@ import com.netscape.certsrv.ocsp.IOCSPAuthority;
 import com.netscape.certsrv.ocsp.IOCSPService;
 import com.netscape.certsrv.ocsp.IOCSPStore;
 import com.netscape.certsrv.security.SigningUnit;
+import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.certsrv.util.IStatsSubsystem;
 import com.netscape.cms.logging.Logger;
 import com.netscape.cms.logging.SignedAuditLogger;
@@ -309,8 +310,10 @@ public class OCSPAuthority implements IOCSPAuthority, IOCSPService, IAuthority {
 
         logger.info("OCSPAuthority: Initializing OCSP signing unit");
 
+        SigningUnitConfig ocspSigningConfig = mConfig.getSigningUnitConfig();
+
         mSigningUnit = new OCSPSigningUnit();
-        mSigningUnit.init(mConfig.getSubStore(PROP_SIGNING_SUBSTORE, ConfigStore.class));
+        mSigningUnit.init(ocspSigningConfig);
 
         getOCSPSigningAlgorithms();
     }

--- a/base/ocsp/src/main/java/com/netscape/ocsp/OCSPSigningUnit.java
+++ b/base/ocsp/src/main/java/com/netscape/ocsp/OCSPSigningUnit.java
@@ -29,9 +29,9 @@ import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.certsrv.security.SigningUnit;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -49,11 +49,11 @@ public final class OCSPSigningUnit extends SigningUnit {
 
     @Override
     public void updateConfig(String nickname, String tokenname) {
-        mConfig.putString(PROP_CERT_NICKNAME, nickname);
-        mConfig.putString(PROP_TOKEN_NAME, tokenname);
+        mConfig.setCertNickname(nickname);
+        mConfig.setTokenName(tokenname);
     }
 
-    public void init(ConfigStore config) throws EBaseException {
+    public void init(SigningUnitConfig config) throws EBaseException {
 
         logger.debug("OCSPSigningUnit.init(" + config.getName() + ")");
 
@@ -64,9 +64,9 @@ public final class OCSPSigningUnit extends SigningUnit {
         try {
             mManager = CryptoManager.getInstance();
 
-            mNickname = config.getString(PROP_CERT_NICKNAME);
+            mNickname = config.getCertNickname();
 
-            tokenname = config.getString(PROP_TOKEN_NAME);
+            tokenname = config.getTokenName();
             mToken = CryptoUtil.getKeyStorageToken(tokenname);
             if (!CryptoUtil.isInternalToken(tokenname)) {
                 mNickname = tokenname + ":" + mNickname;
@@ -89,7 +89,7 @@ public final class OCSPSigningUnit extends SigningUnit {
             mPubk = mCert.getPublicKey();
 
             // get def alg and check if def sign alg is valid for token.
-            mDefSigningAlgname = config.getString(PROP_DEFAULT_SIGNALG);
+            mDefSigningAlgname = config.getDefaultSigningAlgorithm();
             mDefSigningAlgorithm = checkSigningAlgorithmFromName(mDefSigningAlgname);
             logger.debug("SigningUnit: signing algorithm: " + mDefSigningAlgorithm);
 

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPConfig.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPConfig.java
@@ -5,10 +5,14 @@
 //
 package org.dogtagpki.server.ocsp;
 
+import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.base.SimpleProperties;
 
+/**
+ * Provides ocsp.* parameters.
+ */
 public class OCSPConfig extends ConfigStore {
 
     public OCSPConfig(ConfigStorage storage) {
@@ -17,5 +21,12 @@ public class OCSPConfig extends ConfigStore {
 
     public OCSPConfig(String name, SimpleProperties source) {
         super(name, source);
+    }
+
+    /**
+     * Returns ocsp.signing.* parameters.
+     */
+    public SigningUnitConfig getSigningUnitConfig() {
+        return getSubStore("signing", SigningUnitConfig.class);
     }
 }

--- a/base/server/src/main/java/com/netscape/certsrv/ocsp/IOCSPAuthority.java
+++ b/base/server/src/main/java/com/netscape/certsrv/ocsp/IOCSPAuthority.java
@@ -41,7 +41,6 @@ public interface IOCSPAuthority extends ISubsystem {
 
     public final static String PROP_DEF_STORE_ID = "storeId";
     public final static String PROP_STORE = "store";
-    public final static String PROP_SIGNING_SUBSTORE = "signing";
     public static final String PROP_NICKNAME = "certNickname";
     public final static String PROP_NEW_NICKNAME = "newNickname";
 

--- a/base/server/src/main/java/com/netscape/certsrv/security/SigningUnit.java
+++ b/base/server/src/main/java/com/netscape/certsrv/security/SigningUnit.java
@@ -38,7 +38,6 @@ import org.mozilla.jss.netscape.security.x509.X509Key;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.ca.ECAException;
-import com.netscape.cmscore.base.ConfigStore;
 
 /**
  * A class represents the signing unit which is
@@ -49,21 +48,6 @@ import com.netscape.cmscore.base.ConfigStore;
 public abstract class SigningUnit {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SigningUnit.class);
-
-    public static final String PROP_DEFAULT_SIGNALG = "defaultSigningAlgorithm";
-
-    /**
-     * @deprecated The cacertnickname has been replaced with certnickname.
-     *
-     * TODO: Remove cacertnickname property from existing instances with
-     * an upgrade script.
-     */
-    @Deprecated
-    public static final String PROP_CA_CERT_NICKNAME = "cacertnickname";
-    public static final String PROP_CERT_NICKNAME = "certnickname";
-
-    public static final String PROP_TOKEN_NAME = "tokenname";
-    public static final String PROP_NEW_NICKNAME = "newNickname";
 
     protected CryptoManager mManager;
     protected CryptoToken mToken;
@@ -76,7 +60,7 @@ public abstract class SigningUnit {
     protected String mNickname;
 
     protected boolean mInited;
-    protected ConfigStore mConfig;
+    protected SigningUnitConfig mConfig;
 
     protected String mDefSigningAlgname;
     protected SignatureAlgorithm mDefSigningAlgorithm;
@@ -95,7 +79,7 @@ public abstract class SigningUnit {
      * @exception EBaseException failed to get new nickname
      */
     public String getNewNickName() throws EBaseException {
-        return mConfig.getString(PROP_NEW_NICKNAME, "");
+        return mConfig.getNewNickname();
     }
 
     /**
@@ -104,7 +88,7 @@ public abstract class SigningUnit {
      * @param name nickname
      */
     public void setNewNickName(String name) {
-        mConfig.putString(PROP_NEW_NICKNAME, name);
+        mConfig.setNewNickname(name);
     }
 
     /**
@@ -192,7 +176,7 @@ public abstract class SigningUnit {
      * @exception EBaseException failed to set default signing algorithm
      */
     public void setDefaultAlgorithm(String algorithm) throws EBaseException {
-        mConfig.putString(PROP_DEFAULT_SIGNALG, algorithm);
+        mConfig.setDefaultSigningAlgorithm(algorithm);
         mDefSigningAlgname = algorithm;
         logger.info("Default signing algorithm is set to " + algorithm);
     }
@@ -228,7 +212,7 @@ public abstract class SigningUnit {
      * @exception EBaseException failed to retrieve name
      */
     public String getTokenName() throws EBaseException {
-        return mConfig.getString(PROP_TOKEN_NAME);
+        return mConfig.getTokenName();
     }
 
     /**

--- a/base/server/src/main/java/com/netscape/certsrv/security/SigningUnitConfig.java
+++ b/base/server/src/main/java/com/netscape/certsrv/security/SigningUnitConfig.java
@@ -1,0 +1,80 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.certsrv.security;
+
+import com.netscape.certsrv.base.EBaseException;
+import com.netscape.cmscore.base.ConfigStorage;
+import com.netscape.cmscore.base.ConfigStore;
+import com.netscape.cmscore.base.SimpleProperties;
+
+public class SigningUnitConfig extends ConfigStore {
+
+    public SigningUnitConfig(ConfigStorage storage) {
+        super(storage);
+    }
+
+    public SigningUnitConfig(String name, SimpleProperties source) {
+        super(name, source);
+    }
+
+    public String getCertNickname() throws EBaseException {
+        return getString("certnickname");
+    }
+
+    public void setCertNickname(String nickname) {
+        putString("certnickname", nickname);
+    }
+
+    /**
+     * @deprecated The cacertnickname has been replaced with certnickname.
+     *
+     * TODO: Remove cacertnickname property from existing instances with
+     * an upgrade script.
+     */
+    @Deprecated(since = "11.3.0", forRemoval = true)
+    public String getCACertNickname() throws EBaseException {
+        return getString("cacertnickname");
+    }
+
+    /**
+     * @deprecated The cacertnickname has been replaced with certnickname.
+     *
+     * TODO: Remove cacertnickname property from existing instances with
+     * an upgrade script.
+     */
+    @Deprecated(since = "11.3.0", forRemoval = true)
+    public void setCACertNickname(String nickname) {
+        putString("cacertnickname", nickname);
+    }
+
+    public String getNewNickname() throws EBaseException {
+        return getString("newNickname", "");
+    }
+
+    public void setNewNickname(String nickname) {
+        putString("newNickname", nickname);
+    }
+
+    public String getTokenName() throws EBaseException {
+        return getString("tokenname");
+    }
+
+    public void setTokenName(String tokenName) {
+        putString("tokenname", tokenName);
+    }
+
+    public boolean getTestSignatureFailure() throws EBaseException {
+        return getBoolean("testSignatureFailure", false);
+    }
+
+    public String getDefaultSigningAlgorithm() throws EBaseException {
+        return getString("defaultSigningAlgorithm");
+    }
+
+    public void setDefaultSigningAlgorithm(String algorithm) {
+        putString("defaultSigningAlgorithm", algorithm);
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/ca/ICertificateAuthority.java
+++ b/base/server/src/main/java/org/dogtagpki/server/ca/ICertificateAuthority.java
@@ -92,10 +92,7 @@ public interface ICertificateAuthority extends ISubsystem {
     public final static String PROP_ISSUER_NAME = "name";
     public final static String PROP_CA_NAMES = "CAs";
 
-    public final static String PROP_SIGNING_SUBSTORE = "signing";
     public final static String PROP_ENABLE_OCSP = "ocsp";
-    public final static String PROP_OCSP_SIGNING_SUBSTORE = "ocsp_signing";
-    public final static String PROP_CRL_SIGNING_SUBSTORE = "crl_signing";
     public final static String PROP_ID = "id";
 
     /**


### PR DESCRIPTION
The `SigningUnitConfig` class has been added to encapsulate the config params for CA, OCSP, and CRL signing units. The `SigningUnit` classes have been updated to use this class.