### PR TITLE
Update CA container to skip security domain setup

### DIFF
--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -321,6 +321,7 @@ pkispawn \
     -D pki_sslserver_nickname=sslserver \
     -D pki_sslserver_csr_path=/certs/sslserver.csr \
     -D pki_admin_setup=False \
+    -D pki_security_domain_setup=False \
     -D pki_security_manager=False \
     -D pki_systemd_service_create=False \
     -v

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -123,6 +123,7 @@ pki_issuing_ca_uri=https://%(pki_issuing_ca_hostname)s:%(pki_issuing_ca_https_po
 pki_issuing_ca=%(pki_issuing_ca_uri)s
 pki_replication_password=
 pki_status_request_timeout=
+pki_security_domain_setup=True
 pki_security_domain_hostname=%(pki_hostname)s
 pki_security_domain_https_port=8443
 pki_security_domain_uri=https://%(pki_security_domain_hostname)s:%(pki_security_domain_https_port)s

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -121,7 +121,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         finally:
             nssdb.close()
 
-        deployer.setup_security_domain(instance, subsystem)
+        if config.str2bool(deployer.mdict['pki_security_domain_setup']):
+            deployer.setup_security_domain(instance, subsystem)
 
         hierarchy = subsystem.config.get('hierarchy.select')
         issuing_ca = deployer.mdict['pki_issuing_ca']
@@ -252,7 +253,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         subsystem.save()
 
-        if subsystem.type == 'CA':
+        if config.str2bool(deployer.mdict['pki_security_domain_setup']) and \
+                subsystem.type == 'CA':
             logger.info('Setting up subsystem user')
             deployer.setup_subsystem_user(instance, subsystem, system_certs['subsystem'])
 
@@ -263,7 +265,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             logger.info('Setting up admin user')
             deployer.setup_admin_user(subsystem, admin_cert)
 
-        deployer.setup_security_domain_manager(instance, subsystem)
+        if config.str2bool(deployer.mdict['pki_security_domain_setup']):
+            deployer.setup_security_domain_manager(instance, subsystem)
 
         if not config.str2bool(deployer.mdict['pki_share_db']) and not clone:
             logger.info('Setting up database user')


### PR DESCRIPTION
A new `pki_security_domain_setup` parameter has been added to set up a security domain and create a subsystem user during installation (default: `True`).

The CA container has been modified to skip security domain setup and subsystem user creation since it's not needed for container deployments.