### PR TITLE
Add pki <subsystem>-job-find

### DIFF
--- a/base/common/src/main/java/org/dogtagpki/job/JobClient.java
+++ b/base/common/src/main/java/org/dogtagpki/job/JobClient.java
@@ -31,6 +31,11 @@ public class JobClient extends Client {
         resource = createProxy(JobResource.class);
     }
 
+    public JobCollection findJobs() throws Exception {
+        Response response = resource.findJobs();
+        return client.getEntity(response, JobCollection.class);
+    }
+
     public void startJob(String id) throws Exception {
         Response response = resource.startJob(id);
         client.getEntity(response, Void.class);

--- a/base/common/src/main/java/org/dogtagpki/job/JobCollection.java
+++ b/base/common/src/main/java/org/dogtagpki/job/JobCollection.java
@@ -1,0 +1,29 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.job;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.netscape.certsrv.base.DataCollection;
+import com.netscape.certsrv.util.JSONSerializer;
+
+
+/**
+ * @author Endi S. Dewata
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class JobCollection extends DataCollection<JobInfo> implements JSONSerializer {
+
+    @Override
+    public Collection<JobInfo> getEntries() {
+        return super.getEntries();
+    }
+
+}

--- a/base/common/src/main/java/org/dogtagpki/job/JobInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/job/JobInfo.java
@@ -1,0 +1,105 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.job;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.netscape.certsrv.util.JSONSerializer;
+
+/**
+ * @author Endi S. Dewata
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class JobInfo implements JSONSerializer {
+
+    String id;
+    boolean enabled;
+    String cron;
+    String pluginName;
+
+    public String getID() {
+        return id;
+    }
+
+    public void setID(String id) {
+        this.id = id;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getCron() {
+        return cron;
+    }
+
+    public void setCron(String cron) {
+        this.cron = cron;
+    }
+
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public void setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((cron == null) ? 0 : cron.hashCode());
+        result = prime * result + (enabled ? 1231 : 1237);
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((pluginName == null) ? 0 : pluginName.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        JobInfo other = (JobInfo) obj;
+        if (cron == null) {
+            if (other.cron != null)
+                return false;
+        } else if (!cron.equals(other.cron))
+            return false;
+        if (enabled != other.enabled)
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (pluginName == null) {
+            if (other.pluginName != null)
+                return false;
+        } else if (!pluginName.equals(other.pluginName))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/base/common/src/main/java/org/dogtagpki/job/JobResource.java
+++ b/base/common/src/main/java/org/dogtagpki/job/JobResource.java
@@ -6,6 +6,7 @@
 package org.dogtagpki.job;
 
 import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
@@ -18,6 +19,9 @@ import com.netscape.certsrv.base.EBaseException;
 @Path("jobs")
 @RolesAllowed("Administrators")
 public interface JobResource {
+
+    @GET
+    public Response findJobs() throws EBaseException;
 
     @POST
     public Response startJob(String id) throws EBaseException;

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/KRAApplication.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/KRAApplication.java
@@ -10,6 +10,7 @@ import org.dogtagpki.server.rest.AccountService;
 import org.dogtagpki.server.rest.AuditService;
 import org.dogtagpki.server.rest.AuthMethodInterceptor;
 import org.dogtagpki.server.rest.GroupService;
+import org.dogtagpki.server.rest.JobService;
 import org.dogtagpki.server.rest.KRAInfoService;
 import org.dogtagpki.server.rest.MessageFormatInterceptor;
 import org.dogtagpki.server.rest.PKIExceptionMapper;
@@ -38,6 +39,9 @@ public class KRAApplication extends Application {
         // keys and keyrequests
         classes.add(KeyService.class);
         classes.add(KeyRequestService.class);
+
+        // job management
+        classes.add(JobService.class);
 
         // selftests
         classes.add(SelfTestService.class);

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/rest/OCSPApplication.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/rest/OCSPApplication.java
@@ -10,6 +10,7 @@ import org.dogtagpki.server.rest.AccountService;
 import org.dogtagpki.server.rest.AuditService;
 import org.dogtagpki.server.rest.AuthMethodInterceptor;
 import org.dogtagpki.server.rest.GroupService;
+import org.dogtagpki.server.rest.JobService;
 import org.dogtagpki.server.rest.MessageFormatInterceptor;
 import org.dogtagpki.server.rest.PKIExceptionMapper;
 import org.dogtagpki.server.rest.SelfTestService;
@@ -33,6 +34,9 @@ public class OCSPApplication extends Application {
 
         // security domain
         classes.add(OCSPSecurityDomainService.class);
+
+        // job management
+        classes.add(JobService.class);
 
         // selftests
         classes.add(SelfTestService.class);

--- a/base/server/src/main/java/org/dogtagpki/server/rest/JobService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/JobService.java
@@ -5,15 +5,23 @@
 //
 package org.dogtagpki.server.rest;
 
+import java.util.Enumeration;
+
 import javax.ws.rs.core.Response;
 
+import org.dogtagpki.job.JobCollection;
+import org.dogtagpki.job.JobInfo;
 import org.dogtagpki.job.JobResource;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.cms.servlet.base.SubsystemService;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.jobs.JobConfig;
+import com.netscape.cmscore.jobs.JobsConfig;
 import com.netscape.cmscore.jobs.JobsScheduler;
+import com.netscape.cmscore.jobs.JobsSchedulerConfig;
 
 /**
  * @author Endi S. Dewata
@@ -21,6 +29,42 @@ import com.netscape.cmscore.jobs.JobsScheduler;
 public class JobService extends SubsystemService implements JobResource {
 
     public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JobService.class);
+
+    public JobInfo createJobData(String id, JobConfig jobConfig) throws EBaseException {
+
+        JobInfo jobData = new JobInfo();
+        jobData.setID(id);
+        jobData.setEnabled(jobConfig.isEnabled());
+        jobData.setCron(jobConfig.getCron());
+        jobData.setPluginName(jobConfig.getPluginName());
+
+        return jobData;
+    }
+
+    @Override
+    public Response findJobs() throws EBaseException {
+
+        logger.info("JobService: Finding jobs");
+
+        JobCollection response = new JobCollection();
+
+        CMSEngine engine = CMS.getCMSEngine();
+        EngineConfig engineConfig = engine.getConfig();
+        JobsSchedulerConfig jobsSchedulerConfig = engineConfig.getJobsSchedulerConfig();
+        JobsConfig jobsConfig = jobsSchedulerConfig.getJobsConfig();
+
+        Enumeration<String> list = jobsConfig.getSubStoreNames();
+        while (list.hasMoreElements()) {
+            String id = list.nextElement();
+            logger.info("JobService: - " + id);
+
+            JobConfig jobConfig = jobsConfig.getJobConfig(id);
+            JobInfo jobData = createJobData(id, jobConfig);
+            response.addEntry(jobData);
+        }
+
+        return createOKResponse(response);
+    }
 
     @Override
     public Response startJob(String id) throws EBaseException {

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/rest/TKSApplication.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/rest/TKSApplication.java
@@ -10,6 +10,7 @@ import org.dogtagpki.server.rest.AccountService;
 import org.dogtagpki.server.rest.AuditService;
 import org.dogtagpki.server.rest.AuthMethodInterceptor;
 import org.dogtagpki.server.rest.GroupService;
+import org.dogtagpki.server.rest.JobService;
 import org.dogtagpki.server.rest.MessageFormatInterceptor;
 import org.dogtagpki.server.rest.PKIExceptionMapper;
 import org.dogtagpki.server.rest.SelfTestService;
@@ -28,6 +29,9 @@ public class TKSApplication extends Application {
 
         // audit
         classes.add(AuditService.class);
+
+        // job management
+        classes.add(JobService.class);
 
         // selftests
         classes.add(SelfTestService.class);

--- a/base/tools/src/main/java/com/netscape/cmstools/job/JobCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/job/JobCLI.java
@@ -7,6 +7,7 @@ package com.netscape.cmstools.job;
 
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.job.JobClient;
+import org.dogtagpki.job.JobInfo;
 
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.cmstools.cli.SubsystemCLI;
@@ -21,6 +22,7 @@ public class JobCLI extends CLI {
     public JobCLI(SubsystemCLI parent) {
         super("job", "Job management commands", parent);
 
+        addModule(new JobFindCLI(this));
         addModule(new JobStartCLI(this));
     }
 
@@ -35,5 +37,17 @@ public class JobCLI extends CLI {
         jobClient = new JobClient(client, subsystem);
 
         return jobClient;
+    }
+
+    public static void printJob(JobInfo jobData) {
+        System.out.println("  Job ID: " + jobData.getID());
+        System.out.println("  Enabled: " + jobData.isEnabled());
+
+        String cron = jobData.getCron();
+        if (cron != null) {
+            System.out.println("  Cron: " + cron);
+        }
+
+        System.out.println("  Plugin: " + jobData.getPluginName());
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/job/JobFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/job/JobFindCLI.java
@@ -1,0 +1,60 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.job;
+
+import java.util.Collection;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CommandCLI;
+import org.dogtagpki.job.JobClient;
+import org.dogtagpki.job.JobCollection;
+import org.dogtagpki.job.JobInfo;
+
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class JobFindCLI extends CommandCLI {
+
+    public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JobFindCLI.class);
+
+    JobCLI jobCLI;
+
+    public JobFindCLI(JobCLI jobCLI) {
+        super("find", "Find jobs", jobCLI);
+        this.jobCLI = jobCLI;
+    }
+
+    @Override
+    public void printHelp() {
+        formatter.printHelp(getFullName(), options);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        JobClient jobClient = jobCLI.getJobClient();
+        JobCollection response = jobClient.findJobs();
+
+        Collection<JobInfo> entries = response.getEntries();
+        boolean first = true;
+
+        for (JobInfo jobData : entries) {
+
+            if (first) {
+                first = false;
+            } else {
+                System.out.println();
+            }
+
+            JobCLI.printJob(jobData);
+        }
+    }
+}

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRACLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRACLI.java
@@ -25,6 +25,7 @@ import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmstools.cli.SubsystemCLI;
 import com.netscape.cmstools.config.ConfigCLI;
 import com.netscape.cmstools.group.GroupCLI;
+import com.netscape.cmstools.job.JobCLI;
 import com.netscape.cmstools.logging.AuditCLI;
 import com.netscape.cmstools.range.RangeCLI;
 import com.netscape.cmstools.selftests.SelfTestCLI;
@@ -46,6 +47,7 @@ public class KRACLI extends SubsystemCLI {
         addModule(new KRACertCLI(this));
         addModule(new ConfigCLI(this));
         addModule(new GroupCLI(this));
+        addModule(new JobCLI(this));
         addModule(new KRAKeyCLI(this));
         addModule(new RangeCLI(this));
         addModule(new SelfTestCLI(this));

--- a/base/tools/src/main/java/com/netscape/cmstools/ocsp/OCSPCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ocsp/OCSPCLI.java
@@ -25,6 +25,7 @@ import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmstools.cli.SubsystemCLI;
 import com.netscape.cmstools.config.ConfigCLI;
 import com.netscape.cmstools.group.GroupCLI;
+import com.netscape.cmstools.job.JobCLI;
 import com.netscape.cmstools.logging.AuditCLI;
 import com.netscape.cmstools.selftests.SelfTestCLI;
 import com.netscape.cmstools.user.UserCLI;
@@ -42,6 +43,7 @@ public class OCSPCLI extends SubsystemCLI {
         addModule(new AuditCLI(this));
         addModule(new ConfigCLI(this));
         addModule(new GroupCLI(this));
+        addModule(new JobCLI(this));
         addModule(new SelfTestCLI(this));
         addModule(new UserCLI(this));
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/tks/TKSCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tks/TKSCLI.java
@@ -25,6 +25,7 @@ import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmstools.cli.SubsystemCLI;
 import com.netscape.cmstools.config.ConfigCLI;
 import com.netscape.cmstools.group.GroupCLI;
+import com.netscape.cmstools.job.JobCLI;
 import com.netscape.cmstools.logging.AuditCLI;
 import com.netscape.cmstools.selftests.SelfTestCLI;
 import com.netscape.cmstools.user.UserCLI;
@@ -43,6 +44,7 @@ public class TKSCLI extends SubsystemCLI {
         addModule(new TKSCertCLI(this));
         addModule(new ConfigCLI(this));
         addModule(new GroupCLI(this));
+        addModule(new JobCLI(this));
         addModule(new SelfTestCLI(this));
         addModule(new TPSConnectorCLI(this));
         addModule(new TKSKeyCLI(this));

--- a/base/tools/src/main/java/com/netscape/cmstools/tps/TPSCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tps/TPSCLI.java
@@ -24,6 +24,7 @@ import com.netscape.certsrv.tps.TPSClient;
 import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmstools.cli.SubsystemCLI;
 import com.netscape.cmstools.group.GroupCLI;
+import com.netscape.cmstools.job.JobCLI;
 import com.netscape.cmstools.logging.ActivityCLI;
 import com.netscape.cmstools.logging.AuditCLI;
 import com.netscape.cmstools.selftests.SelfTestCLI;
@@ -52,6 +53,7 @@ public class TPSCLI extends SubsystemCLI {
         addModule(new TPSConfigCLI(this));
         addModule(new ConnectorCLI(this));
         addModule(new GroupCLI(this));
+        addModule(new JobCLI(this));
         addModule(new ProfileCLI(this));
         addModule(new SelfTestCLI(this));
         addModule(new TokenCLI(this));

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/TPSApplication.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/TPSApplication.java
@@ -26,6 +26,7 @@ import org.dogtagpki.server.rest.ACLInterceptor;
 import org.dogtagpki.server.rest.AuditService;
 import org.dogtagpki.server.rest.AuthMethodInterceptor;
 import org.dogtagpki.server.rest.GroupService;
+import org.dogtagpki.server.rest.JobService;
 import org.dogtagpki.server.rest.MessageFormatInterceptor;
 import org.dogtagpki.server.rest.PKIExceptionMapper;
 import org.dogtagpki.server.rest.SelfTestService;
@@ -72,6 +73,9 @@ public class TPSApplication extends Application {
         // profiles
         classes.add(TPSProfileService.class);
         classes.add(ProfileMappingService.class);
+
+        // job management
+        classes.add(JobService.class);
 
         // selftests
         classes.add(SelfTestService.class);

--- a/docs/changes/v11.3.0/Tools-Changes.adoc
+++ b/docs/changes/v11.3.0/Tools-Changes.adoc
@@ -4,3 +4,8 @@
 
 The `pki-server <subsystem>-redeploy` command has been added to undeploy
 then redeploy a subsystem.
+
+== New pki <subsystem>-job-* CLI ==
+
+The `pki <subsystem>-job-*` commands have been added to manage jobs in a subsystem.
+These commands can only be used by the administrator.


### PR DESCRIPTION
The `pki <subsystem>-job-find` command has been added to display the jobs in a subsystem.

https://github.com/edewata/pki/blob/cli/docs/changes/v11.3.0/Tools-Changes.adoc
https://github.com/dogtagpki/pki/wiki/PKI-Job-CLI
