### PR TITLE
Build RPM with Maven

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" APPLICATION_VERSION_P
 
 set(APP_SERVER "tomcat-9.0" CACHE STRING "Application server")
 
+option(WITH_JAVA "Build Java binaries." TRUE)
+
 option(WITH_SERVER "Build server package" ON)
 option(WITH_CA "Build CA package" ON)
 option(WITH_KRA "Build KRA package" ON)
@@ -120,6 +122,30 @@ include(ConfigureChecks)
 configure_file(cmake/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 add_definitions(-DHAVE_CONFIG_H)
+
+# java target
+add_custom_target(
+    java
+    COMMENT "Building Java binaries"
+)
+
+# console target
+add_custom_target(
+    console
+    COMMENT "Building PKI console"
+)
+
+# javadoc target
+add_custom_target(
+    javadoc
+    COMMENT "Building Javadoc"
+)
+
+# native target
+add_custom_target(
+    native ALL
+    COMMENT "Building native binaries"
+)
 
 # uninstall target
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,8 +50,11 @@ jobs:
               rpm -qlp "/root/build/pki/RPMS/$rpm" | tee -a file_list
       done
 
-      # exclude RPM-specific files
+      # exclude Maven-specific and RPM-specific files
+      # from comparison with CMake files
       sed -i \
+          -e '/^\/usr\/share\/maven-metadata\//d' \
+          -e '/^\/usr\/share\/maven-poms\//d' \
           -e '/^\/usr\/share\/licenses\//d' \
           -e '/^\/usr\/share\/man\//d' \
           -e '/^\/usr\/share\/doc\//d' \

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -436,32 +436,24 @@ if(WITH_SERVER OR WITH_CA OR WITH_KRA OR WITH_OCSP OR WITH_TKS OR WITH_TPS OR WI
         ${PKI_TOMCAT_9_0_JAR}
         ${PKI_SERVER_JAR})
 
-    list(APPEND PKI_JAVADOC_DEPENDS
-        pki-server-jar)
-
     if(WITH_CA)
         add_subdirectory(ca)
-        list(APPEND PKI_JAVADOC_DEPENDS pki-ca-jar)
     endif(WITH_CA)
 
     if(WITH_KRA)
         add_subdirectory(kra)
-        list(APPEND PKI_JAVADOC_DEPENDS pki-kra-jar)
     endif(WITH_KRA)
 
     if(WITH_OCSP)
         add_subdirectory(ocsp)
-        list(APPEND PKI_JAVADOC_DEPENDS pki-ocsp-jar)
     endif(WITH_OCSP)
 
     if(WITH_TKS)
         add_subdirectory(tks)
-        list(APPEND PKI_JAVADOC_DEPENDS pki-tks-jar)
     endif(WITH_TKS)
 
     if(WITH_TPS)
         add_subdirectory(tps)
-        list(APPEND PKI_JAVADOC_DEPENDS pki-tps-jar)
     endif(WITH_TPS)
 
     if(WITH_ACME)

--- a/base/acme/CMakeLists.txt
+++ b/base/acme/CMakeLists.txt
@@ -24,6 +24,8 @@ javac(pki-acme-classes
         pki-server-jar
 )
 
+add_dependencies(java pki-acme-classes)
+
 set(PKI_ACME_JAR ${CMAKE_BINARY_DIR}/dist/pki-acme.jar
     CACHE INTERNAL "pki-acme.jar"
 )
@@ -46,6 +48,8 @@ jar(pki-acme-jar
         pki-acme-classes
 )
 
+add_dependencies(java pki-acme-jar)
+
 add_custom_target(pki-acme-links ALL
     COMMENT "Creating links for ACME")
 
@@ -59,12 +63,14 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
-install(
-    FILES
-        ${PKI_ACME_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_ACME_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 install(
     FILES

--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -34,6 +34,8 @@ javac(pki-ca-classes
         pki-server-jar
 )
 
+add_dependencies(java pki-ca-classes)
+
 set(PKI_CA_JAR ${CMAKE_BINARY_DIR}/dist/pki-ca.jar
     CACHE INTERNAL "pki-ca.jar"
 )
@@ -56,6 +58,8 @@ jar(pki-ca-jar
         pki-ca-classes
 )
 
+add_dependencies(java pki-ca-jar)
+
 # Create links at /usr/share/pki/ca/webapps/ca/admin/console.
 # Create links in /usr/share/pki/ca/webapps/ca/WEB-INF/lib.
 # This can be customized for different platforms in RPM spec.
@@ -74,12 +78,14 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
-install(
-    FILES
-        ${PKI_CA_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_CA_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 # install directories
 install(

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -20,6 +20,8 @@ javac(pki-common-classes
         ${CMAKE_CURRENT_BINARY_DIR}/classes
 )
 
+add_dependencies(java pki-common-classes)
+
 set(PKI_COMMON_JAR ${CMAKE_BINARY_DIR}/dist/pki-common.jar
     CACHE INTERNAL "pki-common.jar"
 )
@@ -41,6 +43,8 @@ jar(pki-common-jar
     DEPENDS
         pki-common-classes
 )
+
+add_dependencies(java pki-common-jar)
 
 if(RUN_TESTS)
     javac(pki-common-test-classes
@@ -65,6 +69,8 @@ if(RUN_TESTS)
             pki-common-jar
     )
 
+    add_dependencies(java pki-common-test-classes)
+
     add_junit_test(test-pki-common
         CLASSPATH
             ${JAVAX_ACTIVATION_JAR}
@@ -85,6 +91,9 @@ if(RUN_TESTS)
         DEPENDS
             pki-common-test-classes
     )
+
+    add_dependencies(java test-pki-common)
+
 endif(RUN_TESTS)
 
 # Create /usr/share/pki/lib. This can be customized for different platforms in RPM spec.
@@ -144,12 +153,14 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/share/etc/pki.conf
 )
 
-install(
-    FILES
-        ${PKI_COMMON_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_COMMON_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 install(
     DIRECTORY

--- a/base/common/examples/CMakeLists.txt
+++ b/base/common/examples/CMakeLists.txt
@@ -14,6 +14,8 @@ javac(pki-examples-classes
         pki-common-jar
 )
 
+add_dependencies(java pki-examples-classes)
+
 install(
     DIRECTORY
         java

--- a/base/console/CMakeLists.txt
+++ b/base/console/CMakeLists.txt
@@ -18,6 +18,8 @@ javac(pki-console-classes
         pki-common-jar
 )
 
+add_dependencies(console pki-console-classes)
+
 set(PKI_CONSOLE_JAR ${CMAKE_BINARY_DIR}/dist/pki-console.jar
     CACHE INTERNAL "pki-console.jar"
 )
@@ -44,6 +46,8 @@ jar(pki-console-jar
     DEPENDS
         pki-console-classes
 )
+
+add_dependencies(console pki-console-jar)
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/bin/pkiconsole

--- a/base/est/CMakeLists.txt
+++ b/base/est/CMakeLists.txt
@@ -26,6 +26,8 @@ javac(pki-est-classes
         pki-server-jar
 )
 
+add_dependencies(java pki-est-classes)
+
 set(PKI_EST_JAR ${CMAKE_BINARY_DIR}/dist/pki-est.jar
     CACHE INTERNAL "pki-est.jar"
 )
@@ -48,6 +50,8 @@ jar(pki-est-jar
         pki-est-classes
 )
 
+add_dependencies(java pki-est-jar)
+
 add_custom_target(pki-est-links ALL
     COMMENT "Creating links for EST")
 
@@ -61,12 +65,14 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
-install(
-    FILES
-        ${PKI_EST_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_EST_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 # install deployment descriptor
 install(

--- a/base/javadoc/CMakeLists.txt
+++ b/base/javadoc/CMakeLists.txt
@@ -94,10 +94,9 @@ javadoc(pki-javadoc
         -version
         -quiet
         ${doclintstr}
-    DEPENDS
-        pki-common-jar pki-tools-jar
-        ${PKI_JAVADOC_DEPENDS}
 )
+
+add_dependencies(javadoc pki-javadoc)
 
 install(
     DIRECTORY

--- a/base/kra/CMakeLists.txt
+++ b/base/kra/CMakeLists.txt
@@ -25,6 +25,8 @@ javac(pki-kra-classes
         pki-server-jar
 )
 
+add_dependencies(java pki-kra-classes)
+
 set(PKI_KRA_JAR ${CMAKE_BINARY_DIR}/dist/pki-kra.jar
     CACHE INTERNAL "pki-kra.jar"
 )
@@ -47,6 +49,8 @@ jar(pki-kra-jar
         pki-kra-classes
 )
 
+add_dependencies(java pki-kra-jar)
+
 # Create links at /usr/share/pki/kra/webapps/kra/admin/console.
 # Create links in /usr/share/pki/kra/webapps/kra/WEB-INF/lib.
 # This can be customized for different platforms in RPM spec.
@@ -66,12 +70,14 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
-install(
-    FILES
-        ${PKI_KRA_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_KRA_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 # install directories
 install(

--- a/base/ocsp/CMakeLists.txt
+++ b/base/ocsp/CMakeLists.txt
@@ -26,6 +26,8 @@ javac(pki-ocsp-classes
         pki-server-jar
 )
 
+add_dependencies(java pki-ocsp-classes)
+
 set(PKI_OCSP_JAR ${CMAKE_BINARY_DIR}/dist/pki-ocsp.jar
     CACHE INTERNAL "pki-ocsp.jar"
 )
@@ -48,6 +50,8 @@ jar(pki-ocsp-jar
         pki-ocsp-classes
 )
 
+add_dependencies(java pki-ocsp-jar)
+
 # Create links at /usr/share/pki/ocsp/webapps/ocsp/admin/console.
 # Create links in /usr/share/pki/ocsp/webapps/ocsp/WEB-INF/lib.
 # This can be customized for different platforms in RPM spec.
@@ -67,12 +71,14 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
-install(
-    FILES
-        ${PKI_OCSP_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_OCSP_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 # install directories
 install(

--- a/base/server-webapp/CMakeLists.txt
+++ b/base/server-webapp/CMakeLists.txt
@@ -18,6 +18,8 @@ javac(pki-server-webapp-classes
         pki-server-jar
 )
 
+add_dependencies(java pki-server-webapp-classes)
+
 set(PKI_SERVER_WEBAPP_JAR ${CMAKE_BINARY_DIR}/dist/pki-server-webapp.jar
     CACHE INTERNAL "pki-server-webapp.jar"
 )
@@ -42,6 +44,8 @@ jar(pki-server-webapp-jar
         pki-server-webapp-classes
 )
 
+add_dependencies(java pki-server-webapp-jar)
+
 # Create /usr/share/pki/server/webapps/pki/WEB-INF/lib. This can be customized for different platforms in RPM spec.
 
 add_custom_target(pki-server-webapp-lib ALL
@@ -64,12 +68,14 @@ install(
         ${DATA_INSTALL_DIR}/server
 )
 
-install(
-    FILES
-        ${PKI_SERVER_WEBAPP_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_SERVER_WEBAPP_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 install(
     DIRECTORY

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -29,6 +29,8 @@ javac(pki-server-classes
         pki-common-jar pki-tools-jar pki-tomcat-jar pki-tomcat-9.0-jar
 )
 
+add_dependencies(java pki-server-classes)
+
 set(PKI_SERVER_JAR ${CMAKE_BINARY_DIR}/dist/pki-server.jar
     CACHE INTERNAL "pki-server.jar"
 )
@@ -58,6 +60,8 @@ jar(pki-server-jar
         pki-server-classes
 )
 
+add_dependencies(java pki-server-jar)
+
 if(RUN_TESTS)
     # build pki-server-test
     javac(pki-server-test-classes
@@ -79,6 +83,8 @@ if(RUN_TESTS)
             pki-common-test-classes pki-common-jar pki-server-jar
     )
 
+    add_dependencies(java pki-server-test-classes)
+
     add_junit_test(test-pki-server
         CLASSPATH
             ${SLF4J_API_JAR} ${SLF4J_SIMPLE_JAR}
@@ -97,6 +103,9 @@ if(RUN_TESTS)
         DEPENDS
             pki-server-test-classes
     )
+
+    add_dependencies(java test-pki-server)
+
 endif(RUN_TESTS)
 
 # Create /usr/share/pki/server/lib. This can be customized for different platforms in RPM spec.
@@ -186,12 +195,14 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/share/etc/tomcat.conf
 )
 
-install(
-    FILES
-        ${PKI_SERVER_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_SERVER_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 install(
     DIRECTORY

--- a/base/tks/CMakeLists.txt
+++ b/base/tks/CMakeLists.txt
@@ -27,6 +27,8 @@ javac(pki-tks-classes
         pki-server-jar
 )
 
+add_dependencies(java pki-tks-classes)
+
 set(PKI_TKS_JAR ${CMAKE_BINARY_DIR}/dist/pki-tks.jar
     CACHE INTERNAL "pki-tks.jar"
 )
@@ -49,6 +51,8 @@ jar(pki-tks-jar
         pki-tks-classes
 )
 
+add_dependencies(java pki-tks-jar)
+
 # Create links at /usr/share/pki/tks/webapps/tks/admin/console.
 # Create /usr/share/pki/tks/webapps/tks/WEB-INF/lib.
 # This can be customized for different platforms in RPM spec.
@@ -68,12 +72,14 @@ add_custom_command(
     COMMAND ln -sf ../../../../../../../..${RESTEASY_SERVLET_INITIALIZER_JAR} webapp/lib/resteasy-servlet-intializer.jar
 )
 
-install(
-    FILES
-        ${PKI_TKS_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_TKS_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 # install directories
 install(

--- a/base/tomcat-9.0/CMakeLists.txt
+++ b/base/tomcat-9.0/CMakeLists.txt
@@ -21,6 +21,8 @@ javac(pki-tomcat-9.0-classes
         pki-tomcat-jar
 )
 
+add_dependencies(java pki-tomcat-9.0-classes)
+
 set(PKI_TOMCAT_9_0_JAR ${CMAKE_BINARY_DIR}/dist/pki-tomcat-9.0.jar
     CACHE INTERNAL "pki-tomcat-9.0.jar"
 )
@@ -43,12 +45,16 @@ jar(pki-tomcat-9.0-jar
         pki-tomcat-9.0-classes
 )
 
-install(
-    FILES
-        ${PKI_TOMCAT_9_0_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+add_dependencies(java pki-tomcat-9.0-jar)
+
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_TOMCAT_9_0_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 install(
     DIRECTORY

--- a/base/tomcat/CMakeLists.txt
+++ b/base/tomcat/CMakeLists.txt
@@ -20,6 +20,8 @@ javac(pki-tomcat-classes
         pki-common-jar
 )
 
+add_dependencies(java pki-tomcat-classes)
+
 set(PKI_TOMCAT_JAR ${CMAKE_BINARY_DIR}/dist/pki-tomcat.jar
     CACHE INTERNAL "pki-tomcat.jar"
 )
@@ -42,9 +44,13 @@ jar(pki-tomcat-jar
         pki-tomcat-classes
 )
 
-install(
-    FILES
-        ${PKI_TOMCAT_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+add_dependencies(java pki-tomcat-jar)
+
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_TOMCAT_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)

--- a/base/tools/CMakeLists.txt
+++ b/base/tools/CMakeLists.txt
@@ -29,6 +29,8 @@ javac(pki-tools-classes
         pki-common-jar
 )
 
+add_dependencies(java pki-tools-classes)
+
 set(PKI_TOOLS_JAR ${CMAKE_BINARY_DIR}/dist/pki-tools.jar
     CACHE INTERNAL "pki-tools.jar"
 )
@@ -51,12 +53,16 @@ jar(pki-tools-jar
         pki-tools-classes
 )
 
-install(
-    FILES
-        ${PKI_TOOLS_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+add_dependencies(java pki-tools-jar)
+
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_TOOLS_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 install(
     FILES

--- a/base/tools/src/main/native/bulkissuance/CMakeLists.txt
+++ b/base/tools/src/main/native/bulkissuance/CMakeLists.txt
@@ -18,7 +18,8 @@ set(bulkissuance_SRCS
 
 include_directories(${BULKISSUANCE_PRIVATE_INCLUDE_DIRS})
 
-add_executable(bulkissuance ${bulkissuance_SRCS})
+add_executable(bulkissuance EXCLUDE_FROM_ALL ${bulkissuance_SRCS})
+add_dependencies(native bulkissuance)
 
 target_link_libraries(bulkissuance ${BULKISSUANCE_LINK_LIBRARIES})
 

--- a/base/tools/src/main/native/p12tool/CMakeLists.txt
+++ b/base/tools/src/main/native/p12tool/CMakeLists.txt
@@ -22,8 +22,8 @@ set(p12tool_SRCS
 
 include_directories(${P12TOOL_PRIVATE_INCLUDE_DIRS})
 
-add_executable(p12tool ${p12tool_SRCS})
-add_dependencies(p12tool pki-common-jar)
+add_executable(p12tool EXCLUDE_FROM_ALL ${p12tool_SRCS})
+add_dependencies(native p12tool)
 target_link_libraries(p12tool ${P12TOOL_LINK_LIBRARIES})
 
 install(

--- a/base/tools/src/main/native/p7tool/CMakeLists.txt
+++ b/base/tools/src/main/native/p7tool/CMakeLists.txt
@@ -21,8 +21,8 @@ set(p7tool_SRCS
 
 include_directories(${P7TOOL_PRIVATE_INCLUDE_DIRS})
 
-add_executable(p7tool ${p7tool_SRCS})
-add_dependencies(p7tool pki-common-jar)
+add_executable(p7tool EXCLUDE_FROM_ALL ${p7tool_SRCS})
+add_dependencies(native p7tool)
 target_link_libraries(p7tool ${P7TOOL_LINK_LIBRARIES})
 
 install(

--- a/base/tools/src/main/native/pistool/src/CMakeLists.txt
+++ b/base/tools/src/main/native/pistool/src/CMakeLists.txt
@@ -66,8 +66,8 @@ set(pistool_SRCS
 
 include_directories(${PISTOOL_PRIVATE_INCLUDE_DIRS})
 
-add_executable(pistool ${pistool_SRCS})
-add_dependencies(pistool sslget)
+add_executable(pistool EXCLUDE_FROM_ALL ${pistool_SRCS})
+add_dependencies(native pistool)
 target_link_libraries(pistool ${PISTOOL_LINK_LIBRARIES})
 
 install(

--- a/base/tools/src/main/native/revoker/CMakeLists.txt
+++ b/base/tools/src/main/native/revoker/CMakeLists.txt
@@ -18,8 +18,8 @@ set(revoker_SRCS
 
 include_directories(${REVOKER_PRIVATE_INCLUDE_DIRS})
 
-add_executable(revoker ${revoker_SRCS})
-add_dependencies(revoker p7tool)
+add_executable(revoker EXCLUDE_FROM_ALL ${revoker_SRCS})
+add_dependencies(native revoker)
 target_link_libraries(revoker ${REVOKER_LINK_LIBRARIES})
 
 install(

--- a/base/tools/src/main/native/setpin/CMakeLists.txt
+++ b/base/tools/src/main/native/setpin/CMakeLists.txt
@@ -24,8 +24,8 @@ set(setpin_SRCS
 
 include_directories(${SETPIN_PRIVATE_INCLUDE_DIRS})
 
-add_executable(setpin ${setpin_SRCS})
-add_dependencies(setpin revoker)
+add_executable(setpin EXCLUDE_FROM_ALL ${setpin_SRCS})
+add_dependencies(native setpin)
 target_link_libraries(setpin ${SETPIN_LINK_LIBRARIES})
 
 install(

--- a/base/tools/src/main/native/sslget/CMakeLists.txt
+++ b/base/tools/src/main/native/sslget/CMakeLists.txt
@@ -18,8 +18,8 @@ set(sslget_SRCS
 
 include_directories(${SSLGET_PRIVATE_INCLUDE_DIRS})
 
-add_executable(sslget ${sslget_SRCS})
-add_dependencies(sslget setpin)
+add_executable(sslget EXCLUDE_FROM_ALL ${sslget_SRCS})
+add_dependencies(native sslget)
 target_link_libraries(sslget ${SSLGET_LINK_LIBRARIES})
 
 install(

--- a/base/tools/src/main/native/tkstool/CMakeLists.txt
+++ b/base/tools/src/main/native/tkstool/CMakeLists.txt
@@ -33,8 +33,8 @@ set(tkstool_SRCS
 
 include_directories(${TKSTOOL_PRIVATE_INCLUDE_DIRS})
 
-add_executable(tkstool ${tkstool_SRCS})
-add_dependencies(tkstool sslget)
+add_executable(tkstool EXCLUDE_FROM_ALL ${tkstool_SRCS})
+add_dependencies(native tkstool)
 target_link_libraries(tkstool ${TKSTOOL_LINK_LIBRARIES})
 
 install(

--- a/base/tps/CMakeLists.txt
+++ b/base/tps/CMakeLists.txt
@@ -25,6 +25,8 @@ javac(pki-tps-classes
         pki-server-jar
 )
 
+add_dependencies(java pki-tps-classes)
+
 set(PKI_TPS_JAR ${CMAKE_BINARY_DIR}/dist/pki-tps.jar
     CACHE INTERNAL "pki-tps.jar"
 )
@@ -46,6 +48,8 @@ jar(pki-tps-jar
     DEPENDS
         pki-tps-classes
 )
+
+add_dependencies(java pki-tps-jar)
 
 # TPS does not support admin console.
 # Create links in /usr/share/pki/tps/webapps/tps/WEB-INF/lib.
@@ -74,12 +78,14 @@ add_custom_command(
     COMMAND go-md2man -in ${CMAKE_SOURCE_DIR}/docs/manuals/man5/pki-tps-profile.5.md -out man/man5/pki-tps-profile.5
 )
 
-install(
-    FILES
-        ${PKI_TPS_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${CMAKE_BINARY_DIR}/dist/pki-tps.jar
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)
 
 # install directories
 install(

--- a/cmake/Modules/JUnit.cmake
+++ b/cmake/Modules/JUnit.cmake
@@ -46,7 +46,7 @@ function(add_junit_test target)
 
     endforeach(arg)
 
-    add_custom_target(${target} ALL
+    add_custom_target(${target}
         DEPENDS ${depends}
         COMMENT "Running JUnit ${target}")
 

--- a/cmake/Modules/Java.cmake
+++ b/cmake/Modules/Java.cmake
@@ -65,7 +65,7 @@ function(javac target)
 
     set(file_list "${CMAKE_CURRENT_BINARY_DIR}/${target}.files")
 
-    add_custom_target(${target} ALL
+    add_custom_target(${target}
         DEPENDS ${depends}
         COMMENT "Compiling Java sources for ${target}")
 
@@ -150,7 +150,7 @@ function(jar target)
 
     endforeach(arg)
 
-    add_custom_target(${target} ALL
+    add_custom_target(${target}
         DEPENDS ${depends}
         COMMENT "Packaging resources for ${target}")
 
@@ -285,7 +285,7 @@ function(javadoc target)
 
     set(command ${command} ${files} ${packages})
 
-    add_custom_target(${target} ALL
+    add_custom_target(${target}
         DEPENDS ${depends}
         COMMENT "Generating Javadoc for ${target}")
 
@@ -320,7 +320,7 @@ function(link target)
 
     endforeach(arg)
 
-    add_custom_target(${target} ALL
+    add_custom_target(${target}
         DEPENDS ${depends}
         COMMENT "Linking ${target} to ${source}")
 

--- a/themes/dogtag/console-ui/src/CMakeLists.txt
+++ b/themes/dogtag/console-ui/src/CMakeLists.txt
@@ -17,6 +17,8 @@ jar(pki-console-theme-jar
         com/netscape/admin/certsrv/theme/certmgmt.gif
 )
 
+add_dependencies(console pki-console-theme-jar)
+
 install(
     FILES
         ${PKI_CONSOLE_THEME_JAR}


### PR DESCRIPTION
The RPM spec file has been modified to build Java binaries and run unit tests with Maven, then build PKI console, Javadoc, and native binaries with CMake. In the future it might be possible to build everything with Maven.

The `build.sh` has been modified to provide an option to skip building Java binaries. The CMake scripts have been modified to provide separate build targets for Java binaries, PKI console, Javadoc, and native binaries. The `javac()`, `jar()`, `javadoc()`, `link()`, and `add_junit_test()` macros have been modified to no longer be included in the default build target to provide more controls over the build process.