### PR TITLE
Update client classes to use JAX-RS client API

### DIFF
--- a/base/common/src/main/java/org/dogtagpki/ca/CASystemCertClient.java
+++ b/base/common/src/main/java/org/dogtagpki/ca/CASystemCertClient.java
@@ -44,15 +44,8 @@ public class CASystemCertClient extends Client {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CASystemCertClient.class);
 
-    public CASystemCertResource resource;
-
     public CASystemCertClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, "systemcert");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(CASystemCertResource.class);
+        super(client, subsystem, "config/cert");
     }
 
     public CertData getSigningCert() throws Exception {
@@ -61,9 +54,7 @@ public class CASystemCertClient extends Client {
 
         try {
             logger.info("Gettting CA signing certificate chain through REST service");
-
-            Response response = resource.getSigningCert();
-            certData = client.getEntity(response, CertData.class);
+            certData = get("signing", CertData.class);
 
         } catch (PKIException e) {
             if (e.getCode() != Response.Status.NOT_FOUND.getStatusCode()) {
@@ -114,7 +105,6 @@ public class CASystemCertClient extends Client {
     }
 
     public CertData getTransportCert() throws Exception {
-        Response response = resource.getTransportCert();
-        return client.getEntity(response, CertData.class);
+        return get("transport", CertData.class);
     }
 }

--- a/base/common/src/main/java/org/dogtagpki/common/InfoClient.java
+++ b/base/common/src/main/java/org/dogtagpki/common/InfoClient.java
@@ -18,8 +18,6 @@
 
 package org.dogtagpki.common;
 
-import javax.ws.rs.core.Response;
-
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
 
@@ -28,19 +26,11 @@ import com.netscape.certsrv.client.PKIClient;
  */
 public class InfoClient extends Client {
 
-    public InfoResource resource;
-
     public InfoClient(PKIClient client) throws Exception {
         super(client, "pki", "info");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(InfoResource.class);
     }
 
     public Info getInfo() throws Exception {
-        Response response = resource.getInfo();
-        return client.getEntity(response, Info.class);
+        return get(Info.class);
     }
 }

--- a/base/common/src/main/java/org/dogtagpki/common/LoginClient.java
+++ b/base/common/src/main/java/org/dogtagpki/common/LoginClient.java
@@ -18,8 +18,6 @@
 
 package org.dogtagpki.common;
 
-import javax.ws.rs.core.Response;
-
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
 
@@ -28,19 +26,11 @@ import com.netscape.certsrv.client.PKIClient;
  */
 public class LoginClient extends Client {
 
-    public LoginResource resource;
-
     public LoginClient(PKIClient client) throws Exception {
         super(client, "pki", "login");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(LoginResource.class);
     }
 
     public void login() throws Exception {
-        Response response = resource.login();
-        client.getEntity(response, Void.class);
+        post(Void.class);
     }
 }

--- a/base/common/src/main/java/org/dogtagpki/job/JobClient.java
+++ b/base/common/src/main/java/org/dogtagpki/job/JobClient.java
@@ -5,8 +5,6 @@
 //
 package org.dogtagpki.job;
 
-import javax.ws.rs.core.Response;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,29 +18,19 @@ public class JobClient extends Client {
 
     public static final Logger logger = LoggerFactory.getLogger(JobClient.class);
 
-    JobResource resource;
-
     public JobClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, "config");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(JobResource.class);
+        super(client, subsystem, "jobs");
     }
 
     public JobCollection findJobs() throws Exception {
-        Response response = resource.findJobs();
-        return client.getEntity(response, JobCollection.class);
+        return get(JobCollection.class);
     }
 
     public JobInfo getJob(String id) throws Exception {
-        Response response = resource.getJob(id);
-        return client.getEntity(response, JobInfo.class);
+        return get(id, JobInfo.class);
     }
 
     public void startJob(String id) throws Exception {
-        Response response = resource.startJob(id);
-        client.getEntity(response, Void.class);
+        post(id + "/start", Void.class);
     }
 }

--- a/base/common/src/main/java/org/dogtagpki/kra/KRASystemCertClient.java
+++ b/base/common/src/main/java/org/dogtagpki/kra/KRASystemCertClient.java
@@ -17,8 +17,6 @@
 //--- END COPYRIGHT BLOCK ---
 package org.dogtagpki.kra;
 
-import javax.ws.rs.core.Response;
-
 import com.netscape.certsrv.cert.CertData;
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
@@ -28,19 +26,11 @@ import com.netscape.certsrv.client.PKIClient;
  */
 public class KRASystemCertClient extends Client {
 
-    public KRASystemCertResource resource;
-
     public KRASystemCertClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, "systemcert");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(KRASystemCertResource.class);
+        super(client, subsystem, "config/cert");
     }
 
     public CertData getTransportCert() throws Exception {
-        Response response = resource.getTransportCert();
-        return client.getEntity(response, CertData.class);
+        return get("transport", CertData.class);
     }
 }


### PR DESCRIPTION
Some client classes have been updated to use JAX-RS client API instead of the obsolete RESTEasy client API.
