### PR TITLE
Use the system Python 3 for scripts

### DIFF
--- a/base/server/scripts/pki-server-nuxwdog
+++ b/base/server/scripts/pki-server-nuxwdog
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Authors:
 #     Dinesh Prasanth M K <dmoluguw@redhat.com>


### PR DESCRIPTION
Now Python 3 is the default everywhere we can ask for the system Python for rather forcing the shell to use what is specified in the PATH