### PR TITLE
Fix RPM build warnings

### DIFF
--- a/base/est/CMakeLists.txt
+++ b/base/est/CMakeLists.txt
@@ -51,11 +51,11 @@ add_custom_target(pki-est-links ALL
 add_custom_command(
     TARGET pki-est-links
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf /usr/share/java/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
-    COMMAND ln -sf /usr/share/java/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
-    COMMAND ln -sf /usr/share/java/pki/pki-est.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-est.jar
+    COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
+    COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-certsrv.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-est.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-est.jar
 )
 
 install(


### PR DESCRIPTION
The following absolute links generated RPM build warnings:

```
/usr/share/pki/est/webapps/est/WEB-INF/lib/pki-certsrv.jar -> /usr/share/java/pki/pki-certsrv.jar
/usr/share/pki/est/webapps/est/WEB-INF/lib/pki-cms.jar -> /usr/share/java/pki/pki-cms.jar
/usr/share/pki/est/webapps/est/WEB-INF/lib/pki-est.jar -> /usr/share/java/pki/pki-est.jar
/usr/share/pki/est/webapps/est/WEB-INF/lib/slf4j-api.jar -> /usr/share/java/slf4j/slf4j-api.jar
/usr/share/pki/est/webapps/est/WEB-INF/lib/slf4j-jdk14.jar -> /usr/share/java/slf4j/slf4j-jdk14.jar
```

They have been replaced with relative links.