### PR TITLE
[v10.13] Disable not usable profiles

### DIFF
--- a/base/ca/shared/profiles/ca/caAgentFileSigning.cfg
+++ b/base/ca/shared/profiles/ca/caAgentFileSigning.cfg
@@ -1,6 +1,6 @@
 desc=This certificate profile is for getting file signing certificate with agent authentication.
-visible=true
-enable=true
+visible=false
+enable=false
 enableBy=admin
 auth.instance_id=AgentCertAuth
 name=Agent-Authenticated File Signing

--- a/base/ca/shared/profiles/ca/caDirPinUserCert.cfg
+++ b/base/ca/shared/profiles/ca/caDirPinUserCert.cfg
@@ -1,5 +1,5 @@
 desc=This certificate profile is for enrolling user certificates with directory-pin-based authentication.
-visible=true
+visible=false
 enable=false
 enableBy=admin
 name=Directory-Pin-Authenticated User Dual-Use Certificate Enrollment

--- a/base/ca/shared/profiles/ca/caDirUserCert.cfg
+++ b/base/ca/shared/profiles/ca/caDirUserCert.cfg
@@ -1,6 +1,6 @@
 desc=This certificate profile is for enrolling user certificates with directory-based authentication.
-visible=true
-enable=true
+visible=false
+enable=false
 enableBy=admin
 name=Directory-Authenticated User Dual-Use Certificate Enrollment
 auth.instance_id=UserDirEnrollment

--- a/base/ca/shared/profiles/ca/caECDirPinUserCert.cfg
+++ b/base/ca/shared/profiles/ca/caECDirPinUserCert.cfg
@@ -1,5 +1,5 @@
 desc=This certificate profile is for enrolling user ECC certificates with directory-pin-based authentication.
-visible=true
+visible=false
 enable=false
 enableBy=admin
 name=Directory-Pin-Authenticated User Dual-Use ECC Certificate Enrollment

--- a/base/ca/shared/profiles/ca/caECDirUserCert.cfg
+++ b/base/ca/shared/profiles/ca/caECDirUserCert.cfg
@@ -1,6 +1,6 @@
 desc=This certificate profile is for enrolling user ECC certificates with directory-based authentication.
-visible=true
-enable=true
+visible=false
+enable=false
 enableBy=admin
 name=Directory-Authenticated User ECC Certificate Enrollment
 auth.instance_id=UserDirEnrollment

--- a/base/ca/shared/profiles/ca/caECUserCert.cfg
+++ b/base/ca/shared/profiles/ca/caECUserCert.cfg
@@ -1,6 +1,6 @@
 desc=This certificate profile is for enrolling user ECC certificates.
 visible=false
-enable=true
+enable=false
 enableBy=admin
 name=Manual User Dual-Use ECC Certificate Enrollment
 auth.class_id=

--- a/base/ca/shared/profiles/ca/caUUIDdeviceCert.cfg
+++ b/base/ca/shared/profiles/ca/caUUIDdeviceCert.cfg
@@ -1,5 +1,5 @@
 desc=This certificate profile is for enrolling device certificates to contain UUID in the Subject Alternative Name extension
-visible=true
+visible=false
 enable=false
 enableBy=admin
 name=Manual device Dual-Use Certificate Enrollment to contain UUID in SAN

--- a/base/ca/shared/profiles/ca/caUserCert.cfg
+++ b/base/ca/shared/profiles/ca/caUserCert.cfg
@@ -1,5 +1,5 @@
 desc=This certificate profile is for enrolling user certificates.
-visible=true
+visible=false
 enable=true
 enableBy=admin
 name=Manual User Dual-Use Certificate Enrollment

--- a/base/ca/shared/profiles/ca/caUserSMIMEcapCert.cfg
+++ b/base/ca/shared/profiles/ca/caUserSMIMEcapCert.cfg
@@ -1,6 +1,6 @@
 desc=This certificate profile is for enrolling user certificates with S/MIME capabilities extension - OID: 1.2.840.113549.1.9.15
-visible=true
-enable=true
+visible=false
+enable=false
 enableBy=admin
 name=Manual User Dual-Use S/MIME capabilities Certificate Enrollment
 auth.class_id=


### PR DESCRIPTION
Some profiles cannot be used in the CA's EE pages because they require deprecated and not supported html tags. These profile are made invisible and disabled if possible.

Resolve bug  [2118662](https://bugzilla.redhat.com/show_bug.cgi?id=2118662)