### PR TITLE
ProxyRealm: setContainer() on RealmBase instances

### DIFF
--- a/base/tomcat-9.0/src/main/java/com/netscape/cms/tomcat/ProxyRealm.java
+++ b/base/tomcat-9.0/src/main/java/com/netscape/cms/tomcat/ProxyRealm.java
@@ -13,6 +13,7 @@ import org.apache.catalina.Container;
 import org.apache.catalina.Context;
 import org.apache.catalina.CredentialHandler;
 import org.apache.catalina.Realm;
+import org.apache.catalina.realm.RealmBase;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
@@ -65,6 +66,12 @@ public class ProxyRealm implements Realm {
     public static void registerRealm(String contextName, Realm realm) {
         ProxyRealm proxy = proxies.get(contextName);
         if (proxy == null) return;
+
+        if (realm instanceof RealmBase) {
+            // RealmBase instances from Tomcat require Container to be set.
+            // Propagate it from the ProxyRealm to the RealmBase instance.
+            ((RealmBase) realm).setContainer(proxy.getContainer());
+        }
 
         proxy.setRealm(realm);
     }


### PR DESCRIPTION
Instances of RealmBase fail to initialise if the Container has not
been set.  It is hard (impossible?) to get the Container from the
servlet context.  But ProxyRealm instances have the Container set
(if it was initialised by Tomcat itself).

Update ProxyRealm to propagate the Container to proxied RealmBase
instances during registerRealm().

As a result, it is now possible to use "native" RealmBase instances
(e.g. MemoryRealm) with ProxyRealm, as long as they are registered
into the ProxyRealm prior to invoking their init() method.

Part of: https://github.com/dogtagpki/pki/issues/3297