### PR TITLE
Publish pki-server image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,11 @@ jobs:
           docker tag pki-dist ${{ vars.REGISTRY }}/$NAMESPACE/pki-dist:latest
           docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-dist:latest
 
+      - name: Publish pki-server image
+        run: |
+          docker tag pki-server ${{ vars.REGISTRY }}/$NAMESPACE/pki-server:latest
+          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-server:latest
+
       - name: Publish pki-ca image
         run: |
           docker tag pki-ca ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest


### PR DESCRIPTION
The publish job has been modified to publish the `pki-server` image to Quay.io such that it can be used for development and testing without the complexity of setting up an actual PKI subsystem.

https://github.com/dogtagpki/pki/wiki/Deploying-PKI-Server-Container
https://github.com/dogtagpki/pki/wiki/Running-PKI-Server-Container-as-Systemd-Service