### PR TITLE
Introduce a retry to wait-for-build.yml

### DIFF
--- a/.github/workflows/wait-for-build.yml
+++ b/.github/workflows/wait-for-build.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.2.0
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
           check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
+          wait-interval: 60
         if: github.event_name == 'push'
 
       - name: Wait for build
@@ -23,7 +23,40 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           check-name: 'Building PKI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
+          wait-interval: 60
+        if: github.event_name == 'pull_request'
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v3
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+  waiting-for-build2:
+    name: Waiting For Build - 2nd attempt
+    runs-on: ubuntu-latest
+    needs: waiting-for-build
+    if: ${{ failure() }}
+    steps:
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'Building PKI'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 60
+        if: github.event_name == 'push'
+
+      - name: Wait for build
+        uses: lewagon/wait-on-check-action@v1.2.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Building PKI'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 60
         if: github.event_name == 'pull_request'
 
       - name: Retrieve PKI images


### PR DESCRIPTION
If the waiting-for-build-job fails, run a second job. This should allow multiple CI suites to run simultaneously again. Additional runs can be added if needed. This is a bit of a dirty hack, but GitHub actions doesn't allow loop control flow and there is no way to extend the timeout of the build job.

I tried this is in my fork and hit an API limit so I bumped the `wait-interval` to 60s.