### PR TITLE
Reduce dependency on CMS.getCMSEngine()

### DIFF
--- a/base/server/src/main/java/com/netscape/certsrv/evaluators/AccessEvaluator.java
+++ b/base/server/src/main/java/com/netscape/certsrv/evaluators/AccessEvaluator.java
@@ -19,6 +19,8 @@ package com.netscape.certsrv.evaluators;
 
 import org.dogtagpki.server.authentication.AuthToken;
 
+import com.netscape.cmscore.apps.CMSEngine;
+
 /**
  * A class represents an evaluator. An evaluator is used to
  * evaluate an expression. For example, one can write an evaluator to
@@ -28,8 +30,17 @@ import org.dogtagpki.server.authentication.AuthToken;
  */
 public abstract class AccessEvaluator {
 
+    protected CMSEngine engine;
     protected String type;
     protected String description;
+
+    public CMSEngine getCMSEngine() {
+        return engine;
+    }
+
+    public void setCMSEngine(CMSEngine engine) {
+        this.engine = engine;
+    }
 
     /**
      * Initialize the evaluator

--- a/base/server/src/main/java/com/netscape/cms/authorization/AAclAuthz.java
+++ b/base/server/src/main/java/com/netscape/cms/authorization/AAclAuthz.java
@@ -137,6 +137,7 @@ public abstract class AAclAuthz extends AuthzManager {
             }
 
             if (evaluator != null) {
+                evaluator.setCMSEngine(engine);
                 evaluator.init();
                 // store evaluator
                 registerEvaluator(type, evaluator);

--- a/base/server/src/main/java/com/netscape/cms/authorization/AAclAuthz.java
+++ b/base/server/src/main/java/com/netscape/cms/authorization/AAclAuthz.java
@@ -36,7 +36,6 @@ import com.netscape.certsrv.authorization.EAuthzInternalError;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.evaluators.AccessEvaluator;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStore;
 
@@ -108,7 +107,6 @@ public abstract class AAclAuthz extends AuthzManager {
         logger.debug("AAclAuthz: init begins");
 
         // load access evaluators specified in the config file
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig mainConfig = engine.getConfig();
 
         ConfigStore evalConfig = mainConfig.getSubStore(PROP_EVAL, ConfigStore.class);
@@ -826,9 +824,8 @@ public abstract class AAclAuthz extends AuthzManager {
         throw new EAuthzAccessDenied(CMS.getUserMessage("CMS_AUTHORIZATION_AUTHZ_ACCESS_DENIED", params));
     }
 
-    public static EvaluationOrder getOrder() {
+    public EvaluationOrder getOrder() {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
         AuthorizationConfig authzConfig = cs.getAuthorizationConfig();
 

--- a/base/server/src/main/java/com/netscape/cms/authorization/BasicGroupAuthz.java
+++ b/base/server/src/main/java/com/netscape/cms/authorization/BasicGroupAuthz.java
@@ -33,8 +33,6 @@ import com.netscape.certsrv.authorization.EAuthzInternalError;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.IExtendedPluginInfo;
 import com.netscape.certsrv.evaluators.AccessEvaluator;
-import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.usrgrp.Group;
 import com.netscape.cmscore.usrgrp.UGSubsystem;
 
@@ -81,7 +79,6 @@ public class BasicGroupAuthz extends AuthzManager implements IExtendedPluginInfo
             throw new EAuthzAccessDenied("No userid provided");
         }
 
-        CMSEngine engine = CMS.getCMSEngine();
         UGSubsystem ug = engine.getUGSubsystem();
         Group group = ug.getGroupFromName(groupName);
         if (!group.isMember(user)) {

--- a/base/server/src/main/java/com/netscape/cms/authorization/DirAclAuthz.java
+++ b/base/server/src/main/java/com/netscape/cms/authorization/DirAclAuthz.java
@@ -26,7 +26,6 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.IExtendedPluginInfo;
 import com.netscape.certsrv.ldap.ELdapException;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
 import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
@@ -111,7 +110,6 @@ public class DirAclAuthz extends AAclAuthz
 
         super.init(name, implName, config);
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
 
         searchBase = config.getString(PROP_SEARCHBASE, null);

--- a/base/server/src/main/java/com/netscape/cms/evaluators/GroupAccessEvaluator.java
+++ b/base/server/src/main/java/com/netscape/cms/evaluators/GroupAccessEvaluator.java
@@ -45,9 +45,6 @@ public class GroupAccessEvaluator extends AccessEvaluator {
         this.description = "group membership evaluator";
     }
 
-    /**
-     * initialization. nothing for now.
-     */
     @Override
     public void init() {
         logger.debug("GroupAccessEvaluator: init");
@@ -76,7 +73,6 @@ public class GroupAccessEvaluator extends AccessEvaluator {
     @Override
     public boolean evaluate(AuthToken authToken, String type, String op, String value) {
 
-        CMSEngine engine = CMS.getCMSEngine();
         UGSubsystem ug = engine.getUGSubsystem();
 
         if (type.equals(this.type)) {

--- a/base/server/src/main/java/com/netscape/cms/servlet/admin/ACLAdminServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/admin/ACLAdminServlet.java
@@ -39,6 +39,7 @@ import com.netscape.certsrv.logging.AuditEvent;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.cms.authorization.ACL;
 import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStore;
 
 /**
@@ -649,6 +650,8 @@ public class ACLAdminServlet extends AdminServlet {
 
             // initialize the access evaluator
             if (evaluator != null) {
+                CMSEngine engine = getCMSEngine();
+                evaluator.setCMSEngine(engine);
                 evaluator.init();
                 // add evaluator to list
                 mAuthzMgr.registerEvaluator(type, evaluator);

--- a/base/server/src/main/java/com/netscape/cms/servlet/admin/GroupMemberProcessor.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/admin/GroupMemberProcessor.java
@@ -41,7 +41,6 @@ import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.logging.event.ConfigRoleEvent;
 import com.netscape.cms.servlet.processors.Processor;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.usrgrp.Group;
 import com.netscape.cmscore.usrgrp.UGSubsystem;
@@ -59,8 +58,6 @@ public class GroupMemberProcessor extends Processor {
     public final static String MULTI_ROLE_ENFORCE_GROUP_LIST = "multiroles.false.groupEnforceList";
 
     public static String[] multiRoleGroupEnforceList;
-
-    CMSEngine engine = CMS.getCMSEngine();
 
     protected UriInfo uriInfo;
 
@@ -171,7 +168,6 @@ public class GroupMemberProcessor extends Processor {
     public GroupMemberData addGroupMember(GroupMemberData groupMemberData) {
         String groupID = groupMemberData.getGroupID();
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig config = engine.getConfig();
 
         try {
@@ -251,7 +247,6 @@ public class GroupMemberProcessor extends Processor {
             return true;
         }
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig config = engine.getConfig();
 
         String groupList = null;

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/GetCookie.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/GetCookie.java
@@ -189,6 +189,7 @@ public class GetCookie extends CMSServlet {
 
             try {
                 SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(httpReq));
+                processor.setCMSEngine(engine);
 
                 InstallToken installToken = processor.getInstallToken(uid, addr, subsystem);
                 String cookie = installToken.getToken();

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/SecurityDomainProcessor.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/SecurityDomainProcessor.java
@@ -53,7 +53,6 @@ import com.netscape.certsrv.system.SecurityDomainHost;
 import com.netscape.certsrv.system.SecurityDomainSubsystem;
 import com.netscape.cms.servlet.processors.Processor;
 import com.netscape.cmscore.apps.CMS;
-import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
 import com.netscape.cmscore.ldapconn.LdapBoundConnFactory;
@@ -96,7 +95,6 @@ public class SecurityDomainProcessor extends Processor {
             String subsystem) throws Exception {
 
         subsystem = subsystem.toUpperCase();
-        CMSEngine engine = CMS.getCMSEngine();
         UGSubsystem ugSubsystem = engine.getUGSubsystem();
 
         String group = getEnterpriseGroupName(subsystem);
@@ -161,9 +159,7 @@ public class SecurityDomainProcessor extends Processor {
 
     public DomainInfo getDomainInfo() throws EBaseException {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
-
         PKISocketConfig socketConfig = cs.getSocketConfig();
 
         LdapBoundConnFactory connFactory = null;
@@ -391,7 +387,6 @@ public class SecurityDomainProcessor extends Processor {
             String securePort)
             throws EBaseException {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
@@ -503,9 +498,7 @@ public class SecurityDomainProcessor extends Processor {
             String domainManager,
             String clone) throws EBaseException {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
-
         PKISocketConfig socketConfig = cs.getSocketConfig();
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
@@ -627,9 +620,7 @@ public class SecurityDomainProcessor extends Processor {
         LdapBoundConnFactory connFactory = null;
         LDAPConnection conn = null;
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
-
         PKISocketConfig socketConfig = cs.getSocketConfig();
 
         try {
@@ -673,9 +664,7 @@ public class SecurityDomainProcessor extends Processor {
         LdapBoundConnFactory connFactory = null;
         LDAPConnection conn = null;
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
-
         PKISocketConfig socketConfig = cs.getSocketConfig();
 
         try {

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/UpdateDomainXML.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/UpdateDomainXML.java
@@ -168,6 +168,7 @@ public class UpdateDomainXML extends CMSServlet {
         }
 
         SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(cmsReq.getHttpReq()));
+        processor.setCMSEngine(engine);
 
         String status;
         if ((operation != null) && (operation.equals("remove"))) {

--- a/base/server/src/main/java/com/netscape/cms/servlet/processors/Processor.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/processors/Processor.java
@@ -12,6 +12,7 @@ import com.netscape.certsrv.base.EPropertyNotFound;
 import com.netscape.cms.logging.Logger;
 import com.netscape.cms.logging.SignedAuditLogger;
 import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.logging.Auditor;
 
 public class Processor {
@@ -23,10 +24,19 @@ public class Processor {
 
     protected String id;
     protected Locale locale;
+    protected CMSEngine engine;
 
     public Processor(String id, Locale locale) throws EPropertyNotFound, EBaseException {
         this.id = id;
         this.locale = locale;
+    }
+
+    public CMSEngine getCMSEngine() {
+        return engine;
+    }
+
+    public void setCMSEngine(CMSEngine engine) {
+        this.engine = engine;
     }
 
     public String getUserMessage(String messageId, String... params) {

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -755,7 +755,11 @@ public class CMSEngine {
         String checkInterval = config.getString("securitydomain.checkinterval", "5000");
 
         if (source.equals("ldap")) {
-            mSecurityDomainSessionTable = new LDAPSecurityDomainSessionTable(Long.parseLong(flushInterval));
+            LDAPSecurityDomainSessionTable sessionTable = new LDAPSecurityDomainSessionTable(Long.parseLong(flushInterval));
+            sessionTable.setCMSEngine(this);
+            sessionTable.init();
+            mSecurityDomainSessionTable = sessionTable;
+
         } else {
             mSecurityDomainSessionTable = new MemorySecurityDomainSessionTable(Long.parseLong(flushInterval));
         }

--- a/base/server/src/main/java/com/netscape/cmscore/authorization/AuthzSubsystem.java
+++ b/base/server/src/main/java/com/netscape/cmscore/authorization/AuthzSubsystem.java
@@ -138,7 +138,7 @@ public class AuthzSubsystem extends Subsystem {
 
                 try {
                     authzMgrInst = (AuthzManager) Class.forName(className).getDeclaredConstructor().newInstance();
-
+                    authzMgrInst.setCMSEngine(engine);
                     authzMgrInst.init(insName, implName, authzMgrConfig);
                     isEnable = true;
 

--- a/base/server/src/main/java/com/netscape/cmscore/session/LDAPSecurityDomainSessionTable.java
+++ b/base/server/src/main/java/com/netscape/cmscore/session/LDAPSecurityDomainSessionTable.java
@@ -25,7 +25,6 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.base.SecurityDomainSessionTable;
 import com.netscape.certsrv.ldap.ELdapException;
-import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
@@ -49,12 +48,23 @@ public class LDAPSecurityDomainSessionTable
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LDAPSecurityDomainSessionTable.class);
 
+    protected CMSEngine engine;
     private LdapBoundConnFactory mLdapConnFactory;
 
-    public LDAPSecurityDomainSessionTable(long timeToLive) throws ELdapException, EBaseException {
+    public LDAPSecurityDomainSessionTable(long timeToLive) {
         this.timeToLive = timeToLive;
+    }
 
-        CMSEngine engine = CMS.getCMSEngine();
+    public CMSEngine getCMSEngine() {
+        return engine;
+    }
+
+    public void setCMSEngine(CMSEngine engine) {
+        this.engine = engine;
+    }
+
+    public void init() throws ELdapException, EBaseException {
+
         EngineConfig cs = engine.getConfig();
 
         PKISocketConfig socketConfig = cs.getSocketConfig();
@@ -68,7 +78,6 @@ public class LDAPSecurityDomainSessionTable
     public int addEntry(String sessionId, String ip,
             String uid, String group) throws Exception {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
 
@@ -133,7 +142,6 @@ public class LDAPSecurityDomainSessionTable
     @Override
     public int removeEntry(String sessionId) throws Exception {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
 
@@ -168,7 +176,6 @@ public class LDAPSecurityDomainSessionTable
     @Override
     public boolean sessionExists(String sessionId) throws Exception {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
 
@@ -202,7 +209,6 @@ public class LDAPSecurityDomainSessionTable
 
         logger.debug("LDAPSecurityDomainSessionTable: getSessionIds() ");
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
 
@@ -252,7 +258,6 @@ public class LDAPSecurityDomainSessionTable
 
     private String getStringValue(String sessionId, String attr) throws Exception {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
 
@@ -313,7 +318,6 @@ public class LDAPSecurityDomainSessionTable
     @Override
     public int getSize() throws Exception {
 
-        CMSEngine engine = CMS.getCMSEngine();
         EngineConfig cs = engine.getConfig();
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
 

--- a/base/server/src/main/java/org/dogtagpki/server/authorization/AuthzManager.java
+++ b/base/server/src/main/java/org/dogtagpki/server/authorization/AuthzManager.java
@@ -28,12 +28,15 @@ import com.netscape.certsrv.authorization.EAuthzInternalError;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.evaluators.AccessEvaluator;
 import com.netscape.cms.authorization.ACL;
+import com.netscape.cmscore.apps.CMSEngine;
 
 /**
  * Authorization Manager interface needs to be implemented by all
  * authorization managers.
  */
 public abstract class AuthzManager {
+
+    protected CMSEngine engine;
 
     // name of this authorization manager instance
     protected String name;
@@ -43,6 +46,14 @@ public abstract class AuthzManager {
 
     // configuration store
     protected AuthzManagerConfig config;
+
+    public CMSEngine getCMSEngine() {
+        return engine;
+    }
+
+    public void setCMSEngine(CMSEngine engine) {
+        this.engine = engine;
+    }
 
     /**
      * Get the name of this authorization manager instance.

--- a/base/server/src/main/java/org/dogtagpki/server/rest/GroupService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/GroupService.java
@@ -342,6 +342,7 @@ public class GroupService extends SubsystemService implements GroupResource {
 
         try {
             GroupMemberProcessor processor = new GroupMemberProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
             processor.setUriInfo(uriInfo);
             return createOKResponse(processor.findGroupMembers(groupID, filter, start, size));
 
@@ -362,6 +363,7 @@ public class GroupService extends SubsystemService implements GroupResource {
 
         try {
             GroupMemberProcessor processor = new GroupMemberProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
             processor.setUriInfo(uriInfo);
             return createOKResponse(processor.getGroupMember(groupID, memberID));
 
@@ -382,6 +384,7 @@ public class GroupService extends SubsystemService implements GroupResource {
 
         try {
             GroupMemberProcessor processor = new GroupMemberProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
             processor.setUriInfo(uriInfo);
             groupMemberData = processor.addGroupMember(groupMemberData);
 
@@ -410,6 +413,7 @@ public class GroupService extends SubsystemService implements GroupResource {
 
         try {
             GroupMemberProcessor processor = new GroupMemberProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
             processor.setUriInfo(uriInfo);
             processor.removeGroupMember(groupID, memberID);
 

--- a/base/server/src/main/java/org/dogtagpki/server/rest/SecurityDomainService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/SecurityDomainService.java
@@ -61,6 +61,8 @@ public class SecurityDomainService extends PKIService implements SecurityDomainR
             String user = servletRequest.getUserPrincipal().getName();
 
             SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
+
             InstallToken installToken = processor.getInstallToken(user, hostname, subsystem);
             return createOKResponse(installToken);
 
@@ -83,6 +85,8 @@ public class SecurityDomainService extends PKIService implements SecurityDomainR
 
         try {
             SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
+
             DomainInfo domainInfo = processor.getDomainInfo();
             return createOKResponse(domainInfo);
 
@@ -108,6 +112,7 @@ public class SecurityDomainService extends PKIService implements SecurityDomainR
             Collection<SecurityDomainHost> hosts = new ArrayList<>();
 
             SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
 
             DomainInfo domainInfo = processor.getDomainInfo();
             logger.debug("SecurityDomainService: domain: " + domainInfo.getName());
@@ -144,6 +149,7 @@ public class SecurityDomainService extends PKIService implements SecurityDomainR
         logger.info("SecurityDomainService: Getting security domain host \"" + hostID + "\"");
         try {
             SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
 
             DomainInfo domainInfo = processor.getDomainInfo();
             logger.debug("SecurityDomainService: domain: " + domainInfo.getName());
@@ -231,6 +237,8 @@ public class SecurityDomainService extends PKIService implements SecurityDomainR
             logger.debug("SecurityDomainService: clone: " + clone);
 
             SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
+
             String status = processor.addHost(
                     hostID,
                     type,
@@ -287,6 +295,8 @@ public class SecurityDomainService extends PKIService implements SecurityDomainR
             logger.debug("SecurityDomainService: port: " + port);
 
             SecurityDomainProcessor processor = new SecurityDomainProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
+
             String status = processor.removeHost(hostID, type, hostname, port);
             logger.debug("SecurityDomainService: status: " + status);
 

--- a/base/server/src/main/java/org/dogtagpki/server/rest/UserService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/UserService.java
@@ -1053,10 +1053,10 @@ public class UserService extends SubsystemService implements UserResource {
         if (userID == null) throw new BadRequestException("User ID is null.");
         if (groupID == null) throw new BadRequestException("Group ID is null.");
 
+        CMSEngine engine = getCMSEngine();
         User user = null;
 
         try {
-            CMSEngine engine = getCMSEngine();
             UGSubsystem userGroupManager = engine.getUGSubsystem();
             user = userGroupManager.getUser(userID);
         } catch (Exception e) {
@@ -1074,6 +1074,7 @@ public class UserService extends SubsystemService implements UserResource {
             groupMemberData.setGroupID(groupID);
 
             GroupMemberProcessor processor = new GroupMemberProcessor(getLocale(headers));
+            processor.setCMSEngine(engine);
             processor.setUriInfo(uriInfo);
             processor.addGroupMember(groupMemberData);
 
@@ -1104,6 +1105,7 @@ public class UserService extends SubsystemService implements UserResource {
 
         try {
             GroupMemberProcessor processor = new GroupMemberProcessor(getLocale(headers));
+            processor.setCMSEngine(getCMSEngine());
             processor.setUriInfo(uriInfo);
             processor.removeGroupMember(groupID, userID);
 


### PR DESCRIPTION
A new `engine` field has been added to the following classes to reduce the dependency on the static `CMS.getCMSEngine()` method:
* `LDAPSecurityDomainSessionTable`
* `Processor`
* `AccessEvaluator`
* `AuthzManager`
