### PR TITLE
Bump redhat-rpm-config dependency

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -148,7 +148,14 @@ BuildRequires:    gcc-c++
 BuildRequires:    zip
 BuildRequires:    %{java_devel}
 BuildRequires:    javapackages-tools
-BuildRequires:    redhat-rpm-config
+
+# redhat-rpm-config defines java_arches macro
+%if 0%{?fedora} && 0%{?fedora} <= 35
+BuildRequires:    redhat-rpm-config >= 201
+%else
+BuildRequires:    redhat-rpm-config >= 219
+%endif
+
 BuildRequires:    apache-commons-cli
 BuildRequires:    apache-commons-codec
 BuildRequires:    apache-commons-io


### PR DESCRIPTION
`java_arches` macro was add into `redhat-rpm-config` in version 201 on F35 and in version 219 on F36 or later.

https://src.fedoraproject.org/rpms/redhat-rpm-config/c/1926c37598951ae30749eb212b2412973a0300e5?branch=f35
https://src.fedoraproject.org/rpms/redhat-rpm-config/c/42b3f9289ae0764e3737eb380e620d3028dc6ce3?branch=f36
https://src.fedoraproject.org/rpms/redhat-rpm-config/c/f8b207df3be5c6de96864d25514d22e136b1fe87?branch=rawhide