### PR TITLE
Fix: Bug 2094066 - CC: missing audit event CLIENT_ACCESS_SESSION_ESTA…

### DIFF
--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -392,6 +392,7 @@ public class CMSEngine implements ServletContextListener {
 
         boolean skipPublishingCheck = config.getBoolean("cms.password.ignore.publishing.failure", true);
         String pwList = config.getString("cms.passwordlist", "internaldb,replicationdb");
+        boolean skipLdapConnTest = config.getBoolean("cms.password.skipLdapConnTest",false);
         String tags[] = StringUtils.split(pwList, ",");
         LDAPConfig ldapConfig = config.getInternalDBConfig();
         LDAPConnectionConfig connConfig = ldapConfig.getConnectionConfig();
@@ -496,6 +497,10 @@ public class CMSEngine implements ServletContextListener {
                 }
             }
 
+            if(skipLdapConnTest == true) {
+                logger.debug("CMSEngine.initializePasswordStore(): skipping ldap conn test per configuration.");
+                return;
+            }
             int iteration = 0;
             int result = PW_INVALID_CREDENTIALS;
 
@@ -1102,8 +1107,8 @@ public class CMSEngine implements ServletContextListener {
         initSubsystemListeners();
         initSecurityProvider();
         initPluginRegistry();
-        initDatabase();
         initLogSubsystem();
+        initDatabase();
         initJssSubsystem();
         initDBSubsystem();
         initUGSubsystem();


### PR DESCRIPTION
…BLISH when CS instance acting as a client and fails to connect (#4097)

This simple fix allows a testing scenario where faiiled connections attempts when the given CS subsystem is acting as a client can be viewed properly early during the subsystme's startup sequence. This is needed because the CA often attempts to make a pool of persistent SSL connections to it's ldap server. This fix solves this issue with 2 approaches.

1. We establish an undocumented test-only config setting that allows the subsystem at startup to skip the early connection test to LDAP. The reason we want to do this is because this test takes place very early in the startup sequence, well before the audit logging system or the logging system has had a chance to come up. This can result in unreported connection failures.

This can be set simply like this in the CS.cfg:

cms.password.skipLdapConnTest=true

This setting will always default to false since we only want to skip this test very rarely.

2. Slightly switch the order of startup in a subysystem by  making sure the ldap DB section is started up before the logging section. This allows any failures to establish the previously mentioned connection to be properly logged in the audit log.

audit 3.