### PR TITLE
Fix maven compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/artifacts/
 tests/tests.retry
 base/tools/test/PKICertImport/dbs
 target/
+.flattened-pom.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
           -Dfile=/usr/lib/java/jss.jar \
           -DgroupId=org.dogtagpki \
           -DartifactId=jss \
-          -Dversion=5.3.0-SNAPSHOT \
+          -Dversion=5.4.0-SNAPSHOT \
           -Dpackaging=jar \
           -DgeneratePom=true
     displayName: Install JSS into Maven repo
@@ -90,7 +90,7 @@ jobs:
           -f /root/src \
           -Dfile=/usr/share/java/tomcatjss.jar \
           -DgroupId=org.dogtagpki \
-          -DartifactId=tomcatjss \
+          -DartifactId=tomcatjss-tomcat-9.0 \
           -Dversion=8.3.0-SNAPSHOT \
           -Dpackaging=jar \
           -DgeneratePom=true

--- a/pom.xml
+++ b/pom.xml
@@ -184,12 +184,12 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jss</artifactId>
-            <version>5.3.0-SNAPSHOT</version>
+            <version>5.4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>tomcatjss</artifactId>
+            <artifactId>tomcatjss-tomcat-9.0</artifactId>
             <version>8.3.0-SNAPSHOT</version>
         </dependency>
 
@@ -217,6 +217,31 @@
                 <configuration>
                     <release>17</release>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The commit incluide:
- update JSS version
- modify the tomcatjss dependecy to the correct module
- add flatten plugin to fix the installation phase using the `revision` property

If the dependency are installed (**jss**, **tomcatjss** and **ldap-sdk**) with `mvn install` then `pki` can be compiled with maven.

The only problem is that the test are not correctly configured so for now the compile has been executed with the option `mvn package -Dmaven.test.skip=true`.