### PR TITLE
Use Python XML to remove default LockOutRealm

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1846,6 +1846,27 @@ class ServerConfig(object):
         sslcert = self.get_sslcert(sslhost, certType)
         sslhost.remove(sslcert)
 
+    def get_realm(self, className):
+        '''
+        Find realm by class name.
+        '''
+
+        server = self.document.getroot()
+        return server.find('.//Realm[@className="%s"]' % className)
+
+    def remove_realm(self, className):
+        '''
+        Remove realm by class name.
+        '''
+
+        realm = self.get_realm(className)
+
+        if realm is None:
+            return
+
+        service = realm.getparent()
+        service.remove(realm)
+
     def get_valves(self):
         '''
         Find all valves.

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -273,6 +273,9 @@ class PKIDeployer:
 
             server_config.add_connector(connector)
 
+        logger.info('Removing LockOutRealm')
+        server_config.remove_realm('org.apache.catalina.realm.LockOutRealm')
+
         if config.str2bool(self.mdict['pki_enable_access_log']):
 
             logger.info('Enabling access log')

--- a/base/tomcat-9.0/conf/server.xml
+++ b/base/tomcat-9.0/conf/server.xml
@@ -167,18 +167,14 @@
 
       <!-- Use the LockOutRealm to prevent attempts to guess user passwords
            via a brute-force attack -->
-      <!--
       <Realm className="org.apache.catalina.realm.LockOutRealm">
-      -->
         <!-- This Realm uses the UserDatabase configured in the global JNDI
              resources under the key "UserDatabase".  Any edits
              that are performed against this UserDatabase are immediately
              available for use by the Realm.  -->
-      <!--
         <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
                resourceName="UserDatabase"/>
       </Realm>
-      -->
 
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">


### PR DESCRIPTION
The `UserDatabaseRealm` is nested inside `LockOutRealm` so it will be removed as well.

This will reduce the difference between the `server.xml` template in PKI and the default `server.xml` provided by Tomcat.

