### PR TITLE
[v10.13] Move the realm developed for ACME to the server package

### DIFF
--- a/base/server/src/main/java/com/netscape/cms/realm/PKIInMemoryRealm.java
+++ b/base/server/src/main/java/com/netscape/cms/realm/PKIInMemoryRealm.java
@@ -1,0 +1,66 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cms.realm;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.catalina.LifecycleException;
+
+import com.netscape.cmscore.usrgrp.User;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKIInMemoryRealm extends RealmCommon {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIInMemoryRealm.class);
+
+    String username;
+    String password;
+
+    User user;
+    List<String> roles;
+
+    @Override
+    public void initInternal() throws LifecycleException {
+
+        username = config.getParameter("username");
+        password = config.getParameter("password");
+        String roleList = config.getParameter("roles");
+
+        user = new User();
+        user.setUserID(username);
+        user.setFullName("Administrator");
+
+        if (roleList == null) {
+            roles = new ArrayList<>();
+            roles.add("Administrators");
+        }
+        else {
+            roles = Stream.of(roleList.split(",")).map(String::trim).collect(Collectors.toList());
+        }
+    }
+
+    @Override
+    public Principal authenticate(String username, String password) {
+
+        logger.info("Authenticating user " + username + " with password");
+
+        if (!this.username.equals(username)) {
+            return null;
+        }
+
+        if (!this.password.equals(password)) {
+            return null;
+        }
+
+        return new PKIPrincipal(user, null, roles);
+    }
+}

--- a/base/server/src/main/java/com/netscape/cms/realm/PKILDAPRealm.java
+++ b/base/server/src/main/java/com/netscape/cms/realm/PKILDAPRealm.java
@@ -1,0 +1,420 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cms.realm;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.catalina.LifecycleException;
+import org.mozilla.jss.netscape.security.util.Cert;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.base.FileConfigStore;
+import com.netscape.cmscore.ldapconn.LDAPAuthenticationConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapBoundConnFactory;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmscore.usrgrp.User;
+import com.netscape.cmsutil.password.IPasswordStore;
+import com.netscape.cmsutil.password.PlainPasswordFile;
+
+import netscape.ldap.LDAPAttribute;
+import netscape.ldap.LDAPConnection;
+import netscape.ldap.LDAPEntry;
+import netscape.ldap.LDAPException;
+import netscape.ldap.LDAPSearchResults;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKILDAPRealm extends RealmCommon {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKILDAPRealm.class);
+
+    String usersDN;
+    String groupsDN;
+
+    PKISocketConfig socketConfig;
+    LDAPConnectionConfig connConfig;
+    LDAPAuthenticationConfig authConfig;
+    LdapBoundConnFactory connFactory;
+
+    @Override
+    public void initInternal() throws LifecycleException {
+
+        logger.info("Initializing realm");
+
+        EngineConfig cs;
+        IPasswordStore ps;
+        LDAPConfig ldapConfig;
+
+        String configFile = config.getParameter("configFile");
+
+        if (configFile == null) {
+
+            logger.info("Loading LDAP realm config from realm.conf");
+
+            cs = new EngineConfig();
+            ps = new PlainPasswordFile();
+            ldapConfig = new LDAPConfig(null);
+
+            for (String name : config.getParameterNames()) {
+                String value = config.getParameter(name);
+
+                if (name.equals("usersDN")) {
+                    continue;
+
+                } else if (name.equals("groupsDN")) {
+                    continue;
+
+                } else if (name.equals("url")) {
+                    logger.info("- URL: " + value);
+
+                    URI url;
+                    try {
+                        url = new URI(value);
+                    } catch (URISyntaxException e) {
+                        throw new LifecycleException("No valid ldap url : " + value, e);
+                    }
+                    String host = url.getHost();
+                    String port = "" + url.getPort();
+
+                    String protocol = url.getScheme();
+                    String secureConn;
+                    if ("ldap".equals(protocol)) {
+                        secureConn = "false";
+                    } else if ("ldaps".equals(protocol)) {
+                        secureConn = "true";
+                    } else {
+                        throw new LifecycleException("Unsupported LDAP protocol: " + protocol);
+                    }
+
+                    ldapConfig.put("ldapconn.host", host);
+                    ldapConfig.put("ldapconn.port", port);
+                    ldapConfig.put("ldapconn.secureConn", secureConn);
+
+                } else if (name.equals("authType")) {
+                    logger.info("- authentication type: " + value);
+                    ldapConfig.put("ldapauth.authtype", value);
+
+                } else if (name.equals("bindDN")) {
+                    logger.info("- bind DN: " + value);
+                    ldapConfig.put("ldapauth.bindDN", value);
+
+                } else if (name.equals("bindPassword")) {
+                    ldapConfig.put("ldapauth.bindPassword", value);
+
+                } else if (name.equals("nickname")) {
+                    logger.info("- nickname: " + value);
+                    ldapConfig.put("ldapauth.clientCertNickname", value);
+
+                } else if (name.equals("minConns")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else if (name.equals("maxConns")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else if (name.equals("maxResults")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else if (name.equals("errorIfDown")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else if (name.startsWith("ldapauth.")) {
+                    ldapConfig.put(name, value);
+                    logger.info("- " + name + ": " + value);
+
+                } else if (name.startsWith("ldapconn.")) {
+                    logger.info("- " + name + ": " + value);
+                    ldapConfig.put(name, value);
+
+                } else {
+                    cs.put(name, value);
+                }
+            }
+
+        } else {
+
+            logger.info("Loading LDAP realm config from " + configFile);
+
+            try {
+                cs = new EngineConfig(new FileConfigStore(configFile));
+                cs.load();
+
+                ps = IPasswordStore.create(cs.getPasswordStoreConfig());
+            } catch (Exception e) {
+                throw new LifecycleException("Cannot load config file " + configFile, e);
+            }
+            ldapConfig = cs.getInternalDBConfig();
+        }
+
+        socketConfig = cs.getSocketConfig();
+        connConfig = ldapConfig.getConnectionConfig();
+        authConfig = ldapConfig.getAuthenticationConfig();
+
+        usersDN = config.getParameter("usersDN");
+        logger.info("- users DN: " + usersDN);
+
+        groupsDN = config.getParameter("groupsDN");
+        logger.info("- groups DN: " + groupsDN);
+
+        connFactory = new LdapBoundConnFactory("LDAPRealm");
+        try {
+            connFactory.init(socketConfig, ldapConfig, ps);
+        } catch (Exception e) {
+            throw new LifecycleException("LDAP connection problem:" + e.getMessage(), e);
+        }
+    }
+
+    public User createUser(LDAPEntry entry) throws Exception {
+        User user = new User();
+
+        user.setUserDN(entry.getDN());
+
+        LDAPAttribute uidAttr = entry.getAttribute("uid");
+        String uid = uidAttr.getStringValueArray()[0];
+        user.setUserID(uid);
+
+        LDAPAttribute cnAttr = entry.getAttribute("cn");
+        if (cnAttr != null) {
+            user.setFullName(cnAttr.getStringValues().nextElement());
+        }
+
+        LDAPAttribute mailAttr = entry.getAttribute("mail");
+        if (mailAttr != null) {
+            user.setEmail(mailAttr.getStringValues().nextElement());
+        }
+
+        LDAPAttribute phoneAttr = entry.getAttribute("telephoneNumber");
+        if (phoneAttr != null) {
+            user.setPhone(phoneAttr.getStringValues().nextElement());
+        }
+
+        LDAPAttribute userCertificate = entry.getAttribute("userCertificate");
+        if (userCertificate != null) {
+            byte[][] binCerts = userCertificate.getByteValueArray();
+            X509Certificate[] certs = new X509Certificate[binCerts.length];
+            for (int i = 0; i < binCerts.length; i++) {
+                certs[i] = new X509CertImpl(binCerts[i]);
+            }
+            user.setX509Certificates(certs);
+        }
+
+        return user;
+    }
+
+    public List<String> getUserRoles(LDAPConnection conn, String userDN) throws Exception {
+
+        List<String> roles = new ArrayList<>();
+        String filter = "uniqueMember=" + userDN;
+
+        logger.info("Getting user roles:");
+        logger.info("- base DN: " + groupsDN);
+        logger.info("- filter: " + filter);
+
+        LDAPSearchResults results = conn.search(
+                groupsDN,
+                LDAPConnection.SCOPE_ONE,
+                filter,
+                null, /* get all attributes*/
+                false /* return attribute values */
+        );
+
+        logger.info("Roles:");
+        while (results.hasMoreElements()) {
+            LDAPEntry groupEntry = results.next();
+            logger.info("- " + groupEntry.getDN());
+
+            LDAPAttribute cnAttr = groupEntry.getAttribute("cn");
+            String role = cnAttr.getStringValues().nextElement();
+            roles.add(role);
+        }
+
+        return roles;
+    }
+
+    public User findUserByUsername(LDAPConnection conn, String username) throws Exception {
+
+        String filter = "uid=" + username;
+
+        logger.info("Finding user by username:");
+        logger.info("- base DN: " + usersDN);
+        logger.info("- filter: " + filter);
+
+        LDAPSearchResults results = conn.search(
+                usersDN,
+                LDAPConnection.SCOPE_ONE,
+                filter,
+                null, /* get all attributes*/
+                false /* return attribute values */
+        );
+
+        if (!results.hasMoreElements()) {
+            logger.info("User not found");
+            return null;
+        }
+
+        LDAPEntry entry = results.next();
+        logger.info("User: " + entry.getDN());
+
+        return createUser(entry);
+    }
+
+    public String getCertID(X509Certificate cert) {
+        return cert.getVersion() + ";"
+                + cert.getSerialNumber() + ";"
+                + cert.getIssuerDN() + ";"
+                + cert.getSubjectDN();
+    }
+
+    public User findUserByCertID(LDAPConnection conn, String certID) throws Exception {
+
+        String filter = "description=" + certID;
+
+        logger.info("Finding user by cert:");
+        logger.info("- base DN: " + usersDN);
+        logger.info("- filter: " + filter);
+
+        LDAPSearchResults results = conn.search(
+                usersDN,
+                LDAPConnection.SCOPE_ONE,
+                filter,
+                null, /* get all attributes*/
+                false /* return attribute values */
+        );
+
+        if (!results.hasMoreElements()) {
+            logger.info("User not found");
+            return null;
+        }
+
+        LDAPEntry entry = results.next();
+        logger.info("User: " + entry.getDN());
+
+        return createUser(entry);
+    }
+
+    @Override
+    public Principal authenticate(String username, String password) {
+
+        logger.info("Authenticating user " + username + " with password");
+
+        LDAPConnection conn = null; 
+        try {
+            conn = connFactory.getConn();
+            User user = findUserByUsername(conn, username);
+
+            if (user == null) {
+                return null;
+            }
+
+            PKISocketFactory socketFactory = new PKISocketFactory(connConfig.isSecure());
+            socketFactory.init(socketConfig);
+
+            LDAPConnection authConn = new LDAPConnection(socketFactory);
+            try {
+                authConn.connect(connConfig.getHostname(), connConfig.getPort());
+                authConn.authenticate(user.getUserDN(), password);
+
+            } catch (LDAPException e) {
+                if (e.getLDAPResultCode() == LDAPException.INVALID_CREDENTIALS) {
+                    return null;
+                } else {
+                    throw new RuntimeException(e);
+                }
+            } finally {
+                authConn.close();
+            }
+
+            List<String> roles = getUserRoles(conn, user.getUserDN());
+            return new PKIPrincipal(user, null, roles);
+        } catch (Exception e) {
+            logger.error("Problem to verify user credentials", e);
+            throw new RuntimeException(e);
+        } finally {
+            connFactory.returnConn(conn);
+        }
+    }
+
+    @Override
+    public Principal authenticate(X509Certificate[] certChain) {
+        LDAPConnection conn = null; 
+        logger.info("Authenticating user with client certificate");
+
+        try {
+            // sort cert chain from leaf to root
+            certChain = Cert.sortCertificateChain(certChain, true);
+
+            // get leaf cert
+            X509Certificate cert = certChain[0];
+
+            // cert already validated during SSL handshake
+
+            conn = connFactory.getConn();
+            // find user by cert ID
+            String certID = getCertID(cert);
+            User user = findUserByCertID(conn, certID);
+
+            if (user == null) {
+                return null;
+            }
+
+            // validate cert data
+            boolean found = false;
+            byte[] data = cert.getEncoded();
+
+            X509Certificate[] certs = user.getX509Certificates();
+            if (certs != null) {
+                for (X509Certificate c : certs) {
+                    if (Arrays.equals(data, c.getEncoded())) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!found) {
+                return null;
+            }
+
+            // create user principal
+            List<String> roles = getUserRoles(conn, user.getUserDN());
+            return new PKIPrincipal(user, null, roles);
+
+        } catch (Exception e) {
+            logger.error("Problem to verify the certificate", e);
+            throw new RuntimeException(e);
+        } finally {
+            connFactory.returnConn(conn);
+        }
+    }
+
+    @Override
+    public void stopInternal() throws LifecycleException {
+
+        logger.info("Shutting down realm");
+
+        if(connFactory != null) {
+            try {
+                connFactory.shutdown();
+            } catch (Exception e) {
+                throw new LifecycleException("Cannot close the LDAP connection factory: " + e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/base/server/src/main/java/com/netscape/cms/realm/PKIPostgreSQLRealm.java
+++ b/base/server/src/main/java/com/netscape/cms/realm/PKIPostgreSQLRealm.java
@@ -1,0 +1,398 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cms.realm;
+
+import java.io.FileReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.realm.MessageDigestCredentialHandler;
+import org.apache.commons.lang3.StringUtils;
+import org.mozilla.jss.netscape.security.util.Cert;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+
+import com.netscape.cmscore.usrgrp.User;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class PKIPostgreSQLRealm extends RealmCommon {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIPostgreSQLRealm.class);
+
+    Properties info;
+    String url;
+
+    Properties statements;
+    Connection connection;
+
+    MessageDigestCredentialHandler handler;
+
+    @Override
+    public void initInternal() throws LifecycleException {
+
+        logger.info("Initializing realm");
+
+        info = new Properties();
+        for (String name : config.getParameterNames()) {
+            String value = config.getParameter(name);
+
+            if (!"password".equals(name)) {
+                logger.info("- " + name + ": " + value);
+            }
+
+            info.put(name, value);
+        }
+
+        url = (String) info.remove("url");
+
+        String statementsFilename = info.getProperty(
+                "statements");
+
+        logger.info("Loading statements from " + statementsFilename);
+
+        statements = new Properties();
+        try (FileReader reader = new FileReader(statementsFilename)) {
+            statements.load(reader);
+        }
+        catch (Exception e) {
+            throw new LifecycleException("Cannot read statements file: "  + statementsFilename,  e);
+        }
+
+        for (String name : statements.stringPropertyNames()) {
+            String value = statements.getProperty(name);
+            logger.info("- " + name + ": " + value);
+        }
+
+        logger.info("Initializing credential handler:");
+        // https://tomcat.apache.org/tomcat-9.0-doc/config/credentialhandler.html
+
+        String algorithm = info.getProperty("credentialHandler.algorithm");
+        if (algorithm == null) {
+            // tomcat-digest uses SHA-512 by default
+            // https://tomcat.apache.org/tomcat-9.0-doc/realm-howto.html
+            algorithm = "SHA-512";
+        }
+        logger.info("- algorithm: " + algorithm);
+
+        String encoding = info.getProperty("credentialHandler.encoding");
+        logger.info("- encoding: " + encoding);
+
+        String iterations = info.getProperty("credentialHandler.iterations");
+        logger.info("- iterations: " + iterations);
+
+        String saltLength = info.getProperty("credentialHandler.saltLength");
+        logger.info("- salt length: " + saltLength);
+
+        handler = new MessageDigestCredentialHandler();
+        try {
+            handler.setAlgorithm(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new LifecycleException("No such algorithm: " + algorithm,  e);
+        }
+        if (encoding != null) {
+            handler.setEncoding(encoding);
+        }
+
+        if (iterations != null) {
+            handler.setIterations(Integer.parseInt(iterations));
+        }
+
+        if (saltLength != null) {
+            handler.setSaltLength(Integer.parseInt(saltLength));
+        }
+    }
+
+    /**
+     * This method will create the tables if they do not exist.
+     */
+    public void setup() throws Exception {
+
+        logger.info("Setting up realm");
+
+        String filename = "/usr/share/pki/acme/realm/postgresql/create.sql";
+        String content = new String(Files.readAllBytes(Paths.get(filename)));
+
+        String[] statements = content.split(";");
+        for (String sql : statements) {
+            sql = sql.trim();
+            if (StringUtils.isEmpty(sql)) continue;
+            logger.info("SQL: " + sql);
+
+            try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.executeUpdate();
+
+            } catch (SQLException e) {
+
+                // https://www.postgresql.org/docs/current/errcodes-appendix.html
+                String sqlState = e.getSQLState();
+
+                // If table already exists, ignore
+                if ("42P07".equals(sqlState)) continue;
+
+                logger.error("Unable to set up PostgreSQL realm: " + e.getMessage());
+                logger.error("SQL state: " + sqlState);
+
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * This method will create the initial connection, validate
+     * the current connection, or reestablish the connection if
+     * it's closed.
+     *
+     * TODO: Use connection pool.
+     */
+    public void connect() throws Exception {
+
+        if (connection == null) { // create the initial connection
+            logger.info("Connecting to " + url);
+            connection = DriverManager.getConnection(url, info);
+            setup();
+            return;
+        }
+
+        // validate the current connection
+        try (Statement st = connection.createStatement();
+            ResultSet rs = st.executeQuery("SELECT 1")) {
+
+        } catch (SQLException e) {
+
+            if (connection.isClosed()) { // reestablish the connection
+                logger.info("Reconnecting to " + url);
+                connection = DriverManager.getConnection(url, info);
+                return;
+            }
+
+            logger.error("Unable to access database: " + e.getMessage());
+
+            // https://www.postgresql.org/docs/current/errcodes-appendix.html
+            logger.error("SQL state: " + e.getSQLState());
+
+            throw e;
+        }
+    }
+
+    public User createUser(ResultSet rs) throws Exception {
+        User user = new User();
+
+        String userID = rs.getString("id");
+        user.setUserID(userID);
+
+        String fullName = rs.getString("full_name");
+        user.setFullName(fullName);
+
+        String password = rs.getString("password");
+        user.setPassword(password);
+
+        return user;
+    }
+
+    public User getUserByID(String userID) throws Exception {
+
+        logger.info("Getting user " + userID);
+
+        String sql = statements.getProperty("getUserByID");
+        logger.info("SQL: " + sql);
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, userID);
+
+            try (ResultSet rs = ps.executeQuery()) {
+
+                if (!rs.next()) {
+                    return null;
+                }
+
+                return createUser(rs);
+            }
+        }
+    }
+
+    public String getCertID(X509Certificate cert) {
+        return cert.getVersion() + ";"
+                + cert.getSerialNumber() + ";"
+                + cert.getIssuerDN() + ";"
+                + cert.getSubjectDN();
+    }
+
+    public User getUserByCertID(String certID) throws Exception {
+
+        logger.info("Getting user for cert " + certID);
+
+        String sql = statements.getProperty("getUserByCertID");
+        logger.info("SQL: " + sql);
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, certID);
+
+            try (ResultSet rs = ps.executeQuery()) {
+
+                if (!rs.next()) {
+                    return null;
+                }
+
+                return createUser(rs);
+            }
+        }
+    }
+
+    public List<X509Certificate> getUserCerts(String userID) throws Exception {
+
+        logger.info("Getting certs for user " + userID);
+
+        String sql = statements.getProperty("getUserCerts");
+        logger.info("SQL: " + sql);
+
+        List<X509Certificate> results = new ArrayList<>();
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, userID);
+
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    byte[] data = rs.getBytes("data");
+                    results.add(new X509CertImpl(data));
+                }
+            }
+        }
+
+        return results;
+    }
+
+    public List<String> getUserRoles(String userID) throws Exception {
+
+        logger.info("Getting roles for user " + userID);
+
+        String sql = statements.getProperty("getUserRoles");
+        logger.info("SQL: " + sql);
+
+        List<String> roles = new ArrayList<>();
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, userID);
+
+            try (ResultSet rs = ps.executeQuery()) {
+
+                while (rs.next()) {
+                    String rolename = rs.getString("group_id");
+                    roles.add(rolename);
+                }
+            }
+        }
+
+        return roles;
+    }
+
+    @Override
+    public Principal authenticate(String username, String credentials) {
+
+        logger.info("Authenticating user " + username + " with password");
+        try {
+            connect();
+
+            User user = getUserByID(username);
+            if (user == null) {
+                return null;
+            }
+
+            String storedCredentials = user.getPassword();
+            if (!handler.matches(credentials, storedCredentials)) {
+                return null;
+            }
+
+            List<String> roles = getUserRoles(username);
+            return new PKIPrincipal(user, null, roles);
+        } catch (Exception e) {
+            logger.error("Problem to verify user credentials: "+ e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Principal authenticate(X509Certificate[] certChain) {
+
+        try {
+
+            // sort cert chain from leaf to root
+            certChain = Cert.sortCertificateChain(certChain, true);
+
+            // get leaf cert
+            X509Certificate cert = certChain[0];
+
+            // cert already validated during SSL handshake
+
+            // find user by cert ID
+            String certID = getCertID(cert);
+            logger.info("Authenticating user with certificate " + certID);
+
+            connect();
+            User user = getUserByCertID(certID);
+
+            if (user == null) {
+                logger.warn("Unable to authenticate user with certificate " + certID + ": User not found");
+                return null;
+            }
+
+            List<X509Certificate> certs = getUserCerts(user.getUserID());
+            if (certs == null || certs.isEmpty()) {
+                logger.warn("Unable to authenticate user " + user.getUserID() + ": User has no certificates");
+                return null;
+            }
+            // validate cert data
+            boolean found = false;
+            byte[] data = cert.getEncoded();
+
+            for (X509Certificate c : certs) {
+                if (Arrays.equals(data, c.getEncoded())) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                return null;
+            }
+
+            // create user principal
+            List<String> roles = getUserRoles(user.getUserID());
+            return new PKIPrincipal(user, null, roles);
+        } catch(Exception e) {
+            logger.error("Problem to verify the certificate", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stopInternal() throws LifecycleException {
+
+        logger.info("Shutting down realm");
+
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch(Exception e) {
+                throw new LifecycleException("Cannot close the DB connection: " + e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/base/server/src/main/java/com/netscape/cms/realm/RealmCommon.java
+++ b/base/server/src/main/java/com/netscape/cms/realm/RealmCommon.java
@@ -1,0 +1,46 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cms.realm;
+
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+
+import org.apache.catalina.realm.RealmBase;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class RealmCommon extends RealmBase {
+
+    protected RealmConfig config;
+
+    public RealmConfig getConfig() {
+        return config;
+    }
+
+    public void setConfig(RealmConfig config) {
+        this.config = config;
+    }
+
+    public Principal authenticate(String username, String password) {
+        return null;
+    }
+
+    public Principal authenticate(X509Certificate[] certs) {
+        return null;
+    }
+
+
+    @Override
+    protected String getPassword(String arg0) {
+        return null;
+    }
+
+    @Override
+    protected Principal getPrincipal(String arg0) {
+        return null;
+    }
+}

--- a/base/server/src/main/java/com/netscape/cms/realm/RealmConfig.java
+++ b/base/server/src/main/java/com/netscape/cms/realm/RealmConfig.java
@@ -1,0 +1,105 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cms.realm; 
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Endi S. Dewata
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class RealmConfig {
+
+    @JsonProperty("class")
+    private String className;
+
+    private Map<String, String> parameters = new LinkedHashMap<>();
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters.clear();
+        this.parameters.putAll(parameters);
+    }
+
+    @JsonIgnore
+    public Collection<String> getParameterNames() {
+        return parameters.keySet();
+    }
+
+    public String getParameter(String name) {
+        return parameters.get(name);
+    }
+
+    public void setParameter(String name, String value) {
+        parameters.put(name, value);
+    }
+
+    public String removeParameter(String name) {
+        return parameters.remove(name);
+    }
+
+    public String toJSON() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+
+    public static RealmConfig fromJSON(String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, RealmConfig.class);
+    }
+
+    public static RealmConfig fromProperties(Properties props) throws Exception {
+
+        RealmConfig config = new RealmConfig();
+
+        for (Entry<Object, Object> entry : props.entrySet()) {
+
+            String key = entry.getKey().toString();
+            String value = entry.getValue().toString();
+
+            if (key.equals("class")) {
+                config.setClassName(value);
+
+            } else {
+                config.setParameter(key, value);
+            }
+        }
+
+        return config;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
(Cherry pick to `v10.13` branch of https://github.com/dogtagpki/pki/pull/4161)

ACME subsystem contains a set of realm working with the ProxyRealm and
allowing to configure different authentication models.
These realm are moved outside of ACME package so they can be used by
other subsystems (e.g. EST).
Additionally, these realm have been updated to extend the tomcat
RealmBase so they do not need to be wrapped to be used with the
ProxyRealm.
Finally, the InMemoryRealm supports multiple roles.

However, the configuration model is different from the container managed
realm so, at the moment, they cannot replace the tomcat realm to use at
container level.

To avoid risk and extra QE work, this commit DOES NOT update the
ACME classes.  This results in some code duplication, but this
commit is only intended for the v10.13 release branch.  In the
mainline branches, the ACME realm classes WERE refactored to use the
new realm classes.