### PR TITLE
Restore standalone OCSP installation test

### DIFF
--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -1,0 +1,169 @@
+name: Standalone OCSP
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      db-image:
+        required: false
+        type: string
+
+jobs:
+  # https://github.com/dogtagpki/pki/wiki/Installing-Standalone-OCSP
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          path: pki-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ inputs.db-image }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Create CA signing cert
+        run: |
+          docker exec pki pki -d nssdb nss-cert-request \
+              --subject "CN=CA Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr ca_signing.csr
+          docker exec pki pki -d nssdb nss-cert-issue \
+              --csr ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert ca_signing.crt
+          docker exec pki pki -d nssdb nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+      - name: Install OCSP (step 1)
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ocsp-standalone-step1.cfg \
+              -s OCSP \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -v
+
+      - name: Issue OCSP signing cert
+        run: |
+          docker exec pki openssl req -text -noout -in ocsp_signing.csr
+          docker exec pki pki -d nssdb nss-cert-issue \
+              --issuer ca_signing \
+              --csr ocsp_signing.csr \
+              --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+              --cert ocsp_signing.crt
+          docker exec pki openssl x509 -text -noout -in ocsp_signing.crt
+
+      - name: Issue subsystem cert
+        run: |
+          docker exec pki openssl req -text -noout -in subsystem.csr
+          docker exec pki pki -d nssdb nss-cert-issue \
+              --issuer ca_signing \
+              --csr subsystem.csr \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --cert subsystem.crt
+          docker exec pki openssl x509 -text -noout -in subsystem.crt
+
+      - name: Issue SSL server cert
+        run: |
+          docker exec pki openssl req -text -noout -in sslserver.csr
+          docker exec pki pki -d nssdb nss-cert-issue \
+              --issuer ca_signing \
+              --csr sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --cert sslserver.crt
+          docker exec pki openssl x509 -text -noout -in sslserver.crt
+
+      - name: Issue OCSP audit signing cert
+        run: |
+          docker exec pki openssl req -text -noout -in ocsp_audit_signing.csr
+          docker exec pki pki -d nssdb nss-cert-issue \
+              --issuer ca_signing \
+              --csr ocsp_audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert ocsp_audit_signing.crt
+          docker exec pki openssl x509 -text -noout -in ocsp_audit_signing.crt
+
+      - name: Issue OCSP admin cert
+        run: |
+          docker exec pki openssl req -text -noout -in ocsp_admin.csr
+          docker exec pki pki -d nssdb nss-cert-issue \
+              --issuer ca_signing \
+              --csr ocsp_admin.csr \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --cert ocsp_admin.crt
+          docker exec pki openssl x509 -text -noout -in ocsp_admin.crt
+
+      - name: Install OCSP (step 2)
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ocsp-standalone-step2.cfg \
+              -s OCSP \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -v
+
+          docker exec pki pki-server cert-find
+
+      # TODO: Fix DogtagOCSPConnectivityCheck to work without CA
+      # - name: Run PKI healthcheck
+      #   run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Check admin cert
+        run: |
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec pki pki -n ocspadmin ocsp-user-show ocspadmin
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove OCSP
+        run: docker exec pki pkidestroy -i pki-tomcat -s OCSP -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ocsp-standalone-${{ inputs.os }}
+          path: |
+            /tmp/artifacts/pki

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -121,6 +121,16 @@ jobs:
       os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
+  ocsp-standalone-test:
+    name: Standalone OCSP
+    needs: [init, build]
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    uses: ./.github/workflows/ocsp-standalone-test.yml
+    with:
+      os: ${{ matrix.os }}
+      db-image: ${{ needs.init.outputs.db-image }}
+
   ocsp-crl-direct-test:
     name: OCSP with direct CRL publishing
     needs: [init, build]


### PR DESCRIPTION
Previously there was a standalone OCSP installation test, but it was converted into CRL publishing tests.

In the future it might be important to test other installation-related operations without the complexity of CRL publishing, so the original test has now been restored.