### PR TITLE
Fixes for the TPS UI

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/tps/authenticator/AuthenticatorData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/authenticator/AuthenticatorData.java
@@ -18,15 +18,12 @@
 
 package com.netscape.certsrv.tps.authenticator;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -65,20 +62,6 @@ public class AuthenticatorData implements JSONSerializer {
 
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
-    }
-
-    public static class PropertyList {
-        @JsonProperty("Property")
-        public List<Property> properties = new ArrayList<>();
-    }
-
-    public static class Property {
-
-        @JsonValue
-        public String name;
-
-        @JsonValue
-        public String value;
     }
 
     @Override

--- a/base/common/src/main/java/com/netscape/certsrv/tps/cert/TPSCertData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/cert/TPSCertData.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -33,15 +34,25 @@ import com.netscape.certsrv.util.JSONSerializer;
 public class TPSCertData implements JSONSerializer {
 
     String id;
+    @JsonProperty("SerialNumber")
     String serialNumber;
+    @JsonProperty("Subject")
     String subject;
+    @JsonProperty("UserID")
     String userID;
+    @JsonProperty("TokenID")
     String tokenID;
+    @JsonProperty("Origin")
     String origin;
+    @JsonProperty("Type")
     String type;
+    @JsonProperty("KeyType")
     String keyType;
+    @JsonProperty("Status")
     String status;
+    @JsonProperty("CreateTime")
     Date createTime;
+    @JsonProperty("ModifyTime")
     Date modifyTime;
 
     public String getID() {

--- a/base/common/src/main/java/com/netscape/certsrv/tps/connector/ConnectorData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/connector/ConnectorData.java
@@ -18,15 +18,12 @@
 
 package com.netscape.certsrv.tps.connector;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -64,20 +61,6 @@ public class ConnectorData implements JSONSerializer {
 
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
-    }
-
-    public static class PropertyList {
-        @JsonProperty("Property")
-        public List<Property> properties = new ArrayList<>();
-    }
-
-    public static class Property {
-
-        @JsonValue
-        public String name;
-
-        @JsonValue
-        public String value;
     }
 
     @Override

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileCollection.java
@@ -18,8 +18,6 @@
 
 package com.netscape.certsrv.tps.profile;
 
-import java.util.Collection;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -30,10 +28,4 @@ import com.netscape.certsrv.base.DataCollection;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class ProfileCollection extends DataCollection<ProfileData> {
-
-    @Override
-    public Collection<ProfileData> getEntries() {
-        return super.getEntries();
-    }
-}
+public class ProfileCollection extends DataCollection<ProfileData> {}

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileData.java
@@ -18,15 +18,12 @@
 
 package com.netscape.certsrv.tps.profile;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -73,21 +70,6 @@ public class ProfileData implements JSONSerializer {
 
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
-    }
-
-
-    public static class PropertyList {
-        @JsonProperty("Property")
-        public List<Property> properties = new ArrayList<>();
-    }
-
-    public static class Property {
-
-        @JsonValue
-        public String name;
-
-        @JsonValue
-        public String value;
     }
 
     @Override

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingData.java
@@ -18,15 +18,12 @@
 
 package com.netscape.certsrv.tps.profile;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -64,20 +61,6 @@ public class ProfileMappingData implements JSONSerializer {
 
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
-    }
-
-    public static class PropertyList {
-        @JsonProperty("Property")
-        public List<Property> properties = new ArrayList<>();
-    }
-
-    public static class Property {
-
-        @JsonValue
-        public String name;
-
-        @JsonValue
-        public String value;
     }
 
     @Override

--- a/base/common/src/main/java/org/dogtagpki/common/ConfigData.java
+++ b/base/common/src/main/java/org/dogtagpki/common/ConfigData.java
@@ -19,15 +19,12 @@
 
 package org.dogtagpki.common;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -56,20 +53,6 @@ public class ConfigData implements JSONSerializer {
 
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
-    }
-
-    public static class PropertyList {
-        @JsonProperty("Property")
-        public List<Property> properties = new ArrayList<>();
-    }
-
-    public static class Property {
-
-        @JsonValue
-        public String name;
-
-        @JsonValue
-        public String value;
     }
 
     @Override

--- a/base/server/share/webapps/pki/js/pki-ui.js
+++ b/base/server/share/webapps/pki/js/pki-ui.js
@@ -527,7 +527,15 @@ var Table = Backbone.View.extend({
 
         _(self.entries).each(function(item, index) {
             if (!self.matchesFilter(item, self.searchFilter)) return;
-            self.filteredEntries.push(item);
+            if (item["name"]) {
+                //object is already a property
+                self.filteredEntries.push(item);
+            } else {
+                var property = {};
+                property["name"] = index;
+                property["value"] = item;
+                self.filteredEntries.push(property);
+            }
         });
 
         self.sort();

--- a/base/tps/shared/webapps/tps/js/authenticator.js
+++ b/base/tps/shared/webapps/tps/js/authenticator.js
@@ -26,16 +26,14 @@ var AuthenticatorModel = Model.extend({
             id: response.id,
             authenticatorID: response.id,
             status: response.Status,
-            properties: response.Properties.Property
+            properties: response.Properties
         };
     },
     createRequest: function(attributes) {
         return {
             id: attributes.authenticatorID,
             Status: attributes.status,
-            Properties: {
-                Property: attributes.properties
-            }
+            properties: attributes.properties
         };
     },
     changeStatus: function(action, options) {
@@ -57,9 +55,6 @@ var AuthenticatorCollection = Collection.extend({
     urlRoot: "/tps/rest/authenticators",
     getEntries: function(response) {
         return response.entries;
-    },
-    getLinks: function(response) {
-        return response.Link;
     },
     parseEntry: function(entry) {
         return new AuthenticatorModel({

--- a/base/tps/shared/webapps/tps/js/cert.js
+++ b/base/tps/shared/webapps/tps/js/cert.js
@@ -59,9 +59,6 @@ var CertificateCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         var custModifyTime = (entry.ModifyTime == null) ? undefined : new Date(entry.ModifyTime)
         return new CertificateModel({

--- a/base/tps/shared/webapps/tps/js/config.js
+++ b/base/tps/shared/webapps/tps/js/config.js
@@ -27,15 +27,13 @@ var ConfigModel = Model.extend({
         return {
             id: "config",
             status: response.Status,
-            properties: response.Properties.Property
+            properties: response.Properties
         };
     },
     createRequest: function(entry) {
         return {
             Status: entry.status,
-            Properties: {
-                Property: entry.properties
-            }
+            Properties: entry.properties
         };
     }
 });
@@ -127,12 +125,19 @@ var ConfigPage = EntryPage.extend({
         self.propertiesTable.render();
 
         var text = "";
-        _.each(properties, function(property) {
-            var name = property.name;
-            var value = property.value;
-            text += name + "=" + value + "\n";
+         _.each(properties, function(property) {
+            if (property.name) {
+                var name = property.name;
+                var value = property.value;
+                text += name + "=" + value + "\n";
+            }
         });
-        self.propertiesTextarea.val(text);
+        if (text.length == 0) {
+            for (var property in properties) {
+                 text += property + "=" + properties[property] + "\n";
+            }
+        }
+         self.propertiesTextarea.val(text);
     },
     getProperties: function() {
         var self = this;

--- a/base/tps/shared/webapps/tps/js/connector.js
+++ b/base/tps/shared/webapps/tps/js/connector.js
@@ -26,16 +26,14 @@ var ConnectorModel = Model.extend({
             id: response.id,
             connectorID: response.id,
             status: response.Status,
-            properties: response.Properties.Property
+            properties: response.Properties
         };
     },
     createRequest: function(attributes) {
         return {
             id: attributes.connectorID,
             Status: attributes.status,
-            Properties: {
-                Property: attributes.properties
-            }
+            Properties: attributes.properties
         };
     },
     changeStatus: function(action, options) {
@@ -57,9 +55,6 @@ var ConnectorCollection = Collection.extend({
     urlRoot: "/tps/rest/connectors",
     getEntries: function(response) {
         return response.entries;
-    },
-    getLinks: function(response) {
-        return response.Link;
     },
     parseEntry: function(entry) {
         return new ConnectorModel({

--- a/base/tps/shared/webapps/tps/js/profile-mapping.js
+++ b/base/tps/shared/webapps/tps/js/profile-mapping.js
@@ -26,16 +26,14 @@ var ProfileMappingModel = Model.extend({
             id: response.id,
             profileMappingID: response.id,
             status: response.Status,
-            properties: response.Properties.Property
+            properties: response.Properties
         };
     },
     createRequest: function(attributes) {
         return {
             id: attributes.profileMappingID,
             Status: attributes.status,
-            Properties: {
-                Property: attributes.properties
-            }
+            properties: attributes.properties
         };
     },
     changeStatus: function(action, options) {
@@ -57,9 +55,6 @@ var ProfileMappingCollection = Collection.extend({
     urlRoot: "/tps/rest/profile-mappings",
     getEntries: function(response) {
         return response.entries;
-    },
-    getLinks: function(response) {
-        return response.Link;
     },
     parseEntry: function(entry) {
         return new ProfileMappingModel({

--- a/base/tps/shared/webapps/tps/js/profile.js
+++ b/base/tps/shared/webapps/tps/js/profile.js
@@ -26,7 +26,7 @@ var ProfileModel = Model.extend({
             id: response.id,
             profileID: response.id,
             status: response.Status,
-            properties: response.Properties.Property
+            properties: response.Properties
         };
     },
     createRequest: function(attributes) {
@@ -34,9 +34,7 @@ var ProfileModel = Model.extend({
             id: attributes.id,
             ProfileID: attributes.profileID,
             Status: attributes.status,
-            Properties: {
-                Property: attributes.properties
-            }
+            Properties: attributes.properties
         };
     },
     changeStatus: function(action, options) {
@@ -58,9 +56,6 @@ var ProfileCollection = Collection.extend({
     urlRoot: "/tps/rest/profiles",
     getEntries: function(response) {
         return response.entries;
-    },
-    getLinks: function(response) {
-        return response.Link;
     },
     parseEntry: function(entry) {
         return new ProfileModel({

--- a/base/tps/shared/webapps/tps/js/selftest.js
+++ b/base/tps/shared/webapps/tps/js/selftest.js
@@ -58,9 +58,6 @@ var SelfTestCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         return new SelfTestModel({
             id: entry.id,

--- a/base/tps/shared/webapps/tps/js/token.js
+++ b/base/tps/shared/webapps/tps/js/token.js
@@ -87,9 +87,6 @@ var TokenCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         var custModifyTimestamp = (entry.ModifyTimestamp == null) ? undefined : new Date(entry.ModifyTimestamp)
         return new TokenModel({

--- a/base/tps/shared/webapps/tps/js/tps.js
+++ b/base/tps/shared/webapps/tps/js/tps.js
@@ -447,10 +447,17 @@ var ConfigEntryPage = EntryPage.extend({
 
         var text = "";
         _.each(properties, function(property) {
-            var name = property.name;
-            var value = property.value;
-            text += name + "=" + value + "\n";
+            if (property.name) {
+                var name = property.name;
+                var value = property.value;
+                text += name + "=" + value + "\n";
+            }
         });
+        if (text.length == 0) {
+            for (var property in properties) {
+                 text += property + "=" + properties[property] + "\n";
+            }
+        }
         self.propertiesTextarea.val(text);
     },
     getProperties: function() {


### PR DESCRIPTION
This is the first part of fixes for #2049901 and #1875637, they are not directly related but it so happens that the resolution is and the change was getting large, so here we are.

The first commit fixes the certificate display, which was broken by accidental renaming of the properties in the `Response` object when the mapper was converted from XML to JSON.

The second commit removes some inner classes that were used to provide additional marshalling for properties with the XML mappers. There is no JSON replacement for that, so I removed these classes. This leaves the code as broken as it was.

The third commit repairs the mapping by allowing the JS front end to work with the String map that is used in the rest of the code, so the properties once again display in the UI.  