### PR TITLE
Update CA container to support existing database user

### DIFF
--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -8,6 +8,7 @@ on:
         type: string
 
 jobs:
+  # https://github.com/dogtagpki/pki/wiki/Deploying-CA-Container
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -207,6 +208,7 @@ jobs:
       - name: Connect DS container to network
         run: docker network connect example ds --alias ds.example.com
 
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
       - name: Configure DS database
         run: |
           docker exec ds ldapadd \
@@ -307,20 +309,6 @@ jobs:
               -w Secret.123 \
               -f $SHARED/acl.ldif
 
-      - name: Grant access to PKI database user
-        run: |
-          sed \
-              -e 's/{rootSuffix}/dc=example,dc=com/g' \
-              -e 's/{dbuser}/uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com/g' \
-              base/server/database/ds/db-access-grant.ldif \
-              | tee db-access-grant.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/db-access-grant.ldif \
-              -c
-
       - name: Add CA VLV indexes
         run: |
           sed \
@@ -372,6 +360,91 @@ jobs:
 
           echo "0" > expected
           diff expected nsTaskExitCode
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database-User
+      - name: Add database user
+        run: |
+          docker exec -i ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          objectClass: person
+          objectClass: organizationalPerson
+          objectClass: inetOrgPerson
+          objectClass: cmsuser
+          cn: pkidbuser
+          sn: pkidbuser
+          uid: pkidbuser
+          userState: 1
+          userType: agentType
+          EOF
+
+      - name: Assign subsystem cert to database user
+        run: |
+          # convert cert from PEM to DER
+          docker cp client:subsystem.crt subsystem.crt
+          openssl x509 -outform der -in subsystem.crt -out subsystem.der
+          docker cp subsystem.der ds:subsystem.der
+
+          # get serial number
+          openssl x509 -text -noout -in subsystem.crt | tee output
+          SERIAL=$(sed -En 'N; s/^ *Serial Number:\n *(.*)$/\1/p; D' output)
+          echo "SERIAL: $SERIAL"
+          HEX_SERIAL=$(echo "$SERIAL" | tr -d ':')
+          echo "HEX_SERIAL: $HEX_SERIAL"
+          DEC_SERIAL=$(python -c "print(int('$HEX_SERIAL', 16))")
+          echo "DEC_SERIAL: $DEC_SERIAL"
+
+          docker exec -i ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: description
+          description: 2;$DEC_SERIAL;CN=CA Signing Certificate;CN=Subsystem Certificate
+          -
+          add: seeAlso
+          seeAlso: CN=Subsystem Certificate
+          -
+          add: userCertificate
+          userCertificate:< file:subsystem.der
+          -
+          EOF
+
+      - name: Add database user into CA groups
+        run: |
+          docker exec -i ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: cn=Subsystem Group,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Certificate Manager Agents,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+          EOF
+
+      - name: Grant database user access to CA database
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=example,dc=com/g' \
+              -e 's/{dbuser}/uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/server/database/ds/db-access-grant.ldif \
+              | tee db-access-grant.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/db-access-grant.ldif \
+              -c
 
       - name: Set up CA container
         run: |

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -5,7 +5,6 @@
 # - do not create security domain
 # - support existing subsystem user
 # - support existing admin user
-# - support existing database user
 
 echo "################################################################################"
 
@@ -299,14 +298,16 @@ fi
 echo "################################################################################"
 echo "INFO: Creating PKI CA"
 
-# Create CA with existing certs and keys, with RSNv3,
-# without security manager, and without systemd service.
+# Create CA with existing certs and keys, with existing database,
+# with existing database user, with RSNv3, without security manager,
+# and without systemd service.
 pkispawn \
     -f /usr/share/pki/server/examples/installation/ca.cfg \
     -s CA \
     -D pki_ds_hostname=ds.example.com \
     -D pki_ds_ldap_port=3389 \
     -D pki_ds_setup=False \
+    -D pki_share_db=True \
     -D pki_request_id_generator=random \
     -D pki_cert_id_generator=random \
     -D pki_existing=True \


### PR DESCRIPTION
The CA container test has been modified to set up a database user before starting up the CA container. The `pki-ca-run` has been modified to use the existing (i.e. shared) database user.