### PR TITLE
Add test for publishing CRL to OCSP responder

### DIFF
--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -1253,6 +1253,7 @@ jobs:
             /tmp/artifacts/tertiary
 
   # https://github.com/dogtagpki/pki/wiki/Installing-Standalone-OCSP
+  # https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-OCSP-Responder
   ocsp-standalone-test:
     name: Testing standalone OCSP
     needs: [init, build]
@@ -1434,6 +1435,168 @@ jobs:
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec ocsp pki -n ocspadmin ocsp-user-show ocspadmin
+
+      - name: Create CA user in OCSP
+        run: |
+          # export CA subsystem cert
+          docker exec ca pki-server cert-export subsystem --cert-file ${SHARED}/subsystem.crt
+
+          # create CA user with CA subsystem cert
+          docker exec ocsp pki-server ocsp-user-add CA --full-name "CA" --type agentType
+          docker exec ocsp pki-server ocsp-user-cert-add CA --cert ${SHARED}/subsystem.crt
+          docker exec ocsp pki-server ocsp-group-member-add "Trusted Managers" CA
+
+      - name: Create CRL issuing point in OCSP
+        run: |
+          # convert CA signing cert into PKCS #7 chain
+          docker exec ocsp pki pkcs7-cert-import --pkcs7 ca_signing.p7 --input-file ${SHARED}/ca_signing.crt
+          docker exec ocsp pki pkcs7-cert-find --pkcs7 ca_signing.p7
+
+          # create CRL issuing point with the PKCS #7 chain
+          docker exec ocsp pki-server ocsp-crl-issuingpoint-add --cert-chain ca_signing.p7
+
+      - name: Configure OCSP publishing in CA
+        run: |
+          # configure OCSP publisher
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.enableClientAuth true
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.host ocsp.example.com
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.nickName subsystem
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.path /ocsp/agent/ocsp/addCRL
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.pluginName OCSPPublisher
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.port 8443
+
+          # configure CRL publishing rule
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.enable true
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.mapper NoMap
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.pluginName Rule
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.publisher OCSPPublisher
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.type crl
+
+          # enable CRL publishing
+          docker exec ca pki-server ca-config-set ca.publish.enable true
+
+          # set buffer size to 0 so that revocation will take effect immediately
+          docker exec ca pki-server ca-config-set auths.revocationChecking.bufferSize 0
+
+          # update CRL immediately after each cert revocation
+          docker exec ca pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
+
+          # restart CA subsystem
+          docker exec ca pki-server ca-undeploy --wait
+          docker exec ca pki-server ca-deploy --wait
+
+      - name: Check OCSP responder with no CRLs
+        run: |
+          # create CA agent and its cert
+          docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-create.sh
+          docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-cert-create.sh
+
+          # get cert serial number
+          docker exec ca pki nss-cert-show caagent | tee output
+          CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          # check cert status using OCSPClient
+          docker exec ocsp OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # the responder should fail
+          sed -n "s/^SEVERE:\s*\(\S*\)/\1/p" stderr > actual
+          echo "InvalidBERException: Incorrect tag: expected [UNIVERSAL 16], found [UNIVERSAL 28]" > expected
+          diff expected actual
+
+          # check cert status using OpenSSL
+          docker exec ocsp openssl ocsp \
+              -url http://ocsp.example.com:8080/ocsp/ee/ocsp \
+              -CAfile ${SHARED}/ca_signing.crt \
+              -issuer ${SHARED}/ca_signing.crt \
+              -serial $CERT_ID \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # remove the random parts of stderr so it can be compared
+          sed -i "s/^[^:]*:error:/error:/g" stderr
+
+          # the responder should fail
+          echo "Error querying OCSP responder" > expected
+          echo "error:1E800076:HTTP routines:OSSL_HTTP_REQ_CTX_nbio:unexpected content type:crypto/http/http_client.c:676:expected=application/ocsp-response, actual=text/html" >> expected
+          echo "error:1E800067:HTTP routines:OSSL_HTTP_REQ_CTX_exchange:error receiving:crypto/http/http_client.c:874:server=http://ocsp.example.com:8080" >> expected
+
+          diff expected stderr
+
+      - name: Check OCSP responder with revoked cert
+        run: |
+          # revoke CA agent cert
+          docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-cert-revoke.sh
+
+          # get cert serial number
+          docker exec ca pki nss-cert-show caagent | tee output
+          CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          # check cert status using OCSPClient
+          docker exec ocsp OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID | tee output
+
+          # the status should be revoked
+          sed -n "s/^CertStatus=\(.*\)$/\1/p" output > actual
+          echo Revoked > expected
+          diff expected actual
+
+          # check cert status using OpenSSL
+          docker exec ocsp openssl ocsp \
+              -url http://ocsp.example.com:8080/ocsp/ee/ocsp \
+              -CAfile ${SHARED}/ca_signing.crt \
+              -issuer ${SHARED}/ca_signing.crt \
+              -serial $CERT_ID | tee output
+
+          # the status should be revoked
+          sed -n "s/^$CERT_ID:\s*\(\S*\)$/\1/p" output > actual
+          echo revoked > expected
+          diff expected actual
+
+      - name: Check OCSP responder with unrevoked cert
+        run: |
+          # unrevoke CA agent cert
+          docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-cert-unrevoke.sh
+
+          # get cert serial number
+          docker exec ca pki nss-cert-show caagent | tee output
+          CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          # check cert status using OCSPClient
+          docker exec ocsp OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID | tee output
+
+          # the status should be good
+          sed -n "s/^CertStatus=\(.*\)$/\1/p" output > actual
+          echo Good > expected
+          diff expected actual
+
+          # check cert status using OpenSSL
+          docker exec ocsp openssl ocsp \
+              -url http://ocsp.example.com:8080/ocsp/ee/ocsp \
+              -CAfile ${SHARED}/ca_signing.crt \
+              -issuer ${SHARED}/ca_signing.crt \
+              -serial $CERT_ID | tee output
+
+          # the status should be good
+          sed -n "s/^$CERT_ID:\s*\(\S*\)$/\1/p" output > actual
+          echo good > expected
+          diff expected actual
 
       - name: Gather artifacts from CA containers
         if: always()


### PR DESCRIPTION
The standalone OCSP test has been modified to configure the CA to publish the CRLs to the OCSP responder.

https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-OCSP-Responder