### PR TITLE
Fix token filtering in TPS UI

### DIFF
--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/TokenService.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/TokenService.java
@@ -402,7 +402,7 @@ public class TokenService extends SubsystemService implements TokenResource {
         String method = "TokenService.retrieveTokensWithoutVLV: ";
 
         // search without VLV
-        List<TokenRecord> tokens = (List<TokenRecord>) database.findRecords(filter);
+        List<TokenRecord> tokens = (List<TokenRecord>) database.findRecords(filter, attributes);
         int total = tokens.size();
         logger.debug(method + "total: " + total);
 


### PR DESCRIPTION
Only the filter created from input in the search bar was being used to compose the ldapsearch query. The attributes were passed across from the client and into the processing method but were not then passed on to the database.

Resolves #2178816