### PR TITLE
Drop DRMTool

### DIFF
--- a/base/tools/CMakeLists.txt
+++ b/base/tools/CMakeLists.txt
@@ -54,20 +54,9 @@ install(
         ${JAVA_JAR_INSTALL_DIR}/pki
 )
 
-# Create compatibility symlink for DRMTool.cfg -> KRATool.cfg
-
-add_custom_target(pki-DRMTool-cfg-link ALL
-    COMMENT "Creating link for DRMTool.cfg")
-
-add_custom_command(
-    TARGET pki-DRMTool-cfg-link
-    COMMAND ln -sf ../../../..${JAVA_JAR_INSTALL_DIR}/pki/tools/KRATool.cfg ${CMAKE_CURRENT_BINARY_DIR}/DRMTool.cfg
-)
-
 install(
     FILES
         src/main/resources/KRATool.cfg
-        ${CMAKE_CURRENT_BINARY_DIR}/DRMTool.cfg
     DESTINATION
         ${SHARE_INSTALL_PREFIX}/pki/tools
 )
@@ -123,32 +112,11 @@ install(
         WORLD_READ
 )
 
-# Create compatibility symlink for DRMTool.1.gz -> KRATool.1.gz
-
-add_custom_target(pki-DRMTool-man-link ALL
-    COMMENT "Creating link for DRMTool man page")
-
-add_custom_command(
-    TARGET pki-DRMTool-man-link
-    COMMAND ln -sf ../..${MAN_INSTALL_DIR}/man1/KRATool.1.gz ${CMAKE_CURRENT_BINARY_DIR}/DRMTool.1.gz
-)
-
 install(
     DIRECTORY
         examples/
     DESTINATION
         ${DATA_INSTALL_DIR}/tools/examples/
-)
-
-install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/DRMTool.1.gz
-    DESTINATION
-        ${MAN_INSTALL_DIR}/man1
-    PERMISSIONS
-        OWNER_READ OWNER_WRITE
-        GROUP_READ
-        WORLD_READ
 )
 
 install(

--- a/base/tools/templates/CMakeLists.txt
+++ b/base/tools/templates/CMakeLists.txt
@@ -38,27 +38,6 @@ foreach(PKI_COMMAND ${PKI_COMMANDS})
     )
 endforeach(PKI_COMMAND)
 
-# Create compatibility symlink for DRMTool -> KRATool
-
-add_custom_target(pki-DRMTool-link ALL
-    COMMENT "Creating link for DRMTool")
-
-add_custom_command(
-    TARGET pki-DRMTool-link
-    COMMAND ln -sf ../..${BIN_INSTALL_DIR}/KRATool DRMTool
-)
-
-install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/DRMTool
-    DESTINATION
-        ${BIN_INSTALL_DIR}
-    PERMISSIONS
-        OWNER_EXECUTE OWNER_WRITE OWNER_READ
-        GROUP_EXECUTE GROUP_READ
-        WORLD_EXECUTE WORLD_READ
-)
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pretty_print_cert_command_wrapper.in ${CMAKE_CURRENT_BINARY_DIR}/PrettyPrintCert @ONLY)
 
 install(

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -15,3 +15,8 @@ configuration file.
 
 The `sslget` command has been deprecated.
 Use `pki` CLI or the `curl` command instead.
+
+== Drop DRMTool ==
+
+The `DRMTool` command is no longer available.
+Use `KRATool` command instead.

--- a/pki.spec
+++ b/pki.spec
@@ -1032,7 +1032,6 @@ fi
 %{_bindir}/CMCRevoke
 %{_bindir}/CMCSharedToken
 %{_bindir}/CRMFPopClient
-%{_bindir}/DRMTool
 %{_bindir}/ExtJoiner
 %{_bindir}/GenExtKeyUsage
 %{_bindir}/GenIssuerAltNameExt
@@ -1057,7 +1056,6 @@ fi
 %{_mandir}/man1/CMCRequest.1.gz
 %{_mandir}/man1/CMCSharedToken.1.gz
 %{_mandir}/man1/CMCResponse.1.gz
-%{_mandir}/man1/DRMTool.1.gz
 %{_mandir}/man1/KRATool.1.gz
 %{_mandir}/man1/PrettyPrintCert.1.gz
 %{_mandir}/man1/PrettyPrintCrl.1.gz


### PR DESCRIPTION
The `DRMTool` command, its config file, and its manual page are actually just links to their counterparts in `KRATool`. Some of those links are actually broken, but `rpminspect` is only generating warnings for broken links instead of failing. Since the tool has long been deprecated the tool and the links can be dropped.

https://github.com/edewata/pki/blob/build/docs/changes/v11.5.0/Tools-Changes.adoc

**Note:** `rpminspect` is failing but it seems to be unrelated.