### PR TITLE
Fix bug in AgentCertService.revokeCert

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AgentCertService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AgentCertService.java
@@ -244,7 +244,7 @@ public class AgentCertService extends PKIService implements AgentCertResource {
             }
 
             // Find target cert record if different from client cert.
-            CertRecord targetRecord = id.equals(clientSerialNumber) ? clientRecord : processor.getCertificateRecord(id);
+            CertRecord targetRecord = clientRecord != null && id.toBigInteger().equals(clientSerialNumber) ? clientRecord : processor.getCertificateRecord(id);
             X509CertImpl targetCert = targetRecord.getCertificate();
 
             processor.createCRLExtension();


### PR DESCRIPTION
Motivation: Sonar highlighted this code as new because it changed location, and it contains a potential NPE which causes the check to fail. It will fail for 30 days from the merge (as that is the the default time Sonar considers code "new"). This update addresses the NPE, so on-merge Sonar checks will pass again, and also addresses a bug I discovered in the process.

The current implementation always gets the CertRecord from the RevocationProcessor instead of the provided clientRecord as the id comparison was done between two different types, hence is always false.

The fix compares the id's as BigInteger types, and checks the clientRecord for null first as it is dereferenced later without a null check and is instantiated null.