### PR TITLE
Fix bug in TPSConnectorClient.getConnector()

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/system/TPSConnectorClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/system/TPSConnectorClient.java
@@ -33,7 +33,7 @@ public class TPSConnectorClient extends Client {
 
     public TPSConnectorData getConnector(String host, String port) throws Exception {
         TPSConnectorCollection connectors = findConnectors(host, port, null, null);
-        if (connectors.getTotal() < 1) {
+        if (connectors.getEntries().isEmpty()) {
             throw new ResourceNotFoundException("Connector not found: " + host + ":" + port);
         }
         return connectors.getEntries().iterator().next();


### PR DESCRIPTION
Previously, if connectors.getTotal() < 1 then we threw ResourceNotFoundException. Then we proceed to try access the next element in the connectors.getEntries() iterator.

The issue here is that DataCollection offers no guarantee that the total field is equivalent to connectors.getEntries().size(), it is left to calling code to update the total. This causes NoSuchElementException to be thrown on TPS startup. The connector not being present is actually expected by the calling code, so that is fine, but it is ugly that there is a stack trace associated with expected behaviour.

We now check connectors.getEntries().isEmpty() instead, throwing the correct ResourceNotFoundException, which is properly handled by the calling code.