### PR TITLE
Provide a nickname with token and all tokens/passwords when modifying trust during installation

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2037,13 +2037,18 @@ class PKIDeployer:
 
         logger.info('Setting up trust flags')
 
+        if pki.nssdb.normalize_token(self.mdict.get('pki_token_name')):
+            token = self.mdict['pki_token_name'] + ":"
+        else:
+            token = ""
+
         if subsystem.type == 'CA':
             nssdb.modify_cert(
-                nickname=self.mdict['pki_ca_signing_nickname'],
+                nickname=token + self.mdict['pki_ca_signing_nickname'],
                 trust_attributes='CTu,Cu,Cu')
 
         nssdb.modify_cert(
-            nickname=self.mdict['pki_audit_signing_nickname'],
+            nickname=token + self.mdict['pki_audit_signing_nickname'],
             trust_attributes='u,u,Pu')
 
         # Reset the NSS database ownership and permissions


### PR DESCRIPTION
In an IPA replica installation with an HSM the audit trust is not being set.

It isn't set because the nickname is not available in the NSS database so certutil -M fails with "no such certifiate."

In order to add the trust one needs to authenticate to the token to find the cert. It also needs the NSS softokn password so the trust can be written.

certutil -f can take a file with token:password pairs and will search for the appropriate token.

The internal NSS token names are hardcoded because I could find no other way in an NSS tool to obtain the name other than scraping modutil -list output, which just seems awful. I can try to do that if desired.