### PR TITLE
CLI improvements

### DIFF
--- a/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
+++ b/base/server/healthcheck/pki/server/healthcheck/meta/connectivity.py
@@ -26,6 +26,9 @@ class DogtagCACertsConnectivityCheck(MetaPlugin):
 
         self.instance.load()
 
+        server_config = self.instance.get_server_config()
+        secure_port = server_config.get_secure_port()
+
         ca = self.instance.get_subsystem('ca')
 
         if not ca:
@@ -42,7 +45,7 @@ class DogtagCACertsConnectivityCheck(MetaPlugin):
                 # the server is up AND is able to respond back
                 connection = PKIConnection(protocol='https',
                                            hostname='localhost',
-                                           port='8443',
+                                           port=secure_port,
                                            verify=False)
 
                 cert_client = CertClient(connection)
@@ -98,6 +101,9 @@ class DogtagKRAConnectivityCheck(MetaPlugin):
 
         self.instance.load()
 
+        server_config = self.instance.get_server_config()
+        secure_port = server_config.get_secure_port()
+
         kra = self.instance.get_subsystem('kra')
 
         if not kra:
@@ -114,7 +120,7 @@ class DogtagKRAConnectivityCheck(MetaPlugin):
                 # the server is up AND is able to respond back
                 connection = PKIConnection(protocol='https',
                                            hostname='localhost',
-                                           port='8443',
+                                           port=secure_port,
                                            verify=False)
 
                 system_cert_client = SystemCertClient(connection)

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -75,6 +75,8 @@ class HTTPConnectorCLI(pki.cli.CLI):
         HTTPConnectorCLI.print_param(connector, 'name', 'Connector ID')
         HTTPConnectorCLI.print_param(connector, 'port', 'Port')
         HTTPConnectorCLI.print_param(connector, 'protocol', 'Protocol')
+        HTTPConnectorCLI.print_param(connector, 'redirectPort', 'Redirect Port')
+        HTTPConnectorCLI.print_param(connector, 'address', 'Address')
         HTTPConnectorCLI.print_param(connector, 'scheme', 'Scheme')
         HTTPConnectorCLI.print_param(connector, 'secure', 'Secure')
         HTTPConnectorCLI.print_param(connector, 'SSLEnabled', 'SSL Enabled')


### PR DESCRIPTION
The `pki-server http-connector-find` has been modified to display additional params for AJP connectors.

The `DogtagCACertsConnectivityCheck` and `DogtagKRAConnectivityCheck` have been modified to get the secure port from `server.xml`.
