### PR TITLE
Remove code in web UI to retrieve Links from requests

### DIFF
--- a/base/ca/shared/webapps/ca/js/cert.js
+++ b/base/ca/shared/webapps/ca/js/cert.js
@@ -40,9 +40,6 @@ var CertificateCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         return new CertificateModel({
             id: entry.id,

--- a/base/ca/shared/webapps/ca/js/certrequest.js
+++ b/base/ca/shared/webapps/ca/js/certrequest.js
@@ -40,9 +40,6 @@ var CertRequestCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         var url = entry.requestURL;
         var i = url.lastIndexOf('/');

--- a/base/ca/shared/webapps/ca/js/profile.js
+++ b/base/ca/shared/webapps/ca/js/profile.js
@@ -42,9 +42,6 @@ var ProfileCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         return new ProfileModel({
             id: entry.profileId,

--- a/base/kra/shared/webapps/kra/js/key.js
+++ b/base/kra/shared/webapps/kra/js/key.js
@@ -39,9 +39,6 @@ var KeyCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         var i = entry.keyURL.lastIndexOf('/');
         var id = entry.keyURL.substring(i + 1);

--- a/base/kra/shared/webapps/kra/js/keyrequest.js
+++ b/base/kra/shared/webapps/kra/js/keyrequest.js
@@ -40,9 +40,6 @@ var KeyRequestCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         var requestURL = entry.requestURL;
         var i = requestURL.lastIndexOf('/');

--- a/base/server/share/webapps/pki/js/pki-group.js
+++ b/base/server/share/webapps/pki/js/pki-group.js
@@ -57,9 +57,6 @@ var GroupCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         var self = this;
         return new GroupModel({
@@ -104,9 +101,6 @@ var GroupMemberCollection = Collection.extend({
     },
     getEntries: function(response) {
         return response.Member;
-    },
-    getLinks: function(response) {
-        return response.Link;
     },
     model: function(attrs, options) {
         var self = this;

--- a/base/server/share/webapps/pki/js/pki-user.js
+++ b/base/server/share/webapps/pki/js/pki-user.js
@@ -84,9 +84,6 @@ var UserCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         var self = this;
         return new UserModel({
@@ -145,9 +142,6 @@ var UserRoleCollection = Collection.extend({
     },
     getEntries: function(response) {
         return response.Membership;
-    },
-    getLinks: function(response) {
-        return response.Link;
     },
     model: function(attrs, options) {
         var self = this;
@@ -219,9 +213,6 @@ var UserCertCollection = Collection.extend({
     },
     getEntries: function(response) {
         return response.Cert;
-    },
-    getLinks: function(response) {
-        return response.Link;
     },
     model: function(attrs, options) {
         var self = this;

--- a/base/server/share/webapps/pki/js/pki.js
+++ b/base/server/share/webapps/pki/js/pki.js
@@ -132,7 +132,6 @@ var Collection = Backbone.Collection.extend({
         self.urlRoot = options.urlRoot || self.urlRoot;
 
         self.options = options;
-        self.links = {};
         self.query({});
     },
     url: function() {
@@ -143,11 +142,6 @@ var Collection = Backbone.Collection.extend({
 
         // get total entries
         self.total = self.getTotal(response);
-
-        // parse links
-        var links = self.getLinks(response);
-        links = links == undefined ? [] : [].concat(links);
-        self.parseLinks(links);
 
         // convert entries into models
         var models = [];
@@ -167,28 +161,8 @@ var Collection = Backbone.Collection.extend({
     getEntries: function(response) {
         return null;
     },
-    getLinks: function(response) {
-        return null;
-    },
     parseEntry: function(entry) {
         return null;
-    },
-    parseLinks: function(links) {
-        var self = this;
-        self.links = {};
-        _(links).each(function(link) {
-            var name = link.rel;
-            var href = link.href;
-            self.links[name] = href;
-        });
-    },
-    link: function(name) {
-        return this.links[name];
-    },
-    go: function(name) {
-        var self = this;
-        if (self.links[name] == undefined) return;
-        self.currentURL = self.links[name];
     },
     query: function(params) {
         var self = this;

--- a/base/tps/shared/webapps/tps/js/activity.js
+++ b/base/tps/shared/webapps/tps/js/activity.js
@@ -52,9 +52,6 @@ var ActivityCollection = Collection.extend({
     getEntries: function(response) {
         return response.entries;
     },
-    getLinks: function(response) {
-        return response.Link;
-    },
     parseEntry: function(entry) {
         return new ActivityModel({
             id: entry.id,


### PR DESCRIPTION
Some time ago we removed the Link objects from server-side classes. Therefore, there is nothing to retrieve so these redundant methods can also be removed.