### PR TITLE
Add test for lightweight CA

### DIFF
--- a/.github/workflows/ca-lightweight-test.yml
+++ b/.github/workflows/ca-lightweight-test.yml
@@ -1,0 +1,201 @@
+name: Lightweight CA
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      db-image:
+        required: false
+        type: string
+
+jobs:
+  # docs/installation/ca/Installing_CA.md
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          path: pki-runner.tar
+
+      - name: Load runner image
+        run: docker load --input pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ inputs.db-image }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Check admin user
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Check host CA
+        run: |
+          docker exec pki pki -n caadmin ca-authority-find | tee output
+
+          # there should be 1 authority initially
+          echo "1" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          # it should be a host CA
+          echo "true" > expected
+          sed -n 's/^\s*Host authority:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          # store host CA ID
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > hostca-id
+
+      - name: Check certs and keys in NSS database
+        run: |
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-cert-find | tee output
+
+          # there should be 5 certs
+          echo "5" > expected
+          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-key-find | tee output
+
+          # there should be 5 keys
+          echo "5" > expected
+          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Create lightweight CA
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+
+          # create a LWCA under the host CA
+          docker exec pki pki -n caadmin ca-authority-create \
+              --parent $HOSTCA_ID \
+              CN="Lightweight CA" | tee output
+
+          # store LWCA ID
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > lwca-id
+
+          docker exec pki pki -n caadmin ca-authority-find | tee output
+
+          # there should be 2 authorities now
+          echo "2" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Check certs and keys in NSS database
+        run: |
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-cert-find | tee output
+
+          # there should be 6 certs now
+          echo "6" > expected
+          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-key-find | tee output
+
+          # there should be 6 keys now
+          echo "6" > expected
+          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Check enrollment against lightweight CA
+        run: |
+          LWCA_ID=$(cat lwca-id)
+
+          # submit enrollment request against LWCA
+          docker exec pki pki client-cert-request \
+              --issuer-id $LWCA_ID \
+              UID=testuser | tee output
+
+          # get request ID
+          REQUEST_ID=$(sed -n -e 's/^\s*Request ID:\s*\(.*\)$/\1/p' output)
+
+          # approve request
+          docker exec pki pki \
+              -n caadmin \
+              ca-cert-request-approve \
+              $REQUEST_ID \
+              --force | tee output
+
+          # get cert ID
+          CERT_ID=$(sed -n -e 's/^\s*Certificate ID:\s*\(.*\)$/\1/p' output)
+
+          docker exec pki pki ca-cert-show $CERT_ID | tee output
+
+          # verify that it's signed by LWCA
+          echo "CN=Lightweight CA" > expected
+          sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ca-lightweight-${{ inputs.os }}
+          path: |
+            /tmp/artifacts/pki

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -199,6 +199,16 @@ jobs:
       os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
+  ca-lightweight-test:
+    name: Lightweight CA
+    needs: [init, build]
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    uses: ./.github/workflows/ca-lightweight-test.yml
+    with:
+      os: ${{ matrix.os }}
+      db-image: ${{ needs.init.outputs.db-image }}
+
   subca-basic-test:
     name: Basic Sub-CA
     needs: [init, build]


### PR DESCRIPTION
A new test has been added to test basic lightweight CA operations. The test will install a CA, then create a lightweight CA, and perform an enrollment against it. The issued cert should be signed by the lightweight CA.