### PR TITLE
Bug 2094066 CC: audit event CLIENT_ACCESS_SESSION_ESTABLISH contains …

### DIFF
--- a/base/util/src/main/java/com/netscape/cmsutil/http/JssSSLSocketFactory.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/http/JssSSLSocketFactory.java
@@ -99,11 +99,6 @@ public class JssSSLSocketFactory implements ISocketFactory {
             s = new SSLSocket(host, port, null, 0, certApprovalCallback,
                     clientCertCallback);
 
-            Socket js = new Socket(InetAddress.getByName(host), port);
-            s = new SSLSocket(js, host,
-                    certApprovalCallback,
-                    clientCertCallback);
-
             s.setUseClientMode(true);
             s.setSoTimeout(timeout);
 


### PR DESCRIPTION
…wrong port

This patch fixes the case when ca->kra during a CRMF request the
audit event CLIENT_ACCESS_SESSION_ESTABLISH contains wrong port.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2094066