### PR TITLE
Use Python XML to configure unsecure connector

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -264,7 +264,7 @@ class PKIServer(object):
     def export_ca_cert(self):
 
         server_config = self.get_server_config()
-        connector = server_config.get_connector('Secure')
+        connector = server_config.get_connector(name='Secure')
 
         if connector is None:
             # HTTPS connector not configured, skip
@@ -1304,7 +1304,7 @@ grant codeBase "file:%s" {
         # Load SSL server cert nickname from server.xml
 
         server_config = self.get_server_config()
-        connector = server_config.get_connector('Secure')
+        connector = server_config.get_connector(name='Secure')
 
         if connector is None:
             return None
@@ -1324,7 +1324,7 @@ grant codeBase "file:%s" {
             fullname = nickname
 
         server_config = self.get_server_config()
-        connector = server_config.get_connector('Secure')
+        connector = server_config.get_connector(name='Secure')
 
         if connector is None:
             raise KeyError('Connector not found: Secure')
@@ -1773,16 +1773,20 @@ class ServerConfig(object):
 
         return connectors
 
-    def get_connector(self, name):
+    def get_connector(self, name=None, port=None):
+        '''
+        Find connector by name or port.
+        '''
 
-        connectors = self.get_connectors()
+        server = self.document.getroot()
 
-        for connector in connectors:
-            n = connector.get('name')
-            if n == name:
-                return connector
+        xpath = 'Service[@name="Catalina"]/Connector'
+        if name is not None:
+            xpath = xpath + '[@name="%s"]' % name
+        if port is not None:
+            xpath = xpath + '[@port="%s"]' % port
 
-        return None
+        return server.find(xpath)
 
     def create_connector(self, name):
 
@@ -1809,7 +1813,7 @@ class ServerConfig(object):
 
     def remove_connector(self, name):
 
-        connector = self.get_connector(name)
+        connector = self.get_connector(name=name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % name)

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -211,7 +211,7 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
 
         server_config = instance.get_server_config()
 
-        connector = server_config.get_connector(name)
+        connector = server_config.get_connector(name=name)
 
         if connector is not None:
             raise Exception('Connector already exists: %s' % name)
@@ -437,7 +437,7 @@ class HTTPConnectorShowCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(name)
+        connector = server_config.get_connector(name=name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % name)
@@ -573,7 +573,7 @@ class HTTPConnectorModCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(name)
+        connector = server_config.get_connector(name=name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % name)
@@ -744,7 +744,7 @@ class SSLHostAddCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(connector_name)
+        connector = server_config.get_connector(name=connector_name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
@@ -832,7 +832,7 @@ class SSLHostDeleteCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(connector_name)
+        connector = server_config.get_connector(name=connector_name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
@@ -903,7 +903,7 @@ class SSLHostFindCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(connector_name)
+        connector = server_config.get_connector(name=connector_name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
@@ -1014,7 +1014,7 @@ class SSLHostModifyCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(connector_name)
+        connector = server_config.get_connector(name=connector_name)
 
         if connector is None:
             logger.error('Connector not found: %s', connector_name)
@@ -1110,7 +1110,7 @@ class SSLHostShowCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(connector_name)
+        connector = server_config.get_connector(name=connector_name)
 
         if connector is None:
             logger.error('Connector not found: %s', connector_name)
@@ -1263,7 +1263,7 @@ class SSLCertAddCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(connector_name)
+        connector = server_config.get_connector(name=connector_name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
@@ -1364,7 +1364,7 @@ class SSLCertDeleteCLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(connector_name)
+        connector = server_config.get_connector(name=connector_name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)
@@ -1444,7 +1444,7 @@ class SSLCertFindLI(pki.cli.CLI):
         instance.load()
 
         server_config = instance.get_server_config()
-        connector = server_config.get_connector(connector_name)
+        connector = server_config.get_connector(name=connector_name)
 
         if connector is None:
             raise KeyError('Connector not found: %s' % connector_name)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -259,6 +259,19 @@ class PKIDeployer:
         logger.info('Removing UserDatabase')
         server_config.remove_global_naming_resource('UserDatabase')
 
+        logger.info('Configuring Unsecure connector')
+        connector = server_config.get_connector(port='8080')
+        connector.set('name', 'Unsecure')
+        connector.set('port', self.mdict['pki_http_port'])
+        connector.set('redirectPort', self.mdict['pki_https_port'])
+        connector.set('maxHttpHeaderSize', '8192')
+        connector.set('acceptCount', '100')
+        connector.set('maxThreads', '150')
+        connector.set('minSpareThreads', '25')
+        connector.set('enableLookups', 'false')
+        connector.set('connectionTimeout', '80000')
+        connector.set('disableUploadTimeout', 'true')
+
         if config.str2bool(self.mdict['pki_enable_proxy']):
 
             logger.info('Adding AJP connector for IPv4')

--- a/base/tomcat-9.0/conf/server.xml
+++ b/base/tomcat-9.0/conf/server.xml
@@ -69,29 +69,17 @@
          Java HTTP Connector: /docs/config/http.html
          Java AJP  Connector: /docs/config/ajp.html
          APR (HTTP/AJP) Connector: /docs/apr.html
-         Define a non-SSL/TLS HTTP/1.1 Connector on port [pki_http_port]
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
     -->
-
-    <!-- Shared Ports:  Unsecure Port Connector -->
-    <Connector name="Unsecure"
-               port="[pki_http_port]"
-               protocol="HTTP/1.1"
-               redirectPort="[pki_https_port]"
-               maxHttpHeaderSize="8192"
-               acceptCount="100"
-               maxThreads="150"
-               minSpareThreads="25"
-               enableLookups="false"
-               connectionTimeout="80000"
-               disableUploadTimeout="true"
-               />
-
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"
-               port="[pki_http_port]" protocol="HTTP/1.1"
+               port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000"
-               redirectPort="[pki_https_port]" />
+               redirectPort="8443" />
     -->
 
     <!-- Define a SSL/TLS HTTP/1.1 Connector on port [pki_https_port]


### PR DESCRIPTION
This will reduce the difference between the `server.xml` template in PKI and the default `server.xml` provided by Tomcat.