### PR TITLE
Use Python XML to update Tomcat admin port

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1641,6 +1641,10 @@ class ServerConfig(object):
         server = self.document.getroot()
         return server.get('port')
 
+    def set_port(self, port):
+        server = self.document.getroot()
+        server.set('port', port)
+
     def get_unsecure_port(self):
 
         for connector in self.get_connectors():

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -246,6 +246,9 @@ class PKIDeployer:
         # Configure /etc/pki/<instance>/server.xml
         server_config = instance.get_server_config()
 
+        logger.info('Configuring Tomcat admin port')
+        server_config.set_port(self.mdict['pki_tomcat_server_port'])
+
         if config.str2bool(self.mdict['pki_enable_proxy']):
 
             logger.info('Adding AJP connector for IPv4')

--- a/base/tomcat-9.0/conf/server.xml
+++ b/base/tomcat-9.0/conf/server.xml
@@ -24,7 +24,7 @@
      define subcomponents such as "Valves" at this level.
      Documentation at /docs/config/server.html
  -->
-<Server port="[pki_tomcat_server_port]" shutdown="SHUTDOWN">
+<Server port="8005" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
   <!-- Security listener. Documentation at /docs/config/listeners.html
   <Listener className="org.apache.catalina.security.SecurityListener" />


### PR DESCRIPTION
This will reduce the difference between the `server.xml` template in PKI and the default `server.xml` provided by Tomcat.