### PR TITLE
Fix temporary SSL server key removal

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -64,14 +64,22 @@ jobs:
               -D pki_request_id_generator=random \
               -v
 
-          # set buffer size to 0 so that revocation takes effect immediately
-          docker exec pki pki-server ca-config-set auths.revocationChecking.bufferSize 0
+      - name: Check CA certs and keys
+        run: |
+          # check certs
+          docker exec pki pki-server cert-find
 
-          # enable signed audit log
-          docker exec pki pki-server ca-config-set log.instance.SignedAudit.logSigning true
+          # check keys
+          echo "Secret.123" > password.txt
+          docker cp password.txt pki:password.txt
+          docker exec pki certutil -K \
+              -d /etc/pki/pki-tomcat/alias \
+              -f password.txt | tee output
 
-          # restart CA subsystem
-          docker exec pki pki-server ca-redeploy --wait
+          # there should be no orphaned keys
+          echo "0" > expected
+          grep "(orphan)" output | wc -l > actual
+          diff expected actual
 
       - name: Check CA signing cert
         run: |
@@ -119,6 +127,17 @@ jobs:
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Update CA configuration
+        run: |
+          # set buffer size to 0 so that revocation takes effect immediately
+          docker exec pki pki-server ca-config-set auths.revocationChecking.bufferSize 0
+
+          # enable signed audit log
+          docker exec pki pki-server ca-config-set log.instance.SignedAudit.logSigning true
+
+          # restart CA subsystem
+          docker exec pki pki-server ca-redeploy --wait
 
       - name: Initialize PKI client
         run: |

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -63,6 +63,23 @@ jobs:
               -D pki_random_serial_numbers_enable=True \
               -v
 
+      - name: Check CA certs and keys
+        run: |
+          # check certs
+          docker exec pki pki-server cert-find
+
+          # check keys
+          echo "Secret.123" > password.txt
+          docker cp password.txt pki:password.txt
+          docker exec pki certutil -K \
+              -d /etc/pki/pki-tomcat/alias \
+              -f password.txt | tee output
+
+          # there should be no orphaned keys
+          echo "0" > expected
+          grep "(orphan)" output | wc -l > actual
+          diff expected actual
+
       # https://github.com/dogtagpki/pki/wiki/Configuring-CA-with-Random-Serial-Numbers-v3
       - name: Switch to RSNv3
         run: |

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -63,6 +63,23 @@ jobs:
               -D pki_request_id_generator=legacy \
               -v
 
+      - name: Check CA certs and keys
+        run: |
+          # check certs
+          docker exec pki pki-server cert-find
+
+          # check keys
+          echo "Secret.123" > password.txt
+          docker cp password.txt pki:password.txt
+          docker exec pki certutil -K \
+              -d /etc/pki/pki-tomcat/alias \
+              -f password.txt | tee output
+
+          # there should be no orphaned keys
+          echo "0" > expected
+          grep "(orphan)" output | wc -l > actual
+          diff expected actual
+
       # https://github.com/dogtagpki/pki/wiki/Configuring-CA-with-Random-Serial-Numbers-v3
       - name: Switch to RSNv3
         run: |

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -52,7 +52,7 @@ jobs:
 
           docker exec ipa pki-server cert-export ca_signing --cert-file ca_signing.crt
 
-      - name: Check DS certs
+      - name: Check DS certs and keys
         run: |
           docker exec ipa ls -la /etc/dirsrv/slapd-EXAMPLE-COM
           docker exec ipa pki -d /etc/dirsrv/slapd-EXAMPLE-COM nss-cert-find
@@ -62,11 +62,24 @@ jobs:
               -d /etc/dirsrv/slapd-EXAMPLE-COM \
               -C /etc/dirsrv/slapd-EXAMPLE-COM/pwdfile.txt \
               nss-key-find
+          docker exec ipa certutil -K \
+              -d /etc/dirsrv/slapd-EXAMPLE-COM \
+              -f /etc/dirsrv/slapd-EXAMPLE-COM/pwdfile.txt
 
-      - name: Check PKI certs
+      - name: Check PKI certs and keys
         run: |
-          docker exec ipa ls -la /etc/pki/pki-tomcat/alias
+          # check certs
           docker exec ipa pki-server cert-find
+
+          # check keys
+          docker exec ipa certutil -K \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/alias/pwdfile.txt | tee output
+
+          # there should be no orphaned keys
+          echo "0" > expected
+          grep "(orphan)" output | wc -l > actual
+          diff expected actual
 
       - name: Check CA admin cert
         run: |

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1790,14 +1790,10 @@ class PKIDeployer:
             nssdb.close()
             shutil.rmtree(tmpdir)
 
-    def remove_temp_sslserver_cert(self, instance, sslserver):
-
-        # TODO: replace with pki-server cert-import sslserver
+    def remove_temp_sslserver_cert(self, instance):
 
         nickname = self.mdict['pki_self_signed_nickname']
-        token = sslserver['token']
-
-        logger.info('Removing temp SSL server cert from internal token: %s', nickname)
+        logger.info('Removing temp SSL server cert: %s', nickname)
 
         nssdb = instance.open_nssdb(
             user=self.mdict['pki_user'],
@@ -1805,14 +1801,8 @@ class PKIDeployer:
         )
 
         try:
-            # Remove temp SSL server cert from internal token.
-            # Remove temp key too if the perm cert uses HSM.
-            if pki.nssdb.normalize_token(token):
-                remove_key = True
-            else:
-                remove_key = False
-
-            nssdb.remove_cert(nickname=nickname, remove_key=remove_key)
+            # remove temp SSL server cert and key
+            nssdb.remove_cert(nickname=nickname, remove_key=True)
 
         finally:
             nssdb.close()

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -286,7 +286,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                     timeout=deployer.request_timeout)
 
                 # Remove temp SSL server cert.
-                deployer.remove_temp_sslserver_cert(instance, system_certs['sslserver'])
+                deployer.remove_temp_sslserver_cert(instance)
 
             # Store perm SSL server cert nickname and token
             nickname = system_certs['sslserver']['nickname']


### PR DESCRIPTION
In the past `pkispawn` used the same nickname for the temporary and the permanent SSL server certs. Initially it would create the temporary cert and the key, then it would create the permanent cert with the same key, then drop the temporary cert while keeping the key.

Recently the code was changed to use separate nicknames to simplify installation which would generate separate keys too. It removed the temporary cert, but not the temporary key. Now the code has been updated to remove the temporary key as well.

Some tests have been modified to check for orphaned keys after installation.

Resolves: https://github.com/dogtagpki/pki/issues/4103