### PR TITLE
Rename pki-cms.jar to pki-server.jar

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -350,12 +350,12 @@ if(WITH_SERVER OR WITH_CA OR WITH_KRA OR WITH_OCSP OR WITH_TKS OR WITH_TPS OR WI
         com.netscape.cms)
 
     list(APPEND PKI_JAVADOC_CLASSPATH
-        ${PKI_TOMCAT_JAR}
-        ${PKI_CMS_JAR})
+        ${PKI_SERVER_JAR}
+        ${PKI_TOMCAT_JAR})
 
     list(APPEND PKI_JAVADOC_DEPENDS
-        pki-tomcat-jar
-        pki-cms-jar)
+        pki-server-jar
+        pki-tomcat-jar)
 
     if(WITH_CA)
         add_subdirectory(ca)

--- a/base/acme/CMakeLists.txt
+++ b/base/acme/CMakeLists.txt
@@ -14,9 +14,9 @@ javac(pki-acme-classes
         ${JACKSON2_CORE_JAR} ${JACKSON2_DATABIND_JAR}
         ${JSS_JAR}
         ${LDAPJDK_JAR}
-        ${PKI_COMMON_JAR} ${PKI_TOMCAT_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_SERVER_JAR} ${PKI_TOMCAT_JAR}
     DEPENDS
-        pki-common-jar pki-cms-jar
+        pki-common-jar pki-server-jar
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
@@ -49,7 +49,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-acme.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-acme.jar
 )
 

--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-ca
 javac(pki-ca-classes
     DEPENDS
-        pki-common-jar pki-cms-jar
+        pki-common-jar pki-server-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -25,7 +25,7 @@ javac(pki-ca-classes
         ${TOMCAT_CATALINA_JAR}
         ${TOMCATJSS_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
-        ${PKI_COMMON_JAR} ${PKI_TOMCAT_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_SERVER_JAR} ${PKI_TOMCAT_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
@@ -61,7 +61,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-ca.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-ca.jar
 )
 

--- a/base/est/CMakeLists.txt
+++ b/base/est/CMakeLists.txt
@@ -17,10 +17,10 @@ javac(pki-est-classes
         ${JSS_JAR}
         ${PKI_CMSUTIL_JAR}
         ${PKI_COMMON_JAR}
-        ${PKI_CMS_JAR}
-	${PKI_TOMCAT_JAR} 
+        ${PKI_SERVER_JAR}
+        ${PKI_TOMCAT_JAR}
     DEPENDS
-        pki-common-jar pki-cms-jar
+        pki-common-jar pki-server-jar
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
@@ -53,7 +53,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-est.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-est.jar
 )
 

--- a/base/kra/CMakeLists.txt
+++ b/base/kra/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-kra
 javac(pki-kra-classes
     DEPENDS
-        pki-common-jar pki-cms-jar
+        pki-common-jar pki-server-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -20,7 +20,7 @@ javac(pki-kra-classes
         ${LDAPJDK_JAR}
         ${SERVLET_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
-        ${PKI_COMMON_JAR} ${PKI_CMS_JAR} ${TOMCAT_CATALINA_JAR}
+        ${PKI_COMMON_JAR} ${PKI_SERVER_JAR} ${TOMCAT_CATALINA_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
@@ -57,7 +57,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-kra.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-kra.jar
 )
 

--- a/base/ocsp/CMakeLists.txt
+++ b/base/ocsp/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-ocsp
 javac(pki-ocsp-classes
     DEPENDS
-        pki-common-jar pki-cms-jar
+        pki-common-jar pki-server-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -19,7 +19,7 @@ javac(pki-ocsp-classes
         ${JSS_JAR} ${JSS_SYMKEY_JAR}
         ${LDAPJDK_JAR}
         ${TOMCATJSS_JAR}
-        ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_SERVER_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
@@ -56,7 +56,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-ocsp.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-ocsp.jar
 )
 

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -31,12 +31,12 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/MANIFEST.MF
 )
 
-# build pki-cms.jar
-jar(pki-cms-jar
+# build pki-server.jar
+jar(pki-server-jar
     DEPENDS
         pki-server-classes
     CREATE
-        ${CMAKE_BINARY_DIR}/dist/pki-cms.jar
+        ${CMAKE_BINARY_DIR}/dist/pki-server.jar
     OPTIONS
         m
     PARAMS
@@ -51,17 +51,17 @@ jar(pki-cms-jar
         UserMessages.properties
 )
 
-set(PKI_CMS_JAR ${CMAKE_BINARY_DIR}/dist/pki-cms.jar CACHE INTERNAL "pki-cms jar file")
+set(PKI_SERVER_JAR ${CMAKE_BINARY_DIR}/dist/pki-server.jar CACHE INTERNAL "pki-server jar file")
 
 if(RUN_TESTS)
     # build pki-server-test
     javac(pki-server-test-classes
         DEPENDS
-            pki-common-test-classes pki-common-jar pki-cms-jar
+            pki-common-test-classes pki-common-jar pki-server-jar
         SOURCES
             src/test/java/*.java
         CLASSPATH
-            ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
+            ${PKI_COMMON_JAR} ${PKI_SERVER_JAR}
             ${LDAPJDK_JAR} ${SERVLET_JAR}
             ${JSS_JAR} ${JSS_SYMKEY_JAR}
             ${HAMCREST_JAR} ${JUNIT_JAR} ${COMMONS_CODEC_JAR} ${COMMONS_IO_JAR}
@@ -88,7 +88,7 @@ if(RUN_TESTS)
             pki-server-test-classes
         CLASSPATH
             ${SLF4J_API_JAR} ${SLF4J_SIMPLE_JAR}
-            ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
+            ${PKI_COMMON_JAR} ${PKI_SERVER_JAR}
             ${LDAPJDK_JAR} ${SERVLET_JAR}
             ${COMMONS_CODEC_JAR} ${COMMONS_LANG3_JAR}
             ${JSS_JAR} ${JSS_SYMKEY_JAR}
@@ -161,7 +161,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-server.jar
 )
 
 add_custom_target(pki-server-man ALL
@@ -203,7 +203,7 @@ configure_file(
 
 install(
     FILES
-        ${CMAKE_BINARY_DIR}/dist/pki-cms.jar
+        ${CMAKE_BINARY_DIR}/dist/pki-server.jar
     DESTINATION
         ${JAVA_JAR_INSTALL_DIR}/pki
 )

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -774,15 +774,15 @@ class PKISubsystem(object):
         tmpdir = tempfile.mkdtemp()
 
         try:
-            # export audit-events.properties from pki-cms.jar
-            cms_jar = \
-                '/usr/share/pki/%s/webapps/%s/WEB-INF/lib/pki-cms.jar' \
+            # export audit-events.properties from pki-server.jar
+            server_jar = \
+                '/usr/share/pki/%s/webapps/%s/WEB-INF/lib/pki-server.jar' \
                 % (self.name, self.name)
 
             cmd = [
                 'jar',
                 'xf',
-                cms_jar,
+                server_jar,
                 'audit-events.properties'
             ]
 

--- a/base/server/src/main/resources/META-INF/MANIFEST.MF
+++ b/base/server/src/main/resources/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
-Name: pki-cms
+Name: pki-server
 Specification-Version: ${APPLICATION_VERSION}
 Implementation-Version: ${IMPL_VERSION}

--- a/base/tks/CMakeLists.txt
+++ b/base/tks/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-tks
 javac(pki-tks-classes
     DEPENDS
-        pki-common-jar pki-cms-jar
+        pki-common-jar pki-server-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -22,7 +22,7 @@ javac(pki-tks-classes
         ${JSS_JAR} ${JSS_SYMKEY_JAR}
         ${SERVLET_JAR} ${TOMCAT_CATALINA_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
-        ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_SERVER_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
@@ -59,7 +59,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tks.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-tks.jar
 )
 

--- a/base/tps/CMakeLists.txt
+++ b/base/tps/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory(${APP_SERVER})
 # build pki-tps
 javac(pki-tps-classes
     DEPENDS
-        pki-common-jar pki-cms-jar
+        pki-common-jar pki-server-jar
     SOURCES
         src/main/java/*.java
     CLASSPATH
@@ -20,7 +20,7 @@ javac(pki-tps-classes
         ${JSS_JAR} ${JSS_SYMKEY_JAR}
         ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}
         ${SERVLET_JAR} ${TOMCAT_CATALINA_JAR}
-        ${PKI_COMMON_JAR} ${PKI_CMS_JAR}
+        ${PKI_COMMON_JAR} ${PKI_SERVER_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
@@ -55,7 +55,7 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../../../..${SLF4J_API_JAR} webapp/lib/slf4j-api.jar
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
-    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-cms.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-cms.jar
+    COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tps.jar ${CMAKE_CURRENT_BINARY_DIR}/webapp/lib/pki-tps.jar
 )
 

--- a/build.sh
+++ b/build.sh
@@ -713,8 +713,8 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
 
     if [[ " ${PKGS_TO_BUILD[*]} " =~ " server " ]]; then
         echo "- server:"
+        echo "    $WORK_DIR/dist/pki-server.jar"
         echo "    $WORK_DIR/dist/pki-tomcat.jar"
-        echo "    $WORK_DIR/dist/pki-cms.jar"
     fi
 
     if [[ " ${PKGS_TO_BUILD[*]} " =~ " acme " ]]; then

--- a/docs/changes/v11.4.0/Server-Changes.adoc
+++ b/docs/changes/v11.4.0/Server-Changes.adoc
@@ -10,3 +10,7 @@ The `<subsystem>-add-user` methods accept a new option `--attributes` which take
 
 Previously the `pki-certsrv.jar` was installed under `WEB-INF/lib` folder of each web application.
 The file has been moved into the `common/lib` folder and renamed into `pki-common.jar` such that it is available for the entire server.
+
+== Renaming pki-cms.jar to pki-server.jar ==
+
+The `pki-cms.jar` has been renamed into `pki-server.jar` to better reflect the content of the file.

--- a/pki.spec
+++ b/pki.spec
@@ -1104,7 +1104,7 @@ fi
 %dir %{_sysconfdir}/systemd/system/pki-tomcatd-nuxwdog.target.wants
 %attr(644,-,-) %{_unitdir}/pki-tomcatd-nuxwdog@.service
 %attr(644,-,-) %{_unitdir}/pki-tomcatd-nuxwdog.target
-%{_javadir}/pki/pki-cms.jar
+%{_javadir}/pki/pki-server.jar
 %{_javadir}/pki/pki-tomcat.jar
 %dir %{_sharedstatedir}/pki
 %{_mandir}/man1/pkidaemon.1.gz


### PR DESCRIPTION
The `pki-cms.jar` has been renamed to `pki-server.jar` to better reflect the content of the file which comes from `base/server`.