### PR TITLE
Fix pki.policy

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -303,11 +303,13 @@ class PKIServer(object):
 
         logger.info('Creating catalina.policy')
 
+        # add "do not edit" warning
         filename = '/usr/share/pki/server/conf/catalina.policy'
         logger.info('Appending %s', filename)
         with open(filename, 'r', encoding='utf-8') as f:
             content = f.read()
 
+        # add Tomcat's default policy
         filename = '/usr/share/tomcat/conf/catalina.policy'
         logger.info('Appending %s', filename)
         with open(filename, 'r', encoding='utf-8') as f:
@@ -315,11 +317,13 @@ class PKIServer(object):
 
         content += '\n\n'
 
+        # add PKI's default policy
         filename = '/usr/share/pki/server/conf/pki.policy'
         logger.info('Appending %s', filename)
         with open(filename, 'r', encoding='utf-8') as f:
             content += f.read()
 
+        # generate policies for libraries in <instance>/common/lib
         for root, _, filenames in os.walk(self.common_lib_dir):
             for filename in filenames:
                 filepath = os.path.join(root, filename)
@@ -330,6 +334,7 @@ grant codeBase "file:%s" {
 };
 ''' % filepath
 
+        # add admin's custom policy
         filename = '%s/custom.policy' % self.conf_dir
         if os.path.exists(filename):
             logger.info('Appending %s', filename)
@@ -337,6 +342,7 @@ grant codeBase "file:%s" {
             with open(filename, 'r', encoding='utf-8') as f:
                 content += f.read()
 
+        # store everything into <instance>/conf/catalina.policy
         filename = '%s/catalina.policy' % self.conf_dir
         logger.info('Storing %s', filename)
         with open(filename, 'w', encoding='utf-8') as f:

--- a/base/server/share/conf/pki.policy
+++ b/base/server/share/conf/pki.policy
@@ -10,8 +10,14 @@
 // Tomcat.
 // ============================================================================
 
+// According to /etc/tomcat/catalina.policy:
+// This permission is required when using javac to compile JSPs on Java 9
+// onwards
+grant codeBase "jrt:/jdk.compiler" {
+        permission java.security.AllPermission;
+};
+
 grant codeBase "file:${catalina.home}/bin/tomcat-juli.jar" {
-        permission java.lang.RuntimePermission "accessClassInPackage.sun.util.logging.resources";
 
         // Allow Tomcat JULI to read shared PKI files including logging.properties.
         permission java.io.FilePermission "/usr/share/pki/-", "read";
@@ -20,74 +26,18 @@ grant codeBase "file:${catalina.home}/bin/tomcat-juli.jar" {
         permission java.io.FilePermission "${catalina.base}/logs/-", "read,write";
 };
 
-grant codeBase "file:${catalina.base}/bin/bootstrap.jar" {
-        permission java.security.AllPermission;
-};
-
+// According to /etc/tomcat/catalina.policy:
+// If using a per instance lib directory, i.e. ${catalina.base}/lib,
+// then the following permission will need to be uncommented
 grant codeBase "file:${catalina.base}/lib/-" {
         permission java.security.AllPermission;
 };
 
-grant codeBase "file:/usr/share/java/ecj.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/ecj/ecj.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/eclipse/-" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/glassfish-jsp.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/jaxb-api.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/jakarta-activation/jakarta.activation.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/jaxme/jaxmeapi.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/jaxp_parser_impl.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/jboss-web.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/servlet.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/slf4j/slf4j-jdk14.jar" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/tomcat/-" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:/usr/share/java/tomcat-el-api.jar" {
-        permission java.security.AllPermission;
-};
-
+// required for Fedora
 grant codeBase "file:/usr/share/java/tomcat-servlet-api.jar" {
         permission java.security.AllPermission;
 };
 
 grant codeBase "file:/usr/share/java/pki/-" {
-        permission java.security.AllPermission;
-};
-
-grant codeBase "file:${catalina.base}/webapps/-" {
         permission java.security.AllPermission;
 };


### PR DESCRIPTION
The `pki.policy` has been updated such that it works on both Fedora and RHEL. Some obsolete policies have been removed as well.