### PR TITLE
Add test for user cert publishing

### DIFF
--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -499,6 +499,15 @@ jobs:
           path: |
             /tmp/artifacts/pki
 
+  ca-user-cert-publish-test:
+    name: CA user cert publishing
+    needs: [init, build]
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    uses: ./.github/workflows/ca-user-cert-publishing-test.yml
+    with:
+      os: ${{ matrix.os }}
+
   # https://github.com/dogtagpki/pki/wiki/Publishing-CRL-to-File-System
   crl-file-test:
     name: Testing file-based CRL publishing

--- a/.github/workflows/ca-user-cert-publishing-test.yml
+++ b/.github/workflows/ca-user-cert-publishing-test.yml
@@ -1,0 +1,247 @@
+name: CA user cert publishing
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-ca-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          COPR_REPO: ${{ needs.init.outputs.repo }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Prepare publishing subtree
+        run: |
+          docker exec -i pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: ou=people,dc=pki,dc=example,dc=com
+          objectClass: organizationalUnit
+          ou: people
+
+          dn: uid=testuser,ou=people,dc=pki,dc=example,dc=com
+          objectClass: person
+          objectClass: organizationalPerson
+          objectClass: inetOrgPerson
+          uid: testuser
+          cn: Test User
+          sn: User
+          EOF
+
+      - name: Configure user cert publishing
+        run: |
+          # configure LDAP connection
+          docker exec pki pki-server ca-config-set ca.publish.ldappublish.enable true
+          docker exec pki pki-server ca-config-set ca.publish.ldappublish.ldap.ldapauth.authtype BasicAuth
+          docker exec pki pki-server ca-config-set ca.publish.ldappublish.ldap.ldapauth.bindDN "cn=Directory Manager"
+          docker exec pki pki-server ca-config-set ca.publish.ldappublish.ldap.ldapauth.bindPWPrompt internaldb
+          docker exec pki pki-server ca-config-set ca.publish.ldappublish.ldap.ldapconn.host ds.example.com
+          docker exec pki pki-server ca-config-set ca.publish.ldappublish.ldap.ldapconn.port 3389
+          docker exec pki pki-server ca-config-set ca.publish.ldappublish.ldap.ldapconn.secureConn false
+
+          # configure LDAP-based user cert publisher
+          docker exec pki pki-server ca-config-set ca.publish.publisher.instance.LdapUserCertPublisher.certAttr "userCertificate;binary"
+          docker exec pki pki-server ca-config-set ca.publish.publisher.instance.LdapUserCertPublisher.pluginName LdapUserCertPublisher
+
+          # configure user cert mapper
+          docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapUserCertMap.dnPattern "uid=\$subj.UID,ou=people,dc=pki,dc=example,dc=com"
+          docker exec pki pki-server ca-config-set ca.publish.mapper.instance.LdapUserCertMap.pluginName LdapSimpleMap
+
+          # configure user cert publishing rule
+          docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapUserCertRule.enable true
+          docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapUserCertRule.mapper LdapUserCertMap
+          docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapUserCertRule.pluginName Rule
+          docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapUserCertRule.predicate ""
+          docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapUserCertRule.publisher LdapUserCertPublisher
+          docker exec pki pki-server ca-config-set ca.publish.rule.instance.LdapUserCertRule.type certs
+
+          # enable publishing
+          docker exec pki pki-server ca-config-set ca.publish.enable true
+
+          # restart CA subsystem
+          docker exec pki pki-server ca-undeploy --wait
+          docker exec pki pki-server ca-deploy --wait
+
+      - name: Check CA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Check user before enrollment
+        run: |
+          docker exec pki ldapsearch \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -b "uid=testuser,ou=people,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -t | tee output
+
+          # there should be no cert attributes
+          grep "userCertificate;binary:" output | wc -l > actual
+          echo "0" > expected
+          diff expected actual
+
+      - name: Enroll user cert
+        run: |
+          docker exec pki pki client-cert-request uid=testuser | tee output
+
+          REQUEST_ID=$(sed -n -e 's/^ *Request ID: *\(.*\)$/\1/p' output)
+          echo "REQUEST_ID: $REQUEST_ID"
+
+          docker exec pki pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
+          CERT_ID=$(sed -n -e 's/^ *Certificate ID: *\(.*\)$/\1/p' output)
+          echo "CERT_ID: $CERT_ID"
+          echo $CERT_ID > cert.id
+
+      - name: Check user after enrollment
+        run: |
+          docker exec pki ldapsearch \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -b "uid=testuser,ou=people,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -t | tee output
+
+          # there should be one cert attribute
+          grep "userCertificate;binary:" output | wc -l > actual
+          echo "1" > expected
+          diff expected actual
+
+          FILENAME=$(sed -n 's/userCertificate;binary:< file:\/\/\(.*\)$/\1/p' output)
+          echo "FILENAME: $FILENAME"
+
+          # check the cert
+          docker exec pki openssl x509 \
+              -in "$FILENAME" \
+              -inform DER \
+              -text -noout
+
+      - name: Revoke user cert
+        run: |
+          CERT_ID=$(cat cert.id)
+          docker exec pki pki -n caadmin ca-cert-hold $CERT_ID --force
+
+      - name: Check user after revocation
+        run: |
+          docker exec pki ldapsearch \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -b "uid=testuser,ou=people,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -t | tee output
+
+          # there should be no cert attributes
+          grep "userCertificate;binary:" output | wc -l > actual
+          echo "0" > expected
+          diff expected actual
+
+      - name: Unrevoke user cert
+        run: |
+          CERT_ID=$(cat cert.id)
+          docker exec pki pki -n caadmin ca-cert-release-hold $CERT_ID --force
+
+      - name: Check user after unrevocation
+        run: |
+          docker exec pki ldapsearch \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -b "uid=testuser,ou=people,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -t | tee output
+
+          # there should be one cert attribute
+          grep "userCertificate;binary:" output | wc -l > actual
+          echo "1" > expected
+          diff expected actual
+
+          FILENAME=$(sed -n 's/userCertificate;binary:< file:\/\/\(.*\)$/\1/p' output)
+          echo "FILENAME: $FILENAME"
+
+          # check the cert
+          docker exec pki openssl x509 \
+              -in "$FILENAME" \
+              -inform DER \
+              -text -noout
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ca-user-cert-publishing-${{ inputs.os }}
+          path: |
+            /tmp/artifacts/pki


### PR DESCRIPTION
A new test has been added to verify user cert publishing in CA. When a new cert is issued, it will be added into the user entry
in LDAP. If the cert is revoked, it will be removed from the user entry. If the cert is unrevoked, it will be restored into the user entry.

https://github.com/dogtagpki/pki/wiki/Publishing-User-Certificates-to-LDAP-Server