### PR TITLE
ExternalProcessConstraint: fix copy/paste mistake in initialisation

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/profile/constraint/ExternalProcessConstraint.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/constraint/ExternalProcessConstraint.java
@@ -84,7 +84,7 @@ public class ExternalProcessConstraint extends EnrollConstraint {
 
         timeout = DEFAULT_TIMEOUT;
         String timeoutConfig = getConfig(CONFIG_TIMEOUT);
-        if (this.executable != null && !this.executable.isEmpty()) {
+        if (timeoutConfig != null && !timeoutConfig.isEmpty()) {
             try {
                 timeout = Integer.valueOf(timeoutConfig).longValue();
             } catch (NumberFormatException e) {


### PR DESCRIPTION
Initialsation of "timeout" config incorrectly references the
"executable" config.  This is the result of a copy/paste mistake.
Fix the behaviour to refer to the correct variable.