### PR TITLE
Create separate build for ACME tests

### DIFF
--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve PKI images
+      - name: Retrieve ACME images
         uses: actions/cache@v3
         with:
-          key: pki-images-${{ github.sha }}
-          path: pki-images.tar
+          key: acme-images-${{ github.sha }}
+          path: acme-images.tar
 
-      - name: Load PKI images
-        run: docker load --input pki-images.tar
+      - name: Load ACME images
+        run: docker load --input acme-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve PKI images
+      - name: Retrieve ACME images
         uses: actions/cache@v3
         with:
-          key: pki-images-${{ github.sha }}
-          path: pki-images.tar
+          key: acme-images-${{ github.sha }}
+          path: acme-images.tar
 
-      - name: Load PKI images
-        run: docker load --input pki-images.tar
+      - name: Load ACME images
+        run: docker load --input acme-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-postgresql-test.yml
+++ b/.github/workflows/acme-postgresql-test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve PKI images
+      - name: Retrieve ACME images
         uses: actions/cache@v3
         with:
-          key: pki-images-${{ github.sha }}
-          path: pki-images.tar
+          key: acme-images-${{ github.sha }}
+          path: acme-images.tar
 
-      - name: Load PKI images
-        run: docker load --input pki-images.tar
+      - name: Load ACME images
+        run: docker load --input acme-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Retrieve PKI images
+      - name: Retrieve ACME images
         uses: actions/cache@v3
         with:
-          key: pki-images-${{ github.sha }}
-          path: pki-images.tar
+          key: acme-images-${{ github.sha }}
+          path: acme-images.tar
 
-      - name: Load PKI images
-        run: docker load --input pki-images.tar
+      - name: Load ACME images
+        run: docker load --input acme-images.tar
 
       - name: Create network
         run: docker network create example

--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -2,6 +2,9 @@ name: ACME Tests
 
 on: [push, pull_request]
 
+env:
+  NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || github.repository_owner }}
+
 jobs:
   init:
     name: Initialization
@@ -9,10 +12,83 @@ jobs:
     secrets: inherit
 
   build:
-    name: Waiting for build
+    name: Building ACME images
     needs: init
-    uses: ./.github/workflows/wait-for-build.yml
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        id: cache-buildx
+        uses: actions/cache@v3
+        with:
+          key: buildx-${{ hashFiles('pki.spec') }}
+          path: /tmp/.buildx-cache
+
+      - name: Build pki-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
+            COPR_REPO=${{ vars.COPR_REPO }}
+          tags: pki-deps
+          target: pki-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-builder-deps image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
+            COPR_REPO=${{ vars.COPR_REPO }}
+          tags: pki-builder-deps
+          target: pki-builder-deps
+          cache-to: type=local,dest=/tmp/.buildx-cache
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+
+      - name: Build pki-runner image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
+            COPR_REPO=${{ vars.COPR_REPO }}
+            BUILD_OPTS=--with-pkgs=base,server,ca,acme --without-test
+          tags: pki-runner
+          target: pki-runner
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker
+
+      - name: Build pki-acme image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=${{ needs.init.outputs.base-image }}
+            COPR_REPO=${{ vars.COPR_REPO }}
+            BUILD_OPTS=--with-pkgs=base,server,ca,acme --without-test
+          tags: pki-acme
+          target: pki-acme
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker
+
+      - name: Save ACME images
+        run: |
+          docker images
+          docker save -o acme-images.tar pki-runner pki-acme
+
+      - name: Store ACME images
+        uses: actions/cache@v3
+        with:
+          key: acme-images-${{ github.sha }}
+          path: acme-images.tar
 
   acme-certbot-test:
     name: ACME with certbot
@@ -41,3 +117,39 @@ jobs:
     uses: ./.github/workflows/acme-postgresql-test.yml
     with:
       db-image: ${{ needs.init.outputs.db-image }}
+
+  publish:
+    if: github.event_name == 'push' && github.ref_name == 'master'
+    name: Publishing ACME images
+    needs: [init, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: vars.REGISTRY == 'ghcr.io'
+
+      - name: Log in to other container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+        if: vars.REGISTRY != 'ghcr.io'
+
+      - name: Retrieve ACME images
+        uses: actions/cache@v3
+        with:
+          key: acme-images-${{ github.sha }}
+          path: acme-images.tar
+
+      - name: Load ACME images
+        run: docker load --input acme-images.tar
+
+      - name: Publish pki-acme image
+        run: |
+          docker tag pki-acme ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:latest
+          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,22 +111,10 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker
 
-      - name: Build pki-acme image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          build-args: |
-            BASE_IMAGE=${{ needs.init.outputs.base-image }}
-            COPR_REPO=${{ vars.COPR_REPO }}
-          tags: pki-acme
-          target: pki-acme
-          cache-from: type=local,src=/tmp/.buildx-cache
-          outputs: type=docker
-
       - name: Save PKI images
         run: |
           docker images
-          docker save -o pki-images.tar pki-dist pki-runner pki-server pki-ca pki-acme
+          docker save -o pki-images.tar pki-dist pki-runner pki-server pki-ca
 
       - name: Store PKI images
         uses: actions/cache@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,8 +109,3 @@ jobs:
         run: |
           docker tag pki-ca ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest
           docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest
-
-      - name: Publish pki-acme image
-        run: |
-          docker tag pki-acme ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:latest
-          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:latest


### PR DESCRIPTION
The build job in ACME tests workflow has been modified to create just the packages required for ACME tests (without re-running the unit tests since they are already run by the main build job), then publish the ACME image.

This way the main build job no longer needs to build the ACME image so other tests can start earlier, thus reducing the overall execution time.