### PR TITLE
Use Python XML to remove UserDatabase

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1723,6 +1723,27 @@ class ServerConfig(object):
         server = listener.getparent()
         server.remove(listener)
 
+    def get_global_naming_resource(self, name):
+        '''
+        Find global naming resource by name.
+        '''
+
+        server = self.document.getroot()
+        return server.find('GlobalNamingResources/Resource[@name="%s"]' % name)
+
+    def remove_global_naming_resource(self, name):
+        '''
+        Remove global naming resource by name.
+        '''
+
+        resource = self.get_global_naming_resource(name)
+
+        if resource is None:
+            return
+
+        parent = resource.getparent()
+        parent.remove(resource)
+
     def get_connectors(self):
 
         server = self.document.getroot()

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -256,6 +256,9 @@ class PKIDeployer:
         logger.info('Adding PKIListener')
         server_config.create_listener('com.netscape.cms.tomcat.PKIListener')
 
+        logger.info('Removing UserDatabase')
+        server_config.remove_global_naming_resource('UserDatabase')
+
         if config.str2bool(self.mdict['pki_enable_proxy']):
 
             logger.info('Adding AJP connector for IPv4')

--- a/base/tomcat-9.0/conf/server.xml
+++ b/base/tomcat-9.0/conf/server.xml
@@ -42,12 +42,12 @@
   <GlobalNamingResources>
     <!-- Editable user database that can also be used by
          UserDatabaseRealm to authenticate users
+    -->
     <Resource name="UserDatabase" auth="Container"
               type="org.apache.catalina.UserDatabase"
               description="User database that can be updated and saved"
               factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
               pathname="conf/tomcat-users.xml" />
-    -->
   </GlobalNamingResources>
 
   <!-- A "Service" is a collection of one or more "Connectors" that share


### PR DESCRIPTION
This will reduce the difference between the `server.xml` template in PKI and the default `server.xml` provided by Tomcat.