### PR TITLE
Add test for CMC shared token

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1295,3 +1295,272 @@ jobs:
           name: ca-existing-certs-${{ matrix.os }}
           path: |
             /tmp/artifacts/pki
+
+  # https://github.com/dogtagpki/pki/wiki/Issuing-User-Certificate-with-CMC-Shared-Token
+  cmc-shared-token-test:
+    name: Testing CMC shared token
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-ca-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          COPR_REPO: ${{ needs.init.outputs.repo }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -v
+
+      - name: Install CA admin cert
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      # https://github.com/dogtagpki/pki/wiki/Creating-Issuance-Protection-Certificate
+      - name: Create issuance protection cert
+        run: |
+          # generate cert request
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-cert-request \
+              --subject "CN=CA Issuance Protection" \
+              --csr ca_issuance_protection.csr
+
+          # check generated CSR
+          docker exec pki openssl req -text -noout -in ca_issuance_protection.csr
+
+          # create CMC request
+          docker exec pki CMCRequest \
+              /usr/share/pki/server/examples/cmc/ca_issuance_protection-cmc-request.cfg \
+
+          # submit CMC request
+          docker exec pki HttpClient \
+              /usr/share/pki/server/examples/cmc/ca_issuance_protection-cmc-submit.cfg \
+
+          # convert CMC response (DER PKCS #7) into PEM PKCS #7 cert chain
+          docker exec pki CMCResponse \
+              -d /etc/pki/pki-tomcat/alias \
+              -i ca_issuance_protection.cmc-response \
+              -o ca_issuance_protection.p7b
+
+          # check issued cert chain
+          docker exec pki openssl pkcs7 \
+              -print_certs \
+              -in ca_issuance_protection.p7b
+
+          # import cert chain
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              pkcs7-import \
+              --pkcs7 ca_issuance_protection.p7b \
+              ca_issuance_protection
+
+          # check imported cert chain
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-cert-find
+
+          # configure issuance protection nickname
+          docker exec pki pki-server ca-config-set ca.cert.issuance_protection.nickname ca_issuance_protection
+
+      # https://github.com/dogtagpki/pki/wiki/Configuring-CMC-Shared-Token-Authentication
+      - name: Configure shared token auth
+        run: |
+          # update schema
+          docker exec pki ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/ca/auth/ds/schema.ldif
+
+          # add user subtree
+          docker exec pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/ca/auth/ds/create.ldif
+
+          # add user records
+          docker exec pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/ca/auth/ds/example.ldif
+
+          # configure CMC shared token authentication
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.ldap.basedn ou=people,dc=example,dc=com
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.ldap.ldapauth.authtype BasicAuth
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.ldap.ldapauth.bindDN "cn=Directory Manager"
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.ldap.ldapauth.bindPWPrompt "Rule SharedToken"
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.ldap.ldapconn.host ds.example.com
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.ldap.ldapconn.port 3389
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.ldap.ldapconn.secureConn false
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.pluginName SharedToken
+          docker exec pki pki-server ca-config-set auths.instance.SharedToken.shrTokAttr shrTok
+
+          # enable caFullCMCSharedTokenCert profile
+          docker exec pki sed -i \
+              -e "s/^\(enable\)=.*/\1=true/" \
+              /var/lib/pki/pki-tomcat/ca/profiles/ca/caFullCMCSharedTokenCert.cfg
+
+          # restart CA
+          docker exec pki pki-server ca-undeploy --wait
+          docker exec pki pki-server ca-deploy --wait
+
+      # https://github.com/dogtagpki/pki/wiki/Generating-CMC-Shared-Token
+      - name: Generate shared token for user
+        run: |
+          # generate shared token
+          docker exec pki CMCSharedToken \
+              -d /etc/pki/pki-tomcat/alias \
+              -p Secret.123 \
+              -n ca_issuance_protection \
+              -s Secret.123 \
+              -o $SHARED/testuser.b64
+
+          # convert into a single line
+          SHARED_TOKEN=$(sed -e :a -e 'N;s/\n//;ba' testuser.b64)
+          echo "SHARED_TOKEN: $SHARED_TOKEN"
+
+          cat > add.ldif << EOF
+          dn: uid=testuser,ou=people,dc=example,dc=com
+          changetype: modify
+          add: objectClass
+          objectClass: extensibleobject
+          -
+          add: shrTok
+          shrTok: $SHARED_TOKEN
+          -
+          EOF
+          cat add.ldif
+
+          # add shared token into user record
+          docker exec pki ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/add.ldif
+
+      # https://github.com/dogtagpki/pki/wiki/Issuing-User-Certificate-with-CMC-Shared-Token
+      - name: Issue user cert with shared token
+        run: |
+          # create key
+          docker exec pki pki nss-key-create --output-format json | tee output
+          KEY_ID=$(jq -r '.keyId' output)
+          echo "KEY_ID: $KEY_ID"
+
+          # generated cert request
+          docker exec pki pki \
+              nss-cert-request \
+              --key-id $KEY_ID \
+              --subject "uid=testuser" \
+              --ext /usr/share/pki/tools/examples/certs/testuser.conf \
+              --csr testuser.csr
+
+          # check generated CSR
+          docker exec pki openssl req -text -noout -in testuser.csr
+
+          # insert key ID into CMCRequest config
+          docker cp \
+              pki:/usr/share/pki/tools/examples/cmc/testuser-cmc-request.cfg \
+              testuser-cmc-request.cfg
+          sed -i \
+              -e "s/^\(request.privKeyId\)=.*/\1=$KEY_ID/" \
+              testuser-cmc-request.cfg
+          cat testuser-cmc-request.cfg
+
+          # create CMC request
+          docker exec pki CMCRequest \
+              $SHARED/testuser-cmc-request.cfg
+
+          # submit CMC request
+          docker exec pki HttpClient \
+              /usr/share/pki/tools/examples/cmc/testuser-cmc-submit.cfg
+
+          # convert CMC response (DER PKCS #7) into PEM PKCS #7 cert chain
+          docker exec pki CMCResponse \
+              -d /root/.dogtag/nssdb \
+              -i testuser.cmc-response \
+              -o testuser.p7b
+
+          # check issued cert chain
+          docker exec pki pki \
+              pkcs7-cert-find \
+              --pkcs7 testuser.p7b
+
+          # import cert chain
+          docker exec pki pki \
+              pkcs7-import \
+              --pkcs7 testuser.p7b \
+              testuser
+
+          # check imported cert chain
+          docker exec pki pki nss-cert-find
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: cmc-shared-token-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki

--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -79,6 +79,13 @@ set(PKI_CA_JAR ${CMAKE_BINARY_DIR}/dist/pki-ca.jar CACHE INTERNAL "pki-ca jar fi
 # install directories
 install(
     DIRECTORY
+        auth/
+    DESTINATION
+        ${DATA_INSTALL_DIR}/ca/auth/
+)
+
+install(
+    DIRECTORY
         shared/
     DESTINATION
         ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}

--- a/base/ca/auth/ds/create.ldif
+++ b/base/ca/auth/ds/create.ldif
@@ -1,0 +1,10 @@
+dn: ou=people,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: people
+aci: (target = "ldap:///ou=people,dc=example,dc=com")
+ (targetattr=objectClass||dc||ou||uid||cn||sn||givenName)
+ (version 3.0; acl "Allow anyone to read and search basic attributes"; allow (search, read) userdn = "ldap:///anyone";)
+aci: (target = "ldap:///ou=people,dc=example,dc=com")
+ (targetattr=*)
+ (version 3.0; acl "Allow anyone to read and search itself"; allow (search, read) userdn = "ldap:///self";)

--- a/base/ca/auth/ds/example.ldif
+++ b/base/ca/auth/ds/example.ldif
@@ -1,0 +1,10 @@
+dn: uid=testuser,ou=people,dc=example,dc=com
+objectClass: top
+objectClass: person
+objectclass: organizationalPerson
+objectclass: inetorgperson
+uid: testuser
+cn: Test User
+sn: User
+givenName: Test
+userPassword: Secret.123

--- a/base/ca/auth/ds/schema.ldif
+++ b/base/ca/auth/ds/schema.ldif
@@ -1,0 +1,7 @@
+dn: cn=schema
+changetype: modify
+add: attributeTypes
+attributetypes: ( shrTok-oid NAME 'shrTok'
+  DESC 'Attribute type for SharedToken'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  SINGLE-VALUE )

--- a/base/server/examples/cmc/ca_issuance_protection-cmc-request.cfg
+++ b/base/server/examples/cmc/ca_issuance_protection-cmc-request.cfg
@@ -1,0 +1,25 @@
+# NSS database directory where the CA agent certificate is stored.
+dbdir=/root/.dogtag/nssdb
+
+# NSS database password.
+password=
+
+# Token name (default is internal).
+tokenname=internal
+
+# Nickname for agent certificate.
+nickname=caadmin
+
+# Request format: pkcs10 or crmf.
+format=pkcs10
+
+# Total number of PKCS10/CRMF requests.
+numRequests=1
+
+# Path to the PKCS10/CRMF request.
+# The content must be in Base-64 encoded format.
+# Multiple files are supported. They must be separated by space.
+input=ca_issuance_protection.csr
+
+# Path for the CMC request.
+output=ca_issuance_protection.cmc-request

--- a/base/server/examples/cmc/ca_issuance_protection-cmc-submit.cfg
+++ b/base/server/examples/cmc/ca_issuance_protection-cmc-submit.cfg
@@ -1,0 +1,33 @@
+# PKI server host name.
+host=pki.example.com
+
+# PKI server port number.
+port=8443
+
+# Use secure connection.
+# For secure connection with ECC, set environment variable 'export NSS_USE_DECODED_CKA_EC_POINT=1'.
+secure=true
+
+# Use client authentication.
+clientmode=true
+
+# NSS database directory where the CA agent certificate is stored.
+dbdir=/root/.dogtag/nssdb
+
+# NSS database password.
+password=
+
+# Token name (default: internal).
+tokenname=internal
+
+# Nickname of agent certificate.
+nickname=caadmin
+
+# CMC servlet path
+servlet=/ca/ee/ca/profileSubmitCMCFull?profileId=caCMCcaIssuanceProtectionCert
+
+# Path for the CMC request.
+input=ca_issuance_protection.cmc-request
+
+# Path for the CMC response.
+output=ca_issuance_protection.cmc-response

--- a/base/tools/CMakeLists.txt
+++ b/base/tools/CMakeLists.txt
@@ -133,6 +133,13 @@ add_custom_command(
 )
 
 install(
+    DIRECTORY
+        examples/
+    DESTINATION
+        ${DATA_INSTALL_DIR}/tools/examples/
+)
+
+install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/DRMTool.1.gz
     DESTINATION

--- a/base/tools/examples/certs/testuser.conf
+++ b/base/tools/examples/certs/testuser.conf
@@ -1,0 +1,1 @@
+subjectKeyIdentifier   = hash

--- a/base/tools/examples/cmc/testuser-cmc-request.cfg
+++ b/base/tools/examples/cmc/testuser-cmc-request.cfg
@@ -1,0 +1,50 @@
+# NSS database directory where the CA agent certificate is stored.
+dbdir=/root/.dogtag/nssdb
+
+# NSS database password.
+password=
+
+# Token name (default is internal).
+tokenname=internal
+
+# Nickname for agent certificate.
+nickname=caadmin
+
+# Request format: pkcs10 or crmf.
+format=pkcs10
+
+# Total number of PKCS10/CRMF requests.
+numRequests=1
+
+# Path to the PKCS10/CRMF request.
+# The content must be in Base-64 encoded format.
+# Multiple files are supported. They must be separated by space.
+input=testuser.csr
+
+# Path for the CMC request.
+output=testuser.cmc-request
+
+### identityProofV2.enable: if true, then the request will contain this control. Otherwise, false.
+### Note that if both identityProof and identityProofV2 are enabled,
+### identityProofV2 takes precedence; Only one of them can be active at a time
+### Supported hashAlg are:
+###  SHA-1, SHA-256, SHA-384, and SHA-512
+### Supported macAlg are:
+###  SHA-1-HMAC, SHA-256-HMAC, SHA-384-HMAC, and SHA-512-HMAC
+identityProofV2.enable=true
+identityProofV2.hashAlg=SHA-512
+identityProofV2.macAlg=SHA-256-HMAC
+
+### identityProofV2.sharedSecret: Shared Secret
+witness.sharedSecret=Secret.123
+
+popLinkWitnessV2.enable=true
+popLinkWitnessV2.keyGenAlg=SHA-256
+popLinkWitnessV2.macAlg=SHA-256-HMAC
+
+request.useSharedSecret=true
+request.privKeyId=
+
+### identification works with identityProofV2
+identification.enable=true
+identification=testuser

--- a/base/tools/examples/cmc/testuser-cmc-submit.cfg
+++ b/base/tools/examples/cmc/testuser-cmc-submit.cfg
@@ -1,0 +1,33 @@
+# PKI server host name.
+host=pki.example.com
+
+# PKI server port number.
+port=8443
+
+# Use secure connection.
+# For secure connection with ECC, set environment variable 'export NSS_USE_DECODED_CKA_EC_POINT=1'.
+secure=true
+
+# Use client authentication.
+clientmode=true
+
+# NSS database directory where the CA agent certificate is stored.
+dbdir=/root/.dogtag/nssdb
+
+# NSS database password.
+password=
+
+# Token name (default: internal).
+tokenname=internal
+
+# Nickname of agent certificate.
+nickname=caadmin
+
+# CMC servlet path
+servlet=/ca/ee/ca/profileSubmitCMCFull?profileId=caFullCMCSharedTokenCert
+
+# Path for the CMC request.
+input=testuser.cmc-request
+
+# Path for the CMC response.
+output=testuser.cmc-response


### PR DESCRIPTION
A new test has been added for issuing a user cert using CMC shared token authentication.

The files in `base/ca/auth/ds` provide a sample authentication database.

The files in `base/server/examples/cmc` provide a sample CMC configuration for generating the issuance protection cert.

The file in `base/tools/examples/certs` provides a sample `pki nss` CLI [configuration](https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-Extensions) for generating a CSR for the user cert.

The files in `base/tools/examples/cmc` provide sample CMC configuration for generating the user cert.

Docs:

* https://github.com/dogtagpki/pki/wiki/Creating-Issuance-Protection-Certificate
* https://github.com/dogtagpki/pki/wiki/Configuring-CMC-Shared-Token-Authentication
* https://github.com/dogtagpki/pki/wiki/Generating-CMC-Shared-Token
* https://github.com/dogtagpki/pki/wiki/Issuing-User-Certificate-with-CMC-Shared-Token

If audit is not required, this might resolve this issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2089756