### PR TITLE
Update to non-deprecated versions of CI build actions.

### DIFF
--- a/.github/workflows/PKICertImport-test.yml
+++ b/.github/workflows/PKICertImport-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -17,7 +17,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -17,7 +17,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -75,7 +75,7 @@ jobs:
           path: pki-runner.tar
 
       - name: Build server image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -50,10 +50,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -63,7 +63,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -75,7 +75,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -17,7 +17,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-shared-token-test.yml
+++ b/.github/workflows/ca-shared-token-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -75,7 +75,7 @@ jobs:
           path: pki-runner.tar
 
       - name: Build server image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -21,7 +21,7 @@ jobs:
       matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3
@@ -69,7 +69,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/kra-rsnv3-test.yml
+++ b/.github/workflows/kra-rsnv3-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ocsp-cmc-test.yml
+++ b/.github/workflows/ocsp-cmc-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/pki-nss-aes-test.yml
+++ b/.github/workflows/pki-nss-aes-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/pki-nss-ecc-test.yml
+++ b/.github/workflows/pki-nss-ecc-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/pki-nss-exts-test.yml
+++ b/.github/workflows/pki-nss-exts-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/pki-nss-hsm-test.yml
+++ b/.github/workflows/pki-nss-hsm-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/pki-nss-rsa-test.yml
+++ b/.github/workflows/pki-nss-rsa-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/pki-pkcs11-test.yml
+++ b/.github/workflows/pki-pkcs11-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/pki-pkcs12-test.yml
+++ b/.github/workflows/pki-pkcs12-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/pki-pkcs7-test.yml
+++ b/.github/workflows/pki-pkcs7-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -84,7 +84,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -87,7 +87,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/rpminspect-test.yml
+++ b/.github/workflows/rpminspect-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve builder image
         uses: actions/cache@v3

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/server-https-jks-test.yml
+++ b/.github/workflows/server-https-jks-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/server-https-pem-test.yml
+++ b/.github/workflows/server-https-pem-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/server-https-pkcs12-test.yml
+++ b/.github/workflows/server-https-pkcs12-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -75,7 +75,7 @@ jobs:
           path: pki-runner.tar
 
       - name: Build server image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/server-upgrade-test.yml
+++ b/.github/workflows/server-upgrade-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -77,7 +77,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -96,7 +96,7 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -112,7 +112,7 @@ jobs:
           git rebase pki/${{ needs.retrieve-pr.outputs.pr-base }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -122,7 +122,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -134,7 +134,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -171,7 +171,7 @@ jobs:
         run: docker load --input pki-runner.tar
 
       - name: Checkout pulled branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -18,7 +18,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build builder image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -75,7 +75,7 @@ jobs:
           path: pki-builder.tar
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -16,7 +16,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -18,7 +18,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -15,7 +15,7 @@ jobs:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Retrieve runner image
         uses: actions/cache@v3

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -12,7 +12,7 @@ jobs:
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize workflow
         id: init
@@ -32,10 +32,10 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache pki-deps image
         id: cache-pki-deps
@@ -45,7 +45,7 @@ jobs:
           path: /tmp/cache-pki-deps
 
       - name: Build pki-deps image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache-pki-deps.outputs.cache-hit != 'true'
 
       - name: Build runner image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           build-args: |


### PR DESCRIPTION
Support for node12 will be removed in mid-2023, so futureproof now.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

First stage of #4193