### PR TITLE
Fix adding Profile/Profile Mapping in TPS UI

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileData.java
@@ -24,7 +24,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.certsrv.util.StringHashMapValueDeserializer;
 
 /**
  * @author Endi S. Dewata
@@ -36,6 +38,7 @@ public class ProfileData implements JSONSerializer {
     String id;
     String profileID;
     String status;
+    @JsonDeserialize(using = StringHashMapValueDeserializer.class)
     Map<String, String> properties;
 
     public String getID() {
@@ -46,6 +49,7 @@ public class ProfileData implements JSONSerializer {
         this.id = id;
     }
 
+    @JsonProperty("ProfileID")
     public String getProfileID() {
         return profileID;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingCollection.java
@@ -18,22 +18,15 @@
 
 package com.netscape.certsrv.tps.profile;
 
-import java.util.Collection;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.base.DataCollection;
+import com.netscape.certsrv.util.JSONSerializer;
 
 /**
  * @author Endi S. Dewata
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class ProfileMappingCollection extends DataCollection<ProfileMappingData> {
-
-    @Override
-    public Collection<ProfileMappingData> getEntries() {
-        return super.getEntries();
-    }
-}
+public class ProfileMappingCollection extends DataCollection<ProfileMappingData> implements JSONSerializer {}

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingData.java
@@ -19,22 +19,27 @@
 package com.netscape.certsrv.tps.profile;
 
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.certsrv.util.StringHashMapValueDeserializer;
 
 /**
  * @author Endi S. Dewata
  */
 @JsonInclude(Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown=true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProfileMappingData implements JSONSerializer {
 
     String id;
+    String profileMappingID;
     String status;
+    @JsonDeserialize(using = StringHashMapValueDeserializer.class)
     Map<String, String> properties;
 
     public String getID() {
@@ -43,6 +48,15 @@ public class ProfileMappingData implements JSONSerializer {
 
     public void setID(String id) {
         this.id = id;
+    }
+
+    @JsonProperty("ProfileMappingID")
+    public String getProfileMappingID() {
+        return profileMappingID;
+    }
+
+    public void setProfileMappingID(String profileMappingID) {
+        this.profileMappingID = profileMappingID;
     }
 
     @JsonProperty("Status")
@@ -65,12 +79,7 @@ public class ProfileMappingData implements JSONSerializer {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((properties == null) ? 0 : properties.hashCode());
-        result = prime * result + ((status == null) ? 0 : status.hashCode());
-        return result;
+        return Objects.hash(id, profileMappingID, properties, status);
     }
 
     @Override
@@ -82,22 +91,19 @@ public class ProfileMappingData implements JSONSerializer {
         if (getClass() != obj.getClass())
             return false;
         ProfileMappingData other = (ProfileMappingData) obj;
-        if (id == null) {
-            if (other.id != null)
-                return false;
-        } else if (!id.equals(other.id))
-            return false;
-        if (properties == null) {
-            if (other.properties != null)
-                return false;
-        } else if (!properties.equals(other.properties))
-            return false;
-        if (status == null) {
-            if (other.status != null)
-                return false;
-        } else if (!status.equals(other.status))
-            return false;
-        return true;
+        return Objects.equals(id, other.id) &&
+                Objects.equals(profileMappingID, other.profileMappingID) &&
+                Objects.equals(properties, other.properties) &&
+                Objects.equals(status, other.status);
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return toJSON();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/util/StringHashMapValueDeserializer.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/StringHashMapValueDeserializer.java
@@ -1,0 +1,32 @@
+package com.netscape.certsrv.util;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+public class StringHashMapValueDeserializer extends JsonDeserializer<HashMap<String, String>> {
+
+    @Override
+    public HashMap<String, String> deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
+        HashMap<String, String> ret = new HashMap<>();
+        TreeNode node = parser.getCodec().readTree(parser);
+        if (node != null && node.isArray()) {
+            // If node is an array take the first element, if already map-like use it directly.
+            node = node.get(0);
+        }
+        if (node != null) {
+            for (Iterator<String> iter = node.fieldNames(); iter.hasNext();) {
+                String field = iter.next();
+                TextNode valueNode = (TextNode) node.get(field);
+                ret.put(field, valueNode.asText());
+            }
+        }
+        return ret;
+    }
+}

--- a/base/server/share/webapps/pki/js/pki.js
+++ b/base/server/share/webapps/pki/js/pki.js
@@ -108,6 +108,12 @@ var Model = Backbone.Model.extend({
     save: function(attributes, options) {
         var self = this;
         if (attributes == undefined) attributes = self.attributes;
+        // convert properties into expected format
+        props = {}
+        for (attr in attributes.properties) {
+            props[attributes.properties[attr]["name"]] = attributes.properties[attr]["value"]
+        }
+        attributes.properties = props
         // convert attributes into JSON request
         var request = self.createRequest(attributes);
         // remove old attributes

--- a/base/tps/shared/webapps/tps/js/profile-mapping.js
+++ b/base/tps/shared/webapps/tps/js/profile-mapping.js
@@ -31,9 +31,10 @@ var ProfileMappingModel = Model.extend({
     },
     createRequest: function(attributes) {
         return {
-            id: attributes.profileMappingID,
+            id: attributes.id,
+            ProfileMappingID: attributes.profileMappingID,
             Status: attributes.status,
-            properties: attributes.properties
+            Properties: attributes.properties
         };
     },
     changeStatus: function(action, options) {

--- a/base/tps/shared/webapps/tps/js/tps.js
+++ b/base/tps/shared/webapps/tps/js/tps.js
@@ -433,7 +433,7 @@ var ConfigEntryPage = EntryPage.extend({
     saveEntry: function() {
         var self = this;
 
-        if (!self.entry.profileID.match(TPS.PROFILE_ID_PATTERN)) {
+        if (self.entry.length && !self.entry.profileID.match(TPS.PROFILE_ID_PATTERN)) {
             throw "Invalid profile ID: " + self.entry.profileID;
         }
 


### PR DESCRIPTION
There were some naming mismatches and request format issues which are now resolved.

In addition, there was a larger problem that JS arrays are not always deserialised correctly, so a new `StringHashMapValueDeserializer` class is introduced to assist with this.

Adding `ProfileMappingData` objects still did not work, as the `id` and `profileMappingID` were used interchangeably causing a null reference. `ProfileMappingData` has been modified to be of the same format as `ProfileData`.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1875637