### PR TITLE
Replace BASE64_MATRIX with BASE64_OS

### DIFF
--- a/.github/workflows/PKICertImport-test.yml
+++ b/.github/workflows/PKICertImport-test.yml
@@ -3,9 +3,6 @@ name: PKICertImport
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -3,9 +3,6 @@ name: ACME with certbot
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -25,7 +22,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -585,7 +582,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: acme-certbot-server-${{ inputs.os }}
+          name: acme-certbot-server
           path: |
             /tmp/artifacts/pki
 
@@ -593,5 +590,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: acme-certbot-client-${{ inputs.os }}
+          name: acme-certbot-client
           path: /tmp/artifacts/client

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -3,9 +3,6 @@ name: ACME container
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -33,7 +30,7 @@ jobs:
       - name: Retrieve pki-acme image
         uses: actions/cache@v3
         with:
-          key: pki-acme-${{ inputs.os }}-${{ github.sha }}
+          key: pki-acme-${{ github.sha }}
           path: pki-acme.tar
 
       - name: Load pki-acme image
@@ -137,12 +134,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: acme-container-server-${{ inputs.os }}
+          name: acme-container-server
           path: /tmp/artifacts/server
 
       - name: Upload artifacts from client container
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: acme-container-client-${{ inputs.os }}
+          name: acme-container-client
           path: /tmp/artifacts/client

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -3,9 +3,6 @@ name: ACME server switchover
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -25,7 +22,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -201,7 +198,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: acme-switchover-server-${{ inputs.os }}
+          name: acme-switchover-server
           path: |
             /tmp/artifacts/pki
 
@@ -209,5 +206,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: acme-switchover-client-${{ inputs.os }}
+          name: acme-switchover-client
           path: /tmp/artifacts/client

--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,29 +34,20 @@ jobs:
   acme-certbot-test:
     name: ACME with certbot
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/acme-certbot-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   acme-switchover-test:
     name: ACME server switchover
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/acme-switchover-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   acme-container-test:
     name: ACME container
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/acme-container-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ jobs:
     name: Building PKI
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -26,7 +24,7 @@ jobs:
         id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          key: buildx-${{ hashFiles('pki.spec') }}
           path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
@@ -34,7 +32,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
@@ -46,7 +44,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-builder-deps
           target: pki-builder-deps
@@ -58,7 +56,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-builder
           target: pki-builder
@@ -68,7 +66,7 @@ jobs:
       - name: Store pki-builder image
         uses: actions/cache@v3
         with:
-          key: pki-builder-${{ matrix.os }}-${{ github.sha }}
+          key: pki-builder-${{ github.sha }}
           path: pki-builder.tar
 
       - name: Build pki-dist image
@@ -76,7 +74,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-dist
           target: pki-dist
@@ -86,7 +84,7 @@ jobs:
       - name: Store pki-dist image
         uses: actions/cache@v3
         with:
-          key: pki-dist-${{ matrix.os }}-${{ github.sha }}
+          key: pki-dist-${{ github.sha }}
           path: pki-dist.tar
 
       - name: Build pki-runner image
@@ -94,7 +92,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
@@ -104,7 +102,7 @@ jobs:
       - name: Store pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Build pki-server image
@@ -112,7 +110,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-server
           target: pki-server
@@ -122,7 +120,7 @@ jobs:
       - name: Store pki-server image
         uses: actions/cache@v3
         with:
-          key: pki-server-${{ matrix.os }}-${{ github.sha }}
+          key: pki-server-${{ github.sha }}
           path: pki-server.tar
 
       - name: Build pki-ca image
@@ -130,7 +128,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-ca
           target: pki-ca
@@ -140,7 +138,7 @@ jobs:
       - name: Store pki-ca image
         uses: actions/cache@v3
         with:
-          key: pki-ca-${{ matrix.os }}-${{ github.sha }}
+          key: pki-ca-${{ github.sha }}
           path: pki-ca.tar
 
       - name: Build pki-acme image
@@ -148,7 +146,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-acme
           target: pki-acme
@@ -158,7 +156,7 @@ jobs:
       - name: Store pki-acme image
         uses: actions/cache@v3
         with:
-          key: pki-acme-${{ matrix.os }}-${{ github.sha }}
+          key: pki-acme-${{ github.sha }}
           path: pki-acme.tar
 
       - name: Build ipa-runner image
@@ -166,7 +164,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: ipa-runner
           target: ipa-runner
@@ -176,5 +174,5 @@ jobs:
       - name: Store ipa-runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ matrix.os }}-${{ github.sha }}
+          key: ipa-runner-${{ github.sha }}
           path: ipa-runner.tar

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic CA
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -199,6 +196,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-basic-${{ inputs.os }}
+          name: ca-basic
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -3,9 +3,6 @@ name: CA clone with HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -321,7 +318,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-primary-${{ inputs.os }}
+          name: ca-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -329,7 +326,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-secondary-${{ inputs.os }}
+          name: ca-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -337,6 +334,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-tertiary-${{ inputs.os }}
+          name: ca-clone-tertiary
           path: |
             /tmp/artifacts/tertiary

--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -3,9 +3,6 @@ name: CA clone with secure DS
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -25,7 +22,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -312,7 +309,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-secure-ds-primary-${{ inputs.os }}
+          name: ca-clone-secure-ds-primary
           path: |
             /tmp/artifacts/primary
 
@@ -320,6 +317,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-secure-ds-secondary-${{ inputs.os }}
+          name: ca-clone-secure-ds-secondary
           path: |
             /tmp/artifacts/secondary

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -3,9 +3,6 @@ name: CA clone
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -225,7 +222,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-primary-${{ inputs.os }}
+          name: ca-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -233,7 +230,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-secondary-${{ inputs.os }}
+          name: ca-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -241,6 +238,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-tertiary-${{ inputs.os }}
+          name: ca-clone-tertiary
           path: |
             /tmp/artifacts/tertiary

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -3,9 +3,6 @@ name: CA container
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -33,7 +30,7 @@ jobs:
       - name: Retrieve pki-ca image
         uses: actions/cache@v3
         with:
-          key: pki-ca-${{ inputs.os }}-${{ github.sha }}
+          key: pki-ca-${{ github.sha }}
           path: pki-ca.tar
 
       - name: Load pki-ca image
@@ -690,12 +687,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-container-ca-${{ inputs.os }}
+          name: ca-container-ca
           path: /tmp/artifacts/ca
 
       - name: Upload artifacts from client container
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-container-client-${{ inputs.os }}
+          name: ca-container-client
           path: /tmp/artifacts/client

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -3,9 +3,6 @@ name: CA CRL database
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -29,7 +26,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -408,6 +405,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-crl-${{ inputs.os }}
+          name: ca-crl
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -3,9 +3,6 @@ name: CA connection with DS
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -3,9 +3,6 @@ name: CA with ECC
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -144,6 +141,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-ecc-${{ inputs.os }}
+          name: ca-ecc
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -3,9 +3,6 @@ name: CA with existing certs
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -390,6 +387,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-existing-certs-${{ inputs.os }}
+          name: ca-existing-certs
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -3,9 +3,6 @@ name: CA with existing DS
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -262,6 +259,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-existing-ds-${{ inputs.os }}
+          name: ca-existing-ds
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -3,9 +3,6 @@ name: CA with existing HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -520,6 +517,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-existing-hsm-${{ inputs.os }}
+          name: ca-existing-hsm
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -3,9 +3,6 @@ name: CA with existing NSS database
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -381,6 +378,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-existing-nssdb-${{ inputs.os }}
+          name: ca-existing-nssdb
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -3,9 +3,6 @@ name: CA with HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -244,6 +241,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-hsm-${{ inputs.os }}
+          name: ca-hsm
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-lightweight-hsm-test.yml
+++ b/.github/workflows/ca-lightweight-hsm-test.yml
@@ -3,9 +3,6 @@ name: Lightweight CA
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -320,6 +317,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-lightweight-hsm-${{ inputs.os }}
+          name: ca-lightweight-hsm
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-lightweight-test.yml
+++ b/.github/workflows/ca-lightweight-test.yml
@@ -3,9 +3,6 @@ name: Lightweight CA
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -234,6 +231,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-lightweight-${{ inputs.os }}
+          name: ca-lightweight
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -3,9 +3,6 @@ name: CA with request notification
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -149,6 +146,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-notification-request-${{ inputs.os }}
+          name: ca-notification-request
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-pruning-test.yml
+++ b/.github/workflows/ca-pruning-test.yml
@@ -3,9 +3,6 @@ name: CA database pruning
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -454,6 +451,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-pruning-${{ inputs.os }}
+          name: ca-pruning
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -3,9 +3,6 @@ name: CA with CA cert publishing
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -161,6 +158,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-ldap-${{ inputs.os }}
+          name: ca-ldap
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -3,9 +3,6 @@ name: CA with file-based CRL publishing
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -29,7 +26,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -264,6 +261,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-publishing-crl-file-${{ inputs.os }}
+          name: ca-publishing-crl-file
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -3,9 +3,6 @@ name: CA with LDAP-based CRL publishing
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -29,7 +26,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -312,6 +309,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-publishing-crl-ldap-${{ inputs.os }}
+          name: ca-publishing-crl-ldap
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -3,9 +3,6 @@ name: CA with user cert publishing
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -453,6 +450,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-user-cert-publishing-${{ inputs.os }}
+          name: ca-user-cert-publishing
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -3,9 +3,6 @@ name: CA with RSA/PSS
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -180,6 +177,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-rsa-pss-${{ inputs.os }}
+          name: ca-rsa-pss
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -3,9 +3,6 @@ name: CA with RSNv1
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -148,6 +145,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-random-v1-${{ inputs.os }}
+          name: ca-random-v1
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -3,9 +3,6 @@ name: CA with secure DS
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -160,6 +157,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-secure-ds-${{ inputs.os }}
+          name: ca-secure-ds
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -3,9 +3,6 @@ name: CA with Sequential Serial Numbers
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -141,6 +138,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-sequential-${{ inputs.os }}
+          name: ca-sequential
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-shared-token-test.yml
+++ b/.github/workflows/ca-shared-token-test.yml
@@ -3,9 +3,6 @@ name: CA with shared token
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -271,6 +268,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-shared-token-${{ inputs.os }}
+          name: ca-shared-token
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,169 +34,118 @@ jobs:
   ca-basic-test:
     name: Basic CA
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-ecc-test:
     name: CA with ECC
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-ecc-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-rsa-pss-test:
     name: CA with RSA/PSS
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-rsa-pss-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-existing-certs-test:
     name: CA with existing certs
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-existing-certs-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-existing-nssdb-test:
     name: CA with existing NSS database
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-existing-nssdb-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-existing-hsm-test:
     name: CA with existing HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-existing-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-existing-ds-test:
     name: CA with existing DS
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-existing-ds-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-shared-token-test:
     name: CA with shared token
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-shared-token-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-hsm-test:
     name: CA with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-container-test:
     name: CA container
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-container-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-ds-connection-test:
     name: CA connection with DS
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-ds-connection-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-lightweight-test:
     name: Lightweight CA
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-lightweight-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-lightweight-hsm-test:
     name: Lightweight CA with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-lightweight-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   subca-basic-test:
     name: Basic Sub-CA
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/subca-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   subca-cmc-test:
     name: Sub-CA with CMC
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/subca-cmc-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   subca-external-test:
     name: Sub-CA with external cert
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/subca-external-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   subca-hsm-test:
     name: Sub-CA with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/subca-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,139 +34,97 @@ jobs:
   ca-clone-test:
     name: CA clone
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-clone-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-clone-hsm-test:
     name: CA clone with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-clone-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-secure-ds-test:
     name: CA with secure DS
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-secure-ds-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-clone-secure-ds-test:
     name: CA clone with secure DS
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-clone-secure-ds-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-rsnv1-test:
     name: CA with RSNv1
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-rsnv1-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-sequential-test:
     name: CA with Sequential Serial Numbers
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-sequential-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-crl-test:
     name: CA CRL database
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-crl-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-publishing-ca-cert-test:
     name: CA with CA cert publishing
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-publishing-ca-cert-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-publishing-user-cert-test:
     name: CA with user cert publishing
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-publishing-user-cert-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-publishing-crl-file-test:
     name: CA with file-based CRL publishing
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-publishing-crl-file-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-publishing-crl-ldap-test:
     name: CA with LDAP-based CRL publishing
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-publishing-crl-ldap-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-notification-request-test:
     name: CA with request notification
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-notification-request-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ca-pruning-test:
     name: CA database pruning
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ca-pruning-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   scep-test:
     name: SCEP responder
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/scep-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -40,8 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -49,7 +45,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/est-basic-test.yml
+++ b/.github/workflows/est-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic EST
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/est-tests.yml
+++ b/.github/workflows/est-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,10 +34,7 @@ jobs:
   est-basic-test:
     name: Basic EST
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/est-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -2,15 +2,15 @@ name: Initialization
 on:
   workflow_call:
     secrets:
-      BASE64_MATRIX:
+      BASE64_OS:
         required: false
       BASE64_REPO:
         required: false
       BASE64_DATABASE:
         required: false
     outputs:
-      matrix:
-        value: ${{ jobs.init.outputs.matrix }}
+      base-image:
+        value: ${{ jobs.init.outputs.base-image }}
       repo:
         value: ${{ jobs.init.outputs.repo }}
       db-image:
@@ -21,7 +21,7 @@ jobs:
     name: Initializing workflow
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.init.outputs.matrix }}
+      base-image: ${{ steps.init.outputs.base-image }}
       repo: ${{ steps.init.outputs.repo }}
       db-image: ${{ steps.init.outputs.db-image }}
     steps:
@@ -31,7 +31,7 @@ jobs:
       - name: Initialize workflow
         id: init
         env:
-          BASE64_MATRIX: ${{ secrets.BASE64_MATRIX }}
+          BASE64_OS: ${{ secrets.BASE64_OS }}
           BASE64_REPO: ${{ secrets.BASE64_REPO }}
           BASE64_DATABASE: ${{ secrets.BASE64_DATABASE }}
         run: |

--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -3,9 +3,6 @@ name: IPA ACME
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve ipa-runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ inputs.os }}-${{ github.sha }}
+          key: ipa-runner-${{ github.sha }}
           path: ipa-runner.tar
 
       - name: Load ipa-runner image
@@ -160,6 +157,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ipa-acme-${{ inputs.os }}
+          name: ipa-acme
           path: |
             /tmp/artifacts/ipa

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic IPA
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve ipa-runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ inputs.os }}-${{ github.sha }}
+          key: ipa-runner-${{ github.sha }}
           path: ipa-runner.tar
 
       - name: Load ipa-runner image
@@ -189,6 +186,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ipa-basic-test-${{ inputs.os }}
+          name: ipa-basic-test
           path: |
             /tmp/artifacts/ipa

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -3,9 +3,6 @@ name: IPA clone
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve ipa-runner image
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ inputs.os }}-${{ github.sha }}
+          key: ipa-runner-${{ github.sha }}
           path: ipa-runner.tar
 
       - name: Load ipa-runner image
@@ -152,7 +149,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ipa-clone-primary-${{ inputs.os }}
+          name: ipa-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -160,6 +157,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ipa-clone-secondary-${{ inputs.os }}
+          name: ipa-clone-secondary
           path: |
             /tmp/artifacts/secondary

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,29 +34,20 @@ jobs:
   ipa-basic-test:
     name: Basic IPA
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ipa-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ipa-acme-test:
     name: IPA ACME
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ipa-acme-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ipa-clone-test:
     name: IPA clone
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ipa-clone-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic KRA
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -208,6 +205,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-basic-${{ inputs.os }}
+          name: kra-basic
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -3,9 +3,6 @@ name: KRA clone
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -258,7 +255,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-clone-primary-${{ inputs.os }}
+          name: kra-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -266,7 +263,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-clone-secondary-${{ inputs.os }}
+          name: kra-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -274,6 +271,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-clone-tertiary-${{ inputs.os }}
+          name: kra-clone-tertiary
           path: |
             /tmp/artifacts/tertiary

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -3,9 +3,6 @@ name: KRA with CMC
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -327,7 +324,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-cmc-ca-${{ inputs.os }}
+          name: kra-cmc-ca
           path: |
             /tmp/artifacts/ca
 
@@ -335,6 +332,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-cmc-kra-${{ inputs.os }}
+          name: kra-cmc-kra
           path: |
             /tmp/artifacts/kra

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -3,9 +3,6 @@ name: KRA with external certs
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -241,7 +238,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-external-certs-ca-${{ inputs.os }}
+          name: kra-external-certs-ca
           path: |
             /tmp/artifacts/ca
 
@@ -249,6 +246,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-external-certs-kra-${{ inputs.os }}
+          name: kra-external-certs-kra
           path: |
             /tmp/artifacts/kra

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -3,9 +3,6 @@ name: KRA with HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -257,6 +254,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-hsm-${{ inputs.os }}
+          name: kra-hsm
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/kra-rsnv3-test.yml
+++ b/.github/workflows/kra-rsnv3-test.yml
@@ -3,9 +3,6 @@ name: KRA with RSNv3
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -135,6 +132,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-rsnv3-${{ inputs.os }}
+          name: kra-rsnv3
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -3,9 +3,6 @@ name: KRA on separate instance
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -160,7 +157,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-separate-ca-${{ inputs.os }}
+          name: kra-separate-ca
           path: |
             /tmp/artifacts/ca
 
@@ -168,6 +165,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-separate-kra-${{ inputs.os }}
+          name: kra-separate-kra
           path: |
             /tmp/artifacts/kra

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -3,9 +3,6 @@ name: Standalone KRA
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -177,6 +174,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: kra-standalone-${{ inputs.os }}
+          name: kra-standalone
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,79 +34,55 @@ jobs:
   kra-basic-test:
     name: Basic KRA
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/kra-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   kra-separate-test:
     name: KRA on separate instance
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/kra-separate-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   kra-external-certs-test:
     name: KRA with external certs
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/kra-external-certs-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   kra-cmc-test:
     name: KRA with CMC
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/kra-cmc-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   kra-clone-test:
     name: KRA clone
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/kra-clone-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   kra-standalone-test:
     name: Standalone KRA
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/kra-standalone-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   kra-rsnv3-test:
     name: KRA with RSNv3
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/kra-rsnv3-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   kra-hsm-test:
     name: KRA with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/kra-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic OCSP
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -265,6 +262,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-basic-test-${{ inputs.os }}
+          name: ocsp-basic-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -3,9 +3,6 @@ name: OCSP clone
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -252,7 +249,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-clone-primary-${{ inputs.os }}
+          name: ocsp-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -260,7 +257,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-clone-secondary-${{ inputs.os }}
+          name: ocsp-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -268,6 +265,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-clone-tertiary-${{ inputs.os }}
+          name: ocsp-clone-tertiary
           path: |
             /tmp/artifacts/tertiary

--- a/.github/workflows/ocsp-cmc-test.yml
+++ b/.github/workflows/ocsp-cmc-test.yml
@@ -3,9 +3,6 @@ name: OCSP with CMC
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -295,7 +292,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-cmc-ca-${{ inputs.os }}
+          name: ocsp-cmc-ca
           path: |
             /tmp/artifacts/ca
 
@@ -303,6 +300,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-cmc-ocsp-${{ inputs.os }}
+          name: ocsp-cmc-ocsp
           path: |
             /tmp/artifacts/ocsp

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -3,9 +3,6 @@ name: OCSP with direct CRL publishing
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -30,7 +27,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -426,7 +423,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-crl-direct-ca-${{ inputs.os }}
+          name: ocsp-crl-direct-ca
           path: |
             /tmp/artifacts/ca
 
@@ -434,6 +431,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-crl-direct-ocsp-${{ inputs.os }}
+          name: ocsp-crl-direct-ocsp
           path: |
             /tmp/artifacts/ocsp

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -3,9 +3,6 @@ name: OCSP with LDAP-based CRL publishing
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -31,7 +28,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -598,7 +595,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-crl-ldap-ca-${{ inputs.os }}
+          name: ocsp-crl-ldap-ca
           path: |
             /tmp/artifacts/ca
 
@@ -606,6 +603,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-crl-ldap-ocsp-${{ inputs.os }}
+          name: ocsp-crl-ldap-ocsp
           path: |
             /tmp/artifacts/ocsp

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -3,9 +3,6 @@ name: OCSP with external certs
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -216,7 +213,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-external-certs-ca-${{ inputs.os }}
+          name: ocsp-external-certs-ca
           path: |
             /tmp/artifacts/ca
 
@@ -224,6 +221,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-external-certs-ocsp-${{ inputs.os }}
+          name: ocsp-external-certs-ocsp
           path: |
             /tmp/artifacts/ocsp

--- a/.github/workflows/ocsp-hsm-test.yml
+++ b/.github/workflows/ocsp-hsm-test.yml
@@ -3,9 +3,6 @@ name: OCSP with HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -232,6 +229,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-hsm-test-${{ inputs.os }}
+          name: ocsp-hsm-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -3,9 +3,6 @@ name: OCSP on separate instance
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -144,7 +141,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-separate-ca-${{ inputs.os }}
+          name: ocsp-separate-ca
           path: |
             /tmp/artifacts/ca
 
@@ -152,6 +149,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-separate-ocsp-${{ inputs.os }}
+          name: ocsp-separate-ocsp
           path: |
             /tmp/artifacts/ocsp

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -3,9 +3,6 @@ name: Standalone OCSP
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -164,6 +161,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ocsp-standalone-${{ inputs.os }}
+          name: ocsp-standalone
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,89 +34,62 @@ jobs:
   ocsp-basic-test:
     name: Basic OCSP
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ocsp-separate-test:
     name: OCSP on separate instance
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-separate-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ocsp-external-certs-test:
     name: OCSP with external certs
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-external-certs-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ocsp-cmc-test:
     name: OCSP with CMC
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-cmc-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ocsp-clone-test:
     name: OCSP clone
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-clone-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ocsp-standalone-test:
     name: Standalone OCSP
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-standalone-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ocsp-crl-direct-test:
     name: OCSP with direct CRL publishing
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-crl-direct-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ocsp-crl-ldap-test:
     name: OCSP with LDAP-based CRL publishing
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-crl-ldap-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   ocsp-hsm-test:
     name: OCSP with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/ocsp-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/.github/workflows/pki-nss-aes-test.yml
+++ b/.github/workflows/pki-nss-aes-test.yml
@@ -3,9 +3,6 @@ name: PKI NSS CLI with AES
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/pki-nss-ecc-test.yml
+++ b/.github/workflows/pki-nss-ecc-test.yml
@@ -3,9 +3,6 @@ name: PKI NSS CLI with ECC
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/pki-nss-exts-test.yml
+++ b/.github/workflows/pki-nss-exts-test.yml
@@ -3,9 +3,6 @@ name: PKI NSS CLI with Extensions
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/pki-nss-hsm-test.yml
+++ b/.github/workflows/pki-nss-hsm-test.yml
@@ -3,9 +3,6 @@ name: PKI NSS CLI with HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/pki-nss-rsa-test.yml
+++ b/.github/workflows/pki-nss-rsa-test.yml
@@ -3,9 +3,6 @@ name: PKI NSS CLI with RSA
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/pki-pkcs11-test.yml
+++ b/.github/workflows/pki-pkcs11-test.yml
@@ -3,9 +3,6 @@ name: PKI PKCS11 CLI
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/pki-pkcs12-test.yml
+++ b/.github/workflows/pki-pkcs12-test.yml
@@ -3,9 +3,6 @@ name: PKI PKCS12 CLI
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/pki-pkcs7-test.yml
+++ b/.github/workflows/pki-pkcs7-test.yml
@@ -3,9 +3,6 @@ name: PKI PKCS7 CLI
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,6 @@ jobs:
     name: Publishing PKI
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -32,7 +30,7 @@ jobs:
       - name: Retrieve pki-dist image
         uses: actions/cache@v3
         with:
-          key: pki-dist-${{ matrix.os }}-${{ github.sha }}
+          key: pki-dist-${{ github.sha }}
           path: pki-dist.tar
 
       - name: Publish pki-dist image
@@ -44,7 +42,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Publish pki-runner image

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -39,8 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -48,7 +44,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name:  pki-runner imagemage

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building P'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -42,8 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHARED: /tmp/workdir/pki
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone the repository
         uses: actions/checkout@v3
@@ -58,7 +54,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ matrix.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -127,6 +123,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: sanity-${{ matrix.os }}
+          name: sanity
           path: |
             /tmp/artifacts/pki1

--- a/.github/workflows/rpminspect-test.yml
+++ b/.github/workflows/rpminspect-test.yml
@@ -3,9 +3,6 @@ name: rpminspect
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-builder image
         uses: actions/cache@v3
         with:
-          key: pki-builder-${{ inputs.os }}-${{ github.sha }}
+          key: pki-builder-${{ github.sha }}
           path: pki-builder.tar
 
       - name: Load pki-builder image

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -3,9 +3,6 @@ name: SCEP responder
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name:  pki-runner imagemage
@@ -158,6 +155,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: scep-${{ inputs.os }}
+          name: scep
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic server
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -88,6 +85,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: server-basic-test-${{ inputs.os }}
+          name: server-basic-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -3,9 +3,6 @@ name: Server container
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -32,7 +29,7 @@ jobs:
       - name: Retrieve pki-server image
         uses: actions/cache@v3
         with:
-          key: pki-server-${{ inputs.os }}-${{ github.sha }}
+          key: pki-server-${{ github.sha }}
           path: pki-server.tar
 
       - name: Load pki-server image
@@ -81,5 +78,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: server-container-test-${{ inputs.os }}
+          name: server-container-test
           path: /tmp/artifacts/server

--- a/.github/workflows/server-https-jks-test.yml
+++ b/.github/workflows/server-https-jks-test.yml
@@ -3,9 +3,6 @@ name: HTTPS connector with JKS file
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -114,6 +111,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: server-https-jks-test-${{ inputs.os }}
+          name: server-https-jks-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -3,9 +3,6 @@ name: HTTPS connector with NSS database
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -125,6 +122,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: server-https-nss-test-${{ inputs.os }}
+          name: server-https-nss-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/server-https-pem-test.yml
+++ b/.github/workflows/server-https-pem-test.yml
@@ -3,9 +3,6 @@ name: HTTPS connector with PEM files
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -116,6 +113,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: server-https-pem-test-${{ inputs.os }}
+          name: server-https-pem-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/server-https-pkcs12-test.yml
+++ b/.github/workflows/server-https-pkcs12-test.yml
@@ -3,9 +3,6 @@ name: "HTTPS connector with PKCS #12 file"
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -116,6 +113,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: server-https-pkcs12-test-${{ inputs.os }}
+          name: server-https-pkcs12-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,69 +34,48 @@ jobs:
   server-basic-test:
     name: Basic server
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/server-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   server-https-pem-test:
     name: HTTPS connector with PEM files
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/server-https-pem-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   server-https-jks-test:
     name: HTTPS connector with JKS file
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/server-https-jks-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   server-https-pkcs12-test:
     name: "HTTPS connector with PKCS #12 file"
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/server-https-pkcs12-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   server-https-nss-test:
     name: HTTPS connector with NSS database
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/server-https-nss-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   server-upgrade-test:
     name: Server upgrade
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/server-upgrade-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   server-container-test:
     name: Server container
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/server-container-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/.github/workflows/server-upgrade-test.yml
+++ b/.github/workflows/server-upgrade-test.yml
@@ -3,9 +3,6 @@ name: Server upgrade
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -111,6 +108,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: server-upgrade-test-${{ inputs.os }}
+          name: server-upgrade-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -77,8 +77,6 @@ jobs:
     name: Building PKI for Sonar
     needs: [init, retrieve-pr]
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -103,7 +101,7 @@ jobs:
         id: cache-buildx
         uses: actions/cache@v3
         with:
-          key: buildx-${{ matrix.os }}-${{ hashFiles('pki.spec') }}
+          key: buildx-${{ hashFiles('pki.spec') }}
           path: /tmp/.buildx-cache
 
       - name: Build pki-deps image
@@ -111,7 +109,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-deps
           target: pki-deps
@@ -123,7 +121,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-builder-deps
           target: pki-builder-deps
@@ -135,7 +133,7 @@ jobs:
         with:
           context: .
           build-args: |
-            BASE_IMAGE=registry.fedoraproject.org/fedora:${{ matrix.os }}
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
             COPR_REPO=${{ needs.init.outputs.repo }}
           tags: pki-runner
           target: pki-runner
@@ -145,7 +143,7 @@ jobs:
       - name: Store pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
+          key: pki-sonar-runner-${{ github.event.workflow_run.id }}
           path: pki-runner.tar
         
   sonarcloud:
@@ -153,15 +151,13 @@ jobs:
     needs: [retrieve-pr, init, build]
     if: needs.retrieve-pr.outputs.pr-number != ''
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     env:
       SHARED: /tmp/workdir/pki
     steps:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-sonar-runner-${{ matrix.os }}-${{ github.event.workflow_run.id }}
+          key: pki-sonar-runner-${{ github.event.workflow_run.id }}
           path: pki-runner.tar
 
       - name: Load pki-runner image

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic Sub-CA
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -173,7 +170,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: subca-basic-root-${{ inputs.os }}
+          name: subca-basic-root
           path: |
             /tmp/artifacts/root
 
@@ -181,6 +178,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: subca-basic-subordinate-${{ inputs.os }}
+          name: subca-basic-subordinate
           path: |
             /tmp/artifacts/subordinate

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -3,9 +3,6 @@ name: Sub-CA with CMC
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -228,7 +225,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: subca-cmc-root-${{ inputs.os }}
+          name: subca-cmc-root
           path: |
             /tmp/artifacts/root
 
@@ -236,6 +233,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: subca-cmc-subordinate-${{ inputs.os }}
+          name: subca-cmc-subordinate
           path: |
             /tmp/artifacts/subordinate

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -3,9 +3,6 @@ name: Sub-CA with external cert
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -144,6 +141,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: subca-external-${{ inputs.os }}
+          name: subca-external
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/subca-hsm-test.yml
+++ b/.github/workflows/subca-hsm-test.yml
@@ -3,9 +3,6 @@ name: Sub-CA with HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -303,6 +300,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: subca-hsm-${{ inputs.os }}
+          name: subca-hsm
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic TKS
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name:  pki-runner imagemage
@@ -132,6 +129,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-basic-test-${{ inputs.os }}
+          name: tks-basic-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -3,9 +3,6 @@ name: TKS clone
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -26,7 +23,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -253,7 +250,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-clone-primary-${{ inputs.os }}
+          name: tks-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -261,7 +258,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-clone-secondary-${{ inputs.os }}
+          name: tks-clone-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -269,6 +266,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-clone-tertiary-${{ inputs.os }}
+          name: tks-clone-tertiary
           path: |
             /tmp/artifacts/tertiary

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -3,9 +3,6 @@ name: TKS with external certs
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -210,7 +207,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-external-certs-ca-${{ inputs.os }}
+          name: tks-external-certs-ca
           path: |
             /tmp/artifacts/ca
 
@@ -218,6 +215,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-external-certs-tks-${{ inputs.os }}
+          name: tks-external-certs-tks
           path: |
             /tmp/artifacts/tks

--- a/.github/workflows/tks-hsm-test.yml
+++ b/.github/workflows/tks-hsm-test.yml
@@ -3,9 +3,6 @@ name: TKS with HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -209,6 +206,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-hsm-test-${{ inputs.os }}
+          name: tks-hsm-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -3,9 +3,6 @@ name: TKS on separate instance
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -144,7 +141,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-separate-ca-${{ inputs.os }}
+          name: tks-separate-ca
           path: |
             /tmp/artifacts/ca
 
@@ -152,6 +149,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tks-separate-tks-${{ inputs.os }}
+          name: tks-separate-tks
           path: |
             /tmp/artifacts/tks

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,49 +34,34 @@ jobs:
   tks-basic-test:
     name: Basic TKS
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tks-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   tks-separate-test:
     name: TKS on separate instance
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tks-separate-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   tks-external-certs-test:
     name: TKS with external certs
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tks-external-certs-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   tks-clone-test:
     name: TKS clone
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tks-clone-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   tks-hsm-test:
     name: TKS with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tks-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,101 +34,71 @@ jobs:
   PKICertImport-test:
     name: PKICertImport
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/PKICertImport-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   pki-nss-rsa-test:
     name: PKI NSS CLI with RSA
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/pki-nss-rsa-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   pki-nss-ecc-test:
     name: PKI NSS CLI with ECC
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/pki-nss-ecc-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   pki-nss-aes-test:
     name: PKI NSS CLI with AES
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/pki-nss-aes-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   pki-nss-hsm-test:
     name: PKI NSS CLI with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/pki-nss-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   pki-nss-exts-test:
     name: PKI NSS CLI with Extensions
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/pki-nss-exts-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   pki-pkcs7-test:
     name: PKI PKCS7 CLI
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/pki-pkcs7-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   pki-pkcs11-test:
     name: PKI PKCS11 CLI
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/pki-pkcs11-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   pki-pkcs12-test:
     name: PKI PKCS12 CLI
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/pki-pkcs12-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   rpminspect-test:
     name: rpminspect
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/rpminspect-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   update-version-test:

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -3,9 +3,6 @@ name: Basic TPS
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -237,6 +234,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-basic-test-${{ inputs.os }}
+          name: tps-basic-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -3,9 +3,6 @@ name: TPS clone
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -26,7 +23,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -249,7 +246,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-clone-primary-${{ inputs.os }}
+          name: tps-clone-primary
           path: |
             /tmp/artifacts/primary
 
@@ -257,6 +254,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-clone-secondary-${{ inputs.os }}
+          name: tps-clone-secondary
           path: |
             /tmp/artifacts/secondary

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -3,9 +3,6 @@ name: TPS with external certs
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -305,7 +302,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-external-certs-ca-${{ inputs.os }}
+          name: tps-external-certs-ca
           path: |
             /tmp/artifacts/ca
 
@@ -313,7 +310,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-external-certs-kra-${{ inputs.os }}
+          name: tps-external-certs-kra
           path: |
             /tmp/artifacts/kra
 
@@ -321,7 +318,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-external-certs-tks-${{ inputs.os }}
+          name: tps-external-certs-tks
           path: |
             /tmp/artifacts/tks
 
@@ -329,6 +326,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-external-certs-tps-${{ inputs.os }}
+          name: tps-external-certs-tps
           path: |
             /tmp/artifacts/tps

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -3,9 +3,6 @@ name: TPS with HSM
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -24,7 +21,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -297,6 +294,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-hsm-test-${{ inputs.os }}
+          name: tps-hsm-test
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -3,9 +3,6 @@ name: TPS on separate instance
 on:
   workflow_call:
     inputs:
-      os:
-        required: true
-        type: string
       db-image:
         required: false
         type: string
@@ -23,7 +20,7 @@ jobs:
       - name: Retrieve pki-runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ inputs.os }}-${{ github.sha }}
+          key: pki-runner-${{ github.sha }}
           path: pki-runner.tar
 
       - name: Load pki-runner image
@@ -247,7 +244,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-separate-ca-${{ inputs.os }}
+          name: tps-separate-ca
           path: |
             /tmp/artifacts/ca
 
@@ -255,7 +252,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-separate-kra-${{ inputs.os }}
+          name: tps-separate-kra
           path: |
             /tmp/artifacts/kra
 
@@ -263,7 +260,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-separate-tks-${{ inputs.os }}
+          name: tps-separate-tks
           path: |
             /tmp/artifacts/tks
 
@@ -271,6 +268,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: tps-separate-tps-${{ inputs.os }}
+          name: tps-separate-tps
           path: |
             /tmp/artifacts/tps

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -12,14 +12,12 @@ jobs:
     name: Waiting for build
     needs: init
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'push'
@@ -28,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI (${{ matrix.os }})'
+          check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
         if: github.event_name == 'pull_request'
@@ -36,49 +34,34 @@ jobs:
   tps-basic-test:
     name: Basic TPS
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tps-basic-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   tps-separate-test:
     name: TPS on separate instance
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tps-separate-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   tps-external-certs-test:
     name: TPS with external certs
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tps-external-certs-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   tps-clone-test:
     name: TPS clone
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tps-clone-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}
 
   tps-hsm-test:
     name: TPS with HSM
     needs: [init, build]
-    strategy:
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     uses: ./.github/workflows/tps-hsm-test.yml
     with:
-      os: ${{ matrix.os }}
       db-image: ${{ needs.init.outputs.db-image }}

--- a/tests/bin/init-workflow.sh
+++ b/tests/bin/init-workflow.sh
@@ -1,14 +1,15 @@
 #!/bin/bash -e
 
-if [ "$BASE64_MATRIX" == "" ]
+if [ "$BASE64_OS" != "" ]
 then
-    MATRIX="{\"os\":[\"latest\"]}"
+    OS_VERSION=$(echo "$BASE64_OS" | base64 -d)
 else
-    MATRIX=$(echo "$BASE64_MATRIX" | base64 -d)
+    OS_VERSION=latest
 fi
 
-echo "MATRIX: $MATRIX"
-echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+BASE_IMAGE=registry.fedoraproject.org/fedora:$OS_VERSION
+echo "BASE_IMAGE: $BASE_IMAGE"
+echo "base-image=$BASE_IMAGE" >> $GITHUB_OUTPUT
 
 if [ "$BASE64_REPO" == "" ]
 then


### PR DESCRIPTION
Previously the `BASE64_MATRIX` parameter provided a mechanism to test against multiple Fedora versions at once. However, since the test resources are limited and only one of the versions is eventually published, the parameter has been replaced with a new `BASE64_OS` parameter which only supports a single Fedora version.

https://github.com/dogtagpki/pki/wiki/Configuring-Test-OS