### PR TITLE
Add pki-server <subsystem>-user-role commands

### DIFF
--- a/.github/workflows/ca-admin-user-test.yml
+++ b/.github/workflows/ca-admin-user-test.yml
@@ -59,6 +59,14 @@ jobs:
               -D pki_request_id_generator=random \
               -v
 
+      - name: Check CA users
+        run: |
+          docker exec pki pki-server ca-user-find
+
+      - name: Check CA groups
+        run: |
+          docker exec pki pki-server ca-group-find
+
       - name: Check CA admin user
         run: |
           docker exec pki pki-server ca-user-show caadmin | tee output
@@ -75,7 +83,7 @@ jobs:
           CERT_ID=$(cat cert.id)
           echo "CERT_ID: $CERT_ID"
 
-      - name: Authentication with CA admin cert should work
+      - name: Authentication and authorization with CA admin cert should work
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
@@ -99,7 +107,6 @@ jobs:
 
       - name: Authentication with CA admin cert should not work
         run: |
-          rc=0
           docker exec pki pki -n caadmin ca-user-find \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
@@ -120,6 +127,43 @@ jobs:
           diff cert.id actual
 
       - name: Authentication with CA admin cert should work again
+        run: |
+          docker exec pki pki -n caadmin ca-user-find
+
+      - name: Check CA admin roles
+        run: |
+          docker exec pki pki-server ca-user-role-find caadmin | tee output
+
+          echo "Administrators" > expected
+          echo "Certificate Manager Agents" >> expected
+          echo "Enterprise CA Administrators" >> expected
+          echo "Enterprise KRA Administrators" >> expected
+          echo "Enterprise OCSP Administrators" >> expected
+          echo "Enterprise RA Administrators" >> expected
+          echo "Enterprise TKS Administrators" >> expected
+          echo "Enterprise TPS Administrators" >> expected
+          echo "Security Domain Administrators" >> expected
+
+          sed -n 's/^ *Role ID: *\(.*\)$/\1/p' output | sort > actual
+          diff expected actual
+
+      - name: Remove CA admin role
+        run: |
+          docker exec pki pki-server ca-user-role-del caadmin Administrators
+
+      - name: Authorization with CA admin cert should not work
+        run: |
+          docker exec pki pki -n caadmin ca-user-find \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          echo "ForbiddenException: Authorization Error" > expected
+          diff expected stderr
+
+      - name: Restore CA admin role
+        run: |
+          docker exec pki pki-server ca-user-role-add caadmin Administrators
+
+      - name: Authorization with CA admin cert should work again
         run: |
           docker exec pki pki -n caadmin ca-user-find
 

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -805,6 +805,7 @@ class UserRoleCLI(pki.cli.CLI):
 
         self.parent = parent
         self.add_module(UserRoleFindCLI(self))
+        self.add_module(UserRoleAddCLI(self))
 
 
 class UserRoleFindCLI(pki.cli.CLI):
@@ -893,3 +894,93 @@ class UserRoleFindCLI(pki.cli.CLI):
             sys.exit(1)
 
         subsystem.find_user_roles(user_id, output_format=output_format)
+
+
+class UserRoleAddCLI(pki.cli.CLI):
+    '''
+    Add {subsystem} user role
+    '''
+
+    help = '''\
+        Usage: pki-server {subsystem}-user-role-add [OPTIONS] <user ID> <role ID>
+
+          -i, --instance <instance ID>       Instance ID (default: pki-tomcat)
+          -v, --verbose                      Run in verbose mode.
+              --debug                        Run in debug mode.
+              --help                         Show help message.
+    '''
+
+    def __init__(self, parent):
+        super().__init__(
+            'add',
+            inspect.cleandoc(self.__class__.__doc__).format(
+                subsystem=parent.parent.parent.name.upper()))
+
+        self.parent = parent
+
+    def print_help(self):
+        print(textwrap.dedent(self.__class__.help).format(
+            subsystem=self.parent.parent.parent.name))
+
+    def execute(self, argv):
+        try:
+            opts, args = getopt.gnu_getopt(argv, 'i:v', [
+                'instance=',
+                'verbose', 'debug', 'help'])
+
+        except getopt.GetoptError as e:
+            logger.error(e)
+            self.print_help()
+            sys.exit(1)
+
+        instance_name = 'pki-tomcat'
+        subsystem_name = self.parent.parent.parent.name
+
+        for o, a in opts:
+            if o in ('-i', '--instance'):
+                instance_name = a
+
+            elif o in ('-v', '--verbose'):
+                logging.getLogger().setLevel(logging.INFO)
+
+            elif o == '--debug':
+                logging.getLogger().setLevel(logging.DEBUG)
+
+            elif o == '--help':
+                self.print_help()
+                sys.exit()
+
+            else:
+                logger.error('Invalid option: %s', o)
+                self.print_help()
+                sys.exit(1)
+
+        if len(args) < 1:
+            logger.error('Missing user ID')
+            self.print_help()
+            sys.exit(1)
+
+        user_id = args[0]
+
+        if len(args) < 2:
+            logger.error('Missing role ID')
+            self.print_help()
+            sys.exit(1)
+
+        role_id = args[1]
+
+        instance = pki.server.instance.PKIServerFactory.create(instance_name)
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        subsystem.add_user_role(user_id, role_id)

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -806,6 +806,7 @@ class UserRoleCLI(pki.cli.CLI):
         self.parent = parent
         self.add_module(UserRoleFindCLI(self))
         self.add_module(UserRoleAddCLI(self))
+        self.add_module(UserRoleRemoveCLI(self))
 
 
 class UserRoleFindCLI(pki.cli.CLI):
@@ -984,3 +985,93 @@ class UserRoleAddCLI(pki.cli.CLI):
             sys.exit(1)
 
         subsystem.add_user_role(user_id, role_id)
+
+
+class UserRoleRemoveCLI(pki.cli.CLI):
+    '''
+    Remove {subsystem} user role
+    '''
+
+    help = '''\
+        Usage: pki-server {subsystem}-user-role-del [OPTIONS] <user ID> <role ID>
+
+          -i, --instance <instance ID>       Instance ID (default: pki-tomcat)
+          -v, --verbose                      Run in verbose mode.
+              --debug                        Run in debug mode.
+              --help                         Show help message.
+    '''
+
+    def __init__(self, parent):
+        super().__init__(
+            'del',
+            inspect.cleandoc(self.__class__.__doc__).format(
+                subsystem=parent.parent.parent.name.upper()))
+
+        self.parent = parent
+
+    def print_help(self):
+        print(textwrap.dedent(self.__class__.help).format(
+            subsystem=self.parent.parent.parent.name))
+
+    def execute(self, argv):
+        try:
+            opts, args = getopt.gnu_getopt(argv, 'i:v', [
+                'instance=',
+                'verbose', 'debug', 'help'])
+
+        except getopt.GetoptError as e:
+            logger.error(e)
+            self.print_help()
+            sys.exit(1)
+
+        instance_name = 'pki-tomcat'
+        subsystem_name = self.parent.parent.parent.name
+
+        for o, a in opts:
+            if o in ('-i', '--instance'):
+                instance_name = a
+
+            elif o in ('-v', '--verbose'):
+                logging.getLogger().setLevel(logging.INFO)
+
+            elif o == '--debug':
+                logging.getLogger().setLevel(logging.DEBUG)
+
+            elif o == '--help':
+                self.print_help()
+                sys.exit()
+
+            else:
+                logger.error('Invalid option: %s', o)
+                self.print_help()
+                sys.exit(1)
+
+        if len(args) < 1:
+            logger.error('Missing user ID')
+            self.print_help()
+            sys.exit(1)
+
+        user_id = args[0]
+
+        if len(args) < 2:
+            logger.error('Missing role ID')
+            self.print_help()
+            sys.exit(1)
+
+        role_id = args[1]
+
+        instance = pki.server.instance.PKIServerFactory.create(instance_name)
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        subsystem.remove_user_role(user_id, role_id)

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -31,6 +31,7 @@ class UserCLI(pki.cli.CLI):
         self.add_module(UserShowCLI(self))
 
         self.add_module(UserCertCLI(self))
+        self.add_module(UserRoleCLI(self))
 
 
 class UserAddCLI(pki.cli.CLI):
@@ -795,3 +796,100 @@ class UserCertRemoveCLI(pki.cli.CLI):
             sys.exit(1)
 
         subsystem.remove_user_cert(user_id, cert_id)
+
+
+class UserRoleCLI(pki.cli.CLI):
+
+    def __init__(self, parent):
+        super().__init__('role', '%s user role management commands' % parent.parent.name.upper())
+
+        self.parent = parent
+        self.add_module(UserRoleFindCLI(self))
+
+
+class UserRoleFindCLI(pki.cli.CLI):
+    '''
+    Find {subsystem} user roles
+    '''
+
+    help = '''\
+        Usage: pki-server {subsystem}-user-role-find [OPTIONS] <user ID>
+
+          -i, --instance <instance ID>       Instance ID (default: pki-tomcat)
+              --output-format <format>       Output format: text (default), json.
+          -v, --verbose                      Run in verbose mode.
+              --debug                        Run in debug mode.
+              --help                         Show help message.
+    '''
+
+    def __init__(self, parent):
+        super().__init__(
+            'find',
+            inspect.cleandoc(self.__class__.__doc__).format(
+                subsystem=parent.parent.parent.name.upper()))
+
+        self.parent = parent
+
+    def print_help(self):
+        print(textwrap.dedent(self.__class__.help).format(
+            subsystem=self.parent.parent.parent.name))
+
+    def execute(self, argv):
+        try:
+            opts, args = getopt.gnu_getopt(argv, 'i:v', [
+                'instance=', 'output-format=',
+                'verbose', 'debug', 'help'])
+
+        except getopt.GetoptError as e:
+            logger.error(e)
+            self.print_help()
+            sys.exit(1)
+
+        instance_name = 'pki-tomcat'
+        subsystem_name = self.parent.parent.parent.name
+        output_format = None
+
+        for o, a in opts:
+            if o in ('-i', '--instance'):
+                instance_name = a
+
+            elif o == '--output-format':
+                output_format = a
+
+            elif o in ('-v', '--verbose'):
+                logging.getLogger().setLevel(logging.INFO)
+
+            elif o == '--debug':
+                logging.getLogger().setLevel(logging.DEBUG)
+
+            elif o == '--help':
+                self.print_help()
+                sys.exit()
+
+            else:
+                logger.error('Invalid option: %s', o)
+                self.print_help()
+                sys.exit(1)
+
+        if len(args) < 1:
+            logger.error('Missing user ID')
+            self.print_help()
+            sys.exit(1)
+
+        user_id = args[0]
+
+        instance = pki.server.instance.PKIServerFactory.create(instance_name)
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        subsystem.find_user_roles(user_id, output_format=output_format)

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1885,6 +1885,27 @@ class PKISubsystem(object):
 
         self.run(cmd)
 
+    def find_user_roles(
+            self,
+            user_id,
+            output_format=None):
+
+        cmd = [self.name + '-user-role-find']
+
+        if output_format:
+            cmd.append('--output-format')
+            cmd.append(output_format)
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(user_id)
+
+        self.run(cmd)
+
     def run(self,
             args,
             input=None,  # pylint: disable=W0622

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1924,6 +1924,24 @@ class PKISubsystem(object):
 
         self.run(cmd)
 
+    def remove_user_role(
+            self,
+            user_id,
+            role_id):
+
+        cmd = [self.name + '-user-role-del']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(user_id)
+        cmd.append(role_id)
+
+        self.run(cmd)
+
     def run(self,
             args,
             input=None,  # pylint: disable=W0622

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1906,6 +1906,24 @@ class PKISubsystem(object):
 
         self.run(cmd)
 
+    def add_user_role(
+            self,
+            user_id,
+            role_id):
+
+        cmd = [self.name + '-user-role-add']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(user_id)
+        cmd.append(role_id)
+
+        self.run(cmd)
+
     def run(self,
             args,
             input=None,  # pylint: disable=W0622

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserCLI.java
@@ -22,5 +22,6 @@ public class SubsystemUserCLI extends CLI {
         addModule(new SubsystemUserShowCLI(this));
 
         addModule(new SubsystemUserCertCLI(this));
+        addModule(new SubsystemUserRoleCLI(this));
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleAddCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleAddCLI.java
@@ -1,0 +1,83 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.certsrv.group.GroupNotFoundException;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.usrgrp.Group;
+import com.netscape.cmscore.usrgrp.UGSubsystem;
+import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemUserRoleAddCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemUserRoleAddCLI.class);
+
+    public SubsystemUserRoleAddCLI(CLI parent) {
+        super("add", "Add " + parent.getParent().getParent().getName().toUpperCase() + " user roles", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing user ID");
+        }
+
+        String userID = cmdArgs[0];
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing role ID");
+        }
+
+        String roleID = cmdArgs[1];
+
+        initializeTomcatJSS();
+        String subsystem = parent.getParent().getParent().getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        UGSubsystemConfig ugConfig = cs.getUGSubsystemConfig();
+        LDAPConfig ldapConfig = ugConfig.getLDAPConfig();
+        ldapConfig.putInteger("minConns", 1);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = PasswordStore.create(psc);
+
+        UGSubsystem ugSubsystem = new UGSubsystem();
+
+        try {
+            ugSubsystem.init(ldapConfig, socketConfig, passwordStore);
+
+            Group group = ugSubsystem.getGroupFromName(roleID);
+
+            if (group == null) {
+                throw new GroupNotFoundException(roleID);
+            }
+
+            ugSubsystem.addUserToGroup(group, userID);
+
+        } finally {
+            ugSubsystem.shutdown();
+        }
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleCLI.java
@@ -1,0 +1,20 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemUserRoleCLI extends CLI {
+
+    public SubsystemUserRoleCLI(CLI parent) {
+        super("role", parent.name.toUpperCase() + " user role management commands", parent);
+
+        addModule(new SubsystemUserRoleFindCLI(this));
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleCLI.java
@@ -17,5 +17,6 @@ public class SubsystemUserRoleCLI extends CLI {
 
         addModule(new SubsystemUserRoleFindCLI(this));
         addModule(new SubsystemUserRoleAddCLI(this));
+        addModule(new SubsystemUserRoleRemoveCLI(this));
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleCLI.java
@@ -16,5 +16,6 @@ public class SubsystemUserRoleCLI extends CLI {
         super("role", parent.name.toUpperCase() + " user role management commands", parent);
 
         addModule(new SubsystemUserRoleFindCLI(this));
+        addModule(new SubsystemUserRoleAddCLI(this));
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleFindCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleFindCLI.java
@@ -1,0 +1,130 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import java.util.Enumeration;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.certsrv.base.UserNotFoundException;
+import com.netscape.certsrv.user.UserMembershipCollection;
+import com.netscape.certsrv.user.UserMembershipData;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.usrgrp.Group;
+import com.netscape.cmscore.usrgrp.UGSubsystem;
+import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
+import com.netscape.cmscore.usrgrp.User;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemUserRoleFindCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemUserRoleFindCLI.class);
+
+    public SubsystemUserRoleFindCLI(CLI parent) {
+        super("find", "Find " + parent.getParent().getParent().getName().toUpperCase() + " user roles", parent);
+    }
+
+    @Override
+    public void createOptions() {
+        Option option = new Option(null, "output-format", true, "Output format: text (default), json.");
+        option.setArgName("format");
+        options.addOption(option);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing user ID");
+        }
+
+        String userID = cmdArgs[0];
+
+        String outputFormat = cmd.getOptionValue("output-format", "text");
+
+        initializeTomcatJSS();
+        String subsystem = parent.getParent().getParent().getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        UGSubsystemConfig ugConfig = cs.getUGSubsystemConfig();
+        LDAPConfig ldapConfig = ugConfig.getLDAPConfig();
+        ldapConfig.putInteger("minConns", 1);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = PasswordStore.create(psc);
+
+        UGSubsystem ugSubsystem = new UGSubsystem();
+        UserMembershipCollection response = new UserMembershipCollection();
+
+        try {
+            ugSubsystem.init(ldapConfig, socketConfig, passwordStore);
+
+            User user = ugSubsystem.getUser(userID);
+
+            if (user == null) {
+                throw new UserNotFoundException(userID);
+            }
+
+            Enumeration<Group> groups = ugSubsystem.findGroupsByUser(user.getUserDN(), null);
+
+            int total = 0;
+
+            while (groups.hasMoreElements()) {
+                Group group = groups.nextElement();
+
+                UserMembershipData userRole = new UserMembershipData();
+                userRole.setID(group.getGroupID());
+                userRole.setUserID(userID);
+
+                response.addEntry(userRole);
+                total++;
+            }
+
+            response.setTotal(total);
+
+        } finally {
+            ugSubsystem.shutdown();
+        }
+
+        if (outputFormat.equalsIgnoreCase("json")) {
+            System.out.println(response.toJSON());
+
+        } else if (outputFormat.equalsIgnoreCase("text")) {
+
+            boolean first = true;
+
+            for (UserMembershipData userRole : response.getEntries()) {
+
+                if (first) {
+                    first = false;
+                } else {
+                    System.out.println();
+                }
+
+                System.out.println("  Role ID: " + userRole.getID());
+            }
+
+        } else {
+            throw new CLIException("Unsupported output format: " + outputFormat);
+        }
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleRemoveCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserRoleRemoveCLI.java
@@ -1,0 +1,83 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.certsrv.group.GroupNotFoundException;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.usrgrp.Group;
+import com.netscape.cmscore.usrgrp.UGSubsystem;
+import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemUserRoleRemoveCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemUserRoleRemoveCLI.class);
+
+    public SubsystemUserRoleRemoveCLI(CLI parent) {
+        super("del", "Remove " + parent.getParent().getParent().getName().toUpperCase() + " user roles", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing user ID");
+        }
+
+        String userID = cmdArgs[0];
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing role ID");
+        }
+
+        String roleID = cmdArgs[1];
+
+        initializeTomcatJSS();
+        String subsystem = parent.getParent().getParent().getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        UGSubsystemConfig ugConfig = cs.getUGSubsystemConfig();
+        LDAPConfig ldapConfig = ugConfig.getLDAPConfig();
+        ldapConfig.putInteger("minConns", 1);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = PasswordStore.create(psc);
+
+        UGSubsystem ugSubsystem = new UGSubsystem();
+
+        try {
+            ugSubsystem.init(ldapConfig, socketConfig, passwordStore);
+
+            Group group = ugSubsystem.getGroupFromName(roleID);
+
+            if (group == null) {
+                throw new GroupNotFoundException(roleID);
+            }
+
+            ugSubsystem.removeUserFromGroup(group, userID);
+
+        } finally {
+            ugSubsystem.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
The `pki-server <subsystem>-user-role-find` command has been added to list the roles (which for now are identical to groups) that the user belongs to.

The `pki-server <subsystem>-user-role-add` command has been added to add a role for a user.

The `pki-server <subsystem>-user-role-del` command has been added to remove a role from a user.

The test for CA admin user has been modified to validate removing and restoring the admin role.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Subsystem-User-Role-CLI
