### PR TITLE
Update CA container to support existing admin user

### DIFF
--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -361,6 +361,118 @@ jobs:
           echo "0" > expected
           diff expected nsTaskExitCode
 
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
+      - name: Add admin user
+        run: |
+          docker exec -i ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          objectClass: person
+          objectClass: organizationalPerson
+          objectClass: inetOrgPerson
+          objectClass: cmsuser
+          cn: admin
+          sn: admin
+          uid: admin
+          mail: admin@example.com
+          userPassword: Secret.123
+          userState: 1
+          userType: adminType
+          EOF
+
+      - name: Assign admin cert to admin user
+        run: |
+          # convert cert from PEM to DER
+          docker cp client:admin.crt admin.crt
+          openssl x509 -outform der -in admin.crt -out admin.der
+          docker cp admin.der ds:admin.der
+
+          # get serial number
+          openssl x509 -text -noout -in admin.crt | tee output
+          SERIAL=$(sed -En 'N; s/^ *Serial Number:\n *(.*)$/\1/p; D' output)
+          echo "SERIAL: $SERIAL"
+          HEX_SERIAL=$(echo "$SERIAL" | tr -d ':')
+          echo "HEX_SERIAL: $HEX_SERIAL"
+          DEC_SERIAL=$(python -c "print(int('$HEX_SERIAL', 16))")
+          echo "DEC_SERIAL: $DEC_SERIAL"
+
+          docker exec -i ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: description
+          description: 2;$DEC_SERIAL;CN=CA Signing Certificate;CN=Administrator
+          -
+          add: userCertificate
+          userCertificate:< file:admin.der
+          -
+          EOF
+
+      - name: Add admin user into CA groups
+        run: |
+          docker exec -i ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: cn=Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Certificate Manager Agents,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Security Domain Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise CA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise KRA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise RA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise TKS Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise OCSP Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise TPS Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+          EOF
+
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database-User
       - name: Add database user
         run: |
@@ -497,17 +609,6 @@ jobs:
 
       - name: Check public operations from client container
         run: |
-          # clean the NSS database
-          docker exec client pki client-init --force
-
-          # install CA signing cert
-          docker cp ca:/certs/ca_signing.crt ca_signing.crt
-          docker cp ca_signing.crt client:ca_signing.crt
-          docker exec client pki nss-cert-import \
-              --cert ca_signing.crt \
-              --trust CT,C,C \
-              ca_signing
-
           # check PKI server info
           docker exec client pki \
               -U https://ca.example.com:8443 \
@@ -520,14 +621,6 @@ jobs:
 
       - name: Check admin operations from client container
         run: |
-          # install admin cert
-          docker cp ca:/certs/admin.p12 admin.p12
-          docker cp admin.p12 client:admin.p12
-          docker exec client pki \
-              pkcs12-import \
-              --pkcs12 admin.p12 \
-              --password Secret.123
-
           # check admin user
           docker exec client pki \
               -U https://ca.example.com:8443 \

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -4,7 +4,6 @@
 # - parameterize hard-coded values
 # - do not create security domain
 # - support existing subsystem user
-# - support existing admin user
 
 echo "################################################################################"
 
@@ -321,11 +320,7 @@ pkispawn \
     -D pki_subsystem_csr_path=/certs/subsystem.csr \
     -D pki_sslserver_nickname=sslserver \
     -D pki_sslserver_csr_path=/certs/sslserver.csr \
-    -D pki_admin_uid=admin \
-    -D pki_admin_email=admin@example.com \
-    -D pki_admin_nickname=admin \
-    -D pki_admin_csr_path=/certs/admin.csr \
-    -D pki_admin_cert_path=/certs/admin.crt \
+    -D pki_admin_setup=False \
     -D pki_security_manager=False \
     -D pki_systemd_service_create=False \
     -v

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -69,6 +69,7 @@ destroy_scriplets=
 # pki_https_port=8443
 # pki_http_port=8080
 
+pki_admin_setup=True
 pki_admin_cert_file=%(pki_client_dir)s/ca_admin.cert
 pki_admin_cert_request_type=pkcs10
 pki_admin_dualkey=False

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -306,7 +306,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             logger.info('Setting up subsystem user')
             deployer.setup_subsystem_user(instance, subsystem, system_certs['subsystem'])
 
-        if not clone:
+        if config.str2bool(deployer.mdict['pki_admin_setup']) and not clone:
             logger.info('Setting up admin cert')
             admin_cert = deployer.setup_admin_cert(subsystem)
 

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -962,20 +962,23 @@ def print_skip_configuration_information(mdict):
 def print_final_install_information(mdict):
 
     print(log.PKI_SPAWN_INFORMATION_HEADER)
-    print("      Administrator's username:             %s" %
-          mdict['pki_admin_uid'])
 
-    if os.path.isfile(mdict['pki_client_admin_cert_p12']):
-        print("      Administrator's PKCS #12 file:\n            %s" %
-              mdict['pki_client_admin_cert_p12'])
+    if config.str2bool(deployer.mdict['pki_admin_setup']):
 
-    if not config.str2bool(mdict['pki_client_database_purge']) and \
-            not config.str2bool(mdict['pki_clone']):
-        print()
-        print("      Administrator's certificate nickname:\n            %s"
-              % mdict['pki_admin_nickname'])
-        print("      Administrator's certificate database:\n            %s"
-              % mdict['pki_client_database_dir'])
+        print("      Administrator's username:             %s" %
+              mdict['pki_admin_uid'])
+
+        if os.path.isfile(mdict['pki_client_admin_cert_p12']):
+            print("      Administrator's PKCS #12 file:\n            %s" %
+                  mdict['pki_client_admin_cert_p12'])
+
+        if not config.str2bool(mdict['pki_client_database_purge']) and \
+                not config.str2bool(mdict['pki_clone']):
+            print()
+            print("      Administrator's certificate nickname:\n            %s"
+                  % mdict['pki_admin_nickname'])
+            print("      Administrator's certificate database:\n            %s"
+                  % mdict['pki_client_database_dir'])
 
     if config.str2bool(mdict['pki_clone']):
         print()


### PR DESCRIPTION
A new `pki_admin_setup` parameter has been added to set up the admin user during installation (default: `True`).

The CA container test has been updated to set up an admin user before creating the CA container. The `pki-ca-run` has been
modified to use the existing admin user.

The test has also been updated to use the existing certs already in the client container to ensure they can be used to access the CA container.

Docs:

* https://github.com/dogtagpki/pki/wiki/Deploying-CA-Container
* https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database-User
* https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User