### PR TITLE
Split SubsystemRangeUpdateCLI

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CARangeCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CARangeCLI.java
@@ -6,7 +6,6 @@
 package org.dogtagpki.server.ca.cli;
 
 import org.dogtagpki.cli.CLI;
-import org.dogtagpki.server.cli.SubsystemRangeUpdateCLI;
 
 /**
  * @author Endi S. Dewata
@@ -16,6 +15,6 @@ public class CARangeCLI extends CLI {
     public CARangeCLI(CLI parent) {
         super("range", "CA range management commands", parent);
 
-        addModule(new SubsystemRangeUpdateCLI(this));
+        addModule(new CARangeUpdateCLI(this));
     }
 }

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CARangeUpdateCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CARangeUpdateCLI.java
@@ -1,0 +1,58 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ca.cli;
+
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemRangeUpdateCLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmscore.apps.DatabaseConfig;
+import com.netscape.cmscore.dbs.CertificateRepository;
+import com.netscape.cmscore.dbs.Repository.IDGenerator;
+import com.netscape.cmscore.ldapconn.LdapAuthInfo;
+import com.netscape.cmscore.ldapconn.LdapConnInfo;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class CARangeUpdateCLI extends SubsystemRangeUpdateCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(CARangeUpdateCLI.class);
+
+    public CARangeUpdateCLI(CLI parent) {
+        super(parent);
+    }
+
+    @Override
+    public void updateSerialNumberRange(
+            PKISocketFactory socketFactory,
+            LdapConnInfo connInfo,
+            LdapAuthInfo authInfo,
+            DatabaseConfig dbConfig,
+            String baseDN) throws Exception {
+
+        String value = dbConfig.getString(
+                CertificateRepository.PROP_CERT_ID_GENERATOR,
+                CertificateRepository.DEFAULT_CERT_ID_GENERATOR);
+        IDGenerator idGenerator = IDGenerator.fromString(value);
+
+        if (idGenerator != IDGenerator.LEGACY) {
+            logger.info("No need to update certificate ID range");
+            return;
+        }
+
+        logger.info("Updating certificate ID range");
+
+        super.updateSerialNumberRange(
+                socketFactory,
+                connInfo,
+                authInfo,
+                dbConfig,
+                baseDN);
+    }
+}

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRARangeCLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRARangeCLI.java
@@ -6,7 +6,6 @@
 package org.dogtagpki.server.kra.cli;
 
 import org.dogtagpki.cli.CLI;
-import org.dogtagpki.server.cli.SubsystemRangeUpdateCLI;
 
 /**
  * @author Endi S. Dewata
@@ -16,6 +15,6 @@ public class KRARangeCLI extends CLI {
     public KRARangeCLI(CLI parent) {
         super("range", "KRA range management commands", parent);
 
-        addModule(new SubsystemRangeUpdateCLI(this));
+        addModule(new KRARangeUpdateCLI(this));
     }
 }

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRARangeUpdateCLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRARangeUpdateCLI.java
@@ -1,0 +1,58 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.kra.cli;
+
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemRangeUpdateCLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmscore.apps.DatabaseConfig;
+import com.netscape.cmscore.dbs.KeyRepository;
+import com.netscape.cmscore.dbs.Repository.IDGenerator;
+import com.netscape.cmscore.ldapconn.LdapAuthInfo;
+import com.netscape.cmscore.ldapconn.LdapConnInfo;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class KRARangeUpdateCLI extends SubsystemRangeUpdateCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(KRARangeUpdateCLI.class);
+
+    public KRARangeUpdateCLI(CLI parent) {
+        super(parent);
+    }
+
+    @Override
+    public void updateSerialNumberRange(
+            PKISocketFactory socketFactory,
+            LdapConnInfo connInfo,
+            LdapAuthInfo authInfo,
+            DatabaseConfig dbConfig,
+            String baseDN) throws Exception {
+
+        String value = dbConfig.getString(
+                KeyRepository.PROP_KEY_ID_GENERATOR,
+                KeyRepository.DEFAULT_KEY_ID_GENERATOR);
+        IDGenerator idGenerator = IDGenerator.fromString(value);
+
+        if (idGenerator != IDGenerator.LEGACY) {
+            logger.info("No need to update key ID range");
+            return;
+        }
+
+        logger.info("Updating key ID range");
+
+        super.updateSerialNumberRange(
+                socketFactory,
+                connInfo,
+                authInfo,
+                dbConfig,
+                baseDN);
+    }
+}


### PR DESCRIPTION
The `SubsystemRangeUpdateCLI` has been split into `CARangeUpdateCLI` and `KRARangeUpdateCLI` to avoid unnecessarily updating ID ranges if the server is configured with RSNv3.

The `CARangeUpdateCLI.updateSerialNumberRange()` will update the cert ID range only if the CA is configured with a legacy cert ID generator.

The `KRARangeUpdateCLI.updateSerialNumberRange()` will update the key ID range only if the KRA is configured with a legacy key ID generator.

The `SubsystemRangeUpdateCLI.updateRequestNumberRange()` will update the cert/key request ID range only if the CA/KRA is configured with a legacy request ID generator.