### PR TITLE
Refactor CMSGateway

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -1748,7 +1748,9 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
         Locale locale = Locale.getDefault();
         CertEnrollmentRequest certRequest =
             CertEnrollmentRequestFactory.create(argBlock, profile, locale);
+
         EnrollmentProcessor processor = new EnrollmentProcessor("createSubCA", locale);
+        processor.setCMSEngine(engine);
 
         Map<String, Object> resultMap = processor.processEnrollment(
             certRequest, null, authorityID, null, authToken);
@@ -1812,6 +1814,8 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
 
         RenewalProcessor processor =
             new RenewalProcessor("renewAuthority", httpReq.getLocale());
+        processor.setCMSEngine(engine);
+
         Map<String, Object> resultMap =
             processor.processRenewal(req, httpReq, null);
         com.netscape.cmscore.request.Request requests[] = (com.netscape.cmscore.request.Request[]) resultMap.get(CAProcessor.ARG_REQUESTS);
@@ -1884,6 +1888,7 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
         logger.debug("revokeAuthority: revoking cert");
         RevocationProcessor processor = new RevocationProcessor(
                 "CertificateAuthority.revokeAuthority", httpReq.getLocale());
+        processor.setCMSEngine(engine);
         processor.setSerialNumber(new CertId(authoritySerial));
         processor.setRevocationReason(RevocationReason.UNSPECIFIED);
         processor.setAuthority(this);

--- a/base/ca/src/main/java/com/netscape/cms/servlet/base/CAIndexServlet.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/base/CAIndexServlet.java
@@ -25,6 +25,7 @@ import com.netscape.cms.servlet.common.CMSGateway;
 import com.netscape.cms.servlet.common.CMSRequest;
 import com.netscape.cms.servlet.common.ECMSGWException;
 import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.CMSEngine;
 
 /**
  * This is the servlet that builds the index page in
@@ -35,7 +36,10 @@ public class CAIndexServlet extends IndexServlet {
     @Override
     public void process(CMSRequest cmsReq) throws EBaseException {
 
-        if (!CMSGateway.getEnableAdminEnroll()) {
+        CMSEngine engine = getCMSEngine();
+        CMSGateway gateway = engine.getCMSGateway();
+
+        if (!gateway.getEnableAdminEnroll()) {
             super.process(cmsReq);
             return;
         }

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/DoRevoke.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/DoRevoke.java
@@ -369,6 +369,7 @@ public class DoRevoke extends CMSServlet {
 
         RevocationProcessor processor =
                 new RevocationProcessor(servletConfig.getServletName(), getLocale(req));
+        processor.setCMSEngine(engine);
 
         processor.setStartTime(startTime);
         processor.setInitiative(initiative);

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/DoUnrevoke.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/DoUnrevoke.java
@@ -236,6 +236,7 @@ public class DoUnrevoke extends CMSServlet {
 
         RevocationProcessor processor = new RevocationProcessor(
                 servletConfig.getServletName(), getLocale(req));
+        processor.setCMSEngine(engine);
 
         processor.setInitiative(initiative);
         processor.setSerialNumber(auditSerialNumber(serialNumbers[0].toString()));

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/EnrollServlet.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/EnrollServlet.java
@@ -69,6 +69,7 @@ import com.netscape.cms.servlet.processors.KeyGenProcessor;
 import com.netscape.cms.servlet.processors.PKCS10Processor;
 import com.netscape.cms.servlet.processors.PKIProcessor;
 import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.authentication.AuthSubsystem;
 import com.netscape.cmscore.base.ArgBlock;
 import com.netscape.cmscore.base.ConfigStore;
@@ -329,10 +330,14 @@ public class EnrollServlet extends CAServlet {
     @Override
     protected void process(CMSRequest cmsReq)
             throws EBaseException {
+
+        CMSEngine engine = getCMSEngine();
+        CMSGateway gateway = engine.getCMSGateway();
+
         // SPECIAL CASE:
         // if it is adminEnroll servlet,check if it's enabled
         if (mId.equals(ADMIN_ENROLL_SERVLET_ID) &&
-                !CMSGateway.getEnableAdminEnroll()) {
+                !gateway.getEnableAdminEnroll()) {
             logger.error(CMS.getLogMessage("ADMIN_SRVLT_ENROLL_ACCESS_AFTER_SETUP"));
             throw new ECMSGWException(
                     CMS.getUserMessage("CMS_GW_REDIRECTING_ADMINENROLL_ERROR",
@@ -1476,10 +1481,14 @@ public class EnrollServlet extends CAServlet {
      */
     protected void checkAdminEnroll(CMSRequest cmsReq, X509CertImpl[] issuedCerts)
             throws EBaseException {
+
+        CMSEngine engine = getCMSEngine();
+        CMSGateway gateway = engine.getCMSGateway();
+
         // this is special case, get the admin certificate
         if (mAuthMgr != null && mAuthMgr.equals(AuthSubsystem.PASSWDUSERDB_AUTHMGR_ID)) {
             addAdminAgent(cmsReq, issuedCerts);
-            CMSGateway.disableAdminEnroll();
+            gateway.disableAdminEnroll();
         }
     }
 

--- a/base/ca/src/main/java/com/netscape/cms/servlet/csadmin/UpdateConnector.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/csadmin/UpdateConnector.java
@@ -148,7 +148,12 @@ public class UpdateConnector extends CMSServlet {
 
         String status = SUCCESS;
         String error = "";
+
+        CAEngine engine = CAEngine.getInstance();
+
         KRAConnectorProcessor processor = new KRAConnectorProcessor(getLocale(httpReq));
+        processor.setCMSEngine(engine);
+
         KRAConnectorInfo info = createConnectorInfo(httpReq);
 
         String url = "https://" + info.getHost() + ":" + info.getPort();
@@ -164,7 +169,6 @@ public class UpdateConnector extends CMSServlet {
             return;
         }
 
-        CAEngine engine = CAEngine.getInstance();
         UGSubsystem ugSubsystem = engine.getUGSubsystem();
 
         String uid = "KRA-" + info.getHost() + "-" + info.getPort();

--- a/base/ca/src/main/java/com/netscape/cms/servlet/processors/CAProcessor.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/processors/CAProcessor.java
@@ -635,7 +635,9 @@ public class CAProcessor extends Processor {
                 // reset the "auditAuthMgrID"
                 auditAuthMgrID = authMgrName;
             }
-            AuthToken authToken = CMSGateway.checkAuthManager(httpReq,
+
+            CMSGateway gateway = engine.getCMSGateway();
+            AuthToken authToken = gateway.checkAuthManager(httpReq,
                     httpArgs,
                     clientCert,
                     authMgrName);

--- a/base/ca/src/main/java/com/netscape/cms/servlet/profile/ProfileProcessServlet.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/profile/ProfileProcessServlet.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.dogtagpki.server.ca.CAEngine;
 import org.mozilla.jss.netscape.security.util.Utils;
 
 import com.netscape.certsrv.authentication.EAuthException;
@@ -79,7 +80,9 @@ public class ProfileProcessServlet extends ProfileServlet {
         args.set(ARG_ERROR_CODE, "0");
         args.set(ARG_ERROR_REASON, "");
 
+        CAEngine engine = (CAEngine) getCMSEngine();
         RequestProcessor processor = new RequestProcessor("caProfileProcess", locale);
+        processor.setCMSEngine(engine);
 
         String op = request.getParameter("op");
         if (op == null) {

--- a/base/ca/src/main/java/com/netscape/cms/servlet/profile/ProfileSubmitServlet.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/profile/ProfileSubmitServlet.java
@@ -246,6 +246,7 @@ public class ProfileSubmitServlet extends ProfileServlet {
 
         CAEngine engine = CAEngine.getInstance();
         EnrollmentProcessor processor = new EnrollmentProcessor("caProfileSubmit", locale);
+        processor.setCMSEngine(engine);
 
         String profileId = processor.getProfileID() == null ? request.getParameter("profileId") : processor.getProfileID();
         logger.debug("ProfileSubmitServlet: profile: " + profileId);
@@ -283,7 +284,9 @@ public class ProfileSubmitServlet extends ProfileServlet {
         HttpServletRequest request = cmsReq.getHttpReq();
         Locale locale = getLocale(request);
 
+        CAEngine engine = (CAEngine) getCMSEngine();
         RenewalProcessor processor = new RenewalProcessor("caProfileSubmit", locale);
+        processor.setCMSEngine(engine);
 
         String profileId = processor.getProfileID() == null ? request.getParameter("profileId") : processor.getProfileID();
         logger.debug("ProfileSubmitServlet: profile: " + profileId);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CASystemCertService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CASystemCertService.java
@@ -70,6 +70,7 @@ public class CASystemCertService extends PKIService implements CASystemCertResou
 
         CAEngine engine = CAEngine.getInstance();
         KRAConnectorProcessor processor = new KRAConnectorProcessor(getLocale(headers));
+        processor.setCMSEngine(engine);
         KRAConnectorInfo info = processor.getConnectorInfo();
 
         String encodedCert = info.getTransportCert();

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertRequestDAO.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertRequestDAO.java
@@ -202,12 +202,17 @@ public class CertRequestDAO extends CMSRequestDAO {
             credentials.set("pwd", password);
         }
 
+        CAEngine engine = CAEngine.getInstance();
+
         HashMap<String, Object> results = null;
         if (data.isRenewal()) {
             RenewalProcessor processor = new RenewalProcessor("caProfileSubmit", locale);
+            processor.setCMSEngine(engine);
             results = processor.processRenewal(data, request, credentials);
+
         } else {
             EnrollmentProcessor processor = new EnrollmentProcessor("caProfileSubmit", locale);
+            processor.setCMSEngine(engine);
             results = processor.processEnrollment(data, request, aid, credentials);
         }
 
@@ -235,7 +240,9 @@ public class CertRequestDAO extends CMSRequestDAO {
             throw new RequestNotFoundException(id);
         }
 
+        CAEngine engine = CAEngine.getInstance();
         RequestProcessor processor = new RequestProcessor("caProfileProcess", locale);
+        processor.setCMSEngine(engine);
 
         AuthToken authToken = null;
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertService.java
@@ -189,6 +189,7 @@ public class CertService extends PKIService implements CertResource {
         RevocationProcessor processor;
         try {
             processor = new RevocationProcessor("caDoRevoke-agent", getLocale(headers));
+            processor.setCMSEngine(engine);
             processor.setStartTime(new Date().getTime());
 
             // TODO: set initiative based on auth info
@@ -346,9 +347,12 @@ public class CertService extends PKIService implements CertResource {
         @SuppressWarnings("unused")
         CertData data = getCertData(id);
 
+        CAEngine engine = (CAEngine) getCMSEngine();
         RevocationProcessor processor;
+
         try {
             processor = new RevocationProcessor("caDoUnrevoke", getLocale(headers));
+            processor.setCMSEngine(engine);
 
             // TODO: set initiative based on auth info
             processor.setInitiative(AuditFormat.FROMAGENT);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/KRAConnectorService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/KRAConnectorService.java
@@ -19,6 +19,8 @@ package org.dogtagpki.server.ca.rest;
 
 import javax.ws.rs.core.Response;
 
+import org.dogtagpki.server.ca.CAEngine;
+
 import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.PKIException;
@@ -39,8 +41,11 @@ public class KRAConnectorService extends PKIService implements KRAConnectorResou
 
         if (info == null) throw new BadRequestException("Missing KRA connector info.");
 
+        CAEngine engine = (CAEngine) getCMSEngine();
+
         try {
             KRAConnectorProcessor processor = new KRAConnectorProcessor(getLocale(headers));
+            processor.setCMSEngine(engine);
             processor.addConnector(info);
             return createNoContentResponse();
         } catch (EBaseException e) {
@@ -52,8 +57,12 @@ public class KRAConnectorService extends PKIService implements KRAConnectorResou
 
     @Override
     public Response addHost(String host, String port) {
+
+        CAEngine engine = (CAEngine) getCMSEngine();
+
         try {
             KRAConnectorProcessor processor = new KRAConnectorProcessor(getLocale(headers));
+            processor.setCMSEngine(engine);
             processor.addHost(host, port);
             return createNoContentResponse();
         } catch (EBaseException e) {
@@ -69,8 +78,11 @@ public class KRAConnectorService extends PKIService implements KRAConnectorResou
         if (host == null) throw new BadRequestException("Missing KRA connector host.");
         if (port == null) throw new BadRequestException("Missing KRA connector port.");
 
+        CAEngine engine = (CAEngine) getCMSEngine();
+
         try {
             KRAConnectorProcessor processor = new KRAConnectorProcessor(getLocale(headers));
+            processor.setCMSEngine(engine);
             processor.removeConnector(host, port);
             return createNoContentResponse();
         } catch (EBaseException e) {
@@ -83,8 +95,11 @@ public class KRAConnectorService extends PKIService implements KRAConnectorResou
     @Override
     public Response getConnectorInfo() {
 
+        CAEngine engine = (CAEngine) getCMSEngine();
+
         try {
             KRAConnectorProcessor processor = new KRAConnectorProcessor(getLocale(headers));
+            processor.setCMSEngine(engine);
             return createOKResponse(processor.getConnectorInfo());
         } catch (EBaseException e) {
             String message = "Unable to get KRA connector: " + e.getMessage();

--- a/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
@@ -104,10 +104,14 @@ public class CAInfoService extends PKIService implements CAInfoResource {
      * any instance data.
      */
     private void addKRAInfo(CAInfo info) throws Exception {
+
+        CAEngine engine = (CAEngine) getCMSEngine();
         KRAConnectorInfo connInfo = null;
+
         try {
             KRAConnectorProcessor processor =
                 new KRAConnectorProcessor(getLocale(headers));
+            processor.setCMSEngine(engine);
             connInfo = processor.getConnectorInfo();
         } catch (Throwable e) {
             // connInfo remains as null

--- a/base/server/src/main/java/com/netscape/cms/servlet/base/CMSServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/base/CMSServlet.java
@@ -1427,7 +1427,10 @@ public abstract class CMSServlet extends HttpServlet {
 
             // reset the "auditAuthMgrID"
             auditAuthMgrID = authMgrName;
-            AuthToken authToken = CMSGateway.checkAuthManager(httpReq,
+
+            CMSEngine engine = getCMSEngine();
+            CMSGateway gateway = engine.getCMSGateway();
+            AuthToken authToken = gateway.checkAuthManager(httpReq,
                     httpArgs,
                     clientCert,
                     authMgrName);

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -57,6 +57,7 @@ import com.netscape.certsrv.request.RequestListener;
 import com.netscape.certsrv.request.RequestStatus;
 import com.netscape.cms.notification.MailNotification;
 import com.netscape.cms.password.PasswordChecker;
+import com.netscape.cms.servlet.common.CMSGateway;
 import com.netscape.cms.servlet.common.CMSRequest;
 import com.netscape.cmscore.authentication.AuthSubsystem;
 import com.netscape.cmscore.authentication.VerifiedCert;
@@ -155,6 +156,7 @@ public class CMSEngine {
     protected RequestSubsystem requestSubsystem = new RequestSubsystem();
     protected AuthSubsystem authSubsystem;
     protected AuthzSubsystem authzSubsystem = AuthzSubsystem.getInstance();
+    protected CMSGateway gateway;
     protected JobsScheduler jobsScheduler = JobsScheduler.getInstance();
 
     public final Map<String, SubsystemInfo> subsystemInfos = new LinkedHashMap<>();
@@ -253,6 +255,10 @@ public class CMSEngine {
 
     public AuthzSubsystem getAuthzSubsystem() {
         return authzSubsystem;
+    }
+
+    public CMSGateway getCMSGateway() {
+        return gateway;
     }
 
     public JobsScheduler getJobsScheduler() {
@@ -709,6 +715,12 @@ public class CMSEngine {
         authzSubsystem.setCMSEngine(this);
         authzSubsystem.init(authzConfig);
         authzSubsystem.startup();
+    }
+
+    public void initCMSGateway() throws Exception {
+        gateway = new CMSGateway();
+        gateway.setCMSEngine(this);
+        gateway.init();
     }
 
     public void initJobsScheduler() throws Exception {
@@ -1182,6 +1194,7 @@ public class CMSEngine {
 
         initAuthSubsystem();
         initAuthzSubsystem();
+        initCMSGateway();
         initJobsScheduler();
 
         configureAutoShutdown();


### PR DESCRIPTION
Previously the `CMSGateway` used the static `CMS.getCMSEngine()` which could potentially cause class loading issues. To avoid the problem the static fields and methods in the class have been converted into non-static, and a new `engine` field has been added to store a reference to the `CMSEngine` instance such that it no longer needs to rely on `CMS.getCMSEngine()`.

All instances of `Processor` have been modified to store the `CMSEngine` object such that it can be used by other objects in the `Processor`.