### PR TITLE
Deprecate sslget

### DIFF
--- a/base/tools/src/main/native/sslget/sslget.c
+++ b/base/tools/src/main/native/sslget/sslget.c
@@ -815,6 +815,8 @@ main(int argc, char **argv)
 	int co;
 	char *crlf;
 
+    fprintf( stderr, "WARNING: sslget has been deprecated. Use pki CLI or curl instead.\n" );
+
     /* Call the NSPR initialization routines */
     PR_Init( PR_SYSTEM_THREAD, PR_PRIORITY_NORMAL, 1);
 

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -10,3 +10,8 @@ The `pki nss-cert-request` and `pki nss-cert-issue` commands have been
 modified to provide a `--subjectAltName` option.
 This option will override the `subjectAltName` parameter in the extension
 configuration file.
+
+== Deprecate sslget ==
+
+The `sslget` command has been deprecated.
+Use `pki` CLI or the `curl` command instead.


### PR DESCRIPTION
The `sslget` command is no longer used by the code so it has been deprecated and might be removed in the future to reduce maintenance. This command can be replaced with `pki` CLI or `curl`.

https://github.com/edewata/pki/blob/deprecation/docs/changes/v11.5.0/Tools-Changes.adoc
