### PR TITLE
Conditionally set empty subject name

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/profile/common/EnrollProfile.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/common/EnrollProfile.java
@@ -378,8 +378,9 @@ public abstract class EnrollProfile extends Profile {
             info.set(X509CertInfo.KEY,
                     new CertificateX509Key(X509Key.parse(new DerValue(dummykey))));
 
+            String defaultSubjectName = mConfig.getString("defaultSubjectName", "");
             info.set(X509CertInfo.SUBJECT,
-                    new CertificateSubjectName(new X500Name("")));
+                    new CertificateSubjectName(new X500Name(defaultSubjectName)));
 
             info.set(X509CertInfo.VALIDITY,
                     new CertificateValidity(new Date(), new Date()));


### PR DESCRIPTION
The empty name is currently required for ACME, but we require it to not
be set on some older branches.

The proposed solution is to set the empty subject by default and
override it in the older branches with a property to not set it.