### PR TITLE
Provide the token password when appropriate in nss-key-find

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -506,13 +506,18 @@ class NSSDatabase(object):
             '-d', self.directory
         ]
 
+        token = self.get_effective_token(token)
+
         if self.password_conf:
             cmd.extend(['-f', self.password_conf])
+
+        elif token:
+            password_file = self.get_password_file(self.tmpdir, token)
+            cmd.extend(['-C', password_file])
 
         elif self.password_file:
             cmd.extend(['-C', self.password_file])
 
-        token = self.get_effective_token(token)
         if token:
             cmd.extend(['--token', token])
             fullname = token + ':' + nickname


### PR DESCRIPTION
Only the internal password or password configuration would be provided. If a token is provided then generate a temporary file containing and pass that in with -C to the pki command.

Signed-off-by: Rob Crittenden <rcritten@redhat.com>