### PR TITLE
Update client classes to use JAX-RS client API

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/ca/CAAgentCertClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/ca/CAAgentCertClient.java
@@ -17,12 +17,11 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.ca;
 
-import javax.ws.rs.core.Response;
+import javax.ws.rs.client.Entity;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netscape.certsrv.cert.AgentCertResource;
 import com.netscape.certsrv.cert.CertData;
 import com.netscape.certsrv.cert.CertRequestInfo;
 import com.netscape.certsrv.cert.CertRevokeRequest;
@@ -37,34 +36,25 @@ public class CAAgentCertClient extends Client {
 
     public final static Logger logger = LoggerFactory.getLogger(CAAgentCertClient.class);
 
-    public AgentCertResource agentCertClient;
-
     public CAAgentCertClient(PKIClient client) throws Exception {
         super(client, "ca", "agent/certs");
-        init();
-    }
-
-    public void init() throws Exception {
-        agentCertClient = createProxy(AgentCertResource.class);
     }
 
     public CertData reviewCert(CertId id) throws Exception {
-        Response response = agentCertClient.reviewCert(id);
-        return client.getEntity(response, CertData.class);
+        return get(id.toHexString(), CertData.class);
     }
 
     public CertRequestInfo revokeCert(CertId id, CertRevokeRequest request) throws Exception {
-        Response response = agentCertClient.revokeCert(id, request);
-        return client.getEntity(response, CertRequestInfo.class);
+        Entity<CertRevokeRequest> entity = client.entity(request);
+        return post(id.toHexString() + "/revoke", null, entity, CertRequestInfo.class);
     }
 
     public CertRequestInfo revokeCACert(CertId id, CertRevokeRequest request) throws Exception {
-        Response response = agentCertClient.revokeCACert(id, request);
-        return client.getEntity(response, CertRequestInfo.class);
+        Entity<CertRevokeRequest> entity = client.entity(request);
+        return post(id.toHexString() + "/revoke-ca", null, entity, CertRequestInfo.class);
     }
 
     public CertRequestInfo unrevokeCert(CertId id) throws Exception {
-        Response response = agentCertClient.unrevokeCert(id);
-        return client.getEntity(response, CertRequestInfo.class);
+        return post(id.toHexString() + "/unrevoke", CertRequestInfo.class);
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/ca/CAAgentCertRequestClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/ca/CAAgentCertRequestClient.java
@@ -17,12 +17,14 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.ca;
 
-import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Entity;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netscape.certsrv.cert.AgentCertRequestResource;
 import com.netscape.certsrv.cert.CertRequestInfos;
 import com.netscape.certsrv.cert.CertReviewResponse;
 import com.netscape.certsrv.client.Client;
@@ -36,60 +38,57 @@ public class CAAgentCertRequestClient extends Client {
 
     public final static Logger logger = LoggerFactory.getLogger(CAAgentCertRequestClient.class);
 
-    public AgentCertRequestResource agentCertRequestClient;
-
     public CAAgentCertRequestClient(PKIClient client) throws Exception {
         super(client, "ca", "agent/certrequests");
-        init();
     }
 
     public CertRequestInfos listRequests(String requestState, String requestType, RequestId start, Integer pageSize,
             Integer maxResults, Integer maxTime) throws Exception {
-        Response response = agentCertRequestClient.listRequests(requestState, requestType, start, pageSize, maxResults, maxTime);
-        return client.getEntity(response, CertRequestInfos.class);
-    }
-
-    public void init() throws Exception {
-        agentCertRequestClient = createProxy(AgentCertRequestResource.class);
+        Map<String, Object> params = new HashMap<>();
+        if (requestType != null) params.put("requestType", requestType);
+        if (start != null) params.put("start", start.toHexString());
+        if (pageSize != null) params.put("pageSize", pageSize);
+        if (maxResults != null) params.put("maxResults", maxResults);
+        if (maxTime != null) params.put("maxTime", maxTime);
+        return get(null, params, CertRequestInfos.class);
     }
 
     public CertReviewResponse reviewRequest(RequestId id) throws Exception {
-        Response response = agentCertRequestClient.reviewRequest(id);
-        return client.getEntity(response, CertReviewResponse.class);
+        return get(id.toHexString(), CertReviewResponse.class);
     }
 
     public void approveRequest(RequestId id, CertReviewResponse data) throws Exception {
-        Response response = agentCertRequestClient.approveRequest(id, data);
-        client.getEntity(response, Void.class);
+        Entity<CertReviewResponse> entity = client.entity(data);
+        post(id.toHexString() + "/approve", null, entity, Void.class);
     }
 
     public void rejectRequest(RequestId id, CertReviewResponse data) throws Exception {
-        Response response = agentCertRequestClient.rejectRequest(id, data);
-        client.getEntity(response, Void.class);
+        Entity<CertReviewResponse> entity = client.entity(data);
+        post(id.toHexString() + "/reject", null, entity, Void.class);
     }
 
     public void cancelRequest(RequestId id, CertReviewResponse data) throws Exception {
-        Response response = agentCertRequestClient.cancelRequest(id, data);
-        client.getEntity(response, Void.class);
+        Entity<CertReviewResponse> entity = client.entity(data);
+        post(id.toHexString() + "/cancel", null, entity, Void.class);
     }
 
     public void updateRequest(RequestId id, CertReviewResponse data) throws Exception {
-        Response response = agentCertRequestClient.updateRequest(id, data);
-        client.getEntity(response, Void.class);
+        Entity<CertReviewResponse> entity = client.entity(data);
+        post(id.toHexString() + "/update", null, entity, Void.class);
     }
 
     public void validateRequest(RequestId id, CertReviewResponse data) throws Exception {
-        Response response = agentCertRequestClient.validateRequest(id, data);
-        client.getEntity(response, Void.class);
+        Entity<CertReviewResponse> entity = client.entity(data);
+        post(id.toHexString() + "/validate", null, entity, Void.class);
     }
 
     public void assignRequest(RequestId id, CertReviewResponse data) throws Exception {
-        Response response = agentCertRequestClient.assignRequest(id, data);
-        client.getEntity(response, Void.class);
+        Entity<CertReviewResponse> entity = client.entity(data);
+        post(id.toHexString() + "/assign", null, entity, Void.class);
     }
 
     public void unassignRequest(RequestId id, CertReviewResponse data) throws Exception {
-        Response response = agentCertRequestClient.unassignRequest(id, data);
-        client.getEntity(response, Void.class);
+        Entity<CertReviewResponse> entity = client.entity(data);
+        post(id.toHexString() + "/unassign", null, entity, Void.class);
     }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/ca/CACertRequestClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/ca/CACertRequestClient.java
@@ -17,7 +17,10 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.ca;
 
-import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Entity;
 
 import org.mozilla.jss.netscape.security.x509.X500Name;
 import org.slf4j.Logger;
@@ -26,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import com.netscape.certsrv.cert.CertEnrollmentRequest;
 import com.netscape.certsrv.cert.CertRequestInfo;
 import com.netscape.certsrv.cert.CertRequestInfos;
-import com.netscape.certsrv.cert.CertRequestResource;
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.profile.ProfileDataInfos;
@@ -39,38 +41,32 @@ public class CACertRequestClient extends Client {
 
     public final static Logger logger = LoggerFactory.getLogger(CACertRequestClient.class);
 
-    public CertRequestResource certRequestClient;
-
     public CACertRequestClient(PKIClient client) throws Exception {
         super(client, "ca", "certrequests");
-        init();
-    }
-
-    public void init() throws Exception {
-        certRequestClient = createProxy(CertRequestResource.class);
     }
 
     public CertRequestInfo getRequest(RequestId id) throws Exception {
-        Response response = certRequestClient.getRequestInfo(id);
-        return client.getEntity(response, CertRequestInfo.class);
+        return get(id.toHexString(), CertRequestInfo.class);
     }
 
     public CertRequestInfos enrollRequest(
             CertEnrollmentRequest data, AuthorityID aid, X500Name adn) throws Exception {
-        String aidString = aid != null ? aid.toString() : null;
-        String adnString = adn != null ? adn.toLdapDNString() : null;
+        Map<String, Object> params = new HashMap<>();
+        if (aid != null) params.put("issuer-id", aid.toString());
+        if (adn != null) params.put("issuer-dn", adn.toLdapDNString());
         String enrollmentRequest = (String) client.marshall(data);
-        Response response = certRequestClient.enrollCert(enrollmentRequest, aidString, adnString);
-        return client.getEntity(response, CertRequestInfos.class);
+        Entity<String> entity = client.entity(enrollmentRequest);
+        return post(null, params, entity, CertRequestInfos.class);
     }
 
     public ProfileDataInfos listEnrollmentTemplates(Integer start, Integer size) throws Exception {
-        Response response = certRequestClient.listEnrollmentTemplates(start, size);
-        return client.getEntity(response, ProfileDataInfos.class);
+        Map<String, Object> params = new HashMap<>();
+        if (start != null) params.put("start",start);
+        if (size != null) params.put("size", size);
+        return get("profiles", ProfileDataInfos.class);
     }
 
     public CertEnrollmentRequest getEnrollmentTemplate(String id) throws Exception {
-        Response response = certRequestClient.getEnrollmentTemplate(id);
-        return client.getEntity(response, CertEnrollmentRequest.class);
+        return get("profiles/" + id, CertEnrollmentRequest.class);
     }
 }


### PR DESCRIPTION
Some client classes have been updated to use JAX-RS client API instead of the obsolete RESTEasy client API.