### PR TITLE
Add publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish PKI
+
+on:
+  workflow_run:
+    workflows: [ 'Build PKI' ]
+    branches:
+      - master
+    types:
+      - completed
+
+jobs:
+  init:
+    name: Initialization
+    uses: ./.github/workflows/init.yml
+    secrets: inherit
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
+
+  publish:
+    name: Publishing PKI
+    needs: init
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retrieve pki-builder image
+        uses: actions/cache@v3
+        with:
+          key: pki-builder-${{ matrix.os }}-${{ github.sha }}
+          path: pki-builder.tar
+
+      - name: Publish pki-builder image
+        run: |
+          docker load --input pki-builder.tar
+          docker tag pki-builder ghcr.io/${{ github.repository_owner }}/pki-builder
+          docker push ghcr.io/${{ github.repository_owner }}/pki-builder
+
+      - name: Retrieve pki-runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
+          path: pki-runner.tar
+
+      - name: Publish pki-runner image
+        run: |
+          docker load --input pki-runner.tar
+          docker tag pki-runner ghcr.io/${{ github.repository_owner }}/pki-runner
+          docker push ghcr.io/${{ github.repository_owner }}/pki-runner


### PR DESCRIPTION
A new job has been added to publish PKI images to GH Packages after the build job in the master branch is complete.

In my repo the publish job worked like this:
https://github.com/edewata/pki/actions/runs/3729592479

and published the following packages:
https://github.com/edewata?tab=packages&repo_name=pki