### PR TITLE
Simplify TPS installation config examples

### DIFF
--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -96,6 +96,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_authdb_hostname=ds.example.com \
               -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
               -v
 
       - name: Check TPS audit signing cert

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -98,6 +98,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_authdb_hostname=primaryds.example.com \
               -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
               -v
 
           docker exec primary pki-server cert-find
@@ -185,6 +186,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_authdb_hostname=secondaryds.example.com \
               -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
               -v
 
           docker exec secondary pki-server cert-find

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -178,6 +178,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_authdb_hostname=tpsds.example.com \
               -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
               -D pki_external=True \
               -D pki_external_step_two=False \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
@@ -233,6 +234,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_authdb_hostname=tpsds.example.com \
               -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
               -D pki_external=True \
               -D pki_external_step_two=True \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -208,6 +208,7 @@ jobs:
               -D pki_sslserver_token=internal \
               -D pki_authdb_hostname=ds.example.com \
               -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -181,6 +181,7 @@ jobs:
               -D pki_ds_ldap_port=3389 \
               -D pki_authdb_hostname=tpsds.example.com \
               -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
               -v
 
           docker exec tps pki-server cert-find

--- a/base/server/examples/installation/tps-clone.cfg
+++ b/base/server/examples/installation/tps-clone.cfg
@@ -25,7 +25,6 @@ pki_sslserver_nickname=sslserver
 pki_subsystem_nickname=subsystem
 
 pki_authdb_basedn=dc=pki,dc=example,dc=com
-pki_enable_server_side_keygen=True
 
 pki_clone=True
 pki_clone_replicate_schema=True

--- a/base/server/examples/installation/tps.cfg
+++ b/base/server/examples/installation/tps.cfg
@@ -23,4 +23,3 @@ pki_sslserver_nickname=sslserver
 pki_subsystem_nickname=subsystem
 
 pki_authdb_basedn=dc=pki,dc=example,dc=com
-pki_enable_server_side_keygen=True


### PR DESCRIPTION
The `tps.cfg` and `tps-clone.cfg` have been modified to no longer set `pki_enable_server_side_keygen` to `True` such that it can be used to install a simple TPS system without KRA.

The current TPS tests have been modified to set the parameter using `pkispawn` command line option such that the tests will continue to work with KRA.