### PR TITLE
Restore some codeBase permissions in pki.policy

### DIFF
--- a/base/server/share/conf/pki.policy
+++ b/base/server/share/conf/pki.policy
@@ -33,11 +33,19 @@ grant codeBase "file:${catalina.base}/lib/-" {
         permission java.security.AllPermission;
 };
 
+grant codeBase "file:/usr/share/java/tomcat-el-api.jar" {
+        permission java.security.AllPermission;
+};
+
 // required for Fedora
 grant codeBase "file:/usr/share/java/tomcat-servlet-api.jar" {
         permission java.security.AllPermission;
 };
 
 grant codeBase "file:/usr/share/java/pki/-" {
+        permission java.security.AllPermission;
+};
+
+grant codeBase "file:${catalina.base}/webapps/-" {
         permission java.security.AllPermission;
 };


### PR DESCRIPTION
These permissions are required at runtime to start the PKI server.

Closes: #4339 