### PR TITLE
Introduce new script to automate the build process

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -181,3 +181,7 @@ jobs:
     uses: ./.github/workflows/rpminspect-test.yml
     with:
       os: ${{ matrix.os }}
+
+  update-version-test:
+    name: Update Version
+    uses: ./.github/workflows/update-version-test.yml

--- a/.github/workflows/update-version-test.yml
+++ b/.github/workflows/update-version-test.yml
@@ -1,0 +1,41 @@
+name: Update Version
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Setup git
+        run: |
+          sudo apt-get -y install git
+          git config --global user.name "Dr. John Doe"
+          git config --global user.email jdoe@example.com
+
+      - name: Update to version with a phase
+        run: |
+          ./update_version.sh 12 1 0 beta1
+          git tag --points-at HEAD  > actual
+          echo v12.1.0-beta1 > expected
+          diff expected actual
+
+      - name: Update to version without a phase
+        run: |
+          ./update_version.sh 12 1 0
+          git tag --points-at HEAD  > actual
+          echo v12.1.0 > expected
+          diff expected actual
+
+      - name: Update to version with a phase again
+        run: |
+          ./update_version.sh 12 2 0 alpha1
+          git tag --points-at HEAD  > actual
+          echo v12.2.0-alpha1 > expected
+          diff expected actual

--- a/revert_update_version.sh
+++ b/revert_update_version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# Use this script to revert the commit and delete the tag created using the update_version.sh script.
+
+HEAD_TAG=$(git tag --points-at HEAD)
+
+HEAD_COMMIT_MESSAGE=$(git log --format=%B -n 1 HEAD)
+UPDATE_COMMIT_MESSAGE="Updating version to"
+
+# Only proceed if the HEAD commit is a version update
+
+if [[ "$HEAD_COMMIT_MESSAGE=" == *"$UPDATE_COMMIT_MESSAGE"* ]]; then
+    git tag -d "$HEAD_TAG"
+    git reset --hard HEAD~1
+else
+    echo "The HEAD commit is not a version update, aborting."
+    exit 1
+fi
+

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,0 +1,95 @@
+#!/bin/bash -e
+
+# Use this script to automate updating pki version.
+#
+# Usage: ./update_version.sh <major> <minor> <update> <phase> # (phase is optional)
+#
+# Explanation:
+# -    change_spec_version
+# -        Updates the spec version to the new version provided
+# -    commit_version_change
+# -        Commits that change
+# -    create_tag
+# -        Creates a tag based on the new version provided
+# -    create_source_tarball
+# -        Creates a source tarball based on the new version provided
+
+NEXT_MAJOR=$1
+NEXT_MINOR=$2
+NEXT_UPDATE=$3
+NEXT_PHASE=$4
+
+if [ -z "$NEXT_PHASE" ] ; then
+    NEXT_VERSION=$NEXT_MAJOR.$NEXT_MINOR.$NEXT_UPDATE
+else
+    NEXT_VERSION=$NEXT_MAJOR.$NEXT_MINOR.$NEXT_UPDATE-$NEXT_PHASE
+fi
+echo "New version is $NEXT_VERSION"
+
+verify_phase() {
+    if [[ "$NEXT_PHASE" =~ ^(alpha|beta)[0-9]+$ ]] ; then
+        echo "$NEXT_PHASE is a valid phase"
+    elif [ -z "$NEXT_PHASE" ] ; then
+        echo "Empty phase"
+    else
+        echo "$NEXT_PHASE is an invalid phase, aborting"
+        exit 1
+    fi
+}
+
+change_spec_version() {
+    CURRENT_MAJOR=$(grep "major_version " pki.spec | grep -Eo '[0-9]+$')
+    CURRENT_MINOR=$(grep "minor_version " pki.spec | grep -Eo '[0-9]+$')
+    CURRENT_UPDATE=$(grep "update_version " pki.spec | grep -Eo '[0-9]+$')
+    CURRENT_PHASE=$(grep "phase " pki.spec | grep -E 'alpha|beta' | awk '{print $(NF)}')
+    CURRENT_RELEASE_NUMBER=$(grep "release_number " pki.spec | grep -Eo '[0-9]+(\.[0-9]+)?$')
+
+    echo "Update major version to $NEXT_MAJOR"
+    sed -i "/major_version /c\%global           major_version $NEXT_MAJOR" pki.spec
+    echo "Update minor version to $NEXT_MINOR"
+    sed -i "/minor_version /c\%global           minor_version $NEXT_MINOR" pki.spec
+    echo "Update update version to $NEXT_UPDATE"
+    sed -i "/update_version /c\%global           update_version $NEXT_UPDATE" pki.spec
+
+    if [[ "$CURRENT_PHASE" != "$NEXT_PHASE" ]] ; then
+        if [ -z "$NEXT_PHASE" ] ; then
+            echo "Remove phase"
+            sed -i "/phase /c\#global           phase" pki.spec
+            echo "Update release_number"
+            sed -i "/release_number /c\%global           release_number 1" pki.spec
+        elif [ -z "$CURRENT_PHASE" ] ; then
+            echo "Add phase, set to $NEXT_PHASE"
+            sed -i "/#global           phase/c\%global           phase $NEXT_PHASE" pki.spec
+            echo "Update release_number"
+            sed -i "/release_number /c\%global           release_number 0.1" pki.spec
+        else
+            echo "Update phase to $NEXT_PHASE"
+            sed -i "/phase /c\%global           phase $NEXT_PHASE" pki.spec
+            echo "Update release_number"
+            IFS='.' read -ra CRL <<< "$CURRENT_RELEASE_NUMBER"
+            (( CRL[1]++ ))
+            sed -i "/release_number /c\%global           release_number ${CRL[0]}.${CRL[1]}" pki.spec
+        fi
+    fi
+}
+
+commit_version_change() {
+    git add pki.spec
+    git commit -m "Updating version to v$NEXT_VERSION"
+ }
+
+create_tag() {
+    git tag v"$NEXT_VERSION"
+}
+
+create_source_tarball() {
+    ./build.sh --source-tag=v"$NEXT_VERSION" src
+}
+
+### Perform operations
+
+verify_phase
+change_spec_version
+commit_version_change
+create_tag
+create_source_tarball


### PR DESCRIPTION
A new script `update_version.sh` is introduced, to start to reduce some of the manual burden of building packages. Usage is as:

`./update_version.sh <major> <minor> <update> <phase>`

...where `phase` is optional.

In this first iteration, it does the following:

* Updates the spec version to the new version provided
* Commits that change
* Creates a tag based on the new version provided
* Creates a source tarball based on the new version provided

Further updates to add resilience/further functionality will follow.