### PR TITLE
Add packit copr_build job on commit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,3 +43,17 @@ jobs:
       - centos-stream-9-x86_64
       - rhel-9-x86_64
 
+  - job: copr_build
+    trigger: commit
+    branch: master
+    additional_repos:
+      - "https://download.copr.fedorainfracloud.org/results/%40pki/master/rhel-9-x86_64/"
+      - "https://download.copr.fedorainfracloud.org/results/%40pki/master/fedora-37-x86_64"
+      - "https://download.copr.fedorainfracloud.org/results/%40pki/master/fedora-38-x86_64"
+      - "https://download.copr.fedorainfracloud.org/results/%40pki/master/fedora-rawhide-x86_64"
+      - "https://download.copr.fedorainfracloud.org/results/%40pki/master/centos-stream-9-x86_64"
+    targets:
+      - fedora-all
+      - centos-stream-9-x86_64
+      - rhel-9-x86_64
+


### PR DESCRIPTION
This commit extends the `packit` COPR builds that run in the CI for PRs to commits, both in forks prior to PR opening and on merge to `master`.

Example run in my fork: https://github.com/ckelleyRH/pki/runs/14586351933
Instructions for enabling it in your own fork: https://packit.dev/docs/guide/

As presented, the COPR builds in the fork go into the `packit` namespace like this: https://copr.fedorainfracloud.org/coprs/packit/ckelleyRH-pki-master/build/6118108/

...and presumably once merged, the on-commit job that will run will also do builds in the `packit` namespace.

I think the `packit` namespace is fine for the forks, but it would have been nicer if the on-commit to `master` builds went into `@pki/master`. It is possible to configure that, but then all the fork builds would also then go into there, and we don't want that. I haven't seen a way to conditionalise that though. I think it is fine for now though, unless anyone can think of a better way.