### PR TITLE
Add pki-builder-deps

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
@@ -83,7 +95,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-acme
           target: pki-acme
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-acme.tar
 
       - name: Store server image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,12 +55,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -71,8 +71,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -83,7 +95,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
@@ -83,7 +95,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-ca
           target: pki-ca
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-ca.tar
 
       - name: Store server image

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: ipa-runner
           target: ipa-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=ipa-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image
@@ -83,7 +95,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-server
           target: pki-server
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-server.tar
 
       - name: Store server image

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -114,12 +114,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -130,8 +130,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -142,7 +154,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build builder image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-builder
           target: pki-builder
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-builder.tar
 
       - name: Store builder image
@@ -83,7 +95,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Cache pki-deps image
-        id: cache-pki-deps
+      - name: Cache Docker layers
+        id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: pki-deps-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/cache-pki-deps
+          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
         uses: docker/build-push-action@v3
@@ -53,8 +53,20 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
-          cache-to: type=local,dest=/tmp/cache-pki-deps
-        if: steps.cache-pki-deps.outputs.cache-hit != 'true'
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
 
       - name: Build runner image
         uses: docker/build-push-action@v3
@@ -65,7 +77,7 @@ jobs:
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
-          cache-from: type=local,src=/tmp/cache-pki-deps
+          cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
       - name: Store runner image

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,17 +38,23 @@ RUN dnf install -y dogtag-pki \
     && rm -rf /var/cache/dnf
 
 ################################################################################
-FROM pki-deps AS pki-builder
+FROM pki-deps AS pki-builder-deps
 
 # Install build tools
 RUN dnf install -y rpm-build
 
 # Import PKI sources
-COPY . /root/pki/
+COPY pki.spec /root/pki/
 WORKDIR /root/pki
 
 # Install PKI build dependencies
 RUN dnf builddep -y --spec pki.spec
+
+################################################################################
+FROM pki-builder-deps AS pki-builder
+
+# Import PKI sources
+COPY . /root/pki/
 
 # Build and install PKI packages
 RUN ./build.sh --work-dir=build rpm


### PR DESCRIPTION
A new `pki-builder-deps` image has been added to store the build dependencies. This image will be stored in GH cache which can shorten the build time by about 2 minutes.

The cache ID, key, and path have been updated since now the cache contains multiple images.

Currently the build takes about 6-7 minutes:
https://github.com/dogtagpki/pki/actions/runs/3331560105/jobs/5511442022

With these changes the build takes about 4-5 minutes:
https://github.com/edewata/pki/actions/runs/3331875461/jobs/5512122593

See also:
https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#local-cache