### PR TITLE
Use DS container in CI tests

### DIFF
--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh primaryds
         env:
-          IMAGE: ${{ inputs.db-image }}
+          IMAGE: pki-runner
           HOSTNAME: primaryds.example.com
           PASSWORD: Secret.123
 
@@ -149,7 +149,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh secondaryds
         env:
-          IMAGE: ${{ inputs.db-image }}
+          IMAGE: pki-runner
           HOSTNAME: secondaryds.example.com
           PASSWORD: Secret.123
 

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           tests/bin/ds-container-create.sh ds
         env:
-          IMAGE: ${{ inputs.db-image }}
+          IMAGE: pki-runner
           HOSTNAME: ds.example.com
           PASSWORD: Secret.123
 

--- a/tests/bin/ds-container-create.sh
+++ b/tests/bin/ds-container-create.sh
@@ -20,6 +20,11 @@ then
     exit 1
 fi
 
+if [ "$IMAGE" == "" ]
+then
+    IMAGE=quay.io/389ds/dirsrv
+fi
+
 create_server() {
 
     echo "Creating DS server"
@@ -94,7 +99,7 @@ dc: pki
 EOF
 }
 
-if [ "$IMAGE" == "" ]
+if [ "$IMAGE" == "pki-runner" ]
 then
     create_server
 else


### PR DESCRIPTION
The `ds-container-create.sh` has been modified such that most tests will use a DS container which is about 30-60 seconds faster to create than a regular DS server.

For now tests for secure DS connection will continue to use a regular DS server, but in the future they may be updated to use a DS container as well.