### PR TITLE
Rename pki-certsrv.jar to pki-common.jar

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,11 +127,11 @@ jobs:
 
   - script: |
       docker exec runner \
-          jar tvf /root/build/dist/pki-certsrv.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
+          jar tvf /root/build/dist/pki-common.jar | awk '{print $8;}' | grep -v '/$' | sort | tee cmake.out
       docker exec runner \
           jar tvf /root/src/base/common/target/pki-common-11.3.0-SNAPSHOT.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort > maven.out
       diff cmake.out maven.out
-    displayName: Compare pki-certsrv.jar
+    displayName: Compare pki-common.jar
 
   - script: |
       docker exec runner \

--- a/base/acme/CMakeLists.txt
+++ b/base/acme/CMakeLists.txt
@@ -14,9 +14,9 @@ javac(pki-acme-classes
         ${JACKSON2_CORE_JAR} ${JACKSON2_DATABIND_JAR}
         ${JSS_JAR}
         ${LDAPJDK_JAR}
-        ${PKI_TOMCAT_JAR} ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_TOMCAT_JAR} ${PKI_CMS_JAR}
     DEPENDS
-        pki-certsrv-jar pki-cms-jar
+        pki-common-jar pki-cms-jar
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )

--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-ca
 javac(pki-ca-classes
     DEPENDS
-        pki-certsrv-jar pki-cms-jar
+        pki-common-jar pki-cms-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -25,7 +25,7 @@ javac(pki-ca-classes
         ${TOMCAT_CATALINA_JAR}
         ${TOMCATJSS_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
-        ${PKI_TOMCAT_JAR} ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_TOMCAT_JAR} ${PKI_CMS_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(common NONE)
 
-# build pki-certsrv
-javac(pki-certsrv-classes
+# build pki-common
+javac(pki-common-classes
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -31,9 +31,9 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/share/etc/pki.conf
 )
 
-jar(pki-certsrv-jar
+jar(pki-common-jar
     CREATE
-        ${CMAKE_BINARY_DIR}/dist/pki-certsrv.jar
+        ${CMAKE_BINARY_DIR}/dist/pki-common.jar
     OPTIONS
         m
     PARAMS
@@ -41,13 +41,13 @@ jar(pki-certsrv-jar
     INPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     DEPENDS
-        pki-certsrv-classes
+        pki-common-classes
 )
 
-set(PKI_CERTSRV_JAR ${CMAKE_BINARY_DIR}/dist/pki-certsrv.jar CACHE INTERNAL "pki-certsrv jar file")
+set(PKI_COMMON_JAR ${CMAKE_BINARY_DIR}/dist/pki-common.jar CACHE INTERNAL "pki-common jar file")
 
 if(RUN_TESTS)
-    javac(pki-certsrv-test-classes
+    javac(pki-common-test-classes
         SOURCES
             src/test/java/*.java
         CLASSPATH
@@ -58,12 +58,12 @@ if(RUN_TESTS)
             ${COMMONS_CLI_JAR} ${COMMONS_CODEC_JAR} ${COMMONS_LANG3_JAR}
             ${HTTPCLIENT_JAR} ${HTTPCORE_JAR}
             ${JACKSON2_ANNOTATIONS_JAR} ${JACKSON2_JAXB_ANNOTATIONS_JAR} ${JACKSON2_CORE_JAR} ${JACKSON2_DATABIND_JAR}
-            ${PKI_CERTSRV_JAR}
+            ${PKI_COMMON_JAR}
             ${HAMCREST_JAR} ${JUNIT_JAR} ${JAXRS_API_JAR}
         OUTPUT_DIR
             ${CMAKE_BINARY_DIR}/test/classes
         DEPENDS
-            pki-certsrv-jar
+            pki-common-jar
     )
 
     execute_process(
@@ -77,7 +77,7 @@ if(RUN_TESTS)
         OUTPUT_VARIABLE DISCOVERED_TESTS
     )
     
-    add_junit_test(test-pki-certsrv
+    add_junit_test(test-pki-common
         CLASSPATH
             ${JAVAX_ACTIVATION_JAR}
             ${JAXB_API_JAR} ${JAXB_IMPL_JAR}
@@ -86,7 +86,7 @@ if(RUN_TESTS)
             ${COMMONS_CLI_JAR} ${COMMONS_CODEC_JAR} ${COMMONS_LANG3_JAR}
             ${HTTPCLIENT_JAR} ${HTTPCORE_JAR}
             ${JACKSON2_ANNOTATIONS_JAR} ${JACKSON2_JAXB_ANNOTATIONS_JAR} ${JACKSON2_CORE_JAR} ${JACKSON2_DATABIND_JAR}
-            ${PKI_CERTSRV_JAR}
+            ${PKI_COMMON_JAR}
             ${HAMCREST_JAR} ${JUNIT_JAR} ${JAXRS_API_JAR}
             ${CMAKE_BINARY_DIR}/test/classes
         TESTS
@@ -94,7 +94,7 @@ if(RUN_TESTS)
         REPORTS_DIR
             reports
         DEPENDS
-            pki-certsrv-test-classes
+            pki-common-test-classes
     )
 endif(RUN_TESTS)
 
@@ -129,7 +129,7 @@ add_custom_command(
     COMMAND ln -sf ../../../..${JSS_SYMKEY_JAR} lib/jss-symkey.jar
     COMMAND ln -sf ../../../..${LDAPJDK_JAR} lib/ldapjdk.jar
     COMMAND ln -sf ../../../..${P11_KIT_TRUST} lib/p11-kit-trust.so
-    COMMAND ln -sf ../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-certsrv.jar
+    COMMAND ln -sf ../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-common.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-common.jar
     COMMAND ln -sf ../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tools.jar ${CMAKE_CURRENT_BINARY_DIR}/lib/pki-tools.jar
     COMMAND ln -sf ../../../..${RESTEASY_CLIENT_JAR} lib/resteasy-client.jar
     COMMAND ln -sf ../../../..${RESTEASY_JACKSON2_PROVIDER_JAR} lib/resteasy-jackson2-provider.jar
@@ -152,7 +152,7 @@ add_custom_command(
 
 install(
     FILES
-        ${CMAKE_BINARY_DIR}/dist/pki-certsrv.jar
+        ${CMAKE_BINARY_DIR}/dist/pki-common.jar
     DESTINATION
         ${JAVA_JAR_INSTALL_DIR}/pki
 )

--- a/base/common/examples/CMakeLists.txt
+++ b/base/common/examples/CMakeLists.txt
@@ -7,11 +7,11 @@ javac(pki-examples-classes
         ${JAXB_API_JAR}
         ${JACKSON2_ANNOTATIONS_JAR}
         ${JSS_JAR}
-        ${PKI_CERTSRV_JAR}
+        ${PKI_COMMON_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     DEPENDS
-        pki-certsrv-jar
+        pki-common-jar
 )
 
 install(

--- a/base/common/src/main/resources/META-INF/MANIFEST.MF
+++ b/base/common/src/main/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
-Name: pki-certsrv
+Name: pki-common
 Specification-Version: ${APPLICATION_VERSION}
 Implementation-Version: ${IMPL_VERSION}

--- a/base/console/CMakeLists.txt
+++ b/base/console/CMakeLists.txt
@@ -3,7 +3,7 @@ project(console NONE)
 # build console classes
 javac(pki-console-classes
     DEPENDS
-        pki-certsrv-jar
+        pki-common-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -12,7 +12,7 @@ javac(pki-console-classes
         ${SLF4J_API_JAR}
         ${BASE_JAR} ${LDAPJDK_JAR} ${MMC_JAR}
         ${MMC_EN_JAR} ${NMCLF_JAR} ${NMCLF_EN_JAR}
-        ${PKI_CERTSRV_JAR}
+        ${PKI_COMMON_JAR}
         ${JSS_JAR} ${COMMONS_CODEC_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes

--- a/base/est/CMakeLists.txt
+++ b/base/est/CMakeLists.txt
@@ -16,11 +16,11 @@ javac(pki-est-classes
         ${TOMCAT_UTIL_JAR}
         ${JSS_JAR}
         ${PKI_CMSUTIL_JAR}
-        ${PKI_CERTSRV_JAR}
+        ${PKI_COMMON_JAR}
         ${PKI_CMS_JAR}
 	${PKI_TOMCAT_JAR} 
     DEPENDS
-        pki-certsrv-jar pki-cms-jar
+        pki-common-jar pki-cms-jar
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )

--- a/base/javadoc/CMakeLists.txt
+++ b/base/javadoc/CMakeLists.txt
@@ -82,7 +82,7 @@ javadoc(pki-javadoc
         ${RESTEASY_JAXRS_JAR} ${RESTEASY_CLIENT_JAR}
         ${JSS_JAR} ${JSS_SYMKEY_JAR}
         ${TOMCATJSS_JAR}
-        ${PKI_CERTSRV_JAR} ${PKI_TOOLS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_TOOLS_JAR}
         ${PKI_JAVADOC_CLASSPATH}
     OPTIONS
         -windowtitle 'pki-javadoc'
@@ -93,7 +93,7 @@ javadoc(pki-javadoc
         -quiet
         ${doclintstr}
     DEPENDS
-        pki-certsrv-jar pki-tools-jar
+        pki-common-jar pki-tools-jar
         ${PKI_JAVADOC_DEPENDS}
 )
 

--- a/base/kra/CMakeLists.txt
+++ b/base/kra/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-kra
 javac(pki-kra-classes
     DEPENDS
-        pki-certsrv-jar pki-cms-jar
+        pki-common-jar pki-cms-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -20,7 +20,7 @@ javac(pki-kra-classes
         ${LDAPJDK_JAR}
         ${SERVLET_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
-        ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR} ${TOMCAT_CATALINA_JAR}
+        ${PKI_COMMON_JAR} ${PKI_CMS_JAR} ${TOMCAT_CATALINA_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )

--- a/base/ocsp/CMakeLists.txt
+++ b/base/ocsp/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-ocsp
 javac(pki-ocsp-classes
     DEPENDS
-        pki-certsrv-jar pki-cms-jar
+        pki-common-jar pki-cms-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -19,7 +19,7 @@ javac(pki-ocsp-classes
         ${JSS_JAR} ${JSS_SYMKEY_JAR}
         ${LDAPJDK_JAR}
         ${TOMCATJSS_JAR}
-        ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(healthcheck)
 # build server classes
 javac(pki-server-classes
     DEPENDS
-        pki-certsrv-jar pki-tools-jar pki-tomcat-jar
+        pki-common-jar pki-tools-jar pki-tomcat-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -21,7 +21,7 @@ javac(pki-server-classes
         ${TOMCATJSS_JAR}
         ${JAVAX_ANNOTATIONS_API_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
-        ${PKI_TOMCAT_JAR} ${PKI_CERTSRV_JAR}
+        ${PKI_COMMON_JAR} ${PKI_TOMCAT_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
@@ -57,11 +57,11 @@ if(RUN_TESTS)
     # build pki-server-test
     javac(pki-server-test-classes
         DEPENDS
-            pki-certsrv-test-classes pki-certsrv-jar pki-cms-jar
+            pki-common-test-classes pki-common-jar pki-cms-jar
         SOURCES
             src/test/java/*.java
         CLASSPATH
-            ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
+            ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
             ${LDAPJDK_JAR} ${SERVLET_JAR}
             ${JSS_JAR} ${JSS_SYMKEY_JAR}
             ${HAMCREST_JAR} ${JUNIT_JAR} ${COMMONS_CODEC_JAR} ${COMMONS_IO_JAR}
@@ -88,7 +88,7 @@ if(RUN_TESTS)
             pki-server-test-classes
         CLASSPATH
             ${SLF4J_API_JAR} ${SLF4J_SIMPLE_JAR}
-            ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
+            ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
             ${LDAPJDK_JAR} ${SERVLET_JAR}
             ${COMMONS_CODEC_JAR} ${COMMONS_LANG3_JAR}
             ${JSS_JAR} ${JSS_SYMKEY_JAR}
@@ -143,7 +143,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../..${JSS_JAR} common/lib/jss.jar
     COMMAND ln -sf ../../../../../..${JSS_SYMKEY_JAR} common/lib/jss-symkey.jar
     COMMAND ln -sf ../../../../../..${LDAPJDK_JAR} common/lib/ldapjdk.jar
-    COMMAND ln -sf ../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-certsrv.jar ${CMAKE_CURRENT_BINARY_DIR}/common/lib/pki-certsrv.jar
+    COMMAND ln -sf ../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-common.jar ${CMAKE_CURRENT_BINARY_DIR}/common/lib/pki-common.jar
     COMMAND ln -sf ../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tomcat.jar ${CMAKE_CURRENT_BINARY_DIR}/common/lib/pki-tomcat.jar
     COMMAND ln -sf ../../../../../..${RESTEASY_CLIENT_JAR} common/lib/resteasy-client.jar
     COMMAND ln -sf ../../../../../..${RESTEASY_JACKSON2_PROVIDER_JAR} common/lib/resteasy-jackson2-provider.jar

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -335,7 +335,7 @@ class PKIInstance(pki.server.PKIServer):
                 'jss.jar',
                 'jss-symkey.jar',
                 'ldapjdk.jar',
-                'pki-certsrv.jar',
+                'pki-common.jar',
                 'pki-tomcat.jar',
                 'tomcatjss.jar']:
 

--- a/base/tks/CMakeLists.txt
+++ b/base/tks/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-tks
 javac(pki-tks-classes
     DEPENDS
-        pki-certsrv-jar pki-cms-jar
+        pki-common-jar pki-cms-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -22,7 +22,7 @@ javac(pki-tks-classes
         ${JSS_JAR} ${JSS_SYMKEY_JAR}
         ${SERVLET_JAR} ${TOMCAT_CATALINA_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
-        ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )

--- a/base/tomcat-9.0/CMakeLists.txt
+++ b/base/tomcat-9.0/CMakeLists.txt
@@ -13,11 +13,11 @@ javac(pki-tomcat-classes
         ${TOMCAT_API_JAR} ${TOMCAT_CATALINA_JAR} ${TOMCAT_COYOTE_JAR} ${TOMCAT_UTIL_SCAN_JAR}
         ${SLF4J_API_JAR}
         ${JSS_JAR} ${TOMCATJSS_JAR}
-        ${PKI_CERTSRV_JAR}
+        ${PKI_COMMON_JAR}
     OUTPUT_DIR
         ${CMAKE_BINARY_DIR}/../tomcat
     DEPENDS
-        pki-certsrv-jar
+        pki-common-jar
 )
 
 configure_file(

--- a/base/tools/CMakeLists.txt
+++ b/base/tools/CMakeLists.txt
@@ -21,11 +21,11 @@ javac(pki-tools-classes
         ${HTTPCLIENT_JAR} ${HTTPCORE_JAR}
         ${SLF4J_API_JAR} ${JAXB_API_JAR}
         ${JSS_JAR} ${JSS_SYMKEY_JAR} ${LDAPJDK_JAR}
-        ${PKI_CERTSRV_JAR}
+        ${PKI_COMMON_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     DEPENDS
-        pki-certsrv-jar tkstool
+        pki-common-jar tkstool
 )
 
 configure_file(

--- a/base/tools/src/main/native/p12tool/CMakeLists.txt
+++ b/base/tools/src/main/native/p12tool/CMakeLists.txt
@@ -23,7 +23,7 @@ set(p12tool_SRCS
 include_directories(${P12TOOL_PRIVATE_INCLUDE_DIRS})
 
 add_executable(p12tool ${p12tool_SRCS})
-add_dependencies(p12tool pki-certsrv-jar)
+add_dependencies(p12tool pki-common-jar)
 target_link_libraries(p12tool ${P12TOOL_LINK_LIBRARIES})
 
 install(

--- a/base/tools/src/main/native/p7tool/CMakeLists.txt
+++ b/base/tools/src/main/native/p7tool/CMakeLists.txt
@@ -22,7 +22,7 @@ set(p7tool_SRCS
 include_directories(${P7TOOL_PRIVATE_INCLUDE_DIRS})
 
 add_executable(p7tool ${p7tool_SRCS})
-add_dependencies(p7tool pki-certsrv-jar)
+add_dependencies(p7tool pki-common-jar)
 target_link_libraries(p7tool ${P7TOOL_LINK_LIBRARIES})
 
 install(

--- a/base/tps/CMakeLists.txt
+++ b/base/tps/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-tps
 javac(pki-tps-classes
     DEPENDS
-        pki-certsrv-jar pki-cms-jar
+        pki-common-jar pki-cms-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -20,7 +20,7 @@ javac(pki-tps-classes
         ${JSS_JAR} ${JSS_SYMKEY_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
         ${SERVLET_JAR} ${TOMCAT_CATALINA_JAR}
-        ${PKI_CERTSRV_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )

--- a/build.sh
+++ b/build.sh
@@ -707,7 +707,7 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
 
     if [[ " ${PKGS_TO_BUILD[*]} " =~ " base " ]]; then
         echo "- base:"
-        echo "    $WORK_DIR/dist/pki-certsrv.jar"
+        echo "    $WORK_DIR/dist/pki-common.jar"
         echo "    $WORK_DIR/dist/pki-tools.jar"
     fi
 

--- a/docs/changes/v11.4.0/Server-Changes.adoc
+++ b/docs/changes/v11.4.0/Server-Changes.adoc
@@ -6,7 +6,7 @@ The `<subsystem>-add-user` methods accept a new option `--attributes` which take
 
 `pki-server <subsystem>-add-user <instance> <other options> --attributes "ham:spam,foo:bar"`
 
-== Relocating pki-certsrv.jar ==
+== Renaming pki-certsrv.jar to pki-common.jar ==
 
 Previously the `pki-certsrv.jar` was installed under `WEB-INF/lib` folder of each web application.
-The file has been moved into the `common/lib` folder such that it is available for the entire server.
+The file has been moved into the `common/lib` folder and renamed into `pki-common.jar` such that it is available for the entire server.

--- a/pki.spec
+++ b/pki.spec
@@ -985,7 +985,7 @@ fi
 %{_datadir}/pki/examples/java/
 %{_datadir}/pki/lib/*.jar
 %dir %{_javadir}/pki
-%{_javadir}/pki/pki-certsrv.jar
+%{_javadir}/pki/pki-common.jar
 
 ################################################################################
 %files -n python3-%{product_id}

--- a/tests/dogtag/shared/rhcs-shared.sh
+++ b/tests/dogtag/shared/rhcs-shared.sh
@@ -192,9 +192,9 @@ set_javapath(){
         if [ $? -eq 0 ] ; then
 		echo $arch | grep "x86_64"
                 if [ $? -eq 0 ] ; then
-                        classpath="./:/usr/lib/java/jss4.jar:/usr/share/java/ldapjdk.jar:/usr/share/java/pki/pki-certsrv.jar:/usr/share/java/pki/pki-cmsutil.jar:/usr/share/java/pki/pki-tools.jar:/usr/share/java/apache-commons-codec.jar:/usr/share/java/pki/pki-silent.jar:/opt/rhqa_pki/java/generateCRMFRequest.jar:"
+                        classpath="./:/usr/lib/java/jss4.jar:/usr/share/java/ldapjdk.jar:/usr/share/java/pki/pki-common.jar:/usr/share/java/pki/pki-cmsutil.jar:/usr/share/java/pki/pki-tools.jar:/usr/share/java/apache-commons-codec.jar:/usr/share/java/pki/pki-silent.jar:/opt/rhqa_pki/java/generateCRMFRequest.jar:"
                 else
-                        classpath="./:/usr/lib/java/jss4.jar:/usr/share/java/ldapjdk.jar:/usr/share/java/pki/pki-certsrv.jar:/usr/share/java/pki/pki-cmsutil.jar:/usr/share/java/pki/pki-tools.jar:/usr/share/java/apache-commons-codec.jar:/usr/share/java/pki/pki-silent.jar:/opt/rhqa_pki/java/generateCRMFRequest.jar:"
+                        classpath="./:/usr/lib/java/jss4.jar:/usr/share/java/ldapjdk.jar:/usr/share/java/pki/pki-common.jar:/usr/share/java/pki/pki-cmsutil.jar:/usr/share/java/pki/pki-tools.jar:/usr/share/java/apache-commons-codec.jar:/usr/share/java/pki/pki-silent.jar:/opt/rhqa_pki/java/generateCRMFRequest.jar:"
                 fi
 		echo "export CLASSPATH=$classpath" >> /opt/rhqa_pki/env.sh
                 return 0


### PR DESCRIPTION
The `pki-certsrv.jar` has been renamed to `pki-common.jar` to better reflect the content of the file which comes from `base/common`.

https://github.com/edewata/pki/blob/install/docs/changes/v11.4.0/Server-Changes.adoc