### PR TITLE
Fix request in queue notifications

### DIFF
--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -1,0 +1,153 @@
+name: CA with request notification
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          path: pki-ca-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-ca-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ needs.init.outputs.db-image }}
+          COPR_REPO: ${{ needs.init.outputs.repo }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install mail server and client
+        run: |
+          docker exec pki dnf install -y postfix mailx
+
+      - name: Start mail server
+        run: |
+          # use only IPv4 since IPv6 is not available by default
+          docker exec pki sed -i \
+              -e 's/^inet_protocols = .*$/inet_protocols = ipv4/' \
+              /etc/postfix/main.cf
+
+          docker exec pki systemctl start postfix
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      # https://github.com/dogtagpki/pki/wiki/Configuring-Notifications
+      - name: Configure request notification
+        run: |
+          docker exec pki pki-server ca-config-set ca.notification.requestInQ.enabled true
+          docker exec pki pki-server ca-config-set ca.notification.requestInQ.recipientEmail root@pki.example.com
+          docker exec pki pki-server ca-config-set ca.notification.requestInQ.senderEmail root@pki.example.com
+
+      - name: Restart CA subsystem
+        run: |
+          docker exec pki pki-server ca-undeploy --wait
+          docker exec pki pki-server ca-deploy --wait
+
+      - name: Check CA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Check messages before enrollment request
+        run: |
+          sleep 60
+
+          echo -ne "q\n" | docker exec -i pki mail \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # there should be no messages
+          echo "No mail for root" > expected
+          diff expected stderr
+
+      - name: Submit enrollment request
+        run: |
+          docker exec pki pki client-cert-request uid=testuser | tee output
+
+          REQUEST_ID=$(sed -n -e 's/^ *Request ID: *\(.*\)$/\1/p' output)
+          echo "REQUEST_ID: $REQUEST_ID"
+          echo $REQUEST_ID > request.id
+
+      - name: Check messages after enrollment request
+        run: |
+          sleep 60
+
+          echo -ne "q\n" | docker exec -i pki mail \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # there should be 1 message
+          echo "Held 1 message in /var/mail/root" > expected
+          tail -1 stdout > actual
+          diff expected actual
+
+          echo -ne "1\nq\n" | docker exec -i pki mail | tee output
+
+          # check email subject
+          REQUEST_ID=$(cat request.id)
+          echo "Certificate Request in Queue (request id: $REQUEST_ID)" > expected
+          sed -n 's/^Subject:\s\+\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ca-notification-request-${{ inputs.os }}
+          path: |
+            /tmp/artifacts/pki

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -145,6 +145,15 @@ jobs:
     with:
       os: ${{ matrix.os }}
 
+  ca-notification-request-test:
+    name: CA with request notification
+    needs: [init, build]
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    uses: ./.github/workflows/ca-notification-request-test.yml
+    with:
+      os: ${{ matrix.os }}
+
   scep-test:
     name: SCEP responder
     needs: [init, build]

--- a/base/ca/src/main/java/com/netscape/cms/listeners/RequestInQListener.java
+++ b/base/ca/src/main/java/com/netscape/cms/listeners/RequestInQListener.java
@@ -165,7 +165,7 @@ public class RequestInQListener implements IRequestListener {
         mn.setFrom(mSenderEmail);
         mn.setTo(mRecipientEmail);
         mn.setSubject(mEmailSubject + " (request id: " +
-                r.getRequestId() + ")");
+                r.getRequestId().toHexString() + ")");
 
         /*
          * get form file from disk
@@ -237,7 +237,7 @@ public class RequestInQListener implements IRequestListener {
 
         RequestId reqId = r.getRequestId();
 
-        mContentParams.put(IEmailFormProcessor.TOKEN_REQUEST_ID, reqId.toString());
+        mContentParams.put(IEmailFormProcessor.TOKEN_REQUEST_ID, reqId.toHexString());
 
         mContentParams.put(IEmailFormProcessor.TOKEN_ID, mId);
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -911,6 +911,7 @@ public class CAEngine extends CMSEngine {
             startPublisherProcessor();
             initCertIssuedListener();
             initCertRevokedListener();
+            initRequestInQueueListener();
         }
 
         super.startupSubsystems();


### PR DESCRIPTION
Previously the `RequestInQListener` was not initialized during startup so the CA did not generate email notifications when it received certificate requests.

To fix the problem the `CAEngine.startupSubsystems()` has been updated to call `initRequestInQueueListener()` properly.

The `RequestInQListener` has also been modified to generate email notifications with hexadecimal request IDs.

A new test has been added to verify the request in queue notifications.

https://github.com/dogtagpki/pki/wiki/Configuring-Notifications