### PR TITLE
[v11.3] Fix: Bug 2122409 - pki-tomcat/kra unable to decrypt when using RSA-OAEP padding in RHEL9 with FIPS enabled

### DIFF
--- a/.github/workflows/kra-oaep-test.yml
+++ b/.github/workflows/kra-oaep-test.yml
@@ -1,0 +1,165 @@
+name: Basic KRA with RSA OAEP padding
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      db-image:
+        required: false
+        type: string
+
+jobs:
+  # docs/installation/kra/Installing_KRA.md
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve pki-runner image
+        uses: actions/cache@v3
+        with:
+          key: pki-kra-runner-${{ inputs.os }}-${{ github.run_id }}
+          path: pki-runner.tar
+
+      - name: Load pki-runner image
+        run: docker load --input pki-runner.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ inputs.db-image }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA without RSA_OAEP
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_request_id_generator=random \
+              -v
+
+          docker exec pki pki-server cert-find
+
+      - name: Verify oaep is not configured in CA
+        run: |
+          [[ -z `docker exec pki pki-server ca-config-show keyWrap.useOAEP` ]]
+
+      - name: Install KRA without RSA_OAEP
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra.cfg \
+              -s KRA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Verify oaep is not configured in KRA
+        run: |
+          [[ -z `docker exec pki pki-server kra-config-show keyWrap.useOAEP` ]]
+
+      - name: Remove pki instance
+        run: |
+          docker exec pki pki-server stop --wait
+          docker exec pki pki-server remove
+          
+      - name: Install CA with RSA_OAEP
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_use_oaep_rsa_keywrap=True \
+              -D pki_request_id_generator=random \
+              -v
+
+          docker exec pki pki-server cert-find
+
+      - name: Verify oaep is configured in CA
+        run: |
+          [[ `docker exec pki pki-server ca-config-show keyWrap.useOAEP` = "true" ]]
+
+      - name: Install KRA with RSA_OAEP
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra.cfg \
+              -s KRA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_use_oaep_rsa_keywrap=True \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Verify oaep is configured in KRA
+        run: |
+          [[ `docker exec pki pki-server kra-config-show keyWrap.useOAEP` = "true" ]]
+              
+      - name: Verify CAInfo
+        run: |
+          docker exec pki curl -k https://pki.example.com:8443/ca/rest/info > info
+          echo -n '{"ArchivalMechanism":"keywrap","EncryptionAlgorithm":"AES/CBC/PKCS5Padding","KeyWrapAlgorithm":"AES KeyWrap/Padding","RsaPublicKeyWrapAlgorithm":"RSA_OAEP","CaRsaPublicKeyWrapAlgorithm":"RSA_OAEP","Attributes":{"Attribute":[]}}' > expectedInfo
+          diff expectedInfo info
+            
+      - name: Verify KRAInfo
+        run: |
+          docker exec pki curl -k https://pki.example.com:8443/kra/rest/info > info
+          echo -n '{"ArchivalMechanism":"keywrap","RecoveryMechanism":"keywrap","EncryptionAlgorithm":"AES/CBC/PKCS5Padding","WrapAlgorithm":"AES KeyWrap/Padding","RsaPublicKeyWrapAlgorithm":"RSA_OAEP","Attributes":{"Attribute":[]}}' > expectedInfo
+          diff expectedInfo info
+            
+      - name: Run PKI healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Verify KRA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+          docker exec pki pki -n caadmin kra-user-show kraadmin
+
+      - name: Verify KRA connector in CA
+        run: |
+          docker exec pki pki -n caadmin ca-kraconnector-show | tee output
+          sed -n 's/\s*Host:\s\+\(\S\+\):.*/\1/p' output > actual
+          echo pki.example.com > expected
+          diff expected actual
+
+      - name: Verify cert key archival
+        run: |
+          docker exec -e CRMFPopClient_Extra pki /usr/share/pki/tests/kra/bin/test-cert-key-archival.sh
+        env:
+          CRMFPopClient_Extra: -oaep
+
+      - name: Remove KRA
+        run: docker exec pki pkidestroy -i pki-tomcat -s KRA -v
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -81,6 +81,16 @@ jobs:
       os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
+  kra-oaep-test:
+    name: KRA with RSA OAEP padding
+    needs: [init, build]
+    strategy:
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    uses: ./.github/workflows/kra-oaep-test.yml
+    with:
+      os: ${{ matrix.os }}
+      db-image: ${{ needs.init.outputs.db-image }}
+
   kra-separate-test:
     name: KRA on separate instance
     needs: [init, build]

--- a/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
@@ -78,6 +78,8 @@ public class CAInfoService extends PKIService implements CAInfoResource {
     private static String archivalMechanism = CAInfo.KEYWRAP_MECHANISM;
     private static String encryptAlgorithm;
     private static String keyWrapAlgorithm;
+    private static String rsaPublicKeyWrapAlgorithm;
+    private static String caRsaPublicKeyWrapAlgorithm;
 
     @Override
     public Response getInfo() throws Exception {
@@ -88,6 +90,7 @@ public class CAInfoService extends PKIService implements CAInfoResource {
         CAInfo info = new CAInfo();
 
         addKRAInfo(info);
+        info.setCaRsaPublicKeyWrapAlgorithm(caRsaPublicKeyWrapAlgorithm);
 
         return createOKResponse(info);
     }
@@ -122,6 +125,7 @@ public class CAInfoService extends PKIService implements CAInfoResource {
             info.setArchivalMechanism(archivalMechanism);
             info.setEncryptAlgorithm(encryptAlgorithm);
             info.setKeyWrapAlgorithm(keyWrapAlgorithm);
+            info.setRsaPublicKeyWrapAlgorithm(rsaPublicKeyWrapAlgorithm);
         }
     }
 
@@ -138,6 +142,8 @@ public class CAInfoService extends PKIService implements CAInfoResource {
             archivalMechanism = kraInfo.getArchivalMechanism();
             encryptAlgorithm = kraInfo.getEncryptAlgorithm();
             keyWrapAlgorithm = kraInfo.getWrapAlgorithm();
+            rsaPublicKeyWrapAlgorithm = kraInfo.getRsaPublicKeyWrapAlgorithm();
+            caRsaPublicKeyWrapAlgorithm =  getCaRsaPublicKeyWrapAlgorithm();
 
             // mark info as authoritative
             kraInfoAuthoritative = true;
@@ -200,5 +206,22 @@ public class CAInfoService extends PKIService implements CAInfoResource {
 
         return new PKIClient(config);
     }
+
+    private static String getCaRsaPublicKeyWrapAlgorithm() throws EBaseException {
+
+        CAEngine engine = CAEngine.getInstance();
+        CAEngineConfig cs = engine.getConfig();
+
+        boolean useOAEP = cs.getBoolean("keyWrap.useOAEP", false);
+
+        String result = "RSA";
+
+        if(useOAEP == true) {
+            result = "RSA_OAEP";
+        }
+
+        return result;
+    }
+
 
 }

--- a/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
@@ -214,13 +214,7 @@ public class CAInfoService extends PKIService implements CAInfoResource {
 
         boolean useOAEP = cs.getBoolean("keyWrap.useOAEP", false);
 
-        String result = "RSA";
-
-        if(useOAEP == true) {
-            result = "RSA_OAEP";
-        }
-
-        return result;
+        return useOAEP ? "RSA_OAEP" : "RSA";
     }
 
 

--- a/base/common/src/main/java/org/dogtagpki/common/CAInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/common/CAInfo.java
@@ -18,9 +18,16 @@
 
 package org.dogtagpki.common;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.netscape.certsrv.base.RESTMessage;
 
 /**
@@ -32,11 +39,15 @@ public class CAInfo extends RESTMessage {
 
     public static final String ENCRYPT_MECHANISM = "encrypt";
     public static final String KEYWRAP_MECHANISM = "keywrap";
+    public static final String RSA_PUBLIC_KEY_WRAP = "RSA";
 
     String archivalMechanism;
     String encryptAlgorithm;
     String keyWrapAlgorithm;
+    String rsaPublicKeyWrapAlgorithm;
+    String caRsaPublicKeyWrapAlgorithm;
 
+    @JsonProperty("ArchivalMechanism")
     public String getArchivalMechanism() {
         return archivalMechanism;
     }
@@ -45,6 +56,7 @@ public class CAInfo extends RESTMessage {
         this.archivalMechanism = archivalMechanism;
     }
 
+    @JsonProperty("EncryptionAlgorithm")
     public String getEncryptAlgorithm() {
         return encryptAlgorithm;
     }
@@ -53,6 +65,7 @@ public class CAInfo extends RESTMessage {
         this.encryptAlgorithm = encryptAlgorithm;
     }
 
+    @JsonProperty("KeyWrapAlgorithm")
     public String getKeyWrapAlgorithm() {
         return keyWrapAlgorithm;
     }
@@ -61,6 +74,25 @@ public class CAInfo extends RESTMessage {
         this.keyWrapAlgorithm = keyWrapAlgorithm;
     }
 
+    @JsonProperty("RsaPublicKeyWrapAlgorithm")
+    public String getRsaPublicKeyWrapAlgorithm() {
+        return rsaPublicKeyWrapAlgorithm;
+    }
+
+    public void setRsaPublicKeyWrapAlgorithm(String rsaPublicKeyWrapAlgorithm) {
+        this.rsaPublicKeyWrapAlgorithm = rsaPublicKeyWrapAlgorithm;
+    }
+
+    @JsonProperty("CaRsaPublicKeyWrapAlgorithm")
+    public String getCaRsaPublicKeyWrapAlgorithm() {
+        return caRsaPublicKeyWrapAlgorithm;
+    }
+
+    public void setCaRsaPublicKeyWrapAlgorithm(String caRsaPublicKeyWrapAlgorithm) {
+        this.caRsaPublicKeyWrapAlgorithm = caRsaPublicKeyWrapAlgorithm;
+    }
+
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -68,6 +100,8 @@ public class CAInfo extends RESTMessage {
         result = prime * result + ((archivalMechanism == null) ? 0 : archivalMechanism.hashCode());
         result = prime * result + ((encryptAlgorithm == null) ? 0 : encryptAlgorithm.hashCode());
         result = prime * result + ((keyWrapAlgorithm == null) ? 0 : keyWrapAlgorithm.hashCode());
+        result = prime * result + ((rsaPublicKeyWrapAlgorithm == null) ? 0 : rsaPublicKeyWrapAlgorithm.hashCode());
+        result = prime * result + ((caRsaPublicKeyWrapAlgorithm == null) ? 0 : caRsaPublicKeyWrapAlgorithm.hashCode());
         return result;
     }
 
@@ -93,10 +127,95 @@ public class CAInfo extends RESTMessage {
         if (keyWrapAlgorithm == null) {
             if (other.keyWrapAlgorithm != null)
                 return false;
-        } else if (!keyWrapAlgorithm.equals(other.keyWrapAlgorithm))
+        } else if (!keyWrapAlgorithm.equals(other.keyWrapAlgorithm)) {
             return false;
+        } else if (!rsaPublicKeyWrapAlgorithm.equals(other.rsaPublicKeyWrapAlgorithm)) {
+            return false;
+        } else if (!caRsaPublicKeyWrapAlgorithm.equals(other.caRsaPublicKeyWrapAlgorithm)) {
+            return false;
+        }
+
         return true;
     }
 
+
+    public Element toDOM(Document document) {
+
+        Element infoElement = document.createElement("CAInfo");
+
+        toDOM(document, infoElement);
+
+        if (archivalMechanism != null) {
+            Element archivalElement = document.createElement("ArchivalMechanism");
+            archivalElement.appendChild(document.createTextNode(archivalMechanism));
+            infoElement.appendChild(archivalElement);
+        }
+
+        if (encryptAlgorithm != null) {
+            Element encryptElement = document.createElement("EncryptionAlgorithm");
+            encryptElement.appendChild(document.createTextNode(encryptAlgorithm));
+            infoElement.appendChild(encryptElement);
+        }
+
+        if (keyWrapAlgorithm != null) {
+            Element wrapElement = document.createElement("WrapAlgorithm");
+            wrapElement.appendChild(document.createTextNode(keyWrapAlgorithm));
+            infoElement.appendChild(wrapElement);
+        }
+
+        if (rsaPublicKeyWrapAlgorithm != null) {
+            Element rsaPublicWrapElement = document.createElement("RsaPublicKeyWrapAlgorithm");
+            rsaPublicWrapElement.appendChild(document.createTextNode(rsaPublicKeyWrapAlgorithm));
+            infoElement.appendChild(rsaPublicWrapElement);
+        }
+
+        if(caRsaPublicKeyWrapAlgorithm != null) {
+            Element caRsaPublicWrapElement = document.createElement("CaRsaPublicKeyWrapAlgorithm");
+            caRsaPublicWrapElement.appendChild(document.createTextNode(caRsaPublicKeyWrapAlgorithm));
+            infoElement.appendChild(caRsaPublicWrapElement);
+        }
+
+
+        return infoElement;
+    }
+
+    public static CAInfo fromDOM(Element infoElement) {
+
+        CAInfo info = new CAInfo();
+
+        fromDOM(infoElement, info);
+
+        NodeList archivalList = infoElement.getElementsByTagName("ArchivalMechanism");
+        if (archivalList.getLength() > 0) {
+            String value = archivalList.item(0).getTextContent();
+            info.setArchivalMechanism(value);
+        }
+
+        NodeList encryptionList = infoElement.getElementsByTagName("EncryptionAlgorithm");
+        if (encryptionList.getLength() > 0) {
+            String value = encryptionList.item(0).getTextContent();
+            info.setEncryptAlgorithm(value);
+        }
+
+        NodeList wrapList = infoElement.getElementsByTagName("KeyWrapAlgorithm");
+        if (wrapList.getLength() > 0) {
+            String value = wrapList.item(0).getTextContent();
+            info.setKeyWrapAlgorithm(value);
+        }
+
+        NodeList rsaPublicKeyWrapList = infoElement.getElementsByTagName("RsaPublicKeyWrapAlgorithm");
+        if (rsaPublicKeyWrapList.getLength() > 0) {
+            String value = rsaPublicKeyWrapList.item(0).getTextContent();
+            info.setRsaPublicKeyWrapAlgorithm(value);
+        }
+
+        NodeList caRsaPublicKeyWrapList = infoElement.getElementsByTagName("CaRsaPublicKeyWrapAlgorithm");
+        if (caRsaPublicKeyWrapList.getLength() > 0) {
+            String value = caRsaPublicKeyWrapList.item(0).getTextContent();
+            info.setCaRsaPublicKeyWrapAlgorithm(value);
+        }
+
+        return info;
+    }
 }
 

--- a/base/common/src/main/java/org/dogtagpki/common/CAInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/common/CAInfo.java
@@ -22,12 +22,10 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.netscape.certsrv.base.RESTMessage;
 
 /**
@@ -139,6 +137,7 @@ public class CAInfo extends RESTMessage {
     }
 
 
+    @Override
     public Element toDOM(Document document) {
 
         Element infoElement = document.createElement("CAInfo");

--- a/base/common/src/main/java/org/dogtagpki/common/CAInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/common/CAInfo.java
@@ -18,10 +18,6 @@
 
 package org.dogtagpki.common;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -134,87 +130,6 @@ public class CAInfo extends RESTMessage {
         }
 
         return true;
-    }
-
-
-    @Override
-    public Element toDOM(Document document) {
-
-        Element infoElement = document.createElement("CAInfo");
-
-        toDOM(document, infoElement);
-
-        if (archivalMechanism != null) {
-            Element archivalElement = document.createElement("ArchivalMechanism");
-            archivalElement.appendChild(document.createTextNode(archivalMechanism));
-            infoElement.appendChild(archivalElement);
-        }
-
-        if (encryptAlgorithm != null) {
-            Element encryptElement = document.createElement("EncryptionAlgorithm");
-            encryptElement.appendChild(document.createTextNode(encryptAlgorithm));
-            infoElement.appendChild(encryptElement);
-        }
-
-        if (keyWrapAlgorithm != null) {
-            Element wrapElement = document.createElement("WrapAlgorithm");
-            wrapElement.appendChild(document.createTextNode(keyWrapAlgorithm));
-            infoElement.appendChild(wrapElement);
-        }
-
-        if (rsaPublicKeyWrapAlgorithm != null) {
-            Element rsaPublicWrapElement = document.createElement("RsaPublicKeyWrapAlgorithm");
-            rsaPublicWrapElement.appendChild(document.createTextNode(rsaPublicKeyWrapAlgorithm));
-            infoElement.appendChild(rsaPublicWrapElement);
-        }
-
-        if(caRsaPublicKeyWrapAlgorithm != null) {
-            Element caRsaPublicWrapElement = document.createElement("CaRsaPublicKeyWrapAlgorithm");
-            caRsaPublicWrapElement.appendChild(document.createTextNode(caRsaPublicKeyWrapAlgorithm));
-            infoElement.appendChild(caRsaPublicWrapElement);
-        }
-
-
-        return infoElement;
-    }
-
-    public static CAInfo fromDOM(Element infoElement) {
-
-        CAInfo info = new CAInfo();
-
-        fromDOM(infoElement, info);
-
-        NodeList archivalList = infoElement.getElementsByTagName("ArchivalMechanism");
-        if (archivalList.getLength() > 0) {
-            String value = archivalList.item(0).getTextContent();
-            info.setArchivalMechanism(value);
-        }
-
-        NodeList encryptionList = infoElement.getElementsByTagName("EncryptionAlgorithm");
-        if (encryptionList.getLength() > 0) {
-            String value = encryptionList.item(0).getTextContent();
-            info.setEncryptAlgorithm(value);
-        }
-
-        NodeList wrapList = infoElement.getElementsByTagName("KeyWrapAlgorithm");
-        if (wrapList.getLength() > 0) {
-            String value = wrapList.item(0).getTextContent();
-            info.setKeyWrapAlgorithm(value);
-        }
-
-        NodeList rsaPublicKeyWrapList = infoElement.getElementsByTagName("RsaPublicKeyWrapAlgorithm");
-        if (rsaPublicKeyWrapList.getLength() > 0) {
-            String value = rsaPublicKeyWrapList.item(0).getTextContent();
-            info.setRsaPublicKeyWrapAlgorithm(value);
-        }
-
-        NodeList caRsaPublicKeyWrapList = infoElement.getElementsByTagName("CaRsaPublicKeyWrapAlgorithm");
-        if (caRsaPublicKeyWrapList.getLength() > 0) {
-            String value = caRsaPublicKeyWrapList.item(0).getTextContent();
-            info.setCaRsaPublicKeyWrapAlgorithm(value);
-        }
-
-        return info;
     }
 }
 

--- a/base/common/src/main/java/org/dogtagpki/common/KRAInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/common/KRAInfo.java
@@ -18,9 +18,14 @@
 
 package org.dogtagpki.common;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.base.RESTMessage;
 
 /**
@@ -34,7 +39,9 @@ public class KRAInfo extends RESTMessage {
     String recoveryMechanism;
     String encryptAlgorithm;
     String wrapAlgorithm;
+    String rsaPublicKeyWrapAlgorithm;
 
+    @JsonProperty("ArchivalMechanism")
     public String getArchivalMechanism() {
         return archivalMechanism;
     }
@@ -43,6 +50,7 @@ public class KRAInfo extends RESTMessage {
         this.archivalMechanism = archivalMechanism;
     }
 
+    @JsonProperty("RecoveryMechanism")
     public String getRecoveryMechanism() {
         return recoveryMechanism;
     }
@@ -51,6 +59,7 @@ public class KRAInfo extends RESTMessage {
         this.recoveryMechanism = recoveryMechanism;
     }
 
+   @JsonProperty("EncryptionAlgorithm")
     public String getEncryptAlgorithm() {
         return encryptAlgorithm;
     }
@@ -59,12 +68,22 @@ public class KRAInfo extends RESTMessage {
         this.encryptAlgorithm = encryptAlgorithm;
     }
 
+    @JsonProperty("WrapAlgorithm")
     public String getWrapAlgorithm() {
         return wrapAlgorithm;
     }
 
     public void setWrapAlgorithm(String wrapAlgorithm) {
         this.wrapAlgorithm = wrapAlgorithm;
+    }
+
+    @JsonProperty("RsaPublicKeyWrapAlgorithm")
+    public String getRsaPublicKeyWrapAlgorithm() {
+        return rsaPublicKeyWrapAlgorithm;
+    }
+
+    public void setRsaPublicKeyWrapAlgorithm(String rsaPublicKeyWrapAlgorithm) {
+        this.rsaPublicKeyWrapAlgorithm = rsaPublicKeyWrapAlgorithm;
     }
 
     @Override
@@ -75,6 +94,7 @@ public class KRAInfo extends RESTMessage {
         result = prime * result + ((encryptAlgorithm == null) ? 0 : encryptAlgorithm.hashCode());
         result = prime * result + ((recoveryMechanism == null) ? 0 : recoveryMechanism.hashCode());
         result = prime * result + ((wrapAlgorithm == null) ? 0 : wrapAlgorithm.hashCode());
+        result = prime * result + ((rsaPublicKeyWrapAlgorithm == null) ? 0 : rsaPublicKeyWrapAlgorithm.hashCode());
         return result;
     }
 
@@ -105,10 +125,89 @@ public class KRAInfo extends RESTMessage {
         if (wrapAlgorithm == null) {
             if (other.wrapAlgorithm != null)
                 return false;
-        } else if (!wrapAlgorithm.equals(other.wrapAlgorithm))
+        } else if (!wrapAlgorithm.equals(other.wrapAlgorithm)) {
+            return false;
+        } else if (!rsaPublicKeyWrapAlgorithm.equals(other.rsaPublicKeyWrapAlgorithm))
             return false;
         return true;
     }
 
+    public Element toDOM(Document document) {
+
+        Element infoElement = document.createElement("KRAInfo");
+
+        toDOM(document, infoElement);
+
+        if (archivalMechanism != null) {
+            Element archivalElement = document.createElement("ArchivalMechanism");
+            archivalElement.appendChild(document.createTextNode(archivalMechanism));
+            infoElement.appendChild(archivalElement);
+        }
+
+        if (recoveryMechanism != null) {
+            Element recoveryElement = document.createElement("RecoveryMechanism");
+            recoveryElement.appendChild(document.createTextNode(recoveryMechanism));
+            infoElement.appendChild(recoveryElement);
+        }
+
+        if (encryptAlgorithm != null) {
+            Element encryptElement = document.createElement("EncryptionAlgorithm");
+            encryptElement.appendChild(document.createTextNode(encryptAlgorithm));
+            infoElement.appendChild(encryptElement);
+        }
+
+        if (wrapAlgorithm != null) {
+            Element wrapElement = document.createElement("WrapAlgorithm");
+            wrapElement.appendChild(document.createTextNode(wrapAlgorithm));
+            infoElement.appendChild(wrapElement);
+        }
+
+        if (rsaPublicKeyWrapAlgorithm != null) {
+            Element rsaPublicWrapElement = document.createElement("RsaPublicKeyWrapAlgorithm");
+            rsaPublicWrapElement.appendChild(document.createTextNode(rsaPublicKeyWrapAlgorithm));
+            infoElement.appendChild(rsaPublicWrapElement);
+        }
+
+        return infoElement;
+    }
+
+    public static KRAInfo fromDOM(Element infoElement) {
+
+        KRAInfo info = new KRAInfo();
+
+        fromDOM(infoElement, info);
+
+        NodeList archivalList = infoElement.getElementsByTagName("ArchivalMechanism");
+        if (archivalList.getLength() > 0) {
+            String value = archivalList.item(0).getTextContent();
+            info.setArchivalMechanism(value);
+        }
+
+        NodeList recoveryList = infoElement.getElementsByTagName("RecoveryMechanism");
+        if (recoveryList.getLength() > 0) {
+            String value = recoveryList.item(0).getTextContent();
+            info.setRecoveryMechanism(value);
+        }
+
+        NodeList encryptionList = infoElement.getElementsByTagName("EncryptionAlgorithm");
+        if (encryptionList.getLength() > 0) {
+            String value = encryptionList.item(0).getTextContent();
+            info.setEncryptAlgorithm(value);
+        }
+
+        NodeList wrapList = infoElement.getElementsByTagName("WrapAlgorithm");
+        if (wrapList.getLength() > 0) {
+            String value = wrapList.item(0).getTextContent();
+            info.setWrapAlgorithm(value);
+        }
+
+        NodeList rsaPublicKeyWrapList = infoElement.getElementsByTagName("RsaPublicKeyWrapAlgorithm");
+        if (rsaPublicKeyWrapList.getLength() > 0) {
+            String value = rsaPublicKeyWrapList.item(0).getTextContent();
+            info.setRsaPublicKeyWrapAlgorithm(value);
+        }
+
+        return info;
+    }
 }
 

--- a/base/common/src/main/java/org/dogtagpki/common/KRAInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/common/KRAInfo.java
@@ -132,6 +132,7 @@ public class KRAInfo extends RESTMessage {
         return true;
     }
 
+    @Override
     public Element toDOM(Document document) {
 
         Element infoElement = document.createElement("KRAInfo");

--- a/base/common/src/main/java/org/dogtagpki/common/KRAInfo.java
+++ b/base/common/src/main/java/org/dogtagpki/common/KRAInfo.java
@@ -18,10 +18,6 @@
 
 package org.dogtagpki.common;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -130,85 +126,6 @@ public class KRAInfo extends RESTMessage {
         } else if (!rsaPublicKeyWrapAlgorithm.equals(other.rsaPublicKeyWrapAlgorithm))
             return false;
         return true;
-    }
-
-    @Override
-    public Element toDOM(Document document) {
-
-        Element infoElement = document.createElement("KRAInfo");
-
-        toDOM(document, infoElement);
-
-        if (archivalMechanism != null) {
-            Element archivalElement = document.createElement("ArchivalMechanism");
-            archivalElement.appendChild(document.createTextNode(archivalMechanism));
-            infoElement.appendChild(archivalElement);
-        }
-
-        if (recoveryMechanism != null) {
-            Element recoveryElement = document.createElement("RecoveryMechanism");
-            recoveryElement.appendChild(document.createTextNode(recoveryMechanism));
-            infoElement.appendChild(recoveryElement);
-        }
-
-        if (encryptAlgorithm != null) {
-            Element encryptElement = document.createElement("EncryptionAlgorithm");
-            encryptElement.appendChild(document.createTextNode(encryptAlgorithm));
-            infoElement.appendChild(encryptElement);
-        }
-
-        if (wrapAlgorithm != null) {
-            Element wrapElement = document.createElement("WrapAlgorithm");
-            wrapElement.appendChild(document.createTextNode(wrapAlgorithm));
-            infoElement.appendChild(wrapElement);
-        }
-
-        if (rsaPublicKeyWrapAlgorithm != null) {
-            Element rsaPublicWrapElement = document.createElement("RsaPublicKeyWrapAlgorithm");
-            rsaPublicWrapElement.appendChild(document.createTextNode(rsaPublicKeyWrapAlgorithm));
-            infoElement.appendChild(rsaPublicWrapElement);
-        }
-
-        return infoElement;
-    }
-
-    public static KRAInfo fromDOM(Element infoElement) {
-
-        KRAInfo info = new KRAInfo();
-
-        fromDOM(infoElement, info);
-
-        NodeList archivalList = infoElement.getElementsByTagName("ArchivalMechanism");
-        if (archivalList.getLength() > 0) {
-            String value = archivalList.item(0).getTextContent();
-            info.setArchivalMechanism(value);
-        }
-
-        NodeList recoveryList = infoElement.getElementsByTagName("RecoveryMechanism");
-        if (recoveryList.getLength() > 0) {
-            String value = recoveryList.item(0).getTextContent();
-            info.setRecoveryMechanism(value);
-        }
-
-        NodeList encryptionList = infoElement.getElementsByTagName("EncryptionAlgorithm");
-        if (encryptionList.getLength() > 0) {
-            String value = encryptionList.item(0).getTextContent();
-            info.setEncryptAlgorithm(value);
-        }
-
-        NodeList wrapList = infoElement.getElementsByTagName("WrapAlgorithm");
-        if (wrapList.getLength() > 0) {
-            String value = wrapList.item(0).getTextContent();
-            info.setWrapAlgorithm(value);
-        }
-
-        NodeList rsaPublicKeyWrapList = infoElement.getElementsByTagName("RsaPublicKeyWrapAlgorithm");
-        if (rsaPublicKeyWrapList.getLength() > 0) {
-            String value = rsaPublicKeyWrapList.item(0).getTextContent();
-            info.setRsaPublicKeyWrapAlgorithm(value);
-        }
-
-        return info;
     }
 }
 

--- a/base/common/src/test/java/org/dogtagpki/common/CAInfoTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/CAInfoTest.java
@@ -17,6 +17,8 @@ public class CAInfoTest {
         before.setArchivalMechanism(CAInfo.KEYWRAP_MECHANISM);
         before.setEncryptAlgorithm(CAInfo.ENCRYPT_MECHANISM);
         before.setKeyWrapAlgorithm(CAInfo.KEYWRAP_MECHANISM);
+        before.setRsaPublicKeyWrapAlgorithm(CAInfo.RSA_PUBLIC_KEY_WRAP);
+        before.setCaRsaPublicKeyWrapAlgorithm(CAInfo.RSA_PUBLIC_KEY_WRAP);
     }
 
     @Test

--- a/base/common/src/test/java/org/dogtagpki/common/KRAInfoTest.java
+++ b/base/common/src/test/java/org/dogtagpki/common/KRAInfoTest.java
@@ -17,6 +17,7 @@ public class KRAInfoTest {
         before.setRecoveryMechanism("keywrap");
         before.setEncryptAlgorithm("AES/CBC/Pad");
         before.setWrapAlgorithm("AES KeyWrap/Padding");
+        before.setRsaPublicKeyWrapAlgorithm("RSA");
     }
 
     @Test

--- a/base/kra/src/main/java/org/dogtagpki/server/rest/KRAInfoService.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/rest/KRAInfoService.java
@@ -61,7 +61,7 @@ public class KRAInfoService extends PKIService implements KRAInfoResource {
         info.setRecoveryMechanism(getRecoveryMechanism());
         info.setEncryptAlgorithm(getEncryptAlgorithm());
         info.setWrapAlgorithm(getWrapAlgorithm());
-
+        info.setRsaPublicKeyWrapAlgorithm(getRsaPublicKeyWrapAlgorithm());
         return createOKResponse(info);
     }
 
@@ -113,6 +113,22 @@ public class KRAInfoService extends PKIService implements KRAInfoResource {
             return "AES/CBC/Padding";
         }
         return params.getPayloadEncryptionAlgorithm().toString();
+    }
+
+    String getRsaPublicKeyWrapAlgorithm() throws EBaseException {
+
+        KRAEngine engine = KRAEngine.getInstance();
+        KRAEngineConfig cs = engine.getConfig();
+
+        boolean useOAEP = cs.getBoolean("keyWrap.useOAEP", false);
+
+        String result = "RSA";
+
+        if(useOAEP == true) { 
+            result = "RSA_OAEP";
+        }
+        
+        return result; 
     }
 }
 

--- a/base/kra/src/main/java/org/dogtagpki/server/rest/KRAInfoService.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/rest/KRAInfoService.java
@@ -122,13 +122,7 @@ public class KRAInfoService extends PKIService implements KRAInfoResource {
 
         boolean useOAEP = cs.getBoolean("keyWrap.useOAEP", false);
 
-        String result = "RSA";
-
-        if(useOAEP == true) { 
-            result = "RSA_OAEP";
-        }
-        
-        return result; 
+        return useOAEP ? "RSA_OAEP" : "RSA";
     }
 }
 

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -168,6 +168,8 @@ pki_subsystem_token=
 
 #Set this if we want to use PSS signing when RSA is specified
 pki_use_pss_rsa_signing_algorithm=False
+#Set this if we want ot use the OAEP key wrap alg.
+pki_use_oaep_rsa_keywrap=False
 pki_theme_enable=True
 pki_theme_server_dir=/usr/share/pki/common-ui
 pki_token_name=

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -270,6 +270,9 @@ class PKIDeployer:
 
     def configure_ca(self, subsystem):
 
+        if config.str2bool(self.mdict['pki_use_oaep_rsa_keywrap']):
+            subsystem.config['keyWrap.useOAEP'] = 'true'
+
         request_id_generator = self.mdict['pki_request_id_generator']
 
         if request_id_generator == 'random':
@@ -330,6 +333,9 @@ class PKIDeployer:
             subsystem.config['ca.defaultOcspUri'] = ocsp_uri
 
     def configure_kra(self, subsystem):
+
+        if config.str2bool(self.mdict['pki_use_oaep_rsa_keywrap']):
+            subsystem.config['keyWrap.useOAEP'] = 'true'
 
         request_id_generator = self.mdict['pki_request_id_generator']
 
@@ -507,10 +513,6 @@ class PKIDeployer:
         subsystem.config['internaldb.ldapauth.bindDN'] = self.mdict['pki_ds_bind_dn']
         subsystem.config['internaldb.basedn'] = self.mdict['pki_ds_base_dn']
         subsystem.config['internaldb.database'] = self.mdict['pki_ds_database']
-
-        useOAEPKeyWrap = self.mdict['pki_use_oaep_rsa_keywrap']
-        if useOAEPKeyWrap == "True":
-            subsystem.config['keyWrap.useOAEP'] = 'true'
 
         if subsystem.type == 'CA':
             self.configure_ca(subsystem)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -508,6 +508,10 @@ class PKIDeployer:
         subsystem.config['internaldb.basedn'] = self.mdict['pki_ds_base_dn']
         subsystem.config['internaldb.database'] = self.mdict['pki_ds_database']
 
+        useOAEPKeyWrap = self.mdict['pki_use_oaep_rsa_keywrap']
+        if useOAEPKeyWrap == "True":
+            subsystem.config['keyWrap.useOAEP'] = 'true'
+
         if subsystem.type == 'CA':
             self.configure_ca(subsystem)
 

--- a/tests/kra/bin/test-cert-key-archival.sh
+++ b/tests/kra/bin/test-cert-key-archival.sh
@@ -11,7 +11,8 @@ CRMFPopClient \
     -f caDualCert \
     -n UID=testuser \
     -u testuser \
-    -b kra_transport.crt | tee output
+    -b kra_transport.crt \
+    ${CRMFPopClient_Extra} | tee output
 
 REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)\s*$/\1/p" output)
 echo "Request ID: $REQUEST_ID"


### PR DESCRIPTION
The purpose of this patch is to continue the improvement of this bug in 2 ways:

1. Create a pikspawn variable to cause pkispawn to create a subsystem configured for oaep `pki_use_oaep_rsa_keywrap=True`, the default is False.

2. Improve the rest calls for kra info and ca info to provide info on whether the ca or kra is using OAEP.

For the Ca, we print out oaep info for both the local CA config and the CA's corresponding KRA.Ex:

KRA info:
```
 https://localhost.localdomain:28443/kra/rest/info

    <KRAInfo>
    <Attributes/>
    <ArchivalMechanism>keywrap</ArchivalMechanism>
    <RecoveryMechanism>keywrap</RecoveryMechanism>
    <EncryptionAlgorithm>AES/CBC/PKCS5Padding</EncryptionAlgorithm>
    <WrapAlgorithm>AES KeyWrap/Padding</WrapAlgorithm>
    <RsaPublicKeyWrapAlgorithm>RSA_OAEP</RsaPublicKeyWrapAlgorithm>
    </KRAInfo>
```

Note the new value for RsaPublicKeyWrapAlgorithm.
    
CA info:
```
https://localhost.localdomain:8443/ca/rest/info
    
    <CAInfo>
    <Attributes/>
    <ArchivalMechanism>keywrap</ArchivalMechanism>
    <EncryptionAlgorithm>AES/CBC/PKCS5Padding</EncryptionAlgorithm>
    <WrapAlgorithm>AES KeyWrap/Padding</WrapAlgorithm>
    <RsaPublicKeyWrapAlgorithm>RSA_OAEP</RsaPublicKeyWrapAlgorithm>
    <CaRsaPublicKeyWrapAlgorithm>RSA_OAEP</CaRsaPublicKeyWrapAlgorithm>
    </CAInfo>
```

The value CARsaPublicKeyWrapAlgorithm simply relfects the CA's CS.cfg oaep value.
The value RsaPublicKeyWrapAlgorithm is part of the info obtained from this CS's KRA subsystem.

This info can be used by interested clients to see if OAEP is in use with the givne KRA or CA.