### PR TITLE
[V10.13] Add AES in SCEP protocol

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1312,6 +1312,7 @@ public class CRSEnrollment extends HttpServlet {
 
     private SymmetricKey moveSymmetricToInternalToken(CryptoContext cx, SymmetricKey sk, SymmetricKey.Type skt, EncryptionAlgorithm ea)
             throws Exception {
+        boolean padding = false;
         KeyPairGeneratorSpi.Usage[] usage = {
                 KeyPairGeneratorSpi.Usage.WRAP,
                 KeyPairGeneratorSpi.Usage.UNWRAP,
@@ -1324,6 +1325,7 @@ public class CRSEnrollment extends HttpServlet {
         if(mUseOAEPKeyWrap) {
             kwAlg = KeyWrapAlgorithm.RSA_OAEP;
             algSpec = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+            padding = true;
         }
         KeyWrapper kw = sk.getOwningToken().getKeyWrapper(kwAlg);;
         kw.initWrap(keyPairWrap.getPublic(), algSpec);
@@ -1333,7 +1335,7 @@ public class CRSEnrollment extends HttpServlet {
         PrivateKey pk = (PrivateKey) keyPairWrap.getPrivate() ;
         kwInt.initUnwrap(pk, algSpec);
 
-        return kwInt.unwrapSymmetric(wrappedSK, skt, SymmetricKey.Usage.DECRYPT, ea.getKeyStrength() / 8);
+        return kwInt.unwrapSymmetric(wrappedSK, skt, SymmetricKey.Usage.DECRYPT, padding ? ea.getKeyStrength() / 8 : 0);
     }
 
     private void getDetailFromRequest(CRSPKIMessage req, CRSPKIMessage crsResp)

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1268,15 +1268,15 @@ public class CRSEnrollment extends HttpServlet {
 
             switch(String.valueOf(mEncryptionAlgorithm)) {
                 case "DES3":
-                    skt = SymmetricKey.Type.DES3;
+                    skt = SymmetricKey.DES3;
                     ea = EncryptionAlgorithm.DES3_CBC;
                     break;
                 case "AES":
-                    skt = SymmetricKey.Type.AES;
+                    skt = SymmetricKey.AES;
                     ea = EncryptionAlgorithm.AES_128_CBC;
                     break;
                 default:
-                    skt = SymmetricKey.Type.DES;
+                    skt = SymmetricKey.DES;
                     ea = EncryptionAlgorithm.DES_CBC;
 
             }
@@ -1970,19 +1970,15 @@ public class CRSEnrollment extends HttpServlet {
             if (issuedCert != null) {
                 SymmetricKey sk;
                 SymmetricKey skinternal;
-                KeyGenAlgorithm kga;
                 EncryptionAlgorithm ea;
                 switch(String.valueOf(mEncryptionAlgorithm)) {
                     case "DES3":
-                        kga = KeyGenAlgorithm.DES3;
                         ea = EncryptionAlgorithm.DES3_CBC;
                         break;
                     case "AES":
-                        kga = KeyGenAlgorithm.AES;
                         ea = EncryptionAlgorithm.AES_128_CBC;
                         break;
                     default:
-                        kga = KeyGenAlgorithm.DES;
                         ea = EncryptionAlgorithm.DES_CBC;
                 }
 
@@ -2069,9 +2065,9 @@ public class CRSEnrollment extends HttpServlet {
             {
                 byte[] signingcertbytes = cx.getSigningCert().getEncoded();
 
-                Certificate.Template sgncert_t = new Certificate.Template();
+                Certificate.Template sgncertT = new Certificate.Template();
                 Certificate sgncert =
-                        (Certificate) sgncert_t.decode(new ByteArrayInputStream(signingcertbytes));
+                        (Certificate) sgncertT.decode(new ByteArrayInputStream(signingcertbytes));
 
                 IssuerAndSerialNumber sgniasn =
                         new IssuerAndSerialNumber(sgncert.getInfo().getIssuer(),
@@ -2233,7 +2229,7 @@ public class CRSEnrollment extends HttpServlet {
                 throws CryptoContextException {
             KeyWrapAlgorithm keyWrapAlg = KeyWrapAlgorithm.RSA;
 
-            if(mUseOAEPKeyWrap == true) {
+            if(mUseOAEPKeyWrap) {
                 keyWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
             }
 
@@ -2250,7 +2246,7 @@ public class CRSEnrollment extends HttpServlet {
                 throws CryptoContextException {
             KeyWrapAlgorithm keyWrapAlg = KeyWrapAlgorithm.RSA;
 
-            if(mUseOAEPKeyWrap == true) {
+            if(mUseOAEPKeyWrap) {
                 keyWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
             }
             try {

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -167,6 +167,8 @@ public class CRSEnrollment extends HttpServlet {
 
     private static final long serialVersionUID = 8483002540957382369L;
 
+    private static final String OAEP_SHA = "SHA-256";
+
     protected ProfileSubsystem mProfileSubsystem;
     protected String mProfileId = null;
     protected ICertAuthority mAuthority;
@@ -1267,7 +1269,7 @@ public class CRSEnrollment extends HttpServlet {
             kw = cx.getKeyWrapper();
             AlgorithmParameterSpec keyWrapConfig = null;
             if(mUseOAEPKeyWrap) {
-                keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                keyWrapConfig = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
                 padding = true;
             }
             kw.initUnwrap(cx.getPrivateKey(), keyWrapConfig);
@@ -1324,7 +1326,7 @@ public class CRSEnrollment extends HttpServlet {
         KeyIdentifier ki = CryptoUtil.createKeyIdentifier(keyPairWrap);
 
         KeyWrapper kw = sk.getOwningToken().getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
-        AlgorithmParameterSpec algSpec = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+        AlgorithmParameterSpec algSpec = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
         kw.initWrap(keyPairWrap.getPublic(), algSpec);
         byte[] wrappedSK = kw.wrap(sk);
 
@@ -2047,7 +2049,7 @@ public class CRSEnrollment extends HttpServlet {
                 KeyWrapper kw = cx.getInternalKeyWrapper();
                 AlgorithmParameterSpec keyWrapConfig = null;
                 if(mUseOAEPKeyWrap) {
-                    keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                    keyWrapConfig = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
                 }
                 kw.initWrap(rcpPK, keyWrapConfig);
 
@@ -2126,7 +2128,7 @@ public class CRSEnrollment extends HttpServlet {
         private CryptoManager cm;
         private CryptoToken internalToken;
         private CryptoToken keyStorageToken;
-        private CryptoToken internalKeyStorageToken;
+        private CryptoToken internalKeyStorageToken = null;
         private KeyGenerator keyGen;
         private Enumeration<?> externalTokens = null;
         private org.mozilla.jss.crypto.X509Certificate signingCert;
@@ -2163,7 +2165,7 @@ public class CRSEnrollment extends HttpServlet {
                     break;
                 default:
                     kga = KeyGenAlgorithm.DES;
-            }
+                }
                 cm = CryptoManager.getInstance();
                 internalToken = cm.getInternalCryptoToken();
                 keyGen = internalToken.getKeyGenerator(kga);
@@ -2174,8 +2176,6 @@ public class CRSEnrollment extends HttpServlet {
                 if (CryptoUtil.isInternalToken(mTokenName)) {
                     internalKeyStorageToken = keyStorageToken;
                     logger.debug("CRSEnrollment: CryptoContext: internal token name: '" + mTokenName + "'");
-                } else {
-                    internalKeyStorageToken = null;
                 }
                 if (!mUseCA && internalKeyStorageToken == null) {
                     PasswordCallback cb = new PWCBsdr();

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1284,7 +1284,7 @@ public class CRSEnrollment extends HttpServlet {
             sk = kw.unwrapSymmetric(req.getWrappedKey(),
                               skt,
                               SymmetricKey.Usage.DECRYPT,
-                              0); // keylength is ignored
+                              ea.getKeyStrength() / 8);
 
             skinternal = cx.getKeyGenerator().clone(sk);
 

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1256,6 +1256,7 @@ public class CRSEnrollment extends HttpServlet {
         KeyWrapper kw;
         Cipher cip;
         EncryptionAlgorithm ea;
+        boolean padding = false;
 
         // Unwrap the session key with the Cert server key
         try {
@@ -1263,6 +1264,7 @@ public class CRSEnrollment extends HttpServlet {
             AlgorithmParameterSpec keyWrapConfig = null;
             if(mUseOAEPKeyWrap) {
                 keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                padding = true;
             }
             kw.initUnwrap(cx.getPrivateKey(), keyWrapConfig);
 
@@ -1284,7 +1286,7 @@ public class CRSEnrollment extends HttpServlet {
             sk = kw.unwrapSymmetric(req.getWrappedKey(),
                               skt,
                               SymmetricKey.Usage.DECRYPT,
-                              ea.getKeyStrength() / 8);
+                              padding ? ea.getKeyStrength() / 8 : 0);
 
             skinternal = cx.getKeyGenerator().clone(sk);
 

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -24,6 +24,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -31,6 +33,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Vector;
 
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -1256,8 +1260,11 @@ public class CRSEnrollment extends HttpServlet {
         // Unwrap the session key with the Cert server key
         try {
             kw = cx.getKeyWrapper();
-
-            kw.initUnwrap(cx.getPrivateKey(), null);
+            AlgorithmParameterSpec keyWrapConfig = null;
+            if(mUseOAEPKeyWrap) {
+                keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+            }
+            kw.initUnwrap(cx.getPrivateKey(), keyWrapConfig);
 
             switch(String.valueOf(mEncryptionAlgorithm)) {
                 case "DES3":
@@ -2011,7 +2018,11 @@ public class CRSEnrollment extends HttpServlet {
                 skinternal = cx.getInternalToken().cloneKey(sk);
 
                 KeyWrapper kw = cx.getInternalKeyWrapper();
-                kw.initWrap(rcpPK, null);
+                AlgorithmParameterSpec keyWrapConfig = null;
+                if(mUseOAEPKeyWrap) {
+                    keyWrapConfig = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+                }
+                kw.initWrap(rcpPK, keyWrapConfig);
 
                 encryptedDesKey = kw.wrap(skinternal);
 

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -20,6 +20,7 @@ package com.netscape.cms.servlet.cert.scep;
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -59,9 +60,11 @@ import org.mozilla.jss.crypto.EncryptionAlgorithm;
 import org.mozilla.jss.crypto.IVParameterSpec;
 import org.mozilla.jss.crypto.KeyGenAlgorithm;
 import org.mozilla.jss.crypto.KeyGenerator;
+import org.mozilla.jss.crypto.KeyPairGeneratorSpi;
 import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.KeyWrapper;
 import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.TokenException;
 import org.mozilla.jss.netscape.security.extensions.CertInfo;
@@ -85,6 +88,7 @@ import org.mozilla.jss.netscape.security.x509.GeneralName;
 import org.mozilla.jss.netscape.security.x509.GeneralNameInterface;
 import org.mozilla.jss.netscape.security.x509.GeneralNames;
 import org.mozilla.jss.netscape.security.x509.IPAddressName;
+import org.mozilla.jss.netscape.security.x509.KeyIdentifier;
 import org.mozilla.jss.netscape.security.x509.KeyUsageExtension;
 import org.mozilla.jss.netscape.security.x509.OIDMap;
 import org.mozilla.jss.netscape.security.x509.RDN;
@@ -1288,10 +1292,13 @@ public class CRSEnrollment extends HttpServlet {
                               SymmetricKey.Usage.DECRYPT,
                               padding ? ea.getKeyStrength() / 8 : 0);
 
-            skinternal = cx.getKeyGenerator().clone(sk);
+            if(mUseOAEPKeyWrap) {
+                skinternal = moveSymmetricToInternalToken(cx, sk, skt, ea);
+            } else {
+                skinternal = cx.getKeyGenerator().clone(sk);
+            }
 
             cip = skinternal.getOwningToken().getCipherContext(ea);
-
             cip.initDecrypt(skinternal, (new IVParameterSpec(req.getIV())));
 
             decryptedP10bytes = cip.doFinal(req.getEncryptedPkcs10());
@@ -1304,6 +1311,28 @@ public class CRSEnrollment extends HttpServlet {
             throw new CRSFailureException("Could not unwrap PKCS10 blob: " + e.getMessage());
         }
 
+    }
+
+    private SymmetricKey moveSymmetricToInternalToken(CryptoContext cx, SymmetricKey sk, SymmetricKey.Type skt, EncryptionAlgorithm ea)
+            throws Exception {
+        KeyPairGeneratorSpi.Usage[] usage = {
+                KeyPairGeneratorSpi.Usage.WRAP,
+                KeyPairGeneratorSpi.Usage.UNWRAP,
+                KeyPairGeneratorSpi.Usage.ENCRYPT,
+                KeyPairGeneratorSpi.Usage.DECRYPT};
+        KeyPair keyPairWrap = CryptoUtil.generateRSAKeyPair(cx.getInternalToken(), 2048, true, true, false, usage, usage);
+        KeyIdentifier ki = CryptoUtil.createKeyIdentifier(keyPairWrap);
+
+        KeyWrapper kw = sk.getOwningToken().getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
+        AlgorithmParameterSpec algSpec = new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+        kw.initWrap(keyPairWrap.getPublic(), algSpec);
+        byte[] wrappedSK = kw.wrap(sk);
+
+        KeyWrapper kwInt = cx.getInternalToken().getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
+        PrivateKey pk = CryptoUtil.findPrivateKey(ki.getIdentifier());
+        kwInt.initUnwrap(pk, algSpec);
+
+        return kwInt.unwrapSymmetric(wrappedSK, skt, SymmetricKey.Usage.DECRYPT, ea.getKeyStrength() / 8);
     }
 
     private void getDetailFromRequest(CRSPKIMessage req, CRSPKIMessage crsResp)
@@ -2234,7 +2263,6 @@ public class CRSEnrollment extends HttpServlet {
             if(mUseOAEPKeyWrap) {
                 keyWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
             }
-
             try {
                 return signingCertPrivKey.getOwningToken().getKeyWrapper(keyWrapAlg);
             } catch (TokenException e) {

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -1293,11 +1293,7 @@ public class CRSEnrollment extends HttpServlet {
                               SymmetricKey.Usage.DECRYPT,
                               padding ? ea.getKeyStrength() / 8 : 0);
 
-            if(mUseOAEPKeyWrap) {
-                skinternal = moveSymmetricToInternalToken(cx, sk, skt, ea);
-            } else {
-                skinternal = cx.getKeyGenerator().clone(sk);
-            }
+            skinternal = moveSymmetricToInternalToken(cx, sk, skt, ea);
 
             cip = skinternal.getOwningToken().getCipherContext(ea);
             cip.initDecrypt(skinternal, (new IVParameterSpec(req.getIV())));
@@ -1323,12 +1319,17 @@ public class CRSEnrollment extends HttpServlet {
                 KeyPairGeneratorSpi.Usage.DECRYPT};
         KeyPair keyPairWrap = CryptoUtil.generateRSAKeyPair(cx.getInternalToken(), 2048, true, true, false, usage, usage);
 
-        KeyWrapper kw = sk.getOwningToken().getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
-        AlgorithmParameterSpec algSpec = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+        KeyWrapAlgorithm kwAlg = KeyWrapAlgorithm.RSA;
+        AlgorithmParameterSpec algSpec = null;
+        if(mUseOAEPKeyWrap) {
+            kwAlg = KeyWrapAlgorithm.RSA_OAEP;
+            algSpec = new OAEPParameterSpec(OAEP_SHA, "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+        }
+        KeyWrapper kw = sk.getOwningToken().getKeyWrapper(kwAlg);;
         kw.initWrap(keyPairWrap.getPublic(), algSpec);
         byte[] wrappedSK = kw.wrap(sk);
 
-        KeyWrapper kwInt = cx.getInternalToken().getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
+        KeyWrapper kwInt = cx.getInternalToken().getKeyWrapper(kwAlg);
         PrivateKey pk = (PrivateKey) keyPairWrap.getPrivate() ;
         kwInt.initUnwrap(pk, algSpec);
 
@@ -2047,11 +2048,7 @@ public class CRSEnrollment extends HttpServlet {
                 // we have to move the key onto the internal token.
                 //skinternal = cx.getInternalKeyStorageToken().cloneKey(sk);
 
-                if(mUseOAEPKeyWrap) {
-                    skinternal = moveSymmetricToInternalToken(cx, sk, skt, ea);
-                } else {
-                    skinternal = cx.getInternalToken().cloneKey(sk);
-                }
+                skinternal = moveSymmetricToInternalToken(cx, sk, skt, ea);
 
                 KeyWrapper kw = cx.getInternalKeyWrapper();
                 AlgorithmParameterSpec keyWrapConfig = null;

--- a/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -91,7 +91,7 @@ public class CRSPKIMessage {
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 1, 1, 1 }
             );
 
-    /* PKCS 1 - rsaEncryption */
+    /* PKCS 1 - rsaOaepEncryption */
     public static OBJECT_IDENTIFIER RSAES_OAEP_ENCRYPTION =
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 1, 1, 7 }
             );

--- a/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -99,6 +99,10 @@ public class CRSPKIMessage {
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 3, 7 }
             );
 
+    public static OBJECT_IDENTIFIER AES_128_CBC_ENCRYPTION =
+            new OBJECT_IDENTIFIER(new long[] { 2, 16, 840, 1, 101, 3, 4, 1, 2 }
+            );
+
     public static OBJECT_IDENTIFIER MD5_DIGEST =
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 2, 5 }
             );
@@ -437,9 +441,17 @@ public class CRSPKIMessage {
         this.ec = ec;
 
         try {
-            OBJECT_IDENTIFIER oid = DES_CBC_ENCRYPTION;
-            if (algorithm != null && algorithm.equals("DES3"))
+            OBJECT_IDENTIFIER oid = null;
+            switch (String.valueOf(algorithm)) {
+            case "DES3":
                 oid = DES_EDE3_CBC_ENCRYPTION;
+                break;
+            case "AES":
+                oid = AES_128_CBC_ENCRYPTION;
+                break;
+            default:
+                oid = DES_CBC_ENCRYPTION;
+            }
 
             AlgorithmIdentifier aid = new AlgorithmIdentifier(oid, new OCTET_STRING(iv));
 
@@ -786,6 +798,8 @@ public class CRSPKIMessage {
 
         if (eci.getContentEncryptionAlgorithm().getOID().equals(DES_EDE3_CBC_ENCRYPTION)) {
             encryptionAlgorithm = "DES3";
+        } else if (eci.getContentEncryptionAlgorithm().getOID().equals(AES_128_CBC_ENCRYPTION)) {
+            encryptionAlgorithm = "AES";
         } else if (eci.getContentEncryptionAlgorithm().getOID().equals(DES_CBC_ENCRYPTION)) {
             encryptionAlgorithm = "DES";
         } else {

--- a/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/scep/CRSPKIMessage.java
@@ -91,6 +91,11 @@ public class CRSPKIMessage {
             new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 1, 1, 1 }
             );
 
+    /* PKCS 1 - rsaEncryption */
+    public static OBJECT_IDENTIFIER RSAES_OAEP_ENCRYPTION =
+            new OBJECT_IDENTIFIER(new long[] { 1, 2, 840, 113549, 1, 1, 7 }
+            );
+
     public static OBJECT_IDENTIFIER DES_CBC_ENCRYPTION =
             new OBJECT_IDENTIFIER(new long[] { 1, 3, 14, 3, 2, 7 }
             );
@@ -840,7 +845,7 @@ public class CRSPKIMessage {
 
         riAlgid = ri.getKeyEncryptionAlgorithmID();
 
-        if (!riAlgid.getOID().equals(RSA_ENCRYPTION)) {
+        if (!(riAlgid.getOID().equals(RSA_ENCRYPTION) || riAlgid.getOID().equals(RSAES_OAEP_ENCRYPTION))) {
             throw new Exception("Request is protected by a key which we can't decrypt");
         }
 


### PR DESCRIPTION
Enable AES support in SCEP protocol as requested in the issue: RHCS-2924.

Test performed with a modified version of PyScep and the code in [this gist](https://gist.github.com/fmarco76/d2e7a3f771617dcfaca95ddc1fbd13ab)