### PR TITLE
Update CA container to support existing certs

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1782,17 +1782,6 @@ jobs:
       - name: Connect DS container to network
         run: docker network connect example ds --alias ds.example.com
 
-      - name: Set up CA container
-        run: |
-          docker run \
-              --name server \
-              --hostname=pki.example.com \
-              --detach \
-              pki-ca
-
-      - name: Connect CA container to network
-        run: docker network connect example server --alias pki.example.com
-
       - name: Set up client container
         run: |
           tests/bin/runner-init.sh client
@@ -1802,60 +1791,252 @@ jobs:
       - name: Connect client container to network
         run: docker network connect example client --alias client.example.com
 
+      - name: Create CA signing cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=CA Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr ca_signing.csr
+          docker exec client pki \
+              nss-cert-issue \
+              --csr ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --months-valid 12 \
+              --cert ca_signing.crt
+          docker exec client pki \
+              nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+          docker exec client pki \
+              nss-cert-show \
+              ca_signing
+
+      - name: Create OCSP signing cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=OCSP Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+              --csr ocsp_signing.csr
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr ocsp_signing.csr \
+              --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+              --cert ocsp_signing.crt
+          docker exec client pki \
+              nss-cert-import \
+              --cert ocsp_signing.crt \
+              ocsp_signing
+          docker exec client pki \
+              nss-cert-show \
+              ocsp_signing
+
+      - name: Create audit signing cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --csr audit_signing.csr
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert audit_signing.crt
+          docker exec client pki \
+              nss-cert-import \
+              --cert audit_signing.crt \
+              --trust ,,P \
+              audit_signing
+          docker exec client pki \
+              nss-cert-show \
+              audit_signing
+
+      - name: Create subsystem cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=Subsystem Certificate" \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --csr subsystem.csr
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr subsystem.csr \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --cert subsystem.crt
+          docker exec client pki \
+              nss-cert-import \
+              --cert subsystem.crt \
+              subsystem
+          docker exec client pki \
+              nss-cert-show \
+              subsystem
+
+      - name: Create SSL server cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=ca.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr sslserver.csr
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --cert sslserver.crt
+          docker exec client pki \
+              nss-cert-import \
+              --cert sslserver.crt \
+              sslserver
+          docker exec client pki \
+              nss-cert-show \
+              sslserver
+
+      - name: Create admin cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr admin.csr
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr admin.csr \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --cert admin.crt
+          docker exec client pki \
+              nss-cert-import \
+              --cert admin.crt \
+              admin
+          docker exec client pki \
+              nss-cert-show \
+              admin
+
+      - name: Export system certs and keys
+        run: |
+          docker exec client pki \
+              pkcs12-export \
+              --pkcs12 server.p12 \
+              --password Secret.123 \
+              ca_signing \
+              ocsp_signing \
+              audit_signing \
+              subsystem \
+              sslserver
+
+      - name: Export admin cert and key
+        run: |
+          docker exec client pki \
+              pkcs12-export \
+              --pkcs12 admin.p12 \
+              --password Secret.123 \
+              admin
+
+      - name: Set up CA container
+        run: |
+          mkdir certs
+          docker cp client:server.p12 certs
+          docker cp client:admin.p12 certs
+          docker cp client:ca_signing.csr certs
+          docker cp client:ocsp_signing.csr certs
+          docker cp client:audit_signing.csr certs
+          docker cp client:subsystem.csr certs
+          docker cp client:sslserver.csr certs
+          docker cp client:admin.csr certs
+          ls -la certs
+
+          docker run \
+              --name ca \
+              --hostname=ca.example.com \
+              --network=example \
+              --network-alias=ca.example.com \
+              -v $PWD/certs:/certs \
+              --detach \
+              pki-ca
+
       - name: Wait for CA container to start
         run: |
-          tests/bin/pki-start-wait.sh client https://pki.example.com:8443
+          tests/bin/pki-start-wait.sh client https://ca.example.com:8443
         env:
           MAX_WAIT: 180
 
-      - name: Check public operations
+      - name: Check server logs
+        if: always()
         run: |
-          docker cp server:ca_signing.crt ca_signing.crt
-          docker cp ca_signing.crt client:ca_signing.crt
+          docker logs ca 2>&1
 
-          # install CA signing cert
-          docker exec client pki \
-              client-cert-import \
-              --ca-cert ca_signing.crt \
-              ca_signing
-
+      - name: Check public operations from CA container
+        run: |
           # check PKI server info
-          docker exec client pki \
-              -U https://pki.example.com:8443 \
-              info
+          docker exec ca pki info
 
           # check certs in CA
-          docker exec client pki \
-              -U https://pki.example.com:8443 \
-              ca-cert-find
+          docker exec ca pki ca-cert-find
 
-      - name: Check admin operations
+      - name: Check admin operations from CA container
         run: |
-          docker cp server:admin.p12 admin.p12
-          docker cp admin.p12 client:admin.p12
-
-          # install admin cert
-          docker exec client pki \
-              client-cert-import \
-              --pkcs12 admin.p12 \
-              --pkcs12-password Secret.123
-
-          # install check admin user
-          docker exec client pki \
-              -U https://pki.example.com:8443 \
+          # check admin user
+          docker exec ca pki \
               -n admin \
               ca-user-show \
               admin
 
-      - name: Gather artifacts from server container
+      - name: Check public operations from client container
+        run: |
+          # clean the NSS database
+          docker exec client pki client-init --force
+
+          # install CA signing cert
+          docker cp ca:/certs/ca_signing.crt ca_signing.crt
+          docker cp ca_signing.crt client:ca_signing.crt
+          docker exec client pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          # check PKI server info
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              info
+
+          # check certs in CA
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              ca-cert-find
+
+      - name: Check admin operations from client container
+        run: |
+          # install admin cert
+          docker cp ca:/certs/admin.p12 admin.p12
+          docker cp admin.p12 client:admin.p12
+          docker exec client pki \
+              pkcs12-import \
+              --pkcs12 admin.p12 \
+              --password Secret.123
+
+          # check admin user
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-user-show \
+              admin
+
+      - name: Gather artifacts from CA container
         if: always()
         run: |
-          mkdir -p /tmp/artifacts/server
-          docker logs server > /tmp/artifacts/server/container.out 2> /tmp/artifacts/server/container.err
-          mkdir -p /tmp/artifacts/server/var/lib
-          docker cp server:/etc/pki /tmp/artifacts/server/etc
-          docker cp server:/var/lib/pki /tmp/artifacts/server/var/lib
-          docker cp server:/var/log/pki /tmp/artifacts/server/var/log
+          mkdir -p /tmp/artifacts/ca
+          docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
+          mkdir -p /tmp/artifacts/ca/var/lib
+          docker cp ca:/etc/pki /tmp/artifacts/ca/etc
+          docker cp ca:/var/lib/pki /tmp/artifacts/ca/var/lib
+          docker cp ca:/var/log/pki /tmp/artifacts/ca/var/log
         continue-on-error: true
 
       - name: Gather artifacts from client container
@@ -1864,12 +2045,12 @@ jobs:
           mkdir -p /tmp/artifacts/client
           docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
 
-      - name: Upload artifacts from server container
+      - name: Upload artifacts from CA container
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ca-container-server-${{ matrix.os }}
-          path: /tmp/artifacts/server
+          name: ca-container-ca-${{ matrix.os }}
+          path: /tmp/artifacts/va
 
       - name: Upload artifacts from client container
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,8 @@ LABEL name="pki-ca" \
 
 EXPOSE 8080 8443
 
+VOLUME [ "/certs" ]
+
 CMD [ "/usr/share/pki/ca/bin/pki-ca-run" ]
 
 ################################################################################

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -1,176 +1,250 @@
-#!/bin/sh -ex
+#!/bin/sh -e
 
 # TODO:
-# - support existing certs and keys created outside of container
 # - support existing database
+# - parameterize hard-coded values
 
 echo "################################################################################"
-echo "INFO: Creating CA signing cert"
 
-pki \
-    -d nssdb \
-    nss-cert-request \
-    --subject "CN=CA Signing Certificate" \
-    --csr ca_signing.csr
+if [ -f /certs/server.p12 ]
+then
+    echo "INFO: Importing system certs and keys"
 
-pki \
-    -d nssdb \
-    nss-cert-issue \
-    --csr ca_signing.csr \
-    --ext /usr/share/pki/server/certs/ca_signing.conf \
-    --months-valid 12 \
-    --cert ca_signing.crt
+    pki pkcs12-import \
+        --pkcs12 /certs/server.p12 \
+        --password Secret.123
+fi
 
-pki \
-    -d nssdb \
-    nss-cert-import \
-    --cert ca_signing.crt \
-    --trust CT,C,C \
-    ca_signing
+if [ -f /certs/admin.p12 ]
+then
+    echo "INFO: Importing admin cert and key"
+
+    pki pkcs12-import \
+        --pkcs12 /certs/admin.p12 \
+        --password Secret.123
+fi
 
 echo "################################################################################"
-echo "INFO: Creating OCSP signing cert"
 
-pki \
-    -d nssdb \
-    nss-cert-request \
-    --subject "CN=OCSP Signing Certificate" \
-    --csr ocsp_signing.csr
+# check if CA signing cert exists
+rc=0
+pki nss-cert-show ca_signing > /dev/null 2>&1 || rc=$?
 
-pki \
-    -d nssdb \
-    nss-cert-issue \
-    --issuer ca_signing \
-    --csr ocsp_signing.csr \
-    --ext /usr/share/pki/server/certs/ocsp_signing.conf \
-    --cert ocsp_signing.crt
+if [ $rc -ne 0 ]
+then
+    echo "INFO: Creating CA signing cert"
 
-pki \
-    -d nssdb \
-    nss-cert-import \
-    --cert ocsp_signing.crt \
-    ocsp_signing
+    pki nss-cert-request \
+        --subject "CN=CA Signing Certificate" \
+        --ext /usr/share/pki/server/certs/ca_signing.conf \
+        --csr /certs/ca_signing.csr
 
-echo "################################################################################"
-echo "INFO: Creating audit signing cert"
+    pki nss-cert-issue \
+        --csr /certs/ca_signing.csr \
+        --ext /usr/share/pki/server/certs/ca_signing.conf \
+        --months-valid 12 \
+        --cert /certs/ca_signing.crt
 
-pki \
-    -d nssdb \
-    nss-cert-request \
-    --subject "CN=Audit Signing Certificate" \
-    --csr audit_signing.csr
+    pki nss-cert-import \
+        --cert /certs/ca_signing.crt \
+        --trust CT,C,C \
+        ca_signing
+fi
 
-pki \
-    -d nssdb \
-    nss-cert-issue \
-    --issuer ca_signing \
-    --csr audit_signing.csr \
-    --ext /usr/share/pki/server/certs/audit_signing.conf \
-    --cert audit_signing.crt
-
-pki \
-    -d nssdb \
-    nss-cert-import \
-    --cert audit_signing.crt \
-    --trust ,,P \
-    audit_signing
+echo "INFO: CA signing cert:"
+pki nss-cert-show ca_signing
 
 echo "################################################################################"
-echo "INFO: Creating subsystem cert"
 
-pki \
-    -d nssdb \
-    nss-cert-request \
-    --subject "CN=Subsystem Certificate" \
-    --csr subsystem.csr
+# check if OCSP signing cert exists
+rc=0
+pki nss-cert-show ocsp_signing > /dev/null 2>&1 || rc=$?
 
-pki \
-    -d nssdb \
-    nss-cert-issue \
-    --issuer ca_signing \
-    --csr subsystem.csr \
-    --ext /usr/share/pki/server/certs/subsystem.conf \
-    --cert subsystem.crt
+if [ $rc -ne 0 ]
+then
+    echo "INFO: Creating OCSP signing cert"
 
-pki \
-    -d nssdb \
-    nss-cert-import \
-    --cert subsystem.crt \
-    subsystem
+    pki nss-cert-request \
+        --subject "CN=OCSP Signing Certificate" \
+        --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+        --csr /certs/ocsp_signing.csr
 
-echo "################################################################################"
-echo "INFO: Creating SSL server cert"
+    pki nss-cert-issue \
+        --issuer ca_signing \
+        --csr /certs/ocsp_signing.csr \
+        --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+        --cert /certs/ocsp_signing.crt
 
-pki \
-    -d nssdb \
-    nss-cert-request \
-    --subject "CN=$HOSTNAME" \
-    --csr sslserver.csr
+    pki nss-cert-import \
+        --cert /certs/ocsp_signing.crt \
+        ocsp_signing
+fi
 
-pki \
-    -d nssdb \
-    nss-cert-issue \
-    --issuer ca_signing \
-    --csr sslserver.csr \
-    --ext /usr/share/pki/server/certs/sslserver.conf \
-    --cert sslserver.crt
-
-pki \
-    -d nssdb \
-    nss-cert-import \
-    --cert sslserver.crt \
-    sslserver
+echo "INFO: OCSP signing cert:"
+pki nss-cert-show ocsp_signing
 
 echo "################################################################################"
-echo "INFO: Creating admin cert"
 
-pki \
-    -d nssdb \
-    nss-cert-request \
-    --subject "CN=Administrator" \
-    --ext /usr/share/pki/server/certs/admin.conf \
-    --csr admin.csr
+# check if audit signing cert exists
+rc=0
+pki nss-cert-show audit_signing > /dev/null 2>&1 || rc=$?
 
-pki \
-    -d nssdb \
-    nss-cert-issue \
-    --issuer ca_signing \
-    --csr admin.csr \
-    --ext /usr/share/pki/server/certs/admin.conf \
-    --cert admin.crt
+if [ $rc -ne 0 ]
+then
+    echo "INFO: Creating audit signing cert"
 
-pki \
-    -d nssdb \
-    nss-cert-import \
-    --cert admin.crt \
-    admin
+    pki nss-cert-request \
+        --subject "CN=Audit Signing Certificate" \
+        --ext /usr/share/pki/server/certs/audit_signing.conf \
+        --csr /certs/audit_signing.csr
 
-echo "################################################################################"
-echo "INFO: Exporting system certs and keys"
+    pki nss-cert-issue \
+        --issuer ca_signing \
+        --csr /certs/audit_signing.csr \
+        --ext /usr/share/pki/server/certs/audit_signing.conf \
+        --cert /certs/audit_signing.crt
 
-pki \
-    -d nssdb \
-    pkcs12-export \
-    --pkcs12 server.p12 \
-    --password Secret.123 \
-    ca_signing \
-    ocsp_signing \
-    audit_signing \
-    subsystem \
-    sslserver
+    pki nss-cert-import \
+        --cert /certs/audit_signing.crt \
+        --trust ,,P \
+        audit_signing
+fi
+
+echo "INFO: Audit signing cert:"
+pki nss-cert-show audit_signing
 
 echo "################################################################################"
-echo "INFO: Exporting admin cert and key"
 
-pki \
-    -d nssdb \
-    pkcs12-export \
-    --pkcs12 admin.p12 \
-    --password Secret.123 \
-    admin
+# check if subsystem cert exists
+rc=0
+pki nss-cert-show subsystem > /dev/null 2>&1 || rc=$?
+
+if [ $rc -ne 0 ]
+then
+    echo "INFO: Creating subsystem cert"
+
+    pki nss-cert-request \
+        --subject "CN=Subsystem Certificate" \
+        --csr /certs/subsystem.csr
+
+    pki nss-cert-issue \
+        --issuer ca_signing \
+        --csr /certs/subsystem.csr \
+        --ext /usr/share/pki/server/certs/subsystem.conf \
+        --cert /certs/subsystem.crt
+
+    pki nss-cert-import \
+        --cert /certs/subsystem.crt \
+        subsystem
+fi
+
+echo "INFO: Subsystem cert:"
+pki nss-cert-show subsystem
 
 echo "################################################################################"
-echo "INFO: Starting PKI CA"
+
+# check if SSL server cert exists
+rc=0
+pki nss-cert-show sslserver > /dev/null 2>&1 || rc=$?
+
+if [ $rc -ne 0 ]
+then
+    echo "INFO: Creating SSL server cert:"
+
+    pki nss-cert-request \
+        --subject "CN=$HOSTNAME" \
+        --ext /usr/share/pki/server/certs/sslserver.conf \
+        --csr /certs/sslserver.csr
+
+    pki nss-cert-issue \
+        --issuer ca_signing \
+        --csr /certs/sslserver.csr \
+        --ext /usr/share/pki/server/certs/sslserver.conf \
+        --cert /certs/sslserver.crt
+
+    pki nss-cert-import \
+        --cert /certs/sslserver.crt \
+        sslserver
+fi
+
+echo "INFO: SSL server cert:"
+pki nss-cert-show sslserver
+
+echo "################################################################################"
+
+# check if admin cert exists
+rc=0
+pki nss-cert-show admin > /dev/null 2>&1 || rc=$?
+
+if [ $rc -ne 0 ]
+then
+    echo "INFO: Creating admin cert"
+
+    pki nss-cert-request \
+        --subject "CN=Administrator" \
+        --ext /usr/share/pki/server/certs/admin.conf \
+        --csr /certs/admin.csr
+
+    pki nss-cert-issue \
+        --issuer ca_signing \
+        --csr /certs/admin.csr \
+        --ext /usr/share/pki/server/certs/admin.conf \
+        --cert /certs/admin.crt
+
+    pki nss-cert-import \
+        --cert /certs/admin.crt \
+        admin
+fi
+
+echo "INFO: Admin cert:"
+pki nss-cert-show admin
+
+echo "################################################################################"
+
+if [ ! -f /certs/server.p12 ]
+then
+    echo "INFO: Exporting system certs and keys"
+
+    pki pkcs12-export \
+        --pkcs12 /certs/server.p12 \
+        --password Secret.123 \
+        ca_signing \
+        ocsp_signing \
+        audit_signing \
+        subsystem \
+        sslserver
+fi
+
+if [ ! -f /certs/admin.p12 ]
+then
+    echo "INFO: Exporting admin cert and key"
+
+    pki pkcs12-export \
+        --pkcs12 /certs/admin.p12 \
+        --password Secret.123 \
+        admin
+fi
+
+if [ ! -f /certs/ca_signing.crt ]
+then
+    echo "INFO: Exporting CA signing cert"
+
+    pki nss-cert-export \
+        --output-file /certs/ca_signing.crt \
+        ca_signing
+fi
+
+if [ ! -f /certs/admin.crt ]
+then
+    echo "INFO: Exporting admin cert"
+
+    pki nss-cert-export \
+        --output-file /certs/admin.crt \
+        admin
+fi
+
+echo "################################################################################"
+echo "INFO: Creating PKI CA"
 
 # Create CA with existing certs and keys, with RSNv3,
 # without security manager, and without systemd service.
@@ -182,29 +256,28 @@ pkispawn \
     -D pki_request_id_generator=random \
     -D pki_cert_id_generator=random \
     -D pki_existing=True \
-    -D pki_pkcs12_path=server.p12 \
+    -D pki_pkcs12_path=/certs/server.p12 \
     -D pki_pkcs12_password=Secret.123 \
     -D pki_ca_signing_nickname=ca_signing \
-    -D pki_ca_signing_csr_path=ca_signing.csr \
+    -D pki_ca_signing_csr_path=/certs/ca_signing.csr \
     -D pki_ocsp_signing_nickname=ocsp_signing \
-    -D pki_ocsp_signing_csr_path=ocsp_signing.csr \
+    -D pki_ocsp_signing_csr_path=/certs/ocsp_signing.csr \
     -D pki_audit_signing_nickname=audit_signing \
-    -D pki_audit_signing_csr_path=audit_signing.csr \
+    -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
     -D pki_subsystem_nickname=subsystem \
-    -D pki_subsystem_csr_path=subsystem.csr \
+    -D pki_subsystem_csr_path=/certs/subsystem.csr \
     -D pki_sslserver_nickname=sslserver \
-    -D pki_sslserver_csr_path=sslserver.csr \
+    -D pki_sslserver_csr_path=/certs/sslserver.csr \
     -D pki_admin_uid=admin \
     -D pki_admin_email=admin@example.com \
     -D pki_admin_nickname=admin \
-    -D pki_admin_csr_path=admin.csr \
-    -D pki_admin_cert_path=admin.crt \
+    -D pki_admin_csr_path=/certs/admin.csr \
+    -D pki_admin_cert_path=/certs/admin.crt \
     -D pki_security_manager=False \
     -D pki_systemd_service_create=False \
     -v
 
-# export CA signing cert to ca_signing.crt
-pki-server cert-export ca_signing --cert-file ca_signing.crt
+echo "################################################################################"
+echo "INFO: Starting PKI CA"
 
-# run PKI server in foreground
 pki-server run --as-current-user


### PR DESCRIPTION
The `pki-ca-run` has been modified to import existing system and admin certs if provided, otherwise it will create new ones.

The test for CA container has been updated to create the certs first, then create the CA container with these certs.

https://github.com/dogtagpki/pki/wiki/Deploying-CA-Container-on-Podman