### PR TITLE
Add tests for CA installation with existing DS

### DIFF
--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -1,0 +1,265 @@
+name: CA with existing DS
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-ca-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          COPR_REPO: ${{ needs.init.outputs.repo }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Configure DS database
+        run: |
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/base/server/database/ds/config.ldif
+
+      - name: Add PKI schema
+        run: |
+          docker exec ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/base/server/database/ds/schema.ldif
+
+      - name: Add CA base entry
+        run: |
+          docker exec -i ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: dc=ca,dc=pki,dc=example,dc=com
+          objectClass: dcObject
+          dc: ca
+          EOF
+
+      - name: Add CA database entries
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/create.ldif \
+              | tee create.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/create.ldif
+
+      - name: Add CA search indexes
+        run: |
+          sed \
+              -e 's/{database}/userroot/g' \
+              base/ca/database/ds/index.ldif \
+              | tee index.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/index.ldif
+
+      - name: Rebuild CA search indexes
+        run: |
+          # start rebuild task
+          sed \
+              -e 's/{database}/userroot/g' \
+              base/ca/database/ds/indextasks.ldif \
+              | tee indextasks.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/indextasks.ldif
+
+          # wait for task to complete
+          while true; do
+              sleep 1
+
+              docker exec ds ldapsearch \
+                  -H ldap://ds.example.com:3389 \
+                  -D "cn=Directory Manager" \
+                  -w Secret.123 \
+                  -b "cn=index1160589770, cn=index, cn=tasks, cn=config" \
+                  -LLL \
+                  nsTaskExitCode \
+                  | tee output
+
+              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
+              cat nsTaskExitCode
+
+              if [ -s nsTaskExitCode ]; then
+                  break
+              fi
+          done
+
+          echo "0" > expected
+          diff expected nsTaskExitCode
+
+      - name: Add CA ACL resources
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/acl.ldif \
+              | tee acl.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/acl.ldif
+
+      - name: Grant access to PKI database user
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=example,dc=com/g' \
+              -e 's/{dbuser}/uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/server/database/ds/db-access-grant.ldif \
+              | tee db-access-grant.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/db-access-grant.ldif \
+              -c
+
+      - name: Add CA VLV indexes
+        run: |
+          sed \
+              -e 's/{instanceId}/pki-tomcat/g' \
+              -e 's/{database}/userroot/g' \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/vlv.ldif \
+              | tee vlv.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/vlv.ldif
+
+      - name: Rebuild CA VLV indexes
+        run: |
+          # start rebuild task
+          sed \
+              -e 's/{database}/userroot/g' \
+              -e 's/{instanceId}/pki-tomcat/g' \
+              base/ca/database/ds/vlvtasks.ldif \
+              | tee vlvtasks.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/vlvtasks.ldif
+
+          # wait for task to complete
+          while true; do
+              sleep 1
+
+              docker exec ds ldapsearch \
+                  -H ldap://ds.example.com:3389 \
+                  -D "cn=Directory Manager" \
+                  -w Secret.123 \
+                  -b "cn=index1160589769, cn=index, cn=tasks, cn=config" \
+                  -LLL \
+                  nsTaskExitCode \
+                  | tee output
+
+              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
+              cat nsTaskExitCode
+
+              if [ -s nsTaskExitCode ]; then
+                  break
+              fi
+          done
+
+          echo "0" > expected
+          diff expected nsTaskExitCode
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_setup=False \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Run PKI healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Check CA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Check DS suffix
+        run: |
+          echo "dc=example,dc=com (userroot)" > expected
+          docker exec ds dsconf localhost backend suffix list | tee actual
+          diff expected actual
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ca-existing-ds-${{ inputs.os }}
+          path: |
+            /tmp/artifacts/pki

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1122,18 +1122,6 @@ jobs:
       - name: Create network
         run: docker network create example
 
-      - name: Set up DS container
-        run: |
-          tests/bin/ds-container-create.sh ds
-        env:
-          IMAGE: ${{ needs.init.outputs.db-image }}
-          COPR_REPO: ${{ needs.init.outputs.repo }}
-          HOSTNAME: ds.example.com
-          PASSWORD: Secret.123
-
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up client container
         run: |
           tests/bin/runner-init.sh client
@@ -1290,6 +1278,184 @@ jobs:
               --pkcs12 admin.p12 \
               --password Secret.123 \
               admin
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          COPR_REPO: ${{ needs.init.outputs.repo }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Configure DS database
+        run: |
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/base/server/database/ds/config.ldif
+
+      - name: Add PKI schema
+        run: |
+          docker exec ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/base/server/database/ds/schema.ldif
+
+      - name: Add CA base entry
+        run: |
+          docker exec -i ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: dc=ca,dc=pki,dc=example,dc=com
+          objectClass: dcObject
+          dc: ca
+          EOF
+
+      - name: Add CA database entries
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/create.ldif \
+              | tee create.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/create.ldif
+
+      - name: Add CA search indexes
+        run: |
+          sed \
+              -e 's/{database}/userroot/g' \
+              base/ca/database/ds/index.ldif \
+              | tee index.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/index.ldif
+
+      - name: Rebuild CA search indexes
+        run: |
+          # start rebuild task
+          sed \
+              -e 's/{database}/userroot/g' \
+              base/ca/database/ds/indextasks.ldif \
+              | tee indextasks.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/indextasks.ldif
+
+          # wait for task to complete
+          while true; do
+              sleep 1
+
+              docker exec ds ldapsearch \
+                  -H ldap://ds.example.com:3389 \
+                  -D "cn=Directory Manager" \
+                  -w Secret.123 \
+                  -b "cn=index1160589770, cn=index, cn=tasks, cn=config" \
+                  -LLL \
+                  nsTaskExitCode \
+                  | tee output
+
+              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
+              cat nsTaskExitCode
+
+              if [ -s nsTaskExitCode ]; then
+                  break
+              fi
+          done
+
+          echo "0" > expected
+          diff expected nsTaskExitCode
+
+      - name: Add CA ACL resources
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/acl.ldif \
+              | tee acl.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/acl.ldif
+
+      - name: Grant access to PKI database user
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=example,dc=com/g' \
+              -e 's/{dbuser}/uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/server/database/ds/db-access-grant.ldif \
+              | tee db-access-grant.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/db-access-grant.ldif \
+              -c
+
+      - name: Add CA VLV indexes
+        run: |
+          sed \
+              -e 's/{instanceId}/pki-tomcat/g' \
+              -e 's/{database}/userroot/g' \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/vlv.ldif \
+              | tee vlv.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/vlv.ldif
+
+      - name: Rebuild CA VLV indexes
+        run: |
+          # start rebuild task
+          sed \
+              -e 's/{database}/userroot/g' \
+              -e 's/{instanceId}/pki-tomcat/g' \
+              base/ca/database/ds/vlvtasks.ldif \
+              | tee vlvtasks.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/vlvtasks.ldif
+
+          # wait for task to complete
+          while true; do
+              sleep 1
+
+              docker exec ds ldapsearch \
+                  -H ldap://ds.example.com:3389 \
+                  -D "cn=Directory Manager" \
+                  -w Secret.123 \
+                  -b "cn=index1160589769, cn=index, cn=tasks, cn=config" \
+                  -LLL \
+                  nsTaskExitCode \
+                  | tee output
+
+              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
+              cat nsTaskExitCode
+
+              if [ -s nsTaskExitCode ]; then
+                  break
+              fi
+          done
+
+          echo "0" > expected
+          diff expected nsTaskExitCode
 
       - name: Set up CA container
         run: |

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -1650,3 +1650,12 @@ jobs:
           name: ca-hsm-${{ matrix.os }}
           path: |
             /tmp/artifacts/pki
+
+  ca-existing-ds-test:
+    name: CA with existing DS
+    needs: [init, build]
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    uses: ./.github/workflows/ca-existing-ds-test.yml
+    with:
+      os: ${{ matrix.os }}

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -1,8 +1,11 @@
 #!/bin/sh -e
 
 # TODO:
-# - support existing database
 # - parameterize hard-coded values
+# - do not create security domain
+# - support existing subsystem user
+# - support existing admin user
+# - support existing database user
 
 echo "################################################################################"
 
@@ -303,6 +306,7 @@ pkispawn \
     -s CA \
     -D pki_ds_hostname=ds.example.com \
     -D pki_ds_ldap_port=3389 \
+    -D pki_ds_setup=False \
     -D pki_request_id_generator=random \
     -D pki_cert_id_generator=random \
     -D pki_existing=True \

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -108,6 +108,7 @@ pki_ds_ldap_port=389
 pki_ds_ldaps_port=636
 pki_ds_password=
 pki_ds_remove_data=True
+pki_ds_setup=True
 pki_ds_secure_connection=False
 pki_ds_secure_connection_ca_nickname=Directory Server CA certificate
 pki_ds_secure_connection_ca_pem_file=

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -243,7 +243,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         subsystem.save()
 
-        deployer.setup_database(subsystem)
+        if config.str2bool(deployer.mdict['pki_ds_setup']):
+            deployer.setup_database(subsystem)
 
         subsystem.load()
 


### PR DESCRIPTION
A new `pki_ds_setup` parameter has been added for setting up the DS during installation (default: `True`).

A new test has been added to set up the DS before installing CA, then install the CA without setting up the DS again.

The test for CA container has also been modified to use an existing DS.

Docs:
* https://github.com/dogtagpki/pki/wiki/Deploying-CA-Container
* https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database

