### PR TITLE
Add PKIService.getCMSEngine()

### DIFF
--- a/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
@@ -45,6 +45,7 @@ import javax.ws.rs.core.UriInfo;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.util.JSONSerializer;
 import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.CMSEngine;
 
 /**
  * Base class for CMS RESTful resources
@@ -349,5 +350,9 @@ public class PKIService {
         }
 
         return map;
+    }
+
+    public CMSEngine getCMSEngine() {
+        return (CMSEngine) servletContext.getAttribute("engine");
     }
 }

--- a/base/server/src/main/java/com/netscape/cmscore/apps/PKIWebListener.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/PKIWebListener.java
@@ -5,6 +5,7 @@
 //
 package com.netscape.cmscore.apps;
 
+import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
@@ -21,7 +22,9 @@ public abstract class PKIWebListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent event) {
 
-        String path = event.getServletContext().getContextPath();
+        ServletContext servletContext = event.getServletContext();
+
+        String path = servletContext.getContextPath();
         String id;
 
         if ("".equals(path)) {
@@ -32,6 +35,7 @@ public abstract class PKIWebListener implements ServletContextListener {
 
         CMSEngine engine = createEngine();
         engine.setID(id);
+        servletContext.setAttribute("engine", engine);
 
         String name = engine.getName();
 
@@ -51,7 +55,9 @@ public abstract class PKIWebListener implements ServletContextListener {
     @Override
     public void contextDestroyed(ServletContextEvent event) {
 
-        CMSEngine engine = CMS.getCMSEngine();
+        ServletContext servletContext = event.getServletContext();
+
+        CMSEngine engine = (CMSEngine) servletContext.getAttribute("engine");
         engine.shutdown();
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/rest/GroupService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/GroupService.java
@@ -55,9 +55,6 @@ public class GroupService extends SubsystemService implements GroupResource {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(GroupService.class);
 
-    CMSEngine engine = CMS.getCMSEngine();
-    public UGSubsystem userGroupManager = engine.getUGSubsystem();
-
     public GroupData createGroupData(Group group) throws Exception {
 
         GroupData groupData = new GroupData();
@@ -92,6 +89,8 @@ public class GroupService extends SubsystemService implements GroupResource {
         size = size == null ? DEFAULT_SIZE : size;
 
         try {
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             Enumeration<Group> groups = userGroupManager.listGroups(filter);
 
             GroupCollection response = new GroupCollection();
@@ -137,7 +136,10 @@ public class GroupService extends SubsystemService implements GroupResource {
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             Group group = userGroupManager.getGroupFromName(groupID);
+
             if (group == null) {
                 logger.error(CMS.getLogMessage("USRGRP_SRVLT_GROUP_NOT_EXIST"));
                 throw new GroupNotFoundException(groupID);
@@ -181,6 +183,8 @@ public class GroupService extends SubsystemService implements GroupResource {
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             Group group = userGroupManager.createGroup(groupID);
 
             // add description if specified
@@ -243,6 +247,8 @@ public class GroupService extends SubsystemService implements GroupResource {
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             Group group = userGroupManager.getGroupFromName(groupID);
 
             if (group == null) {
@@ -305,6 +311,8 @@ public class GroupService extends SubsystemService implements GroupResource {
             }
 
             // if fails, let the exception fall through
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             userGroupManager.removeGroup(groupID);
 
             auditDeleteGroup(groupID, ILogger.SUCCESS);

--- a/base/server/src/main/java/org/dogtagpki/server/rest/JobService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/JobService.java
@@ -22,7 +22,6 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.ResourceNotFoundException;
 import com.netscape.cms.realm.PKIPrincipal;
 import com.netscape.cms.servlet.base.SubsystemService;
-import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.jobs.JobConfig;
@@ -96,7 +95,7 @@ public class JobService extends SubsystemService implements JobResource {
 
         JobCollection response = new JobCollection();
 
-        CMSEngine engine = CMS.getCMSEngine();
+        CMSEngine engine = getCMSEngine();
         EngineConfig engineConfig = engine.getConfig();
         JobsSchedulerConfig jobsSchedulerConfig = engineConfig.getJobsSchedulerConfig();
         JobsConfig jobsConfig = jobsSchedulerConfig.getJobsConfig();
@@ -131,7 +130,7 @@ public class JobService extends SubsystemService implements JobResource {
 
         logger.info("JobService: Getting job " + id);
 
-        CMSEngine engine = CMS.getCMSEngine();
+        CMSEngine engine = getCMSEngine();
         EngineConfig engineConfig = engine.getConfig();
         JobsSchedulerConfig jobsSchedulerConfig = engineConfig.getJobsSchedulerConfig();
         JobsConfig jobsConfig = jobsSchedulerConfig.getJobsConfig();
@@ -162,7 +161,7 @@ public class JobService extends SubsystemService implements JobResource {
 
         logger.info("JobService: Starting job " + id);
 
-        CMSEngine engine = CMS.getCMSEngine();
+        CMSEngine engine = getCMSEngine();
         EngineConfig engineConfig = engine.getConfig();
         JobsSchedulerConfig jobsSchedulerConfig = engineConfig.getJobsSchedulerConfig();
         JobsConfig jobsConfig = jobsSchedulerConfig.getJobsConfig();

--- a/base/server/src/main/java/org/dogtagpki/server/rest/UserService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/UserService.java
@@ -84,9 +84,6 @@ public class UserService extends SubsystemService implements UserResource {
     public final static String BACK_SLASH = "\\";
     public final static String SYSTEM_USER = "$System$";
 
-    CMSEngine engine = CMS.getCMSEngine();
-    public UGSubsystem userGroupManager = engine.getUGSubsystem();
-
     public UserData createUserData(User user) throws Exception {
 
         UserData userData = new UserData();
@@ -123,6 +120,8 @@ public class UserService extends SubsystemService implements UserResource {
         UserCollection response = new UserCollection();
 
         try {
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             Enumeration<User> users = userGroupManager.findUsersByKeyword(filter);
 
             int i = 0;
@@ -180,8 +179,9 @@ public class UserService extends SubsystemService implements UserResource {
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
-            CMSEngine engine = CMS.getCMSEngine();
+            CMSEngine engine = getCMSEngine();
             EngineConfig cs = engine.getConfig();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             User user;
 
             try {
@@ -259,9 +259,6 @@ public class UserService extends SubsystemService implements UserResource {
 
         if (userData == null) throw new BadRequestException("User data is null.");
 
-        CMSEngine engine = CMS.getCMSEngine();
-        EngineConfig cs = engine.getConfig();
-
         String userID = userData.getUserID();
         logger.debug("User ID: " + userID);
 
@@ -285,6 +282,9 @@ public class UserService extends SubsystemService implements UserResource {
                 throw new ForbiddenException(getUserMessage("CMS_ADMIN_SRVLT_SPECIAL_ID", headers, userID));
             }
 
+            CMSEngine engine = getCMSEngine();
+            EngineConfig cs = engine.getConfig();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             User user = userGroupManager.createUser(userID);
 
             String fname = userData.getFullName();
@@ -412,16 +412,17 @@ public class UserService extends SubsystemService implements UserResource {
 
         if (userData == null) throw new BadRequestException("User data is null.");
 
-        CMSEngine engine = CMS.getCMSEngine();
         // ensure that any low-level exceptions are reported
         // to the signed audit log and stored as failures
-        EngineConfig cs = engine.getConfig();
         try {
             if (userID == null) {
                 logger.error(CMS.getLogMessage("ADMIN_SRVLT_NULL_RS_ID"));
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
+            CMSEngine engine = getCMSEngine();
+            EngineConfig cs = engine.getConfig();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             User user = userGroupManager.createUser(userID);
 
             String fullName = userData.getFullName();
@@ -525,6 +526,8 @@ public class UserService extends SubsystemService implements UserResource {
             }
 
             // get list of groups, and see if uid belongs to any
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             Enumeration<Group> groups = userGroupManager.findGroups("*");
 
             while (groups.hasMoreElements()) {
@@ -583,6 +586,8 @@ public class UserService extends SubsystemService implements UserResource {
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             User user = null;
 
             try {
@@ -640,6 +645,8 @@ public class UserService extends SubsystemService implements UserResource {
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             User user = null;
 
             try {
@@ -717,6 +724,8 @@ public class UserService extends SubsystemService implements UserResource {
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             User user = userGroupManager.createUser(userID);
 
             String encoded = userCertData.getEncoded();
@@ -944,6 +953,8 @@ public class UserService extends SubsystemService implements UserResource {
                 throw new BadRequestException(getUserMessage("CMS_ADMIN_SRVLT_NULL_RS_ID", headers));
             }
 
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             User user = userGroupManager.createUser(userID);
             String certID = userCertData.getID();
 
@@ -998,6 +1009,8 @@ public class UserService extends SubsystemService implements UserResource {
         size = size == null ? DEFAULT_SIZE : size;
 
         try {
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             User user = userGroupManager.getUser(userID);
 
             if (user == null) {
@@ -1039,9 +1052,12 @@ public class UserService extends SubsystemService implements UserResource {
 
         if (userID == null) throw new BadRequestException("User ID is null.");
         if (groupID == null) throw new BadRequestException("Group ID is null.");
+
         User user = null;
 
         try {
+            CMSEngine engine = getCMSEngine();
+            UGSubsystem userGroupManager = engine.getUGSubsystem();
             user = userGroupManager.getUser(userID);
         } catch (Exception e) {
             throw new PKIException(getUserMessage("CMS_USRGRP_SRVLT_USER_NOT_EXIST", headers));


### PR DESCRIPTION
Currently the `CMSEngine` object is stored in `CMS.engine` global variable which makes it more complicated to maintain the code. To reduce the problem, the `PKIWebListener` has been modified to store the `CMSEngine` object as an attribute in the servlet context (i.e. web application). The `PKIService.getCMSEngine()` has been added to get the `CMSEngine` object from the servlet context.

The code that depends on the `CMS.engine` will be incrementally updated. Eventually the `CMS.engine` will no longer be used and can be removed.
