### PR TITLE
Publish to GitHub Maven registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,49 @@ jobs:
     secrets: inherit
     if: vars.REGISTRY != ''
 
-  build:
-    name: Waiting for build
+  publish-maven:
+    name: Publishing Maven artifacts
     needs: init
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for build
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Check settings.xml
+        run: |
+          cat ~/.m2/settings.xml
+
+      - name: Update pom.xml
+        run: |
+          sed -i \
+              -e "s/OWNER/$NAMESPACE/g" \
+              -e "s/REPOSITORY/pki/g" \
+              pom.xml
+          cat pom.xml
+
+      - name: Publish Maven artifacts
+        run: |
+          # TODO: Fix test issue due to missing JSS shared libraries.
+          mvn \
+              --batch-mode \
+              --update-snapshots \
+              -DskipTests \
+              deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  wait-for-images:
+    name: Waiting for container images
+    needs: init
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for container images
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
           ref: ${{ github.ref }}
@@ -28,9 +65,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
 
-  publish:
-    name: Publishing PKI
-    needs: [init, build]
+  publish-images:
+    name: Publishing container images
+    needs: [init, wait-for-images]
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Container Registry

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,8 +77,8 @@ jobs:
           mvn install:install-file \
           -f /root/src \
           -Dfile=/usr/lib/java/jss.jar \
-          -DgroupId=org.dogtagpki \
-          -DartifactId=jss \
+          -DgroupId=org.dogtagpki.jss \
+          -DartifactId=jss-base \
           -Dversion=5.4.0-SNAPSHOT \
           -Dpackaging=jar \
           -DgeneratePom=true
@@ -89,9 +89,9 @@ jobs:
           mvn install:install-file \
           -f /root/src \
           -Dfile=/usr/share/java/tomcatjss.jar \
-          -DgroupId=org.dogtagpki \
+          -DgroupId=org.dogtagpki.tomcatjss \
           -DartifactId=tomcatjss-tomcat-9.0 \
-          -Dversion=8.3.0-SNAPSHOT \
+          -Dversion=8.4.0-SNAPSHOT \
           -Dpackaging=jar \
           -DgeneratePom=true
     displayName: Install Tomcat JSS into Maven repo
@@ -101,9 +101,9 @@ jobs:
           mvn install:install-file \
           -f /root/src \
           -Dfile=/usr/share/java/ldapjdk.jar \
-          -DgroupId=org.dogtagpki \
+          -DgroupId=org.dogtagpki.ldap-sdk \
           -DartifactId=ldapjdk \
-          -Dversion=5.3.0-SNAPSHOT \
+          -Dversion=5.4.0-SNAPSHOT \
           -Dpackaging=jar \
           -DgeneratePom=true
     displayName: Install LDAP JDK into Maven repo

--- a/base/acme/pom.xml
+++ b/base/acme/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/ca/pom.xml
+++ b/base/ca/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/common/pom.xml
+++ b/base/common/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/kra/pom.xml
+++ b/base/kra/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/ocsp/pom.xml
+++ b/base/ocsp/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -6,12 +6,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-parent</artifactId>
         <version>${revision}</version>
     </parent>
 
-    <artifactId>pki-base</artifactId>
+    <artifactId>pki-base-parent</artifactId>
     <packaging>pom</packaging>
 
     <modules>

--- a/base/server/pom.xml
+++ b/base/server/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/tks/pom.xml
+++ b/base/tks/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/tomcat-9.0/pom.xml
+++ b/base/tomcat-9.0/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/tomcat/pom.xml
+++ b/base/tomcat/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/tools/pom.xml
+++ b/base/tools/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/base/tps/pom.xml
+++ b/base/tps/pom.xml
@@ -6,8 +6,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.dogtagpki</groupId>
-        <artifactId>pki-base</artifactId>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dogtagpki</groupId>
-    <artifactId>pki</artifactId>
+    <groupId>org.dogtagpki.pki</groupId>
+    <artifactId>pki-parent</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
 
     <properties>
         <revision>11.4.0-SNAPSHOT</revision>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>
@@ -182,21 +183,21 @@
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>jss</artifactId>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
             <version>5.4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>org.dogtagpki.tomcatjss</groupId>
             <artifactId>tomcatjss-tomcat-9.0</artifactId>
-            <version>8.3.0-SNAPSHOT</version>
+            <version>8.4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>org.dogtagpki.ldap-sdk</groupId>
             <artifactId>ldapjdk</artifactId>
-            <version>5.3.0-SNAPSHOT</version>
+            <version>5.4.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -245,5 +246,23 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/OWNER/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/OWNER/REPOSITORY</url>
+        </repository>
+    </distributionManagement>
 
 </project>


### PR DESCRIPTION
A new job has been added to build PKI with Maven and publish the artifacts to GitHub Maven registry. Currently the tests have to be disabled due to missing JSS shared libraries. The group ID and artifact ID have been renamed to follow a more commonly used pattern.

Once it's merged, the packages will look like the following:
https://github.com/edewata?tab=packages&repo_name=pki
