### PR TITLE
Update pki nss-cert-request to support empty subject

### DIFF
--- a/.github/workflows/pki-nss-exts-test.yml
+++ b/.github/workflows/pki-nss-exts-test.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Create SSL server cert request
         run: |
           docker exec pki pki nss-cert-request \
-              --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --subjectAltName "critical, DNS:www.example.com, DNS:pki.example.com" \
               --csr sslserver.csr

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -91,10 +91,6 @@ public class NSSCertRequestCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         String subject = cmd.getOptionValue("subject");
-        if (subject == null) {
-            throw new Exception("Missing subject name");
-        }
-
         String keyID = cmd.getOptionValue("key-id");
         String keyType = cmd.getOptionValue("key-type", "RSA");
         String keySize = cmd.getOptionValue("key-size", "2048");

--- a/tests/bin/test-sslserver-cert-ext.sh
+++ b/tests/bin/test-sslserver-cert-ext.sh
@@ -8,6 +8,11 @@ fi
 
 openssl x509 -text -noout -in $INPUT | tee output
 
+# verfiy subject name
+echo "Subject: " > expected
+sed -En 's/^ *(Subject: .*)$/\1/p' output | tee actual
+diff actual expected
+
 # verfiy SKI extension
 echo "X509v3 Subject Key Identifier: " > expected
 sed -En 's/^ *(X509v3 Subject Key Identifier: .*)$/\1/p' output | tee actual

--- a/tests/bin/test-sslserver-csr-ext.sh
+++ b/tests/bin/test-sslserver-csr-ext.sh
@@ -8,6 +8,11 @@ fi
 
 openssl req -text -noout -in $INPUT | tee output
 
+# verfiy subject name
+echo "Subject: " > expected
+sed -En 's/^ *(Subject: .*)$/\1/p' output | tee actual
+diff actual expected
+
 # verfiy basic constraints extension
 echo "X509v3 Basic Constraints: critical" > expected
 echo "CA:FALSE" >> expected


### PR DESCRIPTION
The `pki nss-cert-request` has been updated to no longer require a `--subject` param such that it can generate a CSR without a subject name.

https://github.com/dogtagpki/pki/wiki/Generating-Certificate-Request-with-PKI-NSS