### PR TITLE
AuthorityClient: add getChainPEM method

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
@@ -57,6 +57,11 @@ public class AuthorityClient extends Client {
         return client.getEntity(response, AuthorityData.class);
     }
 
+    public String getChainPEM(String caIDString) throws Exception {
+        Response response = proxy.getChainPEM(caIDString);
+        return client.getEntity(response, String.class);
+    }
+
     public AuthorityData createCA(AuthorityData data) throws Exception {
         Response response = proxy.createCA(data);
         return client.getEntity(response, AuthorityData.class);


### PR DESCRIPTION
Extend AuthorityClient with a method to retrieve the certificate
chain of a LWCA.

This enhancement is required by the EST feature.

Related: https://github.com/dogtagpki/pki/issues/3297