### PR TITLE
Downgrade dependency to Python 3.6

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -240,6 +240,7 @@ class NSSDatabase(object):
             cmd,
             input=None,  # pylint: disable=W0622
             stdout=None,
+            stderr=None,
             capture_output=False,
             check=False,
             text=None,
@@ -256,13 +257,21 @@ class NSSDatabase(object):
             ]
             cmd = runuser + cmd
 
+        if capture_output:
+            stdout = subprocess.PIPE
+            stderr = subprocess.PIPE
+
+        # don't use capture_output and text params to support Python 3.6
+        # https://stackoverflow.com/questions/53209127/subprocess-unexpected-keyword-argument-capture-output/53209196
+        # https://stackoverflow.com/questions/52663518/python-subprocess-popen-doesnt-take-text-argument
+
         result = subprocess.run(
             cmd,
             input=input,
             stdout=stdout,
-            capture_output=capture_output,
+            stderr=stderr,
             check=check,
-            text=text)
+            universal_newlines=text)
 
         if capture_output:
             logger.debug('stdout: %s', stdout)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2880,10 +2880,14 @@ class PKIDeployer:
                 cmd.append('--verbose')
 
             logger.debug('Command: %s', ' '.join(cmd))
+
+            # don't use text param to support Python 3.6
+            # https://stackoverflow.com/questions/52663518/python-subprocess-popen-doesnt-take-text-argument
+
             subprocess.run(
                 cmd,
                 input=cert,
-                text=True,
+                universal_newlines=True,
                 check=True)
 
         finally:
@@ -3066,10 +3070,14 @@ class PKIDeployer:
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))
+
+        # don't use text param to support Python 3.6
+        # https://stackoverflow.com/questions/52663518/python-subprocess-popen-doesnt-take-text-argument
+
         subprocess.run(
             cmd,
             input=json.dumps(shared_secret),
-            text=True,
+            universal_newlines=True,
             check=True)
 
     def setup_shared_secret(self, instance, subsystem):

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2141,7 +2141,16 @@ class KRAConnector:
                    "--host", krahost,
                    "--port", str(kraport)]
 
-        return subprocess.run(command, capture_output=True, check=True, text=True)
+        # don't use capture_output and text params to support Python 3.6
+        # https://stackoverflow.com/questions/53209127/subprocess-unexpected-keyword-argument-capture-output/53209196
+        # https://stackoverflow.com/questions/52663518/python-subprocess-popen-doesnt-take-text-argument
+
+        return subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            universal_newlines=True)
 
 
 class TPSConnector:
@@ -2413,7 +2422,15 @@ class SecurityDomain:
                    "-v",
                    "-r", update_url, sechost + ":" + str(secagentport)]
 
-        return subprocess.run(command, capture_output=True, check=True, text=True)
+        # don't use text param to support Python 3.6
+        # https://stackoverflow.com/questions/52663518/python-subprocess-popen-doesnt-take-text-argument
+
+        return subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            universal_newlines=True)
 
 
 class Systemd(object):

--- a/pki.spec
+++ b/pki.spec
@@ -168,7 +168,7 @@ BuildRequires:    python3-sphinx
 
 BuildRequires:    resteasy >= 3.0.26
 
-BuildRequires:    python3 >= 3.9
+BuildRequires:    python3 >= 3.6
 BuildRequires:    python3-devel
 BuildRequires:    python3-setuptools
 BuildRequires:    python3-cryptography
@@ -333,7 +333,7 @@ Provides:         pki-base-python3 = %{version}-%{release}
 %{?python_provide:%python_provide python3-pki}
 
 Requires:         %{product_id}-base = %{version}-%{release}
-Requires:         python3 >= 3.9
+Requires:         python3 >= 3.6
 Requires:         python3-cryptography
 Requires:         python3-ldap
 Requires:         python3-lxml


### PR DESCRIPTION
The code has been modified to use Python 3.6 API since the newer version might not be available on some platforms.