### PR TITLE
Fix Azure pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,16 @@ ARG OS_VERSION="latest"
 ARG COPR_REPO="@pki/master"
 
 ################################################################################
-FROM registry.fedoraproject.org/fedora:$OS_VERSION AS pki-runner
+FROM registry.fedoraproject.org/fedora:$OS_VERSION AS fedora-runner
+
+RUN dnf install -y systemd \
+    && dnf clean all \
+    && rm -rf /var/cache/yum
+
+CMD [ "/usr/sbin/init" ]
+
+################################################################################
+FROM fedora-runner AS pki-runner
 
 ARG COPR_REPO
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,39 +1,53 @@
-# Provide docker in container for installing dependencies as root.
-# https://github.com/Microsoft/azure-pipelines-agent/issues/2043#issuecomment-687983301
-resources:
-  containers:
-  - container: fedora_latest
-    image: fedora:latest
-    options: '--name runner -v /usr/bin/docker:/usr/bin/docker:ro'
-
 jobs:
 - job: BuildTest
   pool:
     vmImage: ubuntu-latest
-  strategy:
-    matrix:
-      fedora_latest:
-        image: fedora_latest
-  container: $[variables['image']]
   steps:
   - script: |
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf install -y dnf-plugins-core rpm-build maven
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf copr enable -y @pki/master
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner dnf builddep -y --spec pki.spec
+      docker build \
+          --target fedora-runner \
+          --tag fedora-runner:latest \
+          .
+
+      docker run \
+          --name=runner \
+          -v $BUILD_SOURCESDIRECTORY:/root/src \
+          --privileged \
+          --detach \
+          fedora-runner:latest
+
+      while :
+      do
+          docker exec runner echo "Runner is ready" && break
+
+          echo "Waiting for runner..."
+          sleep 1
+          [ $((++i)) -ge 10 ] && exit 1
+      done
+    displayName: Create runner container
+
+  - script: |
+      docker exec runner dnf install -y dnf-plugins-core rpm-build maven
+      docker exec runner dnf copr enable -y @pki/master
+      docker exec runner dnf builddep -y --spec /root/src/pki.spec
     displayName: Install PKI dependencies
 
   - script: |
-      ./build.sh -v rpm
+      docker exec runner \
+          /root/src/build.sh -v rpm
     displayName: Build PKI RPM packages
 
   - script: |
       # find RPM packages (excluding debug packages)
-      RPMS=$(ls ~/build/pki/RPMS | grep -v debuginfo | grep -v debugsource)
+      docker exec runner \
+          ls /root/build/pki/RPMS | grep -v debuginfo | grep -v debugsource | tee output
+      RPMS=$(cat output)
 
       # get list of files in each RPM package
       for rpm in $RPMS
       do
-          rpm -qlp "~/build/pki/RPMS/$rpm" | tee -a ~/build/pki/files
+          docker exec runner \
+              rpm -qlp "/root/build/pki/RPMS/$rpm" | tee -a files
       done
 
       # exclude RPM-specific files
@@ -43,18 +57,21 @@ jobs:
           -e '/^\/usr\/share\/doc\//d' \
           -e '/^\/usr\/lib\/.build-id\//d' \
           -e '/__pycache__/d' \
-          ~/build/pki/files
+          files
     displayName: Get list of files from RPM packages
 
   - script: |
-      ./build.sh \
-          --work-dir=build \
+      docker exec runner \
+          /root/src/build.sh \
+          --work-dir=/root/build \
           --python-dir=/usr/lib/python3.10/site-packages \
           dist
     displayName: Build PKI with CMake
 
   - script: |
-      mvn install:install-file \
+      docker exec runner \
+          mvn install:install-file \
+          -f /root/src \
           -Dfile=/usr/lib/java/jss.jar \
           -DgroupId=org.dogtagpki \
           -DartifactId=jss \
@@ -62,7 +79,9 @@ jobs:
           -Dpackaging=jar \
           -DgeneratePom=true
 
-      mvn install:install-file \
+      docker exec runner \
+          mvn install:install-file \
+          -f /root/src \
           -Dfile=/usr/lib/java/jss-symkey.jar \
           -DgroupId=org.dogtagpki \
           -DartifactId=jss-symkey \
@@ -72,7 +91,9 @@ jobs:
     displayName: Install JSS into Maven repo
 
   - script: |
-      mvn install:install-file \
+      docker exec runner \
+          mvn install:install-file \
+          -f /root/src \
           -Dfile=/usr/share/java/tomcatjss.jar \
           -DgroupId=org.dogtagpki \
           -DartifactId=tomcatjss \
@@ -82,7 +103,9 @@ jobs:
     displayName: Install Tomcat JSS into Maven repo
 
   - script: |
-      mvn install:install-file \
+      docker exec runner \
+          mvn install:install-file \
+          -f /root/src \
           -Dfile=/usr/share/java/ldapjdk.jar \
           -DgroupId=org.dogtagpki \
           -DartifactId=ldapjdk \
@@ -92,103 +115,120 @@ jobs:
     displayName: Install LDAP JDK into Maven repo
 
   - script: |
-      mvn package -DskipTests
+      docker exec runner \
+          mvn package \
+          -f /root/src \
+          -DskipTests
     displayName: Build PKI with Maven
 
   - script: |
-      jar tvf build/dist/pki-certsrv.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
-      jar tvf base/common/target/pki-common-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      docker exec runner \
+          jar tvf /root/build/dist/pki-certsrv.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      docker exec runner \
+          jar tvf /root/src/base/common/target/pki-common-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
     displayName: Compare pki-certsrv.jar
 
   - script: |
-      jar tvf build/dist/pki-tools.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
-      jar tvf base/tools/target/pki-tools-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      docker exec runner \
+          jar tvf /root/build/dist/pki-tools.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      docker exec runner \
+          jar tvf /root/src/base/tools/target/pki-tools-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
     displayName: Compare pki-tools.jar
 
   - script: |
-      jar tvf build/dist/pki-ca.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
-      jar tvf base/ca/target/pki-ca-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      docker exec runner \
+          jar tvf /root/build/dist/pki-ca.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      docker exec runner \
+          jar tvf /root/src/base/ca/target/pki-ca-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
     displayName: Compare pki-ca.jar
 
   - script: |
-      jar tvf build/dist/pki-kra.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
-      jar tvf base/kra/target/pki-kra-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      docker exec runner \
+          jar tvf /root/build/dist/pki-kra.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      docker exec runner \
+          jar tvf /root/src/base/kra/target/pki-kra-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
     displayName: Compare pki-kra.jar
 
   - script: |
-      jar tvf build/dist/pki-ocsp.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
-      jar tvf base/ocsp/target/pki-ocsp-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      docker exec runner \
+          jar tvf /root/build/dist/pki-ocsp.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      docker exec runner \
+          jar tvf /root/src/base/ocsp/target/pki-ocsp-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
     displayName: Compare pki-ocsp.jar
 
   - script: |
-      jar tvf build/dist/pki-tks.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
-      jar tvf base/tks/target/pki-tks-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      docker exec runner \
+          jar tvf /root/build/dist/pki-tks.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      docker exec runner \
+          jar tvf /root/src/base/tks/target/pki-tks-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
     displayName: Compare pki-tks.jar
 
   - script: |
-      jar tvf build/dist/pki-tps.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
-      jar tvf base/tps/target/pki-tps-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      docker exec runner \
+          jar tvf /root/build/dist/pki-tps.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      docker exec runner \
+          jar tvf /root/src/base/tps/target/pki-tps-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
     displayName: Compare pki-tps.jar
 
   - script: |
-      jar tvf build/dist/pki-acme.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
-      jar tvf base/acme/target/pki-acme-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
+      docker exec runner \
+          jar tvf /root/build/dist/pki-acme.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+      docker exec runner \
+          jar tvf /root/src/base/acme/target/pki-acme-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
     displayName: Compare pki-acme.jar
 
   - script: |
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner ./build.sh \
-          --work-dir=build \
+      docker exec runner \
+          /root/src/build.sh \
+          --work-dir=/root/build \
           install
     displayName: Install PKI with CMake
 
   - script: |
-      cat ~/build/pki/files | while read file
-      do
-          echo "Checking $file"
-          if [ ! -d "$file" ] && [ ! -f "$file" ]
-          then
-              echo "ERROR: $file is missing"
-              exit 1
-          fi
-      done
+      readarray -t files < files
+      docker exec runner ls -ld "${files[@]}"
     displayName: Compare CMake and RPM files
 
   - script: |
       # generate CSR
-      pki nss-cert-request \
+      docker exec runner \
+          pki nss-cert-request \
           --key-type RSA \
           --subject "CN=Certificate Authority" \
           --ext /usr/share/pki/server/certs/ca_signing.conf \
           --csr ca_signing.csr
 
       # issue self-signed cert
-      pki nss-cert-issue \
+      docker exec runner \
+          pki nss-cert-issue \
           --csr ca_signing.csr \
           --ext /usr/share/pki/server/certs/ca_signing.conf \
           --cert ca_signing.crt
 
       # import cert
-      pki nss-cert-import \
+      docker exec runner \
+          pki nss-cert-import \
           --cert ca_signing.crt \
           --trust CT,C,C \
           ca_signing
 
       # display cert
-      pki nss-cert-show ca_signing
+      docker exec runner \
+          pki nss-cert-show ca_signing
     displayName: Test PKI CLI
 
   - script: |
-      # create PKI server
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner pki-server create tomcat@pki
-
-      # remove PKI server
-      docker exec -u 0 -w $BUILD_SOURCESDIRECTORY runner pki-server remove tomcat@pki
+      docker exec runner pki-server create tomcat@pki
+      docker exec runner pki-server start tomcat@pki --wait
+      docker exec runner pki-server status tomcat@pki
+      docker exec runner pki-server stop tomcat@pki --wait
+      docker exec runner pki-server remove tomcat@pki
     displayName: Test PKI Server CLI


### PR DESCRIPTION
Due to recent changes in Azure or Fedora it's no longer possible to run tests with the standard Fedora image.

To fix the problem, the `Dockerfile` has been updated to define a new Fedora image that provides a systemd service. The Azure job has been updated to build the image, create a container with the image, then run the tests with it. The job has also been updated to test creating a server, starting it up, checking the status, shutting it down, and removing the server.

https://github.com/Microsoft/azure-pipelines-agent/issues/2043#issuecomment-1236485349