### PR TITLE
Use Python XML to configure listeners

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1694,6 +1694,9 @@ class ServerConfig(object):
         return None
 
     def create_listener(self, className):
+        '''
+        Create listener and add it after the last listener.
+        '''
 
         listener = etree.Element('Listener')
         listener.set('className', className)
@@ -1708,6 +1711,9 @@ class ServerConfig(object):
         return listener
 
     def remove_listener(self, className):
+        '''
+        Remove listener by class name.
+        '''
 
         listener = self.get_listener(className)
 

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -249,6 +249,13 @@ class PKIDeployer:
         logger.info('Configuring Tomcat admin port')
         server_config.set_port(self.mdict['pki_tomcat_server_port'])
 
+        logger.info('Removing AprLifecycleListener')
+        # It is not needed since PKI server will use JSS-based SSL connector
+        server_config.remove_listener('org.apache.catalina.core.AprLifecycleListener')
+
+        logger.info('Adding PKIListener')
+        server_config.create_listener('com.netscape.cms.tomcat.PKIListener')
+
         if config.str2bool(self.mdict['pki_enable_proxy']):
 
             logger.info('Adding AJP connector for IPv4')

--- a/base/tomcat-9.0/conf/server.xml
+++ b/base/tomcat-9.0/conf/server.xml
@@ -29,17 +29,12 @@
   <!-- Security listener. Documentation at /docs/config/listeners.html
   <Listener className="org.apache.catalina.security.SecurityListener" />
   -->
-  <!--APR library loader. Documentation at /docs/apr.html -->
-  <!-- The following Listener class has been commented out because this -->
-  <!-- implementation depends upon the 'tomcatjss' JSSE module, 'JSS',  -->
-  <!-- and 'NSS' rather than the 'tomcat-native' module! -->
-  <!-- Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" -->
-
+  <!-- APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
-  <Listener className="com.netscape.cms.tomcat.PKIListener"/>
 
   <!-- Global JNDI resources
        Documentation at /docs/jndi-resources-howto.html


### PR DESCRIPTION
This will reduce the difference between the `server.xml` template in PKI and the default `server.xml` provided by Tomcat.