### PR TITLE
Create temporary files to be shared between uses in /tmp

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -370,7 +370,7 @@ class NSSDatabase(object):
             filename)
 
     def create_tmpdir(self):
-        tmpdir = tempfile.mkdtemp()
+        tmpdir = tempfile.mkdtemp(dir='/tmp')
         if self.user:
             os.chown(tmpdir, self.uid, self.gid)
         return tmpdir
@@ -1742,7 +1742,7 @@ class NSSDatabase(object):
         if aia_ext:
             self.__create_aia_ext(exts, aia_ext)
 
-        tmpdir = tempfile.mkdtemp()
+        tmpdir = tempfile.mkdtemp(dir='/tmp')
 
         try:
             if exts:


### PR DESCRIPTION
Some commands need to be executed as the pki user and not root to retain filesystem permissions. There are a few places where passwords are written to files as root to be passed into commands executed by pkiuser.

If a private temporary directory is set before pkispawn is called then this method for sharing passwords between users will not work because the file will be unreadable.

So force these calls to use /tmp directly instead of the private temporary directory.

Fixes: https://github.com/dogtagpki/pki/issues/4475