### PR TITLE
Fix NPE in UsrGrpAdminServlet

### DIFF
--- a/base/server/src/main/java/com/netscape/cms/servlet/admin/UsrGrpAdminServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/admin/UsrGrpAdminServlet.java
@@ -88,21 +88,13 @@ public class UsrGrpAdminServlet extends AdminServlet {
     private static final String MULTI_ROLE_ENFORCE_GROUP_LIST = "multiroles.false.groupEnforceList";
 
     /**
-     * Constructs User/Group manager servlet.
-     */
-    public UsrGrpAdminServlet() {
-        super();
-        CMSEngine engine = getCMSEngine();
-        mAuthz = engine.getAuthzSubsystem();
-    }
-
-    /**
      * Initializes this servlet.
      */
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
         CMSEngine engine = getCMSEngine();
+        mAuthz = engine.getAuthzSubsystem();
         mMgr = engine.getUGSubsystem();
     }
 


### PR DESCRIPTION
In commit 11d268faa93dd3604292fa46e6895c4d6f197af9 the `UsrGrpAdminServlet`'s constructor was modified to get the `CMSEngine` object from the `servletContext` before the field was initialized which triggered a `NullPointerException`. To fix the problem the code in the constructor has been moved into `init()` so that it will run after the `servletContext` initialization.

https://issues.redhat.com/browse/RHEL-626