### PR TITLE
Add test for pki-server upgrade

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -585,6 +585,113 @@ jobs:
           path: |
             /tmp/artifacts/pki
 
+  pki-server-upgrade-test:
+    name: Testing PKI server upgrade
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up server container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect server container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Add upgrade script
+        run: |
+          MAJOR_VERSION=$(sed -n 's/^%global *major_version *\(.*\)$/\1/p' pki.spec)
+          MINOR_VERSION=$(sed -n 's/^%global *minor_version *\(.*\)$/\1/p' pki.spec)
+          UPDATE_VERSION=$(sed -n 's/^%global *update_version *\(.*\)$/\1/p' pki.spec)
+
+          VERSION=$MAJOR_VERSION.$MINOR_VERSION.$UPDATE_VERSION
+          echo "VERSION: $VERSION"
+
+          UPGRADE_DIR=/usr/share/pki/server/upgrade/$VERSION
+          echo "UPGRADE_DIR: $UPGRADE_DIR"
+
+          docker exec pki mkdir -p $UPGRADE_DIR
+          docker exec pki ls $UPGRADE_DIR | tee output
+
+          LAST_SCRIPT=$(tail -1 output)
+          echo "LAST_SCRIPT: $LAST_SCRIPT"
+
+          LAST_INDEX=$(echo "$LAST_SCRIPT" | sed 's/^\([0-9]*\).*$/\1/')
+          echo "LAST_INDEX: $LAST_INDEX"
+
+          if [ -z "$LAST_INDEX" ];then
+              INDEX="01"
+          else
+              INDEX=$((LAST_INDEX + 1))
+              if [ "$INDEX" -lt "10" ];then
+                  INDEX="0$INDEX"
+              fi
+          fi
+          echo "INDEX: $INDEX"
+
+          docker exec pki cp \
+              /usr/share/pki/server/examples/upgrade/01-BasicUpgradeScript.py \
+              $UPGRADE_DIR/$INDEX-BasicUpgradeScript.py
+          docker exec pki ls $UPGRADE_DIR
+
+      - name: Run upgrade without any servers
+        run: |
+          docker exec pki pki-server upgrade -v | tee output
+
+          # verify that the upgrade script was not executed
+          grep "BasicUpgradeScript" output | tee actual
+          [ ! -s actual ]
+
+      - name: Create PKI server
+        run: |
+          docker exec pki pki-server create -v
+
+      - name: Run upgrade with one server
+        run: |
+          docker exec pki pki-server upgrade -v | tee output
+
+          # verify that the upgrade script was executed
+          grep "BasicUpgradeScript:" output | tee actual
+          [ -s actual ]
+
+      - name: Remove PKI server
+        run: |
+          docker exec pki pki-server remove -v
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: pki-server-upgrade-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/pki
+
   pki-container-test:
     name: Testing PKI container
     needs: [init, build]

--- a/base/server/examples/upgrade/01-BasicUpgradeScript.py
+++ b/base/server/examples/upgrade/01-BasicUpgradeScript.py
@@ -1,0 +1,14 @@
+import pki.server.upgrade
+
+
+class BasicUpgradeScript(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Basic upgrade script'
+
+    def upgrade_instance(self, instance):
+        print('BasicUpgradeScript: Upgrading %s instance' % instance.name)
+
+    def upgrade_subsystem(self, instance, subsystem):
+        print('BasicUpgradeScript: Upgrading %s subsystem' % subsystem.name)

--- a/docs/development/Creating-Upgrade-Script.adoc
+++ b/docs/development/Creating-Upgrade-Script.adoc
@@ -1,0 +1,95 @@
+= Creating Upgrade Script =
+
+== Overview ==
+
+This page describes the process to create a new upgrade script for the next release.
+
+It assumes that the `major_version`, `minor_version`, and `update_version` macros
+in link:../../pki.spec[pki.spec] have been updated for the next release.
+
+== Upgrade Folder ==
+
+Upgrade scripts are organized by version numbers in link:../../base/server/upgrade[base/server/upgrade] folder.
+
+The new upgrade script needs to be stored in `base/server/upgrade/<version>` folder
+where the `<version>` is the `<major>.<minor>.<update>` version of the next release.
+
+If the folder does not exist, create the folder.
+
+== Index Number ==
+
+The upgrade scripts for each version are sorted by 2-digit index numbers in the filename (i.e. `<index>-<name>.py`).
+
+To determine the index number of the new upgrade script, find the index number of the last upgrade script
+in `base/server/upgrade/<version>` folder, then increment by `1`.
+
+If this is the first upgrade script for the version, use index number `01`.
+
+== Creating Upgrade Script ==
+
+Once the upgrade folder and the index number have been determined,
+create the upgrade script (i.e. `<index>-<name>.py`) in `base/server/upgrade/<version>` folder:
+
+----
+class <name>(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = ...
+
+    ...
+----
+
+Make sure the class name matches the `<name>` in the filename.
+
+See examples in link:../../base/server/examples/upgrade[base/server/examples/upgrade].
+See also existing upgrade scripts in link:../../base/server/upgrade[base/server/upgrade].
+
+== Quick Test ==
+
+To quickly test the upgrade script, install the script manually:
+
+----
+$ mkdir -p /usr/share/pki/server/upgrade/<version>
+$ cp base/server/upgrade/<version>/<filename> /usr/share/pki/server/upgrade/<version>
+----
+
+Then run the upgrade in verbose mode:
+
+----
+$ pki-server upgrade -v
+----
+
+Finally, verify the changes made by the upgrade script.
+If there are issues, the error messages will appear in the standard error.
+
+== Proper Test ==
+
+To test the upgrade script properly, follow these steps:
+
+- install a build that has been released
+- create a new server instance
+- create a new build that contains the new upgrade script
+- install the new build
+- restart the server instance
+
+Finally, verify the changes made by the upgrade script.
+If there are issues, the error messages will appear in systemd journal.
+
+== Cherry-picking a Commit ==
+
+When cherry-picking a commit that contains an upgrade script to another branch, use the same
+process to determine the upgrade folder and the index number based on the next version
+to be released from that branch.
+Move and rename the upgrade script accordingly.
+
+== Updating a Package ==
+
+If a package is rebased to a new version that contains a new upgrade script,
+the script should already be in the right folder and has the right index number
+assuming that the above procedure was followed correctly.
+
+If the package is patched instead (i.e. maintaining the same version number),
+use the same process to determine the upgrade folder and the index number based
+on the version of the package.
+Update the patch to move and rename the upgrade script accordingly.


### PR DESCRIPTION
A new test has been added to verify the `pki-server upgrade` tool using a basic upgrade script.

https://github.com/edewata/pki/blob/upgrade/docs/development/Creating-Upgrade-Script.adoc