### PR TITLE
Add single-stage CA Dockerfile

### DIFF
--- a/base/ca/Dockerfile
+++ b/base/ca/Dockerfile
@@ -1,0 +1,60 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# https://docs.fedoraproject.org/en-US/containers/guidelines/guidelines/
+
+FROM registry.fedoraproject.org/fedora:latest
+
+ARG NAME="pki-ca"
+ARG SUMMARY="Dogtag PKI Certificate Authority"
+ARG LICENSE="GPLv2 and LGPLv2"
+ARG VERSION="0"
+ARG ARCH="x86_64"
+ARG MAINTAINER="Dogtag PKI Team <devel@lists.dogtagpki.org>"
+ARG VENDOR="Dogtag"
+ARG COMPONENT="dogtag-pki"
+ARG COPR_REPO="@pki/master"
+
+LABEL name="$NAME" \
+      summary="$SUMMARY" \
+      license="$LICENSE" \
+      version="$VERSION" \
+      architecture="$ARCH" \
+      maintainer="$MAINTAINER" \
+      vendor="$VENDOR" \
+      usage="podman run -p 8080:8080 -p 8443:8443 $NAME" \
+      com.redhat.component="$COMPONENT"
+
+EXPOSE 8080 8443
+
+# Enable COPR repo if specified
+RUN if [ -n "$COPR_REPO" ]; then dnf install -y dnf-plugins-core; dnf copr enable -y $COPR_REPO; fi
+
+# Install packages
+RUN dnf install -y rpm-build
+
+# Import PKI sources
+COPY . /tmp/pki/
+WORKDIR /tmp/pki
+
+# Install PKI dependencies
+RUN dnf builddep -y --spec pki.spec
+
+# Build and install PKI packages
+RUN ./build.sh --with-pkgs=base,server,ca --work-dir=/tmp/build rpm \
+    && dnf localinstall -y /tmp/build/RPMS/* \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf \
+    && rm -rf /tmp/build
+
+# Create PKI server
+RUN pki-server create --group root
+
+# Create NSS database
+RUN pki-server nss-create --no-password
+
+VOLUME [ "/certs" ]
+
+CMD [ "/usr/share/pki/ca/bin/pki-ca-run" ]


### PR DESCRIPTION
A new single-stage `Dockerfile` has been added for CA such that the container can be built automatically in [Quay.io](https://quay.io). This is similar to the single-stage `Dockerfile` for ACME in `base/acme` folder.

Note: The CI will continue to use the multi-stage `Dockerfile` in the top level directory since it can generate a smaller image. In the future it might be possible to build the image in the CI then push it to [Quay.io](https://quay.io).

Example: https://quay.io/repository/edewata/pki-ca
Once it's merged, it's possible to provide a demo image that people can try: https://quay.io/repository/dogtagpki/pki-ca

Docs:

* https://github.com/dogtagpki/pki/wiki/Building-CA-Container
* https://github.com/dogtagpki/pki/wiki/Deploying-CA-Container
