### PR TITLE
Update fapolicy rules

### DIFF
--- a/base/server/etc/fapolicy.rules
+++ b/base/server/etc/fapolicy.rules
@@ -1,0 +1,1 @@
+allow perm=open dir=/usr/lib/jvm/ : dir=[WORK_DIR]/

--- a/pki.spec
+++ b/pki.spec
@@ -978,6 +978,26 @@ then
     systemctl daemon-reload
 fi
 
+# Update the fapolicy rules for each PKI server instance
+for instance in $(ls /var/lib/pki)
+do
+    target="/etc/fapolicyd/rules.d/61-pki-$instance.rules"
+
+    sed -e "s/\[WORK_DIR\]/\/var\/lib\/pki\/$instance\/work/g" \
+        /usr/share/pki/server/etc/fapolicy.rules \
+        > $target
+
+    chown root:fapolicyd $target
+    chmod 644 $target
+done
+
+# Restart fapolicy daemon if it's active
+status=$(systemctl is-active fapolicyd)
+if [ "$status" = "active" ]
+then
+    systemctl restart fapolicyd
+fi
+
 # with server
 %endif
 


### PR DESCRIPTION
Previously the fapolicy rules only granted the permissions to a subfolder in Tomcat work directory corresponding to the default engine and host defined in `server.xml`, so if the admin changes the engine or the host the fapolicy rules will need to be changed as well.

To reduce maintenance, the fapolicy rules have been updated to grant the permissions to the entire Tomcat work directory such that the engine or the host can be changed without having to change the fapolicy rules.

Updating fapolicy rules has to be done during RPM upgrade since it requires root permissions. The regular PKI server upgrade scripts run as `pkiuser` so it can't be used here.

The template for the fapolicy rules has been moved into a file such that it can be used both during installation and upgrade.