### PR TITLE
Add pki-server <subsystem>-redeploy

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -68,8 +68,8 @@ jobs:
           # enable signed audit log
           docker exec pki pki-server ca-config-set log.instance.SignedAudit.logSigning true
 
-          # restart PKI server
-          docker exec pki pki-server restart --wait
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Check CA signing cert
         run: |

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -66,8 +66,7 @@ jobs:
           docker exec pki pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
 
           # restart CA subsystem
-          docker exec pki pki-server ca-undeploy --wait
-          docker exec pki pki-server ca-deploy --wait
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -83,8 +83,7 @@ jobs:
 
       - name: Restart CA subsystem
         run: |
-          docker exec pki pki-server ca-undeploy --wait
-          docker exec pki pki-server ca-deploy --wait
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Check CA admin
         run: |

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -115,8 +115,7 @@ jobs:
           docker exec pki pki-server ca-config-set ca.publish.enable true
 
           # restart CA subsystem
-          docker exec pki pki-server ca-undeploy --wait
-          docker exec pki pki-server ca-deploy --wait
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Check published CA cert
         run: |

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -100,8 +100,8 @@ jobs:
           # update CRL immediately after each cert revocation
           docker exec pki pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
 
-          # restart PKI server
-          docker exec pki pki-server restart --wait
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Check CA signing cert
         run: |

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -117,8 +117,7 @@ jobs:
           docker exec pki pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
 
           # restart CA subsystem
-          docker exec pki pki-server ca-undeploy --wait
-          docker exec pki pki-server ca-deploy --wait
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Check CA signing cert
         run: |

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -146,8 +146,7 @@ jobs:
 
       - name: Restart CA subsystem
         run: |
-          docker exec pki pki-server ca-undeploy --wait
-          docker exec pki pki-server ca-deploy --wait
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Check CA admin
         run: |
@@ -317,8 +316,7 @@ jobs:
 
       - name: Restart CA subsystem
         run: |
-          docker exec pki pki-server ca-undeploy --wait
-          docker exec pki pki-server ca-deploy --wait
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Check user 2 before enrollment
         run: |

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -88,8 +88,8 @@ jobs:
           docker exec pki pki-server ca-config-set dbs.cert.id.generator random
           docker exec pki pki-server ca-config-set dbs.cert.id.length 128
 
-          # restart PKI server
-          docker exec pki pki-server restart --wait
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -86,8 +86,8 @@ jobs:
           docker exec pki pki-server ca-config-set dbs.cert.id.generator random
           docker exec pki pki-server ca-config-set dbs.cert.id.length 128
 
-          # restart PKI server
-          docker exec pki pki-server restart --wait
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only

--- a/.github/workflows/ca-shared-token-test.yml
+++ b/.github/workflows/ca-shared-token-test.yml
@@ -161,9 +161,8 @@ jobs:
               -e "s/^\(enable\)=.*/\1=true/" \
               /var/lib/pki/pki-tomcat/ca/profiles/ca/caFullCMCSharedTokenCert.cfg
 
-          # restart CA
-          docker exec pki pki-server ca-undeploy --wait
-          docker exec pki pki-server ca-deploy --wait
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
 
       # https://github.com/dogtagpki/pki/wiki/Generating-CMC-Shared-Token
       - name: Generate shared token for user

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -118,8 +118,8 @@ jobs:
           # update CRL immediately after each cert revocation
           docker exec pki pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
 
-          # restart PKI server
-          docker exec pki pki-server restart --wait
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -239,8 +239,7 @@ jobs:
           docker exec ca pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
 
           # restart CA subsystem
-          docker exec ca pki-server ca-undeploy --wait
-          docker exec ca pki-server ca-deploy --wait
+          docker exec ca pki-server ca-redeploy --wait
 
       - name: Check OCSP responder with no CRLs
         run: |

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -271,8 +271,7 @@ jobs:
           docker exec ca pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
 
           # restart CA subsystem
-          docker exec ca pki-server ca-undeploy --wait
-          docker exec ca pki-server ca-deploy --wait
+          docker exec ca pki-server ca-redeploy --wait
 
       - name: Configure revocation info store in OCSP
         run: |
@@ -292,8 +291,7 @@ jobs:
           docker exec ocsp pki-server ocsp-config-set ocsp.storeId ldapStore
 
           # restart OCSP subsystem
-          docker exec ocsp pki-server ocsp-undeploy --wait
-          docker exec ocsp pki-server ocsp-deploy --wait
+          docker exec ocsp pki-server ocsp-redeploy --wait
 
       - name: Check OCSP responder with no CRLs
         run: |

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -78,9 +78,12 @@ jobs:
       - name: Configure SCEP in CA
         run: |
           docker exec pki pki-server ca-config-set ca.scep.enable true
+
           docker exec pki bash -c "echo UID:$(cat client.ip) > /etc/pki/pki-tomcat/ca/flatfile.txt"
           docker exec pki bash -c "echo PWD:Secret.123 >> /etc/pki/pki-tomcat/ca/flatfile.txt"
-          docker exec pki pki-server restart --wait
+
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Install SSCEP in client container
         run: |

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -70,7 +70,9 @@ jobs:
           docker exec root sed -i \
               -e "s/\(policyset.caCertSet.2.default.params.range\)=.*/\1=7300/" \
               /var/lib/pki/pki-tomcat/ca/profiles/ca/caCMCcaCert.cfg
-          docker exec root pki-server restart --wait
+
+          # restart CA subsystem
+          docker exec root pki-server ca-redeploy --wait
 
       - name: Install root CA admin cert
         run: |

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -156,8 +156,9 @@ jobs:
           docker exec pki pki-server tps-config-set \
               auths.instance.ldap1.ldap.basedn \
               ou=people,dc=example,dc=com
-          docker exec pki pki-server tps-undeploy --wait
-          docker exec pki pki-server tps-deploy --wait
+
+          # restart TPS subsystem
+          docker exec pki pki-server tps-redeploy --wait
 
       - name: Add token
         run: |

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -56,8 +56,10 @@ class ACMECLI(pki.cli.CLI):
 
         self.add_module(ACMECreateCLI())
         self.add_module(ACMERemoveCLI())
+
         self.add_module(pki.server.cli.subsystem.SubsystemDeployCLI(self))
         self.add_module(pki.server.cli.subsystem.SubsystemUndeployCLI(self))
+        self.add_module(pki.server.cli.subsystem.SubsystemRedeployCLI(self))
 
         self.add_module(ACMEMetadataCLI())
         self.add_module(ACMEDatabaseCLI())

--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -51,6 +51,7 @@ class CACLI(pki.cli.CLI):
 
         self.add_module(pki.server.cli.subsystem.SubsystemDeployCLI(self))
         self.add_module(pki.server.cli.subsystem.SubsystemUndeployCLI(self))
+        self.add_module(pki.server.cli.subsystem.SubsystemRedeployCLI(self))
         self.add_module(pki.server.cli.audit.AuditCLI(self))
         self.add_module(CACertCLI())
         self.add_module(CACloneCLI())

--- a/base/server/python/pki/server/cli/kra.py
+++ b/base/server/python/pki/server/cli/kra.py
@@ -49,6 +49,7 @@ class KRACLI(pki.cli.CLI):
 
         self.add_module(pki.server.cli.subsystem.SubsystemDeployCLI(self))
         self.add_module(pki.server.cli.subsystem.SubsystemUndeployCLI(self))
+        self.add_module(pki.server.cli.subsystem.SubsystemRedeployCLI(self))
         self.add_module(pki.server.cli.audit.AuditCLI(self))
         self.add_module(KRACloneCLI())
         self.add_module(pki.server.cli.config.SubsystemConfigCLI(self))

--- a/base/server/python/pki/server/cli/ocsp.py
+++ b/base/server/python/pki/server/cli/ocsp.py
@@ -48,6 +48,7 @@ class OCSPCLI(pki.cli.CLI):
 
         self.add_module(pki.server.cli.subsystem.SubsystemDeployCLI(self))
         self.add_module(pki.server.cli.subsystem.SubsystemUndeployCLI(self))
+        self.add_module(pki.server.cli.subsystem.SubsystemRedeployCLI(self))
         self.add_module(pki.server.cli.audit.AuditCLI(self))
         self.add_module(OCSPCloneCLI())
         self.add_module(OCSPCRLCLI())

--- a/base/server/python/pki/server/cli/tks.py
+++ b/base/server/python/pki/server/cli/tks.py
@@ -48,6 +48,7 @@ class TKSCLI(pki.cli.CLI):
 
         self.add_module(pki.server.cli.subsystem.SubsystemDeployCLI(self))
         self.add_module(pki.server.cli.subsystem.SubsystemUndeployCLI(self))
+        self.add_module(pki.server.cli.subsystem.SubsystemRedeployCLI(self))
         self.add_module(pki.server.cli.audit.AuditCLI(self))
         self.add_module(TKSCloneCLI())
         self.add_module(pki.server.cli.config.SubsystemConfigCLI(self))

--- a/base/server/python/pki/server/cli/tps.py
+++ b/base/server/python/pki/server/cli/tps.py
@@ -48,6 +48,7 @@ class TPSCLI(pki.cli.CLI):
 
         self.add_module(pki.server.cli.subsystem.SubsystemDeployCLI(self))
         self.add_module(pki.server.cli.subsystem.SubsystemUndeployCLI(self))
+        self.add_module(pki.server.cli.subsystem.SubsystemRedeployCLI(self))
         self.add_module(pki.server.cli.audit.AuditCLI(self))
         self.add_module(TPSCloneCLI())
         self.add_module(pki.server.cli.config.SubsystemConfigCLI(self))

--- a/docs/changes/v11.3.0/Tools-Changes.adoc
+++ b/docs/changes/v11.3.0/Tools-Changes.adoc
@@ -1,0 +1,6 @@
+= Tools Changes =
+
+== New pki-server <subsystem>-redeploy CLI ==
+
+The `pki-server <subsystem>-redeploy` command has been added to undeploy
+then redeploy a subsystem.


### PR DESCRIPTION
The `pki-server <subsystem>-redeploy` command has been added to undeploy then redeploy a subsystem.

The tests have been updated to use the new command.

https://github.com/edewata/pki/blob/cli/docs/changes/v11.3.0/Tools-Changes.adoc