### PR TITLE
Add offline support for CAValidityDefault

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/profile/def/CAValidityDefault.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/def/CAValidityDefault.java
@@ -18,24 +18,35 @@
 package com.netscape.cms.profile.def;
 
 import java.io.IOException;
+import java.security.cert.CertificateException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
+import org.dogtagpki.server.ca.CAConfig;
 import org.dogtagpki.server.ca.CAEngine;
 import org.dogtagpki.server.ca.CAEngineConfig;
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.NotInitializedException;
+import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.mozilla.jss.crypto.TokenException;
+import org.mozilla.jss.crypto.X509Certificate;
 import org.mozilla.jss.netscape.security.x509.BasicConstraintsExtension;
 import org.mozilla.jss.netscape.security.x509.CertificateValidity;
 import org.mozilla.jss.netscape.security.x509.PKIXExtensions;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.mozilla.jss.netscape.security.x509.X509CertInfo;
 
+import com.netscape.ca.CASigningUnit;
 import com.netscape.ca.CertificateAuthority;
+import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.certsrv.property.Descriptor;
 import com.netscape.certsrv.property.EPropertyException;
 import com.netscape.certsrv.property.IDescriptor;
+import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.request.Request;
@@ -61,8 +72,6 @@ public class CAValidityDefault extends EnrollDefault {
 
     public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
-    public CertificateAuthority mCA;
-
     public CAValidityDefault() {
         super();
         addConfigName(CONFIG_RANGE);
@@ -78,8 +87,44 @@ public class CAValidityDefault extends EnrollDefault {
     @Override
     public void init(CAEngineConfig engineConfig, ConfigStore config) throws EProfileException {
         super.init(engineConfig, config);
+    }
+
+    public X509CertImpl getSigningCert() throws
+            EBaseException,
+            NotInitializedException,
+            TokenException,
+            CertificateException {
+
         CAEngine engine = CAEngine.getInstance();
-        mCA = engine.getCA();
+
+        if (engine != null) {
+
+            // if running inside server, get signing cert from signing unit object
+
+            CertificateAuthority ca = engine.getCA();
+            CASigningUnit signingUnit = ca.getSigningUnit();
+
+            if (signingUnit == null) {
+                return null;
+            }
+
+            return signingUnit.getCertImpl();
+        }
+
+        // if running outside of server, get signing cert from signing unit config
+
+        CAConfig caConfig = engineConfig.getCAConfig();
+        SigningUnitConfig signingUnitConfig = caConfig.getSigningUnitConfig();
+        String fullName = signingUnitConfig.getFullName();
+
+        try {
+            CryptoManager cm = CryptoManager.getInstance();
+            X509Certificate cert = cm.findCertByNickname(fullName);
+            return new X509CertImpl(cert.getEncoded());
+
+        } catch (ObjectNotFoundException e) {
+            return null;
+        }
     }
 
     @Override
@@ -233,9 +278,15 @@ public class CAValidityDefault extends EnrollDefault {
                             locale, "CMS_INVALID_PROPERTY", name));
             }
 
+            X509CertImpl signingCert;
+            try {
+                signingCert = getSigningCert();
+            } catch (Exception e) {
+                throw new EPropertyException("Unable to get CA signing certificate: " + e.getMessage(), e);
+            }
+
             // not to exceed CA's expiration
-            Date caNotAfter =
-                    mCA.getSigningUnit().getCertImpl().getNotAfter();
+            Date caNotAfter = signingCert.getNotAfter();
 
             if (notAfter.after(caNotAfter)) {
                 if (bypassCAvalidity == false) {
@@ -409,13 +460,20 @@ public class CAValidityDefault extends EnrollDefault {
          */
         boolean bypassCAvalidity = getConfigBoolean(CONFIG_BYPASS_CA_NOTAFTER);
         logger.debug(method + " populate: bypassCAvalidity=" + bypassCAvalidity);
+
+        X509CertImpl signingCert;
+        try {
+            signingCert = getSigningCert();
+        } catch (Exception e) {
+            throw new EProfileException("Unable to get CA signing certificate: " + e.getMessage(), e);
+        }
+
         // not to exceed CA's expiration
         Date caNotAfter = null;
-        if (mCA.getSigningUnit() == null) {
+        if (signingCert == null) {
             // in case of root ca, bypass validity check
         } else {
-            caNotAfter =
-                mCA.getSigningUnit().getCertImpl().getNotAfter();
+            caNotAfter = signingCert.getNotAfter();
         }
 
         if (caNotAfter!= null && notAfter.after(caNotAfter)) {

--- a/base/server/src/main/java/com/netscape/certsrv/security/SigningUnitConfig.java
+++ b/base/server/src/main/java/com/netscape/certsrv/security/SigningUnitConfig.java
@@ -6,9 +6,11 @@
 package com.netscape.certsrv.security;
 
 import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.base.EPropertyNotFound;
 import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.base.SimpleProperties;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 
 public class SigningUnitConfig extends ConfigStore {
 
@@ -64,6 +66,27 @@ public class SigningUnitConfig extends ConfigStore {
 
     public void setTokenName(String tokenName) {
         putString("tokenname", tokenName);
+    }
+
+    public String getFullName() throws EBaseException {
+
+        String nickname;
+        try {
+            nickname = getCertNickname();
+        } catch (EPropertyNotFound e) {
+            nickname = getCACertNickname();
+        }
+
+        String tokenName = getTokenName();
+
+        String fullName;
+        if (CryptoUtil.isInternalToken(tokenName)) {
+            fullName = nickname;
+        } else {
+            fullName = tokenName + ":" + nickname;
+        }
+
+        return fullName;
     }
 
     public boolean getTestSignatureFailure() throws EBaseException {


### PR DESCRIPTION
Previously the `CAValidityDefault` could only be used inside the server since it got the signing cert from the signing unit object which was only available if the server was running.

To improve its usability the code has been modified to get the signing cert from the signing unit config if it's running outside of the server, so it no longer needs the signing unit object.

The `SigningUnitConfig.getFullName()` has been added to get the signing cert fullname like in `CASigningUnit.init()`.