### PR TITLE
Remove instanceRoot in CS.cfg

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/issuer/NSSIssuer.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/issuer/NSSIssuer.java
@@ -26,6 +26,7 @@ import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.x509.Extensions;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
+import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmsutil.password.IPasswordStore;
 import com.netscape.cmsutil.password.PlainPasswordFile;
 
@@ -50,7 +51,7 @@ public class NSSIssuer extends ACMEIssuer {
 
         logger.info("Initializing NSS issuer");
 
-        Path instanceDir = Paths.get(System.getProperty("catalina.base"));
+        Path instanceDir = Paths.get(CMS.getInstanceDir());
 
         String database = config.getParameter("database");
         if (database == null) database = "conf/alias";

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -64,6 +64,7 @@ import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import com.netscape.cms.realm.RealmCommon;
 import com.netscape.cms.realm.RealmConfig;
 import com.netscape.cms.tomcat.ProxyRealm;
+import com.netscape.cmscore.apps.CMS;
 
 /**
  * @author Endi S. Dewata
@@ -446,8 +447,8 @@ public class ACMEEngine {
 
         logger.info("Starting ACME engine");
 
-        String catalinaBase = System.getProperty("catalina.base");
-        String serverConfDir = catalinaBase + File.separator + "conf";
+        String instanceDir = CMS.getInstanceDir();
+        String serverConfDir = instanceDir + File.separator + "conf";
         String acmeConfDir = serverConfDir + File.separator + id;
 
         logger.info("ACME configuration directory: " + acmeConfDir);

--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -19,7 +19,6 @@ securitydomain.checkIP=false
 securitydomain.flushinterval=86400000
 securitydomain.source=ldap
 securitydomain.checkinterval=300000
-instanceRoot=[PKI_INSTANCE_PATH]
 configurationRoot=/ca/conf/
 machineName=[PKI_HOSTNAME]
 instanceId=[PKI_INSTANCE_NAME]

--- a/base/ca/src/main/java/com/netscape/cms/profile/def/AuthInfoAccessExtDefault.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/def/AuthInfoAccessExtDefault.java
@@ -450,8 +450,8 @@ public class AuthInfoAccessExtDefault extends EnrollExtDefault {
         }
 
         // otherwise, get the port from server.xml
-        String instanceRoot = engineConfig.getInstanceDir();
-        String path = instanceRoot + File.separator + "conf" + File.separator + "server.xml";
+        String instanceDir = CMS.getInstanceDir();
+        String path = instanceDir + File.separator + "conf" + File.separator + "server.xml";
 
         ServerXml serverXml = ServerXml.load(path);
         port = serverXml.getUnsecurePort();

--- a/base/ca/src/main/java/com/netscape/cms/publish/publishers/FileBasedPublisher.java
+++ b/base/ca/src/main/java/com/netscape/cms/publish/publishers/FileBasedPublisher.java
@@ -39,8 +39,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.dogtagpki.server.ca.CAEngine;
-import org.dogtagpki.server.ca.CAEngineConfig;
 import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.util.Base64OutputStream;
 
@@ -214,9 +212,6 @@ public class FileBasedPublisher implements ILdapPublisher, IExtendedPluginInfo {
     @Override
     public void init(ConfigStore config) {
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
-
         mConfig = config;
         String dir = null;
 
@@ -247,17 +242,11 @@ public class FileBasedPublisher implements ILdapPublisher, IExtendedPluginInfo {
             mDir = dir;
         } else {
             // maybe it is relative path
-            String mInstanceRoot = null;
+            String instanceDir = CMS.getInstanceDir();
 
-            try {
-                mInstanceRoot = cs.getInstanceDir();
-            } catch (Exception e) {
-                throw new RuntimeException("Invalid Instance Dir " + e);
-            }
-            dirCheck = new File(mInstanceRoot +
-                        File.separator + dir);
+            dirCheck = new File(instanceDir + File.separator + dir);
             if (dirCheck.isDirectory()) {
-                mDir = mInstanceRoot + File.separator + dir;
+                mDir = instanceDir + File.separator + dir;
             } else {
                 throw new RuntimeException("Invalid Directory " + dir);
             }

--- a/base/ca/src/main/java/com/netscape/cms/servlet/admin/ProfileAdminServlet.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/admin/ProfileAdminServlet.java
@@ -2456,7 +2456,7 @@ public class ProfileAdminServlet extends AdminServlet {
                 if (v >= 10) {
                     subpath = "/ca/profiles/";
                 }
-                config = cs.getInstanceDir() + subpath + subname + "/" + id + ".cfg";
+                config = CMS.getInstanceDir() + subpath + subname + "/" + id + ".cfg";
             } catch (EBaseException e) {
                 // store a message in the signed audit log file
                 auditMessage = CMS.getLogMessage(

--- a/base/ca/src/main/java/com/netscape/cmscore/profile/ProfileSubsystem.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/profile/ProfileSubsystem.java
@@ -28,6 +28,7 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.cms.profile.common.Profile;
 import com.netscape.cms.profile.common.ProfileConfig;
+import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.base.FileConfigStorage;
@@ -123,15 +124,8 @@ public class ProfileSubsystem
         CAEngineConfig engineConfig = engine.getConfig();
         PluginRegistry registry = engine.getPluginRegistry();
 
-        try {
-            if (configPath == null) {
-                configPath = engineConfig.getInstanceDir() + "/ca/profiles/ca/" + id + ".cfg";
-            }
-
-        } catch (EBaseException e) {
-            String message = "Unable to create profile: " + e.getMessage();
-            logger.error(message, e);
-            throw new EProfileException(message, e);
+        if (configPath == null) {
+            configPath = CMS.getInstanceDir() + "/ca/profiles/ca/" + id + ".cfg";
         }
 
         try {
@@ -171,12 +165,7 @@ public class ProfileSubsystem
         CAEngine engine = CAEngine.getInstance();
         CAEngineConfig cs = engine.getConfig();
 
-        String configPath;
-        try {
-            configPath = cs.getInstanceDir() + "/ca/profiles/ca/" + id + ".cfg";
-        } catch (EBaseException e) {
-            throw new EProfileException("CMS_PROFILE_DELETE_ERROR");
-        }
+        String configPath = CMS.getInstanceDir() + "/ca/profiles/ca/" + id + ".cfg";
 
         if (isProfileEnable(id)) {
             throw new EProfileException("CMS_PROFILE_DELETE_ENABLEPROFILE");
@@ -222,12 +211,7 @@ public class ProfileSubsystem
         CAEngine engine = CAEngine.getInstance();
         CAEngineConfig cs = engine.getConfig();
 
-        String configPath;
-        try {
-            configPath = cs.getInstanceDir() + "/ca/profiles/ca/" + id + ".cfg";
-        } catch (EBaseException e) {
-            throw new EProfileException("CMS_PROFILE_DELETE_ERROR");
-        }
+        String configPath = CMS.getInstanceDir() + "/ca/profiles/ca/" + id + ".cfg";
 
         try {
             if (mProfiles.size() > 0) {

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCreateCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCreateCLI.java
@@ -157,10 +157,10 @@ public class CACertCreateCLI extends CommandCLI {
         tomcatjss.loadConfig();
         tomcatjss.init();
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
 
         String subsystem = parent.getParent().getName();
-        String confDir = catalinaBase + File.separator + subsystem + File.separator + "conf";
+        String confDir = instanceDir + File.separator + subsystem + File.separator + "conf";
         String configFile = confDir + File.separator + CMS.CONFIG_FILE;
 
         logger.info("Loading " + configFile);
@@ -168,9 +168,8 @@ public class CACertCreateCLI extends CommandCLI {
         CAEngineConfig cs = new CAEngineConfig(storage);
         cs.load();
 
-        String instanceRoot = cs.getInstanceDir();
         String configurationRoot = cs.getString("configurationRoot");
-        String profilePath = instanceRoot + configurationRoot + profileID;
+        String profilePath = instanceDir + configurationRoot + profileID;
 
         logger.info("Loading " + profilePath);
         ConfigStorage profileStorage = new FileConfigStorage(profilePath);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertFindCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertFindCLI.java
@@ -81,14 +81,14 @@ public class CACertFindCLI extends CommandCLI {
 
         int size = 20;
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
 
         TomcatJSS tomcatjss = TomcatJSS.getInstance();
         tomcatjss.loadConfig();
         tomcatjss.init();
 
         String subsystem = parent.getParent().getName();
-        String confDir = catalinaBase + File.separator + subsystem + File.separator + "conf";
+        String confDir = instanceDir + File.separator + subsystem + File.separator + "conf";
         String configFile = confDir + File.separator + CMS.CONFIG_FILE;
 
         logger.info("Loading " + configFile);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertImportCLI.java
@@ -133,10 +133,10 @@ public class CACertImportCLI extends CommandCLI {
         // must be done after JSS initialization for RSA/PSS
         X509CertImpl cert = new X509CertImpl(bytes);
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
 
         String subsystem = parent.getParent().getName();
-        String confDir = catalinaBase + File.separator + subsystem + File.separator + "conf";
+        String confDir = instanceDir + File.separator + subsystem + File.separator + "conf";
         String configFile = confDir + File.separator + CMS.CONFIG_FILE;
 
         logger.info("Loading " + configFile);
@@ -144,9 +144,8 @@ public class CACertImportCLI extends CommandCLI {
         CAEngineConfig cs = new CAEngineConfig(storage);
         cs.load();
 
-        String instanceRoot = cs.getInstanceDir();
         String configurationRoot = cs.getString("configurationRoot");
-        String profilePath = instanceRoot + configurationRoot + profileID;
+        String profilePath = instanceDir + configurationRoot + profileID;
 
         logger.info("Loading " + profilePath);
         ConfigStorage profileStorage = new FileConfigStorage(profilePath);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRemoveCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRemoveCLI.java
@@ -65,14 +65,14 @@ public class CACertRemoveCLI extends CommandCLI {
 
         CertId certID = new CertId(cmdArgs[0]);
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
 
         TomcatJSS tomcatjss = TomcatJSS.getInstance();
         tomcatjss.loadConfig();
         tomcatjss.init();
 
         String subsystem = parent.getParent().getName();
-        String confDir = catalinaBase + File.separator + subsystem + File.separator + "conf";
+        String confDir = instanceDir + File.separator + subsystem + File.separator + "conf";
         String configFile = confDir + File.separator + CMS.CONFIG_FILE;
 
         logger.info("Loading " + configFile);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRequestImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRequestImportCLI.java
@@ -94,7 +94,7 @@ public class CACertRequestImportCLI extends CommandCLI {
             PKILogger.setLevel(Level.INFO);
         }
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
 
         TomcatJSS tomcatjss = TomcatJSS.getInstance();
         tomcatjss.loadConfig();
@@ -139,7 +139,7 @@ public class CACertRequestImportCLI extends CommandCLI {
         }
 
         String subsystem = parent.getParent().getParent().getName();
-        String confDir = catalinaBase + File.separator + subsystem + File.separator + "conf";
+        String confDir = instanceDir + File.separator + subsystem + File.separator + "conf";
         String configFile = confDir + File.separator + CMS.CONFIG_FILE;
 
         logger.info("Loading " + configFile);
@@ -149,9 +149,8 @@ public class CACertRequestImportCLI extends CommandCLI {
 
         String profileID = cmd.getOptionValue("profile");
 
-        String instanceRoot = cs.getInstanceDir();
         String configurationRoot = cs.getString("configurationRoot");
-        String profilePath = instanceRoot + configurationRoot + profileID;
+        String profilePath = instanceDir + configurationRoot + profileID;
 
         logger.info("Loading " + profilePath);
         ConfigStorage profileStorage = new FileConfigStorage(profilePath);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CAProfileImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CAProfileImportCLI.java
@@ -70,14 +70,14 @@ public class CAProfileImportCLI extends CommandCLI {
 
         String inputFolder = cmd.getOptionValue("input-folder", "/usr/share/pki/ca/profiles/ca");
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
 
         TomcatJSS tomcatjss = TomcatJSS.getInstance();
         tomcatjss.loadConfig();
         tomcatjss.init();
 
         String subsystemName = parent.getParent().getName();
-        String configFile = catalinaBase + File.separator + subsystemName + File.separator +
+        String configFile = instanceDir + File.separator + subsystemName + File.separator +
                 "conf" + File.separator + CMS.CONFIG_FILE;
 
         logger.info("Loading " + configFile);
@@ -85,7 +85,7 @@ public class CAProfileImportCLI extends CommandCLI {
         CAEngineConfig cs = new CAEngineConfig(storage);
         cs.load();
 
-        String pluginRegistryFile = catalinaBase + "/conf/" + subsystemName + "/registry.cfg";
+        String pluginRegistryFile = instanceDir + "/conf/" + subsystemName + "/registry.cfg";
         logger.info("Loading " + pluginRegistryFile);
 
         ConfigStore pluginRegistryConfig = cs.getSubStore(PluginRegistry.ID, ConfigStore.class);

--- a/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
@@ -42,6 +42,7 @@ import com.netscape.certsrv.connector.ConnectorsConfig;
 import com.netscape.certsrv.system.KRAConnectorInfo;
 import com.netscape.cms.servlet.admin.KRAConnectorProcessor;
 import com.netscape.cms.servlet.base.PKIService;
+import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
@@ -191,7 +192,7 @@ public class CAInfoService extends PKIService implements CAInfoResource {
         ClientConfig config = new ClientConfig();
         int port = Integer.parseInt(connInfo.getPort());
         config.setServerURL("https", connInfo.getHost(), port);
-        config.setNSSDatabase(cs.getInstanceDir() + "/alias");
+        config.setNSSDatabase(CMS.getInstanceDir() + "/alias");
 
         // Use client cert specified in KRA connector
         String nickname = kraConnectorConfig.getString("nickName", null);

--- a/base/est/src/main/java/org/dogtagpki/est/ESTEngine.java
+++ b/base/est/src/main/java/org/dogtagpki/est/ESTEngine.java
@@ -13,6 +13,7 @@ import org.apache.tomcat.util.IntrospectionUtils;
 import com.netscape.cms.realm.RealmCommon;
 import com.netscape.cms.realm.RealmConfig;
 import com.netscape.cms.tomcat.ProxyRealm;
+import com.netscape.cmscore.apps.CMS;
 
 
 /**
@@ -53,8 +54,8 @@ public class ESTEngine {
         logger.info("Starting EST engine");
 
         String contextPathDirName = "".equals(contextPath) ? "ROOT" : contextPath.substring(1);
-        String catalinaBase = System.getProperty("catalina.base");
-        String serverConfDir = catalinaBase + File.separator + "conf";
+        String instanceDir = CMS.getInstanceDir();
+        String serverConfDir = instanceDir + File.separator + "conf";
         String estConfDir = serverConfDir + File.separator + contextPathDirName;
 
         logger.info("EST configuration directory: " + estConfDir);

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -10,7 +10,6 @@ cs.type=KRA
 admin.interface.uri=kra/admin/console/config/wizard
 agent.interface.uri=kra/agent/kra
 authType=pwd
-instanceRoot=[PKI_INSTANCE_PATH]
 configurationRoot=/kra/conf/
 machineName=[PKI_HOSTNAME]
 instanceId=[PKI_INSTANCE_NAME]

--- a/base/ocsp/shared/conf/CS.cfg
+++ b/base/ocsp/shared/conf/CS.cfg
@@ -66,7 +66,6 @@ preop.cert.subsystem.userfriendlyname=Subsystem Certificate
 preop.cert.subsystem.cncomponent.override=true
 cs.state=0
 authType=pwd
-instanceRoot=[PKI_INSTANCE_PATH]
 configurationRoot=/ocsp/conf/
 machineName=[PKI_HOSTNAME]
 instanceId=[PKI_INSTANCE_NAME]

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/cli/OCSPCRLIssuingPointAddCLI.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/cli/OCSPCRLIssuingPointAddCLI.java
@@ -68,9 +68,9 @@ public class OCSPCRLIssuingPointAddCLI extends CommandCLI {
         tomcatjss.loadConfig();
         tomcatjss.init();
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
         String subsystem = parent.getParent().getParent().getName();
-        String subsystemDir = catalinaBase + File.separator + subsystem;
+        String subsystemDir = instanceDir + File.separator + subsystem;
         String configFile = subsystemDir + File.separator +
                 "conf" + File.separator + CMS.CONFIG_FILE;
 

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/cli/OCSPCRLIssuingPointFindCLI.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/cli/OCSPCRLIssuingPointFindCLI.java
@@ -61,9 +61,9 @@ public class OCSPCRLIssuingPointFindCLI extends CommandCLI {
         tomcatjss.loadConfig();
         tomcatjss.init();
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
         String subsystem = parent.getParent().getParent().getName();
-        String subsystemDir = catalinaBase + File.separator + subsystem;
+        String subsystemDir = instanceDir + File.separator + subsystem;
         String configFile = subsystemDir + File.separator +
                 "conf" + File.separator + CMS.CONFIG_FILE;
 

--- a/base/server/src/main/java/com/netscape/cms/servlet/admin/CMSAdminServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/admin/CMSAdminServlet.java
@@ -933,7 +933,7 @@ public class CMSAdminServlet extends AdminServlet {
                 }
             }
 
-            pathname = mConfig.getInstanceDir() + File.separator + "conf" + File.separator;
+            pathname = CMS.getInstanceDir() + File.separator + "conf" + File.separator;
             dir = pathname;
 
             CMSEngine engine = CMS.getCMSEngine();

--- a/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
@@ -44,6 +44,7 @@ import javax.ws.rs.core.UriInfo;
 
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.cmscore.apps.CMS;
 
 /**
  * Base class for CMS RESTful resources
@@ -86,11 +87,7 @@ public class PKIService {
     @Context
     protected ServletContext servletContext;
 
-    public static Path bannerFile = Paths.get(getInstanceDir(), "conf", "banner.txt");
-
-    public static String getInstanceDir() {
-        return System.getProperty("catalina.base");  // provided by Tomcat
-    }
+    public static final Path bannerFile = Paths.get(CMS.getInstanceDir(), "conf", "banner.txt");
 
     public static boolean isBannerEnabled() {
         return Files.exists(bannerFile);

--- a/base/server/src/main/java/com/netscape/cms/servlet/base/SubsystemService.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/base/SubsystemService.java
@@ -51,7 +51,7 @@ public class SubsystemService extends PKIService {
     }
 
     public String getSubsystemConfDir() {
-        return getInstanceDir() + File.separator + getSubsystemName() + File.separator + "conf";
+        return CMS.getInstanceDir() + File.separator + getSubsystemName() + File.separator + "conf";
     }
 
     public String getSharedSubsystemConfDir() {

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
@@ -80,6 +80,10 @@ public final class CMS {
         return System.getenv("PKI_VERSION");  // defined in tomcat.conf
     }
 
+    public static String getInstanceDir() {
+        return System.getProperty("catalina.base");  // defined by Tomcat
+    }
+
     /**
      * Retrieves the localized user message from UserMessages.properties.
      *

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -356,7 +356,6 @@ public class CMSEngine {
         config = createConfig(storage);
         config.load();
 
-        instanceDir = config.getInstanceDir();
         instanceId = config.getInstanceID();
 
         mConfig = config;
@@ -364,13 +363,6 @@ public class CMSEngine {
 
     public EngineConfig createConfig(ConfigStorage storage) throws Exception {
         return new EngineConfig(storage);
-    }
-
-    /**
-     * Retrieves the instance root path of this server.
-     */
-    public String getInstanceDir() {
-        return instanceDir;
     }
 
     public synchronized IPasswordStore getPasswordStore() throws EBaseException {
@@ -720,8 +712,7 @@ public class CMSEngine {
 
     public void configurePorts() throws Exception {
 
-        String instanceRoot = config.getInstanceDir();
-        String path = instanceRoot + File.separator + "conf" + File.separator + SERVER_XML;
+        String path = instanceDir + File.separator + "conf" + File.separator + SERVER_XML;
 
         serverXml = ServerXml.load(path);
         unsecurePort = serverXml.getUnsecurePort();
@@ -1143,8 +1134,8 @@ public class CMSEngine {
 
         ready = false;
 
-        String catalinaBase = System.getProperty("catalina.base");
-        String serverConfDir = catalinaBase + File.separator + "conf";
+        instanceDir = CMS.getInstanceDir();
+        String serverConfDir = instanceDir + File.separator + "conf";
         String subsystemConfDir = serverConfDir + File.separator + id;
 
         String path = subsystemConfDir + File.separator + "CS.cfg";

--- a/base/server/src/main/java/com/netscape/cmscore/apps/EngineConfig.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/EngineConfig.java
@@ -54,14 +54,6 @@ public class EngineConfig extends ConfigStore {
         putString("instanceId", instanceID);
     }
 
-    public String getInstanceDir() throws EBaseException {
-        return getString("instanceRoot");
-    }
-
-    public void setInstanceDir(String instanceDir) {
-        putString("instanceRoot", instanceDir);
-    }
-
     public String getType() throws EBaseException {
         return getString("cs.type");
     }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SDCreateCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SDCreateCLI.java
@@ -55,14 +55,14 @@ public class SDCreateCLI extends CommandCLI {
 
         String name = cmd.getOptionValue("name");
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
 
         TomcatJSS tomcatjss = TomcatJSS.getInstance();
         tomcatjss.loadConfig();
         tomcatjss.init();
 
         String subsystem = parent.getParent().getName();
-        String subsystemDir = catalinaBase + File.separator + subsystem;
+        String subsystemDir = instanceDir + File.separator + subsystem;
         String subsystemConfDir = subsystemDir + File.separator + "conf";
         String configFile = subsystemConfDir + File.separator + CMS.CONFIG_FILE;
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SDHostAddCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SDHostAddCLI.java
@@ -83,14 +83,14 @@ public class SDHostAddCLI extends CommandCLI {
         boolean domainManager = cmd.hasOption("domain-manager");
         boolean clone = cmd.hasOption("clone");
 
-        String catalinaBase = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
 
         TomcatJSS tomcatjss = TomcatJSS.getInstance();
         tomcatjss.loadConfig();
         tomcatjss.init();
 
         String subsystem = parent.getParent().getParent().getName();
-        String subsystemDir = catalinaBase + File.separator + subsystem;
+        String subsystemDir = instanceDir + File.separator + subsystem;
         String subsystemConfDir = subsystemDir + File.separator + "conf";
         String configFile = subsystemConfDir + File.separator + CMS.CONFIG_FILE;
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemCLI.java
@@ -43,8 +43,8 @@ public abstract class SubsystemCLI extends CommandCLI {
 
     protected EngineConfig getEngineConfig(String subsystem) throws Exception {
 
-        String catalinaBase = System.getProperty("catalina.base");
-        String configDir = catalinaBase + File.separator + subsystem;
+        String instanceDir = CMS.getInstanceDir();
+        String configDir = instanceDir + File.separator + subsystem;
         String configFile = configDir + File.separator + "conf" + File.separator + CMS.CONFIG_FILE;
         logger.debug("{}: Loading {}", getClass().getSimpleName(), configFile);
 

--- a/base/server/src/main/java/org/dogtagpki/server/rest/ACLInterceptor.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/ACLInterceptor.java
@@ -94,7 +94,7 @@ public class ACLInterceptor implements ContainerRequestFilter {
         }
 
         // load custom mapping
-        File customMapping = new File(System.getProperty("catalina.base")
+        File customMapping = new File(CMS.getInstanceDir()
                 + "/" + subsystem + "/conf/acl.properties");
         logger.debug("ACLInterceptor: checking " + customMapping);
         if (customMapping.exists()) {

--- a/base/server/src/main/java/org/dogtagpki/server/rest/AppService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/AppService.java
@@ -23,6 +23,8 @@ import org.dogtagpki.common.AppInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.netscape.cmscore.apps.CMS;
+
 /**
  * @author Endi S. Dewata
  */
@@ -72,7 +74,7 @@ public class AppService {
         Collection<AppInfo> apps = new ArrayList<>();
 
         // get <instance>/conf folder
-        File instanceDir = new File(System.getProperty("catalina.base"));
+        File instanceDir = new File(CMS.getInstanceDir());
         File confDir = new File(instanceDir, "conf");
 
         // get all folders under <instance>/conf

--- a/base/server/src/main/java/org/dogtagpki/server/rest/AuthMethodInterceptor.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/AuthMethodInterceptor.java
@@ -42,6 +42,7 @@ import com.netscape.certsrv.authentication.AuthMethodMapping;
 import com.netscape.certsrv.authentication.ExternalAuthToken;
 import com.netscape.certsrv.base.ForbiddenException;
 import com.netscape.cms.realm.PKIPrincipal;
+import com.netscape.cmscore.apps.CMS;
 
 /**
  * @author Endi S. Dewata
@@ -77,7 +78,7 @@ public class AuthMethodInterceptor implements ContainerRequestFilter {
         }
 
         // load custom mapping
-        File customMapping = new File(System.getProperty("catalina.base") +
+        File customMapping = new File(CMS.getInstanceDir() +
                 "/" + subsystem + "/conf/auth-method.properties");
         logger.debug("AuthMethodInterceptor: checking " + customMapping);
         if (customMapping.exists()) {

--- a/base/server/src/main/java/org/dogtagpki/server/rest/SystemConfigService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/SystemConfigService.java
@@ -38,7 +38,6 @@ public class SystemConfigService extends PKIService {
     public String csSubsystem;
     public String csState;
     public boolean isMasterCA = false;
-    public String instanceRoot;
 
     public SystemConfigService() throws Exception {
 
@@ -53,7 +52,5 @@ public class SystemConfigService extends PKIService {
         if (csType.equals("CA") && domainType.equals("new")) {
             isMasterCA = true;
         }
-
-        instanceRoot = cs.getInstanceDir();
     }
 }

--- a/base/server/upgrade/11.4.0/03-RemoveUnusedParams.py
+++ b/base/server/upgrade/11.4.0/03-RemoveUnusedParams.py
@@ -1,0 +1,29 @@
+# Authors:
+#     Endi S. Dewata <edewata@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import logging
+
+import pki
+
+logger = logging.getLogger(__name__)
+
+
+class RemoveUnusedParams(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Remove unused params'
+
+    def upgrade_subsystem(self, instance, subsystem):
+
+        self.backup(subsystem.cs_conf)
+
+        param = 'instanceRoot'
+        logger.info('Removing %s', param)
+        subsystem.config.pop(param, None)
+
+        subsystem.save()

--- a/base/tks/shared/conf/CS.cfg
+++ b/base/tks/shared/conf/CS.cfg
@@ -57,7 +57,6 @@ preop.cert.admin.profile=adminCert.profile
 preop.module.token=Internal Key Storage Token
 cs.state=0
 authType=pwd
-instanceRoot=[PKI_INSTANCE_PATH]
 configurationRoot=/tks/conf/
 machineName=[PKI_HOSTNAME]
 instanceId=[PKI_INSTANCE_NAME]

--- a/base/tps/shared/conf/CS.cfg
+++ b/base/tps/shared/conf/CS.cfg
@@ -182,7 +182,6 @@ general.search.timelimit.max=10
 general.verifyProof=1
 installDate=[pki_install_time]
 instanceId=[PKI_INSTANCE_NAME]
-instanceRoot=[PKI_INSTANCE_PATH]
 internaldb._000=##
 internaldb._001=## Internal Database
 internaldb._002=##

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSPhoneHome.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSPhoneHome.java
@@ -13,6 +13,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.dogtagpki.tps.main.TPSBuffer;
 
+import com.netscape.cmscore.apps.CMS;
+
 public class TPSPhoneHome extends HttpServlet {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TPSPhoneHome.class);
@@ -80,8 +82,7 @@ public class TPSPhoneHome extends HttpServlet {
         // get subsystem name by removing the / prefix from the context
         String subsystem = context.startsWith("/") ? context.substring(1) : context;
 
-        // catalina.base points to instance dir
-        String instanceDir = System.getProperty("catalina.base");
+        String instanceDir = CMS.getInstanceDir();
         logger.debug("TPSPhoneHome.getConfigPath: instanceDir: " + instanceDir);
 
         //Finish off path of conf directory


### PR DESCRIPTION
The `instanceRoot` param in `CS.cfg` has been removed since the value can be obtained from `catalina.base` system property.

An upgrade script has been added to remove the param from existing instances.