### PR TITLE
Add server backup and restore test

### DIFF
--- a/.github/workflows/server-backup-test.yml
+++ b/.github/workflows/server-backup-test.yml
@@ -1,0 +1,191 @@
+name: Server backup
+
+on:
+  workflow_call:
+    inputs:
+      db-image:
+        required: false
+        type: string
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v3
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: pki-runner
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_hostname=ds.example.com \
+              -D pki_ds_ldap_port=3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Run PKI healthcheck before backup
+        run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Set up PKI client
+        run: |
+          # install signing cert
+          docker exec pki pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
+          docker cp pki:ca_signing.crt .
+          docker cp ca_signing.crt client:.
+          docker exec client pki client-cert-import \
+              --ca-cert ca_signing.crt \
+              ca_signing
+
+          # install admin cert
+          docker cp pki:/root/.dogtag/pki-tomcat/ca_admin_cert.p12 .
+          docker cp ca_admin_cert.p12 client:.
+          docker exec client pki pkcs12-import \
+              --pkcs12 ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Check CA database before backup
+        run: |
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              ca-cert-find \
+              | tee certs.before
+
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              -n caadmin \
+              ca-cert-request-find \
+              | tee requests.before
+
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              -n caadmin \
+              ca-user-find \
+              | tee users.before
+
+      # https://github.com/dogtagpki/pki/wiki/Backing-Up-PKI-Server
+      - name: Back up PKI server
+        run: |
+          docker exec pki pki-server stop --wait
+
+          docker exec pki tar czvf pki-tomcat.tar.gz \
+              -C / \
+              etc/pki/pki-tomcat \
+              etc/sysconfig/pki-tomcat \
+              etc/sysconfig/pki/tomcat/pki-tomcat \
+              etc/systemd/system/pki-tomcatd.target.wants/pki-tomcatd@pki-tomcat.service \
+              var/lib/pki/pki-tomcat \
+              var/log/pki/pki-tomcat
+          docker cp pki:pki-tomcat.tar.gz .
+
+      - name: Remove PKI container
+        run: |
+          docker network disconnect example pki
+          docker rm -f pki
+
+      - name: Recreate PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Reconnect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      # https://github.com/dogtagpki/pki/wiki/Restoring-PKI-Server
+      - name: Restore PKI server
+        run: |
+          docker cp pki-tomcat.tar.gz pki:.
+          docker exec pki tar xzvf pki-tomcat.tar.gz -C /
+
+          docker exec pki pki-server start --wait
+
+      - name: Run PKI healthcheck after restore
+        run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Check CA database after restore
+        run: |
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              ca-cert-find \
+              | tee certs.after
+          diff certs.before certs.after
+
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              -n caadmin \
+              ca-cert-request-find \
+              | tee requests.after
+          diff requests.before requests.after
+
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              -n caadmin \
+              ca-user-find \
+              | tee users.after
+          diff users.before users.after
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: server-backup-restore
+          path: |
+            /tmp/artifacts/pki

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -66,6 +66,13 @@ jobs:
     with:
       db-image: ${{ needs.init.outputs.db-image }}
 
+  server-backup-test:
+    name: Server backup
+    needs: [init, build]
+    uses: ./.github/workflows/server-backup-test.yml
+    with:
+      db-image: ${{ needs.init.outputs.db-image }}
+
   server-upgrade-test:
     name: Server upgrade
     needs: [init, build]


### PR DESCRIPTION
A new test has been added to validate PKI server backup and restore procedure. The current test does not validate the backup and restore procedure for DS or HSM. They can be added separately later.

https://github.com/dogtagpki/pki/wiki/Backing-Up-PKI-Server
https://github.com/dogtagpki/pki/wiki/Restoring-PKI-Server