### PR TITLE
fix LWCA key replication

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/ExternalProcessKeyRetriever.java
+++ b/base/ca/src/main/java/com/netscape/ca/ExternalProcessKeyRetriever.java
@@ -102,7 +102,7 @@ public class ExternalProcessKeyRetriever implements KeyRetriever {
         String result = new String(in.readAllBytes());
         logger.debug("ExternalProcessKeyRetriever: Result:\n" + result);
 
-        JsonNode root = new JSONObject(result).getRootNode();
+        JsonNode root = new JSONObject(result).getJsonNode();
 
         JsonNode certNode = root.path("certificate");
 
@@ -125,11 +125,8 @@ public class ExternalProcessKeyRetriever implements KeyRetriever {
         if (wrappedKeyNode.isMissingNode()) {
             throw new RuntimeException("Missing \"wrapped_key\" node");
         }
-        if (!wrappedKeyNode.isBinary()) {
-            throw new RuntimeException("Invalid \"wrapped_key\" node: " + wrappedKeyNode);
-        }
-
-        byte[] pao = wrappedKeyNode.binaryValue(); // won't return null
+        // won't return null, but throws IOException if base64 decoding fails
+        byte[] pao = wrappedKeyNode.binaryValue();
 
         if (pao.length == 0) {
             throw new RuntimeException("Missing \"wrapped_key\" value");


### PR DESCRIPTION
Commit 47b3affc0dd576cb11dc93561cafffe1a25c2e8e refactors the JSON
handling in ExternalProcessKeyRetriever.  It introduced a regression
that causes lightweight CA key replication to fail.  It scrutinises
an empty node instead of the JSON node containing the object loaded
from the InputStream.  Update the code to scrutinise the correct
node.

Separately, commit 6c116bf52f9691a5e7727d087a615f5009474316 enhanced
the ExternalProcessKeyRetriever diagnostic output.  It also broke
key retrieval.  The `wrapped_key` field value is expected to be a
text node containing base64-encoded data.  We retrieve its decoded
value using `.binaryValue()`.  That commit added a check that throws
an exception if `node.isBinary()` is false.  However, the node is
parsed as a com.fasterxml.jackson.databind.node.TextNode, for which
`.isBinary()` returns false.  This commit removes the check.
`.binaryValue()` will (as before) throw an `IOException` if base64
decoding fails.

Fixes: https://github.com/dogtagpki/pki/issues/4032