### PR TITLE
Add cache for pki-deps image

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
@@ -63,6 +83,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-acme
           target: pki-acme
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-acme.tar
 
       - name: Store server image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -64,6 +83,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
@@ -63,6 +83,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-ca
           target: pki-ca
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-ca.tar
 
       - name: Store server image

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: ipa-runner
           target: ipa-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=ipa-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
@@ -63,6 +83,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-server
           target: pki-server
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-server.tar
 
       - name: Store server image

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -114,6 +114,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -123,6 +142,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build builder image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-builder
           target: pki-builder
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-builder.tar
 
       - name: Store builder image
@@ -63,6 +83,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -37,6 +37,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache pki-deps image
+        id: cache-pki-deps
+        uses: actions/cache@v3
+        with:
+          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/cache-pki-deps
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/cache-pki-deps
+        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+
       - name: Build runner image
         uses: docker/build-push-action@v2
         with:
@@ -46,6 +65,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
+          cache-from: type=local,src=/tmp/cache-pki-deps
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image


### PR DESCRIPTION
The CI build jobs have been modified to build `pki-deps` image then store it in GH cache. In the next CI execution the image will be loaded from the cache, so it could shorten the build time by about 3 minutes. The cache will be invalidated if the `pki.spec` (which defines the dependencies) is modified.