### PR TITLE
Extract the waiting for build step into a new workflow

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   acme-certbot-test:
     name: ACME with certbot

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   ca-basic-test:
     name: Basic CA

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   ca-clone-test:
     name: CA clone

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -11,25 +11,8 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   sonarcloud:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/est-tests.yml
+++ b/.github/workflows/est-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   est-basic-test:
     name: Basic EST

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   kra-basic-test:
     name: Basic KRA

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   ocsp-basic-test:
     name: Basic OCSP

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   python-lint-test:
     name: Python lint

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building P'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   # Tier 0
   installation-sanity-test:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   server-basic-test:
     name: Basic server

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   tks-basic-test:
     name: Basic TKS

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   PKICertImport-test:
     name: PKICertImport

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -11,25 +11,8 @@ jobs:
   build:
     name: Waiting for build
     needs: init
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'push'
-
-      - name: Wait for build
-        uses: lewagon/wait-on-check-action@v1.2.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          check-name: 'Building PKI'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-        if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/wait-for-build.yml
+    secrets: inherit
 
   tps-basic-test:
     name: Basic TPS

--- a/.github/workflows/wait-for-build.yml
+++ b/.github/workflows/wait-for-build.yml
@@ -1,0 +1,36 @@
+name: Waiting For Build
+
+on:
+  workflow_call:
+
+jobs:
+  waiting-for-build:
+    name: Waiting For Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Building PKI'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'push'
+
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+        if: github.event_name == 'pull_request'
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v3
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar


### PR DESCRIPTION
This simplifies the top-level test files slightly. Also, I added a check to pull the images at the end of the wait. This way, the job fails if the build job is not finished. Currently the wait job always succeeds, then all subsequent jobs fail as a result. We can use this fail condition to trigger a retry.