### PR TITLE
Remove duplicate algorithm in OCSPAdminServlet.getSigningAlgConfig()

### DIFF
--- a/base/ocsp/src/main/java/com/netscape/cms/servlet/admin/OCSPAdminServlet.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/servlet/admin/OCSPAdminServlet.java
@@ -470,9 +470,7 @@ public class OCSPAdminServlet extends AdminServlet {
         for (int i = 0; i < algorithms.length; i++) {
             logger.info("OCSPAdminServlet: - " + algorithms[i]);
 
-            if (i == 0) {
-                algorStr.append(algorithms[i]);
-            } else {
+            if (i > 0) {
                 algorStr.append(":");
             }
             algorStr.append(algorithms[i]);


### PR DESCRIPTION
Previously the `OCSPAdminServlet.getSigningAlgConfig()` returned a list that contained a duplicate of the first element:
```
<alg1><alg1>:<alg2>:<alg3>:...
```
The code has been modified to remove the duplicate.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2193458