### PR TITLE
Backport EST preparation changes to v10.11 branch

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AuthorityService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AuthorityService.java
@@ -165,11 +165,13 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
 
         logger.info("AuthorityService: getting cert for authority " + aidString);
 
-        AuthorityID aid;
-        try {
-            aid = new AuthorityID(aidString);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException("Bad AuthorityID: " + aidString);
+        AuthorityID aid = null;
+        if (!AuthorityResource.HOST_AUTHORITY.equals(aidString)) {
+            try {
+                aid = new AuthorityID(aidString);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException("Bad AuthorityID: " + aidString);
+            }
         }
 
         CAEngine engine = CAEngine.getInstance();
@@ -202,11 +204,13 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
 
         logger.info("AuthorityService: getting cert chain for authority " + aidString);
 
-        AuthorityID aid;
-        try {
-            aid = new AuthorityID(aidString);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException("Bad AuthorityID: " + aidString);
+        AuthorityID aid = null;
+        if (!AuthorityResource.HOST_AUTHORITY.equals(aidString)) {
+            try {
+                aid = new AuthorityID(aidString);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException("Bad AuthorityID: " + aidString);
+            }
         }
 
         CAEngine engine = CAEngine.getInstance();

--- a/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
@@ -57,6 +57,11 @@ public class AuthorityClient extends Client {
         return client.getEntity(response, AuthorityData.class);
     }
 
+    public String getChainPEM(String caIDString) throws Exception {
+        Response response = proxy.getChainPEM(caIDString);
+        return client.getEntity(response, String.class);
+    }
+
     public AuthorityData createCA(AuthorityData data) throws Exception {
         Response response = proxy.createCA(data);
         return client.getEntity(response, AuthorityData.class);

--- a/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
@@ -97,24 +97,60 @@ public class PKIService {
         return new String(Files.readAllBytes(bannerFile), "UTF-8").trim();
     }
 
+    /**
+     * Return a match for a candidate media type (which may be a wildcard)
+     * against the default list of valid media types.
+     *
+     * @return the matching MediaType or null if no match
+     */
     public static MediaType resolveFormat(MediaType format) {
+        return resolveFormat(format, MESSAGE_FORMATS);
+    }
 
-        if (format == null) return null;
+    /**
+     * Return a match for a candidate media type (which may be a wildcard)
+     * against a list of valid media types.
+     *
+     * @return the matching MediaType or null if no match
+     */
+    public static MediaType resolveFormat(MediaType candidate, List<MediaType> validTypes) {
+        if (candidate == null) return null;
 
-        for (MediaType supportedFormat : MESSAGE_FORMATS) {
-            if (format.isCompatible(supportedFormat)) return supportedFormat;
+        for (MediaType validType : validTypes) {
+            if (candidate.isCompatible(validType)) return validType;
         }
 
         return null;
     }
 
+    /**
+     * Find a match from a list of candidate media types (which may be wildcards)
+     * against the default list of valid media types.
+     *
+     * Candidates are checked in list order.  Quality values ("q" parameter)
+     * are ignored.
+     *
+     * @return the matching MediaType or null if no match
+     */
     public static MediaType resolveFormat(List<MediaType> formats) {
+        return resolveFormat(formats, MESSAGE_FORMATS);
+    }
 
-        if (formats == null) return null;
+    /**
+     * Find a match from a list of candidate media types (which may be wildcards)
+     * against a list of valid media types.
+     *
+     * Candidates are checked in list order.  Quality values ("q" parameter)
+     * are ignored.
+     *
+     * @return the matching MediaType or null if no match
+     */
+    public static MediaType resolveFormat(List<MediaType> candidates, List<MediaType> validTypes) {
+        if (candidates == null) return null;
 
-        for (MediaType acceptableFormat : formats) {
-            MediaType supportedFormat = resolveFormat(acceptableFormat);
-            if (supportedFormat != null) return supportedFormat;
+        for (MediaType candidate : candidates) {
+            MediaType match = resolveFormat(candidate, validTypes);
+            if (match != null) return match;
         }
 
         return null;

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -685,9 +685,10 @@ public class MainCLI extends CLI {
             System.err.println(t.getMessage());
 
         } else if (t instanceof ProcessingException) {
-            // display the cause of the exception
-            t = t.getCause();
-            System.err.println(t.getClass().getSimpleName() + ": " + t.getMessage());
+            // display the cause of the exception (if available)
+            Throwable e = t.getCause();
+            if (e == null) e = t;
+            System.err.println(e.getClass().getSimpleName() + ": " + e.getMessage());
 
         } else {
             // display the actual Exception


### PR DESCRIPTION
Cherry-pick to `v10.11` of PRs:

- https://github.com/dogtagpki/pki/pull/4058
- https://github.com/dogtagpki/pki/pull/4059
- https://github.com/dogtagpki/pki/pull/4046
- https://github.com/dogtagpki/pki/pull/4049

All cherry picks were without conflicts.

```
0c07b3d54 (Fraser Tweedale, 7 weeks ago)
   cli: handle t.getCause() == null in exception handler

   It is possible that the cause of a ProcessingException is not set. In that
   case, t.getCause() returns null.  As a consequence, handleException()
   throws an unhandled NullPointerException.

   Check that the cause Throwable is non-null before "drilling down" to it.

   Signed-off-by: Fraser Tweedale <ftweedal@redhat.com>
   (cherry picked from commit 70496404fb32063c76d5c7f545b12fbe9ed45ce4)

b01907aba (Fraser Tweedale, 7 weeks ago)
   PKIService: add more general variants of resolveFormat

   PKIService.resolveFormat is used to check a media type, or list of media
   types (possibly including wildcards) against the default list of content
   types understood and produced or processed by Dogtag.

   The current variants compare the parameter against a hardcoded list of
   supported content types.  However, it would be useful to also provide
   general variants that allow the caller to specify both the candidate
   type(s) and the valid/accepted types.  This commit adds those variants.

   Related: https://github.com/dogtagpki/pki/issues/3297
   Signed-off-by: Fraser Tweedale <ftweedal@redhat.com>
   (cherry picked from commit 5bc2aca0c777704d004894a3240a79b818655613)

56829df95 (Fraser Tweedale, 6 weeks ago)
   AuthorityClient: add getChainPEM method

   Extend AuthorityClient with a method to retrieve the certificate chain of a
   LWCA.

   This enhancement is required by the EST feature.

   Related: https://github.com/dogtagpki/pki/issues/3297
   (cherry picked from commit 2475fdf9b640d3a766edf76cbd2340fdbd7dc3d8)

5a36b77bd (Fraser Tweedale, 6 weeks ago)
   AuthorityService: recognise .../authorities/host-authority/(chain|cert)

   The LWCA REST API recognises the special identifier "host-authority" in the
   getCA method, as well as as a parameter in some other methods
   (e.g. nominating the parent CA when creating a new LWCA).  However,
   "host-authority" is not recognised when retrieving the certificate or
   certificate chain of a CA.  The following resources respond with 400 Bad
   Request because "host-authority" is not a UUID:

      /ca/rest/authorities/host-authority/(chain|cert)

   Update these resources to recognise "host-authority" as referring to the
   primary CA in the instance.

   As well as being a general improvement to the API, this work was undertaken
   specifically to make cert chain retrieval easier for the EST service.

   Related: https://github.com/dogtagpki/pki/issues/3297
   (cherry picked from commit 571c4d80910e479ec75a56c7aca8b17f355ff37d)
```