### PR TITLE
Add key attribute options for pki nss-key-create

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
@@ -76,6 +76,16 @@ public class NSSKeyCreateCLI extends CommandCLI {
 
         options.addOption(null, "ssl-ecdh", false, "Generate EC key for SSL with ECDH ECDSA.");
 
+        options.addOption(null, "temporary", false, "Generate temporary key");
+
+        option = new Option(null, "sensitive", true, "Generate sensitive key");
+        option.setArgName("boolean");
+        options.addOption(option);
+
+        option = new Option(null, "extractable", true, "Generate extractable key");
+        option.setArgName("boolean");
+        options.addOption(option);
+
         option = new Option(null, "output-format", true, "Output format: text (default), json.");
         option.setArgName("format");
         options.addOption(option);
@@ -105,6 +115,20 @@ public class NSSKeyCreateCLI extends CommandCLI {
         String curve = cmd.getOptionValue("curve", "nistp256");
         boolean sslECDH = cmd.hasOption("ssl-ecdh");
 
+        boolean temporary = cmd.hasOption("temporary");
+
+        String sensitiveStr = cmd.getOptionValue("sensitive");
+        Boolean sensitive = null;
+        if (sensitiveStr != null) {
+            sensitive = Boolean.valueOf(sensitiveStr);
+        }
+
+        String extractableStr = cmd.getOptionValue("extractable");
+        Boolean extractable = null;
+        if (extractableStr != null) {
+            extractable = Boolean.valueOf(extractableStr);
+        }
+
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
 
@@ -126,6 +150,9 @@ public class NSSKeyCreateCLI extends CommandCLI {
             KeyPair keyPair = nssdb.createRSAKeyPair(
                     token,
                     Integer.parseInt(keySize),
+                    temporary,
+                    sensitive,
+                    extractable,
                     usages,
                     usagesMask);
 
@@ -144,6 +171,9 @@ public class NSSKeyCreateCLI extends CommandCLI {
             KeyPair keyPair = nssdb.createECKeyPair(
                     token,
                     curve,
+                    temporary,
+                    sensitive,
+                    extractable,
                     usages,
                     usagesMask);
 
@@ -164,7 +194,11 @@ public class NSSKeyCreateCLI extends CommandCLI {
 
             KeyGenerator kg = token.getKeyGenerator(KeyGenAlgorithm.AES);
             kg.initialize(Integer.parseInt(keySize));
-            kg.temporaryKeys(false);
+            kg.temporaryKeys(temporary);
+
+            if (sensitive != null) {
+                kg.sensitiveKeys(sensitive);
+            }
 
             SymmetricKey symmetricKey = kg.generate();
             symmetricKey.setNickName(nickname);


### PR DESCRIPTION
The `pki nss-key-create` has been modified to provide temporary, sensitive, and extractable options similar to the options in `PKCS10Client` and `CRMFPopClient`.

The temporary option does not take any argument since a key can only be either permanent or temporary.

The sensitive and extractable options take a boolean argument since the value can be `true`, `false`, or unspecified (default).

RSA and EC keys support all three options, but AES keys only support temporary and sensitive options.