### PR TITLE
Add AES in SCEP protocol

### DIFF
--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -100,7 +100,7 @@ jobs:
               -c ca.crt
           docker exec client openssl x509 -text -noout -in ca.crt
 
-      - name: Enroll certificate with IP address using SSCEP
+      - name: Enroll certificate with IP address using SSCEP and DES3
         run: |
           docker exec client mkrequest -ip $(cat client.ip) Secret.123
           docker exec client openssl req -text -noout -in local.csr
@@ -113,6 +113,30 @@ jobs:
               -E 3des \
               -S sha256
           docker exec client openssl x509 -text -noout -in local.crt
+
+      - name: Configure SCEP in CA with AES
+        run: |
+          docker exec pki pki-server ca-config-set ca.scep.encryptionAlgorithm AES 
+          docker exec pki pki-server ca-config-set ca.scep.allowedEncryptionAlgorithms DES3,AES 
+          docker exec pki bash -c "echo UID:$(cat client.ip) > /etc/pki/pki-tomcat/ca/flatfile.txt"
+          docker exec pki bash -c "echo PWD:Secret.123 >> /etc/pki/pki-tomcat/ca/flatfile.txt"
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
+
+      - name: Enroll certificate with IP address using SSCEP and AES
+        run: |
+          docker exec client mkrequest -ip $(cat client.ip) Secret.123
+          docker exec client openssl req -text -noout -in local.csr
+          docker exec client sscep enroll \
+              -u http://pki.example.com:8080/ca/cgi-bin/pkiclient.exe \
+              -c ca.crt \
+              -k local.key \
+              -r local.csr \
+              -l local.crt \
+              -E aes \
+              -S sha256
+          docker exec client openssl x509 -text -noout -in local.crt
+
 
       - name: Gather artifacts
         if: always()

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1281,7 +1281,7 @@ public class CRSEnrollment extends HttpServlet {
             sk = kw.unwrapSymmetric(req.getWrappedKey(),
                               skt,
                               SymmetricKey.Usage.DECRYPT,
-                              0); // keylength is ignored
+                              ea.getKeyStrength() / 8);
 
             skinternal = cx.getKeyGenerator().clone(sk);
 

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1309,6 +1309,7 @@ public class CRSEnrollment extends HttpServlet {
 
     private SymmetricKey moveSymmetricToInternalToken(CryptoContext cx, SymmetricKey sk, SymmetricKey.Type skt, EncryptionAlgorithm ea)
             throws Exception {
+        boolean padding = false;
         KeyPairGeneratorSpi.Usage[] usage = {
                 KeyPairGeneratorSpi.Usage.WRAP,
                 KeyPairGeneratorSpi.Usage.UNWRAP,
@@ -1321,6 +1322,7 @@ public class CRSEnrollment extends HttpServlet {
         if(mUseOAEPKeyWrap) {
             kwAlg = KeyWrapAlgorithm.RSA_OAEP;
             algSpec = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+            padding = true;
         }
         KeyWrapper kw = sk.getOwningToken().getKeyWrapper(kwAlg);;
         kw.initWrap(keyPairWrap.getPublic(), algSpec);
@@ -1330,7 +1332,7 @@ public class CRSEnrollment extends HttpServlet {
         PrivateKey pk = (PrivateKey) keyPairWrap.getPrivate() ;
         kwInt.initUnwrap(pk, algSpec);
 
-        return kwInt.unwrapSymmetric(wrappedSK, skt, SymmetricKey.Usage.DECRYPT, ea.getKeyStrength() / 8);
+        return kwInt.unwrapSymmetric(wrappedSK, skt, SymmetricKey.Usage.DECRYPT, padding ? ea.getKeyStrength() / 8 : 0);
     }
 
     private void getDetailFromRequest(CRSPKIMessage req, CRSPKIMessage crsResp)

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -164,6 +164,8 @@ public class CRSEnrollment extends HttpServlet {
 
     private static final long serialVersionUID = 8483002540957382369L;
 
+    private static final String OAEP_SHA = "SHA-256";
+
     protected ProfileSubsystem mProfileSubsystem;
     protected String mProfileId = null;
     protected CertificateAuthority mAuthority;
@@ -1263,7 +1265,7 @@ public class CRSEnrollment extends HttpServlet {
             kw = cx.getKeyWrapper();
             AlgorithmParameterSpec keyWrapConfig = null;
             if(mUseOAEPKeyWrap) {
-                keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                keyWrapConfig = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
                 padding = true;
             }
             kw.initUnwrap(cx.getPrivateKey(), keyWrapConfig);
@@ -1319,7 +1321,7 @@ public class CRSEnrollment extends HttpServlet {
         KeyPair keyPairWrap = CryptoUtil.generateRSAKeyPair(cx.getInternalToken(), 2048, true, true, false, usage, usage);
 
         KeyWrapper kw = sk.getOwningToken().getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
-        AlgorithmParameterSpec algSpec = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+        AlgorithmParameterSpec algSpec = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
         kw.initWrap(keyPairWrap.getPublic(), algSpec);
         byte[] wrappedSK = kw.wrap(sk);
 
@@ -2049,7 +2051,7 @@ public class CRSEnrollment extends HttpServlet {
                 KeyWrapper kw = cx.getInternalKeyWrapper();
                 AlgorithmParameterSpec keyWrapConfig = null;
                 if(mUseOAEPKeyWrap) {
-                    keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                    keyWrapConfig = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
                 }
                 kw.initWrap(rcpPK, keyWrapConfig);
 
@@ -2128,7 +2130,7 @@ public class CRSEnrollment extends HttpServlet {
         private CryptoManager cm;
         private CryptoToken internalToken;
         private CryptoToken keyStorageToken;
-        private CryptoToken internalKeyStorageToken;
+        private CryptoToken internalKeyStorageToken = null;
         private KeyGenerator keyGen;
         private Enumeration<?> externalTokens = null;
         private org.mozilla.jss.crypto.X509Certificate signingCert;
@@ -2165,7 +2167,7 @@ public class CRSEnrollment extends HttpServlet {
                     break;
                 default:
                     kga = KeyGenAlgorithm.DES;
-            }
+                }
                 cm = CryptoManager.getInstance();
                 internalToken = cm.getInternalCryptoToken();
                 keyGen = internalToken.getKeyGenerator(kga);
@@ -2176,8 +2178,6 @@ public class CRSEnrollment extends HttpServlet {
                 if (CryptoUtil.isInternalToken(mTokenName)) {
                     internalKeyStorageToken = keyStorageToken;
                     logger.debug("CRSEnrollment: CryptoContext: internal token name: '" + mTokenName + "'");
-                } else {
-                    internalKeyStorageToken = null;
                 }
                 if (!mUseCA && internalKeyStorageToken == null) {
                     PasswordCallback cb = new PWCBsdr();

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -87,7 +87,6 @@ import org.mozilla.jss.netscape.security.x509.GeneralName;
 import org.mozilla.jss.netscape.security.x509.GeneralNameInterface;
 import org.mozilla.jss.netscape.security.x509.GeneralNames;
 import org.mozilla.jss.netscape.security.x509.IPAddressName;
-import org.mozilla.jss.netscape.security.x509.KeyIdentifier;
 import org.mozilla.jss.netscape.security.x509.KeyUsageExtension;
 import org.mozilla.jss.netscape.security.x509.OIDMap;
 import org.mozilla.jss.netscape.security.x509.RDN;
@@ -1318,7 +1317,6 @@ public class CRSEnrollment extends HttpServlet {
                 KeyPairGeneratorSpi.Usage.ENCRYPT,
                 KeyPairGeneratorSpi.Usage.DECRYPT};
         KeyPair keyPairWrap = CryptoUtil.generateRSAKeyPair(cx.getInternalToken(), 2048, true, true, false, usage, usage);
-        KeyIdentifier ki = CryptoUtil.createKeyIdentifier(keyPairWrap);
 
         KeyWrapper kw = sk.getOwningToken().getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
         AlgorithmParameterSpec algSpec = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
@@ -1326,7 +1324,7 @@ public class CRSEnrollment extends HttpServlet {
         byte[] wrappedSK = kw.wrap(sk);
 
         KeyWrapper kwInt = cx.getInternalToken().getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
-        PrivateKey pk = CryptoUtil.findPrivateKey(ki.getIdentifier());
+        PrivateKey pk = (PrivateKey) keyPairWrap.getPrivate() ;
         kwInt.initUnwrap(pk, algSpec);
 
         return kwInt.unwrapSymmetric(wrappedSK, skt, SymmetricKey.Usage.DECRYPT, ea.getKeyStrength() / 8);
@@ -1997,14 +1995,18 @@ public class CRSEnrollment extends HttpServlet {
                 SymmetricKey sk;
                 SymmetricKey skinternal;
                 EncryptionAlgorithm ea;
+                SymmetricKey.Type skt;
                 switch(String.valueOf(mEncryptionAlgorithm)) {
                     case "DES3":
+                        skt = SymmetricKey.DES3;
                         ea = EncryptionAlgorithm.DES3_CBC;
                         break;
                     case "AES":
+                        skt = SymmetricKey.AES;
                         ea = EncryptionAlgorithm.AES_128_CBC;
                         break;
                     default:
+                        skt = SymmetricKey.DES;
                         ea = EncryptionAlgorithm.DES_CBC;
                 }
 
@@ -2037,7 +2039,12 @@ public class CRSEnrollment extends HttpServlet {
 
                 // we have to move the key onto the internal token.
                 //skinternal = cx.getInternalKeyStorageToken().cloneKey(sk);
-                skinternal = cx.getInternalToken().cloneKey(sk);
+
+                if(mUseOAEPKeyWrap) {
+                    skinternal = moveSymmetricToInternalToken(cx, sk, skt, ea);
+                } else {
+                    skinternal = cx.getInternalToken().cloneKey(sk);
+                }
 
                 KeyWrapper kw = cx.getInternalKeyWrapper();
                 AlgorithmParameterSpec keyWrapConfig = null;

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1253,6 +1253,7 @@ public class CRSEnrollment extends HttpServlet {
         KeyWrapper kw;
         Cipher cip;
         EncryptionAlgorithm ea;
+        boolean padding = false;
 
         // Unwrap the session key with the Cert server key
         try {
@@ -1260,6 +1261,7 @@ public class CRSEnrollment extends HttpServlet {
             AlgorithmParameterSpec keyWrapConfig = null;
             if(mUseOAEPKeyWrap) {
                 keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                padding = true;
             }
             kw.initUnwrap(cx.getPrivateKey(), keyWrapConfig);
 
@@ -1281,7 +1283,7 @@ public class CRSEnrollment extends HttpServlet {
             sk = kw.unwrapSymmetric(req.getWrappedKey(),
                               skt,
                               SymmetricKey.Usage.DECRYPT,
-                              ea.getKeyStrength() / 8);
+                              padding ? ea.getKeyStrength() / 8 : 0);
 
             skinternal = cx.getKeyGenerator().clone(sk);
 

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -24,6 +24,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -31,6 +33,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Vector;
 
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -1253,8 +1257,11 @@ public class CRSEnrollment extends HttpServlet {
         // Unwrap the session key with the Cert server key
         try {
             kw = cx.getKeyWrapper();
-
-            kw.initUnwrap(cx.getPrivateKey(), null);
+            AlgorithmParameterSpec keyWrapConfig = null;
+            if(mUseOAEPKeyWrap) {
+                keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+            }
+            kw.initUnwrap(cx.getPrivateKey(), keyWrapConfig);
 
             switch(String.valueOf(mEncryptionAlgorithm)) {
                 case "DES3":
@@ -2006,7 +2013,11 @@ public class CRSEnrollment extends HttpServlet {
                 skinternal = cx.getInternalToken().cloneKey(sk);
 
                 KeyWrapper kw = cx.getInternalKeyWrapper();
-                kw.initWrap(rcpPK, null);
+                AlgorithmParameterSpec keyWrapConfig = null;
+                if(mUseOAEPKeyWrap) {
+                    keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                }
+                kw.initWrap(rcpPK, keyWrapConfig);
 
                 encryptedDesKey = kw.wrap(skinternal);
 

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1265,15 +1265,15 @@ public class CRSEnrollment extends HttpServlet {
 
             switch(String.valueOf(mEncryptionAlgorithm)) {
                 case "DES3":
-                    skt = SymmetricKey.Type.DES3;
+                    skt = SymmetricKey.DES3;
                     ea = EncryptionAlgorithm.DES3_CBC;
                     break;
                 case "AES":
-                    skt = SymmetricKey.Type.AES;
+                    skt = SymmetricKey.AES;
                     ea = EncryptionAlgorithm.AES_128_CBC;
                     break;
                 default:
-                    skt = SymmetricKey.Type.DES;
+                    skt = SymmetricKey.DES;
                     ea = EncryptionAlgorithm.DES_CBC;
 
             }
@@ -1965,19 +1965,15 @@ public class CRSEnrollment extends HttpServlet {
             if (issuedCert != null) {
                 SymmetricKey sk;
                 SymmetricKey skinternal;
-                KeyGenAlgorithm kga;
                 EncryptionAlgorithm ea;
                 switch(String.valueOf(mEncryptionAlgorithm)) {
                     case "DES3":
-                        kga = KeyGenAlgorithm.DES3;
                         ea = EncryptionAlgorithm.DES3_CBC;
                         break;
                     case "AES":
-                        kga = KeyGenAlgorithm.AES;
                         ea = EncryptionAlgorithm.AES_128_CBC;
                         break;
                     default:
-                        kga = KeyGenAlgorithm.DES;
                         ea = EncryptionAlgorithm.DES_CBC;
                 }
 
@@ -2064,9 +2060,9 @@ public class CRSEnrollment extends HttpServlet {
             {
                 byte[] signingcertbytes = cx.getSigningCert().getEncoded();
 
-                Certificate.Template sgncert_t = new Certificate.Template();
+                Certificate.Template sgncertT = new Certificate.Template();
                 Certificate sgncert =
-                        (Certificate) sgncert_t.decode(new ByteArrayInputStream(signingcertbytes));
+                        (Certificate) sgncertT.decode(new ByteArrayInputStream(signingcertbytes));
 
                 IssuerAndSerialNumber sgniasn =
                         new IssuerAndSerialNumber(sgncert.getInfo().getIssuer(),
@@ -2227,7 +2223,7 @@ public class CRSEnrollment extends HttpServlet {
                 throws CryptoContextException {
             KeyWrapAlgorithm keyWrapAlg = KeyWrapAlgorithm.RSA;
 
-            if(mUseOAEPKeyWrap == true) {
+            if(mUseOAEPKeyWrap) {
                 keyWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
             }
 
@@ -2244,7 +2240,7 @@ public class CRSEnrollment extends HttpServlet {
                 throws CryptoContextException {
             KeyWrapAlgorithm keyWrapAlg = KeyWrapAlgorithm.RSA;
 
-            if(mUseOAEPKeyWrap == true) {
+            if(mUseOAEPKeyWrap) {
                 keyWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
             }
             try {

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -19,6 +19,7 @@ package com.netscape.cms.servlet.cert.scep;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -633,7 +634,7 @@ public class CRSEnrollment extends HttpServlet {
 
             /*
              Possible capabilities as of https://tools.ietf.org/html/draft-gutmann-scep-16#section-3.5.1:
-             - AES (currently not supported by Dogtag)
+             - AES
              - DES3
              - GetNextCACert (currently not supported by Dogtag)
              - POSTPKIOperation (currently not supported by Dogtag)
@@ -643,6 +644,10 @@ public class CRSEnrollment extends HttpServlet {
              - SHA-512
              - SCEPStandard (currently not supported by Dogtag due to missing AES support)
             */
+            if (isAlgorithmAllowed(mAllowedEncryptionAlgorithm, "AES")) {
+                response.append("AES\n");
+            }
+
             if (isAlgorithmAllowed(mAllowedEncryptionAlgorithm, "DES3")) {
                 response.append("DES3\n");
             }
@@ -1251,11 +1256,19 @@ public class CRSEnrollment extends HttpServlet {
 
             kw.initUnwrap(cx.getPrivateKey(), null);
 
-            skt = SymmetricKey.Type.DES;
-            ea = EncryptionAlgorithm.DES_CBC;
-            if (mEncryptionAlgorithm != null && mEncryptionAlgorithm.equals("DES3")) {
-                skt = SymmetricKey.Type.DES3;
-                ea = EncryptionAlgorithm.DES3_CBC;
+            switch(String.valueOf(mEncryptionAlgorithm)) {
+                case "DES3":
+                    skt = SymmetricKey.Type.DES3;
+                    ea = EncryptionAlgorithm.DES3_CBC;
+                    break;
+                case "AES":
+                    skt = SymmetricKey.Type.AES;
+                    ea = EncryptionAlgorithm.AES_128_CBC;
+                    break;
+                default:
+                    skt = SymmetricKey.Type.DES;
+                    ea = EncryptionAlgorithm.DES_CBC;
+
             }
 
             sk = kw.unwrapSymmetric(req.getWrappedKey(),
@@ -1263,7 +1276,7 @@ public class CRSEnrollment extends HttpServlet {
                               SymmetricKey.Usage.DECRYPT,
                               0); // keylength is ignored
 
-            skinternal = cx.getDESKeyGenerator().clone(sk);
+            skinternal = cx.getKeyGenerator().clone(sk);
 
             cip = skinternal.getOwningToken().getCipherContext(ea);
 
@@ -1943,45 +1956,43 @@ public class CRSEnrollment extends HttpServlet {
 
         try {
             if (issuedCert != null) {
-
                 SymmetricKey sk;
                 SymmetricKey skinternal;
-
-                KeyGenAlgorithm kga = KeyGenAlgorithm.DES;
-                EncryptionAlgorithm ea = EncryptionAlgorithm.DES_CBC;
-                if (mEncryptionAlgorithm != null && mEncryptionAlgorithm.equals("DES3")) {
-                    kga = KeyGenAlgorithm.DES3;
-                    ea = EncryptionAlgorithm.DES3_CBC;
+                KeyGenAlgorithm kga;
+                EncryptionAlgorithm ea;
+                switch(String.valueOf(mEncryptionAlgorithm)) {
+                    case "DES3":
+                        kga = KeyGenAlgorithm.DES3;
+                        ea = EncryptionAlgorithm.DES3_CBC;
+                        break;
+                    case "AES":
+                        kga = KeyGenAlgorithm.AES;
+                        ea = EncryptionAlgorithm.AES_128_CBC;
+                        break;
+                    default:
+                        kga = KeyGenAlgorithm.DES;
+                        ea = EncryptionAlgorithm.DES_CBC;
                 }
 
                 // 1. Make the Degenerated PKCS7 with the recipient's certificate in it
-
                 byte toBeEncrypted[] =
                         crsResp.makeSignedRep(1, // version
                                 issuedCert.getEncoded()
                                       );
 
                 // 2. Encrypt the above byte array with a new random DES key
-
-                sk = cx.getDESKeyGenerator().generate();
-
-                skinternal = cx.getInternalToken().getKeyGenerator(kga).clone(sk);
+                sk = cx.getKeyGenerator().generate();
 
                 byte[] padded = Cipher.pad(toBeEncrypted, ea.getBlockSize());
-
-                // This should be changed to generate proper DES IV.
-
                 Cipher cipher = cx.getInternalToken().getCipherContext(ea);
+                byte[] iv = new byte[ea.getBlockSize()];
+                SecureRandom random = new SecureRandom();
+                random.nextBytes(iv);
                 IVParameterSpec desIV =
-                        new IVParameterSpec(new byte[] {
-                                (byte) 0xff, (byte) 0x00,
-                                (byte) 0xff, (byte) 0x00,
-                                (byte) 0xff, (byte) 0x00,
-                                (byte) 0xff, (byte) 0x00 });
+                        new IVParameterSpec(iv);
 
                 cipher.initEncrypt(sk, desIV);
                 byte[] encryptedData = cipher.doFinal(padded);
-
                 crsResp.makeEncryptedContentInfo(desIV.getIV(), encryptedData, mEncryptionAlgorithm);
 
                 // 3. Extract the recipient's public key
@@ -1990,17 +2001,17 @@ public class CRSEnrollment extends HttpServlet {
 
                 // 4. Encrypt the DES key with the public key
 
-                // we have to move the key onto the interal token.
+                // we have to move the key onto the internal token.
                 //skinternal = cx.getInternalKeyStorageToken().cloneKey(sk);
                 skinternal = cx.getInternalToken().cloneKey(sk);
 
                 KeyWrapper kw = cx.getInternalKeyWrapper();
                 kw.initWrap(rcpPK, null);
+
                 encryptedDesKey = kw.wrap(skinternal);
 
                 crsResp.setRcpIssuerAndSerialNumber(crsReq.getSgnIssuerAndSerialNumber());
                 crsResp.makeRecipientInfo(0, encryptedDesKey);
-
             }
 
             byte[] ed = crsResp.makeEnvelopedData(0);
@@ -2073,7 +2084,7 @@ public class CRSEnrollment extends HttpServlet {
         private CryptoToken internalToken;
         private CryptoToken keyStorageToken;
         private CryptoToken internalKeyStorageToken;
-        private KeyGenerator DESkg;
+        private KeyGenerator keyGen;
         private Enumeration<?> externalTokens = null;
         private org.mozilla.jss.crypto.X509Certificate signingCert;
         private org.mozilla.jss.crypto.PrivateKey signingCertPrivKey;
@@ -2099,13 +2110,23 @@ public class CRSEnrollment extends HttpServlet {
         public CryptoContext()
                 throws CryptoContextException {
             try {
-                KeyGenAlgorithm kga = KeyGenAlgorithm.DES;
-                if (mEncryptionAlgorithm != null && mEncryptionAlgorithm.equals("DES3")) {
+                KeyGenAlgorithm kga;
+                switch(String.valueOf(mEncryptionAlgorithm)) {
+                case "DES3":
                     kga = KeyGenAlgorithm.DES3;
-                }
+                    break;
+                case "AES":
+                    kga = KeyGenAlgorithm.AES;
+                    break;
+                default:
+                    kga = KeyGenAlgorithm.DES;
+            }
                 cm = CryptoManager.getInstance();
                 internalToken = cm.getInternalCryptoToken();
-                DESkg = internalToken.getKeyGenerator(kga);
+                keyGen = internalToken.getKeyGenerator(kga);
+                if(kga.equals(KeyGenAlgorithm.AES)) {
+                    keyGen.initialize(128);
+                }
                 keyStorageToken = CryptoUtil.getKeyStorageToken(mTokenName);
                 if (CryptoUtil.isInternalToken(mTokenName)) {
                     internalKeyStorageToken = keyStorageToken;
@@ -2158,11 +2179,13 @@ public class CRSEnrollment extends HttpServlet {
                 throw new CryptoContextException("Crypto Token not found: " + e.getMessage());
             } catch (IncorrectPasswordException e) {
                 throw new CryptoContextException("Incorrect Password.");
+            } catch (InvalidAlgorithmParameterException e) {
+                throw new CryptoContextException("Invalid algorithm parameter: " + e.getMessage());
             }
         }
 
-        public KeyGenerator getDESKeyGenerator() {
-            return DESkg;
+        public KeyGenerator getKeyGenerator() {
+            return keyGen;
         }
 
         public CryptoToken getInternalToken() {

--- a/base/common/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -98,6 +98,10 @@ public class CRSPKIMessage {
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 3, 7 }
             );
 
+    public static OBJECT_IDENTIFIER AES_128_CBC_ENCRYPTION =
+            new OBJECT_IDENTIFIER(new long[] { 2, 16, 840, 1, 101, 3, 4, 1, 2 }
+            );
+
     public static OBJECT_IDENTIFIER MD5_DIGEST =
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 2, 5 }
             );
@@ -437,9 +441,17 @@ public class CRSPKIMessage {
         this.ec = ec;
 
         try {
-            OBJECT_IDENTIFIER oid = DES_CBC_ENCRYPTION;
-            if (algorithm != null && algorithm.equals("DES3"))
+            OBJECT_IDENTIFIER oid = null;
+            switch (String.valueOf(algorithm)) {
+            case "DES3":
                 oid = DES_EDE3_CBC_ENCRYPTION;
+                break;
+            case "AES":
+                oid = AES_128_CBC_ENCRYPTION;
+                break;
+            default:
+                oid = DES_CBC_ENCRYPTION;
+            }
 
             AlgorithmIdentifier aid = new AlgorithmIdentifier(oid, new OCTET_STRING(iv));
 
@@ -783,6 +795,8 @@ public class CRSPKIMessage {
 
         if (eci.getContentEncryptionAlgorithm().getOID().equals(DES_EDE3_CBC_ENCRYPTION)) {
             encryptionAlgorithm = "DES3";
+        } else if (eci.getContentEncryptionAlgorithm().getOID().equals(AES_128_CBC_ENCRYPTION)) {
+            encryptionAlgorithm = "AES";
         } else if (eci.getContentEncryptionAlgorithm().getOID().equals(DES_CBC_ENCRYPTION)) {
             encryptionAlgorithm = "DES";
         } else {

--- a/base/common/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -90,7 +90,7 @@ public class CRSPKIMessage {
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 1, 1, 1 }
             );
 
-    /* PKCS 1 - rsaEncryption */
+    /* PKCS 1 - rsaOaepEncryption */
     public static OBJECT_IDENTIFIER RSAES_OAEP_ENCRYPTION =
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 1, 1, 7 }
             );

--- a/base/common/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -90,6 +90,11 @@ public class CRSPKIMessage {
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 1, 1, 1 }
             );
 
+    /* PKCS 1 - rsaEncryption */
+    public static OBJECT_IDENTIFIER RSAES_OAEP_ENCRYPTION =
+            new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 1, 1, 7 }
+            );
+
     public static OBJECT_IDENTIFIER DES_CBC_ENCRYPTION =
             new OBJECT_IDENTIFIER(new long[] { 1, 3, 14, 3, 2, 7 }
             );
@@ -837,7 +842,7 @@ public class CRSPKIMessage {
 
         riAlgid = ri.getKeyEncryptionAlgorithmID();
 
-        if (!riAlgid.getOID().equals(RSA_ENCRYPTION)) {
+        if (!(riAlgid.getOID().equals(RSA_ENCRYPTION) || riAlgid.getOID().equals(RSAES_OAEP_ENCRYPTION))) {
             throw new Exception("Request is protected by a key which we can't decrypt");
         }
 


### PR DESCRIPTION
Following the SCEP specs (https://www.rfc-editor.org/rfc/rfc8894.txt)
the AES support has been introduced for encrypting certificate massage.

Fix #3324