### PR TITLE
Auto-initialize EST application

### DIFF
--- a/base/est/src/main/java/org/dogtagpki/est/ESTApplication.java
+++ b/base/est/src/main/java/org/dogtagpki/est/ESTApplication.java
@@ -13,7 +13,7 @@ import javax.ws.rs.core.Application;
 
 import org.dogtagpki.server.rest.PKIExceptionMapper;
 
-@ApplicationPath("")
+@ApplicationPath("/rest")
 public class ESTApplication extends Application {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ESTApplication.class);

--- a/base/est/webapps/est/WEB-INF/web.xml
+++ b/base/est/webapps/est/WEB-INF/web.xml
@@ -8,34 +8,11 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
     <display-name>EST service</display-name>
 
-    <listener>
-        <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
-    </listener>
-
-    <context-param>
-        <param-name>resteasy.resource.method-interceptors</param-name>
-        <param-value>org.jboss.resteasy.core.ResourceMethodSecurityInterceptor</param-value>
-    </context-param>
-
-    <servlet>
-        <servlet-name>EST</servlet-name>
-        <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-        <init-param>
-            <param-name>javax.ws.rs.Application</param-name>
-            <param-value>org.dogtagpki.est.ESTApplication</param-value>
-        </init-param>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>EST</servlet-name>
-        <url-pattern>/</url-pattern>
-    </servlet-mapping>
-
     <!-- all GET methods are public -->
     <security-constraint>
         <display-name>Require TLS for all resources</display-name>
         <web-resource-collection>
-            <url-pattern>/*</url-pattern>
+            <url-pattern>/rest/*</url-pattern>
             <http-method>GET</http-method>
         </web-resource-collection>
         <user-data-constraint>
@@ -64,7 +41,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <security-constraint>
         <display-name>Require authenticated client for POST resources</display-name>
         <web-resource-collection>
-            <url-pattern>/*</url-pattern>
+            <url-pattern>/rest/*</url-pattern>
             <http-method>POST</http-method>
         </web-resource-collection>
         <auth-constraint>
@@ -79,7 +56,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <security-constraint>
         <display-name>Reject unused methods</display-name>
         <web-resource-collection>
-            <url-pattern>/*</url-pattern>
+            <url-pattern>/rest/*</url-pattern>
             <http-method-omission>GET</http-method-omission>
             <http-method-omission>POST</http-method-omission>
         </web-resource-collection>

--- a/base/tomcat-9.0/conf/Catalina/localhost/rewrite.config
+++ b/base/tomcat-9.0/conf/Catalina/localhost/rewrite.config
@@ -15,4 +15,4 @@ RewriteRule ^/acme/cert/(.*)$ /acme/rest/cert/$1
 RewriteRule ^/acme/revoke-cert$ /acme/rest/revoke-cert
 
 # EST
-RewriteRule ^/.well-known/est/(.*)$ /est/$1
+RewriteRule ^/.well-known/est/(.*)$ /est/rest/$1


### PR DESCRIPTION
The EST webapp has been modified to automatically initialize the EST application without an explicit dependency on RESTEasy. Since a JAX-RS application cannot have an empty path, the EST application needs to be relocated to `/rest` and the endpoints need to be mapped to the new location as well.

https://docs.jboss.org/resteasy/docs/3.0.24.Final/userguide/html_single/#d4e143
https://stackoverflow.com/questions/10874188/jax-rs-application-on-the-root-context-how-can-it-be-done