### PR TITLE
Make xmvn conditional on Fedora

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -152,16 +152,47 @@ find_file(JACKSON2_JAXB_ANNOTATIONS_JAR
 )
 
 execute_process(
-    COMMAND xmvn-resolve jakarta.xml.bind:jakarta.xml.bind-api:4
-    OUTPUT_VARIABLE JAXB_API_JAR
+    COMMAND awk -F= "$1==\"ID\" { print $2 ;}" /etc/os-release
+    OUTPUT_VARIABLE DISTRO
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-execute_process(
-    COMMAND xmvn-resolve jakarta.activation:jakarta.activation-api:2
-    OUTPUT_VARIABLE JAVAX_ACTIVATION_JAR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if(DISTRO STREQUAL "centos" OR DISTRO STREQUAL "fedora" OR DISTRO STREQUAL "rhel")
+    execute_process(
+        COMMAND xmvn-resolve jakarta.xml.bind:jakarta.xml.bind-api:4
+        OUTPUT_VARIABLE JAXB_API_JAR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    find_file(JAXB_API_JAR
+        NAMES
+            jaxb-api.jar
+        PATHS
+            /usr/share/java
+    )
+endif(DISTRO STREQUAL "centos" OR DISTRO STREQUAL "fedora" OR DISTRO STREQUAL "rhel")
+
+if(DISTRO STREQUAL "centos" OR DISTRO STREQUAL "fedora" OR DISTRO STREQUAL "rhel")
+    execute_process(
+        COMMAND xmvn-resolve jakarta.activation:jakarta.activation-api:2
+        OUTPUT_VARIABLE JAVAX_ACTIVATION_JAR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    find_file(JAVAX_ACTIVATION_JAR
+        NAMES
+            jakarta.activation.jar
+            jakarta-activation.jar
+            javax.activation.jar
+            javax-activation.jar
+        PATHS
+            /usr/share/java/jakarta-activation
+            /usr/share/java/jakarta
+            /usr/share/java/javax-activation
+            /usr/share/java/javax
+            /usr/share/java
+    )
+endif(DISTRO STREQUAL "centos" OR DISTRO STREQUAL "fedora" OR DISTRO STREQUAL "rhel")
 
 find_file(JAVAX_ANNOTATIONS_API_JAR
     NAMES


### PR DESCRIPTION
Resolves: #4325

@edewata suggested moving the distro specific bits into the spec file and passing path args into `build.sh`. I present here an alternative for review, where the distro conditional is in the cmake itself. The end result is the same, `xmvn-resolve` is used to find the JARs on Fedora and the old-style `find_file` method is used everywhere else.

If it is decided this is a good direction to take then I will update to resolve all the JARs like this, rather than leaving `jaxb-api` and `jakarta-activation` as magic special cases.