### PR TITLE
Move C flags definitions into RPM spec

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,7 @@ SYSCONF_DIR="/etc"
 SHARE_DIR="/usr/share"
 
 CMAKE="cmake"
+C_FLAGS=
 
 JNI_DIR="/usr/lib/java"
 UNIT_DIR="/usr/lib/systemd/system"
@@ -73,6 +74,7 @@ usage() {
     echo "    --sysconf-dir=<path>   System configuration directory (default: $SYSCONF_DIR)"
     echo "    --share-dir=<path>     Share directory (default: $SHARE_DIR)"
     echo "    --cmake=<path>         Path to CMake executable"
+    echo "    --c-flags=<flags>      C compiler flags"
     echo "    --java-home=<path>     Java home directory"
     echo "    --jni-dir=<path>       JNI directory (default: $JNI_DIR)"
     echo "    --unit-dir=<path>      Systemd unit directory (default: $UNIT_DIR)"
@@ -268,6 +270,9 @@ while getopts v-: arg ; do
         cmake=?*)
             CMAKE=$(readlink -f "$LONG_OPTARG")
             ;;
+        c-flags=?*)
+            C_FLAGS="$LONG_OPTARG"
+            ;;
         java-home=?*)
             # Don't convert Java home into an absolute path since that
             # will prevent PKI from running with other OpenJDK releases.
@@ -339,7 +344,8 @@ while getopts v-: arg ; do
             ;;
         name* | product-name* | product-id* | theme* | work-dir* | \
         prefix-dir* | include-dir* | lib-dir* | sysconf-dir* | share-dir* | \
-        cmake* | java-home* | jni-dir* | unit-dir* | python* | python-dir* | install-dir* | \
+        cmake* | c-flags* | java-home* | jni-dir* | \
+        unit-dir* | python* | python-dir* | install-dir* | \
         source-tag* | spec* | with-pkgs* | without-pkgs* | dist*)
             echo "ERROR: Missing argument for --$OPTARG option" >&2
             exit 1
@@ -404,6 +410,7 @@ if [ "$DEBUG" = true ] ; then
     echo "SYSCONF_DIR: $SYSCONF_DIR"
     echo "SHARE_DIR: $SHARE_DIR"
     echo "CMAKE: $CMAKE"
+    echo "C_FLAGS: $C_FLAGS"
     echo "JAVA_HOME: $JAVA_HOME"
     echo "JNI_DIR: $JNI_DIR"
     echo "PYTHON: $PYTHON"
@@ -625,7 +632,7 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
 
     OPTIONS+=(-DLIB_SUFFIX=64)
     OPTIONS+=(-DBUILD_SHARED_LIBS:BOOL=ON)
-    OPTIONS+=(-DCMAKE_C_FLAGS:STRING="-s")
+    OPTIONS+=(-DCMAKE_C_FLAGS:STRING="$C_FLAGS")
 
     if [ "$VERBOSE" = true ] ; then
         OPTIONS+=(-DCMAKE_JAVA_COMPILE_FLAGS:STRING="-Xlint:deprecation")

--- a/cmake/Modules/DefineCompilerFlags.cmake
+++ b/cmake/Modules/DefineCompilerFlags.cmake
@@ -15,11 +15,6 @@ if (UNIX AND NOT WIN32)
         #       replace '-Wformat-security' with '-Werror=format-security'
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused -Wfloat-equal -Wpointer-arith -Wwrite-strings -Werror=format-security")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-format-attribute")
-        # https://sourceware.org/annobin/annobin.html/Test-gaps.html
-        # https://sourceware.org/annobin/annobin.html/Test-cf-protection.html
-        # https://sourceware.org/annobin/annobin.html/Test-optimization.html
-        # https://sourceware.org/annobin/annobin.html/Test-glibcxx-assertions.html
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fplugin=annobin -fcf-protection=full -O2 -D_GLIBCXX_ASSERTIONS")
 
         # with -fPIC
         check_c_compiler_flag("-fPIC" WITH_FPIC)

--- a/pki.spec
+++ b/pki.spec
@@ -813,6 +813,23 @@ This package provides test suite for %{product_name}.
 # (see /usr/lib/rpm/macros.d/macros.cmake)
 %set_build_flags
 
+# Remove all symbol table and relocation information from the executable.
+C_FLAGS="-s"
+
+%if 0%{?fedora}
+# https://sourceware.org/annobin/annobin.html/Test-gaps.html
+C_FLAGS="$C_FLAGS -fplugin=annobin"
+
+# https://sourceware.org/annobin/annobin.html/Test-cf-protection.html
+C_FLAGS="$C_FLAGS -fcf-protection=full"
+
+# https://sourceware.org/annobin/annobin.html/Test-optimization.html
+C_FLAGS="$C_FLAGS -O2"
+
+# https://sourceware.org/annobin/annobin.html/Test-glibcxx-assertions.html
+C_FLAGS="$C_FLAGS -D_GLIBCXX_ASSERTIONS"
+%endif
+
 pkgs=base\
 %{?with_server:,server}\
 %{?with_ca:,ca}\
@@ -842,6 +859,7 @@ pkgs=base\
     --sysconf-dir=%{_sysconfdir} \
     --share-dir=%{_datadir} \
     --cmake=%{__cmake} \
+    --c-flags="$C_FLAGS" \
     --java-home=%{java_home} \
     --jni-dir=%{_jnidir} \
     --unit-dir=%{_unitdir} \


### PR DESCRIPTION
Some C flags definitions have been moved from CMake file into RPM spec file such that they can be customized for different platforms.

The `build.sh` has been modified to provide a way for the RPM spec file to specify the C flags for CMake.