### PR TITLE
Drop default COPR repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 pki-acme.tar
 pki-builder.tar
+pki-dist.tar
 pki-ca.tar
 pki-runner.tar
 pki-server.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,24 @@ jobs:
           key: pki-builder-${{ matrix.os }}-${{ github.sha }}
           path: pki-builder.tar
 
+      - name: Build pki-dist image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: pki-dist
+          target: pki-dist
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker,dest=pki-dist.tar
+
+      - name: Store pki-dist image
+        uses: actions/cache@v3
+        with:
+          key: pki-dist-${{ matrix.os }}-${{ github.sha }}
+          path: pki-dist.tar
+
       - name: Build pki-runner image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/est-basic-test.yml
+++ b/.github/workflows/est-basic-test.yml
@@ -138,10 +138,18 @@ jobs:
           docker cp realm.conf pki:/etc/pki/pki-tomcat/est/realm.conf
           docker exec pki pki-server restart --wait
 
+      - name: Install libEST in client container
+        run: |
+          docker pull ghcr.io/dogtagpki/libest-dist:latest
+          docker create --name=libest-dist ghcr.io/dogtagpki/libest-dist:latest
+          docker cp libest-dist:/root/RPMS /tmp/RPMS/
+          docker rm -f libest-dist
+
+          docker cp /tmp/RPMS/. client:/root/RPMS/
+          docker exec client bash -c "dnf localinstall -y /root/RPMS/*"
+
       - name: Configure the client
         run: |
-          docker exec client dnf copr enable -y @pki/libest
-          docker exec client dnf install -y libest
           docker exec client curl -o cacert.p7 -k https://pki.example.com:8443/.well-known/est/cacerts
           docker exec client openssl base64 -d --in cacert.p7 --out cacert.p7.der
           docker exec client openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -out cacert.pem

--- a/.github/workflows/pki-nss-hsm-test.yml
+++ b/.github/workflows/pki-nss-hsm-test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create HSM token
         run: |
-          docker exec pki dnf install -y dnf-plugins-core softhsm
+          docker exec pki dnf install -y softhsm
           docker exec pki softhsm2-util --init-token \
               --label HSM \
               --so-pin Secret.HSM \

--- a/.github/workflows/pki-pkcs11-test.yml
+++ b/.github/workflows/pki-pkcs11-test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create HSM token
         run: |
-          docker exec pki dnf install -y dnf-plugins-core softhsm
+          docker exec pki dnf install -y softhsm
           docker exec pki softhsm2-util --init-token \
               --label HSM \
               --so-pin Secret.HSM \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retrieve pki-builder image
+      - name: Retrieve pki-dist image
         uses: actions/cache@v3
         with:
-          key: pki-builder-${{ matrix.os }}-${{ github.sha }}
-          path: pki-builder.tar
+          key: pki-dist-${{ matrix.os }}-${{ github.sha }}
+          path: pki-dist.tar
 
-      - name: Publish pki-builder image
+      - name: Publish pki-dist image
         run: |
-          docker load --input pki-builder.tar
-          docker tag pki-builder ghcr.io/${{ github.repository_owner }}/pki-builder
-          docker push ghcr.io/${{ github.repository_owner }}/pki-builder
+          docker load --input pki-dist.tar
+          docker tag pki-dist ghcr.io/${{ github.repository_owner }}/pki-dist:latest
+          docker push ghcr.io/${{ github.repository_owner }}/pki-dist:latest
 
       - name: Retrieve pki-runner image
         uses: actions/cache@v3

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -90,7 +90,13 @@ jobs:
 
       - name: Install SSCEP in client container
         run: |
-          docker exec client dnf install -y sscep
+          docker pull ghcr.io/dogtagpki/sscep-dist:latest
+          docker create --name=sscep-dist ghcr.io/dogtagpki/sscep-dist:latest
+          docker cp sscep-dist:/root/RPMS /tmp/RPMS/
+          docker rm -f sscep-dist
+
+          docker cp /tmp/RPMS/. client:/root/RPMS/
+          docker exec client bash -c "dnf localinstall -y /root/RPMS/*"
 
       # https://github.com/dogtagpki/pki/wiki/Certificate-Enrollment-with-SSCEP
       - name: Get CA certificate using SSCEP

--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -15,7 +15,7 @@ ARG ARCH="x86_64"
 ARG MAINTAINER="Dogtag PKI Team <devel@lists.dogtagpki.org>"
 ARG VENDOR="Dogtag"
 ARG COMPONENT="dogtag-pki"
-ARG COPR_REPO="@pki/master"
+ARG COPR_REPO=""
 
 LABEL name="$NAME" \
       summary="$SUMMARY" \

--- a/base/ca/Dockerfile
+++ b/base/ca/Dockerfile
@@ -15,7 +15,7 @@ ARG ARCH="x86_64"
 ARG MAINTAINER="Dogtag PKI Team <devel@lists.dogtagpki.org>"
 ARG VENDOR="Dogtag"
 ARG COMPONENT="dogtag-pki"
-ARG COPR_REPO="@pki/master"
+ARG COPR_REPO=""
 
 LABEL name="$NAME" \
       summary="$SUMMARY" \

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -12,7 +12,7 @@ echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
 if [ "$BASE64_REPO" == "" ]
 then
-    REPO="@pki/master"
+    REPO=""
 else
     REPO=$(echo "$BASE64_REPO" | base64 -d)
 fi


### PR DESCRIPTION
The CI has been modified to no longer use a COPR repo by default and instead it will install SSCEP, libEST, JSS, Tomcat JSS, and LDAP SDK from GitHub Packages.

The Azure Pipelines still have a dependency on COPR. It will be removed separately later.

**Note:** Since this PR depends on other PRs, currently it uses the RPMs from my repo. Once the other PRs are merged it will be changed to `dogtagpki` repo.