### PR TITLE
Use Python XML to add RewriteValve

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1889,18 +1889,37 @@ class ServerConfig(object):
         server = self.document.getroot()
         return server.find('.//Valve[@className="%s"]' % className)
 
+    def create_valve(self, className):
+        '''
+        Create valve and add it after the last valve.
+        '''
+
+        valve = etree.Element('Valve')
+        valve.set('className', className)
+
+        self.add_valve(valve)
+
+        return valve
+
     def add_valve(self, valve):
         '''
         Add valve after the last valve.
         '''
 
         server = self.document.getroot()
-        valves = server.findall('.//Valve')
-        last_valve = valves[-1]
 
-        service = last_valve.getparent()
-        index = service.index(last_valve) + 1
-        service.insert(index, valve)
+        # find last valve
+        host = server.find('.//Host[@name="localhost"]')
+        valves = host.findall('Valve')
+
+        # insert new valve after the last valve
+        if len(valves) == 0:
+            index = 0
+        else:
+            last_valve = valves[-1]
+            index = host.index(last_valve) + 1
+
+        host.insert(index, valve)
 
     def remove_valve(self, className):
         '''

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -303,6 +303,9 @@ class PKIDeployer:
             logger.info('Disabling access log')
             server_config.remove_valve('org.apache.catalina.valves.AccessLogValve')
 
+        logger.info('Adding RewriteValve')
+        server_config.create_valve('org.apache.catalina.valves.rewrite.RewriteValve')
+
         server_config.save()
 
     def get_key_params(self, cert_id):

--- a/base/tomcat-9.0/conf/server.xml
+++ b/base/tomcat-9.0/conf/server.xml
@@ -187,8 +187,6 @@
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 
-        <Valve className="org.apache.catalina.valves.rewrite.RewriteValve" />
-
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
This will reduce the difference between the `server.xml` template in PKI and the default `server.xml` provided by Tomcat.