### PR TITLE
Add AuthManager.engine

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/authentication/CAAuthSubsystem.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/CAAuthSubsystem.java
@@ -78,12 +78,14 @@ public class CAAuthSubsystem extends AuthSubsystem {
         logger.info("CAAuthSubsystem: Loading auth manager instance " + CHALLENGE_AUTHMGR_ID);
 
         ChallengePhraseAuthentication challengeAuth = new ChallengePhraseAuthentication();
+        challengeAuth.setCMSEngine(engine);
         challengeAuth.init(mConfig, CHALLENGE_AUTHMGR_ID, CHALLENGE_PLUGIN_ID, null);
         mAuthMgrInsts.put(CHALLENGE_AUTHMGR_ID, new AuthManagerProxy(true, challengeAuth));
 
         logger.info("CAAuthSubsystem: Loading auth manager instance " + SSLCLIENTCERT_AUTHMGR_ID);
 
         SSLClientCertAuthentication sslClientCertAuth = new SSLClientCertAuthentication();
+        sslClientCertAuth.setCMSEngine(engine);
         sslClientCertAuth.init(mConfig, SSLCLIENTCERT_AUTHMGR_ID, SSLCLIENTCERT_PLUGIN_ID, null);
         mAuthMgrInsts.put(SSLCLIENTCERT_AUTHMGR_ID, new AuthManagerProxy(true, sslClientCertAuth));
     }

--- a/base/ca/src/main/java/com/netscape/cms/authentication/CMCAuth.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/CMCAuth.java
@@ -204,8 +204,8 @@ public class CMCAuth extends AuthManager implements IExtendedPluginInfo {
         mImplName = implName;
         mConfig = config;
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         mBypassClientAuth = cs.getBoolean("cmc.bypassClientAuth", false);
     }
@@ -241,8 +241,8 @@ public class CMCAuth extends AuthManager implements IExtendedPluginInfo {
         String auditCertSubject = ILogger.UNIDENTIFIED;
         String auditSignerInfo = ILogger.UNIDENTIFIED;
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         SessionContext auditContext = SessionContext.getExistingContext();
         X509Certificate clientCert =
@@ -715,8 +715,8 @@ public class CMCAuth extends AuthManager implements IExtendedPluginInfo {
             AuthToken authToken,
             SignedData cmcFullReq) throws EBaseException {
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         String method = "CMCAuth: verifySignerInfo: ";
         String msg = "";

--- a/base/ca/src/main/java/com/netscape/cms/authentication/CMCUserSignedAuth.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/CMCUserSignedAuth.java
@@ -250,8 +250,8 @@ public class CMCUserSignedAuth extends AuthManager implements IExtendedPluginInf
         String msg = "";
         logger.debug(method + "begins");
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         String auditSubjectID = getAuditSubjectID();
         String auditReqType = ILogger.UNIDENTIFIED;
@@ -489,7 +489,7 @@ public class CMCUserSignedAuth extends AuthManager implements IExtendedPluginInf
                                     // have a chance to capture user identification info
                                     if (issuerANY != null) {
                                         // get CA signing cert
-                                        CertificateAuthority ca = engine.getCA();
+                                        CertificateAuthority ca = caEngine.getCA();
                                         X500Name caName = ca.getX500Name();
 
                                         try {
@@ -910,8 +910,8 @@ public class CMCUserSignedAuth extends AuthManager implements IExtendedPluginInf
         String msg = "";
         logger.debug(method + "begins");
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         EncapsulatedContentInfo ci = cmcFullReq.getContentInfo();
         OBJECT_IDENTIFIER id = ci.getContentType();

--- a/base/ca/src/main/java/com/netscape/cms/authentication/ChallengePhraseAuthentication.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/ChallengePhraseAuthentication.java
@@ -149,8 +149,8 @@ public class ChallengePhraseAuthentication extends AuthManager {
     public AuthToken authenticate(AuthCredentials authCred)
             throws EMissingCredential, EInvalidCredentials, EBaseException {
 
-        CAEngine engine = CAEngine.getInstance();
-        mCertDB = engine.getCertificateRepository();
+        CAEngine caEngine = (CAEngine) engine;
+        mCertDB = caEngine.getCertificateRepository();
 
         AuthToken authToken = new AuthToken(this);
 

--- a/base/ca/src/main/java/com/netscape/cms/authentication/SSLClientCertAuthentication.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/SSLClientCertAuthentication.java
@@ -105,8 +105,8 @@ public class SSLClientCertAuthentication extends AuthManager {
         }
         logger.debug("SSLCertAuth: Got client certificate");
 
-        CAEngine engine = CAEngine.getInstance();
-        mCertDB = engine.getCertificateRepository();
+        CAEngine caEngine = (CAEngine) engine;
+        mCertDB = caEngine.getCertificateRepository();
 
         X509CertImpl clientCert = (X509CertImpl) x509Certs[0];
 
@@ -135,7 +135,7 @@ public class SSLClientCertAuthentication extends AuthManager {
 
             if (status.equals("VALID")) {
 
-                CertificateAuthority ca = engine.getCA();
+                CertificateAuthority ca = caEngine.getCA();
                 X509CertImpl cacert = ca.getCACert();
                 Principal p = cacert.getSubjectName();
 

--- a/base/ca/src/main/java/com/netscape/cms/authentication/SharedSecret.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/SharedSecret.java
@@ -169,8 +169,8 @@ public class SharedSecret extends DirBasedAuthentication
         logger.debug(method + " begins.");
         super.init(authenticationConfig, name, implName, config);
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         //TODO later:
         //mRemoveShrTok =
@@ -195,7 +195,7 @@ public class SharedSecret extends DirBasedAuthentication
 
         initLdapConn(config);
 
-        issuanceProtPrivKey = engine.getIssuanceProtectionPrivateKey();
+        issuanceProtPrivKey = caEngine.getIssuanceProtectionPrivateKey();
         if (issuanceProtPrivKey != null)
             logger.debug(method + "got issuanceProtPrivKey");
         else {
@@ -203,7 +203,7 @@ public class SharedSecret extends DirBasedAuthentication
             logger.error(msg);
             throw new EBaseException(msg);
         }
-        certRepository = engine.getCertificateRepository();
+        certRepository = caEngine.getCertificateRepository();
         if (certRepository == null) {
             msg = method + "certRepository null";
             logger.error(msg);
@@ -240,8 +240,8 @@ public class SharedSecret extends DirBasedAuthentication
         String method = "SharedSecret.initLdapConn";
         String msg = "";
 
-        CAEngine engine = CAEngine.getInstance();
-        CAEngineConfig cs = engine.getConfig();
+        CAEngine caEngine = (CAEngine) engine;
+        CAEngineConfig cs = caEngine.getConfig();
 
         shrTokLdapConfigStore = config.getLDAPConfig();
         if (shrTokLdapConfigStore == null) {

--- a/base/server/src/main/java/com/netscape/cms/authentication/AgentCertAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/AgentCertAuthentication.java
@@ -41,7 +41,6 @@ import com.netscape.certsrv.usrgrp.CertUserLocator;
 import com.netscape.certsrv.usrgrp.Certificates;
 import com.netscape.certsrv.usrgrp.EUsrGrpException;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.request.Request;
@@ -120,7 +119,6 @@ public class AgentCertAuthentication extends AuthManager {
         logger.debug("AgentCertAuthentication: start");
         logger.debug("authenticator instance name is " + getName());
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig sconfig = engine.getConfig();
         AuthenticationConfig authsConfig = sconfig.getAuthenticationConfig();
         AuthManagersConfig instancesConfig = authsConfig.getAuthManagersConfig();

--- a/base/server/src/main/java/com/netscape/cms/authentication/DirBasedAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/DirBasedAuthentication.java
@@ -50,7 +50,6 @@ import com.netscape.certsrv.ldap.ILdapConnFactory;
 import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.certsrv.property.IDescriptor;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.ldapconn.LDAPAuthenticationConfig;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
@@ -268,7 +267,6 @@ public abstract class DirBasedAuthentication extends AuthManager implements IExt
         mConfig = config;
         String method = "DirBasedAuthentication: init: ";
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
 
         /* initialize ldap server configuration */
@@ -438,7 +436,6 @@ public abstract class DirBasedAuthentication extends AuthManager implements IExt
 
         logger.debug(method + " begins...mBoundConnEnable=" + mBoundConnEnable);
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
 
         PKISocketConfig socketConfig = cs.getSocketConfig();

--- a/base/server/src/main/java/com/netscape/cms/authentication/PortalEnroll.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/PortalEnroll.java
@@ -36,7 +36,6 @@ import com.netscape.certsrv.base.IExtendedPluginInfo;
 import com.netscape.certsrv.ldap.ELdapException;
 import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ArgBlock;
 import com.netscape.cmscore.base.ConfigStore;
@@ -144,7 +143,6 @@ public class PortalEnroll extends DirBasedAuthentication {
             throws EBaseException {
         super.init(authenticationConfig, name, implName, config);
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
 
         /* Get Bind DN for directory server */

--- a/base/server/src/main/java/com/netscape/cms/authentication/SSLclientCertAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/SSLclientCertAuthentication.java
@@ -41,7 +41,6 @@ import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.certsrv.property.IDescriptor;
 import com.netscape.certsrv.usrgrp.Certificates;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.request.Request;
 
@@ -195,7 +194,6 @@ public class SSLclientCertAuthentication extends AuthManager {
             // do nothing; default to true
         }
         if (checkRevocation) {
-            CMSEngine engine = CMS.getCMSEngine();
             if (engine.isRevoked(ci)) {
                 logger.error("SSLclientCertAuthentication: certificate revoked");
                 throw new EInvalidCredentials(CMS.getUserMessage("CMS_AUTHENTICATION_INVALID_CREDENTIAL"));

--- a/base/server/src/main/java/com/netscape/cms/authentication/TokenAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/TokenAuthentication.java
@@ -40,7 +40,6 @@ import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.certsrv.property.IDescriptor;
 import com.netscape.cms.servlet.csadmin.Configurator;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.request.Request;
@@ -109,8 +108,6 @@ public class TokenAuthentication extends AuthManager {
             throws EMissingCredential, EInvalidCredentials, EBaseException {
 
         logger.debug("TokenAuthentication: start");
-
-        CMSEngine engine = CMS.getCMSEngine();
 
         // force SSL handshake
         SessionContext context = SessionContext.getExistingContext();

--- a/base/server/src/main/java/com/netscape/cms/authentication/UidPwdPinDirAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/UidPwdPinDirAuthentication.java
@@ -40,7 +40,6 @@ import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.certsrv.property.Descriptor;
 import com.netscape.certsrv.property.IDescriptor;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
@@ -158,7 +157,6 @@ public class UidPwdPinDirAuthentication extends DirBasedAuthentication {
             throws EBaseException {
         super.init(authenticationConfig, name, implName, config);
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
 
         mRemovePin =

--- a/base/server/src/main/java/com/netscape/cms/authentication/UserPwdDirAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cms/authentication/UserPwdDirAuthentication.java
@@ -43,7 +43,6 @@ import com.netscape.certsrv.property.IDescriptor;
 // cert server x509 imports
 // java sdk imports.
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 // cert server imports.
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.request.Request;
@@ -143,7 +142,6 @@ public class UserPwdDirAuthentication extends DirBasedAuthentication {
         super.init(authenticationConfig, name, implName, config);
 
         logger.debug("UserPwdDirAuthentication init");
-        CMSEngine engine = CMS.getCMSEngine();
         mAttrName = mLdapConfig.getString("attrName", null);
         if (mAttrName == null || mAttrName.trim().length() == 0) {
             throw new EPropertyNotFound(CMS.getUserMessage("CMS_BASE_GET_PROPERTY_FAILED", "attrName"));

--- a/base/server/src/main/java/com/netscape/cms/servlet/admin/AuthAdminServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/admin/AuthAdminServlet.java
@@ -776,6 +776,8 @@ public class AuthAdminServlet extends AdminServlet {
 
             // initialize the authentication manager
             try {
+                CMSEngine engine = getCMSEngine();
+                authMgrInst.setCMSEngine(engine);
                 authMgrInst.init(destStore, id, implname, substore);
             } catch (EBaseException e) {
                 // store a message in the signed audit log file
@@ -1523,6 +1525,8 @@ public class AuthAdminServlet extends AdminServlet {
             // initialize the authentication manager
 
             try {
+                CMSEngine engine = getCMSEngine();
+                newMgrInst.setCMSEngine(engine);
                 newMgrInst.init(destStore, id, implname, substore);
             } catch (EBaseException e) {
                 // store a message in the signed audit log file

--- a/base/server/src/main/java/com/netscape/cms/servlet/cert/RemoteAuthConfig.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/cert/RemoteAuthConfig.java
@@ -509,6 +509,8 @@ public class RemoteAuthConfig extends CMSServlet {
 
         if (authMgrInst != null) {
             try {
+                CMSEngine engine = getCMSEngine();
+                authMgrInst.setCMSEngine(engine);
                 authMgrInst.init(mAuthConfig, instance, plugin, c1);
             } catch (EBaseException e) {
                 c0.removeSubStore(instance);

--- a/base/server/src/main/java/com/netscape/cmscore/authentication/AuthSubsystem.java
+++ b/base/server/src/main/java/com/netscape/cmscore/authentication/AuthSubsystem.java
@@ -145,12 +145,14 @@ public class AuthSubsystem extends Subsystem {
         logger.info("AuthSubsystem: Loading auth manager instance " + PASSWDUSERDB_AUTHMGR_ID);
 
         PasswdUserDBAuthentication passwdUserDBAuth = new PasswdUserDBAuthentication();
+        passwdUserDBAuth.setCMSEngine(engine);
         passwdUserDBAuth.init(mConfig, PASSWDUSERDB_AUTHMGR_ID, PASSWDUSERDB_PLUGIN_ID, null);
         mAuthMgrInsts.put(PASSWDUSERDB_AUTHMGR_ID, new AuthManagerProxy(true, passwdUserDBAuth));
 
         logger.info("AuthSubsystem: Loading auth manager instance " + CERTUSERDB_AUTHMGR_ID);
 
         CertUserDBAuthentication certUserDBAuth = new CertUserDBAuthentication();
+        certUserDBAuth.setCMSEngine(engine);
         certUserDBAuth.init(mConfig, CERTUSERDB_AUTHMGR_ID, CERTUSERDB_PLUGIN_ID, null);
         mAuthMgrInsts.put(CERTUSERDB_AUTHMGR_ID, new AuthManagerProxy(true, certUserDBAuth));
 
@@ -184,6 +186,7 @@ public class AuthSubsystem extends Subsystem {
 
             try {
                 authMgrInst = (AuthManager) Class.forName(className).getDeclaredConstructor().newInstance();
+                authMgrInst.setCMSEngine(engine);
                 authMgrInst.init(mConfig, instName, implName, authMgrConfig);
                 enabled = true;
 

--- a/base/server/src/main/java/com/netscape/cmscore/authentication/CertUserDBAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cmscore/authentication/CertUserDBAuthentication.java
@@ -37,7 +37,6 @@ import com.netscape.certsrv.usrgrp.CertUserLocator;
 import com.netscape.certsrv.usrgrp.Certificates;
 import com.netscape.certsrv.usrgrp.EUsrGrpException;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.request.Request;
 import com.netscape.cmscore.usrgrp.ExactMatchCertUserLocator;
@@ -95,7 +94,6 @@ public class CertUserDBAuthentication extends AuthManager {
         this.authenticationConfig = authenticationConfig;
         mName = name;
         mImplName = implName;
-        CMSEngine engine = CMS.getCMSEngine();
         mConfig = config;
 
         if (authenticationConfig != null) {
@@ -180,7 +178,7 @@ public class CertUserDBAuthentication extends AuthManager {
                 logger.error("CertUserDBAuthentication: " + CMS.getLogMessage("CMSCORE_AUTH_NO_CERT"));
                 throw new EInvalidCredentials(CMS.getUserMessage("CMS_AUTHENTICATION_NO_CERT"));
             }
-            CMSEngine engine = CMS.getCMSEngine();
+
             if (engine.isRevoked(x509Certs)) {
                 logger.error("CertUserDBAuthentication: " + CMS.getLogMessage("CMSCORE_AUTH_REVOKED_CERT"));
                 throw new EInvalidCredentials(CMS.getUserMessage("CMS_AUTHENTICATION_INVALID_CREDENTIAL"));

--- a/base/server/src/main/java/com/netscape/cmscore/authentication/PasswdUserDBAuthentication.java
+++ b/base/server/src/main/java/com/netscape/cmscore/authentication/PasswdUserDBAuthentication.java
@@ -34,7 +34,6 @@ import com.netscape.certsrv.ldap.ELdapException;
 import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.certsrv.property.IDescriptor;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.dbs.DBSubsystem;
@@ -90,7 +89,6 @@ public class PasswdUserDBAuthentication extends AuthManager implements IPasswdUs
         mImplName = implName;
         mConfig = config;
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
 
         PKISocketConfig socketConfig = cs.getSocketConfig();
@@ -149,7 +147,6 @@ public class PasswdUserDBAuthentication extends AuthManager implements IPasswdUs
             throw new EInvalidCredentials(CMS.getUserMessage("CMS_AUTHENTICATION_INVALID_CREDENTIAL"));
         }
 
-        CMSEngine engine = CMS.getCMSEngine();
         UGSubsystem ug = engine.getUGSubsystem();
         User user;
 

--- a/base/server/src/main/java/org/dogtagpki/server/authentication/AuthManager.java
+++ b/base/server/src/main/java/org/dogtagpki/server/authentication/AuthManager.java
@@ -26,6 +26,7 @@ import com.netscape.certsrv.authentication.EMissingCredential;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.profile.EProfileException;
 import com.netscape.certsrv.property.IDescriptor;
+import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStore;
 import com.netscape.cmscore.request.Request;
 
@@ -55,11 +56,20 @@ public abstract class AuthManager {
     public static final String CRED_SESSION_ID = "sessionID";
     public static final String CRED_HOST_NAME = "hostname";
 
+    protected CMSEngine engine;
     protected AuthenticationConfig authenticationConfig;
     protected String mName;
     protected String mImplName;
     protected AuthManagerConfig mConfig;
     protected String[] mConfigParams;
+
+    public CMSEngine getCMSEngine() {
+        return engine;
+    }
+
+    public void setCMSEngine(CMSEngine engine) {
+        this.engine = engine;
+    }
 
     public AuthenticationConfig getAuthenticationConfig() {
         return authenticationConfig;


### PR DESCRIPTION
The `AuthManager.engine` field has been added to store the `CMSEngine` instance such that the auth manager no longer needs to use a static method such as `CMS.getCMSEngine()` or `<engine>.getInstance()` to get the instance.