### PR TITLE
Update client classes to use JAX-RS client API

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/logging/AuditClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/logging/AuditClient.java
@@ -17,6 +17,12 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.logging;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 
@@ -28,39 +34,32 @@ import com.netscape.certsrv.client.PKIClient;
  */
 public class AuditClient extends Client {
 
-    public AuditResource resource;
-
     public AuditClient(PKIClient client, String subsystem) throws Exception {
         super(client, subsystem, "audit");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(AuditResource.class);
     }
 
     public AuditConfig getAuditConfig() throws Exception {
-        Response response = resource.getAuditConfig();
-        return client.getEntity(response, AuditConfig.class);
+        return get(AuditConfig.class);
     }
 
     public AuditConfig updateAuditConfig(AuditConfig auditConfig) throws Exception {
-        Response response = resource.updateAuditConfig(auditConfig);
-        return client.getEntity(response, AuditConfig.class);
+        Entity<AuditConfig> entity = client.entity(auditConfig);
+        return patch(null, null, entity, AuditConfig.class);
     }
 
     public AuditConfig changeAuditStatus(String action) throws Exception {
-        Response response = resource.changeAuditStatus(action);
-        return client.getEntity(response, AuditConfig.class);
+        Map<String, Object> params = new HashMap<>();
+        params.put("action", action);
+        return post(null, params, null, AuditConfig.class);
     }
 
     public AuditFileCollection findAuditFiles() throws Exception {
-        Response response = resource.findAuditFiles();
-        return client.getEntity(response, AuditFileCollection.class);
+        return get("files", AuditFileCollection.class);
     }
 
     public StreamingOutput getAuditFile(String filename) throws Exception {
-        Response response = resource.getAuditFile(filename);
+        WebTarget target = target("files/" + filename, null);
+        Response response = target.request(MediaType.APPLICATION_OCTET_STREAM).get();
         return client.getEntity(response, StreamingOutput.class);
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileClient.java
@@ -17,7 +17,10 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.profile;
 
-import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Entity;
 
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
@@ -27,68 +30,60 @@ import com.netscape.certsrv.client.PKIClient;
  */
 public class ProfileClient extends Client {
 
-    public ProfileResource profileClient;
-
     public ProfileClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, "profile");
-        init();
-    }
-
-    public void init() throws Exception {
-        profileClient = createProxy(ProfileResource.class);
+        super(client, subsystem, "profiles");
     }
 
     public ProfileData retrieveProfile(String id) throws Exception {
-        Response response = profileClient.retrieveProfile(id);
-        return client.getEntity(response, ProfileData.class);
+        return get(id, ProfileData.class);
     }
 
     public byte[] retrieveProfileRaw(String id) throws Exception {
-        Response response = profileClient.retrieveProfileRaw(id);
-        return client.getEntity(response, byte[].class);
+        return get(id + "/raw", byte[].class);
     }
 
     public ProfileDataInfos listProfiles(Integer start, Integer size) throws Exception {
-        Response response =  profileClient.listProfiles(start, size);
-        return client.getEntity(response, ProfileDataInfos.class);
+        Map<String, Object> params = new HashMap<>();
+        if (start != null) params.put("start", start);
+        if (size != null) params.put("size", size);
+        return get(null, params, ProfileDataInfos.class);
     }
 
     public void enableProfile(String id) throws Exception {
-        Response response = profileClient.modifyProfileState(id, "enable");
-        client.getEntity(response, Void.class);
+        Map<String, Object> params = new HashMap<>();
+        params.put("action", "enable");
+        post(id, params, null, Void.class);
     }
 
     public void disableProfile(String id) throws Exception {
-        Response response = profileClient.modifyProfileState(id, "disable");
-        client.getEntity(response, Void.class);
+        Map<String, Object> params = new HashMap<>();
+        params.put("action", "disable");
+        post(id, params, null, Void.class);
     }
 
     public ProfileData createProfile(ProfileData data) throws Exception {
         String createProfileRequest = (String) client.marshall(data);
-        Response response = profileClient.createProfile(createProfileRequest);
-        return client.getEntity(response, ProfileData.class);
+        Entity<String> entity = client.entity(createProfileRequest);
+        return post(null, null, entity, ProfileData.class);
     }
 
     public byte[] createProfileRaw(byte[] properties) throws Exception {
-        Response response =
-            profileClient.createProfileRaw(properties);
-        return client.getEntity(response, byte[].class);
+        Entity<byte[]> entity = client.entity(properties);
+        return post("raw", null, entity, byte[].class);
     }
 
     public ProfileData modifyProfile(ProfileData data) throws Exception {
         String modifyProfileRequest = (String) client.marshall(data);
-        Response response = profileClient.modifyProfile(data.getId(), modifyProfileRequest);
-        return client.getEntity(response, ProfileData.class);
+        Entity<String> entity = client.entity(modifyProfileRequest);
+        return put(data.getId(), null, entity, ProfileData.class);
     }
 
     public byte[] modifyProfileRaw(String profileId, byte[] properties) throws Exception {
-        Response response = profileClient.modifyProfileRaw(profileId, properties);
-        return client.getEntity(response, byte[].class);
+        Entity<byte[]> entity = client.entity(properties);
+        return put(profileId + "/raw", null, entity, byte[].class);
     }
 
     public void deleteProfile(String id) throws Exception {
-        Response response = profileClient.deleteProfile(id);
-        client.getEntity(response, Void.class);
+        delete(id, Void.class);
     }
-
 }

--- a/base/common/src/main/java/com/netscape/certsrv/system/TPSConnectorClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/system/TPSConnectorClient.java
@@ -1,6 +1,9 @@
 package com.netscape.certsrv.system;
 
-import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Entity;
 
 import com.netscape.certsrv.base.ResourceNotFoundException;
 import com.netscape.certsrv.client.Client;
@@ -9,26 +12,27 @@ import com.netscape.certsrv.key.KeyData;
 
 public class TPSConnectorClient extends Client {
 
-    private TPSConnectorResource tpsConnectorClient;
-
     public TPSConnectorClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, "tpsconnector");
-        init();
-    }
-
-    public void init() throws Exception {
-        tpsConnectorClient = createProxy(TPSConnectorResource.class);
+        super(client, subsystem, "admin/tps-connectors");
     }
 
     public TPSConnectorCollection findConnectors(
-            String host, String port, Integer start, Integer size) throws Exception {
-        Response response = tpsConnectorClient.findConnectors(host, port, start, size);
-        return client.getEntity(response, TPSConnectorCollection.class);
+            String host,
+            String port,
+            Integer start,
+            Integer size) throws Exception {
+
+        Map<String, Object> params = new HashMap<>();
+        if (host != null) params.put("host", host);
+        if (port != null) params.put("port", port);
+        if (start != null) params.put("start", start);
+        if (size != null) params.put("size", size);
+
+        return get(null, params, TPSConnectorCollection.class);
     }
 
     public TPSConnectorData getConnector(String id) throws Exception {
-        Response response = tpsConnectorClient.getConnector(id);
-        return client.getEntity(response, TPSConnectorData.class);
+        return get(id, TPSConnectorData.class);
     }
 
     public TPSConnectorData getConnector(String host, String port) throws Exception {
@@ -39,43 +43,42 @@ public class TPSConnectorClient extends Client {
         return connectors.getEntries().iterator().next();
     }
 
-    public TPSConnectorData createConnector(String tpsHost, String tpsPort) throws Exception {
-        Response response = tpsConnectorClient.createConnector(tpsHost, tpsPort);
-        return client.getEntity(response, TPSConnectorData.class);
+    public TPSConnectorData createConnector(String host, String port) throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        if (host != null) params.put("host", host);
+        if (port != null) params.put("port", port);
+        return post(null, params, null, TPSConnectorData.class);
     }
 
     public TPSConnectorData modifyConnector(String id, TPSConnectorData data) throws Exception {
-        Response response = tpsConnectorClient.modifyConnector(id, data);
-        return client.getEntity(response, TPSConnectorData.class);
+        Entity<TPSConnectorData> entity = client.entity(data);
+        return post(id, null, entity, TPSConnectorData.class);
     }
 
     public void deleteConnector(String id) throws Exception {
-        Response response = tpsConnectorClient.deleteConnector(id);
-        client.getEntity(response, Void.class);
-    }
-
-    public KeyData createSharedSecret(String id) throws Exception {
-        Response response = tpsConnectorClient.createSharedSecret(id);
-        return client.getEntity(response, KeyData.class);
-    }
-
-    public KeyData replaceSharedSecret(String id) throws Exception {
-        Response response = tpsConnectorClient.replaceSharedSecret(id);
-        return client.getEntity(response, KeyData.class);
-    };
-
-    public void deleteSharedSecret(String id) throws Exception {
-        Response response = tpsConnectorClient.deleteSharedSecret(id);
-        client.getEntity(response, Void.class);
-    }
-
-    public KeyData getSharedSecret(String id) throws Exception {
-        Response response = tpsConnectorClient.getSharedSecret(id);
-        return client.getEntity(response, KeyData.class);
+        delete(id, Void.class);
     }
 
     public void deleteConnector(String host, String port) throws Exception {
-        Response response = tpsConnectorClient.deleteConnector(host, port);
-        client.getEntity(response, Void.class);
+        Map<String, Object> params = new HashMap<>();
+        if (host != null) params.put("host", host);
+        if (port != null) params.put("port", port);
+        delete(null, params, Void.class);
+    }
+
+    public KeyData createSharedSecret(String id) throws Exception {
+        return post(id + "/shared-secret", null, null, KeyData.class);
+    }
+
+    public KeyData replaceSharedSecret(String id) throws Exception {
+        return put(id + "/shared-secret", null, null, KeyData.class);
+    };
+
+    public void deleteSharedSecret(String id) throws Exception {
+        delete(id + "/shared-secret", Void.class);
+    }
+
+    public KeyData getSharedSecret(String id) throws Exception {
+        return get(id + "/shared-secret", KeyData.class);
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileClient.java
@@ -17,7 +17,10 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.tps.profile;
 
-import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Entity;
 
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
@@ -27,48 +30,43 @@ import com.netscape.certsrv.client.PKIClient;
  */
 public class ProfileClient extends Client {
 
-    public ProfileResource resource;
-
     public ProfileClient(PKIClient client) throws Exception {
         this(client, client.getSubsystem());
     }
 
     public ProfileClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, "profile");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(ProfileResource.class);
+        super(client, subsystem, "profiles");
     }
 
     public ProfileCollection findProfiles(String filter, Integer start, Integer size) throws Exception {
-        Response response = resource.findProfiles(filter, start, size);
-        return client.getEntity(response, ProfileCollection.class);
+        Map<String, Object> params = new HashMap<>();
+        if (filter != null) params.put("filter", filter);
+        if (start != null) params.put("start", start);
+        if (size != null) params.put("size", size);
+        return get(null, params, ProfileCollection.class);
     }
 
     public ProfileData getProfile(String profileID) throws Exception {
-        Response response = resource.getProfile(profileID);
-        return client.getEntity(response, ProfileData.class);
+        return get(profileID, ProfileData.class);
     }
 
     public ProfileData addProfile(ProfileData profileData) throws Exception {
-        Response response = resource.addProfile(profileData);
-        return client.getEntity(response, ProfileData.class);
+        Entity<ProfileData> entity = client.entity(profileData);
+        return post(null, null, entity, ProfileData.class);
     }
 
     public ProfileData updateProfile(String profileID, ProfileData profileData) throws Exception {
-        Response response = resource.updateProfile(profileID, profileData);
-        return client.getEntity(response, ProfileData.class);
+        Entity<ProfileData> entity = client.entity(profileData);
+        return patch(profileID, null, entity, ProfileData.class);
     }
 
     public ProfileData changeProfileStatus(String profileID, String action) throws Exception {
-        Response response = resource.changeStatus(profileID, action);
-        return client.getEntity(response, ProfileData.class);
+        Map<String, Object> params = new HashMap<>();
+        if (action != null) params.put("action", action);
+        return post(profileID, params, null, ProfileData.class);
     }
 
     public void removeProfile(String profileID) throws Exception {
-        Response response = resource.removeProfile(profileID);
-        client.getEntity(response, Void.class);
+        delete(profileID, Void.class);
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/profile/ProfileMappingClient.java
@@ -17,7 +17,10 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.tps.profile;
 
-import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Entity;
 
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
@@ -27,44 +30,39 @@ import com.netscape.certsrv.client.PKIClient;
  */
 public class ProfileMappingClient extends Client {
 
-    public ProfileMappingResource resource;
-
     public ProfileMappingClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, "profile-mapping");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(ProfileMappingResource.class);
+        super(client, subsystem, "profile-mappings");
     }
 
     public ProfileMappingCollection findProfileMappings(String filter, Integer start, Integer size) throws Exception {
-        Response response = resource.findProfileMappings(filter, start, size);
-        return client.getEntity(response, ProfileMappingCollection.class);
+        Map<String, Object> params = new HashMap<>();
+        if (filter != null) params.put("filter", filter);
+        if (start != null) params.put("start", start);
+        if (size != null) params.put("size", size);
+        return get(null, params, ProfileMappingCollection.class);
     }
 
     public ProfileMappingData getProfileMapping(String profileMappingID) throws Exception {
-        Response response = resource.getProfileMapping(profileMappingID);
-        return client.getEntity(response, ProfileMappingData.class);
+        return get(profileMappingID, ProfileMappingData.class);
     }
 
     public ProfileMappingData addProfileMapping(ProfileMappingData profileMappingData) throws Exception {
-        Response response = resource.addProfileMapping(profileMappingData);
-        return client.getEntity(response, ProfileMappingData.class);
+        Entity<ProfileMappingData> entity = client.entity(profileMappingData);
+        return post(null, null, entity, ProfileMappingData.class);
     }
 
     public ProfileMappingData updateProfileMapping(String profileMappingID, ProfileMappingData profileMappingData) throws Exception {
-        Response response = resource.updateProfileMapping(profileMappingID, profileMappingData);
-        return client.getEntity(response, ProfileMappingData.class);
+        Entity<ProfileMappingData> entity = client.entity(profileMappingData);
+        return patch(profileMappingID, null, entity, ProfileMappingData.class);
     }
 
     public ProfileMappingData changeProfileMappingStatus(String profileMappingID, String action) throws Exception {
-        Response response = resource.changeStatus(profileMappingID, action);
-        return client.getEntity(response, ProfileMappingData.class);
+        Map<String, Object> params = new HashMap<>();
+        if (action != null) params.put("action", action);
+        return post(profileMappingID, params, null, ProfileMappingData.class);
     }
 
     public void removeProfileMapping(String profileMappingID) throws Exception {
-        Response response = resource.removeProfileMapping(profileMappingID);
-        client.getEntity(response, Void.class);
+        delete(profileMappingID, Void.class);
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/tps/token/TokenClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/tps/token/TokenClient.java
@@ -17,7 +17,10 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.tps.token;
 
-import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Entity;
 
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
@@ -27,15 +30,8 @@ import com.netscape.certsrv.client.PKIClient;
  */
 public class TokenClient extends Client {
 
-    public TokenResource resource;
-
     public TokenClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, "token");
-        init();
-    }
-
-    public void init() throws Exception {
-        resource = createProxy(TokenResource.class);
+        super(client, subsystem, "tokens");
     }
 
     public TokenCollection findTokens(
@@ -47,40 +43,39 @@ public class TokenClient extends Client {
             Integer start,
             Integer size) throws Exception {
 
-        Response response = resource.findTokens(
-                filter,
-                tokenID,
-                userID,
-                type,
-                status,
-                start,
-                size);
+        Map<String, Object> params = new HashMap<>();
+        if (filter != null) params.put("filter", filter);
+        if (tokenID != null) params.put("tokenID", tokenID);
+        if (userID != null) params.put("userID", userID);
+        if (type != null) params.put("type", type);
+        if (status != null) params.put("status", status);
+        if (start != null) params.put("start", start);
+        if (size != null) params.put("size", size);
 
-        return client.getEntity(response, TokenCollection.class);
+        return get(null, params, TokenCollection.class);
     }
 
     public TokenData getToken(String tokenID) throws Exception {
-        Response response = resource.getToken(tokenID);
-        return client.getEntity(response, TokenData.class);
+        return get(tokenID, TokenData.class);
     }
 
     public TokenData addToken(TokenData tokenData) throws Exception {
-        Response response = resource.addToken(tokenData);
-        return client.getEntity(response, TokenData.class);
+        Entity<TokenData> entity = client.entity(tokenData);
+        return post(null, null, entity, TokenData.class);
     }
 
     public TokenData modifyToken(String tokenID, TokenData tokenData) throws Exception {
-        Response response = resource.modifyToken(tokenID, tokenData);
-        return client.getEntity(response, TokenData.class);
+        Entity<TokenData> entity = client.entity(tokenData);
+        return patch(tokenID, null, entity, TokenData.class);
     }
 
     public TokenData changeTokenStatus(String tokenID, TokenStatus tokenStatus) throws Exception {
-        Response response = resource.changeTokenStatus(tokenID, tokenStatus);
-        return client.getEntity(response, TokenData.class);
+        Map<String, Object> params = new HashMap<>();
+        if (tokenStatus != null) params.put("status", tokenStatus);
+        return post(tokenID, params, null, TokenData.class);
     }
 
     public void removeToken(String tokenID) throws Exception {
-        Response response = resource.removeToken(tokenID);
-        client.getEntity(response, Void.class);
+        delete(tokenID, Void.class);
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/tks/TKSKeyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tks/TKSKeyCLI.java
@@ -7,7 +7,6 @@ package com.netscape.cmstools.tks;
 
 import org.dogtagpki.cli.CLI;
 
-import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.key.KeyData;
 import com.netscape.certsrv.request.RequestId;
 import com.netscape.certsrv.system.TPSConnectorClient;
@@ -39,8 +38,7 @@ public class TKSKeyCLI extends CLI {
 
         if (tpsConnectorClient != null) return tpsConnectorClient;
 
-        PKIClient client = getClient();
-        tpsConnectorClient = (TPSConnectorClient)parent.getClient("tpsconnector");
+        tpsConnectorClient = (TPSConnectorClient) parent.getClient("admin/tps-connectors");
 
         return tpsConnectorClient;
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/tks/TPSConnectorCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tks/TPSConnectorCLI.java
@@ -19,7 +19,6 @@ package com.netscape.cmstools.tks;
 
 import org.dogtagpki.cli.CLI;
 
-import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.system.TPSConnectorClient;
 import com.netscape.certsrv.system.TPSConnectorData;
 
@@ -53,8 +52,7 @@ public class TPSConnectorCLI extends CLI {
 
         if (tpsConnectorClient != null) return tpsConnectorClient;
 
-        PKIClient client = getClient();
-        tpsConnectorClient = (TPSConnectorClient)parent.getClient("tpsconnector");
+        tpsConnectorClient = (TPSConnectorClient) parent.getClient("admin/tps-connectors");
 
         return tpsConnectorClient;
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/tps/profile/ProfileCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tps/profile/ProfileCLI.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import org.dogtagpki.cli.CLI;
 
-import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.tps.profile.ProfileClient;
 import com.netscape.certsrv.tps.profile.ProfileData;
 import com.netscape.cmstools.tps.TPSCLI;
@@ -60,8 +59,7 @@ public class ProfileCLI extends CLI {
 
         if (profileClient != null) return profileClient;
 
-        PKIClient client = getClient();
-        profileClient = (ProfileClient)parent.getClient("profile");
+        profileClient = (ProfileClient) parent.getClient("profiles");
 
         return profileClient;
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/tps/profile/ProfileMappingCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tps/profile/ProfileMappingCLI.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import org.dogtagpki.cli.CLI;
 
-import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.tps.profile.ProfileMappingClient;
 import com.netscape.certsrv.tps.profile.ProfileMappingData;
 
@@ -50,8 +49,7 @@ public class ProfileMappingCLI extends CLI {
 
         if (profileMappingClient != null) return profileMappingClient;
 
-        PKIClient client = getClient();
-        profileMappingClient = (ProfileMappingClient)parent.getClient("profile-mapping");
+        profileMappingClient = (ProfileMappingClient) parent.getClient("profile-mappings");
 
         return profileMappingClient;
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/tps/token/TokenCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tps/token/TokenCLI.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import org.apache.commons.lang3.StringUtils;
 import org.dogtagpki.cli.CLI;
 
-import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.tps.token.TokenClient;
 import com.netscape.certsrv.tps.token.TokenData;
 import com.netscape.certsrv.tps.token.TokenData.TokenStatusData;
@@ -56,8 +55,7 @@ public class TokenCLI extends CLI {
 
         if (tokenClient != null) return tokenClient;
 
-        PKIClient client = getClient();
-        tokenClient = (TokenClient)parent.getClient("token");
+        tokenClient = (TokenClient) parent.getClient("tokens");
 
         return tokenClient;
     }


### PR DESCRIPTION
Some client classes have been updated to use JAX-RS client API instead of the obsolete RESTEasy client API.