### PR TITLE
Update rpminspect test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Save PKI images
         run: |
           docker images
-          docker save -o pki-images.tar pki-builder pki-dist pki-runner pki-server pki-ca pki-acme ipa-runner
+          docker save -o pki-images.tar pki-dist pki-runner pki-server pki-ca pki-acme ipa-runner
 
       - name: Store PKI images
         uses: actions/cache@v3

--- a/.github/workflows/rpminspect-test.yml
+++ b/.github/workflows/rpminspect-test.yml
@@ -26,32 +26,32 @@ jobs:
       - name: Load PKI images
         run: docker load --input pki-images.tar
 
-      - name: Set up builder container
+      - name: Set up PKI container
         run: |
-          docker run \
-              --name=builder \
-              --privileged \
-              --detach \
-              pki-builder
-
-          while :
-          do
-              docker exec builder echo "Container is ready" && break
-              echo "Waiting for container..."
-              sleep 1
-              [ $((++i)) -ge 30 ] && exit 1
-          done
-
-      - name: Check builder container logs
-        if: always()
-        run: |
-          docker logs builder
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
 
       - name: Install rpminspect
         run: |
-          docker exec builder dnf install -y rpminspect-data-fedora
+          docker exec pki dnf install -y rpminspect-data-fedora
+
+      - name: Copy SRPM and RPM packages
+        run: |
+          docker create --name=pki-dist pki-dist
+
+          mkdir /tmp/build
+          docker cp pki-dist:/root/SRPMS/. /tmp/build/SRPMS
+          docker cp pki-dist:/root/RPMS/. /tmp/build/RPMS
+          ls -lR /tmp/build
+
+          docker exec pki mkdir -p build
+          docker cp /tmp/build/. pki:build/
+          docker exec pki ls -lR build
+
+          docker rm -f pki-dist
 
       - name: Run rpminspect on SRPM and RPMs
         run: |
-          docker exec builder cp tests/pki-rpminspect.yaml /usr/share/rpminspect/profiles/fedora/pki-rpminspect.yaml
-          docker exec builder tests/bin/rpminspect.sh
+          docker exec pki cp /usr/share/pki/tests/pki-rpminspect.yaml /usr/share/rpminspect/profiles/fedora/pki-rpminspect.yaml
+          docker exec pki /usr/share/pki/tests/bin/rpminspect.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN ./build.sh --work-dir=build rpm
 FROM alpine:latest AS pki-dist
 
 # Import PKI packages
+COPY --from=pki-builder /root/pki/build/SRPMS /root/SRPMS/
 COPY --from=pki-builder /root/pki/build/RPMS /root/RPMS/
 
 ################################################################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ project(tests)
 
 install(
     FILES
+        pki-rpminspect.yaml
         pylintrc
         tests.yml
         tox.ini

--- a/tests/bin/rpminspect.sh
+++ b/tests/bin/rpminspect.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
-echo "Running RPMInspect on SRPM"
+echo "::group::Running RPMInspect on SRPM"
 rpminspect-fedora -p pki-rpminspect build/SRPMS/*.rpm
+echo "::endgroup::"
 
 # Run RPMInspect on RPMs
 for f in build/RPMS/*rpm; do


### PR DESCRIPTION
The `rpminspect` test has been modified to use `pki-runner` image, get the packages from `pki-dist` image, and get the test files from `pki-tests` package instead of `pki-builder` image. This way it's no longer necessary to store `pki-builder` image in GH cache which reduces the cache size by around 420 MB.