### PR TITLE
Add PKIClientAuthenticator

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIClientAuthenticator.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIClientAuthenticator.java
@@ -1,0 +1,35 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.certsrv.client;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.mozilla.jss.netscape.security.util.Utils;
+
+public class PKIClientAuthenticator implements ClientRequestFilter {
+
+    ClientConfig config;
+
+    public PKIClientAuthenticator(ClientConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+
+        String credentials = config.getUsername() + ":" + config.getPassword();
+        byte[] bytes = credentials.getBytes(StandardCharsets.UTF_8);
+        String authorization = "Basic " + Utils.base64encodeSingleLine(bytes);
+
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+        headers.add("Authorization", authorization);
+    }
+}


### PR DESCRIPTION
The `PKIClientAuthenticator` has been added to provide basic authentication for PKI client using JAX-RS API. This will reduce dependency on deprecated Apache HTTPComponents API.