### PR TITLE
Fix Bug 2122409 - pki-tomcat/kra unable to decrypt when using RSA-OAE…

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/util/CryptoProvider.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/CryptoProvider.java
@@ -26,6 +26,8 @@ public abstract class CryptoProvider {
     public abstract byte[] wrapSymmetricKey(SymmetricKey symmetricKey, PublicKey wrappingKey)
             throws Exception;
 
+    public abstract byte[] wrapSymmetricKey(SymmetricKey symmetricKey, PublicKey wrappingKey, KeyWrapAlgorithm alg) throws Exception;
+
     public abstract byte[] encryptSecret(byte[] secret, byte[] iv, SymmetricKey key, String keyAlgorithm)
             throws Exception;
 

--- a/base/common/src/main/java/com/netscape/certsrv/util/NSSCryptoProvider.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/NSSCryptoProvider.java
@@ -122,6 +122,16 @@ public class NSSCryptoProvider extends CryptoProvider {
     }
 
     @Override
+    public byte[] wrapSymmetricKey(SymmetricKey symmetricKey, PublicKey wrappingKey, KeyWrapAlgorithm alg) throws Exception {
+
+       if (manager == null || token == null) {
+            throw new NotInitializedException();
+       }
+
+       return CryptoUtil.wrapUsingPublicKey(token,wrappingKey,symmetricKey,alg);
+    }
+
+    @Override
     public byte[] encryptSecret(byte[] secret, byte[] iv, SymmetricKey key, String encryptionAlgorithm)
             throws Exception {
         return  encryptSecret(secret, iv, key, getEncryptionAlgorithm(encryptionAlgorithm));

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyArchiveCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyArchiveCLI.java
@@ -65,6 +65,9 @@ public class KRAKeyArchiveCLI extends CommandCLI {
         option = new Option(null, "output-format", true, "Output format: none (default), json");
         option.setArgName("format");
         options.addOption(option);
+
+        option = new Option(null, "oaep", false, "Use OAEP key wrap algorithm.");
+        options.addOption(option);
     }
 
     @Override
@@ -84,12 +87,14 @@ public class KRAKeyArchiveCLI extends CommandCLI {
         String requestFile = cmd.getOptionValue("input");
         String transportNickname = cmd.getOptionValue("transport");
         String outputFormat = cmd.getOptionValue("output-format", "none");
+        boolean useOAEP = cmd.hasOption("oaep");
 
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
 
         KeyRequestResponse response = null;
         KeyClient keyClient = keyCLI.getKeyClient(transportNickname);
+        keyClient.setUseOAEP(useOAEP);
 
         if (inputDataFile != null) {
             // archiving a binary data

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyRetrieveCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyRetrieveCLI.java
@@ -74,6 +74,9 @@ public class KRAKeyRetrieveCLI extends CommandCLI {
         option = new Option(null, "transport", true, "Transport certificate nickname.");
         option.setArgName("Nickname");
         options.addOption(option);
+
+        option = new Option(null, "oaep", false, "Use OAEP key wrap algorithm.");
+        options.addOption(option);
     }
 
     @Override
@@ -105,8 +108,9 @@ public class KRAKeyRetrieveCLI extends CommandCLI {
             String outputDataFile = cmd.getOptionValue("output-data");
             String outputFormat = cmd.getOptionValue("output-format", "xml");
             String transportNickname = cmd.getOptionValue("transport");
-
+            boolean useOAEP = cmd.hasOption("oaep");
             KeyClient keyClient = keyCLI.getKeyClient(transportNickname);
+            keyClient.setUseOAEP(useOAEP);
 
             if (requestFile != null) {
                 Path path = Paths.get(requestFile);


### PR DESCRIPTION
…P padding in RHEL9 with FIPS enabled

    This fix allows the "pki kra-key" cmds the ability to specify OAEP wrapping of the sesssion key before sending the request to the server.

    Ex:

    pki -d . -v -oaep -n  "PKI KRA Administrator for CA RSA" -h  test.host.com -p 19443   kra-key-archive --clientKeyID ID-1 --passphrase 1234

    This example will archive the key using oaep to wrap the session key before sending to the server. If the server / kra is configured to use oaep
    instead of pkcs1, the operation will be successful.

    There will be a similiar "-oaep" switch available fo the kra-key-retrieve cmd as well.