### PR TITLE
Provide the "best" password to certutil

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -555,7 +555,11 @@ class NSSDatabase(object):
             '-d', self.directory
         ]
 
-        if self.password_conf:
+        if token:
+            password_file = self.get_password_file(self.tmpdir, token)
+            cmd.extend(['-C', self.password_file])
+
+        elif self.password_conf:
             cmd.extend(['-f', self.password_conf])
 
         elif self.password_file:
@@ -787,8 +791,9 @@ class NSSDatabase(object):
         if self.token:
             cmd.extend(['-h', self.token])
 
-        if self.password_file:
-            cmd.extend(['-f', self.password_file])
+        password_file = self.get_password_file(self.tmpdir,
+                                               INTERNAL_TOKEN_NAME)
+        cmd.extend(['-f', password_file])
 
         cmd.extend([
             '-n', nickname,
@@ -1411,15 +1416,15 @@ class NSSDatabase(object):
                 '-d', self.directory
             ]
 
-            if self.password_conf:
-                cmd.extend(['-f', self.password_conf])
-
-            elif self.password_file:
-                cmd.extend(['-C', self.password_file])
-
             token = self.get_effective_token(token)
             if token:
                 cmd.extend(['--token', token])
+
+            if self.password_conf:
+                cmd.extend(['-f', self.password_conf])
+            else:
+                password_file = self.get_password_file(self.tmpdir, token)
+                cmd.extend(['-C', password_file])
 
             cmd.extend(['nss-cert-request'])
             cmd.extend(['--subject', subject_dn])

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1709,7 +1709,7 @@ class PKIDeployer:
             cert_data=system_cert['data'],
             cert_format='base64',
             token=request.systemCert.token,
-            use_jss=True)
+            use_jss=False)
 
     def setup_system_certs(self, nssdb, subsystem):
 


### PR DESCRIPTION
Installation would fail when installing with an HSM if the NSS database password was different from the token password. This was due to mostly providing the internal password and not the token password. If a token is present generally favor that except in the case of modifying NSS trust in which case always use the internal db password because that is where the data is stored.

The second patch switches pki nss-cert-import with a direct certutil call. Even though the -C option is passed to the pki command the generated certutil call lacks -f /path/to/password so fails. I couldn't find within the java code where this was failing so as a temporary measure switched to certutil directly. Without this patch the user is prompted 4 times for the token password (signing key, OCSP, Audit, Subsystem).

With these patch sets IdM is installable with softhsm2 non-interactively on Fedora 36.