### PR TITLE
Don't use deprecated python-ldap options

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -188,8 +188,6 @@ class PKIDeployer:
             ds_protocol = 'ldaps'
             ds_port = self.mdict['pki_ds_ldaps_port']
             # ldap.set_option(ldap.OPT_DEBUG_LEVEL, 255)
-            ldap.set_option(ldap.OPT_X_TLS_DEMAND, True)
-            ldap.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND)
             ldap.set_option(ldap.OPT_X_TLS_CACERTFILE,
                             self.mdict['pki_ds_secure_connection_ca_pem_file'])
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)


### PR DESCRIPTION
- `OPT_X_TLS` is deprecated since python-ldap 3.3.0 and was removed in
  3.4.2.
- `OPT_X_TLS_DEMAND` is not a valid option key.

`ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)` is
sufficient to enforce cert validation.

Closes: #4081