### PR TITLE
Bug2093114-cs-tls-client-ciphers

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -561,6 +561,15 @@ ca.Policy.rule.SubjectKeyIdentifierExt.predicate=HTTP_PARAMS.certType==ca
 ca.Policy.rule.UniqueSubjectNameConstraints.enable=false
 ca.Policy.rule.UniqueSubjectNameConstraints.implName=UniqueSubjectNameConstraints
 ca.Policy.rule.UniqueSubjectNameConstraints.predicate=
+ca.connector._000=##
+ca.connector._001=## ca.connector.KRA.clientCiphers specifies list of ciphers
+ca.connector._002=##     to be presented during TLS client hello to it's KRA
+ca.connector._003=##
+ca.connector._004=## For RSA:
+ca.connector._005=## ca.connector.KRA.clientCiphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+ca.connector._006=##
+ca.connector._007=## For ECC:
+ca.connector._008=## ca.connector.KRA.clientCiphers=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
 ca.crl._000=##
 ca.crl._001=## CA CRL
 ca.crl._002=##
@@ -1204,6 +1213,14 @@ subsystem.3.class=com.netscape.cmscore.cert.CrossCertPairSubsystem
 subsystem.3.id=CrossCertPair
 subsystem.4.class=com.netscape.cmscore.util.StatsSubsystem
 subsystem.4.id=stats
+tcp._000=##
+tcp._001=## tcp.clientCiphers specifies list of ciphers to be presented
+tcp._002=##     during TLS client hello to it's ldaps server
+tcp._003=## For RSA:
+tcp._004=## tcp.clientCiphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+tcp._005=##
+tcp._006=## For ECC:
+tcp._007=## tcp.clientCiphers=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
 usrgrp._000=##
 usrgrp._001=## User/Group
 usrgrp._002=##

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -395,6 +395,14 @@ subsystem.1.class=com.netscape.cmscore.selftests.SelfTestSubsystem
 subsystem.1.id=selftests
 subsystem.2.class=com.netscape.cmscore.util.StatsSubsystem
 subsystem.2.id=stats
+tcp._000=##
+tcp._001=## tcp.clientCiphers specifies list of ciphers to be presented
+tcp._002=##     during TLS client hello to it's ldaps server
+tcp._003=## For RSA:
+tcp._004=## tcp.clientCiphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+tcp._005=##
+tcp._006=## For ECC:
+tcp._007=## tcp.clientCiphers=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
 usrgrp._000=##
 usrgrp._001=## User/Group
 usrgrp._002=##

--- a/base/ocsp/shared/conf/CS.cfg
+++ b/base/ocsp/shared/conf/CS.cfg
@@ -315,6 +315,14 @@ subsystem.1.class=com.netscape.cmscore.selftests.SelfTestSubsystem
 subsystem.1.id=selftests
 subsystem.2.class=com.netscape.cmscore.util.StatsSubsystem
 subsystem.2.id=stats
+tcp._000=##
+tcp._001=## tcp.clientCiphers specifies list of ciphers to be presented
+tcp._002=##     during TLS client hello to it's ldaps server
+tcp._003=## For RSA:
+tcp._004=## tcp.clientCiphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+tcp._005=##
+tcp._006=## For ECC:
+tcp._007=## tcp.clientCiphers=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
 usrgrp._000=##
 usrgrp._001=## User/Group
 usrgrp._002=##

--- a/base/server/src/main/java/com/netscape/cmscore/ldapconn/PKISocketConfig.java
+++ b/base/server/src/main/java/com/netscape/cmscore/ldapconn/PKISocketConfig.java
@@ -26,4 +26,8 @@ public class PKISocketConfig extends PropConfigStore {
     public boolean isKeepAlive() throws EBaseException {
         return getBoolean("keepAlive", true);
     }
+
+    public String getClientCiphers() throws EBaseException {
+        return getString("clientCiphers", "");
+    }
 }

--- a/base/tks/shared/conf/CS.cfg
+++ b/base/tks/shared/conf/CS.cfg
@@ -314,6 +314,14 @@ tks.master_key_prefix=
 tks.tksSharedSymKeyName=sharedSecret
 tks.useNewSharedSecretNames=true
 tks.useDefaultSlot=true
+tcp._000=##
+tcp._001=## tcp.clientCiphers specifies list of ciphers to be presented
+tcp._002=##     during TLS client hello to it's ldaps server
+tcp._003=## For RSA:
+tcp._004=## tcp.clientCiphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+tcp._005=##
+tcp._006=## For ECC:
+tcp._007=## tcp.clientCiphers=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
 usrgrp._000=##
 usrgrp._001=## User/Group
 usrgrp._002=##

--- a/base/tps/shared/conf/CS.cfg
+++ b/base/tps/shared/conf/CS.cfg
@@ -2512,6 +2512,24 @@ tps.cert.list=sslserver,subsystem,audit_signing
 tps.cert.sslserver.certusage=SSLServer
 tps.cert.subsystem.certusage=SSLClient
 tps.operations.allowedTransitions=0:0,0:4,4:4,4:0,7:0
+tps.connector._000=##
+tps.connector._001=## tps.connector.<ca|kra|tks id>.clientCiphers specifies list of ciphers
+tps.connector._002=##     to be presented during TLS client hello to it's CA,
+tps.connector._003=##     KRA, or TKS
+tps.connector._004=##
+tps.connector._005=## For RSA:
+tps.connector._006=## tps.connector.<ca|kra|tks id>.clientCiphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+tps.connector._007=##
+tps.connector._008=## For ECC:
+tps.connector._009=## tps.connector.<ca|kra|tks id>.clientCiphers=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+tcp._000=##
+tcp._001=## tcp.clientCiphers specifies list of ciphers to be presented
+tcp._002=##     during TLS client hello to it's ldaps server
+tcp._003=## For RSA:
+tcp._004=## tcp.clientCiphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+tcp._005=##
+tcp._006=## For ECC:
+tcp._007=## tcp.clientCiphers=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
 usrgrp._000=##
 usrgrp._001=## User/Group
 usrgrp._002=##

--- a/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -805,25 +805,48 @@ public class CryptoUtil {
     }
 
     public static void setClientCiphers(String list) throws SocketException {
+          setClientCiphers(null, list);
+    }
+    public static void setClientCiphers(SSLSocket soc, String list) throws SocketException {
+        String method = "CryptoUtil.setClientCiphers:";
+        if (soc == null)
+            logger.debug(method + "begins");
+        else
+            logger.debug(method + "on soc begins");
 
         if (list == null) {
+            logger.debug(method + "no cipher list in call; using default");
             // use default
-            setDefaultSSLCiphers();
+            if (soc == null)
+                setDefaultSSLCiphers();
             return;
         }
 
+        logger.debug(method + "cipher list in call; processing...");
         String ciphers[] = list.split(",");
         if (ciphers.length == 0) return;
 
-        unsetSSLCiphers();
+        if (soc == null)
+            unsetSSLCiphers();
+        else
+            unsetSSLCiphers(soc);
 
         for (String cipher : ciphers) {
-            setSSLCipher(cipher, true);
+            try {
+                if (soc == null)
+                    setSSLCipher(cipher, true);
+                else
+                    setSSLCipher(soc, cipher, true);
+            } catch (Exception e) {
+                logger.debug(method + cipher + " failed to be set: " + e.toString());
+            }
         }
+        logger.debug(method + "ends");
     }
 
     public static void setSSLCiphers(String ciphers) throws SocketException {
-
+        String method = "CryptoUtil.setSSLCiphers:";
+        logger.debug(method + "begins");
         if (ciphers == null) return;
 
         StringTokenizer st = new StringTokenizer(ciphers);
@@ -839,10 +862,25 @@ public class CryptoUtil {
 
             setSSLCipher(cipher, enabled);
         }
+        logger.debug(method + "ends");
+    }
+
+    public static void setSSLCipher(SSLSocket soc, String name, boolean enabled) throws SocketException {
+        logger.debug("CryptoUtil.setSSLCipher on soc: setting cipher:" + name);
+        int cipherID;
+        if (name.toLowerCase().startsWith("0x")) {
+            cipherID = Integer.parseInt(name.substring(2), 16);
+
+        } else {
+            SSLCipher cipher = SSLCipher.valueOf(name);
+            cipherID = cipher.getID();
+        }
+
+        soc.setCipherPreference(cipherID, enabled);
     }
 
     public static void setSSLCipher(String name, boolean enabled) throws SocketException {
-
+        logger.debug("CryptoUtil.setSSLCipher: setting cipher:" + name);
         int cipherID;
         if (name.toLowerCase().startsWith("0x")) {
             cipherID = Integer.parseInt(name.substring(2), 16);
@@ -856,7 +894,7 @@ public class CryptoUtil {
     }
 
     public static void setDefaultSSLCiphers() throws SocketException {
-
+        logger.debug("CryptoUtil.setDefaultSSLCiphers");
         int ciphers[] = SSLSocket.getImplementedCipherSuites();
         if (ciphers == null) return;
 
@@ -891,12 +929,21 @@ public class CryptoUtil {
      * unset all implemented cipehrs; for enforcing strict list of ciphers
      */
     public static void unsetSSLCiphers() throws SocketException {
-
+        logger.debug("CryptoUtil.unsetSSLCiphers");
         int cipherIDs[] = SSLSocket.getImplementedCipherSuites();
         if (cipherIDs == null) return;
 
         for (int cipherID : cipherIDs) {
             SSLSocket.setCipherPreferenceDefault(cipherID, false);
+        }
+    }
+    public static void unsetSSLCiphers(SSLSocket soc) throws SocketException {
+        logger.debug("CryptoUtil.unsetSSLCiphers on soc");
+        int cipherIDs[] = soc.getImplementedCipherSuites();
+        if (cipherIDs == null) return;
+
+        for (int cipherID : cipherIDs) {
+            soc.setCipherPreference(cipherID, false);
         }
     }
 


### PR DESCRIPTION
This patch fixes the issue introdued when the JSS engine was replaced
and the original control (inherited from server.xml) of ciphers when
acting as a client no longer works.
The controls are in two places.  One for when connecting with internal
ldap, while the other when a cs instance is connecting with each other.

It also narrowed the suggested cipher lists, such as the removal of the
SHA1 ciphers.