### PR TITLE
Fix ACME test failures due to certbot changes

### DIFF
--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -259,6 +259,7 @@ jobs:
           docker exec client certbot certonly \
               --server http://pki.example.com:8080/acme/directory \
               -d client.example.com \
+              --key-type rsa \
               --standalone \
               --non-interactive
 

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -85,6 +85,7 @@ jobs:
           docker exec client certbot certonly \
               --server http://pki.example.com:8080/acme/directory \
               -d client.example.com \
+              --key-type rsa \
               --standalone \
               --non-interactive
           docker exec client openssl x509 -text -noout -in /etc/letsencrypt/live/client.example.com/fullchain.pem

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -124,12 +124,14 @@ jobs:
           docker exec client certbot certonly \
               --server http://pki.example.com:8080/acme/directory \
               -d client1.example.com \
+              --key-type rsa \
               --standalone \
               --non-interactive
           docker exec client openssl x509 -text -noout -in /etc/letsencrypt/live/client1.example.com/fullchain.pem
           docker exec client certbot certonly \
               --server http://pki.example.com:8080/acme/directory \
               -d client2.example.com \
+              --key-type rsa \
               --standalone \
               --non-interactive
           docker exec client openssl x509 -text -noout -in /etc/letsencrypt/live/client2.example.com/fullchain.pem

--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -117,6 +117,7 @@ jobs:
           docker exec client certbot certonly \
               --server https://ipa-ca.example.com/acme/directory \
               -d client.example.com \
+              --key-type rsa \
                --standalone \
               --non-interactive
           docker exec client certbot renew \


### PR DESCRIPTION
In certbot 2.0 the default key type was changed to ECDSA, so the ACME tests have been updated to use certbot with RSA keys explicitly as a workaround. In the future the cert profiles might need to be modified to support multiple key types.

https://github.com/certbot/certbot/releases/tag/v2.0.0