### PR TITLE
Address key generation permission issues with SoftHSM2 tokens

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1576,6 +1576,7 @@ class PKIDeployer:
 
         cert_id = self.get_cert_id(subsystem, tag)
         logger.info('Generating %s CSR in %s', cert_id, csr_path)
+        csr_pathname = os.path.join(nssdb.tmpdir, os.path.basename(csr_path))
 
         subject_dn = self.mdict['pki_%s_subject_dn' % cert_id]
 
@@ -1613,7 +1614,7 @@ class PKIDeployer:
 
             nssdb.create_request(
                 subject_dn=subject_dn,
-                request_file=csr_path,
+                request_file=csr_pathname,
                 key_type=key_type,
                 key_size=key_size,
                 curve=curve,
@@ -1625,10 +1626,12 @@ class PKIDeployer:
                 generic_exts=generic_exts,
                 use_jss=True)
 
-            with open(csr_path, encoding='utf-8') as f:
+            with open(csr_pathname, encoding='utf-8') as f:
                 csr = f.read()
 
             b64_csr = pki.nssdb.convert_csr(csr, 'pem', 'base64')
+
+            shutil.move(csr_pathname, csr_path)
 
         subsystem.config['%s.%s.certreq' % (subsystem.name, tag)] = b64_csr
 

--- a/base/server/python/pki/server/deployment/scriptlets/keygen.py
+++ b/base/server/python/pki/server/deployment/scriptlets/keygen.py
@@ -76,7 +76,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if not token:
             token = deployer.mdict['pki_token_name']
 
-        nssdb = subsystem.instance.open_nssdb(token)
+        nssdb = subsystem.instance.open_nssdb(
+            token=token,
+            user=deployer.mdict.get('pki_user'),
+            group=deployer.mdict.get('pki_group'),
+        )
 
         try:
             deployer.generate_csr(


### PR DESCRIPTION
This addresses two issues:

1. We have no control over where the requested CSR will be written or whether we have access to it, so generate the CSR to a temporary location and move it afterward when we will have root permission again.
2. Switch to the NSSDatabase user/group, if any, prior to generation so the private key will have the expected ownership. Otherwise it is owned by root and the token is unreadable by SoftHSM if running as another user.

The scenario is in a two-step externally signed CA installation by IPA. A CSR is correctly produced bu the resulting private key is owned by root so certutil can't "see" it and pkispawn ends up doing a selfsign installation.
IPA requests the CSR be in /root/ipa.csr which the pkiuser has no access to so generate the CSR in a temporary place and move it afterward.