### PR TITLE
Fix cert rest API with json

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/CertReviewResponseFactory.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/CertReviewResponseFactory.java
@@ -104,6 +104,7 @@ public class CertReviewResponseFactory {
                 logger.debug("policyId:" + id);
                 com.netscape.cms.profile.common.ProfilePolicy policy = profile.getProfilePolicy(profileSetId, id);
                 ProfilePolicy dataPolicy = new ProfilePolicy();
+                dataPolicy.setId(id);
 
                 //populate defaults
                 com.netscape.cms.profile.def.PolicyDefault def = policy.getDefault();
@@ -115,7 +116,6 @@ public class CertReviewResponseFactory {
                 PolicyConstraint dataCons = PolicyConstraintFactory.create(locale, policy.getConstraint(),
                         policy.getConstraint().getClass().getSimpleName());
                 dataPolicy.setConstraint(dataCons);
-
                 dataPolicySet.addPolicy(dataPolicy);
             }
         }

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRevokeRequest.java
@@ -39,6 +39,7 @@ import org.xml.sax.InputSource;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.util.JSONSerializer;
 
 /**
@@ -54,6 +55,7 @@ public class CertRevokeRequest implements JSONSerializer {
     String encoded;
     Long nonce;
 
+    @JsonProperty("Reason")
     public String getReason() {
         return reason;
     }
@@ -62,6 +64,7 @@ public class CertRevokeRequest implements JSONSerializer {
         this.reason = reason;
     }
 
+    @JsonProperty("InvalidityDate")
     public Date getInvalidityDate() {
         return invalidityDate;
     }
@@ -70,6 +73,7 @@ public class CertRevokeRequest implements JSONSerializer {
         this.invalidityDate = invalidityDate;
     }
 
+    @JsonProperty("Comments")
     public String getComments() {
         return comments;
     }
@@ -78,6 +82,7 @@ public class CertRevokeRequest implements JSONSerializer {
         this.comments = comments;
     }
 
+    @JsonProperty("Encoded")
     public String getEncoded() {
         return encoded;
     }
@@ -86,6 +91,7 @@ public class CertRevokeRequest implements JSONSerializer {
         this.encoded = encoded;
     }
 
+    @JsonProperty("Nonce")
     public Long getNonce() {
         return nonce;
     }

--- a/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_enrollment.py
+++ b/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_enrollment.py
@@ -68,15 +68,31 @@ class cert_enroll(object):
         inputs = dict()
         inputs['cert_request_type'] = 'pkcs10'
         inputs['cert_request'] = """-----BEGIN CERTIFICATE REQUEST-----
-        MIIBmDCCAQECAQAwWDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk5DMRAwDgYDVQQH
+        MIIEnTCCAoUCAQAwWDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk5DMRAwDgYDVQQH
         DAdSYWxlaWdoMRUwEwYDVQQKDAxSZWQgSGF0IEluYy4xEzARBgNVBAMMClRlc3RT
-        ZXJ2ZXIwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMJpWz92dSYCvWxllrQC
-        Y5atPKCswUwyppRNGPnKmJ77AdHBBI4dFyET+h/+69jQMTLZMa8FX7SbyHvgbgLB
-        P4Q/RzCSE2S87qFNjriOqiQCqJmcrzDzdncJQiP+O7T6MSpLo3smLP7dK1Vd7vK0
-        Vy8yHwV0eBx7DgYedv2slBPHAgMBAAGgADANBgkqhkiG9w0BAQUFAAOBgQBvkxAG
-        KwkfK3TKwLc5Mg0IWp8zGRVwxdIlghAL8DugNocCNNgmZazglJOOehLuk0/NkLX1
-        ZM5RrVgM09W6kcfWZtIwr5Uje2K/+6tW2ZTGrbizs7CNOTMzA/9H8CkHb4H9P/qR
-        T275zHIocYj4smUnXLwWGsBMeGs+OMMbGvSrHg==
+        ZXJ2ZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDAsEgwOUFN9MpJ
+        0kyXqbxtejDWh0m0+u9Dq3gcMGm6AUYggpIWsiIy+rBVSZfM3xj8Oj0vnMQGyhYa
+        LsRku019g1M1gG2M7bLjxbABPmRqsrVVh6494TPSTMoXB0WJ/d5AE4ktVqEzt4kn
+        +mSwojbmgVyQyndefYcQXLHXrFtMJN4TaYJ34Vz78Uo6buSNtXnaZ3DMCNZk3l/U
+        c9Op3/hpBJ+YQorwjZG4d/7rGY8JEShDUpHKJ8J6kaZ3HrhUUqOU+ywCPdtrHPNY
+        JdC33Zz3fs7HAs0FENj+zWKNTHZ/YJ3r59BB33IsWGw/CKOCKJxrUkiHyUXQkmMl
+        +MxNjlFdGhcsJpp6gikZactv6GSfQr6vBOg0139sniu3WdwPO9mBRq32YrJEq4PI
+        7H75a2wuZ/2lTHi1AhNPqX2fEpfEKaoefexezkEsSEqPkTUjU+rv2fzJdtqhVIxT
+        jI4d7zVcNcmrLIsvvtjKwbWS3yiQN2nfBKgsiII+ii4eFbKrQczXDl/2XFt2MzAe
+        zNK2jfkAJmlqx4xu2VYDTdSmcxqz3XETw7Egn2n9YwGX6beVuOqzH299BrbRN7Jp
+        vZ+MtMXi44i9IHzqNWljSjJzLYauRljIGRVj3soKjz8u1NjWH+pyJGODxdNH7AYO
+        lPICvQiWgNwHNn2xhMxKnf+Ob83/kQIDAQABoAAwDQYJKoZIhvcNAQELBQADggIB
+        ALJnAkdcyyyvOGYtpPwPD31J7KvWkY+vX2U0xggL3u4OH40MFsx7/GJM2CKRo5y9
+        qP1UvVqXONSqATPjl4r/wnfWR8GSWCMwQhg+ibzl3YQBdSaPbOdwEnunRCIMlDdE
+        p/midHiyZLYBUtzoz7d4VmoCJacA9JidXV53xhB2U97M6rzZpnh6/eUEtjGQQQuT
+        uCSUjjsl1bVTz4bXOn2PJxCEb2MPYMto7WLkf5JxdwBnROo+BgE4jw62E1MFXg6c
+        8KiJXS6jk1k7vNgHZcNjXLYIC0RRDexizZRe7I3Z85edTgrz8rv/KBW8EFuMjnlX
+        5c/M6NVdtyCHN+ShuZgi083KH3h5tkoM60MvFW9s+v3IHCTRIPxMZvqEQvasVYS0
+        uVo9AZiINYT2MlzO/vvPrDkVmvMrjecgShcSXhe6PelviH8wVDAHCNdwGbbIjQOx
+        DPCxk5CZYoLEhixau8b+rPpCjpFZSDuNw6+n8ojXrhBv5KT6M/9xA8zI76jJ+7h9
+        cU9auWWdOaYysOohyPh6trW/JH+nbZCQGrsIIe/reaSOd7zUCj631lzQVtpLo4ik
+        mHeeIAR7jlZOJuPu9MdUebxWFtxHDOpc7r6IV2RgfBFdm6uBDp/UHRtgULKkSIZA
+        kCrYeSLr942w6B2PSDPhQmPeliSQV4QnJT+0J1Q7fCdH
         -----END CERTIFICATE REQUEST-----"""
         inputs['sn_uid'] = sn_uid
         inputs['sn_e'] = 'example@redhat.com'

--- a/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_revocation.py
+++ b/tests/dogtag/pytest-ansible/pytest/performance_test/test_cert_revocation.py
@@ -55,7 +55,7 @@ class TestClient(threading.Thread):
                 log.info("Revoking Cert : {}".format(self.cert_sn[sn]))
                 revoke_data = self.cert_client.revoke_cert(self.cert_sn[sn], revocation_reason='Key_Compromise')
                 end = timer()
-                revocation_times.append(int(end - start))
+                revocation_times.append(end - start)
             except Exception as error:
                 log.error(error)
         return
@@ -89,7 +89,6 @@ if __name__ == "__main__":
         clients.append(client)
 
     start = timer()
-
     for client in clients:
         client.start()
 
@@ -98,11 +97,10 @@ if __name__ == "__main__":
         client.join()
 
     end = timer()
-
     with open("revocation_times.json", "w") as cf:
         json.dump(revocation_times, cf)
 
-    T = int(end - start)
+    T = end - start
     N = number_of_clients * number_of_tests_per_client
 
     log.info("Number of certs Revoked (N)={}".format(N))


### PR DESCRIPTION
Rest APIs to enroll and revoke certificates using CLI and json format were broken in several points.

For the enrollment the problem was with the policy `id`. It was not included in the lis json sent to the client for review breaking the client. It is now included.
For the revocation there was a name mismatch between client and server.

Additionally, two test files have been fixed. The one for the enrollment has a new CSR because the old one made use of obsolete and not supported algorithm and the other for the revocation has a fixed on the time counter.

Fix https://bugzilla.redhat.com/show_bug.cgi?id=2053189