### PR TITLE
Rename container image tarballs

### DIFF
--- a/.github/workflows/PKICertImport-test.yml
+++ b/.github/workflows/PKICertImport-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-acme-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-acme-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-acme-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -22,19 +22,19 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-acme-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-acme-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-acme-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Retrieve server image
         uses: actions/cache@v3
         with:
           key: pki-acme-server-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-acme-server.tar
+          path: pki-acme.tar
 
       - name: Load ACME image
-        run: docker load --input pki-acme-server.tar
+        run: docker load --input pki-acme.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-acme-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-acme-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-acme-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-acme-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme-runner.tar
+          path: pki-runner.tar
 
       - name: Build server image
         uses: docker/build-push-action@v2
@@ -73,13 +73,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-acme
           target: pki-acme
-          outputs: type=docker,dest=pki-acme-server.tar
+          outputs: type=docker,dest=pki-acme.tar
 
       - name: Store server image
         uses: actions/cache@v3
         with:
           key: pki-acme-server-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme-server.tar
+          path: pki-acme.tar
 
   acme-certbot-test:
     name: ACME with certbot

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,10 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-${{ inputs.key_container}}-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-${{ inputs.key_container }}-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-${{ inputs.key_container }}-runner.tar
+          path: pki-runner.tar

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -22,19 +22,19 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Retrieve server image
         uses: actions/cache@v3
         with:
           key: pki-ca-server-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-server.tar
+          path: pki-ca.tar
 
       - name: Load CA image
-        run: docker load --input pki-ca-server.tar
+        run: docker load --input pki-ca.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-shared-token-test.yml
+++ b/.github/workflows/ca-shared-token-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-ca-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Build server image
         uses: docker/build-push-action@v2
@@ -73,13 +73,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-ca
           target: pki-ca
-          outputs: type=docker,dest=pki-ca-server.tar
+          outputs: type=docker,dest=pki-ca.tar
 
       - name: Store server image
         uses: actions/cache@v3
         with:
           key: pki-ca-server-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-server.tar
+          path: pki-ca.tar
 
   ca-basic-test:
     name: Basic CA

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-ca-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
   ca-clone-test:
     name: CA clone

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-sonar-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-sonar-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-sonar-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up PKI container
         run: |

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-rsnv3-test.yml
+++ b/.github/workflows/kra-rsnv3-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-kra-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-kra-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-kra-runner.tar
+          path: pki-runner.tar
 
   kra-basic-test:
     name: Basic KRA

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-cmc-test.yml
+++ b/.github/workflows/ocsp-cmc-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ocsp-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-ocsp-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ocsp-runner.tar
+          path: pki-runner.tar
 
   ocsp-basic-test:
     name: Basic OCSP

--- a/.github/workflows/pki-nss-aes-test.yml
+++ b/.github/workflows/pki-nss-aes-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-nss-ecc-test.yml
+++ b/.github/workflows/pki-nss-ecc-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-nss-exts-test.yml
+++ b/.github/workflows/pki-nss-exts-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-nss-hsm-test.yml
+++ b/.github/workflows/pki-nss-hsm-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-nss-rsa-test.yml
+++ b/.github/workflows/pki-nss-rsa-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-pkcs11-test.yml
+++ b/.github/workflows/pki-pkcs11-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-pkcs12-test.yml
+++ b/.github/workflows/pki-pkcs12-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-pkcs7-test.yml
+++ b/.github/workflows/pki-pkcs7-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tools-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-python-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-python-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-python-runner.tar
+          path: pki-runner.tar
 
   lint-test:
     name: Running Python lint
@@ -80,10 +80,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-python-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-python-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-python-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Run container
         run: |

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=qe-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: qe-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: qe-runner.tar
+          path: pki-runner.tar
 
   # Tier 0
   installation-sanity-test:
@@ -90,10 +90,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: qe-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: qe-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input qe-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Run master container
         run: |

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -136,13 +136,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-sonar-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
-          path: pki-sonar-runner.tar
+          path: pki-runner.tar
         
   sonarcloud:
     name: Sonar Cloud code analysis
@@ -158,10 +158,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
-          path: pki-sonar-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-sonar-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Checkout pulled branch
         uses: actions/checkout@v2

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-ca-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-ca-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tks-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tks-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tks-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tks-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-tks-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tks-runner.tar
+          path: pki-runner.tar
 
   tks-basic-test:
     name: Basic TKS

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -64,13 +64,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-tools-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tools-runner.tar
+          path: pki-runner.tar
 
   PKICertImport-test:
     name: PKICertImport

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tps-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tps-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tps-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/cache@v3
         with:
           key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          path: pki-runner.tar
 
       - name: Load runner image
-        run: docker load --input pki-tps-runner.tar
+        run: docker load --input pki-runner.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -56,13 +56,13 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          outputs: type=docker,dest=pki-tps-runner.tar
+          outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
         uses: actions/cache@v3
         with:
           key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-tps-runner.tar
+          path: pki-runner.tar
 
   tps-basic-test:
     name: Basic TPS


### PR DESCRIPTION
In the future the CI workflows might be merged so they can reuse the same build to reduce redundancies. To prepare for that, the image tarballs have been renamed to match the actual image names so that they will be consistent across different tests.

For now the cache keys will remain unique for each workflow so that they will not conflict with other workflows. When the workflows are merged in the future, they will need to be renamed as well.