### PR TITLE
Drop legacy CSR header/footer

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/authentication/CMCAuth.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/CMCAuth.java
@@ -289,17 +289,7 @@ public class CMCAuth extends AuthManager implements IExtendedPluginInfo {
             AuthToken authToken = new AuthToken(this);
 
             try {
-                String asciiBASE64Blob;
-
-                int startIndex = cmc.indexOf(CertUtil.CERT_NEW_REQUEST_HEADER);
-                int endIndex = cmc.indexOf(CertUtil.CERT_NEW_REQUEST_FOOTER);
-                if (startIndex != -1 && endIndex != -1) {
-                    startIndex = startIndex + CertUtil.CERT_NEW_REQUEST_HEADER.length();
-                    asciiBASE64Blob = cmc.substring(startIndex, endIndex);
-                } else
-                    asciiBASE64Blob = cmc;
-
-                byte[] cmcBlob = Utils.base64decode(asciiBASE64Blob);
+                byte[] cmcBlob = CertUtil.parseCSR(cmc);
                 ByteArrayInputStream cmcBlobIn = new
                                                  ByteArrayInputStream(cmcBlob);
 

--- a/base/ca/src/main/java/com/netscape/cms/authentication/CMCUserSignedAuth.java
+++ b/base/ca/src/main/java/com/netscape/cms/authentication/CMCUserSignedAuth.java
@@ -315,17 +315,7 @@ public class CMCUserSignedAuth extends AuthManager implements IExtendedPluginInf
             AuthToken authToken = new AuthToken(this);
 
             try {
-                String asciiBASE64Blob;
-
-                int startIndex = cmc.indexOf(CertUtil.CERT_NEW_REQUEST_HEADER);
-                int endIndex = cmc.indexOf(CertUtil.CERT_NEW_REQUEST_FOOTER);
-                if (startIndex != -1 && endIndex != -1) {
-                    startIndex = startIndex + CertUtil.CERT_NEW_REQUEST_HEADER.length();
-                    asciiBASE64Blob = cmc.substring(startIndex, endIndex);
-                } else
-                    asciiBASE64Blob = cmc;
-
-                byte[] cmcBlob = Utils.base64decode(asciiBASE64Blob);
+                byte[] cmcBlob = CertUtil.parseCSR(cmc);
                 ByteArrayInputStream cmcBlobIn = new ByteArrayInputStream(cmcBlob);
 
                 org.mozilla.jss.pkix.cms.ContentInfo cmcReq = (org.mozilla.jss.pkix.cms.ContentInfo) org.mozilla.jss.pkix.cms.ContentInfo

--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/EnrollServlet.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/EnrollServlet.java
@@ -1025,13 +1025,7 @@ public class EnrollServlet extends CAServlet {
 
             byte[] cmc = null;
             if (cmcBase64 != null && !cmcBase64.isBlank()) {
-                int startIndex = cmcBase64.indexOf(CertUtil.CERT_NEW_REQUEST_HEADER);
-                int endIndex = cmcBase64.indexOf(CertUtil.CERT_NEW_REQUEST_FOOTER);
-                if (startIndex != -1 && endIndex != -1) {
-                    startIndex = startIndex + CertUtil.CERT_NEW_REQUEST_HEADER.length();
-                    cmcBase64 = cmcBase64.substring(startIndex, endIndex);
-                }
-                cmc = Utils.base64decode(cmcBase64);
+                cmc = CertUtil.parseCSR(cmcBase64);
             }
 
             String crmfBase64 = httpParams.getValueAsString(CRMF_REQUEST, null);

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -1101,9 +1101,9 @@ class NSSDatabase(object):
 
             # add header and footer
             with open(request_file, 'w', encoding='utf-8') as f:
-                f.write('-----BEGIN NEW CERTIFICATE REQUEST-----\n')
+                f.write(CSR_HEADER + '\n')
                 f.write(b64_request)
-                f.write('-----END NEW CERTIFICATE REQUEST-----\n')
+                f.write(CSR_FOOTER + '\n')
 
         finally:
             shutil.rmtree(tmpdir)

--- a/base/console/src/main/java/com/netscape/admin/certsrv/config/WBaseManualCertRequestPage.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/config/WBaseManualCertRequestPage.java
@@ -33,6 +33,7 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
 import org.dogtag.util.cert.CertUtil;
+import org.mozilla.jss.netscape.security.util.Cert;
 
 import com.netscape.admin.certsrv.CMSAdminUtil;
 import com.netscape.admin.certsrv.config.install.InstallWizardInfo;
@@ -40,6 +41,7 @@ import com.netscape.admin.certsrv.task.CMSConfigCert;
 import com.netscape.admin.certsrv.task.CMSRequestCert;
 import com.netscape.admin.certsrv.wizard.WizardBasePanel;
 import com.netscape.admin.certsrv.wizard.WizardInfo;
+import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.common.ConfigConstants;
 import com.netscape.certsrv.common.Constants;
 import com.netscape.certsrv.common.OpDef;
@@ -126,19 +128,22 @@ public class WBaseManualCertRequestPage extends WizardBasePanel {
 
 			// Break the long single line:header,64 byte lines,trailer
 			// Assuming this is the only format we generate.
-			int head = mReq.indexOf(CertUtil.CERT_NEW_REQUEST_HEADER);
-			int trail = mReq.indexOf(CertUtil.CERT_NEW_REQUEST_FOOTER);
-        	String unwrapped =
-				mReq.substring(head + CertUtil.CERT_NEW_REQUEST_HEADER.length(), trail);
-			String str = CertUtil.CERT_NEW_REQUEST_HEADER + "\n";
+			String unwrapped;
+			try {
+			    unwrapped = CertUtil.unwrapPKCS10(mReq, false);
+			} catch (EBaseException e) {
+			    throw new RuntimeException(e);
+			}
+
+			String str = Cert.REQUEST_HEADER + "\n";
 			int len = unwrapped.length();
 			for (int i = 0; i < len; i=i+64){
 				if (i+64 < len)
 					str = str + unwrapped.substring(i,i+64) +"\n";
 				else
 					str = str + unwrapped.substring(i,len) +"\n";
-		    }
-			str = str + CertUtil.CERT_NEW_REQUEST_FOOTER;
+		        }
+			str = str + Cert.REQUEST_FOOTER;
 			mReq = str;
 	    } else if (mReqFormat.equals(ConfigConstants.PR_REQUEST_CMC)){
 			String str = "";

--- a/base/console/src/main/java/com/netscape/admin/certsrv/security/Response.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/security/Response.java
@@ -34,6 +34,7 @@ import java.util.Vector;
 
 import org.dogtag.util.cert.CertUtil;
 
+import com.netscape.certsrv.base.EBaseException;
 import com.netscape.management.client.util.Debug;
 
 //this class need some optimization....
@@ -68,9 +69,10 @@ class Response {
     boolean _fsecurityDomestic = false, _fsecurityFortezza = false;
 
     void parseCertificate(String response) {
-        if (response.indexOf(CertUtil.CERT_NEW_REQUEST_HEADER) != -1) {
-            _cert = response.substring(response.indexOf(CertUtil.CERT_NEW_REQUEST_HEADER),
-                    response.indexOf(CertUtil.CERT_NEW_REQUEST_FOOTER) + CertUtil.CERT_NEW_REQUEST_FOOTER.length());
+        try {
+            _cert = CertUtil.unwrapPKCS10(response, false);
+        } catch (EBaseException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/docs/user/tools/Using-PKI-CA-Certificate-CLI.adoc
+++ b/docs/user/tools/Using-PKI-CA-Certificate-CLI.adoc
@@ -198,29 +198,9 @@ The request template will be stored in XML format:
 link:https://github.com/dogtagpki/pki/wiki/Generating-Certificate-Request[Generate a certificate request], for example:
 
 ----
-$ PKCS10Client -d ~/.dogtag/nssdb -p Secret.123 -a rsa -l 1024 -o testuser.csr -n "uid=testuser"
-PKCS10Client: Debug: got token.
-PKCS10Client: Debug: thread token set.
-PKCS10Client: token Internal Key Storage Token logged in...
-PKCS10Client: key pair generated.
-PKCS10Client: pair.getPublic() called.
-PKCS10Client: CertificationRequestInfo() created.
-PKCS10Client: CertificationRequest created.
-PKCS10Client: calling Utils.b64encode.
-PKCS10Client: b64encode completes.
------BEGIN NEW CERTIFICATE REQUEST-----
-MIIBfTCB5wIBADAaMRgwFgYKCZImiZPyLGQBARMIdGVzdHVzZXIwgZ8wDQYJKoZI
-hvcNAQEBBQADgY0AMIGJAoGBAPEcxFJBu2lNmIS+MNaZKO43h0dIhKZWZ8wEomQc
-tc9guIUGM5eFU+psj6n0XQCPMIVRe7mrzYHF8mlwAp416P5/97g9U6JOKkTXc5ia
-HVE1JRhykHiQ17Lp7Y6xXxfe6xKAXDoLOPJ4fNdadtbVeIGjudWktjgwh5CQBXsA
-GFP5AgMBAAGgJDAiBggrBgEFBQcHFzEWBBTmaclfLv+kkK5z5kTMP54dlnecUDAN
-BgkqhkiG9w0BAQQFAAOBgQAXrm979HwcG63Z64u+aybYrfOgyWxQ4kTtCA+NKYge
-HC6Z/mlb10J/wggOzrHUbE4IFyjbBo2k1FKe8zYcXIB6Ok5Z0TXueR1zKcb8hE35
-o9dkH2sGJsSqMLN8NRyY5QeqOKmtaX8pm1aPhJ0wkvOYou52YqJdq6LF9KXmBGOH
-hA==
-
------END NEW CERTIFICATE REQUEST-----
-PKCS10Client: done. Request written to file: testuser.csr
+$ PKCS10Client -d ~/.dogtag/nssdb -p Secret.123 -a rsa -l 2048 -o testuser.csr -n "uid=testuser"
+PKCS10Client: Certificate request written into testuser.csr
+PKCS10Client: PKCS#10 request key id written into testuser.csr.keyId
 ----
 
 == Submitting a Certificate Request ==

--- a/tests/dogtag/shared/java/common/ComCrypto.java
+++ b/tests/dogtag/shared/java/common/ComCrypto.java
@@ -32,6 +32,7 @@ import java.net.URLEncoder;
 import java.security.KeyPair;
 import java.lang.Exception;
 
+import org.dogtag.util.cert.CertUtil;
 import org.mozilla.jss.*;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.InternalCertificate;
@@ -53,6 +54,7 @@ import org.mozilla.jss.pkix.crmf.*;
 import org.mozilla.jss.netscape.security.pkcs.PKCS10;
 import org.mozilla.jss.netscape.security.x509.X500Name;
 import org.mozilla.jss.netscape.security.util.BigInt;
+import org.mozilla.jss.netscape.security.util.Cert;
 import org.mozilla.jss.netscape.security.x509.X500Signer;
 
 import sun.misc.BASE64Encoder;
@@ -89,10 +91,7 @@ public class ComCrypto {
     private CryptoStore store = null;
     private Password pass1 = null, pass2 = null;
 
-    private String bstr = "-----BEGIN NEW CERTIFICATE REQUEST-----";
-    private String blob, Blob1 = null;
-    private String Blob2 = null;
-    private String estr = "-----END NEW CERTIFICATE REQUEST-----";
+    private String blob;
 
     private String certprefix = null;
 
@@ -541,13 +540,9 @@ public class ComCrypto {
                         keytype, (byte[]) null, (byte[]) null, (byte[]) null);
 
                 System.out.println("Cert Request Generated.");
+                System.out.println(blob);
 
-                bstr = "-----BEGIN NEW CERTIFICATE REQUEST-----";
-                Blob1 = blob.substring(bstr.length() + 1);
-                Blob2 = Blob1.substring(0, Blob1.indexOf(estr));
-
-                System.out.println(Blob2);
-                pkcs10request = Blob2;
+                pkcs10request = CertUtil.unwrapPKCS10(blob, false);
             }
 
             return true;


### PR DESCRIPTION
The code that generates a CSR has been modified to use the header and footer described in RFC 7468.

The code that parses a CSR has been modified to use `CertUtil.parseCSR()` or `unwrapPKCS10()` such that it can handle both RFC 7468 and legacy headers/footers.

See also:

* https://datatracker.ietf.org/doc/html/rfc7468#section-7
* https://github.com/dogtagpki/pki/issues/3843