### PR TITLE
Bug2093114-performance-improvement-for-cs-tls-client-ciphers

### DIFF
--- a/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -934,6 +934,7 @@ public class CryptoUtil {
         if (cipherIDs == null) return;
 
         for (int cipherID : cipherIDs) {
+            // logger.debug("CryptoUtil.setSSLCipher: unsetting cipher:" + cipherID);
             SSLSocket.setCipherPreferenceDefault(cipherID, false);
         }
     }
@@ -943,6 +944,7 @@ public class CryptoUtil {
         if (cipherIDs == null) return;
 
         for (int cipherID : cipherIDs) {
+            // logger.debug("CryptoUtil.setSSLCipher: unsetting cipher on soc:" + cipherID);
             soc.setCipherPreference(cipherID, false);
         }
     }

--- a/base/util/src/main/java/com/netscape/cmsutil/http/JssSSLSocketFactory.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/http/JssSSLSocketFactory.java
@@ -55,7 +55,31 @@ public class JssSSLSocketFactory implements ISocketFactory {
         if (certNickname != null)
             mClientAuthCertNickname = certNickname;
 
-        mClientCiphers = ciphers;
+        /*
+         * about ciphers
+         * Let it inherit default settings (could have been previously set
+         * in CS.cfg tcp.clientCiphers by PKISocketFactory)
+         * unless it's overwritten by config in respective CS.cfg:
+         *
+         * CA->KRA: ca.connector.KRA.clientCiphers
+         * TPS->KRA/CA/TKS: tps.connector.<ca|kra|tks id>.clientCiphers
+         *
+         * example for RSA CA, in CS.cfg
+         * ca.connector.KRA.clientCiphers=TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+         *
+         * example for ECC CA, in CS.cfg
+         * ca.connector.KRA.clientCiphers=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+         */
+        if (ciphers != null) {
+            mClientCiphers = ciphers.trim();
+            try {
+                if (!mClientCiphers.isEmpty())
+                    CryptoUtil.setClientCiphers(mClientCiphers);
+            } catch (Exception e) {
+                // Exception treated as clientCiphers not set;
+                // handled as default below
+            }
+        }
     }
 
     @Override
@@ -72,13 +96,6 @@ public class JssSSLSocketFactory implements ISocketFactory {
     ) throws IOException, UnknownHostException {
 
         try {
-            /*
-             * Let it inherit default settings
-             * unless it's overwritten by config in respective CS.cfg:
-             *
-             * CA->KRA: ca.connector.KRA.clientCiphers
-             * TPS->KRA/CA/TKS: tps.connector.<ca|kra|tks id>.clientCiphers
-             */
             s = new SSLSocket(host, port, null, 0, certApprovalCallback,
                     clientCertCallback);
 
@@ -97,8 +114,12 @@ public class JssSSLSocketFactory implements ISocketFactory {
             if (this.sockListener != null)
                 s.addSocketListener(this.sockListener);
 
-            if (mClientCiphers != null && !mClientCiphers.trim().isEmpty())
-                CryptoUtil.setClientCiphers(s, mClientCiphers);
+           /** opt for general setting in JssSSLSocketFactory() constructor
+            *  above rather than socket-specific setting
+            *
+            if (mClientCiphers != null && !mClientCiphers.isEmpty())
+            CryptoUtil.setClientCiphers(s, mClientCiphers);
+            */
 
             if (mClientAuthCertNickname != null) {
                 // 052799 setClientCertNickname does not


### PR DESCRIPTION
This patch added the performance improvement that was tabled from
earlier check-in due to time concern.
Instead of per socket-level cipher setting, we opt for cipher
setting at thread level in the class constructors.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2093114