### PR TITLE
Hard-code version number in pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/tests.retry
 base/tools/test/PKICertImport/dbs
 target/
 .flattened-pom.xml
+*.versionsBackup

--- a/base/acme/pom.xml
+++ b/base/acme/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-acme</artifactId>

--- a/base/ca/pom.xml
+++ b/base/ca/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-ca</artifactId>

--- a/base/common/pom.xml
+++ b/base/common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-common</artifactId>

--- a/base/console/pom.xml
+++ b/base/console/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-console</artifactId>

--- a/base/est/pom.xml
+++ b/base/est/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-est</artifactId>

--- a/base/kra/pom.xml
+++ b/base/kra/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-kra</artifactId>

--- a/base/ocsp/pom.xml
+++ b/base/ocsp/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-ocsp</artifactId>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-base-parent</artifactId>

--- a/base/server-webapp/pom.xml
+++ b/base/server-webapp/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-server-webapp</artifactId>

--- a/base/server/pom.xml
+++ b/base/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-server</artifactId>

--- a/base/tks/pom.xml
+++ b/base/tks/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tks</artifactId>

--- a/base/tomcat-9.0/pom.xml
+++ b/base/tomcat-9.0/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tomcat-9.0</artifactId>

--- a/base/tomcat/pom.xml
+++ b/base/tomcat/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tomcat</artifactId>

--- a/base/tools/pom.xml
+++ b/base/tools/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tools</artifactId>

--- a/base/tps/pom.xml
+++ b/base/tps/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>${revision}</version>
+        <version>11.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tps</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki.pki</groupId>
     <artifactId>pki-parent</artifactId>
-    <version>${revision}</version>
+    <version>11.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
-        <revision>11.5.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Some build systems require hard-coding the version number in `pom.xml`, so the `revision` property has been replaced with the actual version number. Updating the version number can be done with the following commands:

```
$ mvn versions:set -DnewVersion=<version>
$ mvn versions:commit
```

The `.gitignore` has been updated to ignore the backup files created by this command.