### PR TITLE
Update CA container to skip system certs import

### DIFF
--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -607,6 +607,19 @@ jobs:
               ca-user-show \
               admin
 
+          docker exec ca pki \
+              client-cert-request \
+              uid=testuser | tee output
+
+          REQUEST_ID=$(sed -n -e 's/^ *Request ID: *\(.*\)$/\1/p' output)
+          echo "REQUEST_ID: $REQUEST_ID"
+
+          docker exec ca pki \
+              -n admin \
+              ca-cert-request-approve \
+              $REQUEST_ID \
+              --force
+
       - name: Check public operations from client container
         run: |
           # check PKI server info
@@ -627,6 +640,21 @@ jobs:
               -n admin \
               ca-user-show \
               admin
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              client-cert-request \
+              uid=testuser | tee output
+
+          REQUEST_ID=$(sed -n -e 's/^ *Request ID: *\(.*\)$/\1/p' output)
+          echo "REQUEST_ID: $REQUEST_ID"
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-cert-request-approve \
+              $REQUEST_ID \
+              --force
 
       - name: Gather artifacts from CA container
         if: always()

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -310,6 +310,7 @@ pkispawn \
     -D pki_request_id_generator=random \
     -D pki_cert_id_generator=random \
     -D pki_existing=True \
+    -D pki_import_system_certs=False \
     -D pki_ca_signing_nickname=ca_signing \
     -D pki_ca_signing_csr_path=/certs/ca_signing.csr \
     -D pki_ocsp_signing_nickname=ocsp_signing \

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -374,6 +374,7 @@ pki_external_step_two=False
 
 pki_external_pkcs12_path=%(pki_pkcs12_path)s
 pki_external_pkcs12_password=%(pki_pkcs12_password)s
+pki_import_system_certs=True
 pki_import_admin_cert=False
 
 pki_ocsp_signing_key_algorithm=SHA256withRSA

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1898,8 +1898,9 @@ class PKIDeployer:
             # might conflict with system certificates to be created later.
             # Also create the certificate request record for renewals.
 
-            self.import_cert_request(subsystem, tag, request)
-            self.import_cert(subsystem, tag, request, system_cert['data'])
+            if config.str2bool(self.mdict['pki_import_system_certs']):
+                self.import_cert_request(subsystem, tag, request)
+                self.import_cert(subsystem, tag, request, system_cert['data'])
 
             return
 


### PR DESCRIPTION
A new `pki_import_system_certs` parameter has been added to import externally provided system certs into the LDAP database during installation (default: `True`).

The CA container has been modified to skip importing the provided system certs into LDAP database since they are not needed for the CA to be functional. The system certs will still be imported into the NSS database so the CA can use them.

The CA container test has been updated to perform cert enrollments to verify that it is functional without the system certs in the LDAP database.