### PR TITLE
Add -flto compiler flag

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -826,6 +826,9 @@ C_FLAGS="$C_FLAGS -O2"
 
 # https://sourceware.org/annobin/annobin.html/Test-glibcxx-assertions.html
 C_FLAGS="$C_FLAGS -D_GLIBCXX_ASSERTIONS"
+
+# https://sourceware.org/annobin/annobin.html/Test-lto.html
+C_FLAGS="$C_FLAGS -flto"
 %endif
 
 pkgs=base\


### PR DESCRIPTION
RPMInspect is failing as it cannot detect whether Link Time Optimisation is being used by GCC. I can't see any reason to not enable this option explicitly from reading docs about it, so I have added it in. See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html