### PR TITLE
Add pki_ds_url param

### DIFF
--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -56,8 +56,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/acme-postgresql-test.yml
+++ b/.github/workflows/acme-postgresql-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -56,8 +56,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -78,8 +78,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -164,8 +163,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -245,8 +243,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca-clone-of-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=tertiaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -106,8 +106,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-secure-ds-primary.cfg \
               -s CA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldaps_port=3636 \
+              -D pki_ds_url=ldaps://primaryds.example.com:3636 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -219,8 +218,7 @@ jobs:
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldaps_port=3636 \
+              -D pki_ds_url=ldaps://secondaryds.example.com:3636 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -273,8 +271,7 @@ jobs:
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldaps_port=3636 \
+              -D pki_ds_url=ldaps://secondaryds.example.com:3636 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -106,8 +105,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -158,8 +156,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=tertiaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -60,8 +60,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-ecc.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -D pki_enable_access_log=False \

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -233,8 +233,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -D pki_external=True \
@@ -244,8 +243,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -D pki_external=True \

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -221,8 +221,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_ds_setup=False \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \

--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -346,8 +346,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -D pki_existing=True \

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -247,8 +247,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -D pki_existing=True \

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -75,8 +75,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/ca-lightweight-hsm-test.yml
+++ b/.github/workflows/ca-lightweight-hsm-test.yml
@@ -73,8 +73,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/ca-lightweight-test.yml
+++ b/.github/workflows/ca-lightweight-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-non-default-user-test.yml
+++ b/.github/workflows/ca-non-default-user-test.yml
@@ -64,8 +64,7 @@ jobs:
               -s CA \
               -D pki_user=pki \
               -D pki_group=pki \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -67,8 +67,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-nuxwdog-test.yml
+++ b/.github/workflows/ca-nuxwdog-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-pruning-test.yml
+++ b/.github/workflows/ca-pruning-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_request_id_generator=random \
               -D pki_cert_id_generator=random \
               -v

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -60,8 +60,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -60,8 +60,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_use_pss_rsa_signing_algorithm=True \
               -D pki_ca_signing_key_algorithm=SHA512withRSA/PSS \
               -D pki_ca_signing_signing_algorithm=SHA512withRSA/PSS \

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_random_serial_numbers_enable=True \
               -v
 

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -105,8 +105,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-secure-ds.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldaps_port=3636 \
+              -D pki_ds_url=ldaps://ds.example.com:3636 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=legacy \
               -D pki_request_id_generator=legacy \
               -v

--- a/.github/workflows/ca-shared-token-test.yml
+++ b/.github/workflows/ca-shared-token-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
       - name: Install CA admin cert

--- a/.github/workflows/est-basic-test.yml
+++ b/.github/workflows/est-basic-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
           docker exec pki pki-server cert-find
 

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -68,8 +67,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -68,8 +67,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -106,8 +104,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -123,8 +120,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -170,8 +166,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=tertiaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -187,8 +182,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=tertiaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -97,8 +96,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra-external-certs-step1.cfg \
               -s KRA \
               -D pki_cert_chain_path=$SHARED/ca_signing.crt \
-              -D pki_ds_hostname=krads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://krads.example.com:3389 \
               -D pki_storage_csr_path=$SHARED/kra_storage.csr \
               -D pki_transport_csr_path=$SHARED/kra_transport.csr \
               -D pki_subsystem_csr_path=$SHARED/subsystem.csr \
@@ -268,8 +266,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra-external-certs-step2.cfg \
               -s KRA \
               -D pki_cert_chain_path=$SHARED/ca_signing.crt \
-              -D pki_ds_hostname=krads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://krads.example.com:3389 \
               -D pki_storage_csr_path=$SHARED/kra_storage.csr \
               -D pki_transport_csr_path=$SHARED/kra_transport.csr \
               -D pki_subsystem_csr_path=$SHARED/subsystem.csr \

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -97,8 +96,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra-external-certs-step1.cfg \
               -s KRA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=krads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://krads.example.com:3389 \
               -D pki_storage_csr_path=${SHARED}/kra_storage.csr \
               -D pki_transport_csr_path=${SHARED}/kra_transport.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
@@ -175,8 +173,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra-external-certs-step2.cfg \
               -s KRA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=krads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://krads.example.com:3389 \
               -D pki_storage_csr_path=${SHARED}/kra_storage.csr \
               -D pki_transport_csr_path=${SHARED}/kra_transport.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -75,8 +75,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -117,8 +116,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/kra-oaep-test.yml
+++ b/.github/workflows/kra-oaep-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_request_id_generator=random \
               -v
 
@@ -71,8 +70,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_request_id_generator=random \
               -v
 
@@ -90,8 +88,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_use_oaep_rsa_keywrap=True \
               -D pki_request_id_generator=random \
               -v
@@ -107,8 +104,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_use_oaep_rsa_keywrap=True \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -97,8 +96,7 @@ jobs:
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
-              -D pki_ds_hostname=krads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://krads.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/kra-sequential-test.yml
+++ b/.github/workflows/kra-sequential-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=legacy \
               -D pki_request_id_generator=legacy \
               -v
@@ -67,8 +66,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_key_id_generator=legacy \
               -D pki_request_id_generator=legacy \
               -v

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -69,8 +69,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra-standalone-step1.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -140,8 +139,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra-standalone-step2.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -68,8 +67,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ocsp.cfg \
               -s OCSP \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
       - name: Check OCSP signing cert

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -68,8 +67,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ocsp.cfg \
               -s OCSP \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
           docker exec primary pki-server cert-find
@@ -104,8 +102,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -121,8 +118,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ocsp-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
           docker exec secondary pki-server cert-find
@@ -166,8 +162,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=tertiaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -183,8 +178,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ocsp-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=tertiaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 
           docker exec tertiary pki-server cert-find

--- a/.github/workflows/ocsp-cmc-test.yml
+++ b/.github/workflows/ocsp-cmc-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -97,8 +96,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp-external-certs-step1.cfg \
               -s OCSP \
               -D pki_cert_chain_path=$SHARED/ca_signing.crt \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -D pki_ocsp_signing_csr_path=$SHARED/ocsp_signing.csr \
               -D pki_subsystem_csr_path=$SHARED/subsystem.csr \
               -D pki_sslserver_csr_path=$SHARED/sslserver.csr \
@@ -241,8 +239,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp-external-certs-step2.cfg \
               -s OCSP \
               -D pki_cert_chain_path=$SHARED/ca_signing.crt \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -D pki_ocsp_signing_csr_path=$SHARED/ocsp_signing.csr \
               -D pki_subsystem_csr_path=$SHARED/subsystem.csr \
               -D pki_sslserver_csr_path=$SHARED/sslserver.csr \

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -61,8 +61,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -101,8 +100,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp-standalone-step1.cfg \
               -s OCSP \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -D pki_ocsp_signing_csr_path=${SHARED}/ocsp_signing.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
@@ -166,8 +164,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp-standalone-step2.cfg \
               -s OCSP \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -D pki_ocsp_signing_csr_path=${SHARED}/ocsp_signing.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -62,8 +62,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -102,8 +101,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp-standalone-step1.cfg \
               -s OCSP \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -D pki_ocsp_signing_csr_path=${SHARED}/ocsp_signing.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
@@ -167,8 +165,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp-standalone-step2.cfg \
               -s OCSP \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -D pki_ocsp_signing_csr_path=${SHARED}/ocsp_signing.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -97,8 +96,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp-external-certs-step1.cfg \
               -s OCSP \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -D pki_ocsp_signing_csr_path=${SHARED}/ocsp_signing.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
@@ -162,8 +160,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp-external-certs-step2.cfg \
               -s OCSP \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -D pki_ocsp_signing_csr_path=${SHARED}/ocsp_signing.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \

--- a/.github/workflows/ocsp-hsm-test.yml
+++ b/.github/workflows/ocsp-hsm-test.yml
@@ -75,8 +75,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -117,8 +116,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ocsp.cfg \
               -s OCSP \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -96,8 +95,7 @@ jobs:
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
-              -D pki_ds_hostname=ocspds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ocspds.example.com:3389 \
               -v
 
           docker exec ocsp pki-server cert-find

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -70,8 +70,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ocsp-standalone-step1.cfg \
               -s OCSP \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
       - name: Issue OCSP signing cert
@@ -129,8 +128,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ocsp-standalone-step2.cfg \
               -s OCSP \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
           docker exec pki pki-server cert-find

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/server-backup-test.yml
+++ b/.github/workflows/server-backup-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec root pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=rootds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://rootds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -93,8 +92,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/subca.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/root-ca_signing.crt \
-              -D pki_ds_hostname=subds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://subds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec root pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=rootds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://rootds.example.com:3389 \
               -D pki_security_domain_name=ROOT \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
@@ -112,8 +111,7 @@ jobs:
           docker exec subordinate pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg \
               -s CA \
-              -D pki_ds_hostname=subds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://subds.example.com:3389 \
               -D pki_ca_signing_csr_path=$SHARED/ca_signing.csr \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
@@ -148,8 +146,7 @@ jobs:
           docker exec subordinate pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-external-cert-step2.cfg \
               -s CA \
-              -D pki_ds_hostname=subds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://subds.example.com:3389 \
               -D pki_cert_chain_path=$SHARED/root-ca_signing.crt \
               -D pki_ca_signing_csr_path=$SHARED/ca_signing.csr \
               -D pki_ca_signing_cert_path=$SHARED/ca_signing.p7b \

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -71,8 +71,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_req_ski=AEB2FA7A07115A0AB994FF9B5BDA8E75D536BC77 \
               -D pki_req_ext_add=True \
               -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
@@ -97,8 +96,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-external-cert-step2.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_req_ski=AEB2FA7A07115A0AB994FF9B5BDA8E75D536BC77 \
               -D pki_req_ext_add=True \
               -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \

--- a/.github/workflows/subca-hsm-test.yml
+++ b/.github/workflows/subca-hsm-test.yml
@@ -96,8 +96,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -123,8 +122,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-external-cert-step2.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -68,8 +67,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
       - name: Check TKS audit signing cert

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -57,8 +57,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -70,8 +69,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
           docker exec primary pki-server cert-find
@@ -106,8 +104,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -123,8 +120,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/tks-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
           docker exec secondary pki-server cert-find
@@ -168,8 +164,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=tertiaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -185,8 +180,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/tks-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=tertiaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 
           docker exec tertiary pki-server cert-find

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -98,8 +97,7 @@ jobs:
               -D pki_security_domain_hostname=ca.example.com \
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=tksds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tksds.example.com:3389 \
               -D pki_external=True \
               -D pki_external_step_two=False \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
@@ -156,8 +154,7 @@ jobs:
               -D pki_security_domain_hostname=ca.example.com \
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
-              -D pki_ds_hostname=tksds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tksds.example.com:3389 \
               -D pki_external=True \
               -D pki_external_step_two=True \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \

--- a/.github/workflows/tks-hsm-test.yml
+++ b/.github/workflows/tks-hsm-test.yml
@@ -75,8 +75,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -117,8 +116,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -96,8 +95,7 @@ jobs:
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
-              -D pki_ds_hostname=tksds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tksds.example.com:3389 \
               -v
 
           docker exec tks pki-server cert-find

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -55,8 +55,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -68,8 +67,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -81,8 +79,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
           docker exec pki pki-server cert-find
@@ -92,8 +89,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/tps.cfg \
               -s TPS \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_authdb_hostname=ds.example.com \
               -D pki_authdb_port=3389 \
               -D pki_enable_server_side_keygen=True \

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -57,8 +57,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -70,8 +69,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -83,8 +81,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
           docker exec primary pki-server cert-find
@@ -94,8 +91,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/tps.cfg \
               -s TPS \
-              -D pki_ds_hostname=primaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_authdb_hostname=primaryds.example.com \
               -D pki_authdb_port=3389 \
               -D pki_enable_server_side_keygen=True \
@@ -133,8 +129,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -150,8 +145,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -167,8 +161,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/tks-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
           docker exec secondary pki-server cert-find
@@ -182,8 +175,7 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/tps-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
-              -D pki_ds_hostname=secondaryds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_authdb_hostname=secondaryds.example.com \
               -D pki_authdb_port=3389 \
               -D pki_enable_server_side_keygen=True \

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -100,8 +99,7 @@ jobs:
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
-              -D pki_ds_hostname=krads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://krads.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -137,8 +135,7 @@ jobs:
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
-              -D pki_ds_hostname=tksds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tksds.example.com:3389 \
               -v
 
           docker exec tks pki-server cert-find
@@ -174,8 +171,7 @@ jobs:
               -D pki_ca_uri=https://ca.example.com:8443 \
               -D pki_kra_uri=https://kra.example.com:8443 \
               -D pki_tks_uri=https://tks.example.com:8443 \
-              -D pki_ds_hostname=tpsds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tpsds.example.com:3389 \
               -D pki_authdb_hostname=tpsds.example.com \
               -D pki_authdb_port=3389 \
               -D pki_enable_server_side_keygen=True \
@@ -230,8 +226,7 @@ jobs:
               -D pki_ca_uri=https://ca.example.com:8443 \
               -D pki_kra_uri=https://kra.example.com:8443 \
               -D pki_tks_uri=https://tks.example.com:8443 \
-              -D pki_ds_hostname=tpsds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tpsds.example.com:3389 \
               -D pki_authdb_hostname=tpsds.example.com \
               -D pki_authdb_port=3389 \
               -D pki_enable_server_side_keygen=True \

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -75,8 +75,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -117,8 +116,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -159,8 +157,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
@@ -197,8 +194,7 @@ jobs:
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/tps.cfg \
               -s TPS \
-              -D pki_ds_hostname=ds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -54,8 +54,7 @@ jobs:
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
-              -D pki_ds_hostname=cads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -96,8 +95,7 @@ jobs:
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
-              -D pki_ds_hostname=krads.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://krads.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -136,8 +134,7 @@ jobs:
               -D pki_cert_chain_nickname=ca_signing \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
-              -D pki_ds_hostname=tksds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tksds.example.com:3389 \
               -v
 
           docker exec tks pki-server cert-find
@@ -177,8 +174,7 @@ jobs:
               -D pki_ca_uri=https://ca.example.com:8443 \
               -D pki_kra_uri=https://kra.example.com:8443 \
               -D pki_tks_uri=https://tks.example.com:8443 \
-              -D pki_ds_hostname=tpsds.example.com \
-              -D pki_ds_ldap_port=3389 \
+              -D pki_ds_url=ldap://tpsds.example.com:3389 \
               -D pki_authdb_hostname=tpsds.example.com \
               -D pki_authdb_port=3389 \
               -D pki_enable_server_side_keygen=True \

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -303,8 +303,7 @@ echo "INFO: Creating PKI CA"
 pkispawn \
     -f /usr/share/pki/server/examples/installation/ca.cfg \
     -s CA \
-    -D pki_ds_hostname=ds.example.com \
-    -D pki_ds_ldap_port=3389 \
+    -D pki_ds_url=ldap://ds.example.com:3389 \
     -D pki_ds_setup=False \
     -D pki_share_db=True \
     -D pki_request_id_generator=random \

--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -755,9 +755,9 @@ internaldb.ldapauth.authtype=BasicAuth
 internaldb.ldapauth.bindDN=cn=Directory Manager
 internaldb.ldapauth.bindPWPrompt=internaldb
 internaldb.ldapauth.clientCertNickname=
-internaldb.ldapconn.host=
-internaldb.ldapconn.port=
-internaldb.ldapconn.secureConn=[pki_ds_secure_connection]
+internaldb.ldapconn.host=localhost
+internaldb.ldapconn.port=389
+internaldb.ldapconn.secureConn=false
 internaldb.multipleSuffix.enable=false
 jobsScheduler._000=##
 jobsScheduler._001=## jobScheduler

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -155,9 +155,9 @@ internaldb.ldapauth.authtype=BasicAuth
 internaldb.ldapauth.bindDN=cn=Directory Manager
 internaldb.ldapauth.bindPWPrompt=internaldb
 internaldb.ldapauth.clientCertNickname=
-internaldb.ldapconn.host=
-internaldb.ldapconn.port=
-internaldb.ldapconn.secureConn=[pki_ds_secure_connection]
+internaldb.ldapconn.host=localhost
+internaldb.ldapconn.port=389
+internaldb.ldapconn.secureConn=false
 internaldb.multipleSuffix.enable=false
 jobsScheduler._000=##
 jobsScheduler._001=## jobScheduler

--- a/base/ocsp/shared/conf/CS.cfg
+++ b/base/ocsp/shared/conf/CS.cfg
@@ -128,9 +128,9 @@ internaldb.ldapauth.authtype=BasicAuth
 internaldb.ldapauth.bindDN=cn=Directory Manager
 internaldb.ldapauth.bindPWPrompt=internaldb
 internaldb.ldapauth.clientCertNickname=
-internaldb.ldapconn.host=
-internaldb.ldapconn.port=
-internaldb.ldapconn.secureConn=[pki_ds_secure_connection]
+internaldb.ldapconn.host=localhost
+internaldb.ldapconn.port=389
+internaldb.ldapconn.secureConn=false
 internaldb.multipleSuffix.enable=false
 jss._000=##
 jss._001=## JSS

--- a/base/server/examples/installation/ca-secure-ds-primary.cfg
+++ b/base/server/examples/installation/ca-secure-ds-primary.cfg
@@ -10,9 +10,7 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_hostname=primary.example.com
-pki_ds_ldaps_port=636
-pki_ds_secure_connection=True
+pki_ds_url=ldaps://primary.example.com:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 

--- a/base/server/examples/installation/ca-secure-ds-secondary.cfg
+++ b/base/server/examples/installation/ca-secure-ds-secondary.cfg
@@ -11,9 +11,7 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_hostname=secondary.example.com
-pki_ds_ldaps_port=636
-pki_ds_secure_connection=True
+pki_ds_url=ldaps://secondary.example.com:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 

--- a/base/server/examples/installation/ca-secure-ds.cfg
+++ b/base/server/examples/installation/ca-secure-ds.cfg
@@ -10,9 +10,7 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_hostname=pki.example.com
-pki_ds_ldaps_port=636
-pki_ds_secure_connection=True
+pki_ds_url=ldaps://pki.example.com:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -398,6 +398,7 @@ class ConfigurationFile:
     """PKI Deployment Configuration File Class"""
 
     def __init__(self, deployer):
+        self.deployer = deployer
         self.mdict = deployer.mdict
         # set useful 'boolean' object variables for this class
         self.clone = config.str2bool(self.mdict['pki_clone'])
@@ -699,8 +700,9 @@ class ConfigurationFile:
         return
 
     def verify_ds_secure_connection_data(self):
+
         # Check to see if a secure connection is being used for the DS
-        if config.str2bool(self.mdict['pki_ds_secure_connection']):
+        if self.deployer.ds_url.scheme == 'ldaps':
             # Verify existence of a local PEM file containing a
             # directory server CA certificate
             self.confirm_file_exists("pki_ds_secure_connection_ca_pem_file")

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -95,7 +95,15 @@ class PKIConfigParser:
 
     DEPRECATED_CA_PARAMS = [
         (['CA'], 'pki_external_csr_path',
-         None, 'pki_ca_signing_csr_path')
+         None, 'pki_ca_signing_csr_path'),
+        (['CA'], 'pki_ds_hostname',
+         None, 'pki_ds_url'),
+        (['CA'], 'pki_ds_ldap_port',
+         None, 'pki_ds_url'),
+        (['CA'], 'pki_ds_ldaps_port',
+         None, 'pki_ds_url'),
+        (['CA'], 'pki_ds_secure_connection',
+         None, 'pki_ds_url'),
     ]
 
     DEPRECATED_KRA_PARAMS = [
@@ -123,6 +131,14 @@ class PKIConfigParser:
          None, 'pki_subsystem_cert_path'),
         (['KRA'], 'pki_external_transport_cert_path',
          None, 'pki_transport_cert_path'),
+        (['KRA'], 'pki_ds_hostname',
+         None, 'pki_ds_url'),
+        (['KRA'], 'pki_ds_ldap_port',
+         None, 'pki_ds_url'),
+        (['KRA'], 'pki_ds_ldaps_port',
+         None, 'pki_ds_url'),
+        (['KRA'], 'pki_ds_secure_connection',
+         None, 'pki_ds_url'),
     ]
 
     DEPRECATED_OCSP_PARAMS = [
@@ -145,13 +161,45 @@ class PKIConfigParser:
         (['OCSP'], 'pki_external_sslserver_cert_path',
          None, 'pki_sslserver_cert_path'),
         (['OCSP'], 'pki_external_subsystem_cert_path',
-         None, 'pki_subsystem_cert_path')
+         None, 'pki_subsystem_cert_path'),
+        (['OCSP'], 'pki_ds_hostname',
+         None, 'pki_ds_url'),
+        (['OCSP'], 'pki_ds_ldap_port',
+         None, 'pki_ds_url'),
+        (['OCSP'], 'pki_ds_ldaps_port',
+         None, 'pki_ds_url'),
+        (['OCSP'], 'pki_ds_secure_connection',
+         None, 'pki_ds_url'),
+    ]
+
+    DEPRECATED_TKS_PARAMS = [
+        (['TKS'], 'pki_ds_hostname',
+         None, 'pki_ds_url'),
+        (['TKS'], 'pki_ds_ldap_port',
+         None, 'pki_ds_url'),
+        (['TKS'], 'pki_ds_ldaps_port',
+         None, 'pki_ds_url'),
+        (['TKS'], 'pki_ds_secure_connection',
+         None, 'pki_ds_url'),
+    ]
+
+    DEPRECATED_TPS_PARAMS = [
+        (['TPS'], 'pki_ds_hostname',
+         None, 'pki_ds_url'),
+        (['TPS'], 'pki_ds_ldap_port',
+         None, 'pki_ds_url'),
+        (['TPS'], 'pki_ds_ldaps_port',
+         None, 'pki_ds_url'),
+        (['TPS'], 'pki_ds_secure_connection',
+         None, 'pki_ds_url'),
     ]
 
     DEPRECATED_PARAMS = DEPRECATED_DEFAULT_PARAMS + \
         DEPRECATED_CA_PARAMS + \
         DEPRECATED_KRA_PARAMS + \
-        DEPRECATED_OCSP_PARAMS
+        DEPRECATED_OCSP_PARAMS + \
+        DEPRECATED_TKS_PARAMS + \
+        DEPRECATED_TPS_PARAMS
 
     def __init__(self, description, epilog, deployer=None):
         self.deployer = deployer
@@ -611,9 +659,6 @@ class PKIConfigParser:
             if 'pki_subordinate' not in self.mdict or\
                not len(self.mdict['pki_subordinate']):
                 self.mdict['pki_subordinate'] = "false"
-
-            self.mdict['pki_ds_secure_connection'] = \
-                self.mdict['pki_ds_secure_connection'].lower()
 
             self.mdict['pki_standalone'] = self.mdict['pki_standalone'].lower()
 

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -227,7 +227,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if len(deployer.tomcat_instance_subsystems()) < 2:
 
             # Check to see if a secure connection is being used for the DS
-            if config.str2bool(deployer.mdict['pki_ds_secure_connection']):
+            if deployer.ds_url.scheme == 'ldaps':
                 # Check to see if a directory server CA certificate
                 # using the same nickname already exists
                 #

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -742,7 +742,7 @@ def check_ds():
                 sys.exit(1)
 
     except ldap.LDAPError:
-        logger.error('Unable to access LDAP server: %s', deployer.ds_url)
+        logger.error('Unable to access LDAP server: %s', deployer.ds_url.geturl())
         raise
 
 

--- a/base/tks/shared/conf/CS.cfg
+++ b/base/tks/shared/conf/CS.cfg
@@ -120,9 +120,9 @@ internaldb.ldapauth.authtype=BasicAuth
 internaldb.ldapauth.bindDN=cn=Directory Manager
 internaldb.ldapauth.bindPWPrompt=internaldb
 internaldb.ldapauth.clientCertNickname=
-internaldb.ldapconn.host=
-internaldb.ldapconn.port=
-internaldb.ldapconn.secureConn=[pki_ds_secure_connection]
+internaldb.ldapconn.host=localhost
+internaldb.ldapconn.port=389
+internaldb.ldapconn.secureConn=false
 internaldb.multipleSuffix.enable=false
 jss._000=##
 jss._001=## JSS

--- a/base/tps/shared/conf/CS.cfg
+++ b/base/tps/shared/conf/CS.cfg
@@ -188,9 +188,9 @@ internaldb.ldapauth.authtype=BasicAuth
 internaldb.ldapauth.bindDN=cn=Directory Manager
 internaldb.ldapauth.bindPWPrompt=internaldb
 internaldb.ldapauth.clientCertNickname=
-internaldb.ldapconn.host=
-internaldb.ldapconn.port=
-internaldb.ldapconn.secureConn=[pki_ds_secure_connection]
+internaldb.ldapconn.host=localhost
+internaldb.ldapconn.port=389
+internaldb.ldapconn.secureConn=false
 internaldb.maxConns=15
 internaldb.minConns=3
 internaldb.multipleSuffix.enable=false

--- a/docs/changes/v11.5.0/Server-Changes.adoc
+++ b/docs/changes/v11.5.0/Server-Changes.adoc
@@ -1,0 +1,10 @@
+= Server Changes =
+
+== Add pki_ds_url parameter ==
+
+A new `pki_ds_url` parameter has been added for `pkispawn` to replace the following parameters:
+
+* `pki_ds_hostname`
+* `pki_ds_ldap_port`
+* `pki_ds_ldaps_port`
+* `pki_ds_secure_connection`

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
@@ -29,8 +29,7 @@ pki_admin_uid=kraadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_ldaps_port=636
-pki_ds_secure_connection=True
+pki_ds_url=ldaps://localhost:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
@@ -29,8 +29,7 @@ pki_admin_uid=ocspadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_ldaps_port=636
-pki_ds_secure_connection=True
+pki_ds_url=ldaps://localhost:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
@@ -29,8 +29,7 @@ pki_admin_uid=tksadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_ldaps_port=636
-pki_ds_secure_connection=True
+pki_ds_url=ldaps://localhost:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
@@ -29,8 +29,7 @@ pki_admin_uid=tpsadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_ldaps_port=636
-pki_ds_secure_connection=True
+pki_ds_url=ldaps://localhost:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 

--- a/docs/manuals/man5/pki_default.cfg.5.md
+++ b/docs/manuals/man5/pki_default.cfg.5.md
@@ -253,8 +253,15 @@ Defaults to True.
 
 ### INTERNAL DATABASE PARAMETERS
 
+**pki_ds_url**  
+URL for the internal database.
+For plain LDAP connection use **ldap://&lt;hostname&gt;:&lt;port&gt;**.
+For secure LDAP connection use **ldaps://&lt;hostname&gt;:&lt;port&gt;**.
+Defaults to ldap://localhost:389.
+
 **pki_ds_hostname**, **pki_ds_ldap_port**, **pki_ds_ldaps_port**  
 Hostname and ports for the internal database.  Defaults to localhost, 389, and 636, respectively.
+**NOTE** Deprecated in favor of **pki_ds_url**.
 
 **pki_ds_bind_dn**, **pki_ds_password**  
 Credentials to connect to the database during installation.
@@ -267,6 +274,7 @@ See the documentation for details.
 Sets whether to require connections to the Directory Server using LDAPS.
 This requires SSL to be set up on the Directory Server first.
 Defaults to false.
+**NOTE** Deprecated in favor of **pki_ds_url**.
 
 **pki_ds_secure_connection_ca_nickname**  
 Once a Directory Server CA certificate has been imported into the PKI security databases (see **pki_ds_secure_connection_ca_pem_file**),

--- a/docs/manuals/man8/pkispawn.8.md
+++ b/docs/manuals/man8/pkispawn.8.md
@@ -1324,7 +1324,7 @@ Once the self-signed CA certificate is obtained, add the following parameters
 into the [DEFAULT] section in **myconfig.txt**:
 
 ```
-pki_ds_secure_connection=True
+pki_ds_url=ldaps://localhost:636
 pki_ds_secure_connection_ca_pem_file=$HOME/dscacert.pem
 ```
 


### PR DESCRIPTION
A new `pki_ds_url param` has been added for `pkispawn` to reduce the number of installation params.

https://github.com/edewata/pki/blob/install/docs/changes/v11.5.0/Server-Changes.adoc
https://github.com/edewata/pki/blob/install/docs/manuals/man5/pki_default.cfg.5.md
