### PR TITLE
AuthorityService: recognise .../authorities/host-authority/(chain|cert)

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AuthorityService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AuthorityService.java
@@ -165,11 +165,13 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
 
         logger.info("AuthorityService: getting cert for authority " + aidString);
 
-        AuthorityID aid;
-        try {
-            aid = new AuthorityID(aidString);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException("Bad AuthorityID: " + aidString);
+        AuthorityID aid = null;
+        if (!AuthorityResource.HOST_AUTHORITY.equals(aidString)) {
+            try {
+                aid = new AuthorityID(aidString);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException("Bad AuthorityID: " + aidString);
+            }
         }
 
         CAEngine engine = CAEngine.getInstance();
@@ -202,11 +204,13 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
 
         logger.info("AuthorityService: getting cert chain for authority " + aidString);
 
-        AuthorityID aid;
-        try {
-            aid = new AuthorityID(aidString);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException("Bad AuthorityID: " + aidString);
+        AuthorityID aid = null;
+        if (!AuthorityResource.HOST_AUTHORITY.equals(aidString)) {
+            try {
+                aid = new AuthorityID(aidString);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException("Bad AuthorityID: " + aidString);
+            }
         }
 
         CAEngine engine = CAEngine.getInstance();


### PR DESCRIPTION
The LWCA REST API recognises the special identifier "host-authority"
in the getCA method, as well as as a parameter in some other methods
(e.g. nominating the parent CA when creating a new LWCA).  However,
"host-authority" is not recognised when retrieving the certificate
or certificate chain of a CA.  The following resources respond with
400 Bad Request because "host-authority" is not a UUID:

   /ca/rest/authorities/host-authority/(chain|cert)

Update these resources to recognise "host-authority" as referring to
the primary CA in the instance.

As well as being a general improvement to the API, this work was
undertaken specifically to make cert chain retrieval easier for the
EST service.

Related: https://github.com/dogtagpki/pki/issues/3297