### PR TITLE
Make workflows call common build.yml workflow

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -1,96 +1,16 @@
 name: ACME Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,acme --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-acme-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme-runner.tar
-
-      - name: Build server image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-acme
-          target: pki-acme
-          outputs: type=docker,dest=pki-acme-server.tar
-
-      - name: Store server image
-        uses: actions/cache@v3
-        with:
-          key: pki-acme-server-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme-server.tar
-
   # docs/installation/acme/Installing_PKI_ACME_Responder.md
   # docs/user/acme/Using_PKI_ACME_Responder_with_Certbot.md
   acme-certbot-test:
     name: Testing ACME with certbot
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -98,11 +18,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-acme-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -111,7 +31,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -257,7 +177,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: acme-server-${{ matrix.os }}
+          name: acme-server
           path: |
             /tmp/artifacts/pki
 
@@ -265,19 +185,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: acme-client-${{ matrix.os }}
+          name: acme-client
           path: /tmp/artifacts/client
 
   # This test verifies that in a cluster the baseURL parameter can be used
   # to replace a server with another server without affecting the client.
   acme-switchover-test:
     name: Testing ACME server switchover
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -285,11 +202,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-acme-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -298,7 +215,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -459,7 +376,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: acme-switchover-server-${{ matrix.os }}
+          name: acme-switchover-server
           path: |
             /tmp/artifacts/pki
 
@@ -467,18 +384,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: acme-switchover-client-${{ matrix.os }}
+          name: acme-switchover-client
           path: /tmp/artifacts/client
 
   # docs/installation/podman/Deploying_PKI_ACME_Responder_on_Podman.md
   acme-container-test:
     name: Testing ACME container
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -486,20 +400,20 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-acme-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Retrieve server image
         uses: actions/cache@v3
         with:
-          key: pki-acme-server-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme-server.tar
+          key: pki-server
+          path: pki-server.tar
 
       - name: Load ACME image
-        run: docker load --input pki-acme-server.tar
+        run: docker load --input pki-server.tar
 
       - name: Create network
         run: docker network create example
@@ -509,7 +423,7 @@ jobs:
           docker run \
               --name server \
               --detach \
-              pki-acme
+              pki-server
 
       - name: Connect ACME container to network
         run: docker network connect example server --alias pki.example.com
@@ -588,12 +502,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: acme-container-server-${{ matrix.os }}
+          name: acme-container-server
           path: /tmp/artifacts/server
 
       - name: Upload artifacts from client container
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: acme-container-client-${{ matrix.os }}
+          name: acme-container-client
           path: /tmp/artifacts/client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,3 +103,30 @@ jobs:
         with:
           key: pki-server
           path: pki-server.tar
+
+  rpminspect-test:
+    name: Run RPMInspect on RPMs
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Download PKI packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pki-build
+          path: |
+            build/
+
+      - name: Install RPMInspect
+        run: |
+          dnf install -y dnf-plugins-core rpm-build findutils
+          dnf copr enable -y copr.fedorainfracloud.org/dcantrell/rpminspect
+          dnf install -y rpminspect rpminspect-data-fedora
+      - name: Run RPMInspect on SRPM and RPMs
+        run: |
+          tests/bin/rpminspect.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build PKI
 on:
   workflow_call:
-    inputs:
-      key_container:
-        required: true
-        type: string
     secrets:
       BASE64_MATRIX:
         required: false
@@ -82,10 +78,10 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-${{ inputs.key_container}}-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
-          key: pki-${{ inputs.key_container }}-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-${{ inputs.key_container }}-runner.tar
+          key: pki-runner
+          path: pki-runner.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ on:
       BASE64_DATABASE:
         required: false
     outputs:
-      matrix:
-        value: ${{ jobs.init.outputs.matrix}}
+      os:
+        value: ${{ jobs.init.outputs.matrix.os}}
       repo:
         value: ${{ jobs.init.outputs.repo}}
       db-image:
@@ -61,7 +61,7 @@ jobs:
       - name: Upload PKI packages
         uses: actions/upload-artifact@v2
         with:
-          name: pki-build-${{ matrix.os }}
+          name: pki-build
           path: |
             build/RPMS/
             build/SRPMS/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,14 @@ jobs:
       - name: Build PKI packages
         run: ./build.sh --with-timestamp --work-dir=build rpm
 
+      - name: Upload PKI packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-build-${{ matrix.os }}
+          path: |
+            build/RPMS/
+            build/SRPMS/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: tests/ipa/Dockerfile
           build-args: |
             OS_VERSION=${{ matrix.os }}
             COPR_REPO=${{ needs.init.outputs.repo }}
@@ -85,3 +86,20 @@ jobs:
         with:
           key: pki-runner
           path: pki-runner.tar
+
+      - name: Build server image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-server
+          target: pki-server
+          outputs: type=docker,dest=pki-server.tar
+
+      - name: Store server image
+        uses: actions/cache@v3
+        with:
+          key: pki-server
+          path: pki-server.tar

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1,23 +1,22 @@
 name: CA Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: true
+        type: string
+      db-image:
+        required: true
+        type: string
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: ca
-    secrets: inherit
-
   # docs/installation/ca/Installing_CA.md
   ca-test:
     name: Testing CA
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -25,11 +24,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -38,8 +37,8 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
-          COPR_REPO: ${{ needs.init.outputs.repo }}
+          IMAGE: ${{ inputs.db-image}}
+          COPR_REPO: ${{ inputs.repo}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -202,19 +201,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-${{ matrix.os }}
+          name: ca
           path: |
             /tmp/artifacts/pki
 
   # docs/installation/ca/Installing_CA_with_ECC.md
   ca-ecc-test:
     name: Testing CA with ECC
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -222,11 +218,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -235,7 +231,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -342,19 +338,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-ecc-${{ matrix.os }}
+          name: ca-ecc
           path: |
             /tmp/artifacts/pki
 
   # docs/installation/ca/Installing-CA-with-RSA-PSS.adoc
   ca-rsa-pss-test:
     name: Testing CA with RSA/PSS
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -362,11 +355,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -375,7 +368,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -518,19 +511,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-rsa-pss-${{ matrix.os }}
+          name: ca-rsa-pss
           path: |
             /tmp/artifacts/pki
 
   # docs/installation/ca/Installing_Subordinate_CA.md
   subca-test:
     name: Testing subordinate CA
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -538,11 +528,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -551,7 +541,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh rootds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: rootds.example.com
           PASSWORD: Secret.123
 
@@ -587,7 +577,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh subds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: subds.example.com
           PASSWORD: Secret.123
 
@@ -687,7 +677,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-root-${{ matrix.os }}
+          name: ca-root
           path: |
             /tmp/artifacts/root
 
@@ -695,19 +685,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-subordinate-${{ matrix.os }}
+          name: ca-subordinate
           path: |
             /tmp/artifacts/subordinate
 
   # docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
   subca-cmc-test:
     name: Testing subordinate CA with CMC
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -715,11 +702,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -728,7 +715,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh rootds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: rootds.example.com
           PASSWORD: Secret.123
 
@@ -783,7 +770,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh subds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: subds.example.com
           PASSWORD: Secret.123
 
@@ -917,7 +904,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-root-cmc-${{ matrix.os }}
+          name: ca-root-cmc
           path: |
             /tmp/artifacts/root
 
@@ -925,19 +912,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-subordinate-cmc-${{ matrix.os }}
+          name: ca-subordinate-cmc
           path: |
             /tmp/artifacts/subordinate
 
   # docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
   ca-external-cert-test:
     name: Testing CA with external signing certificate
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -945,11 +929,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -958,7 +942,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1065,19 +1049,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-external-cert-${{ matrix.os }}
+          name: ca-external-cert
           path: |
             /tmp/artifacts/pki
 
   # docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.md
   ca-existing-certs-test:
     name: Testing CA with existing certificates
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1085,11 +1066,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1098,7 +1079,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1237,19 +1218,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-existing-certs-${{ matrix.os }}
+          name: ca-existing-certs
           path: |
             /tmp/artifacts/pki
 
   # https://github.com/dogtagpki/pki/wiki/Issuing-User-Certificate-with-CMC-Shared-Token
   cmc-shared-token-test:
     name: Testing CMC shared token
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1257,11 +1235,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1270,8 +1248,8 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
-          COPR_REPO: ${{ needs.init.outputs.repo }}
+          IMAGE: ${{ inputs.db-image}}
+          COPR_REPO: ${{ inputs.repo}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1506,6 +1484,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: cmc-shared-token-${{ matrix.os }}
+          name: cmc-shared-token
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -3,71 +3,16 @@ name: CA Tests
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,tests --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-ca-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: ca
+    secrets: inherit
 
   # docs/installation/ca/Installing_CA.md
   ca-test:
     name: Testing CA
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -264,7 +209,7 @@ jobs:
   # docs/installation/ca/Installing_CA_with_ECC.md
   ca-ecc-test:
     name: Testing CA with ECC
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -404,7 +349,7 @@ jobs:
   # docs/installation/ca/Installing-CA-with-RSA-PSS.adoc
   ca-rsa-pss-test:
     name: Testing CA with RSA/PSS
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -580,7 +525,7 @@ jobs:
   # docs/installation/ca/Installing_Subordinate_CA.md
   subca-test:
     name: Testing subordinate CA
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -757,7 +702,7 @@ jobs:
   # docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
   subca-cmc-test:
     name: Testing subordinate CA with CMC
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -987,7 +932,7 @@ jobs:
   # docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
   ca-external-cert-test:
     name: Testing CA with external signing certificate
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -1127,7 +1072,7 @@ jobs:
   # docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.md
   ca-existing-certs-test:
     name: Testing CA with existing certificates
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -1299,7 +1244,7 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/Issuing-User-Certificate-with-CMC-Shared-Token
   cmc-shared-token-test:
     name: Testing CMC shared token
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -1,22 +1,21 @@
 name: CA Tests 2
 
-on: [push, pull_request]
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: true
+        type: string
+      db-image:
+        required: true
+        type: string
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: ca
-    secrets: inherit
-
   ca-clone-test:
     name: Testing CA clone
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -24,11 +23,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -37,7 +36,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -84,7 +83,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -134,7 +133,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tertiaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tertiaryds.example.com
           PASSWORD: Secret.123
 
@@ -223,7 +222,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-clone-primary-${{ matrix.os }}
+          name: ca-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -231,7 +230,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-clone-secondary-${{ matrix.os }}
+          name: ca-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -239,19 +238,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-clone-tertiary-${{ matrix.os }}
+          name: ca-clone-tertiary
           path: |
             /tmp/artifacts/tertiary
 
   # docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
   ca-secure-ds-test:
     name: Testing CA with secure DS
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -259,11 +255,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -272,7 +268,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -395,7 +391,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-secure-ds-${{ matrix.os }}
+          name: ca-secure-ds
           path: |
             /tmp/artifacts/pki
 
@@ -403,12 +399,9 @@ jobs:
   # docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
   ca-clone-secure-ds-test:
     name: Testing CA clone with secure DS
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -416,11 +409,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -429,7 +422,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -540,7 +533,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -703,7 +696,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-secure-ds-primary-${{ matrix.os }}
+          name: ca-secure-ds-primary
           path: |
             /tmp/artifacts/primary
 
@@ -711,19 +704,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-secure-ds-secondary-${{ matrix.os }}
+          name: ca-secure-ds-secondary
           path: |
             /tmp/artifacts/secondary
 
   # https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Random-Serial-Numbers-v1
   ca-random-v1-test:
     name: Testing CA with Random Serial Number v1
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -731,11 +721,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -744,8 +734,8 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
-          COPR_REPO: ${{ needs.init.outputs.repo }}
+          IMAGE: ${{ inputs.db-image}}
+          COPR_REPO: ${{ inputs.repo}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -836,19 +826,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-random-v1-${{ matrix.os }}
+          name: ca-random-v1
           path: |
             /tmp/artifacts/pki
 
   # https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Random-Serial-Numbers-v3
   ca-random-v3-test:
     name: Testing CA with Random Serial Number v3
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -856,11 +843,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -869,8 +856,8 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
-          COPR_REPO: ${{ needs.init.outputs.repo }}
+          IMAGE: ${{ inputs.db-image}}
+          COPR_REPO: ${{ inputs.repo}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -930,7 +917,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-random-v3-${{ matrix.os }}
+          name: ca-random-v3
           path: |
             /tmp/artifacts/pki
 
@@ -1084,12 +1071,9 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-File-System
   crl-file-test:
     name: Testing file-based CRL publishing
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1097,11 +1081,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1110,8 +1094,8 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
-          COPR_REPO: ${{ needs.init.outputs.repo }}
+          IMAGE: ${{ inputs.db-image}}
+          COPR_REPO: ${{ inputs.repo}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1290,19 +1274,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: crl-file-${{ matrix.os }}
+          name: crl-file
           path: |
             /tmp/artifacts/pki
 
   # https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-LDAP-Server
   crl-ldap-test:
     name: Testing LDAP-based CRL publishing
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1310,11 +1291,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1323,8 +1304,8 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
-          COPR_REPO: ${{ needs.init.outputs.repo }}
+          IMAGE: ${{ inputs.db-image}}
+          COPR_REPO: ${{ inputs.repo}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1538,18 +1519,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: crl-ldap-${{ matrix.os }}
+          name: crl-ldap
           path: |
             /tmp/artifacts/pki
 
   scep-test:
     name: Testing SCEP responder
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1557,11 +1535,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1570,7 +1548,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1659,6 +1637,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: scep-${{ matrix.os }}
+          name: scep
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -3,70 +3,15 @@ name: CA Tests 2
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,tests --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-ca-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: ca
+    secrets: inherit
 
   ca-clone-test:
     name: Testing CA clone
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -301,7 +246,7 @@ jobs:
   # docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
   ca-secure-ds-test:
     name: Testing CA with secure DS
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -458,7 +403,7 @@ jobs:
   # docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
   ca-clone-secure-ds-test:
     name: Testing CA clone with secure DS
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -773,7 +718,7 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Random-Serial-Numbers-v1
   ca-random-v1-test:
     name: Testing CA with Random Serial Number v1
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -898,7 +843,7 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Random-Serial-Numbers-v3
   ca-random-v3-test:
     name: Testing CA with Random Serial Number v3
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -1139,7 +1084,7 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-File-System
   crl-file-test:
     name: Testing file-based CRL publishing
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -1352,7 +1297,7 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-LDAP-Server
   crl-ldap-test:
     name: Testing LDAP-based CRL publishing
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -1599,7 +1544,7 @@ jobs:
 
   scep-test:
     name: Testing SCEP responder
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -11,28 +11,6 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Retrieve runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-runner
-          path: pki-runner.tar
-
-      - name: Load runner image
-        run: docker load --input pki-runner.tar
-
-      - name: Set up PKI container
-        run: |
-          tests/bin/runner-init.sh pki
-       
-      - name: Copy build in current folder
-        run: docker cp pki:/usr/share/java/pki ./build
-      
-      - name: Remove maven related file
-        run: rm -f pom.xml
-
       - name: Start Sonar analysis
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,24 +1,15 @@
 name: Code Analysis
-on: [push, pull_request]
+
+on:
+  workflow_call:
 
 jobs:
-  call-build-workflow:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: sonar
-    secrets: inherit
-
-
   sonarcloud:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     name: Sonar Cloud code analysis
-    needs: call-build-workflow
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -26,11 +17,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-sonar-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-sonar-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-sonar-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up PKI container
         run: |

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -1,78 +1,14 @@
 name: IPA Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone the repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,kra,acme --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: tests/ipa/Dockerfile
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: ipa-runner
-          target: ipa-runner
-          outputs: type=docker,dest=ipa-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: ipa-runner.tar
-
   ipa-test:
     name: Testing IPA
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -80,11 +16,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: ipa-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input ipa-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Run IPA container
         run: |
@@ -233,18 +169,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ipa-${{ matrix.os }}
+          name: ipa
           path: |
             /tmp/artifacts/ipa
 
   ipa-acme-test:
     name: Testing IPA ACME
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -252,11 +185,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: ipa-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input ipa-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -388,18 +321,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ipa-acme-${{ matrix.os }}
+          name: ipa-acme
           path: |
             /tmp/artifacts/ipa
 
   ipa-clone-test:
     name: Testing IPA clone
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -407,11 +337,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: ipa-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input ipa-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -534,7 +464,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ipa-clone-primary-${{ matrix.os }}
+          name: ipa-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -542,6 +472,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ipa-clone-secondary-${{ matrix.os }}
+          name: ipa-clone-secondary
           path: |
             /tmp/artifacts/secondary

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -1,23 +1,19 @@
 name: KRA Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
+    inputs:
+      db-image:
+        required: true
+        type: string
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: kra
-    secrets: inherit
-
   # docs/installation/kra/Installing_KRA.md
   kra-test:
     name: Testing KRA
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -25,11 +21,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -38,7 +34,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -208,19 +204,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-${{ matrix.os }}
+          name: kra
           path: |
             /tmp/artifacts/pki
 
   # docs/installation/kra/Installing_KRA_on_Separate_Instance.md
   kra-separate-test:
     name: Testing KRA on separate instance
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -228,11 +221,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -241,7 +234,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -277,7 +270,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh krads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: krads.example.com
           PASSWORD: Secret.123
 
@@ -364,7 +357,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-separate-ca-${{ matrix.os }}
+          name: kra-separate-ca
           path: |
             /tmp/artifacts/ca
 
@@ -372,19 +365,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-separate-kra-${{ matrix.os }}
+          name: kra-separate-kra
           path: |
             /tmp/artifacts/kra
 
   # docs/installation/kra/Installing_KRA_with_External_Certificates.md
   kra-external-certs-test:
     name: Testing KRA with external certificates
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -392,11 +382,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -405,7 +395,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -446,7 +436,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh krads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: krads.example.com
           PASSWORD: Secret.123
 
@@ -596,7 +586,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-external-certs-ca-${{ matrix.os }}
+          name: kra-external-certs-ca
           path: |
             /tmp/artifacts/ca
 
@@ -604,19 +594,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-external-certs-kra-${{ matrix.os }}
+          name: kra-external-certs-kra
           path: |
             /tmp/artifacts/kra
 
   # docs/installation/kra/Installing_KRA_with_External_Certificates.md
   kra-cmc-test:
     name: Testing KRA with CMC
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -624,11 +611,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -637,7 +624,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -678,7 +665,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh krads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: krads.example.com
           PASSWORD: Secret.123
 
@@ -927,7 +914,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-cmc-ca-${{ matrix.os }}
+          name: kra-cmc-ca
           path: |
             /tmp/artifacts/ca
 
@@ -935,19 +922,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-cmc-kra-${{ matrix.os }}
+          name: kra-cmc-kra
           path: |
             /tmp/artifacts/kra
 
   # docs/installation/kra/Installing_KRA_Clone.md
   kra-clone-test:
     name: Testing KRA clone
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -955,11 +939,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -968,7 +952,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -1014,7 +998,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -1076,7 +1060,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tertiaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tertiaryds.example.com
           PASSWORD: Secret.123
 
@@ -1185,7 +1169,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-clone-primary-${{ matrix.os }}
+          name: kra-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -1193,7 +1177,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-clone-secondary-${{ matrix.os }}
+          name: kra-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -1201,18 +1185,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-clone-tertiary-${{ matrix.os }}
+          name: kra-clone-tertiary
           path: |
             /tmp/artifacts/tertiary
 
   kra-standalone-test:
     name: Testing standalone KRA
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1220,11 +1201,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1233,7 +1214,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1374,19 +1355,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-standalone-${{ matrix.os }}
+          name: kra-standalone
           path: |
             /tmp/artifacts/pki
 
   # https://github.com/dogtagpki/pki/wiki/Installing-KRA-with-Random-Serial-Numbers-v3
   kra-random-v3-test:
     name: Testing KRA with Random Serial Number v3
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1394,11 +1372,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1407,7 +1385,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -1505,6 +1483,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: kra-random-v3-${{ matrix.os }}
+          name: kra-random-v3
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -3,71 +3,16 @@ name: KRA Tests
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,kra,tests --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-kra-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: kra
+    secrets: inherit
 
   # docs/installation/kra/Installing_KRA.md
   kra-test:
     name: Testing KRA
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -270,7 +215,7 @@ jobs:
   # docs/installation/kra/Installing_KRA_on_Separate_Instance.md
   kra-separate-test:
     name: Testing KRA on separate instance
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -434,7 +379,7 @@ jobs:
   # docs/installation/kra/Installing_KRA_with_External_Certificates.md
   kra-external-certs-test:
     name: Testing KRA with external certificates
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -666,7 +611,7 @@ jobs:
   # docs/installation/kra/Installing_KRA_with_External_Certificates.md
   kra-cmc-test:
     name: Testing KRA with CMC
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -997,7 +942,7 @@ jobs:
   # docs/installation/kra/Installing_KRA_Clone.md
   kra-clone-test:
     name: Testing KRA clone
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -1262,7 +1207,7 @@ jobs:
 
   kra-standalone-test:
     name: Testing standalone KRA
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -1436,7 +1381,7 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/Installing-KRA-with-Random-Serial-Numbers-v3
   kra-random-v3-test:
     name: Testing KRA with Random Serial Number v3
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -1,23 +1,19 @@
 name: OCSP Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
+    inputs:
+      db-image:
+        required: true
+        type: string
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: ocsp
-    secrets: inherit
-
   # docs/installation/ocsp/Installing_OCSP.md
   ocsp-test:
     name: Testing OCSP
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -25,11 +21,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -38,7 +34,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -266,18 +262,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-${{ matrix.os }}
+          name: ocsp
           path: |
             /tmp/artifacts/pki
 
   ocsp-separate-test:
     name: Testing OCSP on separate instance
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -285,11 +278,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -298,7 +291,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -334,7 +327,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ocspds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ocspds.example.com
           PASSWORD: Secret.123
 
@@ -406,7 +399,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-separate-ca-${{ matrix.os }}
+          name: ocsp-separate-ca
           path: |
             /tmp/artifacts/ca
 
@@ -414,19 +407,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-separate-ocsp-${{ matrix.os }}
+          name: ocsp-separate-ocsp
           path: |
             /tmp/artifacts/ocsp
 
   # docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
   ocsp-external-certs-test:
     name: Testing OCSP with external certificates
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -434,11 +424,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -447,7 +437,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -488,7 +478,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ocspds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ocspds.example.com
           PASSWORD: Secret.123
 
@@ -626,7 +616,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-external-certs-ca-${{ matrix.os }}
+          name: ocsp-external-certs-ca
           path: |
             /tmp/artifacts/ca
 
@@ -634,19 +624,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-external-certs-ocsp-${{ matrix.os }}
+          name: ocsp-external-certs-ocsp
           path: |
             /tmp/artifacts/ocsp
 
   # docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
   ocsp-cmc-test:
     name: Testing OCSP with CMC
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -654,11 +641,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -667,7 +654,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -708,7 +695,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ocspds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ocspds.example.com
           PASSWORD: Secret.123
 
@@ -925,7 +912,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-cmc-ca-${{ matrix.os }}
+          name: ocsp-cmc-ca
           path: |
             /tmp/artifacts/ca
 
@@ -933,19 +920,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-cmc-ocsp-${{ matrix.os }}
+          name: ocsp-cmc-ocsp
           path: |
             /tmp/artifacts/ocsp
 
   # docs/installation/ocsp/Installing_OCSP_Clone.md
   ocsp-clone-test:
     name: Testing OCSP clone
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -953,11 +937,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -966,7 +950,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -1010,7 +994,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -1070,7 +1054,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tertiaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tertiaryds.example.com
           PASSWORD: Secret.123
 
@@ -1177,7 +1161,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-clone-primary-${{ matrix.os }}
+          name: ocsp-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -1185,7 +1169,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-clone-secondary-${{ matrix.os }}
+          name: ocsp-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -1193,19 +1177,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-clone-tertiary-${{ matrix.os }}
+          name: ocsp-clone-tertiary
           path: |
             /tmp/artifacts/tertiary
 
   # https://github.com/dogtagpki/pki/wiki/Installing-Standalone-OCSP
   ocsp-standalone-test:
     name: Testing standalone OCSP
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1213,11 +1194,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -1226,7 +1207,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -1265,7 +1246,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ocspds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ocspds.example.com
           PASSWORD: Secret.123
 
@@ -1404,7 +1385,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-standalone-ca-${{ matrix.os }}
+          name: ocsp-standalone-ca
           path: |
             /tmp/artifacts/ca
 
@@ -1412,6 +1393,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ocsp-standalone-ocsp-${{ matrix.os }}
+          name: ocsp-standalone-ocsp
           path: |
             /tmp/artifacts/ocsp

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -3,71 +3,16 @@ name: OCSP Tests
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,ocsp,tests --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-ocsp-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: ocsp
+    secrets: inherit
 
   # docs/installation/ocsp/Installing_OCSP.md
   ocsp-test:
     name: Testing OCSP
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -327,7 +272,7 @@ jobs:
 
   ocsp-separate-test:
     name: Testing OCSP on separate instance
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -476,7 +421,7 @@ jobs:
   # docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
   ocsp-external-certs-test:
     name: Testing OCSP with external certificates
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -696,7 +641,7 @@ jobs:
   # docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
   ocsp-cmc-test:
     name: Testing OCSP with CMC
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -995,7 +940,7 @@ jobs:
   # docs/installation/ocsp/Installing_OCSP_Clone.md
   ocsp-clone-test:
     name: Testing OCSP clone
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -1255,7 +1200,7 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/Installing-Standalone-OCSP
   ocsp-standalone-test:
     name: Testing standalone OCSP
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -41,3 +41,9 @@ jobs:
   tools-tests:
     needs: build
     uses: ./.github/workflows/tools-tests.yml
+
+  tps-tests:
+    needs: build
+    uses: ./.github/workflows/tps-tests.yml
+    with:
+      db-image: ${{ needs.call-build-workflow.outputs.db-image }}

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -2,6 +2,10 @@ name: PKI CI
 on: [push, pull_request]
 
 jobs:
+  acme-tests:
+    needs: build
+    uses: ./.github/workflows/acme-tests.yml
+
   build:
     uses: ./.github/workflows/build.yml
     secrets: inherit
@@ -26,6 +30,12 @@ jobs:
     uses: ./.github/workflows/code-analysis.yml
     secrets: inherit
 
+  ipa-tests:
+    needs: build
+    uses: ./.github/workflows/kra-tests.yml
+    with:
+      db-image: ${{ needs.call-build-workflow.outputs.db-image }}
+
   kra-tests:
     needs: build
     uses: ./.github/workflows/kra-tests.yml
@@ -44,6 +54,10 @@ jobs:
   qe-tests:
     needs: build
     uses: ./.github/workflows/qe-tests.yml
+
+  server-tests:
+    needs: build
+    uses: ./.github/workflows/server-tests.yml
 
   tks-tests:
     needs: build

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -25,3 +25,7 @@ jobs:
     uses: ./.github/workflows/kra-tests.yml
     with:
       db-image: ${{ needs.call-build-workflow.outputs.db-image }}
+
+  tools-tests:
+    needs: build
+    uses: ./.github/workflows/tools-tests.yml

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -13,6 +13,13 @@ jobs:
       repo: ${{ needs.call-build-workflow.outputs.repo }}
       db-image: ${{ needs.call-build-workflow.outputs.db-image }}
 
+  ca-tests2:
+    needs: build
+    uses: ./.github/workflows/ca-tests2.yml
+    with:
+      repo: ${{ needs.call-build-workflow.outputs.repo }}
+      db-image: ${{ needs.call-build-workflow.outputs.db-image }}
+
   kra-tests:
     needs: build
     uses: ./.github/workflows/kra-tests.yml

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -32,6 +32,12 @@ jobs:
     with:
       db-image: ${{ needs.call-build-workflow.outputs.db-image }}
 
+  tks-tests:
+    needs: build
+    uses: ./.github/workflows/tks-tests.yml
+    with:
+      db-image: ${{ needs.call-build-workflow.outputs.db-image }}
+
   tools-tests:
     needs: build
     uses: ./.github/workflows/tools-tests.yml

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -26,7 +26,6 @@ jobs:
 
   code-analysis:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    needs: build
     uses: ./.github/workflows/code-analysis.yml
     secrets: inherit
 

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -1,0 +1,14 @@
+name: PKI CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  ca-tests:
+    needs: build
+    uses: ./.github/workflows/ca-tests.yml
+    with:
+      repo: ${{ needs.call-build-workflow.outputs.repo }}
+      db-image: ${{ needs.call-build-workflow.outputs.db-image }}

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -20,6 +20,12 @@ jobs:
       repo: ${{ needs.call-build-workflow.outputs.repo }}
       db-image: ${{ needs.call-build-workflow.outputs.db-image }}
 
+  code-analysis:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: build
+    uses: ./.github/workflows/code-analysis.yml
+    secrets: inherit
+
   kra-tests:
     needs: build
     uses: ./.github/workflows/kra-tests.yml

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -26,6 +26,12 @@ jobs:
     with:
       db-image: ${{ needs.call-build-workflow.outputs.db-image }}
 
+  ocsp-tests:
+    needs: build
+    uses: ./.github/workflows/ocsp-tests.yml
+    with:
+      db-image: ${{ needs.call-build-workflow.outputs.db-image }}
+
   tools-tests:
     needs: build
     uses: ./.github/workflows/tools-tests.yml

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -41,6 +41,10 @@ jobs:
   python-tests:
     uses: ./.github/workflows/python-tests.yml
 
+  qe-tests:
+    needs: build
+    uses: ./.github/workflows/qe-tests.yml
+
   tks-tests:
     needs: build
     uses: ./.github/workflows/tks-tests.yml

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -12,3 +12,9 @@ jobs:
     with:
       repo: ${{ needs.call-build-workflow.outputs.repo }}
       db-image: ${{ needs.call-build-workflow.outputs.db-image }}
+
+  kra-tests:
+    needs: build
+    uses: ./.github/workflows/kra-tests.yml
+    with:
+      db-image: ${{ needs.call-build-workflow.outputs.db-image }}

--- a/.github/workflows/pki-ci.yml
+++ b/.github/workflows/pki-ci.yml
@@ -32,6 +32,9 @@ jobs:
     with:
       db-image: ${{ needs.call-build-workflow.outputs.db-image }}
 
+  python-tests:
+    uses: ./.github/workflows/python-tests.yml
+
   tks-tests:
     needs: build
     uses: ./.github/workflows/tks-tests.yml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,22 +1,14 @@
 name: Python Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: tools
-    secrets: inherit
-
   lint-test:
     name: Running Python lint
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -24,11 +16,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-python-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-python-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-python-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Run container
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,70 +3,15 @@ name: Python Tests
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,tests --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-python-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-python-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-python-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: tools
+    secrets: inherit
 
   lint-test:
     name: Running Python lint
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -1,25 +1,17 @@
 name: QE Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: qe
-    secrets: inherit
-
   # Tier 0
   installation-sanity-test:
     # This job uses Ansible playbooks in the tests dir to setup a PKI deployment.
     # All 5 subsystems are deployed on "discrete" instances
     name: Testing installation sanity
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
@@ -34,11 +26,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-qe-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-qe-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-qe-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Run master container
         run: |
@@ -103,6 +95,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: sanity-${{ matrix.os }}
+          name: sanity
           path: |
             /tmp/artifacts/pki1

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -3,73 +3,18 @@ name: QE Tests
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=qe-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: qe-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: qe-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: qe
+    secrets: inherit
 
   # Tier 0
   installation-sanity-test:
     # This job uses Ansible playbooks in the tests dir to setup a PKI deployment.
     # All 5 subsystems are deployed on "discrete" instances
     name: Testing installation sanity
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -89,11 +34,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: qe-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: qe-runner.tar
+          key: pki-qe-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-qe-runner.tar
 
       - name: Load runner image
-        run: docker load --input qe-runner.tar
+        run: docker load --input pki-qe-runner.tar
 
       - name: Run master container
         run: |

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,95 +1,15 @@
 name: Server Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
-
-      - name: Build server image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-server
-          target: pki-server
-          outputs: type=docker,dest=pki-server.tar
-
-      - name: Store server image
-        uses: actions/cache@v3
-        with:
-          key: pki-server-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-server.tar
-
   # docs/installation/server/Installing_Basic_PKI_Server.md
   pki-server-test:
     name: Testing PKI server
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -97,7 +17,7 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner
           path: pki-runner.tar
 
       - name: Load runner image
@@ -154,19 +74,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: pki-server-test-${{ matrix.os }}
+          name: pki-server-test
           path: |
             /tmp/artifacts/pki
 
   # docs/admin/server/Configuring-HTTPS-Connector-with-PEM-Files.adoc
   pki-server-https-pem-test:
     name: Testing HTTPS connector with PEM files
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -174,7 +91,7 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner
           path: pki-runner.tar
 
       - name: Load runner image
@@ -259,19 +176,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: pki-server-https-pem-test-${{ matrix.os }}
+          name: pki-server-https-pem-test
           path: |
             /tmp/artifacts/pki
 
   # docs/admin/server/Configuring-HTTPS-Connector-with-JKS-File.adoc
   pki-server-https-jks-test:
     name: Testing HTTPS connector with JKS file
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -279,7 +193,7 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner
           path: pki-runner.tar
 
       - name: Load runner image
@@ -362,19 +276,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: pki-server-https-jks-test-${{ matrix.os }}
+          name: pki-server-https-jks-test
           path: |
             /tmp/artifacts/pki
 
   # docs/admin/server/Configuring-HTTPS-Connector-with-PKCS12-File.adoc
   pki-server-https-pkcs12-test:
     name: "Testing HTTPS connector with PKCS #12 file"
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -382,7 +293,7 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner
           path: pki-runner.tar
 
       - name: Load runner image
@@ -467,19 +378,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: pki-server-https-pkcs12-test-${{ matrix.os }}
+          name: pki-server-https-pkcs12-test
           path: |
             /tmp/artifacts/pki
 
   # docs/admin/server/Configuring-HTTPS-Connector-with-NSS-Database.adoc
   pki-server-https-nss-test:
     name: Testing HTTPS connector with NSS database
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -487,7 +395,7 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner
           path: pki-runner.tar
 
       - name: Load runner image
@@ -581,18 +489,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: pki-server-https-nss-test-${{ matrix.os }}
+          name: pki-server-https-nss-test
           path: |
             /tmp/artifacts/pki
 
   pki-container-test:
     name: Testing PKI container
-    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -600,7 +505,7 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner
           path: pki-runner.tar
 
       - name: Load runner image
@@ -609,7 +514,7 @@ jobs:
       - name: Retrieve server image
         uses: actions/cache@v3
         with:
-          key: pki-server-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-server
           path: pki-server.tar
 
       - name: Load server image
@@ -651,5 +556,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: pki-container-test-${{ matrix.os }}
+          name: pki-container-test
           path: /tmp/artifacts/server

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -1,23 +1,19 @@
 name: TKS Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
+    inputs:
+      db-image:
+        required: true
+        type: string
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: tks
-    secrets: inherit
-
   # docs/installation/tks/Installing_TKS.md
   tks-test:
     name: Testing TKS
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -25,11 +21,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tks-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -38,7 +34,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -133,18 +129,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tks-${{ matrix.os }}
+          name: tks
           path: |
             /tmp/artifacts/pki
 
   tks-separate-test:
     name: Testing TKS on separate instance
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -152,11 +145,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tks-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -165,7 +158,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -201,7 +194,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tksds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tksds.example.com
           PASSWORD: Secret.123
 
@@ -273,7 +266,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tks-separate-ca-${{ matrix.os }}
+          name: tks-separate-ca
           path: |
             /tmp/artifacts/ca
 
@@ -281,18 +274,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tks-separate-tks-${{ matrix.os }}
+          name: tks-separate-tks
           path: |
             /tmp/artifacts/tks
 
   tks-external-certs-test:
     name: Testing TKS with external certificates
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -300,11 +290,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tks-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -313,7 +303,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -354,7 +344,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tksds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tksds.example.com
           PASSWORD: Secret.123
 
@@ -479,7 +469,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tks-external-certs-ca-${{ matrix.os }}
+          name: tks-external-certs-ca
           path: |
             /tmp/artifacts/ca
 
@@ -487,7 +477,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tks-external-certs-tks-${{ matrix.os }}
+          name: tks-external-certs-tks
           path: |
             /tmp/artifacts/tks
 
@@ -496,12 +486,9 @@ jobs:
   # then installs DS clone, CA clone, and TKS clone in the secondary containers.
   tks-clone-test:
     name: Testing TKS clone
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -509,11 +496,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tks-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -522,7 +509,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -566,7 +553,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -626,7 +613,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tertiaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tertiaryds.example.com
           PASSWORD: Secret.123
 
@@ -732,7 +719,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tks-clone-primary-${{ matrix.os }}
+          name: tks-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -740,7 +727,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tks-clone-secondary-${{ matrix.os }}
+          name: tks-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -748,6 +735,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tks-clone-tertiary-${{ matrix.os }}
+          name: tks-clone-tertiary
           path: |
             /tmp/artifacts/tertiary

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -3,71 +3,16 @@ name: TKS Tests
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,tks --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-tks-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: tks
+    secrets: inherit
 
   # docs/installation/tks/Installing_TKS.md
   tks-test:
     name: Testing TKS
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -194,7 +139,7 @@ jobs:
 
   tks-separate-test:
     name: Testing TKS on separate instance
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -342,7 +287,7 @@ jobs:
 
   tks-external-certs-test:
     name: Testing TKS with external certificates
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -551,7 +496,7 @@ jobs:
   # then installs DS clone, CA clone, and TKS clone in the secondary containers.
   tks-clone-test:
     name: Testing TKS clone
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -3,83 +3,20 @@ name: Tools Tests
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-timestamp --work-dir=build rpm
-
-      - name: Upload PKI packages
-        uses: actions/upload-artifact@v2
-        with:
-          name: pki-build-${{ matrix.os }}
-          path: |
-            build/RPMS/
-            build/SRPMS/
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-tools-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: tools
+    secrets: inherit
 
   PKICertImport-test:
     name: Testing PKICertImport
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -105,12 +42,12 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-rsa-test:
     name: Testing PKI NSS CLI with RSA
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -303,12 +240,12 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-ecc-test:
     name: Testing PKI NSS CLI with ECC
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -502,12 +439,12 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-aes-test:
     name: Testing PKI NSS CLI with AES
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -549,12 +486,12 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-hsm-test:
     name: Testing PKI NSS CLI with HSM
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -803,12 +740,12 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-exts-test:
     name: Testing PKI NSS CLI with Extensions
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -895,12 +832,12 @@ jobs:
   # docs/user/tools/Using-PKI-PKCS7-CLI.adoc
   pki-pkcs7-test:
     name: Testing PKI PKCS7 CLI
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1049,12 +986,12 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-PKCS11-CLI
   pki-pkcs11-test:
     name: Testing PKI PKCS11 CLI
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1251,12 +1188,12 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-PKCS12-CLI
   pki-pkcs12-test:
     name: Testing PKI PKCS12 CLI
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1422,11 +1359,11 @@ jobs:
 
   rpminspect-test:
     name: Run RPMInspect on RPMs
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     container: registry.fedoraproject.org/fedora:${{ matrix.os }}
     strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1324,26 +1324,3 @@ jobs:
           docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
           sed -n 's/^<.*>\s\+\S\+\s\+\(\S\+\).*/\1/p' output | sort > expected
           diff actual expected
-
-  rpminspect-test:
-    name: Run RPMInspect on RPMs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Download PKI packages
-        uses: actions/download-artifact@v2
-        with:
-          name: pki-build
-          path: |
-            build/
-
-      - name: Install RPMInspect
-        run: |
-          dnf install -y dnf-plugins-core rpm-build findutils
-          dnf copr enable -y copr.fedorainfracloud.org/dcantrell/rpminspect
-          dnf install -y rpminspect rpminspect-data-fedora
-      - name: Run RPMInspect on SRPM and RPMs
-        run: |
-          tests/bin/rpminspect.sh

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,22 +1,14 @@
 name: Tools Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: tools
-    secrets: inherit
-
   PKICertImport-test:
     name: Testing PKICertImport
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -24,11 +16,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -42,12 +34,9 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-rsa-test:
     name: Testing PKI NSS CLI with RSA
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -55,11 +44,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -240,12 +229,9 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-ecc-test:
     name: Testing PKI NSS CLI with ECC
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -253,11 +239,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -439,12 +425,9 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-aes-test:
     name: Testing PKI NSS CLI with AES
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -452,11 +435,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -486,12 +469,9 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-hsm-test:
     name: Testing PKI NSS CLI with HSM
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -499,11 +479,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -740,12 +720,9 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
   pki-nss-exts-test:
     name: Testing PKI NSS CLI with Extensions
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -753,11 +730,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -832,12 +809,9 @@ jobs:
   # docs/user/tools/Using-PKI-PKCS7-CLI.adoc
   pki-pkcs7-test:
     name: Testing PKI PKCS7 CLI
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -845,11 +819,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -986,12 +960,9 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-PKCS11-CLI
   pki-pkcs11-test:
     name: Testing PKI PKCS11 CLI
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -999,11 +970,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -1188,12 +1159,9 @@ jobs:
   # https://github.com/dogtagpki/pki/wiki/PKI-PKCS12-CLI
   pki-pkcs12-test:
     name: Testing PKI PKCS12 CLI
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1201,11 +1169,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |
@@ -1359,11 +1327,7 @@ jobs:
 
   rpminspect-test:
     name: Run RPMInspect on RPMs
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -1371,7 +1335,7 @@ jobs:
       - name: Download PKI packages
         uses: actions/download-artifact@v2
         with:
-          name: pki-build-${{ matrix.os }}
+          name: pki-build
           path: |
             build/
 

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -1,23 +1,19 @@
 name: TPS Tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
+    inputs:
+      db-image:
+        required: true
+        type: string
 
 jobs:
-  call-build-workflow:
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: tps
-    secrets: inherit
-
   # docs/installation/tps/Installing_TPS.md
   tps-test:
     name: Testing TPS
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -25,11 +21,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tps-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -38,7 +34,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 
@@ -212,18 +208,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-${{ matrix.os }}
+          name: tps
           path: |
             /tmp/artifacts/pki
 
   tps-separate-test:
     name: Testing TPS on separate instance
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -231,11 +224,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tps-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -244,7 +237,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -280,7 +273,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh krads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: krads.example.com
           PASSWORD: Secret.123
 
@@ -322,7 +315,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tksds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tksds.example.com
           PASSWORD: Secret.123
 
@@ -360,7 +353,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tpsds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tpsds.example.com
           PASSWORD: Secret.123
 
@@ -455,7 +448,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-separate-ca-${{ matrix.os }}
+          name: tps-separate-ca
           path: |
             /tmp/artifacts/ca
 
@@ -463,7 +456,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-separate-kra-${{ matrix.os }}
+          name: tps-separate-kra
           path: |
             /tmp/artifacts/kra
 
@@ -471,7 +464,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-separate-tks-${{ matrix.os }}
+          name: tps-separate-tks
           path: |
             /tmp/artifacts/tks
 
@@ -479,18 +472,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-separate-tps-${{ matrix.os }}
+          name: tps-separate-tps
           path: |
             /tmp/artifacts/tps
 
   tps-external-certs-test:
     name: Testing TPS with external certificates
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -498,11 +488,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tps-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -511,7 +501,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh cads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: cads.example.com
           PASSWORD: Secret.123
 
@@ -552,7 +542,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh krads
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: krads.example.com
           PASSWORD: Secret.123
 
@@ -590,7 +580,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tksds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tksds.example.com
           PASSWORD: Secret.123
 
@@ -625,7 +615,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh tpsds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: tpsds.example.com
           PASSWORD: Secret.123
 
@@ -788,7 +778,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-external-certs-kra-${{ matrix.os }}
+          name: tps-external-certs-kra
           path: |
             /tmp/artifacts/kra
 
@@ -796,7 +786,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-external-certs-tks-${{ matrix.os }}
+          name: tps-external-certs-tks
           path: |
             /tmp/artifacts/tks
 
@@ -804,7 +794,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-external-certs-tps-${{ matrix.os }}
+          name: tps-external-certs-tps
           path: |
             /tmp/artifacts/tps
 
@@ -813,12 +803,9 @@ jobs:
   # then installs DS clone, CA clone, KRA clone, TKS clone, and TPS clone in the secondary containers.
   tps-clone-test:
     name: Testing TPS clone
-    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -826,11 +813,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          key: pki-runner
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tps-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example
@@ -839,7 +826,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -909,7 +896,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
+          IMAGE: ${{ inputs.db-image}}
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 
@@ -1045,7 +1032,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-clone-primary-${{ matrix.os }}
+          name: tps-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -1053,6 +1040,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: tps-clone-secondary-${{ matrix.os }}
+          name: tps-clone-secondary
           path: |
             /tmp/artifacts/secondary

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -3,71 +3,16 @@ name: TPS Tests
 on: [push, pull_request]
 
 jobs:
-  init:
-    name: Initializing workflow
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
-      repo: ${{ steps.init.outputs.repo }}
-      db-image: ${{ steps.init.outputs.db-image }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Initialize workflow
-        id: init
-        env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
-          BASE64_REPO: ${{ secrets.BASE64_REPO }}
-          BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
-        run: |
-          tests/bin/init-workflow.sh
-
-  # docs/development/Building_PKI.md
-  build:
-    name: Building PKI
-    needs: init
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.os }}
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          dnf install -y dnf-plugins-core rpm-build moby-engine
-          dnf copr enable -y ${{ needs.init.outputs.repo }}
-          dnf builddep -y --allowerasing --spec ./pki.spec --nogpgcheck
-
-      - name: Build PKI packages
-        run: ./build.sh --with-pkgs=base,server,ca,kra,tks,tps --with-timestamp --work-dir=build rpm
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build runner image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          outputs: type=docker,dest=pki-tps-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+  call-build-workflow:
+    uses: ./.github/workflows/build.yml
+    with:
+      key_container: tps
+    secrets: inherit
 
   # docs/installation/tps/Installing_TPS.md
   tps-test:
     name: Testing TPS
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -273,7 +218,7 @@ jobs:
 
   tps-separate-test:
     name: Testing TPS on separate instance
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -540,7 +485,7 @@ jobs:
 
   tps-external-certs-test:
     name: Testing TPS with external certificates
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
@@ -868,7 +813,7 @@ jobs:
   # then installs DS clone, CA clone, KRA clone, TKS clone, and TPS clone in the secondary containers.
   tps-clone-test:
     name: Testing TPS clone
-    needs: [init, build]
+    needs: [call-build-workflow]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki

--- a/tests/ipa/Dockerfile
+++ b/tests/ipa/Dockerfile
@@ -14,7 +14,7 @@ ARG VERSION="0"
 ARG OS_VERSION="latest"
 ARG COPR_REPO="@pki/master"
 
-FROM registry.fedoraproject.org/fedora:$OS_VERSION AS ipa-runner
+FROM registry.fedoraproject.org/fedora:$OS_VERSION AS pki-runner
 
 ARG COPR_REPO
 


### PR DESCRIPTION
Reduces duplication and paves the way for only buildings the packages
once, rather than the current 11 builds.

acme-tests.yml, ipa-tests.yml and server-tests.yml will be handled
separately, as the build steps for those are slightly different.