### PR TITLE
Handle removal of ConfigParser.readfp() in Python 3.12

### DIFF
--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -29,6 +29,7 @@ import logging
 import os
 import string
 
+import six
 from six.moves import input  # pylint: disable=W0622,F0401
 from six.moves import configparser  # pylint: disable=F0401
 from six.moves.urllib.parse import urlparse  # pylint: disable=F0401,E0611
@@ -342,7 +343,10 @@ class PKIConfigParser:
         self.deployer.user_config.optionxform = str
 
         with open(config.default_deployment_cfg, encoding='utf-8') as f:
-            self.deployer.main_config.readfp(f)
+            if six.PY2:
+                self.deployer.main_config.readfp(f)
+            else:
+                self.deployer.main_config.read_file(f)
 
         self.deployer.flatten_master_dict()
 


### PR DESCRIPTION
Per https://docs.python.org/3.12/whatsnew/3.12.html#removed , configparser.ConfigParser.readfp() is removed in Python 3.12. Assuming we still want to keep Python 2 compatibility, since there are still a bunch of uses of six in the codebase, I've changed this to do it the same way as it's done in freeipa ipaserver/install/certs.py, using readfp on Python 2 and read_file on Python 3.