### PR TITLE
Add pki-server ca-cert-create

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCLI.java
@@ -16,6 +16,7 @@ public class CACertCLI extends CLI {
         super("cert", "CA certificate management commands", parent);
 
         addModule(new CACertFindCLI(this));
+        addModule(new CACertCreateCLI(this));
         addModule(new CACertImportCLI(this));
         addModule(new CACertRemoveCLI(this));
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCreateCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCreateCLI.java
@@ -1,0 +1,332 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ca.cli;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.security.KeyPair;
+import java.util.Date;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.tomcat.util.net.jss.TomcatJSS;
+import org.dogtag.util.cert.CertUtil;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.dogtagpki.cli.CommandCLI;
+import org.dogtagpki.server.ca.CAConfig;
+import org.dogtagpki.server.ca.CAEngineConfig;
+import org.dogtagpki.util.logging.PKILogger;
+import org.dogtagpki.util.logging.PKILogger.Level;
+import org.mozilla.jss.asn1.SEQUENCE;
+import org.mozilla.jss.crypto.CryptoToken;
+import org.mozilla.jss.crypto.PrivateKey;
+import org.mozilla.jss.netscape.security.pkcs.PKCS10;
+import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
+import org.mozilla.jss.netscape.security.x509.CertificateIssuerName;
+import org.mozilla.jss.netscape.security.x509.CertificateSubjectName;
+import org.mozilla.jss.netscape.security.x509.X500Name;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+import org.mozilla.jss.netscape.security.x509.X509CertInfo;
+import org.mozilla.jss.netscape.security.x509.X509Key;
+import org.mozilla.jss.pkcs11.PK11PrivKey;
+import org.mozilla.jss.pkcs11.PK11PubKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.ca.CASigningUnit;
+import com.netscape.certsrv.dbs.certdb.CertId;
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.certsrv.security.SigningUnitConfig;
+import com.netscape.cms.servlet.csadmin.BootstrapProfile;
+import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.DatabaseConfig;
+import com.netscape.cmscore.base.ConfigStorage;
+import com.netscape.cmscore.base.ConfigStore;
+import com.netscape.cmscore.base.FileConfigStorage;
+import com.netscape.cmscore.dbs.DBSubsystem;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.request.CertRequestRepository;
+import com.netscape.cmscore.request.Request;
+import com.netscape.cmsutil.crypto.CryptoUtil;
+import com.netscape.cmsutil.password.IPasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class CACertCreateCLI extends CommandCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(CACertCreateCLI.class);
+
+    public CACertCreateCLI(CLI parent) {
+        super("create", "Create certificate from certificate request in CA", parent);
+    }
+
+    @Override
+    public void createOptions() {
+
+        Option option = new Option(null, "request", true, "Request ID");
+        option.setArgName("ID");
+        options.addOption(option);
+
+        option = new Option(null, "profile", true, "Profile ID");
+        option.setArgName("ID");
+        options.addOption(option);
+
+        option = new Option(null, "type", true, "Certificate type: selfsign (default), local");
+        option.setArgName("type");
+        options.addOption(option);
+
+        option = new Option(null, "key-id", true, "Key ID");
+        option.setArgName("ID");
+        options.addOption(option);
+
+        option = new Option(null, "key-token", true, "Key token");
+        option.setArgName("name");
+        options.addOption(option);
+
+        option = new Option(null, "key-algorithm", true, "Key algorithm (default: SHA256withRSA)");
+        option.setArgName("name");
+        options.addOption(option);
+
+        option = new Option(null, "signing-algorithm", true, "Signing algorithm (default: SHA256withRSA)");
+        option.setArgName("name");
+        options.addOption(option);
+
+        option = new Option(null, "serial", true, "Certificate serial number");
+        option.setArgName("serial");
+        options.addOption(option);
+
+        option = new Option(null, "format", true, "Certificate format: PEM (default), DER");
+        option.setArgName("format");
+        options.addOption(option);
+
+        option = new Option(null, "cert", true, "Certificate path");
+        option.setArgName("path");
+        options.addOption(option);
+
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(PKILogger.Level.DEBUG);
+
+        } else if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(Level.INFO);
+        }
+
+        String requestID = cmd.getOptionValue("request");
+        if (requestID == null) {
+            throw new CLIException("Missing request ID");
+        }
+
+        String profileID = cmd.getOptionValue("profile");
+        if (profileID == null) {
+            throw new CLIException("Missing profile ID");
+        }
+
+        String serial = cmd.getOptionValue("serial");
+        if (serial == null) {
+            throw new CLIException("Missing serial number");
+        }
+
+        String certType = cmd.getOptionValue("type", "selfsign");
+
+        String tokenName = cmd.getOptionValue("key-token");
+        String keyAlgorithm = cmd.getOptionValue("key-algorithm", "SHA256withRSA");
+
+        String signingAlgorithm = cmd.getOptionValue("signing-algorithm", "SHA256withRSA");
+
+        CertId certID = new CertId(serial);
+        String certFormat = cmd.getOptionValue("format", "PEM");
+        String certPath = cmd.getOptionValue("cert");
+
+        // initialize JSS in pki-server CLI
+        TomcatJSS tomcatjss = TomcatJSS.getInstance();
+        tomcatjss.loadConfig();
+        tomcatjss.init();
+
+        String catalinaBase = System.getProperty("catalina.base");
+
+        String subsystem = parent.getParent().getName();
+        String confDir = catalinaBase + File.separator + subsystem + File.separator + "conf";
+        String configFile = confDir + File.separator + CMS.CONFIG_FILE;
+
+        logger.info("Loading " + configFile);
+        ConfigStorage storage = new FileConfigStorage(configFile);
+        CAEngineConfig cs = new CAEngineConfig(storage);
+        cs.load();
+
+        String instanceRoot = cs.getInstanceDir();
+        String configurationRoot = cs.getString("configurationRoot");
+        String profilePath = instanceRoot + configurationRoot + profileID;
+
+        logger.info("Loading " + profilePath);
+        ConfigStorage profileStorage = new FileConfigStorage(profilePath);
+        ConfigStore profileConfig = new ConfigStore(profileStorage);
+        profileConfig.load();
+        BootstrapProfile profile = new BootstrapProfile(cs, profileConfig);
+
+        DatabaseConfig dbConfig = cs.getDatabaseConfig();
+        LDAPConfig ldapConfig = dbConfig.getLDAPConfig();
+        ldapConfig.putInteger("minConns", 1);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        IPasswordStore passwordStore = IPasswordStore.create(psc);
+
+        DBSubsystem dbSubsystem = new DBSubsystem();
+        dbSubsystem.init(dbConfig, ldapConfig, socketConfig, passwordStore);
+
+        try {
+            CertRequestRepository requestRepository = new CertRequestRepository(dbSubsystem);
+            requestRepository.init();
+
+            Request requestRecord = requestRepository.readRequest(new RequestId(requestID));
+            if (requestRecord == null) {
+                throw new CLIException("Certificate request not found: " + requestID);
+            }
+
+            String certRequestType = requestRecord.getExtDataInString("cert_request_type");
+            logger.info("Request type: " + certRequestType);
+
+            String certRequest = requestRecord.getExtDataInString("cert_request");
+            logger.info("Request:\n" + certRequest);
+
+            byte[] binCertRequest = CertUtil.parseCSR(certRequest);
+
+            X500Name subjectName;
+            X509Key x509key;
+
+            if (certRequestType.equals("crmf")) {
+                SEQUENCE crmfMsgs = CryptoUtil.parseCRMFMsgs(binCertRequest);
+                subjectName = CryptoUtil.getSubjectName(crmfMsgs);
+                x509key = CryptoUtil.getX509KeyFromCRMFMsgs(crmfMsgs);
+
+            } else if (certRequestType.equals("pkcs10")) {
+                PKCS10 pkcs10 = new PKCS10(binCertRequest);
+                subjectName = pkcs10.getSubjectName();
+                x509key = pkcs10.getSubjectPublicKeyInfo();
+
+            } else {
+                throw new CLIException("Certificate request type not supported: " + certRequestType);
+            }
+
+            logger.info("Subject: " + subjectName);
+            logger.info("Cert type: " + certType);
+
+            X509CertImpl signingCert = null;
+            X500Name issuerName;
+            PrivateKey signingPrivateKey;
+
+            if (certType.equals("selfsign")) {
+
+                String hexKeyID = cmd.getOptionValue("key-id");
+                if (hexKeyID == null) {
+                    throw new CLIException("Missing key ID");
+                }
+
+                logger.info("Key ID: " + hexKeyID);
+                logger.info("Key token: " + tokenName);
+
+                String keyID = hexKeyID;
+                if (keyID.startsWith("0x")) keyID = keyID.substring(2);
+                if (keyID.length() % 2 == 1) keyID = "0" + keyID;
+
+                CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
+                PK11PrivKey privateKey = (PK11PrivKey) CryptoUtil.findPrivateKey(
+                        token,
+                        Hex.decodeHex(keyID));
+
+                if (privateKey == null) {
+                    throw new CLIException("Private key not found: " + hexKeyID);
+                }
+
+                PK11PubKey publicKey = privateKey.getPublicKey();
+                KeyPair keyPair = new KeyPair(publicKey, privateKey);
+
+                issuerName = subjectName;
+                signingPrivateKey = (PrivateKey) keyPair.getPrivate();
+
+            } else { // certType == local
+
+                CAConfig caConfig = cs.getCAConfig();
+                SigningUnitConfig caSigningCfg = caConfig.getSigningUnitConfig();
+
+                // create CA signing unit
+                CASigningUnit signingUnit = new CASigningUnit();
+                signingUnit.init(caSigningCfg, null);
+
+                signingCert = signingUnit.getCertImpl();
+                CertificateSubjectName certSubjectName = signingCert.getSubjectObj();
+
+                // use CA's issuer object to preserve DN encoding
+                issuerName = (X500Name) certSubjectName.get(CertificateIssuerName.DN_NAME);
+                signingPrivateKey = signingUnit.getPrivateKey();
+            }
+
+            logger.info("Issuer: " + issuerName);
+
+            CertificateIssuerName certIssuerName = new CertificateIssuerName(issuerName);
+            CertificateExtensions extensions = new CertificateExtensions();
+
+            Date date = new Date();
+            X509CertInfo certInfo = CryptoUtil.createX509CertInfo(
+                    x509key,
+                    certID.toBigInteger(),
+                    certIssuerName,
+                    subjectName,
+                    date,
+                    date,
+                    keyAlgorithm,
+                    extensions);
+
+            logger.info("Cert info:\n" + certInfo);
+
+            profile.populate(requestRecord, certInfo);
+            requestRepository.updateRequest(requestRecord);
+
+            X509CertImpl certImpl = CryptoUtil.signCert(
+                    signingPrivateKey,
+                    certInfo,
+                    signingAlgorithm);
+
+            byte[] bytes;
+
+            if ("PEM".equalsIgnoreCase(certFormat)) {
+                bytes = CertUtil.toPEM(certImpl).getBytes();
+
+            } else if ("DER".equalsIgnoreCase(certFormat)) {
+                bytes = certImpl.getEncoded();
+
+            } else {
+                throw new CLIException("Unsupported certificate format: " + certFormat);
+            }
+
+            if (certPath != null) {
+                try (PrintStream out = new PrintStream(new FileOutputStream(certPath))) {
+                    out.write(bytes);
+                }
+
+            } else {
+                System.out.write(bytes);
+            }
+
+        } finally {
+            dbSubsystem.shutdown();
+        }
+    }
+}

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CAInstallerService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CAInstallerService.java
@@ -18,47 +18,22 @@
 package org.dogtagpki.server.ca.rest;
 
 import java.math.BigInteger;
-import java.security.KeyPair;
-import java.util.Date;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
-import org.apache.commons.codec.binary.Hex;
-import org.dogtag.util.cert.CertUtil;
-import org.dogtagpki.server.ca.CAConfig;
 import org.dogtagpki.server.ca.CAEngine;
 import org.dogtagpki.server.ca.CAEngineConfig;
 import org.dogtagpki.server.rest.SystemConfigService;
-import org.mozilla.jss.asn1.SEQUENCE;
-import org.mozilla.jss.crypto.CryptoToken;
-import org.mozilla.jss.crypto.PrivateKey;
-import org.mozilla.jss.netscape.security.pkcs.PKCS10;
-import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
-import org.mozilla.jss.netscape.security.x509.CertificateIssuerName;
-import org.mozilla.jss.netscape.security.x509.CertificateSubjectName;
-import org.mozilla.jss.netscape.security.x509.X500Name;
-import org.mozilla.jss.netscape.security.x509.X509CertImpl;
-import org.mozilla.jss.netscape.security.x509.X509CertInfo;
-import org.mozilla.jss.netscape.security.x509.X509Key;
-import org.mozilla.jss.pkcs11.PK11PrivKey;
-import org.mozilla.jss.pkcs11.PK11PubKey;
 
-import com.netscape.ca.CASigningUnit;
 import com.netscape.ca.CertificateAuthority;
 import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.request.RequestId;
-import com.netscape.certsrv.security.SigningUnitConfig;
 import com.netscape.certsrv.system.CertificateSetupRequest;
-import com.netscape.certsrv.system.SystemCertData;
-import com.netscape.cms.servlet.csadmin.BootstrapProfile;
 import com.netscape.cmscore.apps.PreOpConfig;
-import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.dbs.CertificateRepository;
 import com.netscape.cmscore.request.CertRequestRepository;
-import com.netscape.cmscore.request.Request;
-import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
  * @author alee
@@ -138,164 +113,6 @@ public class CAInstallerService extends SystemConfigService {
 
         } catch (Throwable e) {
             logger.error("Unable to create cert ID: " + e.getMessage(), e);
-            throw e;
-        }
-    }
-
-    @POST
-    @Path("createCert")
-    public SystemCertData createCert(CertificateSetupRequest request) throws Exception {
-
-        logger.info("CAInstallerService: Creating cert");
-
-        try {
-            validatePin(request.getPin());
-
-            if (csState.equals("1")) {
-                throw new BadRequestException("System already configured");
-            }
-
-            SystemCertData certData = request.getSystemCert();
-
-            RequestId requestID = certData.getRequestID();
-            logger.info("CAInstallerService: - request ID: " + requestID.toHexString());
-
-            CAEngine engine = CAEngine.getInstance();
-            CAEngineConfig engineConfig = engine.getConfig();
-
-            CertRequestRepository requestRepository = engine.getCertRequestRepository();
-            Request requestRecord = requestRepository.readRequest(requestID);
-
-            String certRequestType = requestRecord.getExtDataInString("cert_request_type");
-            logger.info("CAInstallerService: - request type: " + certRequestType);
-
-            String certRequest = requestRecord.getExtDataInString("cert_request");
-            logger.info("CAInstallerService: - request: " + certRequest);
-
-            byte[] binCertRequest = CertUtil.parseCSR(certRequest);
-
-            X500Name subjectName;
-            X509Key x509key;
-
-            if (certRequestType.equals("crmf")) {
-                SEQUENCE crmfMsgs = CryptoUtil.parseCRMFMsgs(binCertRequest);
-                subjectName = CryptoUtil.getSubjectName(crmfMsgs);
-                x509key = CryptoUtil.getX509KeyFromCRMFMsgs(crmfMsgs);
-
-            } else if (certRequestType.equals("pkcs10")) {
-                PKCS10 pkcs10 = new PKCS10(binCertRequest);
-                subjectName = pkcs10.getSubjectName();
-                x509key = pkcs10.getSubjectPublicKeyInfo();
-
-            } else {
-                throw new Exception("Certificate request type not supported: " + certRequestType);
-            }
-
-            logger.info("CAInstallerService: - subject: " + subjectName);
-
-            CertId certID = certData.getCertID();
-            logger.info("CAInstallerService: - cert ID: " + certID.toHexString());
-
-            // cert type is selfsign or local
-            String certType = certData.getType();
-            logger.info("CAInstallerService: - cert type: " + certType);
-
-            String profileID = certData.getProfile();
-            logger.info("CAInstallerService: - profile: " + profileID);
-
-            String keyAlgorithm = certData.getKeyAlgorithm();
-            logger.info("CAInstallerService: - key algorithm: " + keyAlgorithm);
-
-            X500Name issuerName;
-            PrivateKey signingPrivateKey;
-
-            if (certType.equals("selfsign")) {
-
-                String tokenName = certData.getToken();
-                logger.info("CAInstallerService: - token: " + tokenName);
-                CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
-
-                String hexKeyID = certData.getKeyID();
-                logger.info("CAInstallerService: - key ID: " + hexKeyID);
-
-                String keyID = hexKeyID;
-                if (keyID.startsWith("0x")) keyID = keyID.substring(2);
-                if (keyID.length() % 2 == 1) keyID = "0" + keyID;
-                PK11PrivKey privateKey = (PK11PrivKey) CryptoUtil.findPrivateKey(
-                        token,
-                        Hex.decodeHex(keyID));
-
-                if (privateKey == null) {
-                    throw new Exception("Private key not found: " + hexKeyID);
-                }
-
-                PK11PubKey publicKey = privateKey.getPublicKey();
-                KeyPair keyPair = new KeyPair(publicKey, privateKey);
-
-                issuerName = subjectName;
-                signingPrivateKey = (PrivateKey) keyPair.getPrivate();
-
-            } else { // certType == local
-
-                CAConfig caConfig = engineConfig.getCAConfig();
-                SigningUnitConfig caSigningCfg = caConfig.getSigningUnitConfig();
-
-                // create CA signing unit
-                CASigningUnit signingUnit = new CASigningUnit();
-                signingUnit.init(caSigningCfg, null);
-
-                X509CertImpl caCertImpl = signingUnit.getCertImpl();
-                CertificateSubjectName certSubjectName = caCertImpl.getSubjectObj();
-
-                // use CA's issuer object to preserve DN encoding
-                issuerName = (X500Name) certSubjectName.get(CertificateIssuerName.DN_NAME);
-                signingPrivateKey = signingUnit.getPrivateKey();
-            }
-
-            logger.info("CAInstallerService: - issuer: " + issuerName);
-
-            String signingAlgorithm = certData.getSigningAlgorithm();
-            logger.info("CAInstallerService: - signing algorithm: " + signingAlgorithm);
-
-            CertificateIssuerName certIssuerName = new CertificateIssuerName(issuerName);
-            CertificateExtensions extensions = new CertificateExtensions();
-
-            String instanceRoot = cs.getInstanceDir();
-            String configurationRoot = cs.getString("configurationRoot");
-            String profilePath = instanceRoot + configurationRoot + profileID;
-
-            logger.info("CAInstallerService: Loading " + profilePath);
-            ConfigStore profileConfig = engine.loadConfigStore(profilePath);
-            BootstrapProfile profile = new BootstrapProfile(engineConfig, profileConfig);
-
-            Date date = new Date();
-            X509CertInfo certInfo = CryptoUtil.createX509CertInfo(
-                    x509key,
-                    certID.toBigInteger(),
-                    certIssuerName,
-                    subjectName,
-                    date,
-                    date,
-                    keyAlgorithm,
-                    extensions);
-
-            logger.info("CAInstallerService: Cert info:\n" + certInfo);
-
-            profile.populate(requestRecord, certInfo);
-            requestRepository.updateRequest(requestRecord);
-
-            X509CertImpl certImpl = CryptoUtil.signCert(
-                    signingPrivateKey,
-                    certInfo,
-                    signingAlgorithm);
-
-            byte[] binCert = certImpl.getEncoded();
-            certData.setCert(CryptoUtil.base64Encode(binCert));
-
-            return certData;
-
-        } catch (Throwable e) {
-            logger.error("Unable to create cert: " + e.getMessage(), e);
             throw e;
         }
     }

--- a/base/common/python/pki/system.py
+++ b/base/common/python/pki/system.py
@@ -361,7 +361,6 @@ class SystemConfigClient(object):
 
         self.create_request_id_url = '/rest/installer/createRequestID'
         self.create_cert_id_url = '/rest/installer/createCertID'
-        self.create_cert_url = '/rest/installer/createCert'
         self.init_subsystem_url = '/rest/installer/initSubsystem'
 
         if connection.subsystem is None:
@@ -371,7 +370,6 @@ class SystemConfigClient(object):
 
             self.create_request_id_url = '/' + subsystem + self.create_request_id_url
             self.create_cert_id_url = '/' + subsystem + self.create_cert_id_url
-            self.create_cert_url = '/' + subsystem + self.create_cert_url
             self.init_subsystem_url = '/' + subsystem + self.init_subsystem_url
 
     def createRequestID(self, request):
@@ -407,25 +405,6 @@ class SystemConfigClient(object):
 
         response = self.connection.post(
             self.create_cert_id_url,
-            data,
-            headers)
-
-        return response.json()
-
-    def createCert(self, request):
-        """
-        Create certificate.
-
-        :param request: Certificate setup request
-        :type request: CertificateSetupRequest
-        :return: SystemCertData
-        """
-        data = json.dumps(request, cls=pki.encoder.CustomTypeEncoder)
-        headers = {'Content-type': 'application/json',
-                   'Accept': 'application/json'}
-
-        response = self.connection.post(
-            self.create_cert_url,
             data,
             headers)
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1748,6 +1748,65 @@ class CASubsystem(PKISubsystem):
 
         self.run(cmd, as_current_user=as_current_user)
 
+    def create_cert(
+            self,
+            request_id=None,
+            profile_id=None,
+            cert_type=None,
+            key_id=None,
+            key_token=None,
+            key_algorithm=None,
+            signing_algorithm=None,
+            serial=None,
+            cert_format=None):
+
+        tmpdir = tempfile.mkdtemp()
+
+        try:
+            cmd = ['ca-cert-create']
+
+            if logger.isEnabledFor(logging.DEBUG):
+                cmd.append('--debug')
+
+            elif logger.isEnabledFor(logging.INFO):
+                cmd.append('--verbose')
+
+            if request_id:
+                cmd.extend(['--request', request_id])
+
+            if profile_id:
+                cmd.extend(['--profile', profile_id])
+
+            if cert_type:
+                cmd.extend(['--type', cert_type])
+
+            if key_id:
+                cmd.extend(['--key-id', key_id])
+
+            if key_token:
+                cmd.extend(['--key-token', key_token])
+
+            if key_algorithm:
+                cmd.extend(['--key-algorithm', key_algorithm])
+
+            if signing_algorithm:
+                cmd.extend(['--signing-algorithm', signing_algorithm])
+
+            if serial:
+                cmd.extend(['--serial', serial])
+
+            if cert_format:
+                cmd.extend(['--format', cert_format])
+
+            result = self.run(
+                cmd,
+                capture_output=True)
+
+        finally:
+            shutil.rmtree(tmpdir)
+
+        return result.stdout
+
     def import_cert(
             self,
             cert_data=None,


### PR DESCRIPTION
The `CAInstallerService.createCert()` has been converted into `pki-server ca-cert-create` CLI. The CLI provides a way to create a system certificate without the server running, which would be useful for system recovery.

The installer has been updated to call `CASubsystem.create_cert()` which will call the CLI.

Doc: https://github.com/dogtagpki/pki/wiki/PKI-Server-CA-Certificate-CLI