### PR TITLE
Add test for OCSP with LDAP-based CRL publishing

### DIFF
--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -1054,6 +1054,18 @@ jobs:
               -text \
               -noout | tee ca_signing.txt
 
+      - name: Prepare CA cert publishing subtree
+        run: |
+          docker exec -i pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: dc=crl,dc=pki,dc=example,dc=com
+          objectClass: domain
+          dc: crl
+          EOF
+
       - name: Configure CA cert publishing
         run: |
           # configure LDAP connection
@@ -1072,7 +1084,7 @@ jobs:
 
           # configure CA cert mapper
           docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapCaCertMap.createCAEntry true
-          docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapCaCertMap.dnPattern "cn=Certificate Authority,dc=example,dc=com"
+          docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapCaCertMap.dnPattern "cn=\$subj.cn,dc=crl,dc=pki,dc=example,dc=com"
           docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapCaCertMap.pluginName LdapCaSimpleMap
 
           # configure CA cert publishing rule
@@ -1097,12 +1109,12 @@ jobs:
               -x \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -b "cn=Certificate Authority,dc=example,dc=com" \
+              -b "dc=crl,dc=pki,dc=example,dc=com" \
               -o ldif_wrap=no \
               -t \
-              cACertificate | tee output
+              "(objectClass=pkiCA)" | tee output
 
-          # there should be one published CA cert
+          # there should be one CA cert attribute
           grep "cACertificate;binary:" output | wc -l > actual
           echo "1" > expected
           diff expected actual
@@ -1406,6 +1418,18 @@ jobs:
               -D pki_request_id_generator=random \
               -v
 
+      - name: Prepare CRL publishing subtree
+        run: |
+          docker exec -i pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: dc=crl,dc=pki,dc=example,dc=com
+          objectClass: domain
+          dc: crl
+          EOF
+
       - name: Configure CRL publishing
         run: |
           # configure LDAP connection
@@ -1424,14 +1448,14 @@ jobs:
 
           # configure CRL mapper
           docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapCrlMap.createCAEntry true
-          docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapCrlMap.dnPattern "cn=crl,dc=example,dc=com"
+          docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapCrlMap.dnPattern "cn=\$subj.cn,dc=crl,dc=pki,dc=example,dc=com"
           docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapCrlMap.pluginName LdapCaSimpleMap
 
           # configure CRL publishing rule
           docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.enable true
           docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.mapper LdapCrlMap
           docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.pluginName Rule
-          docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.predicate issuingPointId==MasterCRL
+          docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.predicate ""
           docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.publisher LdapCrlPublisher
           docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.type crl
 
@@ -1499,12 +1523,12 @@ jobs:
               -x \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -b "cn=crl,dc=example,dc=com" \
+              -b "dc=crl,dc=pki,dc=example,dc=com" \
               -o ldif_wrap=no \
               -t \
-              certificateRevocationList | tee output
+              "(objectClass=pkiCA)" | tee output
 
-          # there should be no CRL LDAP entries
+          # there should be no CRL attributes
           grep "certificateRevocationList;binary:" output | wc -l > actual
           echo "0" > expected
           diff expected actual
@@ -1519,12 +1543,12 @@ jobs:
               -x \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -b "cn=crl,dc=example,dc=com" \
+              -b "dc=crl,dc=pki,dc=example,dc=com" \
               -o ldif_wrap=no \
               -t \
-              certificateRevocationList | tee output
+              "(objectClass=pkiCA)" | tee output
 
-          # there should be one CRL LDAP entry
+          # there should be one CRL attribute
           grep "certificateRevocationList;binary:" output | wc -l > actual
           echo "1" > expected
           diff expected actual
@@ -1554,12 +1578,12 @@ jobs:
               -x \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -b "cn=crl,dc=example,dc=com" \
+              -b "dc=crl,dc=pki,dc=example,dc=com" \
               -o ldif_wrap=no \
               -t \
-              certificateRevocationList | tee output
+              "(objectClass=pkiCA)" | tee output
 
-          # there should be one CRL LDAP entry
+          # there should be one CRL attribute
           grep "certificateRevocationList;binary:" output | wc -l > actual
           echo "1" > expected
           diff expected actual

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -1633,3 +1633,524 @@ jobs:
           name: ocsp-standalone-ocsp-${{ matrix.os }}
           path: |
             /tmp/artifacts/ocsp
+
+  # https://github.com/dogtagpki/pki/wiki/Installing-Standalone-OCSP
+  # https://github.com/dogtagpki/pki/wiki/Publishing-CA-Certificate-to-LDAP-Server
+  # https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-LDAP-Server
+  ocsp-ldap-publishing-test:
+    name: Testing OCSP with LDAP-based CRL publishing
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ocsp-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-ocsp-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up CA DS container
+        run: |
+          tests/bin/ds-container-create.sh cads
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          HOSTNAME: cads.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect CA DS container to network
+        run: docker network connect example cads --alias cads.example.com
+
+      - name: Set up CA container
+        run: |
+          tests/bin/runner-init.sh ca
+        env:
+          HOSTNAME: ca.example.com
+
+      - name: Connect CA container to network
+        run: docker network connect example ca --alias ca.example.com
+
+      - name: Install CA in CA container
+        run: |
+          docker exec ca pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=cads.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Install CA admin cert in CA container
+        run: |
+          docker exec ca pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
+          docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
+          docker exec ca pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Set up OCSP DS container
+        run: |
+          tests/bin/ds-container-create.sh ocspds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          HOSTNAME: ocspds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect OCSP DS container to network
+        run: docker network connect example ocspds --alias ocspds.example.com
+
+      - name: Set up OCSP container
+        run: |
+          tests/bin/runner-init.sh ocsp
+        env:
+          HOSTNAME: ocsp.example.com
+
+      - name: Connect OCSP container to network
+        run: docker network connect example ocsp --alias ocsp.example.com
+
+      - name: Install OCSP in OCSP container (step 1)
+        run: |
+          docker exec ocsp pkispawn \
+              -f /usr/share/pki/server/examples/installation/ocsp-standalone-step1.cfg \
+              -s OCSP \
+              -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
+              -D pki_ds_hostname=ocspds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_ocsp_signing_csr_path=${SHARED}/ocsp_signing.csr \
+              -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
+              -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
+              -D pki_audit_signing_csr_path=${SHARED}/ocsp_audit_signing.csr \
+              -D pki_admin_csr_path=${SHARED}/ocsp_admin.csr \
+              -v
+
+      - name: Issue OCSP signing cert
+        run: |
+          docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_signing.csr
+          docker exec ca pki ca-cert-request-submit --profile caOCSPCert --csr-file ${SHARED}/ocsp_signing.csr | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
+          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
+          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_signing.crt
+          docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_signing.crt
+
+      - name: Issue subsystem cert
+        run: |
+          docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
+          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
+          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
+          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/subsystem.crt
+          docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
+
+      - name: Issue SSL server cert
+        run: |
+          docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
+          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
+          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
+          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/sslserver.crt
+          docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
+
+      - name: Issue OCSP audit signing cert
+        run: |
+          docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_audit_signing.csr
+          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/ocsp_audit_signing.csr | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
+          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
+          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_audit_signing.crt
+          docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_audit_signing.crt
+
+      - name: Issue OCSP admin cert
+        run: |
+          docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_admin.csr
+          docker exec ca pki ca-cert-request-submit --profile caUserCert --csr-file ${SHARED}/ocsp_admin.csr --subject uid=ocspadmin | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
+          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
+          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_admin.crt
+          docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_admin.crt
+
+      - name: Install OCSP in OCSP container (step 2)
+        run: |
+          docker exec ocsp pkispawn \
+              -f /usr/share/pki/server/examples/installation/ocsp-standalone-step2.cfg \
+              -s OCSP \
+              -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
+              -D pki_ds_hostname=ocspds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_ocsp_signing_csr_path=${SHARED}/ocsp_signing.csr \
+              -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
+              -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
+              -D pki_audit_signing_csr_path=${SHARED}/ocsp_audit_signing.csr \
+              -D pki_admin_csr_path=${SHARED}/ocsp_admin.csr \
+              -D pki_ocsp_signing_cert_path=${SHARED}/ocsp_signing.crt \
+              -D pki_subsystem_cert_path=${SHARED}/subsystem.crt \
+              -D pki_sslserver_cert_path=${SHARED}/sslserver.crt \
+              -D pki_audit_signing_cert_path=${SHARED}/ocsp_audit_signing.crt \
+              -D pki_admin_cert_path=${SHARED}/ocsp_admin.crt \
+              -v
+
+          docker exec ocsp pki-server cert-find
+
+      # TODO: Fix DogtagOCSPConnectivityCheck to work without CA
+      # - name: Run PKI healthcheck
+      #   run: docker exec ocsp pki-healthcheck --failures-only
+
+      - name: Install OCSP admin cert in OCSP container
+        run: |
+          docker exec ocsp pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
+          docker exec ocsp pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec ocsp pki -n ocspadmin ocsp-user-show ocspadmin
+
+      - name: Prepare CRL publishing subtree
+        run: |
+          docker exec -i ocsp ldapadd \
+              -H ldap://ocspds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: dc=crl,dc=pki,dc=example,dc=com
+          objectClass: domain
+          dc: crl
+          aci: (targetattr!="userPassword || aci")
+           (version 3.0; acl "Enable anonymous access"; allow (read, search, compare) userdn="ldap:///anyone";)
+          EOF
+
+          # verify anonymous access
+          docker exec -i ocsp ldapsearch \
+              -H ldap://ocspds.example.com:3389 \
+              -x \
+              -b "dc=crl,dc=pki,dc=example,dc=com"
+
+      - name: Configure CA cert and CRL publishing in CA
+        run: |
+          # configure LDAP connection
+          docker exec ca pki-server ca-config-set ca.publish.ldappublish.enable true
+          docker exec ca pki-server ca-config-set ca.publish.ldappublish.ldap.ldapauth.authtype BasicAuth
+          docker exec ca pki-server ca-config-set ca.publish.ldappublish.ldap.ldapauth.bindDN "cn=Directory Manager"
+          docker exec ca pki-server ca-config-set ca.publish.ldappublish.ldap.ldapauth.bindPWPrompt internaldb
+          docker exec ca pki-server ca-config-set ca.publish.ldappublish.ldap.ldapconn.host ocspds.example.com
+          docker exec ca pki-server ca-config-set ca.publish.ldappublish.ldap.ldapconn.port 3389
+          docker exec ca pki-server ca-config-set ca.publish.ldappublish.ldap.ldapconn.secureConn false
+
+          # configure LDAP-based CA cert publisher
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.LdapCaCertPublisher.caCertAttr "cACertificate;binary"
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.LdapCaCertPublisher.caObjectClass pkiCA
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.LdapCaCertPublisher.pluginName LdapCaCertPublisher
+
+          # configure CA cert mapper
+          docker exec ca pki-server ca-config-set ca.publish.mapper.instance.LdapCaCertMap.createCAEntry true
+          docker exec ca pki-server ca-config-set ca.publish.mapper.instance.LdapCaCertMap.dnPattern "cn=\$subj.cn,dc=crl,dc=pki,dc=example,dc=com"
+          docker exec ca pki-server ca-config-set ca.publish.mapper.instance.LdapCaCertMap.pluginName LdapCaSimpleMap
+
+          # configure CA cert publishing rule
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCaCertRule.enable true
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCaCertRule.mapper LdapCaCertMap
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCaCertRule.pluginName Rule
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCaCertRule.predicate ""
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCaCertRule.publisher LdapCaCertPublisher
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCaCertRule.type cacert
+
+          # configure LDAP-based CRL publisher
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.LdapCrlPublisher.crlAttr "certificateRevocationList;binary"
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.LdapCrlPublisher.crlObjectClass pkiCA
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.LdapCrlPublisher.pluginName LdapCrlPublisher
+
+          # configure CRL mapper
+          docker exec ca pki-server ca-config-set ca.publish.mapper.instance.LdapCrlMap.createCAEntry true
+          docker exec ca pki-server ca-config-set ca.publish.mapper.instance.LdapCrlMap.dnPattern "cn=\$subj.cn,dc=crl,dc=pki,dc=example,dc=com"
+          docker exec ca pki-server ca-config-set ca.publish.mapper.instance.LdapCrlMap.pluginName LdapCaSimpleMap
+
+          # configure CRL publishing rule
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.enable true
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.mapper LdapCrlMap
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.pluginName Rule
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.predicate ""
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.publisher LdapCrlPublisher
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.LdapCrlRule.type crl
+
+          # enable CRL publishing
+          docker exec ca pki-server ca-config-set ca.publish.enable true
+
+          # set buffer size to 0 so that revocation will take effect immediately
+          docker exec ca pki-server ca-config-set auths.revocationChecking.bufferSize 0
+
+          # update CRL immediately after each cert revocation
+          docker exec ca pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
+
+          # restart CA subsystem
+          docker exec ca pki-server ca-undeploy --wait
+          docker exec ca pki-server ca-deploy --wait
+
+      - name: Configure revocation info store in OCSP
+        run: |
+          # configure LDAP store
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.numConns 1
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.host0 ocspds.example.com
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.port0 3389
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.baseDN0 "dc=crl,dc=pki,dc=example,dc=com"
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.byName true
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.caCertAttr "cACertificate;binary"
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.crlAttr "certificateRevocationList;binary"
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.includeNextUpdate false
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.notFoundAsGood true
+          docker exec ocsp pki-server ocsp-config-set ocsp.store.ldapStore.refreshInSec0 10
+
+          # enable LDAP store
+          docker exec ocsp pki-server ocsp-config-set ocsp.storeId ldapStore
+
+          # restart OCSP subsystem
+          docker exec ocsp pki-server ocsp-undeploy --wait
+          docker exec ocsp pki-server ocsp-deploy --wait
+
+      - name: Check OCSP responder with no CRLs
+        run: |
+          # create CA agent and its cert
+          docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-create.sh
+          docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-cert-create.sh
+
+          # get cert serial number
+          docker exec ca pki nss-cert-show caagent | tee output
+          CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          # wait for CRL cache refresh
+          sleep 10
+
+          # check CRL LDAP entries
+          docker exec ocsp ldapsearch \
+              -H ldap://ocspds.example.com:3389 \
+              -x \
+              -b "dc=crl,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -t \
+              "(objectClass=pkiCA)" | tee output
+
+          # there should be one CA cert attribute
+          grep "cACertificate;binary:" output | wc -l > actual
+          echo "1" > expected
+          diff expected actual
+
+          # there should be no CRL attributes
+          grep "certificateRevocationList;binary:" output | wc -l > actual
+          echo "0" > expected
+          diff expected actual
+
+          # check cert status using OCSPClient
+          docker exec ocsp OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # the responder should fail
+          sed -n "s/^SEVERE:\s*\(\S*\)/\1/p" stderr > actual
+          echo "InvalidBERException: Incorrect tag: expected [UNIVERSAL 16], found [UNIVERSAL 28]" > expected
+          diff expected actual
+
+          # check cert status using OpenSSL
+          docker exec ocsp openssl ocsp \
+              -url http://ocsp.example.com:8080/ocsp/ee/ocsp \
+              -CAfile ${SHARED}/ca_signing.crt \
+              -issuer ${SHARED}/ca_signing.crt \
+              -serial $CERT_ID \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # remove the random parts of stderr so it can be compared
+          sed -i "s/^[^:]*:error:/error:/g" stderr
+
+          # the responder should fail
+          echo "Error querying OCSP responder" > expected
+          echo "error:1E800076:HTTP routines:OSSL_HTTP_REQ_CTX_nbio:unexpected content type:crypto/http/http_client.c:676:expected=application/ocsp-response, actual=text/html" >> expected
+          echo "error:1E800067:HTTP routines:OSSL_HTTP_REQ_CTX_exchange:error receiving:crypto/http/http_client.c:874:server=http://ocsp.example.com:8080" >> expected
+
+          diff expected stderr
+
+      - name: Check OCSP responder with revoked cert
+        run: |
+          # revoke CA agent cert
+          docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-cert-revoke.sh
+
+          # get cert serial number
+          docker exec ca pki nss-cert-show caagent | tee output
+          CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          # wait for CRL cache refresh
+          sleep 10
+
+          # check CRL LDAP entries
+          docker exec ocsp ldapsearch \
+              -H ldap://ocspds.example.com:3389 \
+              -x \
+              -b "dc=crl,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -t \
+              "(objectClass=pkiCA)" | tee output
+
+          # there should be one CA cert attribute
+          grep "cACertificate;binary:" output | wc -l > actual
+          echo "1" > expected
+          diff expected actual
+
+          # there should be one CRL attribute
+          grep "certificateRevocationList;binary:" output | wc -l > actual
+          echo "1" > expected
+          diff expected actual
+
+          FILENAME=$(sed -n 's/certificateRevocationList;binary:< file:\/\/\(.*\)$/\1/p' output)
+          echo "FILENAME: $FILENAME"
+
+          # check the latest CRL
+          docker exec ca openssl crl \
+              -in "$FILENAME" \
+              -inform DER \
+              -text \
+              -noout | tee output
+
+          # check cert status using OCSPClient
+          docker exec ocsp OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID | tee output
+
+          # the status should be revoked
+          sed -n "s/^CertStatus=\(.*\)$/\1/p" output > actual
+          echo Revoked > expected
+          diff expected actual
+
+          # check cert status using OpenSSL
+          docker exec ocsp openssl ocsp \
+              -url http://ocsp.example.com:8080/ocsp/ee/ocsp \
+              -CAfile ${SHARED}/ca_signing.crt \
+              -issuer ${SHARED}/ca_signing.crt \
+              -serial $CERT_ID | tee output
+
+          # the status should be revoked
+          sed -n "s/^$CERT_ID:\s*\(\S*\)$/\1/p" output > actual
+          echo revoked > expected
+          diff expected actual
+
+      - name: Check OCSP responder with unrevoked cert
+        run: |
+          # unrevoke CA agent cert
+          docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-cert-unrevoke.sh
+
+          # get cert serial number
+          docker exec ca pki nss-cert-show caagent | tee output
+          CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          # wait for CRL cache refresh
+          sleep 10
+
+          # check CRL LDAP entries
+          docker exec ocsp ldapsearch \
+              -H ldap://ocspds.example.com:3389 \
+              -x \
+              -b "dc=crl,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -t \
+              "(objectClass=pkiCA)" | tee output
+
+          # there should be one CA cert attribute
+          grep "cACertificate;binary:" output | wc -l > actual
+          echo "1" > expected
+          diff expected actual
+
+          # there should be one CRL attribute
+          grep "certificateRevocationList;binary:" output | wc -l > actual
+          echo "1" > expected
+          diff expected actual
+
+          FILENAME=$(sed -n 's/certificateRevocationList;binary:< file:\/\/\(.*\)$/\1/p' output)
+          echo "FILENAME: $FILENAME"
+
+          # check the latest CRL
+          docker exec ca openssl crl \
+              -in "$FILENAME" \
+              -inform DER \
+              -text \
+              -noout | tee output
+
+          # check cert status using OCSPClient
+          docker exec ocsp OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID | tee output
+
+          # the status should be good
+          sed -n "s/^CertStatus=\(.*\)$/\1/p" output > actual
+          echo Good > expected
+          diff expected actual
+
+          # check cert status using OpenSSL
+          docker exec ocsp openssl ocsp \
+              -url http://ocsp.example.com:8080/ocsp/ee/ocsp \
+              -CAfile ${SHARED}/ca_signing.crt \
+              -issuer ${SHARED}/ca_signing.crt \
+              -serial $CERT_ID | tee output
+
+          # the status should be good
+          sed -n "s/^$CERT_ID:\s*\(\S*\)$/\1/p" output > actual
+          echo good > expected
+          diff expected actual
+
+      - name: Gather artifacts from CA containers
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki cads
+          tests/bin/pki-artifacts-save.sh ca
+        continue-on-error: true
+
+      - name: Gather artifacts from OCSP containers
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ocspds
+          tests/bin/pki-artifacts-save.sh ocsp
+        continue-on-error: true
+
+      - name: Remove OCSP from OCSP container
+        run: docker exec ocsp pkidestroy -i pki-tomcat -s OCSP -v
+
+      - name: Remove CA from CA container
+        run: docker exec ca pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts from CA containers
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ocsp-ldap-publishing-ca-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/ca
+
+      - name: Upload artifacts from OCSP containers
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ocsp-ldap-publishing-ocsp-${{ matrix.os }}
+          path: |
+            /tmp/artifacts/ocsp


### PR DESCRIPTION
A new test has been added to verify that OCSP can consume the CRL published by CA through LDAP.

The tests for CA cert and CRL publishing have been updated to use the same DN pattern, predicate, and search filter for consistency.

Docs:
* https://github.com/dogtagpki/pki/wiki/Configuring-OCSP-Revocation-Info-Store
* https://github.com/dogtagpki/pki/wiki/Publishing-CA-Certificate-to-LDAP-Server
* https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-LDAP-Server