### PR TITLE
Update POM files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,47 +63,63 @@ jobs:
   - script: |
       # get Python <major>.<minor> version
       docker exec runner python3 --version | tee output
-      VERSION=$(sed 's/Python \([0-9]\+\.[0-9]\+\)\..*/\1/' output)
+      PYTHON_VERSION=$(sed 's/Python \([0-9]\+\.[0-9]\+\)\..*/\1/' output)
 
       docker exec runner \
           /root/src/build.sh \
           --work-dir=/root/build \
-          --python-dir=/usr/lib/python$VERSION/site-packages \
+          --python-dir=/usr/lib/python$PYTHON_VERSION/site-packages \
           dist
     displayName: Build PKI with CMake
 
   - script: |
+      # get JSS <major>.<minor>.<update> version
+      docker exec runner rpm -q dogtag-jss | tee output
+      JSS_VERSION=$(sed -e 's/^dogtag-jss-\([0-9]\+\.[0-9]\+\.[0-9]\+\).*$/\1/' output)
+
+      # if built by COPR, jss-base.jar will be installed in /usr/lib/java/jss,
+      # otherwise it will be in /usr/share/java/jss.
+      JSS_BASE_JAR=$(docker exec runner find /usr/share/java/jss /usr/lib/java/jss -name jss-base.jar)
+
       docker exec runner \
           mvn install:install-file \
           -f /root/src \
-          -Dfile=/usr/lib/java/jss.jar \
+          -Dfile=$JSS_BASE_JAR \
           -DgroupId=org.dogtagpki.jss \
           -DartifactId=jss-base \
-          -Dversion=5.4.0-SNAPSHOT \
+          -Dversion=$JSS_VERSION-SNAPSHOT \
           -Dpackaging=jar \
           -DgeneratePom=true
     displayName: Install JSS into Maven repo
 
   - script: |
+      # get Tomcat JSS <major>.<minor>.<update> version
+      docker exec runner rpm -q dogtag-tomcatjss | tee output
+      TOMCATJSS_VERSION=$(sed -e 's/^dogtag-tomcatjss-\([0-9]\+\.[0-9]\+\.[0-9]\+\).*$/\1/' output)
+
       docker exec runner \
           mvn install:install-file \
           -f /root/src \
-          -Dfile=/usr/share/java/tomcatjss.jar \
+          -Dfile=/usr/share/java/tomcatjss/tomcatjss-core.jar \
           -DgroupId=org.dogtagpki.tomcatjss \
-          -DartifactId=tomcatjss-tomcat-9.0 \
-          -Dversion=8.4.0-SNAPSHOT \
+          -DartifactId=tomcatjss-core \
+          -Dversion=$TOMCATJSS_VERSION-SNAPSHOT \
           -Dpackaging=jar \
           -DgeneratePom=true
     displayName: Install Tomcat JSS into Maven repo
 
   - script: |
+      # get LDAP JDK <major>.<minor>.<update> version
+      docker exec runner rpm -q dogtag-ldapjdk | tee output
+      LDAPJDK_VERSION=$(sed -e 's/^dogtag-ldapjdk-\([0-9]\+\.[0-9]\+\.[0-9]\+\).*$/\1/' output)
+
       docker exec runner \
           mvn install:install-file \
           -f /root/src \
           -Dfile=/usr/share/java/ldapjdk.jar \
           -DgroupId=org.dogtagpki.ldap-sdk \
           -DartifactId=ldapjdk \
-          -Dversion=5.4.0-SNAPSHOT \
+          -Dversion=$LDAPJDK_VERSION-SNAPSHOT \
           -Dpackaging=jar \
           -DgeneratePom=true
     displayName: Install LDAP JDK into Maven repo

--- a/base/est/pom.xml
+++ b/base/est/pom.xml
@@ -11,27 +11,21 @@
         <version>${revision}</version>
     </parent>
 
-    <artifactId>pki-common</artifactId>
+    <artifactId>pki-est</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
 
         <dependency>
-            <groupId>org.dogtagpki.jss</groupId>
-            <artifactId>jss-base</artifactId>
-            <version>5.5.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dogtagpki.ldap-sdk</groupId>
-            <artifactId>ldapjdk</artifactId>
-            <version>5.5.0-SNAPSHOT</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-server</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>
 
     <build>
-        <finalName>pki-common</finalName>
+        <finalName>pki-est</finalName>
     </build>
 
 </project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -27,6 +27,7 @@
         <module>tks</module>
         <module>tps</module>
         <module>acme</module>
+        <module>est</module>
     </modules>
 
 </project>

--- a/base/tomcat/pom.xml
+++ b/base/tomcat/pom.xml
@@ -35,6 +35,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.dogtagpki.tomcatjss</groupId>
+            <artifactId>tomcatjss-core</artifactId>
+            <version>8.5.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>pki-common</artifactId>
             <version>${project.version}</version>

--- a/pki.spec
+++ b/pki.spec
@@ -167,7 +167,8 @@ BuildRequires:    mvn(org.apache.commons:commons-lang3)
 BuildRequires:    mvn(commons-logging:commons-logging)
 BuildRequires:    mvn(commons-net:commons-net)
 BuildRequires:    mvn(org.slf4j:slf4j-api)
-BuildRequires:    mvn(org.slf4j:slf4j-jdk14)
+BuildRequires:    mvn(xml-apis:xml-apis)
+BuildRequires:    mvn(xml-resolver:xml-resolver)
 BuildRequires:    mvn(org.junit.jupiter:junit-jupiter-api)
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-client)
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-jackson2-provider)
@@ -177,9 +178,9 @@ BuildRequires:    mvn(org.apache.tomcat:tomcat-catalina)
 BuildRequires:    mvn(org.apache.tomcat:tomcat-servlet-api)
 BuildRequires:    mvn(org.apache.tomcat:tomcat-jaspic-api)
 BuildRequires:    mvn(org.apache.tomcat:tomcat-util-scan)
-BuildRequires:    jss >= 5.4
-BuildRequires:    tomcatjss >= 8.4
-BuildRequires:    ldapjdk >= 5.4
+BuildRequires:    mvn(org.dogtagpki.jss:jss-base) >= 5.5.0
+BuildRequires:    mvn(org.dogtagpki.tomcatjss:tomcatjss-core) >= 8.5.0
+BuildRequires:    mvn(org.dogtagpki.ldap-sdk:ldapjdk) >= 5.5.0
 
 # Python build dependencies
 BuildRequires:    python3 >= 3.9
@@ -374,8 +375,8 @@ Requires:         mvn(org.slf4j:slf4j-jdk14)
 Requires:         mvn(org.jboss.resteasy:resteasy-client)
 Requires:         mvn(org.jboss.resteasy:resteasy-jackson2-provider)
 Requires:         mvn(org.jboss.resteasy:resteasy-jaxrs)
-Requires:         jss >= 5.4
-Requires:         ldapjdk >= 5.4
+Requires:         mvn(org.dogtagpki.jss:jss-base) >= 5.5.0
+Requires:         mvn(org.dogtagpki.ldap-sdk:ldapjdk) >= 5.5.0
 Requires:         %{product_id}-base = %{version}-%{release}
 
 %description -n   %{product_id}-java
@@ -440,12 +441,12 @@ Requires:         selinux-policy-targeted >= 3.13.1-159
 
 Requires:         mvn(org.jboss.resteasy:resteasy-servlet-initializer)
 Requires:         tomcat >= 1:9.0.50
+Requires:         mvn(org.dogtagpki.tomcatjss:tomcatjss-core) >= 8.5.0
 
 Requires:         systemd
 Requires(post):   systemd-units
 Requires(postun): systemd-units
 Requires(pre):    shadow-utils
-Requires:         tomcatjss >= 8.4
 
 # pki-healthcheck depends on the following library
 %if 0%{?rhel}

--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
@@ -177,24 +171,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dogtagpki.jss</groupId>
-            <artifactId>jss-base</artifactId>
-            <version>5.4.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dogtagpki.tomcatjss</groupId>
-            <artifactId>tomcatjss-tomcat-9.0</artifactId>
-            <version>8.4.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dogtagpki.ldap-sdk</groupId>
-            <artifactId>ldapjdk</artifactId>
-            <version>5.4.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.9.0</version>
@@ -251,6 +227,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The POM files have been modified to use the latest dependencies. The dependencies have been moved into the modules that actually need them. The `maven-surefire-plugin` has been added to run JUnit 5 tests properly. A new POM file has also been added for EST.

The RPM spec and Azure pipelines have been updated to use the same dependencies as in the POM files.