### PR TITLE
Bug2190283-part2_LdapSimpleMap_Invalid_cast_warning

### DIFF
--- a/base/server/src/main/java/com/netscape/cms/publish/mappers/LdapSimpleMap.java
+++ b/base/server/src/main/java/com/netscape/cms/publish/mappers/LdapSimpleMap.java
@@ -275,7 +275,9 @@ public class LdapSimpleMap implements ILdapMapper, IExtendedPluginInfo {
                 X509CRLImpl crl = (X509CRLImpl) obj;
                 subjectDN = (X500Name) crl.getIssuerDN();
 
-                logger.warn("LdapSimpleMap: crl issuer dn: " + subjectDN + ": " + e.getMessage(), e);
+                // We know by now that obj is X509CRLImpl instead of
+                //   X509Certificate; no warning needed
+                // logger.warn("LdapSimpleMap: crl issuer dn: " + subjectDN + ": " + e.getMessage(), e);
             } catch (ClassCastException ex) {
                 logger.warn(CMS.getLogMessage("PUBLISH_PUBLISH_OBJ_NOT_SUPPORTED",
                                 ((req == null) ? "" : req.getRequestId().toString())), ex);


### PR DESCRIPTION
This patch was part of the patch that was taken out earlier. It fixes a frivilous WARNING message:

[CRLIssuingPoint-MasterCRL] WARNING: LdapSimpleMap: crl issuer dn:... org.mozilla.jss.netscape.security.x509.X509CRLImpl cannot be cast to java.security.cert.X509Certificate It did not attribute to the CI break so I'm putting it back.

fixes (part2) https://bugzilla.redhat.com/show_bug.cgi?id=2190283