### PR TITLE
Remove configurationRoot in CS.cfg

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -19,7 +19,6 @@ securitydomain.checkIP=false
 securitydomain.flushinterval=86400000
 securitydomain.source=ldap
 securitydomain.checkinterval=300000
-configurationRoot=/ca/conf/
 machineName=[PKI_HOSTNAME]
 instanceId=[PKI_INSTANCE_NAME]
 pidDir=/var/run/pki/tomcat

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCreateCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCreateCLI.java
@@ -168,8 +168,7 @@ public class CACertCreateCLI extends CommandCLI {
         CAEngineConfig cs = new CAEngineConfig(storage);
         cs.load();
 
-        String configurationRoot = cs.getString("configurationRoot");
-        String profilePath = instanceDir + configurationRoot + profileID;
+        String profilePath = confDir + File.separator + profileID;
 
         logger.info("Loading " + profilePath);
         ConfigStorage profileStorage = new FileConfigStorage(profilePath);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertImportCLI.java
@@ -144,8 +144,7 @@ public class CACertImportCLI extends CommandCLI {
         CAEngineConfig cs = new CAEngineConfig(storage);
         cs.load();
 
-        String configurationRoot = cs.getString("configurationRoot");
-        String profilePath = instanceDir + configurationRoot + profileID;
+        String profilePath = confDir + File.separator + profileID;
 
         logger.info("Loading " + profilePath);
         ConfigStorage profileStorage = new FileConfigStorage(profilePath);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRequestImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRequestImportCLI.java
@@ -148,9 +148,7 @@ public class CACertRequestImportCLI extends CommandCLI {
         cs.load();
 
         String profileID = cmd.getOptionValue("profile");
-
-        String configurationRoot = cs.getString("configurationRoot");
-        String profilePath = instanceDir + configurationRoot + profileID;
+        String profilePath = confDir + File.separator + profileID;
 
         logger.info("Loading " + profilePath);
         ConfigStorage profileStorage = new FileConfigStorage(profilePath);

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -10,7 +10,6 @@ cs.type=KRA
 admin.interface.uri=kra/admin/console/config/wizard
 agent.interface.uri=kra/agent/kra
 authType=pwd
-configurationRoot=/kra/conf/
 machineName=[PKI_HOSTNAME]
 instanceId=[PKI_INSTANCE_NAME]
 pidDir=/var/run/pki/tomcat

--- a/base/ocsp/shared/conf/CS.cfg
+++ b/base/ocsp/shared/conf/CS.cfg
@@ -66,7 +66,6 @@ preop.cert.subsystem.userfriendlyname=Subsystem Certificate
 preop.cert.subsystem.cncomponent.override=true
 cs.state=0
 authType=pwd
-configurationRoot=/ocsp/conf/
 machineName=[PKI_HOSTNAME]
 instanceId=[PKI_INSTANCE_NAME]
 preop.pin=[pki_one_time_pin]

--- a/base/server/upgrade/11.4.0/03-RemoveUnusedParams.py
+++ b/base/server/upgrade/11.4.0/03-RemoveUnusedParams.py
@@ -22,7 +22,13 @@ class RemoveUnusedParams(pki.server.upgrade.PKIServerUpgradeScriptlet):
 
         self.backup(subsystem.cs_conf)
 
+        # remove instanceRoot param
         param = 'instanceRoot'
+        logger.info('Removing %s', param)
+        subsystem.config.pop(param, None)
+
+        # remove configurationRoot param
+        param = 'configurationRoot'
         logger.info('Removing %s', param)
         subsystem.config.pop(param, None)
 

--- a/base/tks/shared/conf/CS.cfg
+++ b/base/tks/shared/conf/CS.cfg
@@ -57,7 +57,6 @@ preop.cert.admin.profile=adminCert.profile
 preop.module.token=Internal Key Storage Token
 cs.state=0
 authType=pwd
-configurationRoot=/tks/conf/
 machineName=[PKI_HOSTNAME]
 instanceId=[PKI_INSTANCE_NAME]
 preop.pin=[pki_one_time_pin]

--- a/base/tps/shared/conf/CS.cfg
+++ b/base/tps/shared/conf/CS.cfg
@@ -122,7 +122,6 @@ cms.version=@APPLICATION_VERSION_MAJOR@.@APPLICATION_VERSION_MINOR@
 cms.passwordlist=internaldb
 config.Generals.General.state=Enabled
 config.Generals.General.timestamp=1280283607424406
-configurationRoot=/tps/conf/
 cs.state=0
 cs.type=TPS
 dbs.ldap=internaldb


### PR DESCRIPTION
The `configurationRoot` param in `CS.cfg` has been removed since the value can be determined from other sources.

The upgrade script has been modified to remove the param from existing instances.