### PR TITLE
Add SAN option for pki nss-cert commands

### DIFF
--- a/.github/workflows/pki-nss-exts-test.yml
+++ b/.github/workflows/pki-nss-exts-test.yml
@@ -84,6 +84,7 @@ jobs:
           docker exec pki pki nss-cert-request \
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
+              --subjectAltName "critical, DNS:www.example.com, DNS:pki.example.com" \
               --csr sslserver.csr
 
           docker exec pki /usr/share/pki/tests/bin/test-sslserver-csr-ext.sh
@@ -94,6 +95,7 @@ jobs:
               --issuer ca_signing \
               --csr sslserver.csr \
               --ext /usr/share/pki/server/certs/sslserver.conf \
+              --subjectAltName "critical, DNS:www.example.com, DNS:pki.example.com" \
               --cert sslserver.crt
 
           docker exec pki /usr/share/pki/tests/bin/test-sslserver-cert-ext.sh

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertIssueCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertIssueCLI.java
@@ -49,6 +49,10 @@ public class NSSCertIssueCLI extends CommandCLI {
         option.setArgName("path");
         options.addOption(option);
 
+        option = new Option(null, "subjectAltName", true, "Subject alternative name");
+        option.setArgName("value");
+        options.addOption(option);
+
         option = new Option(null, "serial", true, "Serial number (default is 128-bit random number)");
         option.setArgName("number");
         options.addOption(option);
@@ -76,6 +80,7 @@ public class NSSCertIssueCLI extends CommandCLI {
         String issuerNickname = cmd.getOptionValue("issuer");
         String csrFile = cmd.getOptionValue("csr");
         String extConf = cmd.getOptionValue("ext");
+        String subjectAltName = cmd.getOptionValue("subjectAltName");
         String serialNumber = cmd.getOptionValue("serial");
         String monthsValid = cmd.getOptionValue("months-valid", "3");
         String hash = cmd.getOptionValue("hash", "SHA256");
@@ -103,12 +108,18 @@ public class NSSCertIssueCLI extends CommandCLI {
         byte[] csrBytes = CertUtil.parseCSR(csrPEM);
         PKCS10 pkcs10 = new PKCS10(csrBytes);
 
+        NSSExtensionGenerator generator = new NSSExtensionGenerator();
         Extensions extensions = null;
+
         if (extConf != null) {
-            NSSExtensionGenerator generator = new NSSExtensionGenerator();
             generator.init(extConf);
-            extensions = generator.createExtensions(issuer, pkcs10);
         }
+
+        if (subjectAltName != null) {
+            generator.setParameter("subjectAltName", subjectAltName);
+        }
+
+        extensions = generator.createExtensions(issuer, pkcs10);
 
         String tokenName = clientConfig.getTokenName();
 

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -74,6 +74,10 @@ public class NSSCertRequestCLI extends CommandCLI {
         option.setArgName("path");
         options.addOption(option);
 
+        option = new Option(null, "subjectAltName", true, "Subject alternative name");
+        option.setArgName("value");
+        options.addOption(option);
+
         option = new Option(null, "csr", true, "Certificate signing request");
         option.setArgName("path");
         options.addOption(option);
@@ -99,6 +103,7 @@ public class NSSCertRequestCLI extends CommandCLI {
         boolean sslECDH = cmd.hasOption("ssl-ecdh");
         String hash = cmd.getOptionValue("hash", "SHA256");
         String extConf = cmd.getOptionValue("ext");
+        String subjectAltName = cmd.getOptionValue("subjectAltName");
 
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
@@ -144,14 +149,19 @@ public class NSSCertRequestCLI extends CommandCLI {
             throw new Exception("Unsupported key type: " + keyType);
         }
 
+        NSSExtensionGenerator generator = new NSSExtensionGenerator();
         Extensions extensions = null;
-        if (extConf != null) {
-            NSSExtensionGenerator generator = new NSSExtensionGenerator();
-            generator.init(extConf);
 
-            X509Key subjectKey = CryptoUtil.createX509Key(keyPair.getPublic());
-            extensions = generator.createExtensions(subjectKey);
+        if (extConf != null) {
+            generator.init(extConf);
         }
+
+        if (subjectAltName != null) {
+            generator.setParameter("subjectAltName", subjectAltName);
+        }
+
+        X509Key subjectKey = CryptoUtil.createX509Key(keyPair.getPublic());
+        extensions = generator.createExtensions(subjectKey);
 
         PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
         String keyAlgorithm = hash + "with" + privateKey.getType();

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -3,3 +3,10 @@
 == New pki-server cert-validate CLI ==
 
 The `pki-server cert-validate` command has been added to validate a system certificate.
+
+== New SAN option for pki nss-cert CLIs ==
+
+The `pki nss-cert-request` and `pki nss-cert-issue` commands have been
+modified to provide a `--subjectAltName` option.
+This option will override the `subjectAltName` parameter in the extension
+configuration file.

--- a/tests/bin/test-sslserver-cert-ext.sh
+++ b/tests/bin/test-sslserver-cert-ext.sh
@@ -37,7 +37,7 @@ sed -En 'N; s/^ *(X509v3 Extended Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | 
 diff actual expected
 
 # verfiy SAN extension
-echo "X509v3 Subject Alternative Name: " > expected
-echo "DNS:pki.example.com" >> expected
+echo "X509v3 Subject Alternative Name: critical" > expected
+echo "DNS:www.example.com, DNS:pki.example.com" >> expected
 sed -En 'N; s/^ *(X509v3 Subject Alternative Name: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
 diff actual expected

--- a/tests/bin/test-sslserver-csr-ext.sh
+++ b/tests/bin/test-sslserver-csr-ext.sh
@@ -25,3 +25,9 @@ echo "X509v3 Extended Key Usage: " > expected
 echo "TLS Web Server Authentication, TLS Web Client Authentication" >> expected
 sed -En 'N; s/^ *(X509v3 Extended Key Usage: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
 diff actual expected
+
+# verfiy SAN extension
+echo "X509v3 Subject Alternative Name: critical" > expected
+echo "DNS:www.example.com, DNS:pki.example.com" >> expected
+sed -En 'N; s/^ *(X509v3 Subject Alternative Name: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+diff actual expected


### PR DESCRIPTION
The `pki nss-cert-request` and `pki nss-cert-issue` commands have been modified to provide an option to specify a SAN extension when generating a CSR and issuing a certificate which will make it easier to test SAN extensions.

The `NSSExtensionGenerator` has been modified to support `critical` option and specific DNS names for SAN extension.

The CI test has been updated to validate the new option.

https://github.com/dogtagpki/pki/wiki/Generating-Certificate-Request-with-PKI-NSS
https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-Extensions
