### PR TITLE
Bug2190283-AddCRLServlet-SEVERE-NOT-SUPPORTED-messages

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/servlet/csadmin/UpdateOCSPConfig.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/csadmin/UpdateOCSPConfig.java
@@ -129,7 +129,7 @@ public class UpdateOCSPConfig extends CMSServlet {
             cs.putString(publisherPrefix+".path", "/ocsp/agent/ocsp/addCRL");
             cs.putString(publisherPrefix+".pluginName", "OCSPPublisher");
             cs.putString(publisherPrefix+".enableClientAuth", "true");
-            cs.putString(rulePrefix+".enable", "true");
+            cs.putString(rulePrefix+".enable", "false");
             cs.putString(rulePrefix+".mapper", "NoMap");
             cs.putString(rulePrefix+".pluginName", "Rule");
             cs.putString(rulePrefix+".publisher", "OCSPPublisher-"+ocspname);

--- a/base/server/src/main/java/com/netscape/cms/publish/mappers/LdapSimpleMap.java
+++ b/base/server/src/main/java/com/netscape/cms/publish/mappers/LdapSimpleMap.java
@@ -275,7 +275,9 @@ public class LdapSimpleMap implements ILdapMapper, IExtendedPluginInfo {
                 X509CRLImpl crl = (X509CRLImpl) obj;
                 subjectDN = (X500Name) crl.getIssuerDN();
 
-                logger.warn("LdapSimpleMap: crl issuer dn: " + subjectDN + ": " + e.getMessage(), e);
+                // We know by now that obj is X509CRLImpl instead of
+                //   X509Certificate; no warning needed
+                // logger.warn("LdapSimpleMap: crl issuer dn: " + subjectDN + ": " + e.getMessage(), e);
             } catch (ClassCastException ex) {
                 logger.warn(CMS.getLogMessage("PUBLISH_PUBLISH_OBJ_NOT_SUPPORTED",
                                 ((req == null) ? "" : req.getRequestId().toString())), ex);


### PR DESCRIPTION
This patch fixes the following issue:
It appears that the following parameter in ca's CS.cfg is set to true by default:
ca.publish.rule.instance.ocsprule-ccrsa-1-rhcs10-example-com-32443.enable which triggers the CA to attempt publishing of its CRLs directly from CA->OCSP and causing the following SEVERE error messages:

SEVERE: CRL issuing point CN=CA Signing Certificate, not found.

The CA->OCSP direct push of CRLs appears to not be working. CA->ldap publishing (and ocsp pulling from ldap) is working and
 should be used instead.

In addition, this patch also fixes it so that the following will no longer appear (it has no reason to. See bug description for explanation): [CRLIssuingPoint-MasterCRL] WARNING: LdapSimpleMap: crl issuer dn:... org.mozilla.jss.netscape.security.x509.X509CRLImpl cannot be cast to java.security.cert.X509Certificate

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2190283