### PR TITLE
Update Maven dependencies to Jackson v2.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,37 +119,37 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.11.4</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.11.4</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.4</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
-            <version>2.11.4</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.11.4</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
-            <version>2.11.4</version>
+            <version>2.14.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
These deps are now available in various Maven repositories, so we can use them. The compatibility has been tested already in the CI and it is being used in Fedora already with no issues. This change also resolves various security issues raised by dependabot.