### PR TITLE
Add Subsystem.engine

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -357,8 +357,8 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
         logger.info("CertificateAuthority: Initializing " +
                 (authorityID == null ? "host CA" : "authority " + authorityID));
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         mConfig = cs.getCAConfig();
 
@@ -375,7 +375,7 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
         } catch (CAMissingCertException | CAMissingKeyException e) {
             logger.warn("CertificateAuthority: CA signing key and cert not (yet) present in NSS database");
             signingUnitException = e;
-            engine.startKeyRetriever(this);
+            caEngine.startKeyRetriever(this);
 
         } catch (Exception e) {
             throw new EBaseException(e);

--- a/base/ca/src/main/java/com/netscape/cmscore/cert/CrossCertPairSubsystem.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/cert/CrossCertPairSubsystem.java
@@ -103,13 +103,13 @@ public class CrossCertPairSubsystem extends Subsystem {
 
         logger.debug("CrossCertPairSubsystem: initializing");
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         try {
             mConfig = config;
             synchronized (this) {
-                mPublisherProcessor = engine.getPublisherProcessor();
+                mPublisherProcessor = caEngine.getPublisherProcessor();
             }
 
             // initialize LDAP connection factory

--- a/base/ca/src/main/java/com/netscape/cmscore/profile/LDAPProfileSubsystem.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/profile/LDAPProfileSubsystem.java
@@ -96,8 +96,8 @@ public class LDAPProfileSubsystem
 
         logger.debug("LDAPProfileSubsystem: start init");
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         PKISocketConfig socketConfig = cs.getSocketConfig();
         LDAPConfig dbCfg = cs.getInternalDBConfig();

--- a/base/ca/src/main/java/com/netscape/cmscore/profile/ProfileSubsystem.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/profile/ProfileSubsystem.java
@@ -57,7 +57,6 @@ public class ProfileSubsystem
 
         logger.debug("ProfileSubsystem: initialization");
 
-        CAEngine engine = CAEngine.getInstance();
         PluginRegistry registry = engine.getPluginRegistry();
 
         mConfig = config;

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -409,6 +409,7 @@ public class CAEngine extends CMSEngine {
     public void initAuthSubsystem() throws Exception {
         AuthenticationConfig authConfig = config.getAuthenticationConfig();
         authSubsystem = new CAAuthSubsystem();
+        authSubsystem.setCMSEngine(this);
         authSubsystem.init(authConfig);
         authSubsystem.startup();
     }
@@ -1130,6 +1131,7 @@ public class CAEngine extends CMSEngine {
 
         CAEngineConfig engineConfig = getConfig();
         CAConfig caConfig = engineConfig.getCAConfig();
+        ca.setCMSEngine(this);
         ca.init(caConfig);
 
         updateAuthoritySerialNumber(aid, cert.getSerialNumber());
@@ -1479,6 +1481,7 @@ public class CAEngine extends CMSEngine {
 
             CAEngineConfig engineConfig = getConfig();
             CAConfig caConfig = engineConfig.getCAConfig();
+            ca.setCMSEngine(this);
             ca.init(caConfig);
 
             addCA(aid, ca);

--- a/base/kra/src/main/java/com/netscape/kra/KeyRecoveryAuthority.java
+++ b/base/kra/src/main/java/com/netscape/kra/KeyRecoveryAuthority.java
@@ -309,8 +309,8 @@ public class KeyRecoveryAuthority extends Subsystem implements IAuthority {
         if (mInitialized)
             return;
 
-        KRAEngine engine = KRAEngine.getInstance();
-        KRAEngineConfig engineConfig = engine.getConfig();
+        KRAEngine kraEngine = (KRAEngine) engine;
+        KRAEngineConfig engineConfig = kraEngine.getConfig();
         DBSubsystem dbSubsystem = engine.getDBSubsystem();
 
         mConfig = engineConfig.getKRAConfig();

--- a/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
+++ b/base/ocsp/src/main/java/com/netscape/ocsp/OCSPAuthority.java
@@ -142,8 +142,8 @@ public class OCSPAuthority extends Subsystem implements IAuthority, IOCSPService
     @Override
     public void init(ConfigStore config) throws Exception {
 
-        OCSPEngine engine = OCSPEngine.getInstance();
-        OCSPEngineConfig engineConfig = engine.getConfig();
+        OCSPEngine ocspEngine = (OCSPEngine) engine;
+        OCSPEngineConfig engineConfig = ocspEngine.getConfig();
         DBSubsystem dbSubsystem = engine.getDBSubsystem();
 
         try {

--- a/base/server/src/main/java/com/netscape/certsrv/base/Subsystem.java
+++ b/base/server/src/main/java/com/netscape/certsrv/base/Subsystem.java
@@ -17,6 +17,7 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.base;
 
+import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStore;
 
 /**
@@ -26,8 +27,17 @@ import com.netscape.cmscore.base.ConfigStore;
  */
 public abstract class Subsystem {
 
+    protected CMSEngine engine;
     protected ConfigStore config;
     protected String id;
+
+    public CMSEngine getCMSEngine() {
+        return engine;
+    }
+
+    public void setCMSEngine(CMSEngine engine) {
+        this.engine = engine;
+    }
 
     /**
      * Initializes this subsystem with the given configuration store.

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -643,6 +643,7 @@ public class CMSEngine {
 
     public void initLogSubsystem() throws Exception {
         LoggingConfig logConfig = config.getLoggingConfig();
+        logSubsystem.setCMSEngine(this);
         logSubsystem.init(logConfig);
         logSubsystem.startup();
     }
@@ -675,12 +676,14 @@ public class CMSEngine {
 
     public void initOIDLoaderSubsystem() throws Exception {
         ConfigStore oidLoaderConfig = config.getSubStore(OidLoaderSubsystem.ID, ConfigStore.class);
+        oidLoaderSubsystem.setCMSEngine(this);
         oidLoaderSubsystem.init(oidLoaderConfig);
         oidLoaderSubsystem.startup();
     }
 
     public void initX500NameSubsystem() throws Exception {
         ConfigStore x500NameConfig = config.getSubStore(X500NameSubsystem.ID, ConfigStore.class);
+        x500NameSubsystem.setCMSEngine(this);
         x500NameSubsystem.init(x500NameConfig);
         x500NameSubsystem.startup();
     }
@@ -694,18 +697,21 @@ public class CMSEngine {
     public void initAuthSubsystem() throws Exception {
         AuthenticationConfig authConfig = config.getAuthenticationConfig();
         authSubsystem = new AuthSubsystem();
+        authSubsystem.setCMSEngine(this);
         authSubsystem.init(authConfig);
         authSubsystem.startup();
     }
 
     public void initAuthzSubsystem() throws Exception {
         ConfigStore authzConfig = config.getSubStore(AuthzSubsystem.ID, ConfigStore.class);
+        authzSubsystem.setCMSEngine(this);
         authzSubsystem.init(authzConfig);
         authzSubsystem.startup();
     }
 
     public void initJobsScheduler() throws Exception {
         JobsSchedulerConfig jobsSchedulerConfig = config.getJobsSchedulerConfig();
+        jobsScheduler.setCMSEngine(this);
         jobsScheduler.init(jobsSchedulerConfig);
         jobsScheduler.startup();
     }
@@ -894,6 +900,7 @@ public class CMSEngine {
             if (isPreOpMode()) return;
         }
 
+        subsystem.setCMSEngine(this);
         subsystem.init(subsystemConfig);
     }
 

--- a/base/server/src/main/java/com/netscape/cmscore/authentication/AuthSubsystem.java
+++ b/base/server/src/main/java/com/netscape/cmscore/authentication/AuthSubsystem.java
@@ -38,7 +38,6 @@ import com.netscape.certsrv.authentication.EMissingCredential;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.Subsystem;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStore;
 
@@ -228,7 +227,6 @@ public class AuthSubsystem extends Subsystem {
     @Override
     public void init(ConfigStore config) throws Exception {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig engineConfig = engine.getConfig();
 
         try {

--- a/base/server/src/main/java/com/netscape/cmscore/authorization/AuthzSubsystem.java
+++ b/base/server/src/main/java/com/netscape/cmscore/authorization/AuthzSubsystem.java
@@ -40,7 +40,6 @@ import com.netscape.certsrv.authorization.EAuthzUnknownRealm;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.Subsystem;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStore;
 
@@ -89,7 +88,6 @@ public class AuthzSubsystem extends Subsystem {
     @Override
     public void init(ConfigStore config) throws Exception {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig engineConfig = engine.getConfig();
 
         try {

--- a/base/server/src/main/java/com/netscape/cmscore/selftests/SelfTestSubsystem.java
+++ b/base/server/src/main/java/com/netscape/cmscore/selftests/SelfTestSubsystem.java
@@ -48,7 +48,6 @@ import com.netscape.cms.logging.Logger;
 import com.netscape.cms.logging.SignedAuditLogger;
 import com.netscape.cms.selftests.SelfTest;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStore;
 
 //////////////////////
@@ -528,7 +527,6 @@ public class SelfTestSubsystem extends Subsystem {
 
                     logger.error("SelfTestSubsystem: Disabling subsystem due to selftest failure: " + e.getMessage(), e);
 
-                    CMSEngine engine = CMS.getCMSEngine();
                     engine.disableSubsystem();
 
                     throw new ESelfTestException("Selftest failed: " + e.getMessage(), e);
@@ -1717,7 +1715,6 @@ public class SelfTestSubsystem extends Subsystem {
             instance.startupSelfTest();
         }
 
-        CMSEngine engine = CMS.getCMSEngine();
         if (engine.isPreOpMode()) {
             logger.debug("SelfTestSubsystem.startup(): Do not run selftests in pre-op mode");
             return;

--- a/base/tks/src/main/java/com/netscape/tks/TKSAuthority.java
+++ b/base/tks/src/main/java/com/netscape/tks/TKSAuthority.java
@@ -70,8 +70,8 @@ public class TKSAuthority extends Subsystem implements IAuthority {
     @Override
     public void init(ConfigStore config) throws Exception {
 
-        TKSEngine engine = TKSEngine.getInstance();
-        TKSEngineConfig engineConfig = engine.getConfig();
+        TKSEngine tksEngine = (TKSEngine) engine;
+        TKSEngineConfig engineConfig = tksEngine.getConfig();
 
         mConfig = engineConfig.getTKSConfig();
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSSubsystem.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSSubsystem.java
@@ -101,8 +101,8 @@ public class TPSSubsystem extends Subsystem implements IAuthority {
 
         logger.info("Initializing TPS subsystem");
 
-        org.dogtagpki.server.tps.TPSEngine engine = org.dogtagpki.server.tps.TPSEngine.getInstance();
-        TPSEngineConfig cs = engine.getConfig();
+        org.dogtagpki.server.tps.TPSEngine tpsEngine = (org.dogtagpki.server.tps.TPSEngine) engine;
+        TPSEngineConfig cs = tpsEngine.getConfig();
 
         this.config = cs.getTPSConfig();
 


### PR DESCRIPTION
The `Subsystem.engine` field has been added to store the `CMSEngine` instance such that the subsystem no longer needs to use a static method such as `CMS.getCMSEngine()` or `<engine>.getInstance()` to get the instance.