### PR TITLE
Remove pcre dependency.

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -203,7 +203,6 @@ BuildRequires:    apr-devel
 BuildRequires:    apr-util-devel
 BuildRequires:    cyrus-sasl-devel
 BuildRequires:    httpd-devel >= 2.4.2
-BuildRequires:    pcre-devel
 BuildRequires:    systemd
 BuildRequires:    zlib
 BuildRequires:    zlib-devel


### PR DESCRIPTION
pcre is going to be dropped in Fedora, to be replaced by pcre2

https://bugzilla.redhat.com/show_bug.cgi?id=2128288