### PR TITLE
Ticket 1496 Fixed imports of missing certs

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -2274,6 +2274,10 @@ class NSSDatabase(object):
                 n = n + 1
 
             logger.debug('Number of certs in PKCS #7: %s', n)
+            # Return if there aren't and certificates to add.
+            if n < 1:
+                return
+
             # Import CA certs with default nicknames and trust attributes.
             for i in range(0, n - 1):
                 cert_file = prefix + str(i) + suffix

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -2274,7 +2274,7 @@ class NSSDatabase(object):
                 n = n + 1
 
             logger.debug('Number of certs in PKCS #7: %s', n)
-            # Return if there aren't and certificates to add.
+            # Return if there aren't any certificates to add.
             if n < 1:
                 return
 


### PR DESCRIPTION
Within the import_pkcs7 routine it is possible to attempt to import a certificate when one does not exist.

This patch only attempts to add certificates when there are certificates in the pkcs7 source file.