### PR TITLE
New CLIs

### DIFF
--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -557,6 +557,7 @@ class CACertRequestCLI(pki.cli.CLI):
 
         self.add_module(CACertRequestFindCLI())
         self.add_module(CACertRequestShowCLI())
+        self.add_module(CACertRequestImportCLI())
 
     @staticmethod
     def print_request(request, details=False):
@@ -729,6 +730,96 @@ class CACertRequestShowCLI(pki.cli.CLI):
 
         else:
             CACertRequestCLI.print_request(request, details=True)
+
+
+class CACertRequestImportCLI(pki.cli.CLI):
+
+    def __init__(self):
+        super().__init__('import', 'Import certificate request into CA')
+
+    def print_help(self):
+        print('Usage: pki-server ca-cert-request-import [OPTIONS]')
+        print()
+        print('  -i, --instance <instance ID>     Instance ID (default: pki-tomcat)')
+        print('      --csr <path>                 Certificate request path')
+        print('      --format <format>            Certificate request format: PEM (default), DER')
+        print('      --profile <filename>         Bootstrap profile filename')
+        print('      --request <ID>               Certificate request ID')
+        print('  -v, --verbose                    Run in verbose mode.')
+        print('      --debug                      Run in debug mode.')
+        print('      --help                       Show help message.')
+        print()
+
+    def execute(self, argv):
+
+        try:
+            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
+                'instance=',
+                'csr=', 'format=', 'profile=', 'request=',
+                'verbose', 'debug', 'help'])
+
+        except getopt.GetoptError as e:
+            logger.error(e)
+            self.print_help()
+            sys.exit(1)
+
+        instance_name = 'pki-tomcat'
+        request_path = None
+        request_format = None
+        profile_id = None
+        request_id = None
+
+        for o, a in opts:
+            if o in ('-i', '--instance'):
+                instance_name = a
+
+            elif o == '--csr':
+                request_path = a
+
+            elif o == '--format':
+                request_format = a
+
+            elif o == '--profile':
+                profile_id = a
+
+            elif o == '--request':
+                request_id = a
+
+            elif o in ('-v', '--verbose'):
+                logging.getLogger().setLevel(logging.INFO)
+
+            elif o == '--debug':
+                logging.getLogger().setLevel(logging.DEBUG)
+
+            elif o == '--help':
+                self.print_help()
+                sys.exit()
+
+            else:
+                logger.error('Invalid option: %s', o)
+                self.print_help()
+                sys.exit(1)
+
+        instance = pki.server.instance.PKIServerFactory.create(instance_name)
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem('ca')
+        if not subsystem:
+            logger.error('No CA subsystem in instance %s', instance_name)
+            sys.exit(1)
+
+        result = subsystem.import_cert_request(
+            request_path=request_path,
+            request_format=request_format,
+            profile_id=profile_id,
+            request_id=request_id)
+
+        request_id = result['requestID']
+        print('  Request ID: %s' % request_id)
 
 
 class CACloneCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -544,7 +544,82 @@ class UserCertCLI(pki.cli.CLI):
         super().__init__('cert', '%s user cert management commands' % parent.parent.name.upper())
 
         self.parent = parent
+        self.add_module(UserCertFindCLI(self))
         self.add_module(UserCertAddCLI(self))
+
+
+class UserCertFindCLI(pki.cli.CLI):
+
+    def __init__(self, parent):
+        super().__init__('find', 'Find %s user certificates' % parent.parent.parent.name.upper())
+
+        self.parent = parent
+
+    def print_help(self):
+        print('Usage: pki-server %s-user-cert-find [OPTIONS] <user ID>'
+              % self.parent.parent.parent.name)
+        print()
+        print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('  -v, --verbose                      Run in verbose mode.')
+        print('      --debug                        Run in debug mode.')
+        print('      --help                         Show help message.')
+        print()
+
+    def execute(self, argv):
+        try:
+            opts, args = getopt.gnu_getopt(argv, 'i:v', [
+                'instance=',
+                'verbose', 'debug', 'help'])
+
+        except getopt.GetoptError as e:
+            logger.error(e)
+            self.print_help()
+            sys.exit(1)
+
+        instance_name = 'pki-tomcat'
+        subsystem_name = self.parent.parent.parent.name
+
+        for o, a in opts:
+            if o in ('-i', '--instance'):
+                instance_name = a
+
+            elif o in ('-v', '--verbose'):
+                logging.getLogger().setLevel(logging.INFO)
+
+            elif o == '--debug':
+                logging.getLogger().setLevel(logging.DEBUG)
+
+            elif o == '--help':
+                self.print_help()
+                sys.exit()
+
+            else:
+                logger.error('Invalid option: %s', o)
+                self.print_help()
+                sys.exit(1)
+
+        if len(args) < 1:
+            logger.error('Missing user ID')
+            self.print_help()
+            sys.exit(1)
+
+        user_id = args[0]
+
+        instance = pki.server.instance.PKIServerFactory.create(instance_name)
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        subsystem.find_user_certs(user_id)
 
 
 class UserCertAddCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1766,6 +1766,25 @@ class PKISubsystem(object):
             as_current_user=as_current_user,
             capture_output=True)
 
+    def find_user_certs(
+            self,
+            user_id,
+            as_current_user=False):
+
+        cmd = [self.name + '-user-cert-find']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(user_id)
+
+        self.run(
+            cmd,
+            as_current_user=as_current_user)
+
     def add_user_cert(self, user_id,
                       cert_data=None,
                       cert_path=None,

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCertCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCertCLI.java
@@ -7,6 +7,8 @@ package org.dogtagpki.server.cli;
 
 import org.dogtagpki.cli.CLI;
 
+import com.netscape.certsrv.user.UserCertData;
+
 /**
  * @author Endi S. Dewata
  */
@@ -15,6 +17,31 @@ public class SubsystemUserCertCLI extends CLI {
     public SubsystemUserCertCLI(CLI parent) {
         super("cert", parent.name.toUpperCase() + " user cert management commands", parent);
 
+        addModule(new SubsystemUserCertFindCLI(this));
         addModule(new SubsystemUserCertAddCLI(this));
+    }
+
+    public static void printCert(
+            UserCertData userCertData,
+            boolean showPrettyPrint,
+            boolean showEncoded) {
+
+        System.out.println("  Cert ID: " + userCertData.getID());
+        System.out.println("  Version: " + userCertData.getVersion());
+        System.out.println("  Serial Number: " + userCertData.getSerialNumber().toHexString());
+        System.out.println("  Issuer: " + userCertData.getIssuerDN());
+        System.out.println("  Subject: " + userCertData.getSubjectDN());
+
+        String prettyPrint = userCertData.getPrettyPrint();
+        if (showPrettyPrint && prettyPrint != null) {
+            System.out.println();
+            System.out.println(prettyPrint);
+        }
+
+        String encoded = userCertData.getEncoded();
+        if (showEncoded && encoded != null) {
+            System.out.println();
+            System.out.println(encoded);
+        }
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCertFindCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCertFindCLI.java
@@ -1,0 +1,97 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import java.security.cert.X509Certificate;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.certsrv.dbs.certdb.CertId;
+import com.netscape.certsrv.user.UserCertData;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.usrgrp.UGSubsystem;
+import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
+import com.netscape.cmscore.usrgrp.User;
+import com.netscape.cmsutil.password.IPasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemUserCertFindCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemUserCertFindCLI.class);
+
+    public SubsystemUserCertFindCLI(CLI parent) {
+        super("find", "Find " + parent.getParent().getParent().getName().toUpperCase() + " user certificates", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing user ID");
+        }
+
+        String userID = cmdArgs[0];
+
+        initializeTomcatJSS();
+
+        String subsystem = parent.getParent().getParent().getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        UGSubsystemConfig ugConfig = cs.getUGSubsystemConfig();
+        LDAPConfig ldapConfig = ugConfig.getLDAPConfig();
+        ldapConfig.putInteger("minConns", 1);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        IPasswordStore passwordStore = IPasswordStore.create(psc);
+
+        UGSubsystem ugSubsystem = new UGSubsystem();
+
+        try {
+            ugSubsystem.init(ldapConfig, socketConfig, passwordStore);
+
+            User user = ugSubsystem.getUser(userID);
+            X509Certificate[] certs = user.getX509Certificates();
+
+            if (certs != null) {
+                boolean first = true;
+                for (X509Certificate cert : certs) {
+
+                    if (first) {
+                        first = false;
+                    } else {
+                        System.out.println();
+                    }
+
+                    UserCertData userCertData = new UserCertData();
+
+                    userCertData.setVersion(cert.getVersion());
+                    userCertData.setSerialNumber(new CertId(cert.getSerialNumber()));
+                    userCertData.setIssuerDN(cert.getIssuerDN().toString());
+                    userCertData.setSubjectDN(cert.getSubjectDN().toString());
+
+                    SubsystemUserCertCLI.printCert(userCertData, false, false);
+                }
+            }
+
+        } finally {
+            ugSubsystem.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
The `pki-server ca-cert-request-import` and `pki-server <subsystem>-user-cert-find` commands have been added to support PKI server migration in IPA.

https://github.com/dogtagpki/freeipa/wiki/Migrating-PKI-Server
