### PR TITLE
Update tests and docs to use pki pkcs12-import

### DIFF
--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Test CA admin
         run: |
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           docker exec primary pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec primary pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec primary pki client-cert-import \
+          docker exec primary pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec primary pki -n caadmin ca-user-find
@@ -255,7 +255,7 @@ jobs:
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec secondary pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec secondary pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec secondary pki client-cert-import \
+          docker exec secondary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin ca-user-find

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           docker exec primary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
           docker exec primary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec primary pki client-cert-import \
+          docker exec primary pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec primary pki -n caadmin ca-user-find
@@ -121,7 +121,7 @@ jobs:
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec secondary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec secondary pki client-cert-import \
+          docker exec secondary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin ca-user-find
@@ -172,7 +172,7 @@ jobs:
       - name: Verify users and SD hosts in tertiary PKI container
         run: |
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec tertiary pki client-cert-import \
+          docker exec tertiary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin ca-user-find

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -237,7 +237,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -220,7 +220,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-lightweight-test.yml
+++ b/.github/workflows/ca-lightweight-test.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-pruning-test.yml
+++ b/.github/workflows/ca-pruning-test.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/ca-shared-token-test.yml
+++ b/.github/workflows/ca-shared-token-test.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/est-basic-test.yml
+++ b/.github/workflows/est-basic-test.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           docker exec ipa pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec ipa pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec ipa pki client-cert-import \
+          docker exec ipa pki pkcs12-import \
               --pkcs12 /root/ca-agent.p12 \
               --pkcs12-password Secret.123
           docker exec ipa pki -n ipa-ca-agent ca-user-show admin

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -89,7 +89,7 @@ jobs:
       - name: "Check CA admin PKCS #12 file"
         run: |
           docker exec ipa pki client-cert-import --ca-cert ca_signing.crt ca_signing
-          docker exec ipa pki client-cert-import \
+          docker exec ipa pki pkcs12-import \
               --pkcs12 /root/ca-agent.p12 \
               --pkcs12-password Secret.123
           docker exec ipa pki nss-cert-find
@@ -114,7 +114,7 @@ jobs:
               -out ra-agent.p12 \
               -passout pass:Secret.123 \
               -name ipa-ra-agent
-          docker exec ipa pki client-cert-import \
+          docker exec ipa pki pkcs12-import \
               --pkcs12 ra-agent.p12 \
               --pkcs12-password Secret.123
           docker exec ipa pki nss-cert-find

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -112,7 +112,9 @@ jobs:
           docker exec primary cp /root/ca-agent.p12 ${SHARED}/ca-agent.p12
           docker exec secondary pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec secondary pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec secondary pki client-cert-import --pkcs12 ${SHARED}/ca-agent.p12 --pkcs12-password Secret.123
+          docker exec secondary pki pkcs12-import \
+              --pkcs12 ${SHARED}/ca-agent.p12 \
+              --pkcs12-password Secret.123
           docker exec secondary pki -n ipa-ca-agent ca-user-show admin
 
       - name: Remove IPA server from secondary container

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin kra-user-show kraadmin

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec secondary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec secondary pki client-cert-import \
+          docker exec secondary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin kra-user-show kraadmin
@@ -201,7 +201,7 @@ jobs:
       - name: Verify KRA admin in tertiary PKI container
         run: |
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec tertiary pki client-cert-import \
+          docker exec tertiary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin kra-user-show kraadmin

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           docker exec ca pki-server cert-export ca_signing --cert-file $SHARED/ca_signing.crt
           docker exec ca pki client-cert-import ca_signing --ca-cert $SHARED/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
@@ -298,7 +298,7 @@ jobs:
       - name: Verify KRA admin
         run: |
           docker exec kra pki client-cert-import ca_signing --ca-cert $SHARED/ca_signing.crt
-          docker exec kra pki client-cert-import \
+          docker exec kra pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/kra_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec kra pki -n kraadmin kra-user-show kraadmin

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           docker exec ca pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
@@ -193,7 +193,7 @@ jobs:
       - name: Verify KRA admin
         run: |
           docker exec kra pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec kra pki client-cert-import \
+          docker exec kra pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/kra_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec kra pki -n kraadmin kra-user-show kraadmin

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin kra-user-show kraadmin

--- a/.github/workflows/kra-rsnv3-test.yml
+++ b/.github/workflows/kra-rsnv3-test.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin kra-user-show kraadmin

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           docker exec ca cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec kra pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec kra pki client-cert-import \
+          docker exec kra pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec kra pki -n caadmin --ignore-banner kra-user-show kraadmin
@@ -127,7 +127,7 @@ jobs:
       - name: Verify KRA connector in CA
         run: |
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Verify admin user
         run: |
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/kra_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n kraadmin kra-user-show kraadmin

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec secondary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec secondary pki client-cert-import \
+          docker exec secondary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin ocsp-user-show ocspadmin
@@ -204,7 +204,7 @@ jobs:
       - name: Verify OCSP admin in tertiary PKI container
         run: |
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec tertiary pki client-cert-import \
+          docker exec tertiary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin ocsp-user-show ocspadmin

--- a/.github/workflows/ocsp-cmc-test.yml
+++ b/.github/workflows/ocsp-cmc-test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           docker exec ca pki-server cert-export ca_signing --cert-file $SHARED/ca_signing.crt
           docker exec ca pki client-cert-import ca_signing --ca-cert $SHARED/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
@@ -266,7 +266,7 @@ jobs:
       - name: Verify OCSP admin
         run: |
           docker exec ocsp pki client-cert-import ca_signing --ca-cert $SHARED/ca_signing.crt
-          docker exec ocsp pki client-cert-import \
+          docker exec ocsp pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec ocsp pki -n ocspadmin ocsp-user-show ocspadmin

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           docker exec ca pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
@@ -192,7 +192,7 @@ jobs:
       - name: Install OCSP admin cert in OCSP container
         run: |
           docker exec ocsp pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ocsp pki client-cert-import \
+          docker exec ocsp pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec ocsp pki -n ocspadmin ocsp-user-show ocspadmin

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           docker exec ca pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
@@ -193,7 +193,7 @@ jobs:
       - name: Install OCSP admin cert in OCSP container
         run: |
           docker exec ocsp pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ocsp pki client-cert-import \
+          docker exec ocsp pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec ocsp pki -n ocspadmin ocsp-user-show ocspadmin

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           docker exec ca pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
@@ -187,7 +187,7 @@ jobs:
       - name: Verify OCSP admin
         run: |
           docker exec ocsp pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ocsp pki client-cert-import \
+          docker exec ocsp pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec ocsp pki -n ocspadmin ocsp-user-show ocspadmin

--- a/.github/workflows/ocsp-hsm-test.yml
+++ b/.github/workflows/ocsp-hsm-test.yml
@@ -205,7 +205,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ocsp-user-show ocspadmin

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           docker exec ca cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec ocsp pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ocsp pki client-cert-import \
+          docker exec ocsp pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec ocsp pki -n caadmin --ignore-banner ocsp-user-show ocspadmin

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Check admin cert
         run: |
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n ocspadmin ocsp-user-show ocspadmin

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Verify CA admin
         run: |
           docker exec subordinate pki client-cert-import ca_signing --ca-cert ${SHARED}/root-ca_signing.crt
-          docker exec subordinate pki client-cert-import \
+          docker exec subordinate pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec subordinate pki -n caadmin --ignore-banner ca-user-show caadmin

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           docker exec root pki-server cert-export ca_signing --cert-file $SHARED/root-ca_signing.crt
           docker exec root pki client-cert-import ca_signing --ca-cert $SHARED/root-ca_signing.crt
-          docker exec root pki client-cert-import \
+          docker exec root pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec root pki -n caadmin ca-user-show caadmin
@@ -195,7 +195,7 @@ jobs:
       - name: Verify subordinate CA admin cert
         run: |
           docker exec subordinate pki client-cert-import ca_signing --ca-cert $SHARED/ca_signing.p7b
-          docker exec subordinate pki client-cert-import \
+          docker exec subordinate pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec subordinate pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Verify CA admin
         run: |
           docker exec pki pki client-cert-import ca_signing --ca-cert root-ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/subca-hsm-test.yml
+++ b/.github/workflows/subca-hsm-test.yml
@@ -275,7 +275,7 @@ jobs:
       - name: Check CA admin cert
         run: |
           docker exec pki pki client-cert-import ca_signing --ca-cert root-ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin ca-user-show caadmin

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin tks-user-show tksadmin

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec secondary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec secondary pki client-cert-import \
+          docker exec secondary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin tks-user-show tksadmin
@@ -206,7 +206,7 @@ jobs:
       - name: Verify TKS admin in tertiary PKI container
         run: |
           docker exec tertiary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec tertiary pki client-cert-import \
+          docker exec tertiary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec tertiary pki -n caadmin tks-user-show tksadmin

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           docker exec ca pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
@@ -173,7 +173,7 @@ jobs:
       - name: Verify TKS admin
         run: |
           docker exec tks pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec tks pki client-cert-import \
+          docker exec tks pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/tks_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec tks pki -n tksadmin tks-user-show tksadmin

--- a/.github/workflows/tks-hsm-test.yml
+++ b/.github/workflows/tks-hsm-test.yml
@@ -182,7 +182,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin tks-user-show tksadmin

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           docker exec ca cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec tks pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec tks pki client-cert-import \
+          docker exec tks pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec tks pki -n caadmin --ignore-banner tks-user-show tksadmin

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin tps-user-show tpsadmin

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -202,7 +202,7 @@ jobs:
         run: |
           docker exec primary cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec secondary pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec secondary pki client-cert-import \
+          docker exec secondary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec secondary pki -n caadmin tps-user-show tpsadmin

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           docker exec ca pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
           docker exec ca pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ca pki client-cert-import \
+          docker exec ca pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
@@ -256,7 +256,7 @@ jobs:
       - name: Check TPS admin
         run: |
           docker exec tps pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec tps pki client-cert-import \
+          docker exec tps pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/tps_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec tps pki -n tpsadmin tps-user-show tpsadmin

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -264,7 +264,7 @@ jobs:
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-          docker exec pki pki client-cert-import \
+          docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec pki pki -n caadmin tps-user-show tpsadmin

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           docker exec ca cp /root/.dogtag/pki-tomcat/ca_admin_cert.p12 ${SHARED}/ca_admin_cert.p12
           docker exec tps pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec tps pki client-cert-import \
+          docker exec tps pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
           docker exec tps pki -n caadmin --ignore-banner tps-user-show tpsadmin

--- a/docs/installation/ca/Installing_CA.md
+++ b/docs/installation/ca/Installing_CA.md
@@ -89,7 +89,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_Clone.md
+++ b/docs/installation/ca/Installing_CA_Clone.md
@@ -138,7 +138,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.md
@@ -112,7 +112,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import the master's admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.md
@@ -160,7 +160,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
+++ b/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
@@ -147,7 +147,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_with_ECC.md
+++ b/docs/installation/ca/Installing_CA_with_ECC.md
@@ -101,7 +101,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
@@ -177,7 +177,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.md
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.md
@@ -133,7 +133,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
+++ b/docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
@@ -117,7 +117,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_HSM.md
@@ -102,7 +102,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
+++ b/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
@@ -116,7 +116,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ca/Installing_Subordinate_CA.md
+++ b/docs/installation/ca/Installing_Subordinate_CA.md
@@ -69,7 +69,7 @@ $ pki client-cert-import ca_signing --ca-cert root-ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA.md
+++ b/docs/installation/kra/Installing_KRA.md
@@ -66,7 +66,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA_Clone.md
+++ b/docs/installation/kra/Installing_KRA_Clone.md
@@ -116,7 +116,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
@@ -112,7 +112,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA_on_Separate_Instance.md
+++ b/docs/installation/kra/Installing_KRA_on_Separate_Instance.md
@@ -70,7 +70,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import CA admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
+++ b/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
@@ -168,7 +168,7 @@ $ pki -c Secret.123 client-cert-import --ca-cert ca_signing.crt
 Import the admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/kra_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA_with_ECC.md
+++ b/docs/installation/kra/Installing_KRA_with_ECC.md
@@ -120,7 +120,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA_with_External_Certificates.md
+++ b/docs/installation/kra/Installing_KRA_with_External_Certificates.md
@@ -115,7 +115,7 @@ $ pki -c Secret.123 client-cert-import --ca-cert ca_signing.crt
 Import the admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/kra_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_with_HSM.md
@@ -105,7 +105,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
@@ -117,7 +117,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/kra/Installing_Standalone_KRA.adoc
+++ b/docs/installation/kra/Installing_Standalone_KRA.adoc
@@ -87,7 +87,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ----
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 kra_admin_cert.p12 \
     --pkcs12-password Secret.123
 ----

--- a/docs/installation/ocsp/Installing_OCSP.md
+++ b/docs/installation/ocsp/Installing_OCSP.md
@@ -65,7 +65,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ocsp/Installing_OCSP_Clone.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone.md
@@ -113,7 +113,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
@@ -109,7 +109,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
@@ -161,7 +161,7 @@ $ pki -c Secret.123 client-cert-import --ca-cert ca_signing.crt
 Import the admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ocsp/Installing_OCSP_with_ECC.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_ECC.md
@@ -112,7 +112,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
@@ -112,7 +112,7 @@ $ pki -c Secret.123 client-cert-import --ca-cert ca_signing.crt
 Import the admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.md
@@ -103,7 +103,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
@@ -115,7 +115,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/ocsp/Installing_Standalone_OCSP.adoc
+++ b/docs/installation/ocsp/Installing_Standalone_OCSP.adoc
@@ -85,7 +85,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ----
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ocsp_admin_cert.p12 \
     --pkcs12-password Secret.123
 ----

--- a/docs/installation/tks/Installing_TKS.md
+++ b/docs/installation/tks/Installing_TKS.md
@@ -64,7 +64,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/tks/Installing_TKS_Clone.md
+++ b/docs/installation/tks/Installing_TKS_Clone.md
@@ -110,7 +110,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/tks/Installing_TKS_with_ECC.md
+++ b/docs/installation/tks/Installing_TKS_with_ECC.md
@@ -108,7 +108,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/tks/Installing_TKS_with_HSM.md
+++ b/docs/installation/tks/Installing_TKS_with_HSM.md
@@ -101,7 +101,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
@@ -113,7 +113,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/tps/Installing_TPS.md
+++ b/docs/installation/tps/Installing_TPS.md
@@ -64,7 +64,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/tps/Installing_TPS_Clone.md
+++ b/docs/installation/tps/Installing_TPS_Clone.md
@@ -111,7 +111,7 @@ $ pki client-cert-import ca_signing --ca-cert ca_signing.crt
 Finally, import admin certificate and key with the following command:
 
 ```
-$ pki client-cert-import \
+$ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/tps/Installing_TPS_with_HSM.md
+++ b/docs/installation/tps/Installing_TPS_with_HSM.md
@@ -101,7 +101,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
@@ -113,7 +113,7 @@ $ pki -c Secret.123 client-cert-import ca_signing --ca-cert ca_signing.crt
 Import admin key and certificate:
 
 ```
-$ pki -c Secret.123 client-cert-import \
+$ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
     --pkcs12-password Secret.123
 ```

--- a/tests/bin/ds-container-certs-import.sh
+++ b/tests/bin/ds-container-certs-import.sh
@@ -29,11 +29,12 @@ import_certs_into_server() {
 
     docker cp $INPUT $NAME:certs.p12
 
-    docker exec $NAME pk12util \
+    docker exec $NAME pki \
         -d /etc/dirsrv/slapd-localhost \
-        -k /etc/dirsrv/slapd-localhost/pwdfile.txt \
-        -i certs.p12 \
-        -W Secret.123
+        -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+        pkcs12-import \
+        --pkcs12 certs.p12 \
+        --pkcs12-password Secret.123
 
     echo "Configuring trust flags"
 


### PR DESCRIPTION
The tests and docs have been updated to import PKCS #12 files using `pki pkcs12-import` (which uses JSS) instead of using `pki client-cert-import` (which uses `pk12util`).