### PR TITLE
Fix TPS UI elements broken by XML -> JSON migration

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/logging/AuditConfig.java
+++ b/base/common/src/main/java/com/netscape/certsrv/logging/AuditConfig.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -41,6 +43,7 @@ public class AuditConfig implements JSONSerializer {
 
     Map<String, String> eventConfigs;
 
+    @JsonProperty("Status")
     public String getStatus() {
         return status;
     }
@@ -49,6 +52,7 @@ public class AuditConfig implements JSONSerializer {
         this.status = status;
     }
 
+    @JsonProperty("Signed")
     public Boolean getSigned() {
         return signed;
     }
@@ -57,6 +61,7 @@ public class AuditConfig implements JSONSerializer {
         this.signed = signed;
     }
 
+    @JsonProperty("Interval")
     public Integer getInterval() {
         return interval;
     }
@@ -73,6 +78,7 @@ public class AuditConfig implements JSONSerializer {
         this.bufferSize = bufferSize;
     }
 
+    @JsonProperty("Events")
     public Map<String, String> getEventConfigs() {
         return eventConfigs;
     }
@@ -82,13 +88,16 @@ public class AuditConfig implements JSONSerializer {
     }
 
     public static class EventConfigList {
+        @JsonProperty("Event")
         public List<EventConfig> entries = new ArrayList<>();
     }
 
     public static class EventConfig {
 
+        @JsonValue
         public String name;
 
+        @JsonValue
         public String value;
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/tps/authenticator/AuthenticatorData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/authenticator/AuthenticatorData.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -47,6 +49,7 @@ public class AuthenticatorData implements JSONSerializer {
         this.id = id;
     }
 
+    @JsonProperty("Status")
     public String getStatus() {
         return status;
     }
@@ -55,6 +58,7 @@ public class AuthenticatorData implements JSONSerializer {
         this.status = status;
     }
 
+    @JsonProperty("Properties")
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -64,13 +68,16 @@ public class AuthenticatorData implements JSONSerializer {
     }
 
     public static class PropertyList {
+        @JsonProperty("Property")
         public List<Property> properties = new ArrayList<>();
     }
 
     public static class Property {
 
+        @JsonValue
         public String name;
 
+        @JsonValue
         public String value;
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/tps/connector/ConnectorData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/connector/ConnectorData.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -46,6 +48,7 @@ public class ConnectorData implements JSONSerializer {
         this.id = id;
     }
 
+    @JsonProperty("Status")
     public String getStatus() {
         return status;
     }
@@ -54,6 +57,7 @@ public class ConnectorData implements JSONSerializer {
         this.status = status;
     }
 
+    @JsonProperty("Properties")
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -63,13 +67,16 @@ public class ConnectorData implements JSONSerializer {
     }
 
     public static class PropertyList {
+        @JsonProperty("Property")
         public List<Property> properties = new ArrayList<>();
     }
 
     public static class Property {
 
+        @JsonValue
         public String name;
 
+        @JsonValue
         public String value;
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileData.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -55,6 +57,7 @@ public class ProfileData implements JSONSerializer {
         this.profileID = profileID;
     }
 
+    @JsonProperty("Status")
     public String getStatus() {
         return status;
     }
@@ -63,6 +66,7 @@ public class ProfileData implements JSONSerializer {
         this.status = status;
     }
 
+    @JsonProperty("Properties")
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -73,13 +77,16 @@ public class ProfileData implements JSONSerializer {
 
 
     public static class PropertyList {
+        @JsonProperty("Property")
         public List<Property> properties = new ArrayList<>();
     }
 
     public static class Property {
 
+        @JsonValue
         public String name;
 
+        @JsonValue
         public String value;
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingData.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -46,6 +48,7 @@ public class ProfileMappingData implements JSONSerializer {
         this.id = id;
     }
 
+    @JsonProperty("Status")
     public String getStatus() {
         return status;
     }
@@ -54,6 +57,7 @@ public class ProfileMappingData implements JSONSerializer {
         this.status = status;
     }
 
+    @JsonProperty("Properties")
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -63,13 +67,16 @@ public class ProfileMappingData implements JSONSerializer {
     }
 
     public static class PropertyList {
+        @JsonProperty("Property")
         public List<Property> properties = new ArrayList<>();
     }
 
     public static class Property {
 
+        @JsonValue
         public String name;
 
+        @JsonValue
         public String value;
     }
 

--- a/base/common/src/main/java/org/dogtagpki/common/ConfigData.java
+++ b/base/common/src/main/java/org/dogtagpki/common/ConfigData.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -38,6 +40,7 @@ public class ConfigData implements JSONSerializer {
     String status;
     Map<String, String> properties;
 
+    @JsonProperty("Status")
     public String getStatus() {
         return status;
     }
@@ -46,6 +49,7 @@ public class ConfigData implements JSONSerializer {
         this.status = status;
     }
 
+    @JsonProperty("Properties")
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -55,13 +59,16 @@ public class ConfigData implements JSONSerializer {
     }
 
     public static class PropertyList {
+        @JsonProperty("Property")
         public List<Property> properties = new ArrayList<>();
     }
 
     public static class Property {
 
+        @JsonValue
         public String name;
 
+        @JsonValue
         public String value;
     }
 

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -560,7 +560,7 @@ class PKIDeployer:
 
             logger.info('Validating %s master config params', subsystem.type)
 
-            master_properties = master_config['properties']
+            master_properties = master_config['Properties']
 
             master_hostname = master_properties['internaldb.ldapconn.host']
             master_port = master_properties['internaldb.ldapconn.port']


### PR DESCRIPTION
The field names were erroneously changed by not adding JSON tags to
rename the fields like the original XML implementation.