### PR TITLE
Bug2092522_StatusChange per config for revokeCert and revokeExpiredCert

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
@@ -671,9 +671,14 @@ public class TPSTokendb {
             tdbActivity(ActivityDatabase.OP_CERT_REVOCATION, tokenRecord,
                     ipAddress, logMsg, "success", remoteUser);
 
-        } catch (Exception e) {
+        } catch (TPSException e) {
             logMsg = "certificate not revoked: " + cert.getSerialNumber() + ": " + e;
             CMS.debug(method + ": " + logMsg);
+            if (e.getStatus() == TPSStatus.STATUS_NO_ERROR) {
+                tdbActivity(ActivityDatabase.OP_TOKEN_MODIFY, tokenRecord,
+                        ipAddress, e.getMessage(), "success", remoteUser);
+                return;
+            }
 
             tdbActivity(ActivityDatabase.OP_CERT_REVOCATION, tokenRecord,
                     ipAddress, e.getMessage(), "failure", remoteUser);
@@ -787,7 +792,8 @@ public class TPSTokendb {
                     "certificate revocation (serial " + cert.getSerialNumber() +
                     ") not enabled for tokenType: " + tokenType +
                     ", keyType: " + keyType +
-                    ", state: " + tokenReason);
+                    ", state: " + tokenReason,
+                    TPSStatus.STATUS_NO_ERROR);
         }
 
         // check if expired certificates should be revoked.
@@ -801,11 +807,11 @@ public class TPSTokendb {
             Date now = new Date();
             if (now.after(notAfter)) {
                 throw new TPSException(
-                        "revocation not enabled for expired cert: " + cert.getSerialNumber());
+                        "revocation not enabled for expired cert: " + cert.getSerialNumber(), TPSStatus.STATUS_NO_ERROR);
             }
             if (now.before(notBefore)) {
                 throw new TPSException(
-                        "revocation not enabled for cert that is not yet valid: " + cert.getSerialNumber());
+                        "revocation not enabled for cert that is not yet valid: " + cert.getSerialNumber(), TPSStatus.STATUS_NO_ERROR);
             }
         }
 


### PR DESCRIPTION
This patch fixes "part 1" and "part 3" of Bug 2092522 where it is reported that
 1. if op.enroll.xxx.revokeCert=false, an error message is received at attempt to change token status. e.g. "certificate revocation (serial 0x100024e) not enabled for tokenType: KeyGR, keyType: encryption, state: terminated"
 2. It also should addresses the request in comment#6 regarding expired cert. For that to work, one needs to enable: "op.enroll." + tokenType + ".keyGen." + keyType + ".recovery." + tokenReason + ".revokeExpiredCerts"

fixes part 1&3 of https://bugzilla.redhat.com/show_bug.cgi?id=2092522