### PR TITLE
Call apt-get update before apt-get install

### DIFF
--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y install libxml2-utils
 
       - name: Clone repository

--- a/.github/workflows/update-version-test.yml
+++ b/.github/workflows/update-version-test.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Setup git
         run: |
+          sudo apt-get update
           sudo apt-get -y install git
           git config --global user.name "Dr. John Doe"
           git config --global user.email jdoe@example.com


### PR DESCRIPTION
Some tests were failing during `apt-get install`:

```
$ sudo apt-get -y install libxml2-utils
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  libxml2-utils
0 upgraded, 1 newly installed, 0 to remove and 9 not upgraded. Need to get 40.2 kB of archives.
After this operation, 206 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libxml2-utils amd64 2.9.13+dfsg-1ubuntu0.1
Err:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libxml2-utils amd64 2.9.13+dfsg-1ubuntu0.1
  404  Not Found [IP: 52.147.219.192 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2-utils_2.9.13%2bdfsg-1ubuntu0.1_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

The tests have been updated to call `apt-get update` first.