### PR TITLE
Fix OAEP config in CRSEnrollment

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/KeyRetrieverRunner.java
+++ b/base/ca/src/main/java/com/netscape/ca/KeyRetrieverRunner.java
@@ -54,7 +54,7 @@ public class KeyRetrieverRunner implements Runnable {
         CAEngine engine = CAEngine.getInstance();
         CAEngineConfig cs = engine.getConfig();
         try {
-            this.useOAEPKeyWrap = cs.getBoolean("keyWrap.useOAEP",false);
+            this.useOAEPKeyWrap = cs.getUseOAEPKeyWrap();
         } catch (EBaseException e1) {
             throw new RuntimeException("Invalid value for keyWrap.useOAEP: " + e1);
         }

--- a/base/ca/src/main/java/com/netscape/cms/authentication/SharedSecret.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/SharedSecret.java
@@ -186,7 +186,7 @@ public class SharedSecret extends DirBasedAuthentication
             mShrTokAttr = DEF_SharedToken_ATTR;
         }
 
-        boolean useOAEP = cs.getBoolean("keyWrap.useOAEP",false);
+        boolean useOAEP = cs.getUseOAEPKeyWrap();
         logger.debug(method + " keyWrap.useOAEP: " + useOAEP );
 
         if(useOAEP == true) {

--- a/base/ca/src/main/java/com/netscape/cms/profile/common/EnrollProfile.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/common/EnrollProfile.java
@@ -506,7 +506,7 @@ public abstract class EnrollProfile extends Profile {
             String tokenName = cs.getString("cmc.token", CryptoUtil.INTERNAL_TOKEN_NAME);
             token = CryptoUtil.getCryptoToken(tokenName);
 
-            boolean useOAEP = cs.getBoolean("keyWrap.useOAEP",false);
+            boolean useOAEP = cs.getUseOAEPKeyWrap();
 
             byte[] iv = CryptoUtil.getNonceData(EncryptionAlgorithm.AES_128_CBC.getIVLength());
             IVParameterSpec ivps = new IVParameterSpec(iv);
@@ -1317,7 +1317,7 @@ public abstract class EnrollProfile extends Profile {
             token = CryptoUtil.getKeyStorageToken(tokenName);
 
             KeyWrapAlgorithm wrapAlg = KeyWrapAlgorithm.RSA;
-            boolean useOAEP = cs.getBoolean("keyWrap.useOAEP", false);
+            boolean useOAEP = cs.getUseOAEPKeyWrap();
             if (useOAEP) {
                 wrapAlg = KeyWrapAlgorithm.RSA_OAEP;
             }

--- a/base/ca/src/main/java/com/netscape/cms/profile/def/ServerKeygenUserKeyDefault.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/def/ServerKeygenUserKeyDefault.java
@@ -326,7 +326,7 @@ public class ServerKeygenUserKeyDefault extends EnrollDefault {
                         EncryptionAlgorithm.AES_128_CBC_PAD;
 
                 CAEngineConfig caCfg = engine.getConfig();
-                boolean useOAEP = caCfg.getBoolean("keyWrap.useOAEP",false);
+                boolean useOAEP = caCfg.getUseOAEPKeyWrap();
 
                 KeyWrapAlgorithm wrapAlgorithm = KeyWrapAlgorithm.RSA;
                 if(useOAEP == true) {

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/scep/CRSEnrollment.java
@@ -48,6 +48,7 @@ import org.dogtagpki.server.authentication.AuthManager;
 import org.dogtagpki.server.authentication.AuthToken;
 import org.dogtagpki.server.ca.CAConfig;
 import org.dogtagpki.server.ca.CAEngine;
+import org.dogtagpki.server.ca.CAEngineConfig;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NoSuchTokenException;
 import org.mozilla.jss.NotInitializedException;
@@ -260,6 +261,7 @@ public class CRSEnrollment extends HttpServlet {
             crsCA = "ca";
 
         CAEngine engine = CAEngine.getInstance();
+        CAEngineConfig cs = engine.getConfig();
         JssSubsystem jssSubsystem = engine.getJSSSubsystem();
 
         mAuthority = (CertificateAuthority) engine.getSubsystem(crsCA);
@@ -273,7 +275,7 @@ public class CRSEnrollment extends HttpServlet {
             CAConfig authorityConfig = mAuthority.getConfig();
             ConfigStore scepConfig = authorityConfig.getSubStore("scep", ConfigStore.class);
             mEnabled = scepConfig.getBoolean("enable", false);
-            mUseOAEPKeyWrap = authorityConfig.getBoolean("keyWrap.useOAEP",false);
+            mUseOAEPKeyWrap = cs.getUseOAEPKeyWrap();
             if (sc.getServletName().equals(SERVLET_NAME_DYN_PROFILE)) {
                 mIsDynamicProfileId = true;
                 logger.debug("CRSEnrollment: init: expecting dynamic ProfileId in URL");

--- a/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/rest/CAInfoService.java
@@ -218,7 +218,7 @@ public class CAInfoService extends PKIService implements CAInfoResource {
         CAEngine engine = CAEngine.getInstance();
         CAEngineConfig cs = engine.getConfig();
 
-        boolean useOAEP = cs.getBoolean("keyWrap.useOAEP", false);
+        boolean useOAEP = cs.getUseOAEPKeyWrap();
 
         return useOAEP ? "RSA_OAEP" : "RSA";
     }

--- a/base/kra/src/main/java/com/netscape/kra/NetkeyKeygenService.java
+++ b/base/kra/src/main/java/com/netscape/kra/NetkeyKeygenService.java
@@ -168,7 +168,7 @@ public class NetkeyKeygenService implements IService {
         KRAEngineConfig configStore = engine.getConfig();
         boolean allowEncDecrypt_archival = configStore.getBoolean("kra.allowEncDecrypt.archival", false);
 
-        boolean useOAEPKeyWrap = configStore.getBoolean("keyWrap.useOAEP",false);
+        boolean useOAEPKeyWrap = configStore.getUseOAEPKeyWrap();
         wrapped_des_key = null;
         boolean archive = true;
         byte[] publicKeyData = null;

--- a/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
+++ b/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
@@ -157,7 +157,7 @@ public class RecoveryService implements IService {
             cm = CryptoManager.getInstance();
             config = engine.getConfig();
             tokName = config.getString("kra.storageUnit.hardware", CryptoUtil.INTERNAL_TOKEN_NAME);
-            boolean useOAEPKeyWrap = config.getBoolean("keyWrap.useOAEP",false);
+            boolean useOAEPKeyWrap = config.getUseOAEPKeyWrap();
 
             // default to "KRA transport certificate" would require one to
             // change the nickname for existing KRA transport cert

--- a/base/kra/src/main/java/com/netscape/kra/SecurityDataProcessor.java
+++ b/base/kra/src/main/java/com/netscape/kra/SecurityDataProcessor.java
@@ -109,7 +109,7 @@ public class SecurityDataProcessor {
         try {
             config = engine.getConfig();
             allowEncDecrypt_archival = config.getBoolean("kra.allowEncDecrypt.archival", false);
-            useOAEPKeyWrap = config.getBoolean("keyWrap.useOAEP", false);
+            useOAEPKeyWrap = config.getUseOAEPKeyWrap();
         } catch (Exception e) {
             throw new EBaseException(CMS.getUserMessage("CMS_BASE_CERT_ERROR", e.toString()));
         }
@@ -380,7 +380,7 @@ public class SecurityDataProcessor {
         try {
             config = engine.getConfig();
             allowEncDecrypt_recovery = config.getBoolean("kra.allowEncDecrypt.recovery", false);
-            useOAEPKeyWrap = config.getBoolean("keyWrap.useOAEP", false);
+            useOAEPKeyWrap = config.getUseOAEPKeyWrap();
         } catch (Exception e) {
             throw new EBaseException(CMS.getUserMessage("CMS_BASE_CERT_ERROR", e.toString()));
         }

--- a/base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java
+++ b/base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java
@@ -242,7 +242,7 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
         KRAEngineConfig kraCfg = null;
         kraCfg  = engine.getConfig();
 
-        useOAEPKeyWrap = kraCfg.getBoolean("keyWrap.useOAEP",false);
+        useOAEPKeyWrap = kraCfg.getUseOAEPKeyWrap();
         logger.debug("StorageKeyUnit.init: keyWrap.useOAEP" + useOAEPKeyWrap);
         try {
             mManager = CryptoManager.getInstance();

--- a/base/kra/src/main/java/com/netscape/kra/TokenKeyRecoveryService.java
+++ b/base/kra/src/main/java/com/netscape/kra/TokenKeyRecoveryService.java
@@ -198,7 +198,7 @@ public class TokenKeyRecoveryService implements IService {
         try {
             config = engine.getConfig();
             allowEncDecrypt_recovery = config.getBoolean("kra.allowEncDecrypt.recovery", false);
-            useOAEPKeyWrap = config.getBoolean("keyWrap.useOAEP",false);
+            useOAEPKeyWrap = config.getUseOAEPKeyWrap();
         } catch (Exception e) {
             throw new EBaseException(CMS.getUserMessage("CMS_BASE_CERT_ERROR", e.toString()));
         }

--- a/base/kra/src/main/java/com/netscape/kra/TransportKeyUnit.java
+++ b/base/kra/src/main/java/com/netscape/kra/TransportKeyUnit.java
@@ -91,7 +91,7 @@ public class TransportKeyUnit extends EncryptionUnit {
             KRAEngineConfig kraCfg = null;
             kraCfg  = engine.getConfig();
 
-            boolean useOAEPKeyWrap = kraCfg.getBoolean("keyWrap.useOAEP",false);
+            boolean useOAEPKeyWrap = kraCfg.getUseOAEPKeyWrap();
             logger.debug("TransportKeyUnit: keyWrap.useOAEP:  " + useOAEPKeyWrap);
             if(useOAEPKeyWrap == true) {
                 this.rsaKeyWrapAlg = KeyWrapAlgorithm.RSA_OAEP;

--- a/base/kra/src/main/java/org/dogtagpki/server/rest/KRAInfoService.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/rest/KRAInfoService.java
@@ -120,7 +120,7 @@ public class KRAInfoService extends PKIService implements KRAInfoResource {
         KRAEngine engine = KRAEngine.getInstance();
         KRAEngineConfig cs = engine.getConfig();
 
-        boolean useOAEP = cs.getBoolean("keyWrap.useOAEP", false);
+        boolean useOAEP = cs.getUseOAEPKeyWrap();
 
         return useOAEP ? "RSA_OAEP" : "RSA";
     }

--- a/base/server/src/main/java/com/netscape/cmscore/apps/EngineConfig.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/EngineConfig.java
@@ -141,4 +141,11 @@ public class EngineConfig extends ConfigStore {
     public LoggingConfig getLoggingConfig() {
         return getSubStore("log", LoggingConfig.class);
     }
+
+    /**
+     * Returns keyWrap.useOAEP parameter.
+     */
+    public boolean getUseOAEPKeyWrap() throws EBaseException {
+        return getBoolean("keyWrap.useOAEP", false);
+    }
 }

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/servlet/TokenServlet.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/servlet/TokenServlet.java
@@ -663,7 +663,7 @@ public class TokenServlet extends CMSServlet {
                         keyWrapper = token.getKeyWrapper(KeyWrapAlgorithm.AES_ECB);
                         keyWrapper.initWrap(pubKey, null);
                     } else {
-                        boolean useOAEP = config.getBoolean("keyWrap.useOAEP",false);
+                        boolean useOAEP = config.getUseOAEPKeyWrap();
                         KeyWrapAlgorithm wrapAlg = KeyWrapAlgorithm.RSA;
                         if(useOAEP == true) {
                             wrapAlg = KeyWrapAlgorithm.RSA_OAEP;
@@ -1237,7 +1237,7 @@ public class TokenServlet extends CMSServlet {
                             keyWrapper.initWrap(pubKey, null);
                         } else {
 
-                            boolean useOAEP = config.getBoolean("keyWrap.useOAEP",false);
+                            boolean useOAEP = config.getUseOAEPKeyWrap();
                             KeyWrapAlgorithm wrapAlg = KeyWrapAlgorithm.RSA;
                             if(useOAEP == true) {
                                 wrapAlg = KeyWrapAlgorithm.RSA_OAEP;
@@ -3147,7 +3147,7 @@ public class TokenServlet extends CMSServlet {
                 keyWrapper.initWrap(pubKey, null);
             } else {
 
-                boolean useOAEP = config.getBoolean("keyWrap.useOAEP",false);
+                boolean useOAEP = config.getUseOAEPKeyWrap();
                 KeyWrapAlgorithm wrapAlg = KeyWrapAlgorithm.RSA;
                 if(useOAEP == true) {
                     wrapAlg = KeyWrapAlgorithm.RSA_OAEP;


### PR DESCRIPTION
The `EngineConfig.getUseOAEPKeyWrap()` has been added to read the `keyWrap.useOAEP` param from `CS.cfg`. All code that reads this param has been modified to use this method.

Previously the `CRSEnrollment` was trying to get the `keyWrap.useOAEP` param from the authority config, but it's actually reading a non-existent `ca.keyWrap.useOAEP` param.

To fix the problem the code has been modified to call the `EngineConfig.getUseOAEPKeyWrap()` as well.
