### PR TITLE
Remove pki_restart_configured_instance

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -124,7 +124,6 @@ pki_issuing_ca_uri=https://%(pki_issuing_ca_hostname)s:%(pki_issuing_ca_https_po
 pki_issuing_ca=%(pki_issuing_ca_uri)s
 pki_replication_password=
 pki_status_request_timeout=
-pki_restart_configured_instance=True
 pki_security_domain_hostname=%(pki_hostname)s
 pki_security_domain_https_port=8443
 pki_security_domain_uri=https://%(pki_security_domain_hostname)s:%(pki_security_domain_https_port)s

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -492,8 +492,14 @@ class PKIConfigParser:
             if not section:
                 continue
 
-            # Param found, display deprecation warning.
+            # no new section and no replacement param -> display removal warning
+            if not new_section and not new_param:
+                logger.warning(
+                    'The \'%s\' in [%s] is no longer used. Remove the parameter.',
+                    param, section)
+                return
 
+            # display deprecation warning
             message = 'The \'%s\' in [%s] has been deprecated.' % (param, section)
 
             # If new param is defined in a different section, include it in message.

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -88,7 +88,9 @@ class PKIConfigParser:
         (None, 'pki_pin',
          None, 'pki_server_database_password'),
         (None, 'pki_ajp_host',
-         None, 'pki_ajp_host_ipv4')
+         None, 'pki_ajp_host_ipv4'),
+        (None, 'pki_restart_configured_instance',
+         None, None),
     ]
 
     DEPRECATED_CA_PARAMS = [

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -643,18 +643,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                     max_wait=deployer.startup_timeout,
                     timeout=deployer.request_timeout)
 
-        elif tomcat_instance_subsystems > 1:
-
-            if using_legacy_id_generator:
-                logger.info('Starting %s subsystem', subsystem.type)
-                subsystem.enable(
-                    wait=True,
-                    max_wait=deployer.startup_timeout,
-                    timeout=deployer.request_timeout)
-
-        if using_legacy_id_generator:
-            logger.info('Waiting for %s subsystem', subsystem.type)
-            subsystem.wait_for_startup(deployer.startup_timeout, deployer.request_timeout)
+                logger.info('Waiting for %s subsystem', subsystem.type)
+                subsystem.wait_for_startup(deployer.startup_timeout, deployer.request_timeout)
 
         # Optionally wait for debugger to attach (e. g. - 'eclipse'):
         if config.str2bool(deployer.mdict['pki_enable_java_debugger']):
@@ -780,15 +770,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 max_wait=deployer.startup_timeout,
                 timeout=deployer.request_timeout)
 
-        elif config.str2bool(deployer.mdict['pki_restart_configured_instance']):
-
-            if using_legacy_id_generator:
-                logger.info('Stopping %s subsystem', subsystem.type)
-                subsystem.disable(
-                    wait=True,
-                    max_wait=deployer.startup_timeout,
-                    timeout=deployer.request_timeout)
-
+        else:
             logger.info('Starting %s subsystem', subsystem.type)
             subsystem.enable(
                 wait=True,

--- a/docs/changes/v11.3.0/Server-Changes.adoc
+++ b/docs/changes/v11.3.0/Server-Changes.adoc
@@ -1,0 +1,5 @@
+= Server Changes =
+
+== Remove pki_restart_configured_instance ==
+
+The `pki_restart_configured_instance` parameter for `pkispawn` is no longer used so it has been removed.

--- a/docs/manuals/man5/pki_default.cfg.5.md
+++ b/docs/manuals/man5/pki_default.cfg.5.md
@@ -306,9 +306,6 @@ The URI has the format https://*ca_hostname*:*ca_https_port*.
 
 ### MISCELLANEOUS PARAMETERS
 
-**pki_restart_configured_instance**  
-Sets whether to restart the instance after configuration is complete.  Defaults to True.
-
 **pki_enable_access_log**  
 Located in the [Tomcat] section, this variable determines whether the instance will enable (True) or disable (False) Tomcat access logging.
 Defaults to True.

--- a/tests/dogtag/acceptance/quickinstall/rhcs-install-lib.sh
+++ b/tests/dogtag/acceptance/quickinstall/rhcs-install-lib.sh
@@ -151,7 +151,6 @@ rhcs_install_RootCA() {
 		echo "pki_ds_remove_data=$REMOVE_DATA" >> $INSTANCECFG
 		echo "pki_ds_base_dn=$ROOTCA_DB_SUFFIX" >> $INSTANCECFG
 		echo "pki_ds_database=$ROOTCA_LDAP_INSTANCE_NAME" >> $INSTANCECFG
-		echo "pki_restart_configured_instance=$RESTART_INSTANCE" >> $INSTANCECFG
 		echo "pki_skip_configuration=$SKIP_CONFIG" >> $INSTANCECFG
 		echo "pki_skip_installation=$SKIP_INSTALL" >> $INSTANCECFG
 		echo "pki_enable_access_log=$ENABLE_ACCESS_LOG" >> $INSTANCECFG
@@ -314,7 +313,6 @@ rhcs_install_kra() {
 		echo "pki_ds_remove_data=$REMOVE_DATA" >> $INSTANCECFG
 		echo "pki_ds_base_dn =$(eval echo \$KRA${number}_DB_SUFFIX)" >> $INSTANCECFG
 		echo "pki_ds_database=$(eval echo \$KRA${number}_LDAP_INSTANCE_NAME)" >> $INSTANCECFG
-		echo "pki_restart_configured_instance=$RESTART_INSTANCE" >> $INSTANCECFG
 		echo "pki_skip_configuration=$SKIP_CONFIG" >> $INSTANCECFG
 		echo "pki_skip_installation=$SKIP_INSTALL" >> $INSTANCECFG
 		echo "pki_enable_access_log=$ENABLE_ACCESS_LOG" >> $INSTANCECFG
@@ -465,7 +463,6 @@ rhcs_install_ocsp() {
 		echo "pki_ds_remove_data=$REMOVE_DATA" >> $INSTANCECFG
 		echo "pki_ds_base_dn =$(eval echo \$OCSP${number}_DB_SUFFIX)" >> $INSTANCECFG
 		echo "pki_ds_database=$(eval echo \$OCSP${number}_LDAP_INSTANCE_NAME)" >> $INSTANCECFG
-		echo "pki_restart_configured_instance=$RESTART_INSTANCE" >> $INSTANCECFG
 		echo "pki_skip_configuration=$SKIP_CONFIG" >> $INSTANCECFG
 		echo "pki_skip_installation=$SKIP_INSTALL" >> $INSTANCECFG
 		echo "pki_enable_access_log=$ENABLE_ACCESS_LOG" >> $INSTANCECFG
@@ -607,7 +604,6 @@ rhcs_install_tks() {
 		echo "pki_ds_remove_data=$REMOVE_DATA" >> $INSTANCECFG
 		echo "pki_ds_base_dn =$(eval echo \$TKS${number}_DB_SUFFIX)" >> $INSTANCECFG
 		echo "pki_ds_database=$(eval echo \$TKS${number}_LDAP_INSTANCE_NAME)" >> $INSTANCECFG
-		echo "pki_restart_configured_instance=$RESTART_INSTANCE" >> $INSTANCECFG
 		echo "pki_skip_configuration=$SKIP_CONFIG" >> $INSTANCECFG
 		echo "pki_skip_installation=$SKIP_INSTALL" >> $INSTANCECFG
 		echo "pki_enable_access_log=$ENABLE_ACCESS_LOG" >> $INSTANCECFG
@@ -759,7 +755,6 @@ rhcs_install_tps() {
                 echo "pki_ds_remove_data=$REMOVE_DATA" >> $INSTANCECFG
                 echo "pki_ds_base_dn =$(eval echo \$TPS${number}_DB_SUFFIX)" >> $INSTANCECFG
                 echo "pki_ds_database=$(eval echo \$TPS${number}_LDAP_INSTANCE_NAME)" >> $INSTANCECFG
-                echo "pki_restart_configured_instance=$RESTART_INSTANCE" >> $INSTANCECFG
                 echo "pki_skip_configuration=$SKIP_CONFIG" >> $INSTANCECFG
                 echo "pki_skip_installation=$SKIP_INSTALL" >> $INSTANCECFG
                 echo "pki_enable_access_log=$ENABLE_ACCESS_LOG" >> $INSTANCECFG
@@ -1042,7 +1037,6 @@ rhcs_install_SubCA(){
                 echo "pki_client_database_dir=$(eval echo \$SUBCA${number}_CERTDB_DIR)" >> $INSTANCECFG
                 echo "pki_client_database_password=$(eval echo \$SUBCA${number}_CERTDB_DIR_PASSWORD)" >> $INSTANCECFG
                 echo "pki_client_database_purge=$(eval echo \$SUBCA${number}_CLIENT_DB_PURGE)" >> $INSTANCECFG
- 		echo "pki_restart_configured_instance=$RESTART_INSTANCE" >> $INSTANCECFG
                 echo "pki_skip_configuration=$SKIP_CONFIG" >> $INSTANCECFG
                 echo "pki_skip_installation=$SKIP_INSTALL" >> $INSTANCECFG
                 echo "pki_enable_access_log=$ENABLE_ACCESS_LOG" >> $INSTANCECFG
@@ -1667,7 +1661,6 @@ rhcs_install_CAwithExtCA() {
         echo "pki_client_database_dir=$(eval echo \$SUBCA${number}_CERTDB_DIR)" >> $INSTANCECFG
         echo "pki_client_database_password=$(eval echo \$SUBCA${number}_CERTDB_DIR_PASSWORD)" >> $INSTANCECFG
         echo "pki_client_database_purge=$(eval echo \$SUBCA${number}_CLIENT_DB_PURGE)" >> $INSTANCECFG
-        echo "pki_restart_configured_instance=$RESTART_INSTANCE" >> $INSTANCECFG
 		echo "pki_skip_configuration=$SKIP_CONFIG" >> $INSTANCECFG
                 echo "pki_skip_installation=$SKIP_INSTALL" >> $INSTANCECFG
                 echo "pki_enable_access_log=$ENABLE_ACCESS_LOG" >> $INSTANCECFG


### PR DESCRIPTION
In the past when installing an additional subsystem (after the first one) the subsystem had to be started first to execute some installation steps, then restarted to actually run the subsystem. The `pki_restart_configured_instance` param provided an option to skip the restart to optimize the installation process in IPA.

Now the subsystem no longer needs to be restarted since those steps can be executed offline, so the code has been modified to skip the initial startup. The param has been removed as well since it's no longer used. The `DEPRECATED_PARAMS` list has also been updated to generate a removal warning for this param.

Previously the `PKIConfigParser.validate_user_config()` would generate a deprecation warning for `pkispawn` params listed in the `DEPRECATED_PARAMS` list and show the new section and/or the replacement param.

The code has been updated to generate a removal warning if there is no new section or param name specified in the list.

https://github.com/edewata/pki/blob/install/docs/changes/v11.3.0/Server-Changes.adoc