### PR TITLE
Add basic CA container

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -64,6 +64,23 @@ jobs:
           key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
           path: pki-ca-runner.tar
 
+      - name: Build server image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-ca
+          target: pki-ca
+          outputs: type=docker,dest=pki-ca-server.tar
+
+      - name: Store server image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-server-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-server.tar
+
   # docs/installation/ca/Installing_CA.md
   ca-test:
     name: Testing CA
@@ -1719,3 +1736,144 @@ jobs:
           name: cmc-shared-token-${{ matrix.os }}
           path: |
             /tmp/artifacts/pki
+
+  ca-container-test:
+    name: Testing CA container
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-ca-runner.tar
+
+      - name: Retrieve server image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-server-${{ matrix.os }}-${{ github.run_id }}
+          path: pki-ca-server.tar
+
+      - name: Load CA image
+        run: docker load --input pki-ca-server.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          COPR_REPO: ${{ needs.init.outputs.repo }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up CA container
+        run: |
+          docker run \
+              --name server \
+              --hostname=pki.example.com \
+              --detach \
+              pki-ca
+
+      - name: Connect CA container to network
+        run: docker network connect example server --alias pki.example.com
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Wait for CA container to start
+        run: |
+          tests/bin/pki-start-wait.sh client https://pki.example.com:8443
+        env:
+          MAX_WAIT: 180
+
+      - name: Check public operations
+        run: |
+          docker cp server:ca_signing.crt ca_signing.crt
+          docker cp ca_signing.crt client:ca_signing.crt
+
+          # install CA signing cert
+          docker exec client pki \
+              client-cert-import \
+              --ca-cert ca_signing.crt \
+              ca_signing
+
+          # check PKI server info
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              info
+
+          # check certs in CA
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              ca-cert-find
+
+      - name: Check admin operations
+        run: |
+          docker cp server:admin.p12 admin.p12
+          docker cp admin.p12 client:admin.p12
+
+          # install admin cert
+          docker exec client pki \
+              client-cert-import \
+              --pkcs12 admin.p12 \
+              --pkcs12-password Secret.123
+
+          # install check admin user
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              -n admin \
+              ca-user-show \
+              admin
+
+      - name: Gather artifacts from server container
+        if: always()
+        run: |
+          mkdir -p /tmp/artifacts/server
+          docker logs server > /tmp/artifacts/server/container.out 2> /tmp/artifacts/server/container.err
+          mkdir -p /tmp/artifacts/server/var/lib
+          docker cp server:/etc/pki /tmp/artifacts/server/etc
+          docker cp server:/var/lib/pki /tmp/artifacts/server/var/lib
+          docker cp server:/var/log/pki /tmp/artifacts/server/var/log
+        continue-on-error: true
+
+      - name: Gather artifacts from client container
+        if: always()
+        run: |
+          mkdir -p /tmp/artifacts/client
+          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
+
+      - name: Upload artifacts from server container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ca-container-server-${{ matrix.os }}
+          path: /tmp/artifacts/server
+
+      - name: Upload artifacts from client container
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ca-container-client-${{ matrix.os }}
+          path: /tmp/artifacts/client

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,26 @@ RUN chmod -Rf g+rw /var/lib/tomcats/pki
 CMD [ "/usr/share/pki/server/bin/pki-server-run" ]
 
 ################################################################################
+FROM pki-runner AS pki-ca
+
+ARG SUMMARY="Dogtag PKI Certificate Authority"
+ARG COPR_REPO
+
+LABEL name="pki-ca" \
+      summary="$SUMMARY" \
+      license="$LICENSE" \
+      version="$VERSION" \
+      architecture="$ARCH" \
+      maintainer="$MAINTAINER" \
+      vendor="$VENDOR" \
+      usage="podman run -p 8080:8080 -p 8443:8443 pki-ca" \
+      com.redhat.component="$COMPONENT"
+
+EXPOSE 8080 8443
+
+CMD [ "/usr/share/pki/ca/bin/pki-ca-run" ]
+
+################################################################################
 FROM pki-server AS pki-acme
 
 ARG SUMMARY="Dogtag PKI ACME Responder"

--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -78,6 +78,17 @@ set(PKI_CA_JAR ${CMAKE_BINARY_DIR}/dist/pki-ca.jar CACHE INTERNAL "pki-ca jar fi
 # install directories
 install(
     DIRECTORY
+        bin/
+    DESTINATION
+        ${DATA_INSTALL_DIR}/ca/bin/
+    FILE_PERMISSIONS
+        OWNER_EXECUTE OWNER_READ
+        GROUP_EXECUTE GROUP_READ
+        WORLD_EXECUTE WORLD_READ
+)
+
+install(
+    DIRECTORY
         auth/
     DESTINATION
         ${DATA_INSTALL_DIR}/ca/auth/

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -1,0 +1,29 @@
+#!/bin/sh -ex
+
+# Create CA with RSNv3, without security manager, and
+# without systemd service, then export admin cert and
+# key to admin.p12.
+#
+# TODO:
+# - support existing certs and keys
+# - support existing database
+pkispawn \
+    -f /usr/share/pki/server/examples/installation/ca.cfg \
+    -s CA \
+    -D pki_ds_hostname=ds.example.com \
+    -D pki_ds_ldap_port=3389 \
+    -D pki_request_id_generator=random \
+    -D pki_cert_id_generator=random \
+    -D pki_security_manager=False \
+    -D pki_systemd_service_create=False \
+    -D pki_admin_uid=admin \
+    -D pki_admin_email=admin@example.com \
+    -D pki_admin_nickname=admin \
+    -D pki_client_admin_cert_p12=admin.p12 \
+    -v
+
+# export CA signing cert to ca_signing.crt
+pki-server cert-export ca_signing --cert-file ca_signing.crt
+
+# run PKI server in foreground
+pki-server run --as-current-user

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -290,6 +290,7 @@ pki_tomcat_server_port=8005
 # These are used in the processing of pkispawn and are not supposed
 # to be overwritten by user configuration files.
 #
+pki_systemd_service_create=True
 pki_systemd_service=/lib/systemd/system/pki-tomcatd@.service
 pki_systemd_target=/lib/systemd/system/pki-tomcatd.target
 pki_systemd_target_wants=/etc/systemd/system/pki-tomcatd.target.wants

--- a/base/server/python/pki/server/deployment/scriptlets/finalization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/finalization.py
@@ -61,22 +61,24 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             logger.info('Backing up keys into %s', deployer.mdict['pki_backup_file'])
             deployer.backup_keys(instance, subsystem)
 
-        # Optionally, programmatically 'enable' the configured PKI instance
-        # to be started upon system boot (default is True)
-        if not config.str2bool(deployer.mdict['pki_enable_on_system_boot']):
-            instance.disable()
-        else:
-            instance.enable()
+        if config.str2bool(deployer.mdict['pki_systemd_service_create']):
 
-        if len(instance.get_subsystems()) == 1:
-            logger.info('Starting PKI server')
-            instance.start(
-                wait=True,
-                max_wait=deployer.startup_timeout,
-                timeout=deployer.request_timeout)
+            # Optionally, programmatically 'enable' the configured PKI instance
+            # to be started upon system boot (default is True)
+            if not config.str2bool(deployer.mdict['pki_enable_on_system_boot']):
+                instance.disable()
+            else:
+                instance.enable()
 
-            logger.info('Waiting for %s subsystem', subsystem.type)
-            subsystem.wait_for_startup(deployer.startup_timeout, deployer.request_timeout)
+            if len(instance.get_subsystems()) == 1:
+                logger.info('Starting PKI server')
+                instance.start(
+                    wait=True,
+                    max_wait=deployer.startup_timeout,
+                    timeout=deployer.request_timeout)
+
+                logger.info('Waiting for %s subsystem', subsystem.type)
+                subsystem.wait_for_startup(deployer.startup_timeout, deployer.request_timeout)
 
         # Optionally, 'purge' the entire temporary client infrastructure
         # including the client NSS security databases and password files

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -236,18 +236,6 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             deployer.mdict['pki_tomcat_bin_path'],
             deployer.mdict['pki_tomcat_bin_link'])
 
-        user = deployer.mdict['pki_user']
-        group = deployer.mdict['pki_group']
-
-        if user != 'pkiuser' or group != 'pkiuser':
-            deployer.systemd.set_override(
-                'Service', 'User', user, 'user.conf')
-            deployer.systemd.set_override(
-                'Service', 'Group', group, 'user.conf')
-
-        deployer.systemd.write_overrides()
-        deployer.systemd.daemon_reload()
-
         # Link /var/lib/pki/<instance>/conf to /etc/pki/<instance>
         deployer.symlink.create(
             instance_conf_path,
@@ -258,10 +246,24 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             deployer.mdict['pki_instance_log_path'],
             deployer.mdict['pki_instance_logs_link'])
 
-        # Link /etc/systemd/system/pki-tomcatd.target.wants/pki-tomcatd@<instance>.service
-        # to /lib/systemd/system/pki-tomcatd@.service
-        deployer.symlink.create(deployer.mdict['pki_systemd_service'],
-                                deployer.mdict['pki_systemd_service_link'])
+        if config.str2bool(deployer.mdict['pki_systemd_service_create']):
+
+            user = deployer.mdict['pki_user']
+            group = deployer.mdict['pki_group']
+
+            if user != 'pkiuser' or group != 'pkiuser':
+                deployer.systemd.set_override(
+                    'Service', 'User', user, 'user.conf')
+                deployer.systemd.set_override(
+                    'Service', 'Group', group, 'user.conf')
+
+            deployer.systemd.write_overrides()
+            deployer.systemd.daemon_reload()
+
+            # Link /etc/systemd/system/pki-tomcatd.target.wants/pki-tomcatd@<instance>.service
+            # to /lib/systemd/system/pki-tomcatd@.service
+            deployer.symlink.create(deployer.mdict['pki_systemd_service'],
+                                    deployer.mdict['pki_systemd_service_link'])
 
         # Copy /usr/share/pki/setup/pkidaemon_registry
         # to /etc/sysconfig/pki/tomcat/<instance>/<instance>


### PR DESCRIPTION
The `Dockerfile` has been updated to define a basic container image for CA with some limitations. The `pki-ca-run` has been added to create a CA instance and run it in foreground.

The `pki_systemd_service_create` param has been added to support installing PKI server without systemd service.

A new test has been added to create a CA container and perform some basic operations.
