### PR TITLE
Code cleanup in PKILogger

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCreateCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCreateCLI.java
@@ -24,7 +24,7 @@ import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.server.ca.CAConfig;
 import org.dogtagpki.server.ca.CAEngineConfig;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.PrivateKey;
@@ -128,10 +128,10 @@ public class CACertCreateCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         String requestID = cmd.getOptionValue("request");

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertFindCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertFindCLI.java
@@ -18,7 +18,7 @@ import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.server.ca.CAConfig;
 import org.dogtagpki.server.ca.CAEngineConfig;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,10 +67,10 @@ public class CACertFindCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         CertSearchRequest searchRequest = new CertSearchRequest();

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertImportCLI.java
@@ -18,7 +18,7 @@ import org.dogtagpki.cli.CLI;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.server.ca.CAEngineConfig;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.mozilla.jss.netscape.security.util.Cert;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.slf4j.Logger;
@@ -82,10 +82,10 @@ public class CACertImportCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         if (!cmd.hasOption("cert")) {

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRemoveCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRemoveCLI.java
@@ -14,7 +14,7 @@ import org.dogtagpki.cli.CLI;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.server.ca.CAEngineConfig;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,10 +54,10 @@ public class CACertRemoveCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         String[] cmdArgs = cmd.getArgs();

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRequestImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRequestImportCLI.java
@@ -19,7 +19,7 @@ import org.dogtagpki.cli.CLI;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.server.ca.CAEngineConfig;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,10 +91,10 @@ public class CACertRequestImportCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         String instanceDir = CMS.getInstanceDir();

--- a/base/common/src/main/java/org/dogtagpki/cli/CommandCLI.java
+++ b/base/common/src/main/java/org/dogtagpki/cli/CommandCLI.java
@@ -20,7 +20,7 @@ package org.dogtagpki.cli;
 
 import org.apache.commons.cli.CommandLine;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 
 /**
  * @author Endi S. Dewata
@@ -49,10 +49,10 @@ public class CommandCLI extends CLI {
         }
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         execute(cmd);

--- a/base/common/src/main/java/org/dogtagpki/util/logging/PKILogger.java
+++ b/base/common/src/main/java/org/dogtagpki/util/logging/PKILogger.java
@@ -17,31 +17,30 @@
 // --- END COPYRIGHT BLOCK ---
 package org.dogtagpki.util.logging;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class PKILogger {
 
-    public enum Level {
+    public enum LogLevel {
         ERROR, WARN, INFO, DEBUG, TRACE
-    };
-
-    public static Map<Level, java.util.logging.Level> map = new HashMap<>();
-
-    static {
-        map.put(Level.ERROR, java.util.logging.Level.SEVERE);
-        map.put(Level.WARN, java.util.logging.Level.WARNING);
-        map.put(Level.INFO, java.util.logging.Level.INFO);
-        map.put(Level.DEBUG, java.util.logging.Level.FINE);
-        map.put(Level.TRACE, java.util.logging.Level.FINEST);
     }
 
-    public static void setLevel(Level level) {
+    protected static final Map<LogLevel, Level> map = new EnumMap<>(Map.of(
+            LogLevel.ERROR, Level.SEVERE,
+            LogLevel.WARN, Level.WARNING,
+            LogLevel.INFO, Level.INFO,
+            LogLevel.DEBUG, Level.FINE,
+            LogLevel.TRACE, Level.FINEST));
 
-        java.util.logging.Level julLevel = map.get(level);
+    public static void setLevel(LogLevel level) {
 
-        java.util.logging.Logger.getLogger("org.dogtagpki").setLevel(julLevel);
-        java.util.logging.Logger.getLogger("com.netscape").setLevel(julLevel);
-        java.util.logging.Logger.getLogger("netscape").setLevel(julLevel);
+        Level julLevel = map.get(level);
+
+        Logger.getLogger("org.dogtagpki").setLevel(julLevel);
+        Logger.getLogger("com.netscape").setLevel(julLevel);
+        Logger.getLogger("netscape").setLevel(julLevel);
     }
 }

--- a/base/console/src/main/java/com/netscape/admin/certsrv/Console.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/Console.java
@@ -54,7 +54,7 @@ import org.apache.commons.cli.UnrecognizedOptionException;
 import org.dogtagpki.common.Info;
 import org.dogtagpki.common.InfoClient;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.AlreadyInitializedException;
@@ -1637,10 +1637,10 @@ public class Console implements CommClient {
         String[] cmdArgs = cmd.getArgs();
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(Level.DEBUG);
+            PKILogger.setLevel(LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         String outFile = cmd.getOptionValue("f");

--- a/base/server/src/main/java/com/netscape/cmscore/util/Debug.java
+++ b/base/server/src/main/java/com/netscape/cmscore/util/Debug.java
@@ -69,22 +69,22 @@ public class Debug {
 
     public static void setLevel(int level) {
 
-        PKILogger.Level logLevel;
+        PKILogger.LogLevel logLevel;
 
         if (level <= OBNOXIOUS) {
-            logLevel = PKILogger.Level.TRACE;
+            logLevel = PKILogger.LogLevel.TRACE;
 
         } else if (level <= VERBOSE) {
-            logLevel = PKILogger.Level.DEBUG;
+            logLevel = PKILogger.LogLevel.DEBUG;
 
         } else if (level <= INFORM) {
-            logLevel = PKILogger.Level.INFO;
+            logLevel = PKILogger.LogLevel.INFO;
 
         } else if (level <= WARN) {
-            logLevel = PKILogger.Level.WARN;
+            logLevel = PKILogger.LogLevel.WARN;
 
         } else {
-            logLevel = PKILogger.Level.ERROR;
+            logLevel = PKILogger.LogLevel.ERROR;
         }
 
         PKILogger.setLevel(logLevel);

--- a/base/server/src/main/java/org/dogtagpki/server/cli/PKIServerCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/PKIServerCLI.java
@@ -26,7 +26,7 @@ import org.apache.commons.cli.UnrecognizedOptionException;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,10 +81,10 @@ public class PKIServerCLI extends CLI {
         CommandLine cmd = parser.parse(options, args, true);
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(Level.DEBUG);
+            PKILogger.setLevel(LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         String[] cmdArgs = cmd.getArgs();

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBAccessGrantCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBAccessGrantCLI.java
@@ -8,7 +8,7 @@ package org.dogtagpki.server.cli;
 import org.apache.commons.cli.CommandLine;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,10 +47,10 @@ public class SubsystemDBAccessGrantCLI extends SubsystemCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(Level.DEBUG);
+            PKILogger.setLevel(LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         String[] cmdArgs = cmd.getArgs();

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBAccessRevokeCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBAccessRevokeCLI.java
@@ -8,7 +8,7 @@ package org.dogtagpki.server.cli;
 import org.apache.commons.cli.CommandLine;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,10 +47,10 @@ public class SubsystemDBAccessRevokeCLI extends SubsystemCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(Level.DEBUG);
+            PKILogger.setLevel(LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         String[] cmdArgs = cmd.getArgs();

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationSetupCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationSetupCLI.java
@@ -8,7 +8,7 @@ package org.dogtagpki.server.cli;
 import org.apache.commons.cli.CommandLine;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,10 +56,10 @@ public class SubsystemDBReplicationSetupCLI extends SubsystemCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(Level.DEBUG);
+            PKILogger.setLevel(LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         String masterConfigFile = cmd.getOptionValue("master-config");

--- a/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
@@ -135,10 +135,10 @@ public class OCSPClient {
         }
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(PKILogger.Level.INFO);
+            PKILogger.setLevel(PKILogger.LogLevel.INFO);
         }
 
         String databaseDir = cmd.getOptionValue("d", ".");

--- a/base/tools/src/main/java/com/netscape/cmstools/PKCS12Export.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/PKCS12Export.java
@@ -184,7 +184,7 @@ public class PKCS12Export {
         }
 
         if (debug) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
         }
 
         // TODO: validate parameters

--- a/base/tools/src/main/java/com/netscape/cmstools/acme/ACMEDisableCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/acme/ACMEDisableCLI.java
@@ -9,7 +9,7 @@ import org.apache.commons.cli.CommandLine;
 import org.dogtagpki.acme.ACMEClient;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.cmstools.cli.MainCLI;
@@ -41,10 +41,10 @@ public class ACMEDisableCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         MainCLI mainCLI = (MainCLI) getRoot();

--- a/base/tools/src/main/java/com/netscape/cmstools/acme/ACMEEnableCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/acme/ACMEEnableCLI.java
@@ -9,7 +9,7 @@ import org.apache.commons.cli.CommandLine;
 import org.dogtagpki.acme.ACMEClient;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.cmstools.cli.MainCLI;
@@ -41,10 +41,10 @@ public class ACMEEnableCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         MainCLI mainCLI = (MainCLI) getRoot();

--- a/base/tools/src/main/java/com/netscape/cmstools/acme/ACMEInfoCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/acme/ACMEInfoCLI.java
@@ -13,7 +13,7 @@ import org.dogtagpki.acme.ACMEDirectory;
 import org.dogtagpki.acme.ACMEMetadata;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.client.PKIClient;
@@ -46,10 +46,10 @@ public class ACMEInfoCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         MainCLI mainCLI = (MainCLI) getRoot();

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -49,7 +49,7 @@ import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.common.Info;
 import org.dogtagpki.nss.NSSDatabase;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.NotInitializedException;
 import org.mozilla.jss.crypto.CryptoToken;
@@ -332,10 +332,10 @@ public class MainCLI extends CLI {
     public void parseOptions(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         output = cmd.getOptionValue("output");

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
@@ -26,7 +26,7 @@ import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.nss.NSSDatabase;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.KeyGenAlgorithm;
 import org.mozilla.jss.crypto.KeyGenerator;
@@ -95,10 +95,10 @@ public class NSSKeyCreateCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
 

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyFindCLI.java
@@ -27,7 +27,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.util.logging.PKILogger;
-import org.dogtagpki.util.logging.PKILogger.Level;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.crypto.CryptoStore;
 import org.mozilla.jss.crypto.CryptoToken;
@@ -77,10 +77,10 @@ public class NSSKeyFindCLI extends CommandCLI {
     public void execute(CommandLine cmd) throws Exception {
 
         if (cmd.hasOption("debug")) {
-            PKILogger.setLevel(PKILogger.Level.DEBUG);
+            PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
 
         } else if (cmd.hasOption("verbose")) {
-            PKILogger.setLevel(Level.INFO);
+            PKILogger.setLevel(LogLevel.INFO);
         }
 
         MainCLI mainCLI = (MainCLI) getRoot();


### PR DESCRIPTION
* Rename enum to not name clash java.util.logging.Level
* Remove unnecessary semicolon and fully qualified names
* Replace statically created HashMap with Map.of() generated EnumMap and lower its visibility