### PR TITLE
Drop use of xmvn-resolve in base/CMakeLists.txt

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -157,7 +157,9 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-if(DISTRO STREQUAL "centos" OR DISTRO STREQUAL "fedora" OR DISTRO STREQUAL "rhel")
+find_program(XMVN_RESOLVE /bin/xmvn-resolve)
+
+if(XMVN_RESOLVE)
     execute_process(
         COMMAND xmvn-resolve jakarta.xml.bind:jakarta.xml.bind-api:4
         OUTPUT_VARIABLE JAXB_API_JAR
@@ -170,9 +172,9 @@ else()
         PATHS
             /usr/share/java
     )
-endif(DISTRO STREQUAL "centos" OR DISTRO STREQUAL "fedora" OR DISTRO STREQUAL "rhel")
+endif(XMVN_RESOLVE)
 
-if(DISTRO STREQUAL "centos" OR DISTRO STREQUAL "fedora" OR DISTRO STREQUAL "rhel")
+if(XMVN_RESOLVE)
     execute_process(
         COMMAND xmvn-resolve jakarta.activation:jakarta.activation-api:2
         OUTPUT_VARIABLE JAVAX_ACTIVATION_JAR
@@ -192,7 +194,7 @@ else()
             /usr/share/java/javax
             /usr/share/java
     )
-endif(DISTRO STREQUAL "centos" OR DISTRO STREQUAL "fedora" OR DISTRO STREQUAL "rhel")
+endif(XMVN_RESOLVE)
 
 find_file(JAVAX_ANNOTATIONS_API_JAR
     NAMES

--- a/base/tools/src/main/java/com/netscape/cmstools/AtoB.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/AtoB.java
@@ -57,13 +57,13 @@ public class AtoB {
     public static final String HEADER = "-----BEGIN";
     public static final String TRAILER = "-----END";
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
 
         BufferedReader inputBlob = null;
         String asciiBASE64BlobChunk;
         StringBuffer asciiBASE64Blob = new StringBuffer();
 
-        byte binaryBASE64Blob[] = null;
+        byte[] binaryBASE64Blob = null;
         FileOutputStream outputBlob = null;
 
         // (1) Check that two arguments were submitted to the program

--- a/pki.spec
+++ b/pki.spec
@@ -156,6 +156,7 @@ BuildRequires:    policycoreutils
 # Java build dependencies
 BuildRequires:    %{java_devel}
 BuildRequires:    maven-local
+BuildRequires:    xmvn-tools
 BuildRequires:    javapackages-tools
 BuildRequires:    mvn(commons-cli:commons-cli)
 BuildRequires:    mvn(commons-codec:commons-codec)

--- a/pki.spec
+++ b/pki.spec
@@ -156,7 +156,9 @@ BuildRequires:    policycoreutils
 # Java build dependencies
 BuildRequires:    %{java_devel}
 BuildRequires:    maven-local
+%if 0%{?fedora}
 BuildRequires:    xmvn-tools
+%endif
 BuildRequires:    javapackages-tools
 BuildRequires:    mvn(commons-cli:commons-cli)
 BuildRequires:    mvn(commons-codec:commons-codec)


### PR DESCRIPTION
While xmvn is packaged in CentOS and RHEL, it is buildroot only, so it cannot be used for the resolution of JARs like in Fedora.

Resolves: #2188716