### PR TITLE
Change JUnit dependency from JUnit4 to JUnit5

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -168,7 +168,8 @@ BuildRequires:    mvn(commons-logging:commons-logging)
 BuildRequires:    mvn(commons-net:commons-net)
 BuildRequires:    mvn(org.slf4j:slf4j-api)
 BuildRequires:    mvn(org.slf4j:slf4j-jdk14)
-BuildRequires:    mvn(junit:junit)
+BuildRequires:    mvn(org.junit.jupiter:junit-jupiter-api)
+BuildRequires:    mvn(org.junit.vintage:junit-vintage-engine)
 BuildRequires:    pki-resteasy >= 3.0.26
 BuildRequires:    jss = 5.4
 BuildRequires:    tomcatjss = 8.4

--- a/pom.xml
+++ b/pom.xml
@@ -201,9 +201,16 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
We should see no difference from this change, as JUnit5 currently has JUnit4 as a dependency so nothing should change except we pull more dependencies.