### PR TITLE
Auto-initialize ACME application

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEApplication.java
@@ -14,7 +14,7 @@ import javax.ws.rs.core.Application;
 /**
  * @author Endi S. Dewata
  */
-@ApplicationPath("")
+@ApplicationPath("/rest")
 public class ACMEApplication extends Application {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACMEApplication.class);

--- a/base/acme/webapps/acme/WEB-INF/web.xml
+++ b/base/acme/webapps/acme/WEB-INF/web.xml
@@ -8,103 +8,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
     <display-name>ACME Responder</display-name>
 
-    <listener>
-        <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
-    </listener>
-
-    <context-param>
-        <param-name>resteasy.role.based.security</param-name>
-        <param-value>true</param-value>
-    </context-param>
-
-    <context-param>
-        <param-name>resteasy.resource.method-interceptors</param-name>
-        <param-value>org.jboss.resteasy.core.ResourceMethodSecurityInterceptor</param-value>
-    </context-param>
-
-    <servlet>
-        <servlet-name>ACME</servlet-name>
-        <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-        <init-param>
-            <param-name>javax.ws.rs.Application</param-name>
-            <param-value>org.dogtagpki.acme.server.ACMEApplication</param-value>
-        </init-param>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/login</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/logout</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/enable</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/disable</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/directory</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/new-nonce</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/new-account</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/new-order</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/authz/*</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/chall/*</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/order/*</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/acct/*</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/cert/*</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>ACME</servlet-name>
-        <url-pattern>/revoke-cert</url-pattern>
-    </servlet-mapping>
-
     <security-constraint>
         <display-name>Allow somebody with credentials to log in</display-name>
         <web-resource-collection>
-            <url-pattern>/login</url-pattern>
+            <url-pattern>/rest/login</url-pattern>
             <http-method>POST</http-method>
         </web-resource-collection>
         <auth-constraint>
@@ -118,7 +25,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <security-constraint>
         <display-name>Allow anybody to get login information</display-name>
         <web-resource-collection>
-            <url-pattern>/login</url-pattern>
+            <url-pattern>/rest/login</url-pattern>
             <http-method-omission>POST</http-method-omission>
         </web-resource-collection>
         <user-data-constraint>
@@ -130,7 +37,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
         <display-name>Allow anybody to log out</display-name>
         <web-resource-collection>
             <web-resource-name>Logout Service</web-resource-name>
-            <url-pattern>/logout</url-pattern>
+            <url-pattern>/rest/logout</url-pattern>
         </web-resource-collection>
         <user-data-constraint>
             <transport-guarantee>CONFIDENTIAL</transport-guarantee>
@@ -140,7 +47,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <security-constraint>
         <display-name>Allow administrators to enable ACME services</display-name>
         <web-resource-collection>
-            <url-pattern>/enable</url-pattern>
+            <url-pattern>/rest/enable</url-pattern>
         </web-resource-collection>
         <auth-constraint>
             <role-name>Administrators</role-name>
@@ -154,7 +61,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <security-constraint>
         <display-name>Allow administrators to disable ACME services</display-name>
         <web-resource-collection>
-            <url-pattern>/disable</url-pattern>
+            <url-pattern>/rest/disable</url-pattern>
         </web-resource-collection>
         <auth-constraint>
             <role-name>Administrators</role-name>

--- a/base/tomcat-9.0/conf/Catalina/localhost/rewrite.config
+++ b/base/tomcat-9.0/conf/Catalina/localhost/rewrite.config
@@ -1,1 +1,18 @@
+# ACME
+RewriteRule ^/acme/login$ /acme/rest/login
+RewriteRule ^/acme/logout$ /acme/rest/logout
+RewriteRule ^/acme/enable$ /acme/rest/enable
+RewriteRule ^/acme/disable$ /acme/rest/disable
+RewriteRule ^/acme/directory$ /acme/rest/directory
+RewriteRule ^/acme/new-nonce$ /acme/rest/new-nonce
+RewriteRule ^/acme/new-account$ /acme/rest/new-account
+RewriteRule ^/acme/new-order$ /acme/rest/new-order
+RewriteRule ^/acme/authz/(.*)$ /acme/rest/authz/$1
+RewriteRule ^/acme/chall/(.*)$ /acme/rest/chall/$1
+RewriteRule ^/acme/order/(.*)$ /acme/rest/order/$1
+RewriteRule ^/acme/acct/(.*)$ /acme/rest/acct/$1
+RewriteRule ^/acme/cert/(.*)$ /acme/rest/cert/$1
+RewriteRule ^/acme/revoke-cert$ /acme/rest/revoke-cert
+
+# EST
 RewriteRule ^/.well-known/est/(.*)$ /est/$1


### PR DESCRIPTION
The ACME webapp has been modified to automatically initialize the ACME application without an explicit dependency on RESTEasy. Since a JAX-RS application cannot have an empty path, the ACME application needs to be relocated to `/rest` and the endpoints need to be mapped to the new location as well.

https://docs.jboss.org/resteasy/docs/3.0.24.Final/userguide/html_single/#d4e143
https://stackoverflow.com/questions/10874188/jax-rs-application-on-the-root-context-how-can-it-be-done