### PR TITLE
Remove serialVersionUID from classes that don't implement Serializable

### DIFF
--- a/base/server/src/main/java/com/netscape/certsrv/logging/AuditEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/AuditEvent.java
@@ -140,8 +140,6 @@ public class AuditEvent extends LogEvent {
     public final static String AUDIT_LOG_SIGNING =
             "LOGGING_SIGNED_AUDIT_AUDIT_LOG_SIGNING_3";
 
-    private static final long serialVersionUID = -844306657733902324L;
-
     public AuditEvent() {
     }
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/LogEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/LogEvent.java
@@ -31,8 +31,6 @@ import com.netscape.certsrv.base.EBaseException;
  */
 public class LogEvent {
 
-    private static final long serialVersionUID = 1L;
-
     Object mParams[];
 
     String mEventType;

--- a/base/server/src/main/java/com/netscape/certsrv/logging/SignedAuditEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/SignedAuditEvent.java
@@ -34,8 +34,6 @@ import com.netscape.certsrv.common.Constants;
  */
 public class SignedAuditEvent extends LogEvent {
 
-    private static final long serialVersionUID = 4287822756516673931L;
-
     public final static String RULENAME = "RULENAME";
     public final static String PASSWORD_MASK = "********";
     public final static String NAME_VALUE_DELIMITER = ";;";

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/AccessSessionEstablishEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/AccessSessionEstablishEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class AccessSessionEstablishEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String ACCESS_SESSION_ESTABLISH_SUCCESS =
             "LOGGING_SIGNED_AUDIT_ACCESS_SESSION_ESTABLISH_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/AccessSessionTerminatedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/AccessSessionTerminatedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class AccessSessionTerminatedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String ACCESS_SESSION_TERMINATED =
             "LOGGING_SIGNED_AUDIT_ACCESS_SESSION_TERMINATED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/AsymKeyGenerationEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/AsymKeyGenerationEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class AsymKeyGenerationEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_ASYMKEY_GENERATION_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/AsymKeyGenerationProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/AsymKeyGenerationProcessedEvent.java
@@ -23,8 +23,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class AsymKeyGenerationProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_ASYMKEY_GEN_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/AuthEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/AuthEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class AuthEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String AUTH_SUCCESS =
             "LOGGING_SIGNED_AUDIT_AUTH_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/AuthzEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/AuthzEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class AuthzEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String AUTHZ_SUCCESS =
             "LOGGING_SIGNED_AUDIT_AUTHZ_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/CMCSignedRequestSigVerifyEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/CMCSignedRequestSigVerifyEvent.java
@@ -21,8 +21,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class CMCSignedRequestSigVerifyEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_CMC_SIGNED_REQUEST_SIG_VERIFY";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/CMCUserSignedRequestSigVerifyEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/CMCUserSignedRequestSigVerifyEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class CMCUserSignedRequestSigVerifyEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String CMC_USER_SIGNED_REQUEST_SIG_VERIFY_SUCCESS =
             "LOGGING_SIGNED_AUDIT_CMC_USER_SIGNED_REQUEST_SIG_VERIFY_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/CRLSigningInfoEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/CRLSigningInfoEvent.java
@@ -23,8 +23,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class CRLSigningInfoEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String CRL_SIGNING_INFO =
             "LOGGING_SIGNED_AUDIT_CRL_SIGNING_INFO";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/CertRequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/CertRequestProcessedEvent.java
@@ -28,8 +28,6 @@ import com.netscape.cmscore.request.Request;
 
 public class CertRequestProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_CERT_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/CertSigningInfoEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/CertSigningInfoEvent.java
@@ -25,8 +25,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class CertSigningInfoEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String CERT_SIGNING_INFO =
             "LOGGING_SIGNED_AUDIT_CERT_SIGNING_INFO";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/CertStatusChangeRequestEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/CertStatusChangeRequestEvent.java
@@ -22,8 +22,6 @@ import com.netscape.cmscore.request.Request;
 
 public class CertStatusChangeRequestEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String CERT_STATUS_CHANGE_REQUEST =
             "LOGGING_SIGNED_AUDIT_CERT_STATUS_CHANGE_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/CertStatusChangeRequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/CertStatusChangeRequestProcessedEvent.java
@@ -23,8 +23,6 @@ import com.netscape.cmscore.request.Request;
 
 public class CertStatusChangeRequestProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_CERT_STATUS_CHANGE_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ClientAccessSessionEstablishEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ClientAccessSessionEstablishEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class ClientAccessSessionEstablishEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String CLIENT_ACCESS_SESSION_ESTABLISH_SUCCESS =
             "LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_ESTABLISH_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ClientAccessSessionTerminatedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ClientAccessSessionTerminatedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class ClientAccessSessionTerminatedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String CLIENT_ACCESS_SESSION_TERMINATED =
             "LOGGING_SIGNED_AUDIT_CLIENT_ACCESS_SESSION_TERMINATED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ComputeRandomDataRequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ComputeRandomDataRequestProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class ComputeRandomDataRequestProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String SUCCESS =
             "LOGGING_SIGNED_AUDIT_COMPUTE_RANDOM_DATA_REQUEST_PROCESSED_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ComputeSessionKeyRequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ComputeSessionKeyRequestProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class ComputeSessionKeyRequestProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String SUCCESS =
             "LOGGING_SIGNED_AUDIT_COMPUTE_SESSION_KEY_REQUEST_PROCESSED_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ConfigRoleEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ConfigRoleEvent.java
@@ -17,12 +17,11 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.logging.event;
 
-import com.netscape.certsrv.logging.SignedAuditEvent;
 import org.mozilla.jss.netscape.security.util.Utils;
 
-public class ConfigRoleEvent extends SignedAuditEvent {
+import com.netscape.certsrv.logging.SignedAuditEvent;
 
-    private static final long serialVersionUID = 1L;
+public class ConfigRoleEvent extends SignedAuditEvent {
 
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_CONFIG_ROLE";

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ConfigSignedAuditEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ConfigSignedAuditEvent.java
@@ -21,8 +21,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class ConfigSignedAuditEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_CONFIG_SIGNED_AUDIT";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ConfigTrustedPublicKeyEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ConfigTrustedPublicKeyEvent.java
@@ -21,8 +21,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class ConfigTrustedPublicKeyEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_CONFIG_TRUSTED_PUBLIC_KEY";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/DeltaCRLGenerationEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/DeltaCRLGenerationEvent.java
@@ -24,8 +24,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class DeltaCRLGenerationEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_DELTA_CRL_GENERATION";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/DeltaCRLPublishingEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/DeltaCRLPublishingEvent.java
@@ -24,8 +24,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class DeltaCRLPublishingEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_DELTA_CRL_PUBLISHING";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/DiversifyKeyRequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/DiversifyKeyRequestProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class DiversifyKeyRequestProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String SUCCESS =
             "LOGGING_SIGNED_AUDIT_DIVERSIFY_KEY_REQUEST_PROCESSED_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/EncryptDataRequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/EncryptDataRequestProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class EncryptDataRequestProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String SUCCESS =
             "LOGGING_SIGNED_AUDIT_ENCRYPT_DATA_REQUEST_PROCESSED_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/FullCRLGenerationEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/FullCRLGenerationEvent.java
@@ -24,8 +24,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class FullCRLGenerationEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_FULL_CRL_GENERATION";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/FullCRLPublishingEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/FullCRLPublishingEvent.java
@@ -24,8 +24,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class FullCRLPublishingEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_FULL_CRL_PUBLISHING";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPAddCARequestEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPAddCARequestEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class OCSPAddCARequestEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String OCSP_ADD_CA_REQUEST =
             "LOGGING_SIGNED_AUDIT_OCSP_ADD_CA_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPAddCARequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPAddCARequestProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class OCSPAddCARequestProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String OCSP_ADD_CA_REQUEST_PROCESSED =
             "LOGGING_SIGNED_AUDIT_OCSP_ADD_CA_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPGenerationEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPGenerationEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class OCSPGenerationEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_OCSP_GENERATION";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPRemoveCARequestEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPRemoveCARequestEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class OCSPRemoveCARequestEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String OCSP_REMOVE_CA_REQUEST =
             "LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPRemoveCARequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPRemoveCARequestProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class OCSPRemoveCARequestProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String OCSP_REMOVE_CA_REQUEST_PROCESSED_SUCCESS =
             "LOGGING_SIGNED_AUDIT_OCSP_REMOVE_CA_REQUEST_PROCESSED_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPSigningInfoEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/OCSPSigningInfoEvent.java
@@ -23,8 +23,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class OCSPSigningInfoEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String OCSP_SIGNING_INFO =
             "LOGGING_SIGNED_AUDIT_OCSP_SIGNING_INFO";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/RandomGenerationEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/RandomGenerationEvent.java
@@ -24,8 +24,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class RandomGenerationEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private final static String RANDOM_GENERATION =
             "LOGGING_SIGNED_AUDIT_RANDOM_GENERATION";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/RoleAssumeEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/RoleAssumeEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class RoleAssumeEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_ROLE_ASSUME";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ScheduleCRLGenerationEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ScheduleCRLGenerationEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class ScheduleCRLGenerationEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SCHEDULE_CRL_GENERATION";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataArchivalProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataArchivalProcessedEvent.java
@@ -24,8 +24,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class SecurityDataArchivalProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SECURITY_DATA_ARCHIVAL_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataArchivalRequestEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataArchivalRequestEvent.java
@@ -23,8 +23,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class SecurityDataArchivalRequestEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SECURITY_DATA_ARCHIVAL_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataExportEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataExportEvent.java
@@ -23,8 +23,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class SecurityDataExportEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SECURITY_DATA_EXPORT_KEY";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataInfoEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataInfoEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class SecurityDataInfoEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SECURITY_DATA_INFO";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataRecoveryEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataRecoveryEvent.java
@@ -23,8 +23,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class SecurityDataRecoveryEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataRecoveryProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataRecoveryProcessedEvent.java
@@ -23,8 +23,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class SecurityDataRecoveryProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataRecoveryStateChangeEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataRecoveryStateChangeEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class SecurityDataRecoveryStateChangeEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SECURITY_DATA_RECOVERY_REQUEST_STATE_CHANGE";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataStatusChangeEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SecurityDataStatusChangeEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class SecurityDataStatusChangeEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_KEY_STATUS_CHANGE";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeyGenEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeyGenEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class ServerSideKeyGenEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeyGenProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeyGenProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class ServerSideKeyGenProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeygenEnrollKeyRetrievalEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeygenEnrollKeyRetrievalEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class ServerSideKeygenEnrollKeyRetrievalEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_ENROLL_KEY_RETRIEVAL_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeygenEnrollKeyRetrievalProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeygenEnrollKeyRetrievalProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class ServerSideKeygenEnrollKeyRetrievalProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_ENROLL_KEY_RETRIEVAL_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeygenEnrollKeygenEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeygenEnrollKeygenEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class ServerSideKeygenEnrollKeygenEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_ENROLL_KEYGEN_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeygenEnrollKeygenProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ServerSideKeygenEnrollKeygenProcessedEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class ServerSideKeygenEnrollKeygenProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SERVER_SIDE_KEYGEN_ENROLL_KEYGEN_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SymKeyGenerationEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SymKeyGenerationEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class SymKeyGenerationEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SYMKEY_GENERATION_REQUEST";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/SymKeyGenerationProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/SymKeyGenerationProcessedEvent.java
@@ -23,8 +23,6 @@ import com.netscape.certsrv.request.RequestId;
 
 public class SymKeyGenerationProcessedEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     private static final String LOGGING_PROPERTY =
             "LOGGING_SIGNED_AUDIT_SYMKEY_GEN_REQUEST_PROCESSED";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenAppletUpgradeEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenAppletUpgradeEvent.java
@@ -21,8 +21,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class TokenAppletUpgradeEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String TOKEN_APPLET_UPGRADE_SUCCESS =
             "LOGGING_SIGNED_AUDIT_TOKEN_APPLET_UPGRADE_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenAuthEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenAuthEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class TokenAuthEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String SUCCESS =
             "LOGGING_SIGNED_AUDIT_TOKEN_AUTH_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenFormatEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenFormatEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class TokenFormatEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String SUCCESS =
             "LOGGING_SIGNED_AUDIT_TOKEN_FORMAT_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenKeyChangeoverEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenKeyChangeoverEvent.java
@@ -21,8 +21,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class TokenKeyChangeoverEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String TOKEN_KEY_CHANGEOVER_SUCCESS =
             "LOGGING_SIGNED_AUDIT_TOKEN_KEY_CHANGEOVER_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenPinResetEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/TokenPinResetEvent.java
@@ -22,8 +22,6 @@ import com.netscape.certsrv.logging.SignedAuditEvent;
 
 public class TokenPinResetEvent extends SignedAuditEvent {
 
-    private static final long serialVersionUID = 1L;
-
     public final static String SUCCESS =
             "LOGGING_SIGNED_AUDIT_TOKEN_PIN_RESET_SUCCESS";
 

--- a/base/server/src/main/java/com/netscape/cmscore/base/ArgBlock.java
+++ b/base/server/src/main/java/com/netscape/cmscore/base/ArgBlock.java
@@ -49,7 +49,6 @@ import com.netscape.cmscore.apps.CMS;
 public class ArgBlock {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ArgBlock.class);
-    private static final long serialVersionUID = -6054531129316353282L;
     /*==========================================================
      * variables
      *==========================================================*/

--- a/base/server/src/test/java/com/netscape/cmscore/request/RequestDefaultStub.java
+++ b/base/server/src/test/java/com/netscape/cmscore/request/RequestDefaultStub.java
@@ -22,7 +22,6 @@ import com.netscape.certsrv.request.RequestStatus;
  * Default testing stub for the Request class.
  */
 public class RequestDefaultStub extends Request {
-    private static final long serialVersionUID = -8466522941927034614L;
 
     public RequestDefaultStub() {
         super(null);

--- a/base/server/src/test/java/com/netscape/cmscore/request/RequestQueueTest.java
+++ b/base/server/src/test/java/com/netscape/cmscore/request/RequestQueueTest.java
@@ -51,7 +51,6 @@ public class RequestQueueTest extends CMSBaseTestCase {
     }
 
     static class RequestStub extends RequestDefaultStub {
-        private static final long serialVersionUID = -9058189963961484835L;
 
         String[] keys = new String[] { "key1", "key2" };
         boolean getExtDataKeysCalled = false;


### PR DESCRIPTION
Most/all of this is from classes inheriting from `LogEvent`. In the past `LogEvent` implemented an interface called `ILogEvent`, which in turn extended `Serializable`. `ILogEvent` no longer exists, so none of these classes are `Serializable`, so the field is not used and unnecessary.