### PR TITLE
Update IPA tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,22 +123,10 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker
 
-      - name: Build ipa-runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            BASE_IMAGE=${{ needs.init.outputs.base-image }}
-            COPR_REPO=${{ needs.init.outputs.repo }}
-          tags: ipa-runner
-          target: ipa-runner
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker
-
       - name: Save PKI images
         run: |
           docker images
-          docker save -o pki-images.tar pki-dist pki-runner pki-server pki-ca pki-acme ipa-runner
+          docker save -o pki-images.tar pki-dist pki-runner pki-server pki-ca pki-acme
 
       - name: Store PKI images
         uses: actions/cache@v3

--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve PKI images
+      - name: Retrieve IPA images
         uses: actions/cache@v3
         with:
-          key: pki-images-${{ github.sha }}
-          path: pki-images.tar
+          key: ipa-images-${{ github.sha }}
+          path: ipa-images.tar
 
-      - name: Load PKI images
-        run: docker load --input pki-images.tar
+      - name: Load IPA images
+        run: docker load --input ipa-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve PKI images
+      - name: Retrieve IPA images
         uses: actions/cache@v3
         with:
-          key: pki-images-${{ github.sha }}
-          path: pki-images.tar
+          key: ipa-images-${{ github.sha }}
+          path: ipa-images.tar
 
-      - name: Load PKI images
-        run: docker load --input pki-images.tar
+      - name: Load IPA images
+        run: docker load --input ipa-images.tar
 
       - name: Run IPA container
         run: |

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve PKI images
+      - name: Retrieve IPA images
         uses: actions/cache@v3
         with:
-          key: pki-images-${{ github.sha }}
-          path: pki-images.tar
+          key: ipa-images-${{ github.sha }}
+          path: ipa-images.tar
 
-      - name: Load PKI images
-        run: docker load --input pki-images.tar
+      - name: Load IPA images
+        run: docker load --input ipa-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -9,27 +9,45 @@ jobs:
     secrets: inherit
 
   build:
-    name: Waiting for build
+    name: Building IPA images
     needs: init
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
+      - name: Clone repository
+        uses: actions/checkout@v3
 
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        id: cache-buildx
+        uses: actions/cache@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+          key: buildx-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
+
+      - name: Build ipa-runner image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
+            COPR_REPO=${{ needs.init.outputs.repo }}
+          tags: ipa-runner
+          target: ipa-runner
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker
+
+      - name: Save IPA images
+        run: |
+          docker images
+          docker save -o ipa-images.tar ipa-runner
+
+      - name: Store IPA images
+        uses: actions/cache@v3
+        with:
+          key: ipa-images-${{ github.sha }}
+          path: ipa-images.tar
 
   ipa-basic-test:
     name: Basic IPA


### PR DESCRIPTION
The IPA test workflow has been modified to build `ipa-runner` image separately from the main build workflow. This way the non-IPA test workflows can start the test earlier because they don't need to wait for `ipa-runner` to be built anymore.