### PR TITLE
Re-enable the licence check.

### DIFF
--- a/tests/pki-rpminspect.yaml
+++ b/tests/pki-rpminspect.yaml
@@ -2,11 +2,6 @@
 
 ---
 inspections:
-    # License check fails because of a bug in rpminspect, see:
-    # https://github.com/rpminspect/rpminspect/issues/858
-    # https://github.com/rpminspect/rpminspect/issues/1117
-    license: off
-
     # Don't run metadata check as we can't know the build host subdomain
     # of CI runners in advance to add to an allow list
     metadata: off


### PR DESCRIPTION
With the release of `rpminspect-data-fedora-1.10-1.fc37` the bug in this check is resolved, so we can run it again.