### PR TITLE
Bug2092522-Token Status Change failed when revokeCert false

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
@@ -783,11 +783,12 @@ public class TPSTokendb {
         boolean revokeCerts = configStore.getBoolean(config, true);
 
         if (!revokeCerts) {
-            throw new TPSException(
+            CMS.debug( method +
                     "certificate revocation (serial " + cert.getSerialNumber() +
                     ") not enabled for tokenType: " + tokenType +
                     ", keyType: " + keyType +
                     ", state: " + tokenReason);
+            return;
         }
 
         // check if expired certificates should be revoked.
@@ -800,12 +801,14 @@ public class TPSTokendb {
             Date notAfter = cert.getValidNotAfter();
             Date now = new Date();
             if (now.after(notAfter)) {
-                throw new TPSException(
+                CMS.debug(method +
                         "revocation not enabled for expired cert: " + cert.getSerialNumber());
+                return;
             }
             if (now.before(notBefore)) {
-                throw new TPSException(
+                CMS.debug(method +
                         "revocation not enabled for cert that is not yet valid: " + cert.getSerialNumber());
+                return;
             }
         }
 


### PR DESCRIPTION
This patch fixes "part 1" of Bug 2092522 where it is reported that if op.enroll.xxx.revokeCert=false, an error message is received at attempt to change token status. e.g.
"certificate revocation (serial 0x100024e) not enabled for tokenType: KeyGR, keyType: encryption, state: terminated"

It also should addresses the request in comment#6 regarding expired cert.
For that to work, one needs to enable:
"op.enroll." + tokenType + ".keyGen." + keyType + ".recovery." + tokenReason + ".revokeExpiredCerts"

fixes part 1 of https://bugzilla.redhat.com/show_bug.cgi?id=2092522