### PR TITLE
Add pki-server <subsystem>-user-cert-del

### DIFF
--- a/.github/workflows/ca-admin-user-test.yml
+++ b/.github/workflows/ca-admin-user-test.yml
@@ -1,0 +1,142 @@
+name: CA admin user
+
+on:
+  workflow_call:
+    inputs:
+      db-image:
+        required: false
+        type: string
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v3
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ inputs.db-image }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Check CA admin user
+        run: |
+          docker exec pki pki-server ca-user-show caadmin | tee output
+
+          echo "adminType" > expected
+          sed -n 's/^ *Type: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check CA admin certs
+        run: |
+          docker exec pki pki-server ca-user-cert-find caadmin | tee output
+
+          sed -n 's/^ *Cert ID: *\(.*\)$/\1/p' output > cert.id
+          CERT_ID=$(cat cert.id)
+          echo "CERT_ID: $CERT_ID"
+
+      - name: Authentication with CA admin cert should work
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki -n caadmin ca-user-find
+
+      - name: Remove CA admin cert
+        run: |
+          CERT_ID=$(cat cert.id)
+          echo "CERT_ID: $CERT_ID"
+
+          docker exec pki pki-server ca-user-cert-del caadmin "$CERT_ID"
+
+          # admin should have no certs
+          docker exec pki pki-server ca-user-cert-find caadmin | tee actual
+          diff /dev/null actual
+
+      - name: Authentication with CA admin cert should not work
+        run: |
+          rc=0
+          docker exec pki pki -n caadmin ca-user-find \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          echo "PKIException: Unauthorized" > expected
+          diff expected stderr
+
+      - name: Restore CA admin cert
+        run: |
+          CERT_ID=$(cat cert.id)
+          echo "CERT_ID: $CERT_ID"
+
+          docker exec pki pki nss-cert-export caadmin > caadmin.crt
+          cat caadmin.crt | docker exec -i pki pki-server ca-user-cert-add caadmin
+
+          # new admin cert ID should match the original admin cert ID
+          docker exec pki pki-server ca-user-cert-find caadmin | tee output
+          sed -n 's/^ *Cert ID: *\(.*\)$/\1/p' output > actual
+          diff cert.id actual
+
+      - name: Authentication with CA admin cert should work again
+        run: |
+          docker exec pki pki -n caadmin ca-user-find
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ca-admin-user
+          path: |
+            /tmp/artifacts/pki

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -129,6 +129,13 @@ jobs:
     with:
       db-image: ${{ needs.init.outputs.db-image }}
 
+  ca-admin-user-test:
+    name: CA admin user
+    needs: [init, build]
+    uses: ./.github/workflows/ca-admin-user-test.yml
+    with:
+      db-image: ${{ needs.init.outputs.db-image }}
+
   ca-non-default-user-test:
     name: CA with non-default user
     needs: [init, build]

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -546,6 +546,7 @@ class UserCertCLI(pki.cli.CLI):
         self.parent = parent
         self.add_module(UserCertFindCLI(self))
         self.add_module(UserCertAddCLI(self))
+        self.add_module(UserCertRemoveCLI(self))
 
 
 class UserCertFindCLI(pki.cli.CLI):
@@ -704,3 +705,93 @@ class UserCertAddCLI(pki.cli.CLI):
             sys.exit(1)
 
         subsystem.add_user_cert(user_id, cert_path=cert_path, cert_format=cert_format)
+
+
+class UserCertRemoveCLI(pki.cli.CLI):
+    '''
+    Remove {subsystem} user certificate
+    '''
+
+    help = '''\
+        Usage: pki-server {subsystem}-user-cert-del [OPTIONS] <user ID> <cert ID>
+
+          -i, --instance <instance ID>       Instance ID (default: pki-tomcat).
+          -v, --verbose                      Run in verbose mode.
+              --debug                        Run in debug mode.
+              --help                         Show help message.
+    '''
+
+    def __init__(self, parent):
+        super().__init__(
+            'del',
+            inspect.cleandoc(self.__class__.__doc__).format(
+                subsystem=parent.parent.parent.name.upper()))
+
+        self.parent = parent
+
+    def print_help(self):
+        print(textwrap.dedent(self.__class__.help).format(
+            subsystem=self.parent.parent.parent.name))
+
+    def execute(self, argv):
+
+        try:
+            opts, args = getopt.gnu_getopt(argv, 'i:v', [
+                'instance=',
+                'verbose', 'debug', 'help'])
+
+        except getopt.GetoptError as e:
+            logger.error(e)
+            self.print_help()
+            sys.exit(1)
+
+        instance_name = 'pki-tomcat'
+        subsystem_name = self.parent.parent.parent.name
+
+        for o, a in opts:
+            if o in ('-i', '--instance'):
+                instance_name = a
+
+            elif o in ('-v', '--verbose'):
+                logging.getLogger().setLevel(logging.INFO)
+
+            elif o == '--debug':
+                logging.getLogger().setLevel(logging.DEBUG)
+
+            elif o == '--help':
+                self.print_help()
+                sys.exit()
+
+            else:
+                logger.error('Invalid option: %s', o)
+                self.print_help()
+                sys.exit(1)
+
+        if len(args) < 1:
+            logger.error('Missing user ID')
+            self.print_help()
+            sys.exit(1)
+
+        if len(args) < 2:
+            logger.error('Missing certificate ID')
+            self.print_help()
+            sys.exit(1)
+
+        user_id = args[0]
+        cert_id = args[1]
+
+        instance = pki.server.instance.PKIServerFactory.create(instance_name)
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        subsystem.remove_user_cert(user_id, cert_id)

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1870,6 +1870,21 @@ class PKISubsystem(object):
             as_current_user=as_current_user,
             capture_output=True)
 
+    def remove_user_cert(self, user_id, cert_id):
+
+        cmd = [self.name + '-user-cert-del']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(user_id)
+        cmd.append(cert_id)
+
+        self.run(cmd)
+
     def run(self,
             args,
             input=None,  # pylint: disable=W0622

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCertCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCertCLI.java
@@ -19,6 +19,7 @@ public class SubsystemUserCertCLI extends CLI {
 
         addModule(new SubsystemUserCertFindCLI(this));
         addModule(new SubsystemUserCertAddCLI(this));
+        addModule(new SubsystemUserCertRemoveCLI(this));
     }
 
     public static void printCert(

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCertRemoveCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCertRemoveCLI.java
@@ -1,0 +1,74 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.usrgrp.UGSubsystem;
+import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemUserCertRemoveCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemUserCertRemoveCLI.class);
+
+    public SubsystemUserCertRemoveCLI(CLI parent) {
+        super("del", "Remove " + parent.getParent().getParent().getName().toUpperCase() + " user cert", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing user ID");
+        }
+
+        if (cmdArgs.length < 2) {
+            throw new CLIException("Missing certificate ID");
+        }
+
+        String userID = cmdArgs[0];
+        String certID = cmdArgs[1];
+
+        initializeTomcatJSS();
+
+        String subsystem = parent.getParent().getParent().getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        UGSubsystemConfig ugConfig = cs.getUGSubsystemConfig();
+        LDAPConfig ldapConfig = ugConfig.getLDAPConfig();
+        ldapConfig.putInteger("minConns", 1);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = PasswordStore.create(psc);
+
+        UGSubsystem ugSubsystem = new UGSubsystem();
+
+        try {
+            ugSubsystem.init(ldapConfig, socketConfig, passwordStore);
+            ugSubsystem.removeUserCert(userID, certID);
+
+        } finally {
+            ugSubsystem.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
The `pki-server <subsystem>-user-cert-del` command has been added to remove a cert from the user record such that the cert cannot be used for authentication.

A new test has been added to validate removing and restoring the admin cert.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Subsystem-User-Certificate-CLI
