### PR TITLE
Fix Java home directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -269,7 +269,9 @@ while getopts v-: arg ; do
             CMAKE=$(readlink -f "$LONG_OPTARG")
             ;;
         java-home=?*)
-            JAVA_HOME=$(readlink -f "$LONG_OPTARG")
+            # Don't convert Java home into an absolute path since that
+            # will prevent PKI from running with other OpenJDK releases.
+            JAVA_HOME="$LONG_OPTARG"
             ;;
         jni-dir=?*)
             JNI_DIR=$(readlink -f "$LONG_OPTARG")


### PR DESCRIPTION
Previously the `build.sh` would convert the Java home directory provided by `pki.spec` into an absolute path which would point to a specific OpenJDK release used to build the package. This prevented PKI from running with other OpenJDK releases.

The `build.sh` has been modified to use the original Java home directory provided by `pki.spec` which is a generic path that will work across multiple OpenJDK releases.