### PR TITLE
Add roles configuration option to PKIInMemoryRealm

### DIFF
--- a/base/server/src/main/java/com/netscape/cms/realm/PKIInMemoryRealm.java
+++ b/base/server/src/main/java/com/netscape/cms/realm/PKIInMemoryRealm.java
@@ -8,6 +8,8 @@ package com.netscape.cms.realm;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.catalina.LifecycleException;
 
@@ -28,16 +30,21 @@ public class PKIInMemoryRealm extends RealmCommon {
 
     @Override
     public void initInternal () throws LifecycleException {
-
         username = config.getParameter("username");
         password = config.getParameter("password");
+        String roleList = config.getParameter("roles");
 
         user = new User();
         user.setUserID(username);
         user.setFullName("Administrator");
 
-        roles = new ArrayList<>();
-        roles.add("Administrators");
+        if (roleList == null) {
+            roles = new ArrayList<>();
+            roles.add("Administrators");
+        }
+        else {
+            roles = Stream.of(roleList.split(",")).map(String::trim).collect(Collectors.toList());
+        }
     }
 
     @Override


### PR DESCRIPTION
Some subsystem could require a specific role in order to work. Therefore, the in memory realm, which is mainly used for test, should allow to configure the user and the role.