### PR TITLE
Update admin cert profile in tests

### DIFF
--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Issue KRA admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile caUserCert --csr-file ${SHARED}/kra_admin.csr --subject uid=kraadmin | tee output
+          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/kra_admin.csr | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
           docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
           CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Issue OCSP admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile caUserCert --csr-file ${SHARED}/ocsp_admin.csr --subject uid=ocspadmin | tee output
+          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/ocsp_admin.csr | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
           docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
           CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Issue OCSP admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile caUserCert --csr-file ${SHARED}/ocsp_admin.csr --subject uid=ocspadmin | tee output
+          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/ocsp_admin.csr | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
           docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
           CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Issue OCSP admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile caUserCert --csr-file ${SHARED}/ocsp_admin.csr --subject uid=ocspadmin | tee output
+          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/ocsp_admin.csr | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
           docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
           CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Issue TKS admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/tks_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile caUserCert --csr-file ${SHARED}/tks_admin.csr --subject uid=tksadmin | tee output
+          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/tks_admin.csr | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
           docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
           CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Issue TPS admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/tps_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile caUserCert --csr-file ${SHARED}/tps_admin.csr --subject uid=tpsadmin | sed -n 's/Request ID: *\(.*\)/\1/p' > tps_admin.reqid
+          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/tps_admin.csr | sed -n 's/Request ID: *\(.*\)/\1/p' > tps_admin.reqid
           docker exec ca pki -n caadmin ca-cert-request-approve `cat tps_admin.reqid` --force | sed -n 's/Certificate ID: *\(.*\)/\1/p' > tps_admin.certid
           docker exec ca pki ca-cert-export `cat tps_admin.certid` --output-file ${SHARED}/tps_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/tps_admin.crt

--- a/base/server/examples/installation/kra-external-certs-step1.cfg
+++ b/base/server/examples/installation/kra-external-certs-step1.cfg
@@ -8,7 +8,6 @@ pki_admin_email=kraadmin@example.com
 pki_admin_name=kraadmin
 pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
-pki_admin_subject_dn=uid=kraadmin
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123

--- a/base/server/examples/installation/kra-external-certs-step2.cfg
+++ b/base/server/examples/installation/kra-external-certs-step2.cfg
@@ -8,7 +8,6 @@ pki_admin_email=kraadmin@example.com
 pki_admin_name=kraadmin
 pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
-pki_admin_subject_dn=uid=kraadmin
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123

--- a/base/server/examples/installation/kra-standalone-step1.cfg
+++ b/base/server/examples/installation/kra-standalone-step1.cfg
@@ -6,7 +6,6 @@ pki_admin_email=kraadmin@example.com
 pki_admin_name=kraadmin
 pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
-pki_admin_subject_dn=uid=kraadmin
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123

--- a/base/server/examples/installation/kra-standalone-step2.cfg
+++ b/base/server/examples/installation/kra-standalone-step2.cfg
@@ -8,7 +8,6 @@ pki_admin_email=kraadmin@example.com
 pki_admin_name=kraadmin
 pki_admin_nickname=kraadmin
 pki_admin_password=Secret.123
-pki_admin_subject_dn=uid=kraadmin
 pki_admin_uid=kraadmin
 
 pki_client_database_password=Secret.123

--- a/base/server/examples/installation/ocsp-external-certs-step1.cfg
+++ b/base/server/examples/installation/ocsp-external-certs-step1.cfg
@@ -8,7 +8,6 @@ pki_admin_email=ocspadmin@example.com
 pki_admin_name=ocspadmin
 pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
-pki_admin_subject_dn=uid=ocspadmin
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123

--- a/base/server/examples/installation/ocsp-external-certs-step2.cfg
+++ b/base/server/examples/installation/ocsp-external-certs-step2.cfg
@@ -8,7 +8,6 @@ pki_admin_email=ocspadmin@example.com
 pki_admin_name=ocspadmin
 pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
-pki_admin_subject_dn=uid=ocspadmin
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123

--- a/base/server/examples/installation/ocsp-standalone-step1.cfg
+++ b/base/server/examples/installation/ocsp-standalone-step1.cfg
@@ -6,7 +6,6 @@ pki_admin_email=ocspadmin@example.com
 pki_admin_name=ocspadmin
 pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
-pki_admin_subject_dn=uid=ocspadmin
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123

--- a/base/server/examples/installation/ocsp-standalone-step2.cfg
+++ b/base/server/examples/installation/ocsp-standalone-step2.cfg
@@ -8,7 +8,6 @@ pki_admin_email=ocspadmin@example.com
 pki_admin_name=ocspadmin
 pki_admin_nickname=ocspadmin
 pki_admin_password=Secret.123
-pki_admin_subject_dn=uid=ocspadmin
 pki_admin_uid=ocspadmin
 
 pki_client_database_password=Secret.123


### PR DESCRIPTION
Previously the subject DN for admin certs in tests were changed into `uid=<username>` since it's required by the `caUserCert` profile.

The tests have been updated to use the `AdminCert` profile which allows any subject DN, so the subject DN no longer needs to be replaced.