### PR TITLE
Use Python XML to add secure connector

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1789,6 +1789,9 @@ class ServerConfig(object):
         return server.find(xpath)
 
     def create_connector(self, name):
+        '''
+        Create connector and add it after the last connector.
+        '''
 
         connector = etree.Element('Connector')
         connector.set('name', name)
@@ -1835,6 +1838,9 @@ class ServerConfig(object):
         raise KeyError('SSL host not found: %s' % hostname)
 
     def create_sslhost(self, connector, hostname='_default_'):
+        '''
+        Create SSL host and add it after the last SSL host.
+        '''
 
         sslhost = etree.Element('SSLHostConfig')
         if hostname != '_default_':
@@ -1862,7 +1868,10 @@ class ServerConfig(object):
 
         raise KeyError('SSL certificate not found: %s' % certType)
 
-    def create_sslcert(self, sslhost, certType):
+    def create_sslcert(self, sslhost, certType='UNDEFINED'):
+        '''
+        Create SSL cert and add it after the last SSL cert.
+        '''
 
         sslcert = etree.Element('Certificate')
         if certType != 'UNDEFINED':

--- a/base/tomcat-9.0/conf/server.xml
+++ b/base/tomcat-9.0/conf/server.xml
@@ -81,46 +81,40 @@
                connectionTimeout="20000"
                redirectPort="8443" />
     -->
-
-    <!-- Define a SSL/TLS HTTP/1.1 Connector on port [pki_https_port]
-         This connector uses the NIO implementation that requires the JSSE
-         style configuration. When using the APR/native implementation, the
-         OpenSSL style configuration is required as described in the APR/native
-         documentation -->
-    <Connector name="Secure"
-               port="[pki_https_port]"
-               protocol="org.dogtagpki.tomcat.Http11NioProtocol"
-               SSLEnabled="true"
-               sslImplementationName="org.dogtagpki.tomcat.JSSImplementation"
-               scheme="https"
-               secure="true"
-               connectionTimeout="80000"
-               keepAliveTimeout="300000"
-               maxHttpHeaderSize="8192"
-               acceptCount="100"
-               maxThreads="150"
-               minSpareThreads="25"
-               enableLookups="false"
-               disableUploadTimeout="true"
-               enableOCSP="false"
-               ocspResponderURL="http://[pki_hostname]:[pki_http_port]/ca/ocsp"
-               ocspResponderCertNickname="ocspSigningCert cert-pki-ca"
-               ocspCacheSize="1000"
-               ocspMinCacheEntryDuration="7200"
-               ocspMaxCacheEntryDuration="14400"
-               ocspTimeout="10"
-               passwordFile="[pki_instance_path]/conf/password.conf"
-               passwordClass="org.apache.tomcat.util.net.jss.PlainPasswordFile"
-               certdbDir="[pki_instance_path]/alias">
-
-        <SSLHostConfig sslProtocol="SSL"
-                       certificateVerification="optional">
-            <Certificate certificateKeystoreType="pkcs11"
-                         certificateKeystoreProvider="Mozilla-JSS"
-                         certificateKeyAlias="sslserver"/>
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
         </SSLHostConfig>
-
     </Connector>
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
     <!--


### PR DESCRIPTION
This will reduce the difference between the `server.xml` template in PKI and the default `server.xml` provided by Tomcat.