### PR TITLE
Fix: Bz_2045101 - [RFE] kra-key-find CLI doesn't have the option to fetch keys corresponding to a specific token owner

### DIFF
--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -202,8 +202,17 @@ jobs:
           docker exec pki pki -n caadmin tps-token-show $CUID | tee output
           sed -n 's/\s*Status:\s\+\(\S\+\)\s*/\1/p' output > actual
           diff expected actual
-
+          
           docker exec pki pki -n caadmin tps-cert-find --token $CUID
+
+      - name: KRA key find
+        run: |          
+          CUID=$(cat cuid | tr [:lower:] [:upper:])
+          USER="testuser"
+          echo $CUID:$USER > expected
+          docker exec pki pki -n caadmin kra-key-find --owner $CUID:$USER | tee output
+          sed -n 's/\s*Owner:\s\+\(\S\+\)\s*/\1/p' output > actual
+          diff expected actual
 
       - name: Gather artifacts
         if: always()

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyClient.java
@@ -133,15 +133,15 @@ public class KeyClient extends Client {
      * @return a KeyInfoCollection object.
      */
     public KeyInfoCollection listKeys(String clientKeyID, String status, Integer maxSize, Integer maxTime,
-            Integer start, Integer size, String realm) throws Exception {
-        Response response = keyClient.listKeys(clientKeyID, status, maxSize, maxTime, start, size, realm);
+            Integer start, Integer size, String realm, String ownerName) throws Exception {
+        Response response = keyClient.listKeys(clientKeyID, status, maxSize, maxTime, start, size, realm, ownerName);
         return client.getEntity(response, KeyInfoCollection.class);
     }
 
     /* for backward compatibility */
     public KeyInfoCollection listKeys(String clientKeyID, String status, Integer maxSize, Integer maxTime,
-            Integer start, Integer size) throws Exception {
-        Response response = keyClient.listKeys(clientKeyID, status, maxSize, maxTime, start, size, null);
+            Integer start, Integer size, String ownerName) throws Exception {
+        Response response = keyClient.listKeys(clientKeyID, status, maxSize, maxTime, start, size, ownerName, null);
         return client.getEntity(response, KeyInfoCollection.class);
     }
 
@@ -726,7 +726,7 @@ public class KeyClient extends Client {
         byte[] nonceData = CryptoUtil.getNonceData(encryptAlgorithm.getIVLength());
         SymmetricKey sessionKey = generateSessionKey();
 	KeyWrapAlgorithm alg = KeyWrapAlgorithm.RSA;
-	
+
 	if(this.useOAEP == true) {
             alg = KeyWrapAlgorithm.RSA_OAEP;
         }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyResource.java
@@ -30,7 +30,8 @@ public interface KeyResource {
                                  @QueryParam("maxTime") Integer maxTime,
                                  @QueryParam("start") Integer start,
                                  @QueryParam("size") Integer size,
-                                 @QueryParam("realm") String realm);
+                                 @QueryParam("realm") String realm,
+                                 @QueryParam("owner") String ownerName);
 
     @GET
     @Path("active/{clientKeyID}")

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyFindCLI.java
@@ -78,6 +78,10 @@ public class KRAKeyFindCLI extends CommandCLI {
         option.setArgName("realm");
         options.addOption(option);
 
+        option = new Option(null, "owner", true, "Owner name");
+        option.setArgName("owner");
+        options.addOption(option);
+
         option = new Option(null, "output-format", true, "Output format: text (default), json");
         option.setArgName("format");
         options.addOption(option);
@@ -95,6 +99,7 @@ public class KRAKeyFindCLI extends CommandCLI {
         String clientKeyID = cmd.getOptionValue("clientKeyID");
         String status = cmd.getOptionValue("status");
         String realm = cmd.getOptionValue("realm");
+        String ownerName = cmd.getOptionValue("owner");
         String outputFormat = cmd.getOptionValue("output-format", "text");
 
         String s = cmd.getOptionValue("maxResults");
@@ -113,7 +118,7 @@ public class KRAKeyFindCLI extends CommandCLI {
         mainCLI.init();
 
         KeyClient keyClient = keyCLI.getKeyClient();
-        KeyInfoCollection keys = keyClient.listKeys(clientKeyID, status, maxResults, maxTime, start, size, realm);
+        KeyInfoCollection keys = keyClient.listKeys(clientKeyID, status, maxResults, maxTime, start, size, realm, ownerName);
 
         if ("json".equalsIgnoreCase(outputFormat)) {
             System.out.println(keys.toJSON());


### PR DESCRIPTION
Add --owner option for kra-key-find to fetch keys corresponding to a specific owner.
Fixes: 2144467, 2045101

Signed-off-by: Pritam Singh <prisingh@redhat.com>