### PR TITLE
New group member CLIs

### DIFF
--- a/base/server/python/pki/server/cli/group.py
+++ b/base/server/python/pki/server/cli/group.py
@@ -108,6 +108,7 @@ class GroupMemberCLI(pki.cli.CLI):
         self.parent = parent
         self.add_module(GroupMemberFindCLI(self))
         self.add_module(GroupMemberAddCLI(self))
+        self.add_module(GroupMemberRemoveCLI(self))
 
 
 class GroupMemberFindCLI(pki.cli.CLI):
@@ -277,3 +278,86 @@ class GroupMemberAddCLI(pki.cli.CLI):
 
         logger.info('Adding %s into %s', member_id, group_id)
         subsystem.add_group_member(group_id, member_id)
+
+
+class GroupMemberRemoveCLI(pki.cli.CLI):
+
+    def __init__(self, parent):
+        super().__init__(
+            'del',
+            'Remove %s group member' % parent.parent.parent.name.upper())
+
+        self.parent = parent
+
+    def print_help(self):
+        print('Usage: pki-server %s-group-member-del [OPTIONS] <group ID> <member ID>'
+              % self.parent.parent.parent.name)
+        print()
+        print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('  -v, --verbose                      Run in verbose mode.')
+        print('      --debug                        Run in debug mode.')
+        print('      --help                         Show help message.')
+        print()
+
+    def execute(self, argv):
+        try:
+            opts, args = getopt.gnu_getopt(argv, 'i:v', [
+                'instance=',
+                'verbose', 'debug', 'help'])
+
+        except getopt.GetoptError as e:
+            logger.error(e)
+            self.print_help()
+            sys.exit(1)
+
+        instance_name = 'pki-tomcat'
+        subsystem_name = self.parent.parent.parent.name
+
+        for o, a in opts:
+            if o in ('-i', '--instance'):
+                instance_name = a
+
+            elif o in ('-v', '--verbose'):
+                logging.getLogger().setLevel(logging.INFO)
+
+            elif o == '--debug':
+                logging.getLogger().setLevel(logging.DEBUG)
+
+            elif o == '--help':
+                self.print_help()
+                sys.exit()
+
+            else:
+                logger.error('Invalid option: %s', o)
+                self.print_help()
+                sys.exit(1)
+
+        if len(args) < 1:
+            logger.error('Missing group ID')
+            self.print_help()
+            sys.exit(1)
+
+        if len(args) < 2:
+            logger.error('Missing member ID')
+            self.print_help()
+            sys.exit(1)
+
+        group_id = args[0]
+        member_id = args[1]
+
+        instance = pki.server.instance.PKIServerFactory.create(instance_name)
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        logger.info('Adding %s into %s', member_id, group_id)
+        subsystem.remove_group_member(group_id, member_id)

--- a/base/server/python/pki/server/cli/group.py
+++ b/base/server/python/pki/server/cli/group.py
@@ -39,6 +39,7 @@ class GroupFindCLI(pki.cli.CLI):
         print('Usage: pki-server %s-group-find [OPTIONS]' % self.parent.parent.name)
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('      --member <ID>                  Member ID')
         print('  -v, --verbose                      Run in verbose mode.')
         print('      --debug                        Run in debug mode.')
         print('      --help                         Show help message.')
@@ -47,7 +48,7 @@ class GroupFindCLI(pki.cli.CLI):
     def execute(self, argv):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
+                'instance=', 'member=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -57,10 +58,14 @@ class GroupFindCLI(pki.cli.CLI):
 
         instance_name = 'pki-tomcat'
         subsystem_name = self.parent.parent.name
+        member_id = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
                 instance_name = a
+
+            elif o == '--member':
+                member_id = a
 
             elif o in ('-v', '--verbose'):
                 logging.getLogger().setLevel(logging.INFO)
@@ -91,7 +96,7 @@ class GroupFindCLI(pki.cli.CLI):
                          subsystem_name.upper(), instance_name)
             sys.exit(1)
 
-        subsystem.find_groups()
+        subsystem.find_groups(member_id=member_id)
 
 
 class GroupMemberCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1590,9 +1590,12 @@ class PKISubsystem(object):
         logger.debug('Command: %s', ' '.join(cmd))
         subprocess.check_call(cmd)
 
-    def find_groups(self, as_current_user=False):
+    def find_groups(self, member_id=None, as_current_user=False):
 
         cmd = [self.name + '-group-find']
+
+        if member_id is not None:
+            cmd.extend(['--member', member_id])
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1642,6 +1642,21 @@ class PKISubsystem(object):
 
         self.run(cmd, as_current_user=as_current_user)
 
+    def remove_group_member(self, group_id, member_id, as_current_user=False):
+
+        cmd = [self.name + '-group-member-del']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(group_id)
+        cmd.append(member_id)
+
+        self.run(cmd, as_current_user=as_current_user)
+
     def find_users(self, see_also=None, as_current_user=False):
 
         cmd = [self.name + '-user-find']

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemGroupFindCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemGroupFindCLI.java
@@ -8,6 +8,7 @@ package org.dogtagpki.server.cli;
 import java.util.Enumeration;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
 import org.dogtagpki.cli.CLI;
 import org.slf4j.Logger;
@@ -19,6 +20,7 @@ import com.netscape.cmscore.ldapconn.PKISocketConfig;
 import com.netscape.cmscore.usrgrp.Group;
 import com.netscape.cmscore.usrgrp.UGSubsystem;
 import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
+import com.netscape.cmscore.usrgrp.User;
 import com.netscape.cmsutil.password.IPasswordStore;
 import com.netscape.cmsutil.password.PasswordStoreConfig;
 
@@ -34,7 +36,18 @@ public class SubsystemGroupFindCLI extends SubsystemCLI {
     }
 
     @Override
+    public void createOptions() {
+
+        Option option = new Option(null, "member", true, "Member ID");
+        option.setArgName("ID");
+        options.addOption(option);
+    }
+
+    @Override
     public void execute(CommandLine cmd) throws Exception {
+
+
+        String memberID = cmd.getOptionValue("member");
 
         initializeTomcatJSS();
         String subsystem = parent.getParent().getName();
@@ -55,7 +68,15 @@ public class SubsystemGroupFindCLI extends SubsystemCLI {
         try {
             ugSubsystem.init(ldapConfig, socketConfig, passwordStore);
 
-            Enumeration<Group> groups = ugSubsystem.listGroups(null);
+            Enumeration<Group> groups;
+            if (memberID != null) {
+                User member = ugSubsystem.getUser(memberID);
+                groups = ugSubsystem.findGroupsByUser(member.getUserDN(), null);
+
+            } else {
+                groups = ugSubsystem.listGroups(null);
+            }
+
             boolean first = true;
 
             while (groups.hasMoreElements()) {

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemGroupMemberCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemGroupMemberCLI.java
@@ -17,5 +17,6 @@ public class SubsystemGroupMemberCLI extends CLI {
 
         addModule(new SubsystemGroupMemberFindCLI(this));
         addModule(new SubsystemGroupMemberAddCLI(this));
+        addModule(new SubsystemGroupMemberRemoveCLI(this));
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemGroupMemberRemoveCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemGroupMemberRemoveCLI.java
@@ -1,0 +1,81 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.usrgrp.Group;
+import com.netscape.cmscore.usrgrp.UGSubsystem;
+import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
+import com.netscape.cmsutil.password.IPasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemGroupMemberRemoveCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemGroupMemberRemoveCLI.class);
+
+    public SubsystemGroupMemberRemoveCLI(CLI parent) {
+        super("del", "Remove " + parent.getParent().getParent().getName().toUpperCase() + " group member", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing group ID");
+        }
+
+        if (cmdArgs.length < 2) {
+            throw new CLIException("Missing member ID");
+        }
+
+        String groupID = cmdArgs[0];
+        String memberID = cmdArgs[1];
+
+        initializeTomcatJSS();
+        String subsystem = parent.getParent().getParent().getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        UGSubsystemConfig ugConfig = cs.getUGSubsystemConfig();
+        LDAPConfig ldapConfig = ugConfig.getLDAPConfig();
+        ldapConfig.putInteger("minConns", 1);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        IPasswordStore passwordStore = IPasswordStore.create(psc);
+
+        UGSubsystem ugSubsystem = new UGSubsystem();
+
+        try {
+            ugSubsystem.init(ldapConfig, socketConfig, passwordStore);
+
+            Group group = ugSubsystem.getGroupFromName(groupID);
+
+            if (group == null) {
+                throw new CLIException("Group " + groupID + " not found");
+            }
+
+            ugSubsystem.removeUserFromGroup(group, memberID);
+
+        } finally {
+            ugSubsystem.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Some CLIs have been added/updated to manage group members to support PKI migration in IPA.

The `pki-server <subsystem>-group-find` has been updated to provide a way to find the groups that contain a user. The `pki-server <subsystem>-group-member-del` has been added to remove a member from a group.

https://github.com/dogtagpki/freeipa/wiki/Migrating-PKI-Server
https://github.com/dogtagpki/pki/wiki/PKI-Server-Subsystem-Group-CLI
