### PR TITLE
Update REST API path for JobResource.startJob()

### DIFF
--- a/base/common/src/main/java/org/dogtagpki/job/JobResource.java
+++ b/base/common/src/main/java/org/dogtagpki/job/JobResource.java
@@ -43,5 +43,6 @@ public interface JobResource {
      * This method can only be executed by an admin or the job owner.
      */
     @POST
-    public Response startJob(String id) throws EBaseException;
+    @Path("{id}/start")
+    public Response startJob(@PathParam("id") String id) throws EBaseException;
 }


### PR DESCRIPTION
The REST API path for `JobResource.startJob()` has been moved to `/ca/rest/jobs/{id}/start` to allow additional operations (e.g. stop) to be added in the future.