### PR TITLE
Add pki_self_signed_nickname

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -130,7 +130,6 @@ pki_security_domain_uri=https://%(pki_security_domain_hostname)s:%(pki_security_
 pki_security_domain_name=%(pki_dns_domainname)s Security Domain
 pki_security_domain_password=
 pki_security_domain_user=caadmin
-pki_self_signed_token=
 #for supporting server cert SAN injection
 pki_san_inject=False
 pki_san_for_server_cert=
@@ -155,6 +154,9 @@ pki_sslserver_key_type=%(pki_ssl_server_key_type)s
 pki_sslserver_nickname=%(pki_ssl_server_nickname)s
 pki_sslserver_subject_dn=%(pki_ssl_server_subject_dn)s
 pki_sslserver_token=%(pki_ssl_server_token)s
+
+pki_self_signed_nickname=temp %(pki_sslserver_nickname)s
+pki_self_signed_token=
 
 pki_subsystem_key_algorithm=SHA256withRSA
 pki_subsystem_signing_algorithm=SHA256withRSA

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -660,6 +660,13 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         try:
             system_certs = deployer.setup_system_certs(nssdb, subsystem)
+
+            # Import perm SSL server cert unless it's already imported
+            # earlier in external/standalone installation.
+
+            if not (standalone or external and subsystem.name in ['kra', 'ocsp']):
+                deployer.import_perm_sslserver_cert(instance, system_certs['sslserver'])
+
         finally:
             nssdb.close()
 
@@ -748,12 +755,6 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
                 # Remove temp SSL server cert.
                 deployer.remove_temp_sslserver_cert(instance, system_certs['sslserver'])
-
-            # Import perm SSL server cert unless it's already imported
-            # earlier in external/standalone installation.
-
-            if not (standalone or external and subsystem.name in ['kra', 'ocsp']):
-                deployer.import_perm_sslserver_cert(instance, system_certs['sslserver'])
 
             # Store perm SSL server cert nickname and token
             nickname = system_certs['sslserver']['nickname']


### PR DESCRIPTION
Previously the installation code was using the same nickname for the temporary (self-signed) and permanent SSL server certs, so the permanent cert could not be imported into the NSS database until the temporary one is removed.

The `pki_self_signed_nickname` parameter has been added to define a separate nickname for the temporary cert, allowing the permanent cert to be imported earlier along with other system certs.

The `PKIDeployer.temp_sslserver_cert_created` is no longer used so it has been removed.