### PR TITLE
Extend check for PKCS#11 modules, skip if already configured

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -100,7 +100,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         if config.str2bool(deployer.mdict['pki_hsm_enable']) and \
                 deployer.mdict['pki_hsm_modulename'] and \
-                deployer.mdict['pki_hsm_libfile']:
+                deployer.mdict['pki_hsm_libfile'] and \
+                not nssdb.module_exists(deployer.mdict['pki_hsm_modulename']):
             nssdb.add_module(
                 deployer.mdict['pki_hsm_modulename'],
                 deployer.mdict['pki_hsm_libfile'])


### PR DESCRIPTION
Extend module_exists() to look in the `p11-kit list-modules` output as well as the modutil output for loaded PKCS#11 modules.

When adding a module, check to see if it is already loaded with that name and library and treat it as a no-op if so.

Fixes: https://github.com/dogtagpki/pki/issues/3208

Signed-off-by: Rob Crittenden <rcritten@redhat.com>