### PR TITLE
Replace pki-server subsystem-cert-validate with pki-server cert-validate

### DIFF
--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -1213,7 +1213,7 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
 class SubsystemCertValidateCLI(pki.cli.CLI):
 
     def __init__(self):
-        super().__init__('validate', 'Validate subsystem certificates')
+        super().__init__('validate', 'Validate subsystem certificates', deprecated=True)
 
     def usage(self):
         print('Usage: pki-server subsystem-cert-validate [OPTIONS] <subsystem ID> [<cert_id>]')
@@ -1225,6 +1225,10 @@ class SubsystemCertValidateCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
+
+        logger.warning(
+            'The pki-server subsystem-cert-validate has been deprecated. '
+            'Use pki-server cert-validate instead.')
 
         try:
             opts, args = getopt.gnu_getopt(argv, 'i:v', [

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -1,0 +1,5 @@
+= Tools Changes =
+
+== New pki-server cert-validate CLI ==
+
+The `pki-server cert-validate` command has been added to validate a system certificate.


### PR DESCRIPTION
The `pki-server subsystem-cert-validate` has been deprecated and replaced with `pki-server cert-validate` since the new command is shorter and only takes one parameter so it is easier to use and more useful, and produces simpler output as well.

Eventually all `pki-server subsystem-cert-*` commands will be replaced with `pki-server cert-*` commands.