### PR TITLE
Remove getNickName() from KeyRecoveryAuthority

### DIFF
--- a/base/kra/src/main/java/com/netscape/kra/KeyRecoveryAuthority.java
+++ b/base/kra/src/main/java/com/netscape/kra/KeyRecoveryAuthority.java
@@ -1493,15 +1493,12 @@ public class KeyRecoveryAuthority extends Subsystem implements IAuthority {
         return mName;
     }
 
-    public String getNickName() {
-        return getNickname();
-    }
-
     /**
      * Returns the nickname of the transport certificate.
      *
      * @return transport certificate nickname.
      */
+    @Override
     public String getNickname() {
         try {
             return mTransportKeyUnit.getNickName();


### PR DESCRIPTION
This method simply calls getNickname(), which is actually implementing a method from IAuthority, which is highly confusing. The method doesn't look to actually be used anywhere so I removed it and added the @Override annotation to the remaining method.