### PR TITLE
Update CA container to use existing NSS database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,12 @@ LABEL name="pki-ca" \
 
 EXPOSE 8080 8443
 
+# Create PKI server
+RUN pki-server create --group root
+
+# Create NSS database
+RUN pki-server nss-create --no-password
+
 VOLUME [ "/certs" ]
 
 CMD [ "/usr/share/pki/ca/bin/pki-ca-run" ]

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -10,7 +10,9 @@ if [ -f /certs/server.p12 ]
 then
     echo "INFO: Importing system certs and keys"
 
-    pki pkcs12-import \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        pkcs12-import \
         --pkcs12 /certs/server.p12 \
         --password Secret.123
 fi
@@ -28,147 +30,207 @@ echo "##########################################################################
 
 # check if CA signing cert exists
 rc=0
-pki nss-cert-show ca_signing > /dev/null 2>&1 || rc=$?
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    ca_signing > /dev/null 2>&1 || rc=$?
 
 if [ $rc -ne 0 ]
 then
     echo "INFO: Creating CA signing cert"
 
-    pki nss-cert-request \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-request \
         --subject "CN=CA Signing Certificate" \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
         --csr /certs/ca_signing.csr
 
-    pki nss-cert-issue \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-issue \
         --csr /certs/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
         --months-valid 12 \
         --cert /certs/ca_signing.crt
 
-    pki nss-cert-import \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-import \
         --cert /certs/ca_signing.crt \
         --trust CT,C,C \
         ca_signing
 fi
 
 echo "INFO: CA signing cert:"
-pki nss-cert-show ca_signing
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    ca_signing
 
 echo "################################################################################"
 
 # check if OCSP signing cert exists
 rc=0
-pki nss-cert-show ocsp_signing > /dev/null 2>&1 || rc=$?
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    ocsp_signing > /dev/null 2>&1 || rc=$?
 
 if [ $rc -ne 0 ]
 then
     echo "INFO: Creating OCSP signing cert"
 
-    pki nss-cert-request \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-request \
         --subject "CN=OCSP Signing Certificate" \
         --ext /usr/share/pki/server/certs/ocsp_signing.conf \
         --csr /certs/ocsp_signing.csr
 
-    pki nss-cert-issue \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-issue \
         --issuer ca_signing \
         --csr /certs/ocsp_signing.csr \
         --ext /usr/share/pki/server/certs/ocsp_signing.conf \
         --cert /certs/ocsp_signing.crt
 
-    pki nss-cert-import \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-import \
         --cert /certs/ocsp_signing.crt \
         ocsp_signing
 fi
 
 echo "INFO: OCSP signing cert:"
-pki nss-cert-show ocsp_signing
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    ocsp_signing
 
 echo "################################################################################"
 
 # check if audit signing cert exists
 rc=0
-pki nss-cert-show audit_signing > /dev/null 2>&1 || rc=$?
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    audit_signing > /dev/null 2>&1 || rc=$?
 
 if [ $rc -ne 0 ]
 then
     echo "INFO: Creating audit signing cert"
 
-    pki nss-cert-request \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-request \
         --subject "CN=Audit Signing Certificate" \
         --ext /usr/share/pki/server/certs/audit_signing.conf \
         --csr /certs/audit_signing.csr
 
-    pki nss-cert-issue \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-issue \
         --issuer ca_signing \
         --csr /certs/audit_signing.csr \
         --ext /usr/share/pki/server/certs/audit_signing.conf \
         --cert /certs/audit_signing.crt
 
-    pki nss-cert-import \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-import \
         --cert /certs/audit_signing.crt \
         --trust ,,P \
         audit_signing
 fi
 
 echo "INFO: Audit signing cert:"
-pki nss-cert-show audit_signing
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    audit_signing
 
 echo "################################################################################"
 
 # check if subsystem cert exists
 rc=0
-pki nss-cert-show subsystem > /dev/null 2>&1 || rc=$?
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    subsystem > /dev/null 2>&1 || rc=$?
 
 if [ $rc -ne 0 ]
 then
     echo "INFO: Creating subsystem cert"
 
-    pki nss-cert-request \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-request \
         --subject "CN=Subsystem Certificate" \
         --csr /certs/subsystem.csr
 
-    pki nss-cert-issue \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-issue \
         --issuer ca_signing \
         --csr /certs/subsystem.csr \
         --ext /usr/share/pki/server/certs/subsystem.conf \
         --cert /certs/subsystem.crt
 
-    pki nss-cert-import \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-import \
         --cert /certs/subsystem.crt \
         subsystem
 fi
 
 echo "INFO: Subsystem cert:"
-pki nss-cert-show subsystem
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    subsystem
 
 echo "################################################################################"
 
 # check if SSL server cert exists
 rc=0
-pki nss-cert-show sslserver > /dev/null 2>&1 || rc=$?
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    sslserver > /dev/null 2>&1 || rc=$?
 
 if [ $rc -ne 0 ]
 then
     echo "INFO: Creating SSL server cert:"
 
-    pki nss-cert-request \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-request \
         --subject "CN=$HOSTNAME" \
         --ext /usr/share/pki/server/certs/sslserver.conf \
         --csr /certs/sslserver.csr
 
-    pki nss-cert-issue \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-issue \
         --issuer ca_signing \
         --csr /certs/sslserver.csr \
         --ext /usr/share/pki/server/certs/sslserver.conf \
         --cert /certs/sslserver.crt
 
-    pki nss-cert-import \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-import \
         --cert /certs/sslserver.crt \
         sslserver
 fi
 
 echo "INFO: SSL server cert:"
-pki nss-cert-show sslserver
+pki \
+    -d /etc/pki/pki-tomcat/alias \
+    nss-cert-show \
+    sslserver
 
 echo "################################################################################"
 
@@ -201,20 +263,6 @@ pki nss-cert-show admin
 
 echo "################################################################################"
 
-if [ ! -f /certs/server.p12 ]
-then
-    echo "INFO: Exporting system certs and keys"
-
-    pki pkcs12-export \
-        --pkcs12 /certs/server.p12 \
-        --password Secret.123 \
-        ca_signing \
-        ocsp_signing \
-        audit_signing \
-        subsystem \
-        sslserver
-fi
-
 if [ ! -f /certs/admin.p12 ]
 then
     echo "INFO: Exporting admin cert and key"
@@ -229,7 +277,9 @@ if [ ! -f /certs/ca_signing.crt ]
 then
     echo "INFO: Exporting CA signing cert"
 
-    pki nss-cert-export \
+    pki \
+        -d /etc/pki/pki-tomcat/alias \
+        nss-cert-export \
         --output-file /certs/ca_signing.crt \
         ca_signing
 fi
@@ -256,8 +306,6 @@ pkispawn \
     -D pki_request_id_generator=random \
     -D pki_cert_id_generator=random \
     -D pki_existing=True \
-    -D pki_pkcs12_path=/certs/server.p12 \
-    -D pki_pkcs12_password=Secret.123 \
     -D pki_ca_signing_nickname=ca_signing \
     -D pki_ca_signing_csr_path=/certs/ca_signing.csr \
     -D pki_ocsp_signing_nickname=ocsp_signing \


### PR DESCRIPTION
`pki-ca`'s `Dockerfile` has been updated to create a PKI server and an NSS database just like in `pki-server`'s Dockerfile.

The `pki-ca-run` has been updated to import the system certs into the server's NSS database (or generate the certs directly in it),
then create a CA with the certs already in the database just like in `pki-server-run`.