### PR TITLE
Fix try-with-resources warnings

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/legacy/server/policy/extensions/NSCCommentExt.java
+++ b/base/ca/src/main/java/org/dogtagpki/legacy/server/policy/extensions/NSCCommentExt.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.security.cert.CertificateException;
 import java.util.Vector;
 
@@ -206,9 +207,10 @@ public class NSCCommentExt extends APolicyRule
         }
         if (mInputType.equals("File")) {
             //		if ((mUserNoticeDisplayText.equals("")) && !(mCommentFile.equals(""))) {
-            try {
-                // Read the comments file
-                BufferedReader fis = new BufferedReader(new FileReader(mCommentFile));
+
+            // Read the comments file
+            try (Reader r = new FileReader(mCommentFile);
+                    BufferedReader fis = new BufferedReader(r)) {
 
                 String line = null;
                 StringBuffer buffer = new StringBuffer();
@@ -216,7 +218,7 @@ public class NSCCommentExt extends APolicyRule
                 while ((line = fis.readLine()) != null)
                     buffer.append(line);
                 mUserNoticeDisplayText = new String(buffer);
-                fis.close();
+
             } catch (IOException e) {
                 setError(req, CMS.getUserMessage("CMS_POLICY_UNEXPECTED_POLICY_ERROR"),
                         NAME, " Comment Text file not found : " + mCommentFile);

--- a/base/common/src/main/java/com/netscape/cmsutil/password/NuxwdogPasswordStore.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/password/NuxwdogPasswordStore.java
@@ -50,8 +50,9 @@ public class NuxwdogPasswordStore implements IPasswordStore {
      */
     private void populateTokenTags(String confFile) throws IOException {
         Properties props = new Properties();
-        InputStream in = new FileInputStream(confFile);
-        props.load(in);
+        try (InputStream in = new FileInputStream(confFile)) {
+            props.load(in);
+        }
 
         tags.add(CryptoUtil.INTERNAL_TOKEN_NAME);
 

--- a/base/common/src/main/java/org/dogtagpki/nss/NSSExtensionGenerator.java
+++ b/base/common/src/main/java/org/dogtagpki/nss/NSSExtensionGenerator.java
@@ -7,6 +7,7 @@ package org.dogtagpki.nss;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -74,7 +75,9 @@ public class NSSExtensionGenerator {
     public void init(String filename) throws Exception {
 
         Properties properties = new Properties();
-        properties.load(new FileInputStream(filename));
+        try (InputStream is = new FileInputStream(filename)) {
+            properties.load(is);
+        }
 
         parameters.clear();
         for (String name : properties.stringPropertyNames()) {

--- a/base/kra/src/test/java/com/netscape/cms/servlet/test/GeneratePKIArchiveOptions.java
+++ b/base/kra/src/test/java/com/netscape/cms/servlet/test/GeneratePKIArchiveOptions.java
@@ -10,6 +10,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Writer;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -91,11 +92,10 @@ public class GeneratePKIArchiveOptions {
     }
 
     private static void write_file(String data, String outFile) throws IOException {
-        FileWriter fstream = new FileWriter(outFile);
-        BufferedWriter out = new BufferedWriter(fstream);
-        out.write(data);
-        //Close the output stream
-        out.close();
+        try (Writer fstream = new FileWriter(outFile);
+                BufferedWriter out = new BufferedWriter(fstream)) {
+            out.write(data);
+        }
     }
 
     public static void main(String args[]) throws Exception {

--- a/base/server/src/main/java/com/netscape/cms/servlet/common/CMSFile.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/common/CMSFile.java
@@ -20,6 +20,7 @@ package com.netscape.cms.servlet.common;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
 import com.netscape.certsrv.base.EBaseException;
@@ -48,9 +49,10 @@ public class CMSFile {
         int fileSize = (int) file.length();
 
         mContent = new byte[fileSize];
-        FileInputStream fileIn = new FileInputStream(file);
-        int actualSize = fileIn.read(mContent);
-        fileIn.close();
+        int actualSize;
+        try (InputStream fileIn = new FileInputStream(file)) {
+            actualSize = fileIn.read(mContent);
+        }
 
         if (actualSize != fileSize) {
             byte[] actualContent = new byte[actualSize];

--- a/base/server/src/main/java/com/netscape/cms/servlet/common/CMSTemplate.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/common/CMSTemplate.java
@@ -22,10 +22,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.util.Enumeration;
@@ -288,23 +290,16 @@ public class CMSTemplate extends CMSFile {
 
         // Debug.trace("FormCache:loadFile");
 
-        /* create input stream, can throw IOException */
-        FileInputStream inStream = new FileInputStream(template);
-        InputStreamReader inReader = new InputStreamReader(inStream, mCharset);
-        ;
-        BufferedReader in = new BufferedReader(inReader);
         StringBuffer buf = new StringBuffer();
-        String line;
+        try (InputStream inStream = new FileInputStream(template);
+                Reader inReader = new InputStreamReader(inStream, mCharset);
+                BufferedReader in = new BufferedReader(inReader)) {
 
-        while ((line = in.readLine()) != null) {
-            buf.append(line);
-            buf.append('\n');
-        }
-        try {
-            in.close();
-            inStream.close();
-        } catch (IOException e) {
-            logger.warn("CMSTemplate: " + CMS.getLogMessage("CMSGW_ERR_CLOSE_TEMPL_FILE", mAbsPath, e.getMessage()), e);
+            String line;
+            while ((line = in.readLine()) != null) {
+                buf.append(line);
+                buf.append('\n');
+            }
         }
         return buf.toString();
     }

--- a/base/tomcat/src/main/java/com/netscape/cms/tomcat/NuxwdogPasswordStore.java
+++ b/base/tomcat/src/main/java/com/netscape/cms/tomcat/NuxwdogPasswordStore.java
@@ -50,8 +50,9 @@ public class NuxwdogPasswordStore implements org.apache.tomcat.util.net.jss.IPas
      */
     private void populateTokenTags(String confFile) throws IOException {
         Properties props = new Properties();
-        InputStream in = new FileInputStream(confFile);
-        props.load(in);
+        try (InputStream in = new FileInputStream(confFile)) {
+            props.load(in);
+        }
 
         tags.add(CryptoUtil.INTERNAL_TOKEN_NAME);
 

--- a/base/tools/src/main/java/com/netscape/cmstools/authority/AuthorityKeyExportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/authority/AuthorityKeyExportCLI.java
@@ -1,5 +1,6 @@
 package com.netscape.cmstools.authority;
 
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.PublicKey;
@@ -159,6 +160,8 @@ public class AuthorityKeyExportCLI extends CommandCLI {
                 params,
                 aid);
 
-        Files.newOutputStream(Paths.get(filename)).write(data);
+        try (OutputStream os = Files.newOutputStream(Paths.get(filename))) {
+            os.write(data);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes some `try-with-resources` warnings reported by SonarCloud:
https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER&types=BUG&id=dogtagpki_pki&open=AYE5lMP2tLTZxWLwchRt