### PR TITLE
flake8: Fix whitespace warning

### DIFF
--- a/base/server/healthcheck/pki/server/healthcheck/clones/plugin.py
+++ b/base/server/healthcheck/pki/server/healthcheck/clones/plugin.py
@@ -130,7 +130,7 @@ class ClonesPlugin(Plugin):
         sechost = None
         secport = None
         ca_subsystem = self.instance.get_subsystem('ca')
-        if(ca_subsystem):
+        if ca_subsystem:
             # make sure this CA is the security domain
             service_host = ca_subsystem.config.get('service.machineName')
             service_port = ca_subsystem.config.get('service.unsecurePort')


### PR DESCRIPTION
New `pycodestyle` 2.9.0 introduced:
> E275: requires whitespace around keywords

https://pycodestyle.pycqa.org/en/latest/developer.html#changes

`flake8` 5.0 that integrates `pycodestyle` found 1 issue in code:
```
./base/server/healthcheck/pki/server/healthcheck/clones/plugin.py:133:11: E275 missing whitespace after keyword
        if(ca_subsystem):
          ^
```

Fixes: https://github.com/dogtagpki/pki/issues/4101