### PR TITLE
Remove CMS.engine

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -123,6 +123,8 @@ import netscape.ldap.LDAPSearchResults;
 
 public class CAEngine extends CMSEngine {
 
+    static CAEngine instance;
+
     protected CertificateRepository certificateRepository;
     protected CRLRepository crlRepository;
     protected ReplicaIDRepository replicaIDRepository;
@@ -186,10 +188,11 @@ public class CAEngine extends CMSEngine {
 
     public CAEngine() {
         super("CA");
+        instance = this;
     }
 
     public static CAEngine getInstance() {
-        return (CAEngine) CMS.getCMSEngine();
+        return instance;
     }
 
     @Override

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/KRAEngine.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/KRAEngine.java
@@ -19,7 +19,6 @@
 package org.dogtagpki.server.kra;
 
 import com.netscape.certsrv.base.Subsystem;
-import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
@@ -28,12 +27,15 @@ import com.netscape.kra.KeyRecoveryAuthority;
 
 public class KRAEngine extends CMSEngine {
 
+    static KRAEngine instance;
+
     public KRAEngine() {
         super("KRA");
+        instance = this;
     }
 
     public static KRAEngine getInstance() {
-        return (KRAEngine) CMS.getCMSEngine();
+        return instance;
     }
 
     @Override

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
@@ -19,7 +19,6 @@
 package org.dogtagpki.server.ocsp;
 
 import com.netscape.certsrv.base.Subsystem;
-import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
@@ -27,12 +26,15 @@ import com.netscape.ocsp.OCSPAuthority;
 
 public class OCSPEngine extends CMSEngine {
 
+    static OCSPEngine instance;
+
     public OCSPEngine() {
         super("OCSP");
+        instance = this;
     }
 
     public static OCSPEngine getInstance() {
-        return (OCSPEngine) CMS.getCMSEngine();
+        return instance;
     }
 
     @Override

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
@@ -32,8 +32,6 @@ import com.netscape.certsrv.base.SessionContext;
  * This represents the CMS server. Plugins can access other
  * public objects such as subsystems via this inteface.
  * This object also include a set of utility functions.
- *
- * @version $Revision$, $Date$
  */
 public final class CMS {
 
@@ -50,16 +48,6 @@ public final class CMS {
 
     public static final int PRE_OP_MODE = 0;
     public static final int RUNNING_MODE = 1;
-
-    private static CMSEngine engine;
-
-    public static CMSEngine getCMSEngine() {
-        return engine;
-    }
-
-    public static void setCMSEngine(CMSEngine engine) {
-        CMS.engine = engine;
-    }
 
     /**
      * Return the product name from /usr/share/pki/CS_SERVER_VERSION

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -186,8 +186,6 @@ public class CMSEngine {
         this.name = name;
 
         logger.info("Creating " + name + " engine");
-
-        CMS.setCMSEngine(this);
     }
 
     public String getID() {

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/TKSEngine.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/TKSEngine.java
@@ -19,7 +19,6 @@
 package org.dogtagpki.server.tks;
 
 import com.netscape.certsrv.base.Subsystem;
-import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.ConfigStore;
@@ -27,12 +26,15 @@ import com.netscape.tks.TKSAuthority;
 
 public class TKSEngine extends CMSEngine {
 
+    static TKSEngine instance;
+
     public TKSEngine() {
         super("TKS");
+        instance = this;
     }
 
     public static TKSEngine getInstance() {
-        return (TKSEngine) CMS.getCMSEngine();
+        return instance;
     }
 
     @Override

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSEngine.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSEngine.java
@@ -37,13 +37,14 @@ import org.dogtagpki.tps.main.Util;
 import org.dogtagpki.tps.msg.EndOpMsg.TPSStatus;
 
 import com.netscape.certsrv.base.EBaseException;
-import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.base.ConfigStorage;
 
 public class TPSEngine extends CMSEngine {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TPSEngine.class);
+
+    static TPSEngine instance;
 
     public enum RA_Algs {
         ALG_RSA,
@@ -209,10 +210,11 @@ public class TPSEngine extends CMSEngine {
 
     public TPSEngine() {
         super("TPS");
+        instance = this;
     }
 
     public static TPSEngine getInstance() {
-        return (TPSEngine) CMS.getCMSEngine();
+        return instance;
     }
 
     @Override


### PR DESCRIPTION
The static `CMS.engine` variable has been removed since it could potentially create conflicts between subsystems. Instead, the engine instances are now stored in the actual engine classes of each subsystem.