### PR TITLE
Auto-initialize JAX-RS applications

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -300,6 +300,13 @@ find_file(RESTEASY_JACKSON2_PROVIDER_JAR
         /usr/share/java/resteasy
 )
 
+find_file(RESTEASY_SERVLET_INITIALIZER_JAR
+    NAMES
+        resteasy-servlet-initializer.jar
+    PATHS
+        /usr/share/java/resteasy
+)
+
 find_file(JASPIC_API_JAR
     NAMES
         jaspic-api.jar

--- a/base/acme/CMakeLists.txt
+++ b/base/acme/CMakeLists.txt
@@ -51,6 +51,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-acme.jar webapp/lib/pki-acme.jar
+    COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
 install(

--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -63,6 +63,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-ca.jar webapp/lib/pki-ca.jar
+    COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
 install(

--- a/base/ca/shared/webapps/ca/WEB-INF/web.xml
+++ b/base/ca/shared/webapps/ca/WEB-INF/web.xml
@@ -3,43 +3,6 @@
 
     <display-name>Certificate Authority</display-name>
 
-   <!-- ==================== RESTEasy Configuration =============== -->
-
-   <listener>
-      <listener-class> org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap </listener-class>
-   </listener>
-
-   <context-param>
-      <param-name>resteasy.servlet.mapping.prefix</param-name>
-      <param-value>/rest</param-value>
-   </context-param>
-
-   <context-param>
-      <param-name>resteasy.role.based.security</param-name>
-      <param-value>true</param-value>
-   </context-param>
-
-   <context-param>
-      <param-name>resteasy.resource.method-interceptors</param-name>
-      <param-value>
-         org.jboss.resteasy.core.ResourceMethodSecurityInterceptor
-      </param-value>
-   </context-param>
-
-   <servlet>
-      <servlet-name>Resteasy</servlet-name>
-      <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-      <init-param>
-         <param-name>javax.ws.rs.Application</param-name>
-         <param-value>org.dogtagpki.server.ca.rest.CAApplication</param-value>
-      </init-param>
-   </servlet>
-   
-   <servlet-mapping>
-      <servlet-name>Resteasy</servlet-name>
-      <url-pattern>/rest/*</url-pattern>
-   </servlet-mapping>
-
     <security-constraint>
         <web-resource-collection>
             <web-resource-name>Account Services</web-resource-name>

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CAApplication.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CAApplication.java
@@ -3,6 +3,7 @@ package org.dogtagpki.server.ca.rest;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import org.dogtagpki.server.rest.ACLInterceptor;
@@ -19,6 +20,7 @@ import org.dogtagpki.server.rest.SelfTestService;
 import org.dogtagpki.server.rest.SessionContextInterceptor;
 import org.dogtagpki.server.rest.UserService;
 
+@ApplicationPath("/rest")
 public class CAApplication extends Application {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CAApplication.class);

--- a/base/est/CMakeLists.txt
+++ b/base/est/CMakeLists.txt
@@ -55,6 +55,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-est.jar webapp/lib/pki-est.jar
+    COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
 install(

--- a/base/kra/CMakeLists.txt
+++ b/base/kra/CMakeLists.txt
@@ -59,6 +59,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-kra.jar webapp/lib/pki-kra.jar
+    COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
 install(

--- a/base/kra/shared/webapps/kra/WEB-INF/web.xml
+++ b/base/kra/shared/webapps/kra/WEB-INF/web.xml
@@ -547,44 +547,6 @@
                          <param-value> admin          </param-value> </init-param>
    </servlet>
 
-
-   <!-- ==================== RESTEasy Configuration =============== -->
-
-   <listener>
-      <listener-class> org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap </listener-class>
-   </listener>
-
-   <context-param>
-      <param-name>resteasy.servlet.mapping.prefix</param-name>
-      <param-value>/rest</param-value>
-   </context-param>
-
-   <context-param>
-      <param-name>resteasy.role.based.security</param-name>
-      <param-value>true</param-value>
-   </context-param>
-
-   <context-param>
-      <param-name>resteasy.resource.method-interceptors</param-name>
-      <param-value>
-         org.jboss.resteasy.core.ResourceMethodSecurityInterceptor
-      </param-value>
-   </context-param>
-
-   <servlet>
-      <servlet-name>Resteasy</servlet-name>
-      <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-      <init-param>
-         <param-name>javax.ws.rs.Application</param-name>
-         <param-value>org.dogtagpki.server.kra.rest.KRAApplication</param-value>
-      </init-param>
-   </servlet>
-
-   <servlet-mapping>
-      <servlet-name>Resteasy</servlet-name>
-      <url-pattern>/rest/*</url-pattern>
-   </servlet-mapping>
-
    <servlet-mapping>
       <servlet-name>  kraserver  </servlet-name>
       <url-pattern>   /server  </url-pattern>

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/KRAApplication.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/KRAApplication.java
@@ -3,6 +3,7 @@ package org.dogtagpki.server.kra.rest;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import org.dogtagpki.server.rest.ACLInterceptor;
@@ -18,6 +19,7 @@ import org.dogtagpki.server.rest.SelfTestService;
 import org.dogtagpki.server.rest.SessionContextInterceptor;
 import org.dogtagpki.server.rest.UserService;
 
+@ApplicationPath("/rest")
 public class KRAApplication extends Application {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(KRAApplication.class);

--- a/base/ocsp/CMakeLists.txt
+++ b/base/ocsp/CMakeLists.txt
@@ -58,6 +58,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-ocsp.jar webapp/lib/pki-ocsp.jar
+    COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
 install(

--- a/base/ocsp/shared/webapps/ocsp/WEB-INF/web.xml
+++ b/base/ocsp/shared/webapps/ocsp/WEB-INF/web.xml
@@ -446,41 +446,6 @@
                          <param-value> admin          </param-value> </init-param>
    </servlet>
 
-   <listener>
-      <listener-class> org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap </listener-class>
-   </listener>
-
-   <context-param>
-      <param-name>resteasy.servlet.mapping.prefix</param-name>
-      <param-value>/rest</param-value>
-   </context-param>
-
-   <context-param>
-      <param-name>resteasy.role.based.security</param-name>
-      <param-value>true</param-value>
-   </context-param>
-
-   <context-param>
-      <param-name>resteasy.resource.method-interceptors</param-name>
-      <param-value>
-         org.jboss.resteasy.core.ResourceMethodSecurityInterceptor
-      </param-value>
-   </context-param>
-
-   <servlet>
-      <servlet-name>Resteasy</servlet-name>
-      <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-      <init-param>
-         <param-name>javax.ws.rs.Application</param-name>
-         <param-value>org.dogtagpki.server.ocsp.rest.OCSPApplication</param-value>
-      </init-param>
-   </servlet>
-
-   <servlet-mapping>
-      <servlet-name>Resteasy</servlet-name>
-      <url-pattern>/rest/*</url-pattern>
-   </servlet-mapping>
-
    <servlet-mapping>
       <servlet-name>  ocspacl  </servlet-name>
       <url-pattern>   /acl  </url-pattern>

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/rest/OCSPApplication.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/rest/OCSPApplication.java
@@ -3,6 +3,7 @@ package org.dogtagpki.server.ocsp.rest;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import org.dogtagpki.server.rest.ACLInterceptor;
@@ -17,6 +18,7 @@ import org.dogtagpki.server.rest.SelfTestService;
 import org.dogtagpki.server.rest.SessionContextInterceptor;
 import org.dogtagpki.server.rest.UserService;
 
+@ApplicationPath("/rest")
 public class OCSPApplication extends Application {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OCSPApplication.class);

--- a/base/server-webapp/CMakeLists.txt
+++ b/base/server-webapp/CMakeLists.txt
@@ -53,6 +53,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server-webapp.jar webapp/lib/pki-server-webapp.jar
+    COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
 install(

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/rest/PKIApplication.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/rest/PKIApplication.java
@@ -21,8 +21,10 @@ package org.dogtagpki.server.rest;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
+@ApplicationPath("/rest")
 public class PKIApplication extends Application {
 
     private Set<Object> singletons = new LinkedHashSet<>();

--- a/base/server-webapp/webapps/pki/WEB-INF/web.xml
+++ b/base/server-webapp/webapps/pki/WEB-INF/web.xml
@@ -3,41 +3,6 @@
 
     <display-name>PKI</display-name>
 
-    <listener>
-        <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
-    </listener>
-
-    <context-param>
-        <param-name>resteasy.servlet.mapping.prefix</param-name>
-        <param-value>/rest</param-value>
-    </context-param>
-
-    <context-param>
-        <param-name>resteasy.role.based.security</param-name>
-        <param-value>true</param-value>
-    </context-param>
-
-    <context-param>
-        <param-name>resteasy.resource.method-interceptors</param-name>
-        <param-value>
-            org.jboss.resteasy.core.ResourceMethodSecurityInterceptor
-        </param-value>
-    </context-param>
-
-    <servlet>
-        <servlet-name>Resteasy</servlet-name>
-        <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-        <init-param>
-            <param-name>javax.ws.rs.Application</param-name>
-            <param-value>org.dogtagpki.server.rest.PKIApplication</param-value>
-         </init-param>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>Resteasy</servlet-name>
-        <url-pattern>/rest/*</url-pattern>
-    </servlet-mapping>
-
     <mime-mapping>
         <extension>properties</extension>
         <mime-type>text/plain</mime-type>

--- a/base/tks/CMakeLists.txt
+++ b/base/tks/CMakeLists.txt
@@ -61,6 +61,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tks.jar webapp/lib/pki-tks.jar
+    COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
 install(

--- a/base/tks/shared/webapps/tks/WEB-INF/web.xml
+++ b/base/tks/shared/webapps/tks/WEB-INF/web.xml
@@ -234,41 +234,6 @@
                          <param-value> tksGetStatus </param-value> </init-param>
    </servlet>
 
-   <listener>
-      <listener-class> org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap </listener-class>
-   </listener>
-
-   <context-param>
-      <param-name>resteasy.servlet.mapping.prefix</param-name>
-      <param-value>/rest</param-value>
-   </context-param>
-
-   <context-param>
-      <param-name>resteasy.role.based.security</param-name>
-      <param-value>true</param-value>
-   </context-param>
-
-   <context-param>
-      <param-name>resteasy.resource.method-interceptors</param-name>
-      <param-value>
-         org.jboss.resteasy.core.ResourceMethodSecurityInterceptor
-      </param-value>
-   </context-param>
-
-   <servlet>
-      <servlet-name>Resteasy</servlet-name>
-      <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-      <init-param>
-         <param-name>javax.ws.rs.Application</param-name>
-         <param-value>org.dogtagpki.server.tks.rest.TKSApplication</param-value>
-      </init-param>
-   </servlet>
-
-   <servlet-mapping>
-      <servlet-name>Resteasy</servlet-name>
-      <url-pattern>/rest/*</url-pattern>
-   </servlet-mapping>
-                                                                                
    <servlet-mapping>
       <servlet-name>  tksug  </servlet-name>
       <url-pattern>   /ug  </url-pattern>

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/rest/TKSApplication.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/rest/TKSApplication.java
@@ -3,6 +3,7 @@ package org.dogtagpki.server.tks.rest;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import org.dogtagpki.server.rest.ACLInterceptor;
@@ -17,6 +18,7 @@ import org.dogtagpki.server.rest.SelfTestService;
 import org.dogtagpki.server.rest.SessionContextInterceptor;
 import org.dogtagpki.server.rest.UserService;
 
+@ApplicationPath("/rest")
 public class TKSApplication extends Application {
 
     private Set<Object> singletons = new LinkedHashSet<>();

--- a/base/tps/CMakeLists.txt
+++ b/base/tps/CMakeLists.txt
@@ -57,6 +57,7 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${SLF4J_JDK14_JAR} webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tps.jar webapp/lib/pki-tps.jar
+    COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
 add_custom_target(pki-tps-man ALL

--- a/base/tps/shared/webapps/tps/WEB-INF/web.xml
+++ b/base/tps/shared/webapps/tps/WEB-INF/web.xml
@@ -88,39 +88,6 @@
         <servlet-class>org.dogtagpki.server.tps.TPSServlet</servlet-class>
     </servlet>
 
-    <listener>
-        <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
-    </listener>
-
-    <context-param>
-        <param-name>resteasy.servlet.mapping.prefix</param-name>
-        <param-value>/rest</param-value>
-    </context-param>
-
-    <context-param>
-        <param-name>resteasy.role.based.security</param-name>
-        <param-value>true</param-value>
-    </context-param>
-
-    <context-param>
-        <param-name>resteasy.resource.method-interceptors</param-name>
-        <param-value>org.jboss.resteasy.core.ResourceMethodSecurityInterceptor</param-value>
-    </context-param>
-
-    <servlet>
-        <servlet-name>Resteasy</servlet-name>
-        <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-        <init-param>
-            <param-name>javax.ws.rs.Application</param-name>
-            <param-value>org.dogtagpki.server.tps.rest.TPSApplication</param-value>
-        </init-param>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>Resteasy</servlet-name>
-        <url-pattern>/rest/*</url-pattern>
-    </servlet-mapping>
-
     <servlet-mapping>
         <servlet-name>tpsug</servlet-name>
         <url-pattern>/ug</url-pattern>

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/TPSApplication.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/TPSApplication.java
@@ -20,6 +20,7 @@ package org.dogtagpki.server.tps.rest;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import org.dogtagpki.server.rest.ACLInterceptor;
@@ -38,6 +39,7 @@ import org.dogtagpki.server.tps.config.ConfigService;
 /**
  * @author Endi S. Dewata <edewata@redhat.com>
  */
+@ApplicationPath("/rest")
 public class TPSApplication extends Application {
 
     private Set<Object> singletons = new LinkedHashSet<>();

--- a/pki.spec
+++ b/pki.spec
@@ -169,7 +169,10 @@ BuildRequires:    mvn(commons-net:commons-net)
 BuildRequires:    mvn(org.slf4j:slf4j-api)
 BuildRequires:    mvn(org.slf4j:slf4j-jdk14)
 BuildRequires:    mvn(org.junit.jupiter:junit-jupiter-api)
-BuildRequires:    pki-resteasy >= 3.0.26
+BuildRequires:    mvn(org.jboss.resteasy:resteasy-client)
+BuildRequires:    mvn(org.jboss.resteasy:resteasy-jackson2-provider)
+BuildRequires:    mvn(org.jboss.resteasy:resteasy-jaxrs)
+BuildRequires:    mvn(org.jboss.resteasy:resteasy-servlet-initializer)
 BuildRequires:    jss >= 5.4
 BuildRequires:    tomcatjss >= 8.4
 BuildRequires:    ldapjdk >= 5.4
@@ -376,10 +379,12 @@ Requires:         mvn(commons-logging:commons-logging)
 Requires:         mvn(commons-net:commons-net)
 Requires:         mvn(org.slf4j:slf4j-api)
 Requires:         mvn(org.slf4j:slf4j-jdk14)
+Requires:         mvn(org.jboss.resteasy:resteasy-client)
+Requires:         mvn(org.jboss.resteasy:resteasy-jackson2-provider)
+Requires:         mvn(org.jboss.resteasy:resteasy-jaxrs)
 Requires:         jss >= 5.4
 Requires:         ldapjdk >= 5.4
 Requires:         %{product_id}-base = %{version}-%{release}
-Requires:         pki-resteasy >= 3.0.26
 
 %description -n   %{product_id}-java
 This package provides common and client libraries for Java.
@@ -441,6 +446,7 @@ Requires:         python3-policycoreutils
 
 Requires:         selinux-policy-targeted >= 3.13.1-159
 
+Requires:         mvn(org.jboss.resteasy:resteasy-servlet-initializer)
 %if 0%{?rhel} && ! 0%{?eln}
 Requires:         pki-servlet-engine >= 9.0.31
 %else

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-servlet-initializer</artifactId>
+            <version>3.0.26.Final</version>
+        </dependency>
+
+        <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
             <version>1.4.01</version>


### PR DESCRIPTION
The `pki.spec`, `pom.xml`, and CMake files have been modified to include `resteasy-servlet-initializer` to enable automatic initialization of JAX-RS applications in all webapps.

The `web.xml` files in most webapps (except ACME and EST) have been modified to drop the RESTEasy servlet declaration and let the JAX-RS applications be initialized automatically by `resteasy-servlet-initializer`.

**Note:** ACME and EST will be updated separately later.

https://docs.jboss.org/resteasy/docs/3.0.24.Final/userguide/html_single/#d4e143
