### PR TITLE
Allow installation with a softhsm token

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -695,6 +695,7 @@ class NSSDatabase(object):
         Import certificate using pki nss-cert-import command.
         In the future this will replace add_cert().
         '''
+        check = True
 
         cmd = [
             'pki',
@@ -710,6 +711,11 @@ class NSSDatabase(object):
         token = self.get_effective_token(token)
         if token:
             cmd.extend(['--token', token])
+
+            # Don't check the return value as a workaround for NSS upstream
+            # BZ https://bugzilla.mozilla.org/show_bug.cgi?id=1782980
+            # Trust is most likely ,, anyway so there is no loss.
+            check = False
 
         cmd.extend(['nss-cert-import'])
 
@@ -731,7 +737,7 @@ class NSSDatabase(object):
 
         cmd.append(nickname)
 
-        self.run(cmd, input=cert_data, text=True, check=True, runas=True)
+        self.run(cmd, input=cert_data, text=True, check=check, runas=True)
 
     def add_ca_cert(self, cert_file, trust_attributes='CT,C,C'):
 

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -838,13 +838,16 @@ grant codeBase "file:%s" {
 
         pki.util.chown(self.nssdb_dir, self.uid, self.gid)
 
-    def open_nssdb(self, token=pki.nssdb.INTERNAL_TOKEN_NAME):
+    def open_nssdb(self, token=pki.nssdb.INTERNAL_TOKEN_NAME,
+                   user=None, group=None):
         return pki.nssdb.NSSDatabase(
             directory=self.nssdb_dir,
             token=token,
             password=self.get_token_password(token),
             internal_password=self.get_token_password(),
-            passwords=self.passwords)
+            passwords=self.passwords,
+            user=user,
+            group=group)
 
     def get_webapps(self):
 

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1264,7 +1264,10 @@ class PKIDeployer:
         else:
             raise Exception('Unsupported key type: %s' % key_type)
 
-        nssdb = subsystem.instance.open_nssdb()
+        nssdb = subsystem.instance.open_nssdb(
+            user=self.mdict['pki_user'],
+            group=self.mdict['pki_group']
+        )
         try:
             result = nssdb.create_key(
                 token=token,
@@ -1436,7 +1439,10 @@ class PKIDeployer:
         instance.set_sslserver_cert_nickname(nickname)
 
         tmpdir = tempfile.mkdtemp()
-        nssdb = instance.open_nssdb()
+        nssdb = instance.open_nssdb(
+            user=self.mdict['pki_user'],
+            group=self.mdict['pki_group']
+        )
 
         try:
             logger.info('Checking existing temp SSL server cert: %s', nickname)
@@ -1508,7 +1514,10 @@ class PKIDeployer:
 
         logger.info('Removing temp SSL server cert from internal token: %s', nickname)
 
-        nssdb = instance.open_nssdb()
+        nssdb = instance.open_nssdb(
+            user=self.mdict['pki_user'],
+            group=self.mdict['pki_group']
+        )
 
         try:
             # Remove temp SSL server cert from internal token.

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -631,7 +631,9 @@ class PKIDeployer:
         token = pki.nssdb.normalize_token(cert['token'])
 
         if not token:
-            token = self.mdict['pki_token_name']
+            token = self.mdict.get('pki_sslserver_token')
+            if not token:
+                token = self.mdict['pki_token_name']
 
         nssdb.import_cert_chain(
             nickname=nickname,

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -57,7 +57,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         subsystem.save()
 
         token = pki.nssdb.normalize_token(deployer.mdict['pki_token_name'])
-        nssdb = instance.open_nssdb()
+        nssdb = instance.open_nssdb(
+            user=deployer.mdict['pki_user'],
+            group=deployer.mdict['pki_group'])
 
         existing = deployer.configuration_file.existing
         step_two = deployer.configuration_file.external_step_two
@@ -444,7 +446,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if 'pki_one_time_pin' not in deployer.mdict:
             deployer.mdict['pki_one_time_pin'] = subsystem.config['preop.pin']
 
-        nssdb = subsystem.instance.open_nssdb()
+        nssdb = subsystem.instance.open_nssdb(
+            user=deployer.mdict['pki_user'],
+            group=deployer.mdict['pki_group'])
 
         try:
             system_certs = deployer.setup_system_certs(nssdb, subsystem)

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -547,7 +547,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             token = pki.nssdb.normalize_token(system_certs['sslserver']['token'])
 
             if not token:
-                token = deployer.mdict['pki_token_name']
+                token = deployer.mdict.get('pki_sslserver_token')
+                if not token:
+                    token = deployer.mdict['pki_token_name']
 
             instance.set_sslserver_cert_nickname(nickname, token)
 

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -419,7 +419,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         nssdb = pki.nssdb.NSSDatabase(
             directory=deployer.mdict['pki_client_database_dir'],
-            password_file=deployer.mdict['pki_client_password_conf'])
+            password_file=deployer.mdict['pki_client_password_conf'],
+            user=deployer.mdict['pki_user'],
+            group=deployer.mdict['pki_group'])
 
         try:
             if not nssdb.exists():


### PR DESCRIPTION
A patchset which allows a basic IPA server installation using the softhsm2 PKCS#11 driver.

Tested on Fedora 36.

The first patch adds a user/group option to the ```nssdb.py::NSSDatabase``` class so that runuser can be called in certain cases so that filesystem permissions are consistent. If executed as root then some commands will leave softhsm token files unreadable by pkiuser.

The second patch honors the server cert token override ```pki_sslserver_token```. The installation requires that the private key be extracted which will fail on HSMs.

The final patch is a workaround for a bug in certutil. The trust flags are stored in the NSS database softokn but there is a bug in certutil that never tries to authenticate to it. When this is addressed upstream additional work will be required in PKI so that all passwords are written to the temporary password file. certmonger access multiple lines of the form: ```token:password``` and will see the right one when asked.

This works with IPA with one change. A change to ```ipaserver/install/cainstance.py``` is needed to set the pki_pin to match the softhsm token password. Most of the calls in the ```nssdb.py::NSSDatabase``` class don't consider which password to pass to commands. Changing that in PKI is very invasive and outside the scope for now of just getting it working.

I'll eventually not require a change to IPA but currently it had no consideration of tokens so that will need to be addressed in general.

I got this working with this pki.ini:
```
[DEFAULT]
pki_hsm_enable=True
pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
pki_hsm_modulename=softhsm2
pki_token_name=softhsm_token
pki_token_password=password
pki_sslserver_token=internal
pki_server_database_password=password
```

Installing with:
```ipa-server-install -a password -p password -r EXAMPLE.TEST -U --setup-dns --allow-zone-overlap --no-forwarders -N --auto-reverse --pki-config-override=/root/pki.ini```

This hacky change to IPA:
```
diff --git a/ipaserver/install/cainstance.py b/ipaserver/install/cainstance.p
y
index 1215a3253..60a0c5662 100644
--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -534,6 +534,7 @@ class CAInstance(DogtagInstance):
                 os.path.isfile(paths.PKI_TOMCAT_PASSWORD_CONF)):
             # generate pin which we know can be used for FIPS NSS database
             pki_pin = ipautil.ipa_generate_password()
+            pki_pin = 'password'
             cfg['pki_server_database_password'] = pki_pin
         else:
             pki_pin = None
```

The token was created with:
```
runuser -u pkiuser -- /usr/bin/softhsm2-util --init-token --free --pin password --so-pin password --label softhsm_token
```

The HSM user/group permissions were setup following https://www.dogtagpki.org/wiki/SoftHSM