### PR TITLE
Fix pkidestroy failures

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -1913,7 +1913,7 @@ class KRAConnector:
         self.password = deployer.password
         self.ca_cert = os.path.join(self.mdict['pki_server_database_path'], "ca.crt")
 
-    def deregister(self, instance, subsystem, critical_failure=False):
+    def deregister(self, instance, subsystem, critical_failure=True):
         krahost = None
         kraport = None
         try:
@@ -2080,7 +2080,7 @@ class TPSConnector:
         self.mdict = deployer.mdict
         self.password = deployer.password
 
-    def deregister(self, instance, subsystem, critical_failure=False):
+    def deregister(self, instance, subsystem, critical_failure=True):
         tkshost = None
         tksport = None
         try:
@@ -2171,7 +2171,7 @@ class SecurityDomain:
         self.mdict = deployer.mdict
         self.password = deployer.password
 
-    def deregister(self, instance, subsystem, critical_failure=False):
+    def deregister(self, instance, subsystem, critical_failure=True):
 
         cs_cfg = PKIConfigParser.read_simple_configuration_file(subsystem.cs_conf)
         machinename = cs_cfg.get('machineName')

--- a/base/server/python/pki/server/deployment/scriptlets/initialization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/initialization.py
@@ -199,22 +199,25 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             # get ports to remove selinux context
             deployer.configuration_file.populate_non_default_ports()
 
-            # remove kra connector from CA if this is a KRA
-            deployer.kra_connector.deregister(instance, subsystem)
+            if not config.str2bool(deployer.mdict['pki_standalone']) \
+                    and not config.str2bool(deployer.mdict['pki_external']):
 
-            # remove tps connector from TKS if this is a TPS
-            deployer.tps_connector.deregister(instance, subsystem)
+                # remove kra connector from CA if this is a KRA
+                deployer.kra_connector.deregister(instance, subsystem)
 
-            # de-register instance from its Security Domain
-            #
-            #     NOTE:  Since the security domain of an instance must be up
-            #            and running in order to be de-registered, this step
-            #            must be done PRIOR to instance shutdown because this
-            #            instance's security domain may be a part of a
-            #            tightly-coupled shared instance.
-            #
+                # remove tps connector from TKS if this is a TPS
+                deployer.tps_connector.deregister(instance, subsystem)
 
-            deployer.security_domain.deregister(instance, subsystem)
+                # de-register instance from its Security Domain
+                #
+                #     NOTE:  Since the security domain of an instance must be up
+                #            and running in order to be de-registered, this step
+                #            must be done PRIOR to instance shutdown because this
+                #            instance's security domain may be a part of a
+                #            tightly-coupled shared instance.
+                #
+
+                deployer.security_domain.deregister(instance, subsystem)
 
         except Exception as e:  # pylint: disable=broad-except
             logger.error(str(e))


### PR DESCRIPTION
Previously in standalone and external cases `pkidestroy` failed to deregister the subsystem since in those cases the subsystem was (correctly) not registered in the first place, so there is actually no need to deregister the subsystem. The code had been suppressing these failures which could potentially suppress other problems as well.

Now the code has been modified to skip deregistration in those cases so it's no longer necessary to suppress any failures.