### PR TITLE
Fix audit log

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/profile/common/EnrollProfile.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/common/EnrollProfile.java
@@ -2750,7 +2750,7 @@ public abstract class EnrollProfile extends Profile {
 
         if (request != null) {
             // overwrite "requesterID" if and only if "id" != null
-            String id = request.getRequestId().toString();
+            String id = request.getRequestId().toHexString();
 
             if (id != null) {
                 requesterID = id.trim();

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/EnrollServlet.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/EnrollServlet.java
@@ -766,7 +766,7 @@ public class EnrollServlet extends CAServlet {
             // retrieve the actual "auditRequesterID"
             if (req != null) {
                 // overwrite "auditRequesterID" if and only if "id" != null
-                id = req.getRequestId().toString();
+                id = req.getRequestId().toHexString();
                 if (id != null) {
                     auditRequesterID = id.trim();
                 }

--- a/base/ca/src/main/java/com/netscape/cms/servlet/processors/CAProcessor.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/processors/CAProcessor.java
@@ -950,7 +950,7 @@ public class CAProcessor extends Processor {
 
         if (request != null) {
             // overwrite "requesterID" if and only if "id" != null
-            String id = request.getRequestId().toString();
+            String id = request.getRequestId().toHexString();
 
             if (id != null) {
                 requesterID = id.trim();

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/CertRequestProcessedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/CertRequestProcessedEvent.java
@@ -65,7 +65,7 @@ public class CertRequestProcessedEvent extends SignedAuditEvent {
         event.setAttribute("SubjectID", subjectID);
         event.setAttribute("Outcome", ILogger.SUCCESS);
         event.setAttribute("ReqID", requesterID);
-        event.setAttribute("CertSerialNum", x509cert.getSerialNumber());
+        event.setAttribute("CertSerialNum", "0x" + x509cert.getSerialNumber().toString(16));
 
         return event;
     }


### PR DESCRIPTION
Requests and certificate identifiers are now written in hex format in the output and in the log. CA signed audit log was still using the decimal format making difficult to mach the requests. Audit logs are converted to the hex format.