### PR TITLE
Consolidate build jobs

### DIFF
--- a/.github/workflows/PKICertImport-test.yml
+++ b/.github/workflows/PKICertImport-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-acme-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -21,22 +21,22 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-acme-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
-      - name: Retrieve server image
+      - name: Retrieve pki-acme image
         uses: actions/cache@v3
         with:
-          key: pki-acme-server-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-acme-${{ inputs.os }}-${{ github.sha }}
           path: pki-acme.tar
 
-      - name: Load ACME image
+      - name: Load pki-acme image
         run: docker load --input pki-acme.tar
 
       - name: Create network

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-acme-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -8,86 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-acme-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
-
-      - name: Build server image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-acme
-          target: pki-acme
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-acme.tar
-
-      - name: Store server image
-        uses: actions/cache@v3
-        with:
-          key: pki-acme-server-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-acme.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   acme-certbot-test:
     name: ACME with certbot

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,24 +1,6 @@
 name: Build PKI
-on:
-  workflow_call:
-    inputs:
-      key_container:
-        required: true
-        type: string
-    secrets:
-      BASE64_MATRIX:
-        required: false
-      BASE64_REPO:
-        required: false
-      BASE64_DATABASE:
-        required: false
-    outputs:
-      matrix:
-        value: ${{ jobs.init.outputs.matrix }}
-      repo:
-        value: ${{ jobs.init.outputs.repo }}
-      db-image:
-        value: ${{ jobs.init.outputs.db-image }}
+
+on: [push, pull_request]
 
 jobs:
   init:
@@ -71,7 +53,25 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
         if: steps.cache-buildx.outputs.cache-hit != 'true'
 
-      - name: Build runner image
+      - name: Build pki-builder image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-builder
+          target: pki-builder
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=pki-builder.tar
+
+      - name: Store pki-builder image
+        uses: actions/cache@v3
+        with:
+          key: pki-builder-${{ matrix.os }}-${{ github.sha }}
+          path: pki-builder.tar
+
+      - name: Build pki-runner image
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -83,8 +83,80 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
-      - name: Store runner image
+      - name: Store pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-${{ inputs.key_container }}-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
           path: pki-runner.tar
+
+      - name: Build pki-server image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-server
+          target: pki-server
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=pki-server.tar
+
+      - name: Store pki-server image
+        uses: actions/cache@v3
+        with:
+          key: pki-server-${{ matrix.os }}-${{ github.sha }}
+          path: pki-server.tar
+
+      - name: Build pki-ca image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-ca
+          target: pki-ca
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=pki-ca.tar
+
+      - name: Store pki-ca image
+        uses: actions/cache@v3
+        with:
+          key: pki-ca-${{ matrix.os }}-${{ github.sha }}
+          path: pki-ca.tar
+
+      - name: Build pki-acme image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-acme
+          target: pki-acme
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=pki-acme.tar
+
+      - name: Store pki-acme image
+        uses: actions/cache@v3
+        with:
+          key: pki-acme-${{ matrix.os }}-${{ github.sha }}
+          path: pki-acme.tar
+
+      - name: Build ipa-runner image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            OS_VERSION=${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: ipa-runner
+          target: ipa-runner
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=ipa-runner.tar
+
+      - name: Store ipa-runner image
+        uses: actions/cache@v3
+        with:
+          key: ipa-runner-${{ matrix.os }}-${{ github.sha }}
+          path: ipa-runner.tar

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -21,22 +21,22 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
-      - name: Retrieve server image
+      - name: Retrieve pki-ca image
         uses: actions/cache@v3
         with:
-          key: pki-ca-server-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-ca-${{ inputs.os }}-${{ github.sha }}
           path: pki-ca.tar
 
-      - name: Load CA image
+      - name: Load pki-ca image
         run: docker load --input pki-ca.tar
 
       - name: Create network

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-lightweight-hsm-test.yml
+++ b/.github/workflows/ca-lightweight-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-lightweight-test.yml
+++ b/.github/workflows/ca-lightweight-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-pruning-test.yml
+++ b/.github/workflows/ca-pruning-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-shared-token-test.yml
+++ b/.github/workflows/ca-shared-token-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -8,86 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
-
-      - name: Build server image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-ca
-          target: pki-ca
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-ca.tar
-
-      - name: Store server image
-        uses: actions/cache@v3
-        with:
-          key: pki-ca-server-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-ca.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   ca-basic-test:
     name: Basic CA

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-ca-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   ca-clone-test:
     name: CA clone

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -2,34 +2,57 @@ name: Code Analysis
 on: [push, pull_request]
 
 jobs:
-  call-build-workflow:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/build.yml
-    with:
-      key_container: sonar
+  init:
+    name: Initialization
+    uses: ./.github/workflows/init.yml
     secrets: inherit
 
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    name: Waiting for build
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
+
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   sonarcloud:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     name: Sonar Cloud code analysis
-    needs: call-build-workflow
+    needs: [init, build]
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
     strategy:
-      matrix: ${{ fromJSON(needs.call-build-workflow.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-sonar-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up PKI container

--- a/.github/workflows/est-basic-test.yml
+++ b/.github/workflows/est-basic-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-est-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/est-tests.yml
+++ b/.github/workflows/est-tests.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-est-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   est-basic-test:
     name: Basic EST

--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve ipa-runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: ipa-runner-${{ inputs.os }}-${{ github.sha }}
           path: ipa-runner.tar
 
-      - name: Load runner image
+      - name: Load ipa-runner image
         run: docker load --input ipa-runner.tar
 
       - name: Create network

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve ipa-runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: ipa-runner-${{ inputs.os }}-${{ github.sha }}
           path: ipa-runner.tar
 
-      - name: Load runner image
+      - name: Load ipa-runner image
         run: docker load --input ipa-runner.tar
 
       - name: Run IPA container

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve ipa-runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: ipa-runner-${{ inputs.os }}-${{ github.sha }}
           path: ipa-runner.tar
 
-      - name: Load runner image
+      - name: Load ipa-runner image
         run: docker load --input ipa-runner.tar
 
       - name: Create network

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone the repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: ipa-runner
-          target: ipa-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=ipa-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: ipa-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: ipa-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   ipa-basic-test:
     name: Basic IPA

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/kra-rsnv3-test.yml
+++ b/.github/workflows/kra-rsnv3-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-kra-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   kra-basic-test:
     name: Basic KRA

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-cmc-test.yml
+++ b/.github/workflows/ocsp-cmc-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-hsm-test.yml
+++ b/.github/workflows/ocsp-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ocsp-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-ocsp-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   ocsp-basic-test:
     name: Basic OCSP

--- a/.github/workflows/pki-nss-aes-test.yml
+++ b/.github/workflows/pki-nss-aes-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/pki-nss-ecc-test.yml
+++ b/.github/workflows/pki-nss-ecc-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/pki-nss-exts-test.yml
+++ b/.github/workflows/pki-nss-exts-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/pki-nss-hsm-test.yml
+++ b/.github/workflows/pki-nss-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/pki-nss-rsa-test.yml
+++ b/.github/workflows/pki-nss-rsa-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/pki-pkcs11-test.yml
+++ b/.github/workflows/pki-pkcs11-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/pki-pkcs12-test.yml
+++ b/.github/workflows/pki-pkcs12-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/pki-pkcs7-test.yml
+++ b/.github/workflows/pki-pkcs7-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tools-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Set up runner container

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-python-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   lint-test:
     name: Running Python lint
@@ -83,13 +45,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-python-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name:  pki-runner imagemage
         run: docker load --input pki-runner.tar
 
       - name: Run container

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: qe-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   # Tier 0
   installation-sanity-test:
@@ -93,13 +55,13 @@ jobs:
           pip3 install -r tests/dogtag/pytest-ansible/requirements.txt
           pip3 install -e tests/dogtag/pytest-ansible
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: qe-runner-${{ matrix.os }}-${{ github.run_id }}
+          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Run master container

--- a/.github/workflows/rpminspect-test.yml
+++ b/.github/workflows/rpminspect-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve builder image
+      - name: Retrieve pki-builder image
         uses: actions/cache@v3
         with:
-          key: pki-tools-builder-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-builder-${{ inputs.os }}-${{ github.sha }}
           path: pki-builder.tar
 
-      - name: Load builder image
+      - name: Load pki-builder image
         run: docker load --input pki-builder.tar
 
       - name: Set up builder container

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name:  pki-runner imagemage
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -20,22 +20,22 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
-      - name: Retrieve server image
+      - name: Retrieve pki-server image
         uses: actions/cache@v3
         with:
-          key: pki-server-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-server-${{ inputs.os }}-${{ github.sha }}
           path: pki-server.tar
 
-      - name: Load server image
+      - name: Load pki-server image
         run: docker load --input pki-server.tar
 
       - name: Create network

--- a/.github/workflows/server-https-jks-test.yml
+++ b/.github/workflows/server-https-jks-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/server-https-pem-test.yml
+++ b/.github/workflows/server-https-pem-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/server-https-pkcs12-test.yml
+++ b/.github/workflows/server-https-pkcs12-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -8,86 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
-
-      - name: Build server image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-server
-          target: pki-server
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-server.tar
-
-      - name: Store server image
-        uses: actions/cache@v3
-        with:
-          key: pki-server-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-server.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   server-basic-test:
     name: Basic server

--- a/.github/workflows/server-upgrade-test.yml
+++ b/.github/workflows/server-upgrade-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -74,7 +74,7 @@ jobs:
     secrets: inherit
 
   build:
-    name: Building PKI
+    name: Building PKI for Sonar
     needs: [init, retrieve-pr]
     runs-on: ubuntu-latest
     strategy:
@@ -130,7 +130,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
         if: steps.cache-buildx.outputs.cache-hit != 'true'
 
-      - name: Build runner image
+      - name: Build pki-runner image
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -142,7 +142,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker,dest=pki-runner.tar
 
-      - name: Store runner image
+      - name: Store pki-runner image
         uses: actions/cache@v3
         with:
           key: pki-sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
@@ -158,13 +158,13 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
           key: pki-sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Checkout pulled branch

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/subca-hsm-test.yml
+++ b/.github/workflows/subca-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-ca-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name:  pki-runner imagemage
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tks-hsm-test.yml
+++ b/.github/workflows/tks-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tks-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-tks-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   tks-basic-test:
     name: Basic TKS

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -8,86 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build builder image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder
-          target: pki-builder
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-builder.tar
-
-      - name: Store builder image
-        uses: actions/cache@v3
-        with:
-          key: pki-tools-builder-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-builder.tar
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-tools-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   PKICertImport-test:
     name: PKICertImport

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve runner image
+      - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-tps-runner-${{ inputs.os }}-${{ github.run_id }}
+          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
           path: pki-runner.tar
 
-      - name: Load runner image
+      - name: Load pki-runner image
         run: docker load --input pki-runner.tar
 
       - name: Create network

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -8,68 +8,30 @@ jobs:
     uses: ./.github/workflows/init.yml
     secrets: inherit
 
-  # docs/development/Building_PKI.md
   build:
-    name: Building PKI
+    name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
-          path: /tmp/.buildx-cache
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
 
-      - name: Build pki-deps image
-        uses: docker/build-push-action@v3
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-deps
-          target: pki-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build pki-builder-deps image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-builder-deps
-          target: pki-builder-deps
-          cache-to: type=local,dest=/tmp/.buildx-cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-
-      - name: Build runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            OS_VERSION=${{ matrix.os }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: pki-runner
-          target: pki-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-tps-runner-${{ matrix.os }}-${{ github.run_id }}
-          path: pki-runner.tar
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI (${{ matrix.os }})'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
 
   tps-basic-test:
     name: Basic TPS


### PR DESCRIPTION
The build jobs in all workflows (except in `sonarcloud-pull.yml`) have been consolidated into `build.yml` such that the build will be created just once by the build workflow, and the test workflows will use the same build once it's completed.

https://github.com/lewagon/wait-on-check-action