### PR TITLE
Fix pylint failures on F37

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -99,4 +99,7 @@ jobs:
           HOSTNAME: pki.example.com
 
       - name: Run Python lint
-        run: docker exec pki /usr/share/pki/tests/bin/pki-lint
+        run: |
+          docker exec pki pylint-3 --version
+          docker exec pki python3-flake8 --version
+          docker exec pki /usr/share/pki/tests/bin/pki-lint

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -275,7 +275,7 @@ class PKIConfigParser:
             pki.specification_version()))
 
         charset = string.digits + string.ascii_lowercase + string.ascii_uppercase
-        self.deployer.main_config = configparser.SafeConfigParser({
+        self.deployer.main_config = configparser.ConfigParser({
             'application_version': application_version,
             'pki_instance_name': default_instance_name,
             'pki_http_port': default_http_port,
@@ -292,7 +292,7 @@ class PKIConfigParser:
         # Make keys case-sensitive!
         self.deployer.main_config.optionxform = str
 
-        self.deployer.user_config = configparser.SafeConfigParser()
+        self.deployer.user_config = configparser.ConfigParser()
         self.deployer.user_config.optionxform = str
 
         with open(config.default_deployment_cfg, encoding='utf-8') as f:

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -57,11 +57,6 @@ disable=W0511,W0105,W0142,C,R,W0232,W0707
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=yes
 
@@ -144,9 +139,6 @@ generated-members=REQUEST,acl_users,aq_parent
 
 [BASIC]
 
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply,input
-
 # Regular expression which should only match correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
@@ -200,9 +192,6 @@ max-locals=15
 
 # Maximum number of return / yield for function / method body
 max-returns=6
-
-# Maximum number of branch for function / method body
-max-branchs=12
 
 # Maximum number of statements in function / method body
 max-statements=50


### PR DESCRIPTION
/usr/share/pki/tests/pylintrc:1:0: E0015: Unrecognized option found: files-output, bad-functions, max-branchs (unrecognized-option)

/usr/lib/python3.11/site-packages/pki/server/deployment/pkiparser.py:278:36: W1512: Using deprecated class SafeConfigParser of module configparser (deprecated-class)

/usr/lib/python3.11/site-packages/pki/server/deployment/pkiparser.py:295:36: W1512: Using deprecated class SafeConfigParser of module configparser (deprecated-class)

**Note:** The Azure pipeline failures should be fixed by PR #4226.