### PR TITLE
Update HSM password in tests and docs

### DIFF
--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -67,8 +67,8 @@ jobs:
               softhsm2-util \
               --init-token \
               --label HSM \
-              --so-pin Secret.123 \
-              --pin Secret.123 \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
               --free
 
           docker exec pki ls -laR /var/lib/softhsm/tokens
@@ -82,7 +82,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_ca_signing_token=HSM \
               -D pki_ocsp_signing_token=HSM \
@@ -155,7 +155,7 @@ jobs:
 
       - name: Check system certs in HSM
         run: |
-          echo Secret.123 > password.txt
+          echo Secret.HSM > password.txt
           echo "4" > expected
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -67,8 +67,8 @@ jobs:
               softhsm2-util \
               --init-token \
               --label HSM \
-              --so-pin Secret.123 \
-              --pin Secret.123 \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
               --free
 
           docker exec pki ls -laR /var/lib/softhsm/tokens
@@ -82,7 +82,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_ca_signing_token=HSM \
               -D pki_ocsp_signing_token=HSM \
@@ -124,7 +124,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_storage_token=HSM \
               -D pki_transport_token=HSM \

--- a/.github/workflows/ocsp-hsm-test.yml
+++ b/.github/workflows/ocsp-hsm-test.yml
@@ -67,8 +67,8 @@ jobs:
               softhsm2-util \
               --init-token \
               --label HSM \
-              --so-pin Secret.123 \
-              --pin Secret.123 \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
               --free
 
           docker exec pki ls -laR /var/lib/softhsm/tokens
@@ -82,7 +82,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_ca_signing_token=HSM \
               -D pki_ocsp_signing_token=HSM \
@@ -124,7 +124,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_ocsp_signing_token=HSM \
               -D pki_audit_signing_token=HSM \

--- a/.github/workflows/pki-nss-hsm-test.yml
+++ b/.github/workflows/pki-nss-hsm-test.yml
@@ -41,14 +41,14 @@ jobs:
           docker exec pki dnf install -y dnf-plugins-core softhsm
           docker exec pki softhsm2-util --init-token \
               --label HSM \
-              --so-pin Secret.123 \
-              --pin Secret.123 \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
               --free
           docker exec pki softhsm2-util --show-slots
 
           # create password.conf
           echo "internal=" > password.conf
-          echo "hardware-HSM=Secret.123" >> password.conf
+          echo "hardware-HSM=Secret.HSM" >> password.conf
 
       - name: Create key in HSM
         run: |
@@ -92,7 +92,7 @@ jobs:
 
           docker exec pki certutil -K -d /root/.dogtag/nssdb || true
 
-          echo "Secret.123" > password.txt
+          echo "Secret.HSM" > password.txt
           docker exec pki certutil -K \
               -d /root/.dogtag/nssdb \
               -f $SHARED/password.txt \

--- a/.github/workflows/pki-pkcs11-test.yml
+++ b/.github/workflows/pki-pkcs11-test.yml
@@ -41,8 +41,8 @@ jobs:
           docker exec pki dnf install -y dnf-plugins-core softhsm
           docker exec pki softhsm2-util --init-token \
               --label HSM \
-              --so-pin Secret.123 \
-              --pin Secret.123 \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
               --free
           docker exec pki softhsm2-util --show-slots
 
@@ -64,7 +64,7 @@ jobs:
       - name: Create cert in HSM
         run: |
           echo "internal=" > password.conf
-          echo "hardware-HSM=Secret.123" >> password.conf
+          echo "hardware-HSM=Secret.HSM" >> password.conf
 
           docker exec pki pki \
               --token HSM \
@@ -105,7 +105,7 @@ jobs:
           docker exec pki pki pkcs11-cert-export cert2
 
           # HSM should have cert2 only
-          echo "Secret.123" > password.txt
+          echo "Secret.HSM" > password.txt
           docker exec pki certutil -L \
               -d /root/.dogtag/nssdb \
               -h HSM \

--- a/.github/workflows/tks-hsm-test.yml
+++ b/.github/workflows/tks-hsm-test.yml
@@ -67,8 +67,8 @@ jobs:
               softhsm2-util \
               --init-token \
               --label HSM \
-              --so-pin Secret.123 \
-              --pin Secret.123 \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
               --free
 
           docker exec pki ls -laR /var/lib/softhsm/tokens
@@ -82,7 +82,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_ca_signing_token=HSM \
               -D pki_ocsp_signing_token=HSM \
@@ -124,7 +124,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -67,8 +67,8 @@ jobs:
               softhsm2-util \
               --init-token \
               --label HSM \
-              --so-pin Secret.123 \
-              --pin Secret.123 \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
               --free
 
           docker exec pki ls -laR /var/lib/softhsm/tokens
@@ -82,7 +82,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_ca_signing_token=HSM \
               -D pki_ocsp_signing_token=HSM \
@@ -124,7 +124,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_storage_token=HSM \
               -D pki_transport_token=HSM \
@@ -166,7 +166,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
@@ -204,7 +204,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
-              -D pki_token_password=Secret.123 \
+              -D pki_token_password=Secret.HSM \
               -D pki_server_database_password=Secret.123 \
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.md
@@ -23,7 +23,7 @@ pki_hsm_enable=True
 pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
 pki_hsm_modulename=softhsm
 pki_token_name=token
-pki_token_password=Secret.123
+pki_token_password=Secret.HSM
 
 [CA]
 pki_admin_email=caadmin@example.com

--- a/docs/installation/ca/Installing_CA_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_HSM.md
@@ -20,7 +20,7 @@ pki_hsm_enable=True
 pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
 pki_hsm_modulename=softhsm
 pki_token_name=token
-pki_token_password=Secret.123
+pki_token_password=Secret.HSM
 
 [CA]
 pki_admin_email=caadmin@example.com

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
@@ -23,7 +23,7 @@ pki_hsm_enable=True
 pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
 pki_hsm_modulename=softhsm
 pki_token_name=token
-pki_token_password=Secret.123
+pki_token_password=Secret.HSM
 
 [KRA]
 pki_admin_email=kraadmin@example.com

--- a/docs/installation/kra/Installing_KRA_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_with_HSM.md
@@ -20,7 +20,7 @@ pki_hsm_enable=True
 pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
 pki_hsm_modulename=softhsm
 pki_token_name=token
-pki_token_password=Secret.123
+pki_token_password=Secret.HSM
 
 [KRA]
 pki_admin_cert_file=ca_admin.cert

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
@@ -23,7 +23,7 @@ pki_hsm_enable=True
 pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
 pki_hsm_modulename=softhsm
 pki_token_name=token
-pki_token_password=Secret.123
+pki_token_password=Secret.HSM
 
 [OCSP]
 pki_admin_email=ocspadmin@example.com

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.md
@@ -20,7 +20,7 @@ pki_hsm_enable=True
 pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
 pki_hsm_modulename=softhsm
 pki_token_name=token
-pki_token_password=Secret.123
+pki_token_password=Secret.HSM
 
 [OCSP]
 pki_admin_cert_file=ca_admin.cert

--- a/docs/installation/tks/Installing_TKS_with_HSM.md
+++ b/docs/installation/tks/Installing_TKS_with_HSM.md
@@ -20,7 +20,7 @@ pki_hsm_enable=True
 pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
 pki_hsm_modulename=softhsm
 pki_token_name=token
-pki_token_password=Secret.123
+pki_token_password=Secret.HSM
 
 [TKS]
 pki_admin_cert_file=ca_admin.cert

--- a/docs/installation/tps/Installing_TPS_with_HSM.md
+++ b/docs/installation/tps/Installing_TPS_with_HSM.md
@@ -20,7 +20,7 @@ pki_hsm_enable=True
 pki_hsm_libfile=/usr/lib64/pkcs11/libsofthsm2.so
 pki_hsm_modulename=softhsm
 pki_token_name=token
-pki_token_password=Secret.123
+pki_token_password=Secret.HSM
 
 [TPS]
 pki_admin_cert_file=ca_admin.cert


### PR DESCRIPTION
The HSM password in the tests and docs has been changed to show where it is used and that it can be different from the internal NSS database password.