### PR TITLE
Rename TPSEngine into TPS

### DIFF
--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSSubsystem.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSSubsystem.java
@@ -35,7 +35,7 @@ import org.dogtagpki.server.tps.dbs.TPSCertDatabase;
 import org.dogtagpki.server.tps.dbs.TPSCertRecord;
 import org.dogtagpki.server.tps.dbs.TokenDatabase;
 import org.dogtagpki.server.tps.dbs.TokenRecord;
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 import org.dogtagpki.server.tps.mapping.MappingResolverManager;
 import org.dogtagpki.tps.TPSConnection;
 import org.dogtagpki.tps.main.TPSException;
@@ -80,7 +80,7 @@ public class TPSSubsystem implements IAuthority {
     public AuthenticationManager authManager;
     public MappingResolverManager mappingResolverManager;
 
-    public TPSEngine tpsEngine;
+    public TPS tpsEngine;
     public TokenDB tdb;
 
     public Map<TokenStatus, Collection<TokenStatus>> uiTransitions;
@@ -138,12 +138,12 @@ public class TPSSubsystem implements IAuthority {
         uiTransitions = loadTokenStateTransitions("tokendb.allowedTransitions", allowedTransitions);
 
         operationTransitions = loadAndValidateTokenStateTransitions(
-                defaultConfig, cs, TPSEngine.CFG_OPERATIONS_ALLOWED_TRANSITIONS);
+                defaultConfig, cs, TPS.CFG_OPERATIONS_ALLOWED_TRANSITIONS);
 
         configureTPSConnection(cs);
         tdb = new TokenDB(this);
 
-        tpsEngine = new TPSEngine();
+        tpsEngine = new TPS();
         tpsEngine.init();
     }
 
@@ -278,14 +278,14 @@ public class TPSSubsystem implements IAuthority {
     }
 
     public void configureTPSConnection(ConfigStore cs) {
-        String configValue = TPSEngine.CFG_CONNECTION_PREFIX + "." + TPSEngine.CFG_CONNECTION_MAX_MESSAGE_SIZE;
+        String configValue = TPS.CFG_CONNECTION_PREFIX + "." + TPS.CFG_CONNECTION_MAX_MESSAGE_SIZE;
         int configValueDefault = TPSConnection.MAX_MESSAGE_SIZE_DEFAULT;
 
         logger.debug("TPSConnection: Retrieving config value with name: " + configValue);
         try {
             // Try to set TPSConnection static variable to CS.cfg config value
             TPSConnection.setMaxMessageSize(cs.getInteger(configValue));
-            logger.debug("TPSConnection: " + TPSEngine.CFG_CONNECTION_MAX_MESSAGE_SIZE +
+            logger.debug("TPSConnection: " + TPS.CFG_CONNECTION_MAX_MESSAGE_SIZE +
                     " set to " + TPSConnection.getMaxMessageSize());
         } catch(EBaseException e) {
             // Set TPSConnection static variable to default value
@@ -391,7 +391,7 @@ public class TPSSubsystem implements IAuthority {
         return cm.findCertByNickname(nickname);
     }
 
-    public TPSEngine getEngine() {
+    public TPS getEngine() {
         return tpsEngine;
     }
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/channel/SecureChannel.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/channel/SecureChannel.java
@@ -20,7 +20,7 @@ package org.dogtagpki.server.tps.channel;
 import java.io.IOException;
 
 import org.dogtagpki.server.tps.TPSEngineConfig;
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 import org.dogtagpki.server.tps.processor.TPSProcessor;
 import org.dogtagpki.tps.apdu.APDU;
 import org.dogtagpki.tps.apdu.APDUResponse;
@@ -783,7 +783,7 @@ public class SecureChannel {
         TPSBuffer emptySDAID = new TPSBuffer();
 
         if (isGP211()) {
-            TPSBuffer cardMgrGP211AIDBuff = new TPSBuffer(TPSEngine.CFG_DEF_CARDMGR_211_INSTANCE_AID);
+            TPSBuffer cardMgrGP211AIDBuff = new TPSBuffer(TPS.CFG_DEF_CARDMGR_211_INSTANCE_AID);
             installLoadGP211(packageAID, cardMgrGP211AIDBuff, fileLength);
             return;
         }

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/cms/CARemoteRequestHandler.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/cms/CARemoteRequestHandler.java
@@ -28,7 +28,7 @@ import org.dogtagpki.server.connector.IRemoteRequest;
 import org.dogtagpki.server.tps.TPSConfig;
 import org.dogtagpki.server.tps.TPSEngineConfig;
 import org.dogtagpki.server.tps.TPSSubsystem;
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 import org.dogtagpki.tps.main.TPSBuffer;
 import org.dogtagpki.tps.main.Util;
 import org.mozilla.jss.CryptoManager;
@@ -109,7 +109,7 @@ public class CARemoteRequestHandler extends RemoteRequestHandler
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig conf = engine.getConfig();
         String profileId =
-                conf.getString(TPSEngine.OP_ENROLL_PREFIX + "." +
+                conf.getString(TPS.OP_ENROLL_PREFIX + "." +
                         tokenType + ".keyGen." +
                         keyType + ".ca.profileId");
 
@@ -424,7 +424,7 @@ public class CARemoteRequestHandler extends RemoteRequestHandler
         TPSEngineConfig conf = engine.getConfig();
 
         String profileId =
-                conf.getString(TPSEngine.OP_ENROLL_PREFIX + "." +
+                conf.getString(TPS.OP_ENROLL_PREFIX + "." +
                         tokenType + ".renewal." +
                         keyType + ".ca.profileId");
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/engine/TPS.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/engine/TPS.java
@@ -37,9 +37,9 @@ import org.dogtagpki.tps.msg.EndOpMsg.TPSStatus;
 
 import com.netscape.certsrv.base.EBaseException;
 
-public class TPSEngine {
+public class TPS {
 
-    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TPSEngine.class);
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TPS.class);
 
     public enum RA_Algs {
         ALG_RSA,
@@ -207,7 +207,7 @@ public class TPSEngine {
         //ToDo
     }
 
-    public TPSEngine() {
+    public TPS() {
     }
 
     public int initialize(String cfg_path) {
@@ -229,11 +229,11 @@ public class TPSEngine {
 
         if (cuid == null || kdd == null || keyInfo == null || sequenceCounter == null || derivationConstant == null
                 || tokenType == null) {
-            throw new TPSException("TPSEngine.computeSessionKeySCP02: Invalid input data!",
+            throw new TPSException("TPS.computeSessionKeySCP02: Invalid input data!",
                     TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
         }
 
-        logger.debug("TPSEngine.computeSessionKeySCP02");
+        logger.debug("TPS.computeSessionKeySCP02");
 
         TKSRemoteRequestHandler tks = null;
 
@@ -242,14 +242,14 @@ public class TPSEngine {
             tks = new TKSRemoteRequestHandler(connId, inKeySet);
             resp = tks.computeSessionKeySCP02(kdd,cuid, keyInfo, sequenceCounter, derivationConstant, tokenType);
         } catch (EBaseException e) {
-            throw new TPSException("TPSEngine.computeSessionKeySCP02: Error computing session key!" + e,
+            throw new TPSException("TPS.computeSessionKeySCP02: Error computing session key!" + e,
                     TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
         }
 
         int status = resp.getStatus();
         if (status != 0) {
-            logger.error("TPSEngine.computeSessionKeySCP02: Non zero status result: " + status);
-            throw new TPSException("TPSEngine.computeSessionKeySCP02: invalid returned status: " + status,
+            logger.error("TPS.computeSessionKeySCP02: Non zero status result: " + status);
+            throw new TPSException("TPS.computeSessionKeySCP02: invalid returned status: " + status,
                      TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
 
         }
@@ -270,11 +270,11 @@ public class TPSEngine {
         if (cuid == null || kdd == null || keyInfo == null || card_challenge == null || host_challenge == null
                 || card_cryptogram == null || connId == null || tokenType == null) {
 
-            throw new TPSException("TPSEngine.computeSessionKeySCP03: Invalid input data!",
+            throw new TPSException("TPS.computeSessionKeySCP03: Invalid input data!",
                     TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
         }
 
-        logger.debug("TPSEngine.computeSessionKeysSCP03");
+        logger.debug("TPS.computeSessionKeysSCP03");
 
         TKSRemoteRequestHandler tks = null;
 
@@ -284,14 +284,14 @@ public class TPSEngine {
             resp = tks.computeSessionKeysSCP03(kdd, cuid, keyInfo, card_challenge, card_cryptogram, host_challenge,
                     tokenType);
         } catch (EBaseException e) {
-            throw new TPSException("TPSEngine.computeSessionKeysSCP03: Error computing session keys!" + e,
+            throw new TPSException("TPS.computeSessionKeysSCP03: Error computing session keys!" + e,
                     TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
         }
 
         int status = resp.getStatus();
         if (status != 0) {
-            logger.error("TPSEngine.computeSessionKeysSCP03: Non zero status result: " + status);
-            throw new TPSException("TPSEngine.computeSessionKeysSCP03: invalid returned status: " + status,
+            logger.error("TPS.computeSessionKeysSCP03: Non zero status result: " + status);
+            throw new TPSException("TPS.computeSessionKeysSCP03: invalid returned status: " + status,
                     TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
 
         }
@@ -312,12 +312,12 @@ public class TPSEngine {
         if (cuid == null || kdd == null || keyInfo == null || card_challenge == null || host_challenge == null
                 || card_cryptogram == null || connId == null || tokenType == null) {
 
-            throw new TPSException("TPSEngine.computeSessionKey: Invalid input data!",
+            throw new TPSException("TPS.computeSessionKey: Invalid input data!",
                     TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
 
         }
 
-        logger.debug("TPSEngine.computeSessionKey");
+        logger.debug("TPS.computeSessionKey");
 
         TKSRemoteRequestHandler tks = null;
 
@@ -326,14 +326,14 @@ public class TPSEngine {
             tks = new TKSRemoteRequestHandler(connId, inKeySet);
             resp = tks.computeSessionKey(kdd,cuid, keyInfo, card_challenge, card_cryptogram, host_challenge, tokenType);
         } catch (EBaseException e) {
-            throw new TPSException("TPSEngine.computeSessionKey: Error computing session key!" + e,
+            throw new TPSException("TPS.computeSessionKey: Error computing session key!" + e,
                     TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
         }
 
         int status = resp.getStatus();
         if (status != 0) {
-            logger.error("TPSEngine.computeSessionKey: Non zero status result: " + status);
-            throw new TPSException("TPSEngine.computeSessionKey: invalid returned status: " + status,
+            logger.error("TPS.computeSessionKey: Non zero status result: " + status);
+            throw new TPSException("TPS.computeSessionKey: invalid returned status: " + status,
                     TPSStatus.STATUS_ERROR_SECURE_CHANNEL);
 
         }
@@ -345,7 +345,7 @@ public class TPSEngine {
     public CARetrieveCertResponse recoverCertificate(TPSCertRecord cert, String serialS, String keyType, String caConnID)
             throws TPSException {
 
-        String method = "TPSEngine.recoverCertificate";
+        String method = "TPS.recoverCertificate";
 
         logger.debug(method + ": serial # =" + serialS);
 
@@ -386,7 +386,7 @@ public class TPSEngine {
     public CARenewCertResponse renewCertificate(TPSCertRecord cert, String serialS, String tokenType, String keyType,
             String caConnID) throws TPSException {
 
-        String method = "TPSEngine.renewCertificate";
+        String method = "TPS.renewCertificate";
 
         logger.debug(method + " entering...");
 
@@ -431,7 +431,7 @@ public class TPSEngine {
     public TPSBuffer createKeySetData(TPSBuffer newMasterVersion, TPSBuffer oldVersion, int protocol, TPSBuffer cuid, TPSBuffer kdd, TPSBuffer wrappedDekSessionKey, String connId, String inKeyset)
             throws TPSException {
 
-        String method = "TPSEngine.createKeySetData:";
+        String method = "TPS.createKeySetData:";
         logger.debug(method + " entering...");
 
         if (newMasterVersion == null || oldVersion == null || cuid == null || kdd == null || connId == null) {
@@ -491,7 +491,7 @@ public class TPSEngine {
             isECC = true;
         }
 
-        logger.debug("TPSEngine.isAlgorithmECC: result: " + isECC);
+        logger.debug("TPS.isAlgorithmECC: result: " + isECC);
         return isECC;
 
     }
@@ -534,8 +534,8 @@ public class TPSEngine {
             String userid,
             TPSBuffer sDesKey,
             String b64cert, String drmConnId,BigInteger keyid) throws TPSException {
-        String method = "TPSEngine.recoverKey";
-        logger.debug("TPSEngine.recoverKey");
+        String method = "TPS.recoverKey";
+        logger.debug("TPS.recoverKey");
         if (cuid == null)
             logger.debug(method + ": cuid null");
         else if (userid == null)
@@ -548,7 +548,7 @@ public class TPSEngine {
             logger.debug(method + ": drmConnId null");
 
         if (cuid == null || userid == null || sDesKey == null ||  drmConnId == null) {
-            throw new TPSException("TPSEngine.recoverKey: invalid input data!", TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
+            throw new TPSException("TPS.recoverKey: invalid input data!", TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
         }
 
         KRARecoverKeyResponse resp = null;
@@ -559,34 +559,34 @@ public class TPSEngine {
 
             resp = kra.recoverKey(cuid, userid, Util.specialURLEncode(sDesKey), (b64cert != null) ? Util.uriEncode(b64cert) : b64cert,keyid);
         } catch (EBaseException e) {
-            throw new TPSException("TPSEngine.recoverKey: Problem creating or using KRARemoteRequestHandler! "
+            throw new TPSException("TPS.recoverKey: Problem creating or using KRARemoteRequestHandler! "
                     + e.toString(), TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
 
         } catch (UnsupportedEncodingException e) {
-            throw new TPSException("TPSEngine.recoverKey: Problem creating or using KRARemoteRequestHandler! "
+            throw new TPSException("TPS.recoverKey: Problem creating or using KRARemoteRequestHandler! "
                     + e.toString(), TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
         }
 
         int status = resp.getStatus();
 
         if (status != 0) {
-            throw new TPSException("TPSEngine.recoverKey: Bad status from server: " + status,
+            throw new TPSException("TPS.recoverKey: Bad status from server: " + status,
                     TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
         }
 
         if (resp.getPublicKey() == null) {
-            throw new TPSException("TPSEngine.recoverKey: invalid public key from server! ",
+            throw new TPSException("TPS.recoverKey: invalid public key from server! ",
                     TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
         }
 
         if (resp.getWrappedPrivKey() == null) {
-            throw new TPSException("TPSEngine.recoverKey: invalid private key from server! ",
+            throw new TPSException("TPS.recoverKey: invalid private key from server! ",
                     TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
 
         }
 
         if (resp.getIVParam() == null) {
-            throw new TPSException("TPSEngine.recoverKey: invalid iv vector from server!",
+            throw new TPSException("TPS.recoverKey: invalid iv vector from server!",
                     TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
         }
 
@@ -600,13 +600,13 @@ public class TPSEngine {
             boolean isECC) throws TPSException {
 
 /*
-        logger.debug("TPSEngine.serverSideKeyGen entering... keySize: " + keySize + " cuid: " + cuid + " userid: "
+        logger.debug("TPS.serverSideKeyGen entering... keySize: " + keySize + " cuid: " + cuid + " userid: "
                 + userid + " drmConnId: " + drmConnId + " wrappedDesKey: " + wrappedDesKey + " archive: " + archive
                 + " isECC: " + isECC);
 */
 
         if (cuid == null || userid == null || drmConnId == null || wrappedDesKey == null) {
-            throw new TPSException("TPSEngine.serverSideKeyGen: Invalid input data!",
+            throw new TPSException("TPS.serverSideKeyGen: Invalid input data!",
                     TPSStatus.STATUS_ERROR_MAC_ENROLL_PDU);
         }
 
@@ -620,30 +620,30 @@ public class TPSEngine {
                     Util.specialURLEncode(wrappedDesKey), archive);
 
         } catch (EBaseException e) {
-            throw new TPSException("TPSEngine.serverSideKeyGen: Problem creating  or using KRARemoteRequestHandler! "
+            throw new TPSException("TPS.serverSideKeyGen: Problem creating  or using KRARemoteRequestHandler! "
                     + e.toString());
         }
 
         int status = resp.getStatus();
 
         if (status != 0) {
-            throw new TPSException("TPSEngine.serverSideKeyGen: Bad status from server: " + status,
+            throw new TPSException("TPS.serverSideKeyGen: Bad status from server: " + status,
                     TPSStatus.STATUS_ERROR_MAC_ENROLL_PDU);
         }
 
         if (resp.getPublicKey() == null) {
-            throw new TPSException("TPSEngine.serverSideKeyGen: invalid public key from server! ",
+            throw new TPSException("TPS.serverSideKeyGen: invalid public key from server! ",
                     TPSStatus.STATUS_ERROR_MAC_ENROLL_PDU);
         }
 
         if (resp.getWrappedPrivKey() == null) {
-            throw new TPSException("TPSEngine.serverSideKeyGen: invalid private key from server! ",
+            throw new TPSException("TPS.serverSideKeyGen: invalid private key from server! ",
                     TPSStatus.STATUS_ERROR_MAC_ENROLL_PDU);
 
         }
 
         if (resp.getIVParam() == null) {
-            throw new TPSException("TPSEngine.serverSideKeyGen: invalid iv vector from server!",
+            throw new TPSException("TPS.serverSideKeyGen: invalid iv vector from server!",
                     TPSStatus.STATUS_ERROR_MAC_ENROLL_PDU);
         }
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/main/ExternalRegAttrs.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/main/ExternalRegAttrs.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import org.dogtagpki.server.authentication.AuthManagersConfig;
 import org.dogtagpki.server.authentication.AuthenticationConfig;
 import org.dogtagpki.server.tps.TPSEngineConfig;
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 
 import com.netscape.certsrv.base.EBaseException;
 
@@ -50,8 +50,8 @@ public class ExternalRegAttrs {
             logger.debug(method + ": getting config: auths.instance." + configName);
             ldapAttrNameCertsToRecover = instancesConfig.getString(configName, "certsToRecover");
 
-            String RH_Delegation_Cfg = TPSEngine.CFG_EXTERNAL_REG + "." +
-                    TPSEngine.CFG_ER_DELEGATION + ".enable";
+            String RH_Delegation_Cfg = TPS.CFG_EXTERNAL_REG + "." +
+                    TPS.CFG_ER_DELEGATION + ".enable";
             isDelegation = configStore.getBoolean(RH_Delegation_Cfg, false);
 
             configName = authId + ".externalReg.registrationTypeAttributeName";

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/mapping/FilterMappingResolver.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/mapping/FilterMappingResolver.java
@@ -1,6 +1,6 @@
 package org.dogtagpki.server.tps.mapping;
 
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 import org.dogtagpki.tps.main.TPSException;
 import org.dogtagpki.tps.msg.EndOpMsg.TPSStatus;
 
@@ -69,7 +69,7 @@ public class FilterMappingResolver extends BaseMappingResolver {
         extKeySet = mappingParams.getString(FilterMappingParams.FILTER_PARAM_EXT_KEY_SET, null);
         logger.debug(method + " param keySet extension: " + extKeySet);
 
-        String configName = prefix + "." + TPSEngine.CFG_PROFILE_MAPPING_ORDER;
+        String configName = prefix + "." + TPS.CFG_PROFILE_MAPPING_ORDER;
 
         try {
             logger.debug(method + " getting mapping order:" +

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/CertEnrollInfo.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/CertEnrollInfo.java
@@ -22,7 +22,7 @@ import org.dogtagpki.server.tps.cms.CARenewCertResponse;
 import org.dogtagpki.server.tps.cms.CARetrieveCertResponse;
 import org.dogtagpki.server.tps.cms.KRARecoverKeyResponse;
 import org.dogtagpki.server.tps.dbs.TokenRecord;
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 import org.dogtagpki.server.tps.main.ObjectSpec;
 
 public class CertEnrollInfo {
@@ -52,13 +52,13 @@ public class CertEnrollInfo {
     private int startProgress;
     private int endProgress;
 
-    private TPSEngine.ENROLL_MODES enrollmentMode = TPSEngine.ENROLL_MODES.MODE_ENROLL;
+    private TPS.ENROLL_MODES enrollmentMode = TPS.ENROLL_MODES.MODE_ENROLL;
 
-    public void setEnrollmentMode(TPSEngine.ENROLL_MODES mode) {
+    public void setEnrollmentMode(TPS.ENROLL_MODES mode) {
         enrollmentMode = mode;
     }
 
-    public TPSEngine.ENROLL_MODES getEnrollmentMode() {
+    public TPS.ENROLL_MODES getEnrollmentMode() {
         return enrollmentMode;
     }
 
@@ -216,7 +216,7 @@ public class CertEnrollInfo {
     }
 
     public boolean getIsRecoveryMode() {
-        if (enrollmentMode == TPSEngine.ENROLL_MODES.MODE_RECOVERY) {
+        if (enrollmentMode == TPS.ENROLL_MODES.MODE_RECOVERY) {
             return true;
         }
 
@@ -224,7 +224,7 @@ public class CertEnrollInfo {
     }
 
     public boolean getIsRenewalMode() {
-        if (enrollmentMode == TPSEngine.ENROLL_MODES.MODE_RENEWAL) {
+        if (enrollmentMode == TPS.ENROLL_MODES.MODE_RENEWAL) {
             return true;
         }
 
@@ -232,7 +232,7 @@ public class CertEnrollInfo {
     }
 
     public boolean getIsEnrollmentMode() {
-        if (enrollmentMode == TPSEngine.ENROLL_MODES.MODE_ENROLL) {
+        if (enrollmentMode == TPS.ENROLL_MODES.MODE_ENROLL) {
             return true;
         }
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
@@ -34,8 +34,8 @@ import org.dogtagpki.server.tps.dbs.ActivityDatabase;
 import org.dogtagpki.server.tps.dbs.TPSCertRecord;
 import org.dogtagpki.server.tps.dbs.TokenCertStatus;
 import org.dogtagpki.server.tps.dbs.TokenRecord;
-import org.dogtagpki.server.tps.engine.TPSEngine;
-import org.dogtagpki.server.tps.engine.TPSEngine.ENROLL_MODES;
+import org.dogtagpki.server.tps.engine.TPS;
+import org.dogtagpki.server.tps.engine.TPS.ENROLL_MODES;
 import org.dogtagpki.server.tps.main.AttributeSpec;
 import org.dogtagpki.server.tps.main.ExternalRegAttrs;
 import org.dogtagpki.server.tps.main.ExternalRegCertToRecover;
@@ -175,7 +175,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
             try {
                 logger.debug(method + " isExternalReg: calling requestUserId");
                 userAuth = getAuthentication(authId);
-                processAuthentication(TPSEngine.ENROLL_OP, userAuth, cuid, tokenRecord);
+                processAuthentication(TPS.ENROLL_OP, userAuth, cuid, tokenRecord);
                 auditAuthSuccess(userid, currentTokenOperation, appletInfo, authId);
 
             } catch (Exception e) {
@@ -358,7 +358,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
             }
         } else {
             logger.debug(method + " token does not exist");
-            checkAllowUnknownToken(TPSEngine.ENROLL_OP);
+            checkAllowUnknownToken(TPS.ENROLL_OP);
             logger.debug(method + "force a format");
             doForceFormat = true;
         }
@@ -1241,7 +1241,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                     // ToDo: This section has not been tested to work.. Make sure this works.
 
                     configStore = engine.getConfig();
-                    configName = TPSEngine.OP_ENROLL_PREFIX + "." + getSelectedTokenType()
+                    configName = TPS.OP_ENROLL_PREFIX + "." + getSelectedTokenType()
                             + ".temporaryToken.tokenType";
                     try {
                         String tmpTokenType = configStore.getString(configName);
@@ -1467,7 +1467,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                             + certsInfo.getCurrentCertIndex());
                     generateCertificate(certsInfo, channel, appletInfo,
                             "encryption",
-                            TPSEngine.ENROLL_MODES.MODE_RECOVERY,
+                            TPS.ENROLL_MODES.MODE_RECOVERY,
                             newCertId, certRecoveredInfo);
 
                     logger.debug(method + "after generateCertificate() with MODE_RECOVERY");
@@ -1554,7 +1554,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
             String graceBeforeS = null;
             String graceAfterS = null;
             try {
-                String keyTypePrefix = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + ".renewal." + keyType;
+                String keyTypePrefix = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + ".renewal." + keyType;
 
                 //TODO: profileId is actually gotten in the CARemoteRequestHandler.
                 configName = keyTypePrefix + ".ca.profileId";
@@ -1625,12 +1625,12 @@ public class TPSEnrollProcessor extends TPSProcessor {
                                 getCAConnectorID("renewal", keyType));
                         cEnrollInfo.setRenewedCertData(certResponse);
 
-                        generateCertificate(certsInfo, channel, aInfo, keyType, TPSEngine.ENROLL_MODES.MODE_RENEWAL,
+                        generateCertificate(certsInfo, channel, aInfo, keyType, TPS.ENROLL_MODES.MODE_RENEWAL,
                                 -1, cEnrollInfo);
 
                         numActuallyRenewed++;
 
-                        if (keyType.equals(TPSEngine.CFG_ENCRYPTION)) {
+                        if (keyType.equals(TPS.CFG_ENCRYPTION)) {
                             logger.debug(method
                                     + ": found old encryption cert (just renewed) to attempt to recover back to token, in order to read old emails.");
                             logger.debug(method + " adding cert: " + cert);
@@ -1684,7 +1684,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                 try {
 
                     CARetrieveCertResponse certResponse = tps.getEngine().recoverCertificate(toBeRecovered,
-                            serialToRecover, TPSEngine.CFG_ENCRYPTION, getCAConnectorID());
+                            serialToRecover, TPS.CFG_ENCRYPTION, getCAConnectorID());
 
                     String b64cert = certResponse.getCertB64();
                     logger.debug(method +": cert blob recovered");
@@ -1710,7 +1710,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                             + newCertId);
                     generateCertificate(certsInfo, channel, aInfo,
                             "encryption",
-                            TPSEngine.ENROLL_MODES.MODE_RECOVERY,
+                            TPS.ENROLL_MODES.MODE_RECOVERY,
                             newCertId, cEnrollInfo);
 
                     //We don't want this quasi old encryption cert in the official list.
@@ -1804,7 +1804,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
         boolean enabled = false;
 
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + ".renewal."
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + ".renewal."
                     + keyType + "." + "enable";
             enabled = configStore.getBoolean(
                     configValue, false);
@@ -1846,8 +1846,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
         String keyType = null;
 
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
-                    + TPSEngine.CFG_RENEW_KEYTYPE_VALUE + "." + keyTypeIndex;
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
+                    + TPS.CFG_RENEW_KEYTYPE_VALUE + "." + keyTypeIndex;
             keyType = configStore.getString(
                     configValue, null);
 
@@ -1877,8 +1877,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int keyTypeNum = 0;
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
-                    + TPSEngine.CFG_RENEW_KEYTYPE_NUM;
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
+                    + TPS.CFG_RENEW_KEYTYPE_NUM;
             keyTypeNum = configStore.getInteger(
                     configValue, 0);
 
@@ -1933,10 +1933,10 @@ public class TPSEnrollProcessor extends TPSProcessor {
             keyTypeValue = getRecoveryKeyTypeValue(reason, i);
             scheme = getRecoveryScheme(reason, keyTypeValue);
 
-            if (scheme.equals(TPSEngine.RECOVERY_SCHEME_GENERATE_NEW_KEY_AND_RECOVER_LAST)) {
+            if (scheme.equals(TPS.RECOVERY_SCHEME_GENERATE_NEW_KEY_AND_RECOVER_LAST)) {
 
                 //Make sure we are not signing:
-                if (keyTypeValue.equals(TPSEngine.CFG_SIGNING)) {
+                if (keyTypeValue.equals(TPS.CFG_SIGNING)) {
                     throw new TPSException(
                             method + ": Can't have GenerateNewAndRecoverLast scheme with a signing key!",
                             TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
@@ -1965,7 +1965,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
             keyTypeValue = getRecoveryKeyTypeValue(reason, i);
             scheme = getRecoveryScheme(reason, keyTypeValue);
 
-            if (scheme.equals(TPSEngine.RECOVERY_SCHEME_GENERATE_NEW_KEY_AND_RECOVER_LAST)) {
+            if (scheme.equals(TPS.RECOVERY_SCHEME_GENERATE_NEW_KEY_AND_RECOVER_LAST)) {
                 logger.debug(method + ": scheme GenerateNewKeyAndRecoverLast found.");
                 isGenerateAndRecover = true;
 
@@ -1973,10 +1973,10 @@ public class TPSEnrollProcessor extends TPSProcessor {
                 isGenerateAndRecover = false;
             }
 
-            if (scheme.equals(TPSEngine.RECOVERY_GENERATE_NEW_KEY) || isGenerateAndRecover) {
+            if (scheme.equals(TPS.RECOVERY_GENERATE_NEW_KEY) || isGenerateAndRecover) {
                 legalScheme = true;
                 CertEnrollInfo cEnrollInfo = new CertEnrollInfo();
-                generateCertificate(certsInfo, channel, aInfo, keyTypeValue, TPSEngine.ENROLL_MODES.MODE_ENROLL,
+                generateCertificate(certsInfo, channel, aInfo, keyTypeValue, TPS.ENROLL_MODES.MODE_ENROLL,
                         actualCertIndex, cEnrollInfo);
 
                 actualCertIndex = cEnrollInfo.getCertIdIndex();
@@ -1985,7 +1985,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
 
             }
 
-            if (scheme.equals(TPSEngine.RECOVERY_RECOVER_LAST) || isGenerateAndRecover) {
+            if (scheme.equals(TPS.RECOVERY_RECOVER_LAST) || isGenerateAndRecover) {
                 legalScheme = true;
                 logger.debug(method + ": scheme RecoverLast found, or isGenerateAndRecove is true");
                 if (isGenerateAndRecover) {
@@ -2044,7 +2044,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                     cEnrollInfo.setRecoveredCertData(certResponse);
                     cEnrollInfo.setRecoveredKeyData(keyResponse);
 
-                    generateCertificate(certsInfo, channel, aInfo, keyTypeValue, TPSEngine.ENROLL_MODES.MODE_RECOVERY,
+                    generateCertificate(certsInfo, channel, aInfo, keyTypeValue, TPS.ENROLL_MODES.MODE_RECOVERY,
                             actualCertIndex, cEnrollInfo);
 
                     // unrevoke cert if needed
@@ -2120,7 +2120,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
             String keyType = getConfiguredKeyType(i);
             certsInfo.setCurrentCertIndex(i);
             try {
-                generateCertificate(certsInfo, channel, aInfo, keyType, TPSEngine.ENROLL_MODES.MODE_ENROLL, -1, null);
+                generateCertificate(certsInfo, channel, aInfo, keyType, TPS.ENROLL_MODES.MODE_ENROLL, -1, null);
             } catch (TPSException e) {
                 logger.warn("TPSEnrollProcess.generateCertificates: exception:" + e.getMessage(), e);
                 noFailedCerts = false;
@@ -2155,7 +2155,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
 
-        String configName = TPSEngine.OP_ENROLL_PREFIX + "." + getSelectedTokenType() + ".keyGen.tokenName";
+        String configName = TPS.OP_ENROLL_PREFIX + "." + getSelectedTokenType() + ".keyGen.tokenName";
         String pattern = null;
 
         try {
@@ -2191,7 +2191,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
      * renewal enrollment
      */
     private void generateCertificate(EnrolledCertsInfo certsInfo, SecureChannel channel, AppletInfo aInfo,
-            String keyType, TPSEngine.ENROLL_MODES mode, int certIdNumOverride, CertEnrollInfo cEnrollInfo)
+            String keyType, TPS.ENROLL_MODES mode, int certIdNumOverride, CertEnrollInfo cEnrollInfo)
             throws TPSException, IOException {
 
         final String method = "TPSEnrollProcessor.generateCertificate";
@@ -2223,7 +2223,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
 
         try {
 
-            String keyTypePrefix = TPSEngine.OP_ENROLL_PREFIX + "." + getSelectedTokenType() + "." + operationModifier
+            String keyTypePrefix = TPS.OP_ENROLL_PREFIX + "." + getSelectedTokenType() + "." + operationModifier
                     + "." + keyType;
             logger.debug(method + ": keyTypePrefix: " + keyTypePrefix);
 
@@ -2396,7 +2396,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
      * Renewal enrollment
      */
     private void enrollOneCertificate(EnrolledCertsInfo certsInfo, CertEnrollInfo cEnrollInfo, AppletInfo aInfo,
-            SecureChannel channel, TPSEngine.ENROLL_MODES mode)
+            SecureChannel channel, TPS.ENROLL_MODES mode)
             throws TPSException, IOException {
 
         String method = "TPSEnrollProcessor.enrollOneCertificate";
@@ -2634,7 +2634,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                      */
                     TPSEngineConfig configStore = engine.getConfig();
                     String configName;
-                    configName = TPSEngine.OP_ENROLL_PREFIX + "." +
+                    configName = TPS.OP_ENROLL_PREFIX + "." +
                             getSelectedTokenType() + ".keyGen." +
                             cEnrollInfo.getKeyType() + ".dnpattern";
                     try {
@@ -2652,7 +2652,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                      *     becomes:
                      *       0123456789.abc@redhat.com
                      */
-                    configName = TPSEngine.OP_ENROLL_PREFIX + "." +
+                    configName = TPS.OP_ENROLL_PREFIX + "." +
                             getSelectedTokenType() + ".keyGen." +
                             cEnrollInfo.getKeyType() + ".SANpattern";
                     try {
@@ -3448,7 +3448,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
         boolean serverSideKeygen = false;
 
         try {
-            String configValue = cInfo.getKeyTypePrefix() + "." + TPSEngine.CFG_SERVER_KEYGEN_ENABLE;
+            String configValue = cInfo.getKeyTypePrefix() + "." + TPS.CFG_SERVER_KEYGEN_ENABLE;
             logger.debug("TPSEnrollProcessor.checkForServerSideKeyGen: config: " + configValue);
             serverSideKeygen = configStore.getBoolean(
                     configValue, false);
@@ -3476,7 +3476,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
         boolean serverKeyArchival = false;
 
         try {
-            String configValue = cInfo.getKeyTypePrefix() + "." + TPSEngine.CFG_SERVER_KEY_ARCHIVAL;
+            String configValue = cInfo.getKeyTypePrefix() + "." + TPS.CFG_SERVER_KEY_ARCHIVAL;
             logger.debug("TPSEnrollProcessor.checkForServerKeyArchival: config: " + configValue);
             serverKeyArchival = configStore.getBoolean(
                     configValue, false);
@@ -3504,8 +3504,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
         boolean objectOverwrite = false;
 
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + getSelectedTokenType() + ".keyGen."
-                    + cInfo.getKeyType() + "." + TPSEngine.CFG_OVERWRITE;
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + getSelectedTokenType() + ".keyGen."
+                    + cInfo.getKeyType() + "." + TPS.CFG_OVERWRITE;
 
             logger.debug("TPSProcess.checkForObjectOverwrite: config: " + configValue);
             objectOverwrite = configStore.getBoolean(
@@ -3530,8 +3530,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
         String keyType = null;
 
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
-                    + TPSEngine.CFG_KEYGEN_KEYTYPE_VALUE + "." + keyTypeIndex;
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
+                    + TPS.CFG_KEYGEN_KEYTYPE_VALUE + "." + keyTypeIndex;
             keyType = configStore.getString(
                     configValue, null);
 
@@ -3557,14 +3557,14 @@ public class TPSEnrollProcessor extends TPSProcessor {
 
     private String getDRMConnectorID(String keyType) throws TPSException {
         if(keyType == null || keyType.isEmpty())
-            keyType = TPSEngine.CFG_ENCRYPTION;
+            keyType = TPS.CFG_ENCRYPTION;
 
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
         String id = null;
 
-        String config = "op." + currentTokenOperation + "." + selectedTokenType + "." + TPSEngine.CFG_KEYGEN
-                + "." + keyType + "." + TPSEngine.CFG_DRM_CONNECTOR;
+        String config = "op." + currentTokenOperation + "." + selectedTokenType + "." + TPS.CFG_KEYGEN
+                + "." + keyType + "." + TPS.CFG_DRM_CONNECTOR;
 
         logger.debug("TPSEnrollProcessor.getDRMConnectorID: config value: " + config);
         try {
@@ -3587,8 +3587,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int keyTypeNum = 0;
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
-                    + TPSEngine.CFG_KEYGEN_KEYTYPE_NUM;
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
+                    + TPS.CFG_KEYGEN_KEYTYPE_NUM;
             logger.debug(method + "getting config value for:" + configValue);
             keyTypeNum = configStore.getInteger(
                     configValue, 0);
@@ -3616,8 +3616,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int enrollmentAlg;
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
-                    + TPSEngine.CFG_KEYGEN_ENCRYPTION + "." + TPSEngine.CFG_ALG;
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + "."
+                    + TPS.CFG_KEYGEN_ENCRYPTION + "." + TPS.CFG_ALG;
 
             logger.debug("TPSProcess.getEnrollmentAlg: configValue: " + configValue);
 
@@ -3647,9 +3647,9 @@ public class TPSEnrollProcessor extends TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         String keyTypeValue;
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "." + TPSEngine.CFG_KEYGEN
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + "." + TPS.CFG_KEYGEN
                     + "."
-                    + TPSEngine.RECOVERY_OP + "." + reason + "." + TPSEngine.CFG_KEYTYPE_VALUE + "." + index;
+                    + TPS.RECOVERY_OP + "." + reason + "." + TPS.CFG_KEYTYPE_VALUE + "." + index;
 
             logger.debug("TPSProcess.getRecoveryKeyTypeValue: configValue: " + configValue);
 
@@ -3684,9 +3684,9 @@ public class TPSEnrollProcessor extends TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         String scheme = null;
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "." + TPSEngine.CFG_KEYGEN
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + "." + TPS.CFG_KEYGEN
                     + "." + keyTypeValue + "."
-                    + TPSEngine.RECOVERY_OP + "." + reason + "." + TPSEngine.CFG_SCHEME;
+                    + TPS.RECOVERY_OP + "." + reason + "." + TPS.CFG_SCHEME;
 
             logger.debug("TPSProcess.getRecoveryScheme: configValue: " + configValue);
 
@@ -3720,9 +3720,9 @@ public class TPSEnrollProcessor extends TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int keyTypeNum = 0;
         try {
-            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "." + TPSEngine.CFG_KEYGEN
-                    + "." + TPSEngine.RECOVERY_OP
-                    + "." + reason + "." + TPSEngine.CFG_KEYTYPE_NUM;
+            String configValue = TPS.OP_ENROLL_PREFIX + "." + selectedTokenType + "." + TPS.CFG_KEYGEN
+                    + "." + TPS.RECOVERY_OP
+                    + "." + reason + "." + TPS.CFG_KEYTYPE_NUM;
 
             logger.debug("TPSEnrollProcessor.getNumberCertsForRecovery: configValue: " + configValue);
             keyTypeNum = configStore.getInteger(
@@ -3915,12 +3915,12 @@ public class TPSEnrollProcessor extends TPSProcessor {
         String scheme = null;
 
         if (isExternalReg == true) {
-            scheme = TPSEngine.CFG_EXTERNAL_REG;
+            scheme = TPS.CFG_EXTERNAL_REG;
         } else {
-            scheme = TPSEngine.CFG_NON_EXTERNAL_REG;
+            scheme = TPS.CFG_NON_EXTERNAL_REG;
         }
 
-        String allowMultiConfig = scheme + "." + TPSEngine.CFG_ALLOW_MULTI_TOKENS_USER;
+        String allowMultiConfig = scheme + "." + TPS.CFG_ALLOW_MULTI_TOKENS_USER;
         logger.debug(method + " trying config: tokendb." + allowMultiConfig);
 
         try {

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSPinResetProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSPinResetProcessor.java
@@ -27,7 +27,7 @@ import org.dogtagpki.server.tps.authentication.TPSAuthenticator;
 import org.dogtagpki.server.tps.channel.SecureChannel;
 import org.dogtagpki.server.tps.dbs.ActivityDatabase;
 import org.dogtagpki.server.tps.dbs.TokenRecord;
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 import org.dogtagpki.server.tps.main.ExternalRegAttrs;
 import org.dogtagpki.server.tps.mapping.BaseMappingResolver;
 import org.dogtagpki.server.tps.mapping.FilterMappingParams;
@@ -67,7 +67,7 @@ public class TPSPinResetProcessor extends TPSProcessor {
                      TPSStatus.STATUS_ERROR_MAC_RESET_PIN_PDU);
         }
         setBeginMessage(beginMsg);
-        setCurrentTokenOperation(TPSEngine.PIN_RESET_OP);
+        setCurrentTokenOperation(TPS.PIN_RESET_OP);
         checkIsExternalReg();
 
         resetPin();
@@ -154,7 +154,7 @@ public class TPSPinResetProcessor extends TPSProcessor {
             try {
                 logger.debug(method + " isExternalReg: calling requestUserId");
                 userAuth = getAuthentication(authId);
-                processAuthentication(TPSEngine.PIN_RESET_OP, userAuth, cuid, tokenRecord);
+                processAuthentication(TPS.PIN_RESET_OP, userAuth, cuid, tokenRecord);
                 auditAuthSuccess(userid, currentTokenOperation, appletInfo, authId);
             } catch (Exception e) {
                 auditAuthFailure(userid, currentTokenOperation, appletInfo,

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
@@ -58,7 +58,7 @@ import org.dogtagpki.server.tps.dbs.ActivityDatabase;
 import org.dogtagpki.server.tps.dbs.TPSCertRecord;
 import org.dogtagpki.server.tps.dbs.TokenCertStatus;
 import org.dogtagpki.server.tps.dbs.TokenRecord;
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 import org.dogtagpki.server.tps.main.ExternalRegAttrs;
 //import org.dogtagpki.server.tps.main.ExternalRegCertToDelete;
 import org.dogtagpki.server.tps.main.ExternalRegCertToRecover;
@@ -680,7 +680,7 @@ public class TPSProcessor {
         logger.debug("TPSProcessor.generateSecureChannel: entering.. keyInfoData: " + keyInfoData.toHexString());
         logger.debug("TPSProcessor.generateSecureChannel: isSCP02: " + platProtInfo.isSCP02());
 
-        TPSEngine engine = getTPSEngine();
+        TPS engine = getTPSEngine();
 
         SecureChannel channel = null;
         TPSBuffer hostCryptogram = null;
@@ -1003,7 +1003,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
 
         String appletEncryptionConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_UPDATE_APPLET_ENCRYPTION;
+                + TPS.CFG_UPDATE_APPLET_ENCRYPTION;
 
         logger.debug("TPSProcessor.checkUpdateAppletEncryption config to check: " + appletEncryptionConfig);
 
@@ -1265,12 +1265,12 @@ public class TPSProcessor {
         AuthCredentials userCred;
         String method = "TPSProcessor:processAuthentication:";
         String opPrefix;
-        if (op.equals(TPSEngine.FORMAT_OP))
-            opPrefix = TPSEngine.OP_FORMAT_PREFIX;
-        else if (op.equals(TPSEngine.ENROLL_OP))
-            opPrefix = TPSEngine.OP_ENROLL_PREFIX;
+        if (op.equals(TPS.FORMAT_OP))
+            opPrefix = TPS.OP_FORMAT_PREFIX;
+        else if (op.equals(TPS.ENROLL_OP))
+            opPrefix = TPS.OP_ENROLL_PREFIX;
         else
-            opPrefix = TPSEngine.OP_PIN_RESET_PREFIX;
+            opPrefix = TPS.OP_PIN_RESET_PREFIX;
 
         userCred = requestUserId(op, cuid, userAuth, beginMsg.getExtensions());
         userid = (String) userCred.get(userAuth.getAuthCredName());
@@ -1606,7 +1606,7 @@ public class TPSProcessor {
                 ".ca.conn";
             logger.debug(method + " getting config: " + config);
         } else {
-            config = TPSEngine.OP_FORMAT_PREFIX + "." +
+            config = TPS.OP_FORMAT_PREFIX + "." +
                 selectedTokenType +
                 ".ca.conn";
             logger.debug(method + " getting config: " + config);
@@ -1635,7 +1635,7 @@ public class TPSProcessor {
 
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
-        String configName = TPSEngine.OP_FORMAT_PREFIX + "." + selectedTokenType + ".revokeCert";
+        String configName = TPS.OP_FORMAT_PREFIX + "." + selectedTokenType + ".revokeCert";
         boolean revokeCert = false;
         try {
             logger.debug(method + ": getting config:" + configName);
@@ -1658,7 +1658,7 @@ public class TPSProcessor {
 
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
-        String configName = TPSEngine.OP_FORMAT_PREFIX + "." + selectedTokenType + ".revokeCert.reason";
+        String configName = TPS.OP_FORMAT_PREFIX + "." + selectedTokenType + ".revokeCert.reason";
         logger.debug(method + " finding config: " + configName);
 
         RevocationReason revokeReason = RevocationReason.UNSPECIFIED;
@@ -2203,7 +2203,7 @@ public class TPSProcessor {
                 try {
                     userAuth = getAuthentication(authId);
 
-                    processAuthentication(TPSEngine.FORMAT_OP, userAuth, cuid, tokenRecord);
+                    processAuthentication(TPS.FORMAT_OP, userAuth, cuid, tokenRecord);
                     auditAuthSuccess(userid, currentTokenOperation, appletInfo, authId);
 
                 } catch (Exception e) {
@@ -2309,7 +2309,7 @@ public class TPSProcessor {
         // isExternalReg : user already authenticated earlier
         if (!isExternalReg) {
             // authenticate per profile/tokenType configuration
-            configName = TPSEngine.OP_FORMAT_PREFIX + "." + tokenType + ".auth.enable";
+            configName = TPS.OP_FORMAT_PREFIX + "." + tokenType + ".auth.enable";
             boolean isAuthRequired;
             try {
                 logger.debug("TPSProcessor.format: getting config: " + configName);
@@ -2329,8 +2329,8 @@ public class TPSProcessor {
             if (isAuthRequired && !skipAuth) {
                 TPSAuthenticator userAuth = null;
                 try {
-                    userAuth = getAuthentication(TPSEngine.OP_FORMAT_PREFIX, tokenType);
-                    processAuthentication(TPSEngine.FORMAT_OP, userAuth, cuid, tokenRecord);
+                    userAuth = getAuthentication(TPS.OP_FORMAT_PREFIX, tokenType);
+                    processAuthentication(TPS.FORMAT_OP, userAuth, cuid, tokenRecord);
                     auditAuthSuccess(userid, currentTokenOperation, appletInfo,
                             (userAuth != null) ? userAuth.getID() : null);
 
@@ -2379,7 +2379,7 @@ public class TPSProcessor {
                         TPSStatus.STATUS_ERROR_DISABLED_TOKEN);
             }
         } else {
-            checkAllowUnknownToken(TPSEngine.FORMAT_OP);
+            checkAllowUnknownToken(TPS.FORMAT_OP);
 
             tokenRecord.setTokenStatus(TokenStatus.UNFORMATTED);
             logger.debug("TPSProcessor.format: token does not exist");
@@ -2403,19 +2403,19 @@ public class TPSProcessor {
         TPSBuffer build_id = getAppletVersion();
 
         if (build_id == null) {
-            checkAllowNoAppletToken(TPSEngine.OP_FORMAT_PREFIX);
+            checkAllowNoAppletToken(TPS.OP_FORMAT_PREFIX);
         } else {
             appletVersion = formatCurrentAppletVersion(appletInfo);
         }
 
-        String appletRequiredVersion = checkForAppletUpgrade(TPSEngine.OP_FORMAT_PREFIX);
+        String appletRequiredVersion = checkForAppletUpgrade(TPS.OP_FORMAT_PREFIX);
 
         logger.debug("TPSProcessor.format: appletVersion found: " + appletVersion + " requiredVersion: "
                 + appletRequiredVersion);
 
         String tksConnId = getTKSConnectorID();
 
-        upgradeApplet(appletInfo,TPSEngine.OP_FORMAT_PREFIX, appletRequiredVersion,
+        upgradeApplet(appletInfo,TPS.OP_FORMAT_PREFIX, appletRequiredVersion,
                 beginMsg.getExtensions(), tksConnId,
                 10, 90);
         logger.debug("TPSProcessor.format: Completed applet upgrade.");
@@ -2539,17 +2539,17 @@ public class TPSProcessor {
         String opPrefix = null;
         String opDefault = null;
 
-        if (currentTokenOperation.equals(TPSEngine.FORMAT_OP)) {
-            opPrefix = TPSEngine.OP_FORMAT_PREFIX;
-            opDefault = TPSEngine.CFG_DEF_FORMAT_PROFILE_RESOLVER;
+        if (currentTokenOperation.equals(TPS.FORMAT_OP)) {
+            opPrefix = TPS.OP_FORMAT_PREFIX;
+            opDefault = TPS.CFG_DEF_FORMAT_PROFILE_RESOLVER;
 
-        } else if (currentTokenOperation.equals(TPSEngine.ENROLL_OP)) {
-            opDefault = TPSEngine.CFG_DEF_ENROLL_PROFILE_RESOLVER;
-            opPrefix = TPSEngine.OP_ENROLL_PREFIX;
-        } else if (currentTokenOperation.equals(TPSEngine.PIN_RESET_OP)) {
+        } else if (currentTokenOperation.equals(TPS.ENROLL_OP)) {
+            opDefault = TPS.CFG_DEF_ENROLL_PROFILE_RESOLVER;
+            opPrefix = TPS.OP_ENROLL_PREFIX;
+        } else if (currentTokenOperation.equals(TPS.PIN_RESET_OP)) {
 
-            opDefault = TPSEngine.CFG_DEF_PIN_RESET_PROFILE_RESOLVER;
-            opPrefix = TPSEngine.OP_PIN_RESET_PREFIX;
+            opDefault = TPS.CFG_DEF_PIN_RESET_PROFILE_RESOLVER;
+            opPrefix = TPS.OP_PIN_RESET_PREFIX;
         } else {
             throw new TPSException(
                     "TPSProcessor.getResolverInstanceName: Invalid operation type, can not calculate resolver instance!",
@@ -2557,7 +2557,7 @@ public class TPSProcessor {
         }
 
         String config = opPrefix +
-                "." + TPSEngine.CFG_MAPPING_RESOLVER;
+                "." + TPS.CFG_MAPPING_RESOLVER;
 
         logger.debug("TPSProcessor.getResolverInstanceName: getting config: " + config);
         try {
@@ -2585,7 +2585,7 @@ public class TPSProcessor {
             return null;
         }
         String config = "externalReg" +
-                "." + TPSEngine.CFG_MAPPING_RESOLVER;
+                "." + TPS.CFG_MAPPING_RESOLVER;
 
         logger.debug(method + " getting config: " + config);
         try {
@@ -2654,7 +2654,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         String info = null;
 
-        String config = "op." + currentTokenOperation + "." + selectedTokenType + "." + TPSEngine.CFG_ISSUER_INFO_VALUE;
+        String config = "op." + currentTokenOperation + "." + selectedTokenType + "." + TPS.CFG_ISSUER_INFO_VALUE;
 
         logger.debug("TPSProcessor.getIssuerInfoValue: getting config: " + config);
         try {
@@ -2705,7 +2705,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
 
         String issuerEnabledConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_ISSUER_INFO_ENABLE;
+                + TPS.CFG_ISSUER_INFO_ENABLE;
 
         logger.debug("TPSProcessor.checkIssuerEnabled config to check: " + issuerEnabledConfig);
 
@@ -2729,7 +2729,7 @@ public class TPSProcessor {
 
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
-        String External_Reg_Cfg = TPSEngine.CFG_EXTERNAL_REG + "." + "enable";
+        String External_Reg_Cfg = TPS.CFG_EXTERNAL_REG + "." + "enable";
         logger.debug("TPS_Processor.checkIsExternalReg: getting config:" + External_Reg_Cfg);
 
         try {
@@ -2772,7 +2772,7 @@ public class TPSProcessor {
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
 
-        String noAppletConfig = operation + "." + selectedTokenType + "." + TPSEngine.CFG_ALLOW_NO_APPLET;
+        String noAppletConfig = operation + "." + selectedTokenType + "." + TPS.CFG_ALLOW_NO_APPLET;
         logger.debug("TPSProcessor.checkAllowNoAppletToken: getting config: " + noAppletConfig);
 
         try {
@@ -2796,7 +2796,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
 
         String appletUpdate = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_UPDATE_APPLET_ENABLE;
+                + TPS.CFG_UPDATE_APPLET_ENABLE;
         logger.debug("TPSProcessor.checkForAppletUpdateEnabled: getting config: " + appletUpdate);
         try {
             enabled = configStore.getBoolean(appletUpdate, false);
@@ -2829,7 +2829,7 @@ public class TPSProcessor {
         }
 
         String appletRequiredConfig = operation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_APPLET_UPDATE_REQUIRED_VERSION +  protString;
+                + TPS.CFG_APPLET_UPDATE_REQUIRED_VERSION +  protString;
         logger.debug("TPSProcessor.checkForAppletUpgrade: getting config: " + appletRequiredConfig);
         try {
             requiredVersion = configStore.getString(appletRequiredConfig, null);
@@ -2855,7 +2855,7 @@ public class TPSProcessor {
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
 
-        String unknownConfig = "op." + operation + "." + TPSEngine.CFG_ALLOW_UNKNOWN_TOKEN;
+        String unknownConfig = "op." + operation + "." + TPS.CFG_ALLOW_UNKNOWN_TOKEN;
         logger.debug("TPSProcessor.checkAllowUnknownToken: getting config: " + unknownConfig);
 
         try {
@@ -2899,11 +2899,11 @@ public class TPSProcessor {
         String NetKeyAID = null;
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
-        logger.debug("TPSProcessor.getNetkeyAID: getting config: " + TPSEngine.CFG_DEF_NETKEY_INSTANCE_AID);
+        logger.debug("TPSProcessor.getNetkeyAID: getting config: " + TPS.CFG_DEF_NETKEY_INSTANCE_AID);
         try {
 
-            NetKeyAID = configStore.getString(TPSEngine.CFG_APPLET_NETKEY_INSTANCE_AID,
-                    TPSEngine.CFG_DEF_NETKEY_INSTANCE_AID);
+            NetKeyAID = configStore.getString(TPS.CFG_APPLET_NETKEY_INSTANCE_AID,
+                    TPS.CFG_DEF_NETKEY_INSTANCE_AID);
 
         } catch (EBaseException e1) {
             logger.error("TPS_Processor.getNetkeyAID: Internal Error obtaining mandatory config values: " + e1.getMessage(), e1);
@@ -2920,11 +2920,11 @@ public class TPSProcessor {
         String NetKeyPAID = null;
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
-        logger.debug("TPSProcessor.getNetkeyPAID: getting config: " + TPSEngine.CFG_DEF_NETKEY_FILE_AID);
+        logger.debug("TPSProcessor.getNetkeyPAID: getting config: " + TPS.CFG_DEF_NETKEY_FILE_AID);
         try {
 
             NetKeyPAID = configStore.getString(
-                    TPSEngine.CFG_APPLET_NETKEY_FILE_AID, TPSEngine.CFG_DEF_NETKEY_FILE_AID);
+                    TPS.CFG_APPLET_NETKEY_FILE_AID, TPS.CFG_DEF_NETKEY_FILE_AID);
 
         } catch (EBaseException e1) {
             logger.error("TPS_Processor.getNetkeyAID: Internal Error obtaining mandatory config values: " + e1.getMessage(), e1);
@@ -2941,11 +2941,11 @@ public class TPSProcessor {
         String cardMgrAID = null;
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
-        logger.debug("TPSProcessor.getCardManagerAID: getting config: " + TPSEngine.CFG_APPLET_CARDMGR_INSTANCE_AID);
+        logger.debug("TPSProcessor.getCardManagerAID: getting config: " + TPS.CFG_APPLET_CARDMGR_INSTANCE_AID);
         try {
 
-            cardMgrAID = configStore.getString(TPSEngine.CFG_APPLET_CARDMGR_INSTANCE_AID,
-                    TPSEngine.CFG_DEF_CARDMGR_INSTANCE_AID);
+            cardMgrAID = configStore.getString(TPS.CFG_APPLET_CARDMGR_INSTANCE_AID,
+                    TPS.CFG_DEF_CARDMGR_INSTANCE_AID);
 
         } catch (EBaseException e1) {
             logger.error("TPS_Processor.getNetkeyAID: Internal Error obtaining mandatory config values: " + e1.getMessage(), e1);
@@ -2961,7 +2961,7 @@ public class TPSProcessor {
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSEngineConfig configStore = engine.getConfig();
         String extension = null;
-        String extensionConfig = TPSEngine.CFG_APPLET_EXTENSION;
+        String extensionConfig = TPS.CFG_APPLET_EXTENSION;
 
         try {
             extension = configStore.getString(extensionConfig, "ijc");
@@ -2981,7 +2981,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         String directory = null;
 
-        String directoryConfig = operation + "." + selectedTokenType + "." + TPSEngine.CFG_APPLET_DIRECTORY;
+        String directoryConfig = operation + "." + selectedTokenType + "." + TPS.CFG_APPLET_DIRECTORY;
         logger.debug("TPSProcessor.getAppletDirectory: getting config: " + directoryConfig);
 
         //We need a directory
@@ -3004,7 +3004,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int blockSize = 0;
         try {
-            blockSize = configStore.getInteger(TPSEngine.CFG_CHANNEL_BLOCK_SIZE, TPSEngine.CFG_CHANNEL_DEF_BLOCK_SIZE);
+            blockSize = configStore.getInteger(TPS.CFG_CHANNEL_BLOCK_SIZE, TPS.CFG_CHANNEL_DEF_BLOCK_SIZE);
 
         } catch (EBaseException e) {
             throw new TPSException("TPSProcessor.getChannelBlockSize: Internal error finding config value: " + e,
@@ -3022,8 +3022,8 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int instanceSize = 0;
         try {
-            instanceSize = configStore.getInteger(TPSEngine.CFG_CHANNEL_INSTANCE_SIZE,
-                    TPSEngine.CFG_CHANNEL_DEF_INSTANCE_SIZE);
+            instanceSize = configStore.getInteger(TPS.CFG_CHANNEL_INSTANCE_SIZE,
+                    TPS.CFG_CHANNEL_DEF_INSTANCE_SIZE);
 
         } catch (EBaseException e) {
             throw new TPSException("TPSProcessor.getChannelInstanceSize: Internal error finding config value: " + e,
@@ -3042,8 +3042,8 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int memSize = 0;
         try {
-            memSize = configStore.getInteger(TPSEngine.CFG_CHANNEL_APPLET_MEMORY_SIZE,
-                    TPSEngine.CFG_CHANNEL_DEF_APPLET_MEMORY_SIZE);
+            memSize = configStore.getInteger(TPS.CFG_CHANNEL_APPLET_MEMORY_SIZE,
+                    TPS.CFG_CHANNEL_DEF_APPLET_MEMORY_SIZE);
 
         } catch (EBaseException e) {
             throw new TPSException("TPSProcessor.getAppletMemorySize: Internal error finding config value: " + e,
@@ -3060,7 +3060,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int ver = 0;
         try {
-            ver = configStore.getInteger(TPSEngine.CFG_CHANNEL_DEFKEY_VERSION, 0x0);
+            ver = configStore.getInteger(TPS.CFG_CHANNEL_DEFKEY_VERSION, 0x0);
 
         } catch (EBaseException e) {
             throw new TPSException("TPSProcessor.getChannelDefKeyVersion: Internal error finding config value: " + e,
@@ -3079,7 +3079,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
         int index = 0;
         try {
-            index = configStore.getInteger(TPSEngine.CFG_CHANNEL_DEFKEY_INDEX, 0x0);
+            index = configStore.getInteger(TPS.CFG_CHANNEL_DEFKEY_INDEX, 0x0);
 
         } catch (EBaseException e) {
             throw new TPSException("TPSProcessor.getChannelDefKeyIndex: Internal error finding config value: " + e,
@@ -3189,7 +3189,7 @@ public class TPSProcessor {
 
     }
 
-    public TPSEngine getTPSEngine() {
+    public TPS getTPSEngine() {
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
         TPSSubsystem subsystem = (TPSSubsystem) engine.getSubsystem(TPSSubsystem.ID);
 
@@ -3303,7 +3303,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
 
         String symmConfig = "op" + "." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_SYMM_KEY_UPGRADE_ENABLED;
+                + TPS.CFG_SYMM_KEY_UPGRADE_ENABLED;
 
         logger.debug("TPSProcessor.checkSymmetricKeysEnabled: getting config:" + symmConfig);
         try {
@@ -3421,7 +3421,7 @@ public class TPSProcessor {
 
                 String connId = getTKSConnectorID();
                 TPSBuffer curKeyInfo = channel.getKeyInfoData();
-                TPSEngine engine = getTPSEngine();
+                TPS engine = getTPSEngine();
 
                 int protocol = 1;
                 if (channel.isSCP02()) {
@@ -3719,26 +3719,26 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
 
         String pinResetEnableConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_PIN_RESET_ENABLE;
+                + TPS.CFG_PIN_RESET_ENABLE;
 
         logger.debug("TPSProcessor.checkAndHandlePinReset config to check: " + pinResetEnableConfig);
 
         String minLenConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_PIN_RESET_MIN_LEN;
+                + TPS.CFG_PIN_RESET_MIN_LEN;
 
         logger.debug("TPSProcessor.checkAndHandlePinReset config to check: " + minLenConfig);
 
         String maxLenConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_PIN_RESET_MAX_LEN;
+                + TPS.CFG_PIN_RESET_MAX_LEN;
 
         logger.debug("TPSProcessor.checkAndHandlePinReset config to check: " + maxLenConfig);
 
         String maxRetriesConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_PIN_RESET_MAX_RETRIES;
+                + TPS.CFG_PIN_RESET_MAX_RETRIES;
 
         logger.debug("TPSProcessor.checkAndHandlePinReset config to check: " + maxRetriesConfig);
 
-        String pinStringConfig = TPSEngine.CFG_PIN_RESET_STRING;
+        String pinStringConfig = TPS.CFG_PIN_RESET_STRING;
 
         logger.debug("TPSProcessor.checkAndHandlePinReset config to check: " + pinStringConfig);
 
@@ -3786,12 +3786,12 @@ public class TPSProcessor {
 
         String opPrefix = null;
 
-        if (TPSEngine.ENROLL_OP.equals(currentTokenOperation)) {
-            opPrefix = TPSEngine.OP_ENROLL_PREFIX;
-        } else if (TPSEngine.FORMAT_OP.equals(currentTokenOperation)) {
-            opPrefix = TPSEngine.OP_FORMAT_PREFIX;
+        if (TPS.ENROLL_OP.equals(currentTokenOperation)) {
+            opPrefix = TPS.OP_ENROLL_PREFIX;
+        } else if (TPS.FORMAT_OP.equals(currentTokenOperation)) {
+            opPrefix = TPS.OP_FORMAT_PREFIX;
         } else {
-            opPrefix = TPSEngine.OP_PIN_RESET_PREFIX;
+            opPrefix = TPS.OP_PIN_RESET_PREFIX;
         }
 
         org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
@@ -3819,7 +3819,7 @@ public class TPSProcessor {
                 TPSAuthenticator userAuth = null;
                 try {
                     userAuth = getAuthentication(opPrefix, tokenType);
-                    processAuthentication(TPSEngine.ENROLL_OP, userAuth, appletInfo.getCUIDhexString(), tokenRecord);
+                    processAuthentication(TPS.ENROLL_OP, userAuth, appletInfo.getCUIDhexString(), tokenRecord);
                     auditAuthSuccess(userid, currentTokenOperation, appletInfo,
                             (userAuth != null) ? userAuth.getID() : null);
 
@@ -4022,7 +4022,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
 
         String checkBoundedGPKeyVersionConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_ENABLE_BOUNDED_GP_KEY_VERSION;
+                + TPS.CFG_ENABLE_BOUNDED_GP_KEY_VERSION;
 
         logger.debug(method + " config to check: " + checkBoundedGPKeyVersionConfig);
 
@@ -4040,9 +4040,9 @@ public class TPSProcessor {
         if (result) {
 
             String minConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                    + TPSEngine.CFG_MINIMUM_GP_KEY_VERSION;
+                    + TPS.CFG_MINIMUM_GP_KEY_VERSION;
             String maxConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                    + TPSEngine.CFG_MAXIMUM_GP_KEY_VERSION;
+                    + TPS.CFG_MAXIMUM_GP_KEY_VERSION;
 
             logger.debug(method + " config to check: minConfig: " + minConfig + " maxConfig: " + maxConfig);
 
@@ -4169,7 +4169,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
 
         String checkCUIDMatchesKDDConfig = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_CUID_MUST_MATCH_KDD;
+                + TPS.CFG_CUID_MUST_MATCH_KDD;
 
         logger.debug(method + " config to check: " + checkCUIDMatchesKDDConfig);
 
@@ -4251,7 +4251,7 @@ public class TPSProcessor {
         TPSEngineConfig configStore = engine.getConfig();
 
         String checkValidateVersion = "op." + currentTokenOperation + "." + selectedTokenType + "."
-                + TPSEngine.CFG_VALIDATE_CARD_KEY_INFO_AGAINST_DB;
+                + TPS.CFG_VALIDATE_CARD_KEY_INFO_AGAINST_DB;
 
         logger.debug(method + " config to check: " + checkValidateVersion);
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/TokenService.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/TokenService.java
@@ -38,7 +38,7 @@ import org.dogtagpki.server.tps.TPSSubsystem;
 import org.dogtagpki.server.tps.dbs.ActivityDatabase;
 import org.dogtagpki.server.tps.dbs.TokenDatabase;
 import org.dogtagpki.server.tps.dbs.TokenRecord;
-import org.dogtagpki.server.tps.engine.TPSEngine;
+import org.dogtagpki.server.tps.engine.TPS;
 
 import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.base.PKIException;
@@ -98,11 +98,11 @@ public class TokenService extends SubsystemService implements TokenResource {
         TokenStatus newStatus = tokenState;
         String newReason = null;
 
-        boolean clearOnUnformatUserID = config.getBoolean(TPSEngine.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_USERID, true);
-        boolean clearOnUnformatType = config.getBoolean(TPSEngine.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_TYPE, true);
-        boolean clearOnUnformatAppletID = config.getBoolean(TPSEngine.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_APPLETID, true);
-        boolean clearOnUnformatKeyInfo = config.getBoolean(TPSEngine.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_KEYINFO, true);
-        boolean clearOnUnformatPolicy = config.getBoolean(TPSEngine.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_POLICY, true);
+        boolean clearOnUnformatUserID = config.getBoolean(TPS.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_USERID, true);
+        boolean clearOnUnformatType = config.getBoolean(TPS.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_TYPE, true);
+        boolean clearOnUnformatAppletID = config.getBoolean(TPS.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_APPLETID, true);
+        boolean clearOnUnformatKeyInfo = config.getBoolean(TPS.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_KEYINFO, true);
+        boolean clearOnUnformatPolicy = config.getBoolean(TPS.CFG_TOKENSERVICE_UNFORMATTED_CLEAR_POLICY, true);
 
         auditModParams.put("UserID", tokenRecord.getUserID());
 


### PR DESCRIPTION
Previously there were two `TPSEngine` classes: one is a subclass of `CMSEngine` and the other is a collection of TPS constants and methods. To avoid confusions and conflicts the second one has been renamed into `TPS`.