### PR TITLE
Fix pki-server run

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -545,6 +545,15 @@ grant codeBase "file:%s" {
         else:
             cmd.extend([java_home + '/bin/java'])
 
+            # add JVM options as in /etc/tomcat/conf.d/java-9-start-up-parameters.conf
+            cmd.extend([
+                '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+                '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+                '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+                '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED',
+                '--add-opens', 'java.rmi/sun.rmi.transport=ALL-UNNAMED',
+            ])
+
         if agentpath:
             cmd.extend(['-agentpath:%s' % agentpath])
 


### PR DESCRIPTION
The `pki-server run` command was supposed to run the server on the foreground for troubleshooting and for future containers, but it was not working due to missing JVM parameters.

The code has been updated to include the `--add-opens` options as defined in Tomcat configuration:
`/etc/tomcat/conf.d/java-9-start-up-parameters.conf`