### PR TITLE
Add pki_registry_enable

### DIFF
--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -325,6 +325,7 @@ pkispawn \
     -D pki_security_domain_setup=False \
     -D pki_security_manager=False \
     -D pki_systemd_service_create=False \
+    -D pki_registry_enable=False \
     -v
 
 echo "################################################################################"

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -222,7 +222,6 @@ pki_source_subsystem_path=/usr/share/pki/%(pki_subsystem_type)s
 pki_path=/var/lib/pki
 pki_log_path=/var/log/pki
 pki_configuration_path=/etc/pki
-pki_registry_path=/etc/sysconfig/pki
 pki_instance_path=%(pki_path)s/%(pki_instance_name)s
 pki_instance_log_path=%(pki_log_path)s/%(pki_instance_name)s
 pki_instance_configuration_path=%(pki_configuration_path)s/%(pki_instance_name)s
@@ -319,11 +318,13 @@ pki_tomcat_work_catalina_path=%(pki_tomcat_work_path)s/Catalina
 pki_tomcat_work_catalina_host_path=%(pki_tomcat_work_catalina_path)s/localhost
 pki_tomcat_work_catalina_host_run_path=%(pki_tomcat_work_catalina_host_path)s/_
 pki_tomcat_work_catalina_host_subsystem_path=%(pki_tomcat_work_catalina_host_path)s/%(pki_subsystem_type)s
-pki_instance_registry_path=%(pki_registry_path)s/tomcat/%(pki_instance_name)s
-pki_subsystem_registry_path=%(pki_instance_registry_path)s/%(pki_subsystem_type)s
 pki_tomcat_bin_link=%(pki_instance_path)s/bin
 pki_subsystem_signed_audit_log_path=%(pki_subsystem_log_path)s/signedAudit
 
+pki_registry_enable=True
+pki_registry_path=/etc/sysconfig/pki
+pki_instance_registry_path=%(pki_registry_path)s/tomcat/%(pki_instance_name)s
+pki_subsystem_registry_path=%(pki_instance_registry_path)s/%(pki_subsystem_type)s
 
 ###############################################################################
 ##  CA Configuration:                                                        ##

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -248,7 +248,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             deployer.mdict['pki_instance_log_path'],
             deployer.mdict['pki_instance_logs_link'])
 
-        instance.create_registry()
+        if config.str2bool(deployer.mdict['pki_registry_enable']):
+            instance.create_registry()
 
         if config.str2bool(deployer.mdict['pki_systemd_service_create']):
 
@@ -295,7 +296,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         deployer.systemd.daemon_reload()
 
-        instance.remove_registry(force=deployer.force)
+        if config.str2bool(deployer.mdict['pki_registry_enable']):
+            instance.remove_registry(force=deployer.force)
 
         logger.info('Removing %s', deployer.mdict['pki_instance_path'])
         pki.util.rmtree(path=deployer.mdict['pki_instance_path'],

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -66,7 +66,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         subsystem.create_conf(exist_ok=True)
         subsystem.create_logs(exist_ok=True)
 
-        subsystem.create_registry(exist_ok=True)
+        if config.str2bool(deployer.mdict['pki_registry_enable']):
+            subsystem.create_registry(exist_ok=True)
 
         # Copy /usr/share/pki/<subsystem>/conf/CS.cfg
         # to /etc/pki/<instance>/<subsystem>/CS.cfg
@@ -359,7 +360,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         subsystem = instance.get_subsystem(deployer.mdict['pki_subsystem'].lower())
 
-        subsystem.remove_registry(force=deployer.force)
+        if config.str2bool(deployer.mdict['pki_registry_enable']):
+            subsystem.remove_registry(force=deployer.force)
 
         if deployer.mdict['pki_subsystem'] == "CA":
 

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -624,10 +624,12 @@ def main(argv):
         print()
         sys.exit(1)
 
-    # Store user config and installation manifest into
-    # /etc/sysconfig/pki/tomcat/<instance>/<subsystem>
-    deployer.store_config(instance)
-    deployer.store_manifest(instance)
+    if config.str2bool(deployer.mdict['pki_registry_enable']):
+
+        # Store user config and installation manifest into
+        # /etc/sysconfig/pki/tomcat/<instance>/<subsystem>
+        deployer.store_config(instance)
+        deployer.store_manifest(instance)
 
     external = deployer.configuration_file.external
     standalone = deployer.configuration_file.standalone


### PR DESCRIPTION
`pkispawn` uses a registry to keep track of all instances and subsystems it installed to help future removal. However, in containers it's not necessary to remove the instances and subsystems, so a new `pki_registry_enable` param has been added to disable the registry in a container.