### PR TITLE
Build PKI console with Maven

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -27,9 +27,7 @@
 	<classpathentry kind="lib" path="/usr/share/java/apache-commons-cli.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/apache-commons-logging.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/commons-codec.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/idm-console-base.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/idm-console-mcc.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/idm-console-nmclf.jar"/>
+	<classpathentry kind="lib" path="/usr/share/java/idm-console-framework.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/ldapjdk.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/jaxb-api/jakarta.xml.bind-api.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/jakarta-activation/jakarta.activation-api.jar"/>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,10 @@ add_custom_target(
     COMMENT "Building Java binaries"
 )
 
-# console target
+# theme target
 add_custom_target(
-    console
-    COMMENT "Building PKI console"
+    theme
+    COMMENT "Building PKI theme"
 )
 
 # javadoc target

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
       docker exec runner dnf install -y dnf-plugins-core rpm-build maven
       docker exec runner dnf copr enable -y @pki/master
       docker exec runner dnf builddep -y --spec /root/src/pki.spec
+      docker exec runner dnf install -y dogtag-console-framework
     displayName: Install PKI dependencies
 
   - script: |
@@ -123,6 +124,21 @@ jobs:
           -Dpackaging=jar \
           -DgeneratePom=true
     displayName: Install LDAP JDK into local Maven repo
+
+  - script: |
+      # get IDM Console Framework <major>.<minor>.<update> version
+      IDM_CONSOLE_FRAMEWORK_VERSION=$(docker exec runner rpm -q --qf "%{version}" dogtag-console-framework)
+
+      docker exec runner \
+          mvn install:install-file \
+          -f /root/src \
+          -Dfile=/usr/share/java/idm-console-framework.jar \
+          -DgroupId=org.dogtagpki.console-framework \
+          -DartifactId=console-framework \
+          -Dversion=$IDM_CONSOLE_FRAMEWORK_VERSION-SNAPSHOT \
+          -Dpackaging=jar \
+          -DgeneratePom=true
+    displayName: Install IDM Console Framework into local Maven repo
 
   - script: |
       docker exec runner \

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -375,41 +375,9 @@ find_file(TOMCATJSS_TOMCAT_9_0_JAR
         /usr/share/java/tomcatjss
 )
 
-find_file(BASE_JAR
+find_file(IDM_CONSOLE_FRAMEWORK_JAR
     NAMES
-        idm-console-base.jar
-    PATHS
-        ${JAVA_LIB_INSTALL_DIR}
-        /usr/share/java
-)
-
-find_file(MMC_JAR
-    NAMES
-        idm-console-mcc.jar
-    PATHS
-        ${JAVA_LIB_INSTALL_DIR}
-        /usr/share/java
-)
-
-find_file(MMC_EN_JAR
-    NAMES
-        idm-console-mcc_en.jar
-    PATHS
-        ${JAVA_LIB_INSTALL_DIR}
-        /usr/share/java
-)
-
-find_file(NMCLF_JAR
-    NAMES
-        idm-console-nmclf.jar
-    PATHS
-        ${JAVA_LIB_INSTALL_DIR}
-        /usr/share/java
-)
-
-find_file(NMCLF_EN_JAR
-    NAMES
-        idm-console-nmclf_en.jar
+        idm-console-framework.jar
     PATHS
         ${JAVA_LIB_INSTALL_DIR}
         /usr/share/java

--- a/base/console/CMakeLists.txt
+++ b/base/console/CMakeLists.txt
@@ -8,17 +8,18 @@ javac(pki-console-classes
         ${COMMONS_CLI_JAR}
         ${JAXRS_API_JAR}
         ${SLF4J_API_JAR}
-        ${BASE_JAR} ${LDAPJDK_JAR} ${MMC_JAR}
-        ${MMC_EN_JAR} ${NMCLF_JAR} ${NMCLF_EN_JAR}
+        ${COMMONS_CODEC_JAR}
+        ${JSS_JAR}
+        ${LDAPJDK_JAR}
+        ${IDM_CONSOLE_FRAMEWORK_JAR}
         ${PKI_COMMON_JAR}
-        ${JSS_JAR} ${COMMONS_CODEC_JAR}
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     DEPENDS
         pki-common-jar
 )
 
-add_dependencies(console pki-console-classes)
+add_dependencies(java pki-console-classes)
 
 set(PKI_CONSOLE_JAR ${CMAKE_BINARY_DIR}/dist/pki-console.jar
     CACHE INTERNAL "pki-console.jar"
@@ -47,7 +48,7 @@ jar(pki-console-jar
         pki-console-classes
 )
 
-add_dependencies(console pki-console-jar)
+add_dependencies(java pki-console-jar)
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/bin/pkiconsole
@@ -66,9 +67,11 @@ install(
         WORLD_EXECUTE WORLD_READ
 )
 
-install(
-    FILES
-        ${PKI_CONSOLE_JAR}
-    DESTINATION
-        ${JAVA_JAR_INSTALL_DIR}/pki
-)
+if(WITH_JAVA)
+    install(
+        FILES
+            ${PKI_CONSOLE_JAR}
+        DESTINATION
+            ${JAVA_JAR_INSTALL_DIR}/pki
+    )
+endif(WITH_JAVA)

--- a/base/console/bin/pkiconsole
+++ b/base/console/bin/pkiconsole
@@ -110,12 +110,7 @@ fi
 ###############################################################################
 
 CP=${PKI_LIB}/*
-CP=/usr/share/java/idm-console-nmclf.jar:${CP}
-CP=/usr/share/java/idm-console-nmclf_en.jar:${CP}
-CP=/usr/share/java/idm-console-mcc.jar:${CP}
-CP=/usr/share/java/idm-console-mcc_en.jar:${CP}
-CP=/usr/share/java/idm-console-base.jar:${CP}
-CP=/usr/share/java/389-console_en.jar:${CP}
+CP=/usr/share/java/idm-console-framework.jar:${CP}
 CP=/usr/share/java/${PRODUCT}/pki-console-theme.jar:${CP}
 CP=/usr/share/java/${PRODUCT}/pki-console.jar:${CP}
 export CP

--- a/base/console/pom.xml
+++ b/base/console/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.dogtagpki.pki</groupId>
+        <artifactId>pki-base-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>pki-console</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.dogtagpki.console-framework</groupId>
+            <artifactId>console-framework</artifactId>
+            <version>2.1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>pki-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <finalName>pki-console</finalName>
+    </build>
+
+</project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -28,6 +28,7 @@
         <module>tps</module>
         <module>acme</module>
         <module>est</module>
+        <module>console</module>
     </modules>
 
 </project>

--- a/build.sh
+++ b/build.sh
@@ -710,9 +710,9 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
         make "${OPTIONS[@]}" java
     fi
 
-    if [ "$WITH_CONSOLE" = true ] ; then
-        # build PKI console
-        make "${OPTIONS[@]}" console
+    if [ "$THEME" != "" ] ; then
+        # build PKI theme
+        make "${OPTIONS[@]}" theme
     fi
 
     if [[ " ${PKGS_TO_BUILD[*]} " =~ " javadoc " ]]; then

--- a/pki.spec
+++ b/pki.spec
@@ -719,12 +719,12 @@ This package provides %{product_name} API documentation.
 Summary:          %{product_name} Console Package
 BuildArch:        noarch
 
-BuildRequires:    idm-console-framework >= 2.0
+BuildRequires:    mvn(org.dogtagpki.console-framework:console-framework) >= 2.1.0
 
 Obsoletes:        pki-console < %{version}-%{release}
 Provides:         pki-console = %{version}-%{release}
 
-Requires:         idm-console-framework >= 2.0
+Requires:         mvn(org.dogtagpki.console-framework:console-framework) >= 2.1.0
 Requires:         %{product_id}-java = %{version}-%{release}
 Requires:         %{product_id}-console-theme = %{version}-%{release}
 
@@ -820,6 +820,10 @@ export JAVA_HOME=%{java_home}
 # flatten-maven-plugin is not available in RPM
 %pom_remove_plugin org.codehaus.mojo:flatten-maven-plugin
 
+%if ! %{with console}
+%pom_disable_module console base
+%endif
+
 # build Java binaries and run unit tests with Maven
 %mvn_build %{!?with_test:-f} -j
 
@@ -839,6 +843,11 @@ ln -sf ../../base/tks/target/pki-tks.jar
 ln -sf ../../base/tps/target/pki-tps.jar
 ln -sf ../../base/acme/target/pki-acme.jar
 ln -sf ../../base/est/target/pki-est.jar
+
+%if %{with console}
+ln -sf ../../base/console/target/pki-console.jar
+%endif
+
 popd
 
 # Remove all symbol table and relocation information from the executable.

--- a/tests/dogtag/dev_java_tests/run_junit_tests.sh
+++ b/tests/dogtag/dev_java_tests/run_junit_tests.sh
@@ -46,9 +46,7 @@ run_dev_junit_tests() {
     CLASSPATH=$CLASSPATH:/usr/share/java/apache-commons-codec.jar
     CLASSPATH=$CLASSPATH:/usr/share/java/apache-commons-logging.jar
     CLASSPATH=$CLASSPATH:/usr/share/java/commons-codec.jar
-    CLASSPATH=$CLASSPATH:/usr/share/java/idm-console-base-1.1.7.jar
-    CLASSPATH=$CLASSPATH:/usr/share/java/idm-console-mcc.jar
-    CLASSPATH=$CLASSPATH:/usr/share/java/idm-console-nmclf.jar
+    CLASSPATH=$CLASSPATH:/usr/share/java/idm-console-framework.jar
     CLASSPATH=$CLASSPATH:/usr/share/java/jaxb-api.jar
     CLASSPATH=$CLASSPATH:/usr/share/java/jakarta-activation/jakarta.activation.jar
     CLASSPATH=$CLASSPATH:/usr/share/java/ldapjdk.jar

--- a/themes/dogtag/console-ui/src/CMakeLists.txt
+++ b/themes/dogtag/console-ui/src/CMakeLists.txt
@@ -17,7 +17,7 @@ jar(pki-console-theme-jar
         com/netscape/admin/certsrv/theme/certmgmt.gif
 )
 
-add_dependencies(console pki-console-theme-jar)
+add_dependencies(theme pki-console-theme-jar)
 
 install(
     FILES


### PR DESCRIPTION
A new Maven module has been added for PKI console. The build scripts have been modified to build PKI console with Maven. The `pki-console-theme.jar` will continue to be built with CMake.