### PR TITLE
Adopt HTTP 1.1 for http based connections

### DIFF
--- a/base/common/src/main/java/com/netscape/cmsutil/http/HttpRequest.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/http/HttpRequest.java
@@ -74,7 +74,10 @@ public class HttpRequest extends HttpMessage {
             throw e;
         }
 
-        mLine = mMethod + " " + mURI + " " + Http.HttpVers;
+	String protocol = (getHeader("host") != null) ? Http.Vers1_1 : Http.Vers1_0;
+        mLine = mMethod + " " + mURI + " " + protocol;
+	
+
         super.write(writer);
     }
 

--- a/base/server/src/main/java/com/netscape/cmscore/connector/HttpConnection.java
+++ b/base/server/src/main/java/com/netscape/cmscore/connector/HttpConnection.java
@@ -92,7 +92,9 @@ public class HttpConnection {
                 mHttpreq.setHeader("Content-Type", contentType );
             }
 
-            mHttpreq.setHeader("Connection", "Keep-Alive");
+
+            mHttpreq.setHeader("Host", dest.getHost());
+            logger.debug("HttpConnection: setting Host to " + dest.getHost());
 
             connect();
 


### PR DESCRIPTION
Communication between subsystem on separate instance uses HTTP1.0 in some cases. Since this version of HTTP does not support the Host header, reverse proxies in the communication flow do not work.

This commit uprate the `HttpConnection` to use HTTP1.1 for the communication. Actually, it does not support the full HTTP1.1 protocol but only what is needed for the current communication options.

Solve the bugzilla 2130250