### PR TITLE
Bug2176233_part2_StatusChange_holdRevocationUntilLastCredential

### DIFF
--- a/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
+++ b/base/tps/src/org/dogtagpki/server/tps/TPSTokendb.java
@@ -824,8 +824,9 @@ public class TPSTokendb {
             if (!isLastActiveSharedCert(cert.getSerialNumber(), cert.getIssuedBy(), tokenRecord.getId())) {
                 msg = "revocation not permitted as certificate " + cert.getSerialNumber() +
                         " is shared by another active token";
-                CMS.debug(method + " holdRevocation true; " + msg);
-                throw new TPSException(msg);
+                CMS.debug(method + " holdRevocationUntilLastCredential true; " + msg);
+                throw new TPSException(msg,
+                    TPSStatus.STATUS_NO_ERROR);
             }
         }
         CMS.debug(method + "revocation allowed.");


### PR DESCRIPTION
This patch requires the previous commit that addresses part 1&3 of the
    bug.  This previous commit must be applied first.
      previous commit 5560fe03f02a113583ba6b7f93e191d602b75876

    This patch addresses "part 2" of the Bug 2092522.
    The issue reported regards holdRevocationUntilLastCredential
    when if set, and if there are shared tokens existing, an error
    Exception is thrown.

    fixes part 2 of https://bugzilla.redhat.com/show_bug.cgi?id=2176233