### PR TITLE
Adding useful OCSP debug messages

### DIFF
--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
@@ -17,6 +17,7 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cms.ocsp;
 
+import java.lang.Integer;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.cert.X509CRL;
@@ -206,12 +207,13 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
 
         if (oldCRL != null) {
             if (oldCRL.getThisUpdate().getTime() >= crl.getThisUpdate().getTime()) {
-                logger.info("LDAPStore: no update, received CRL is older than current CRL");
+                logger.info("LDAPStore: no update, received CRL is not newer than current CRL");
                 return; // no update
             }
         }
-        logger.debug("Added '" + caCert.getSubjectDN() + "' into CRL hash");
+        logger.debug("LDAPStore: updateCRLHash: Added '" + caCert.getSubjectDN() + "' into CRL hash");
         mCRLs.put(caCert, crl);
+	logger.debug("LDAPStore: updateCRLHash: mCRLs size= "+ mCRLs.size());
     }
 
     @Override
@@ -379,9 +381,12 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
         while (caCerts.hasMoreElements()) {
             X509CertImpl caCert = caCerts.nextElement();
             MessageDigest md = MessageDigest.getInstance(cid.getDigestName());
+	    logger.debug("LDAPStore: processRequest: cert digest name=" +
+                    cid.getDigestName());
             X509Key key = (X509Key) caCert.getPublicKey();
 
             if (key == null) {
+                logger.debug("LDAPStore: processRequest: mCRLs caCert.getPublicKey() returns null");
                 throw new Exception("Missing issuer key");
             }
 
@@ -389,6 +394,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
             byte keyhsh[] = cid.getIssuerKeyHash().toByteArray();
 
             if (!Arrays.equals(digest, keyhsh)) {
+		logger.debug("LDAPStore: processRequest: CA key digest and cert issuer key hash do not match; continue to look at next CA in mCRLs...");
                 continue;
             }
 
@@ -399,11 +405,11 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
         }
 
         if (theCert == null) {
-            throw new Exception("Missing issuer certificate");
+            throw new Exception("Issuer certificate not found/served");
         }
 
         if (theCRL == null) {
-            throw new Exception("Missing CRL data");
+            throw new Exception("Missing CRL data for issuing CA:" + theCert.getSubjectDN());
         }
 
         GeneralizedTime thisUpdate = new GeneralizedTime(

--- a/base/ocsp/src/main/java/com/netscape/cms/servlet/ocsp/AddCRLServlet.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/servlet/ocsp/AddCRLServlet.java
@@ -408,14 +408,14 @@ public class AddCRLServlet extends CMSServlet {
                     (pt.getThisUpdate().getTime() >=
                     crl.getThisUpdate().getTime())) {
 
-                logger.warn("AddCRLServlet: no update, received CRL is older than current CRL");
+                logger.warn("AddCRLServlet: no update, received CRL is not newer than current CRL");
 
                 if (noUI) {
                     try {
                         resp.setContentType("application/text");
                         resp.getOutputStream().write("status=1\n".getBytes());
                         resp.getOutputStream().write(
-                                "error=Sent CRL is older than the current CRL\n".getBytes());
+                                "error=Sent CRL is not newer than the current CRL\n".getBytes());
                         resp.getOutputStream().flush();
                         cmsReq.setStatus(ICMSRequest.SUCCESS);
 
@@ -428,7 +428,7 @@ public class AddCRLServlet extends CMSServlet {
                     } catch (Exception e) {
                     }
                 } else {
-                    logger.error("AddCRLServlet: CRL is older");
+                    logger.error("AddCRLServlet: CRL is not newer");
 
                     // NOTE:  The signed audit events
                     //        LOGGING_SIGNED_AUDIT_CRL_RETRIEVAL and


### PR DESCRIPTION
This patch fixed and added some useful information in the OCSP area. During investigation setup procedure for ticket RHCS-4264, some debug messages can be confusing.  In addition, more information should be shared for administrators to understand why things are not working as expected.

for https://issues.redhat.com/browse/RHCS-4264