### PR TITLE
Consolidate container image cache

### DIFF
--- a/.github/workflows/PKICertImport-test.yml
+++ b/.github/workflows/PKICertImport-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -18,23 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
-
-      - name: Retrieve pki-acme image
-        uses: actions/cache@v3
-        with:
-          key: pki-acme-${{ github.sha }}
-          path: pki-acme.tar
-
-      - name: Load pki-acme image
-        run: docker load --input pki-acme.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,7 @@ jobs:
           tags: pki-builder
           target: pki-builder
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-builder.tar
-
-      - name: Store pki-builder image
-        uses: actions/cache@v3
-        with:
-          key: pki-builder-${{ github.sha }}
-          path: pki-builder.tar
+          outputs: type=docker
 
       - name: Build pki-dist image
         uses: docker/build-push-action@v3
@@ -79,13 +73,7 @@ jobs:
           tags: pki-dist
           target: pki-dist
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-dist.tar
-
-      - name: Store pki-dist image
-        uses: actions/cache@v3
-        with:
-          key: pki-dist-${{ github.sha }}
-          path: pki-dist.tar
+          outputs: type=docker
 
       - name: Build pki-runner image
         uses: docker/build-push-action@v3
@@ -97,13 +85,7 @@ jobs:
           tags: pki-runner
           target: pki-runner
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-runner.tar
-
-      - name: Store pki-runner image
-        uses: actions/cache@v3
-        with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          outputs: type=docker
 
       - name: Build pki-server image
         uses: docker/build-push-action@v3
@@ -115,13 +97,7 @@ jobs:
           tags: pki-server
           target: pki-server
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-server.tar
-
-      - name: Store pki-server image
-        uses: actions/cache@v3
-        with:
-          key: pki-server-${{ github.sha }}
-          path: pki-server.tar
+          outputs: type=docker
 
       - name: Build pki-ca image
         uses: docker/build-push-action@v3
@@ -133,13 +109,7 @@ jobs:
           tags: pki-ca
           target: pki-ca
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-ca.tar
-
-      - name: Store pki-ca image
-        uses: actions/cache@v3
-        with:
-          key: pki-ca-${{ github.sha }}
-          path: pki-ca.tar
+          outputs: type=docker
 
       - name: Build pki-acme image
         uses: docker/build-push-action@v3
@@ -151,13 +121,7 @@ jobs:
           tags: pki-acme
           target: pki-acme
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=pki-acme.tar
-
-      - name: Store pki-acme image
-        uses: actions/cache@v3
-        with:
-          key: pki-acme-${{ github.sha }}
-          path: pki-acme.tar
+          outputs: type=docker
 
       - name: Build ipa-runner image
         uses: docker/build-push-action@v3
@@ -169,10 +133,15 @@ jobs:
           tags: ipa-runner
           target: ipa-runner
           cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker,dest=ipa-runner.tar
+          outputs: type=docker
 
-      - name: Store ipa-runner image
+      - name: Save PKI images
+        run: |
+          docker images
+          docker save -o pki-images.tar pki-builder pki-dist pki-runner pki-server pki-ca pki-acme ipa-runner
+
+      - name: Store PKI images
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ github.sha }}
-          path: ipa-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -18,23 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
-
-      - name: Retrieve pki-ca image
-        uses: actions/cache@v3
-        with:
-          key: pki-ca-${{ github.sha }}
-          path: pki-ca.tar
-
-      - name: Load pki-ca image
-        run: docker load --input pki-ca.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -23,14 +23,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-lightweight-hsm-test.yml
+++ b/.github/workflows/ca-lightweight-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-lightweight-test.yml
+++ b/.github/workflows/ca-lightweight-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-pruning-test.yml
+++ b/.github/workflows/ca-pruning-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -23,14 +23,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -23,14 +23,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ca-shared-token-test.yml
+++ b/.github/workflows/ca-shared-token-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up PKI container
         run: |

--- a/.github/workflows/est-basic-test.yml
+++ b/.github/workflows/est-basic-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve ipa-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ github.sha }}
-          path: ipa-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load ipa-runner image
-        run: docker load --input ipa-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve ipa-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ github.sha }}
-          path: ipa-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load ipa-runner image
-        run: docker load --input ipa-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Run IPA container
         run: |

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve ipa-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: ipa-runner-${{ github.sha }}
-          path: ipa-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load ipa-runner image
-        run: docker load --input ipa-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-oaep-test.yml
+++ b/.github/workflows/kra-oaep-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-rsnv3-test.yml
+++ b/.github/workflows/kra-rsnv3-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-cmc-test.yml
+++ b/.github/workflows/ocsp-cmc-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -24,14 +24,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -25,14 +25,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-hsm-test.yml
+++ b/.github/workflows/ocsp-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/pki-nss-aes-test.yml
+++ b/.github/workflows/pki-nss-aes-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-nss-ecc-test.yml
+++ b/.github/workflows/pki-nss-ecc-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-nss-exts-test.yml
+++ b/.github/workflows/pki-nss-exts-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-nss-hsm-test.yml
+++ b/.github/workflows/pki-nss-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-nss-rsa-test.yml
+++ b/.github/workflows/pki-nss-rsa-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-pkcs11-test.yml
+++ b/.github/workflows/pki-pkcs11-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-pkcs12-test.yml
+++ b/.github/workflows/pki-pkcs12-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/pki-pkcs7-test.yml
+++ b/.github/workflows/pki-pkcs7-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up runner container
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,38 +49,26 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
         if: vars.REGISTRY != 'ghcr.io'
 
-      - name: Retrieve pki-dist image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-dist-${{ github.sha }}
-          path: pki-dist.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Publish pki-dist image
         run: |
-          docker load --input pki-dist.tar
           docker tag pki-dist ${{ vars.REGISTRY }}/$NAMESPACE/pki-dist:latest
           docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-dist:latest
 
-      - name: Retrieve pki-ca image
-        uses: actions/cache@v3
-        with:
-          key: pki-ca-${{ github.sha }}
-          path: pki-ca.tar
-
       - name: Publish pki-ca image
         run: |
-          docker load --input pki-ca.tar
           docker tag pki-ca ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest
           docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest
 
-      - name: Retrieve pki-acme image
-        uses: actions/cache@v3
-        with:
-          key: pki-acme-${{ github.sha }}
-          path: pki-acme.tar
-
       - name: Publish pki-acme image
         run: |
-          docker load --input pki-acme.tar
           docker tag pki-acme ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:latest
           docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:latest

--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Retrieve runner image
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
       - name: Load runner image
-        run: docker load --input pki-runner.tar
+        run: docker load --input pki-images.tar
 
       - name: Run container
         run: |

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -51,14 +51,14 @@ jobs:
           pip3 install -r tests/dogtag/pytest-ansible/requirements.txt
           pip3 install -e tests/dogtag/pytest-ansible
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Run master container
         run: |

--- a/.github/workflows/rpminspect-test.yml
+++ b/.github/workflows/rpminspect-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-builder image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-builder-${{ github.sha }}
-          path: pki-builder.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-builder image
-        run: docker load --input pki-builder.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Set up builder container
         run: |

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name:  pki-runner imagemage
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -17,23 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
-
-      - name: Retrieve pki-server image
-        uses: actions/cache@v3
-        with:
-          key: pki-server-${{ github.sha }}
-          path: pki-server.tar
-
-      - name: Load pki-server image
-        run: docker load --input pki-server.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/server-https-jks-test.yml
+++ b/.github/workflows/server-https-jks-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/server-https-pem-test.yml
+++ b/.github/workflows/server-https-pem-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/server-https-pkcs12-test.yml
+++ b/.github/workflows/server-https-pkcs12-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/server-upgrade-test.yml
+++ b/.github/workflows/server-upgrade-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/subca-hsm-test.yml
+++ b/.github/workflows/subca-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name:  pki-runner imagemage
-        run: docker load --input pki-runner.tar
+      - name:  Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-hsm-test.yml
+++ b/.github/workflows/tks-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve pki-runner image
+      - name: Retrieve PKI images
         uses: actions/cache@v3
         with:
-          key: pki-runner-${{ github.sha }}
-          path: pki-runner.tar
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
 
-      - name: Load pki-runner image
-        run: docker load --input pki-runner.tar
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
 
       - name: Create network
         run: docker network create example


### PR DESCRIPTION
Previously each container image was stored in a separate cache which in total consumed about 3 GB of space since they contain duplicate layers. Since the quota is only 10 GB, cache eviction happened quite often which slowed down the CI.

To reduce the problem the build job has been modified to store all images into a single cache which saves about 1 GB of space. The test and publish jobs have been modified to use this cache.