### PR TITLE
OCSP responder to serve status check for itself using latest CRL

### DIFF
--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/CRLLdapValidator.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/CRLLdapValidator.java
@@ -56,8 +56,8 @@ public class CRLLdapValidator implements SSLCertificateApprovalCallback {
         try {
             X509CertImpl peerCert = new X509CertImpl(certificate.getEncoded());
             Enumeration<ICRLIssuingPointRecord> eCRL = crlStore.searchAllCRLIssuingPointRecord(-1);
-            AuthorityKeyIdentifierExtension aPeeExt = (AuthorityKeyIdentifierExtension) peerCert.getExtension(PKIXExtensions.AuthorityKey_Id.toString());
-            if(aPeeExt == null) {
+            AuthorityKeyIdentifierExtension peerAKIExt = (AuthorityKeyIdentifierExtension) peerCert.getExtension(PKIXExtensions.AuthorityKey_Id.toString());
+            if(peerAKIExt == null) {
                 logger.error("CRLLdapValidator: the certificate has not Authority Key Identifier Extension. CRL verification cannot be done.");
                 return false;
             }
@@ -66,15 +66,15 @@ public class CRLLdapValidator implements SSLCertificateApprovalCallback {
                 logger.debug("CRLLdapValidator: CRL check issuer  " + tPt.getId());
                 X509CertImpl caCert = new X509CertImpl(tPt.getCACert());
                 try {
-                    SubjectKeyIdentifierExtension sCaExt = (SubjectKeyIdentifierExtension) caCert.getExtension(PKIXExtensions.SubjectKey_Id.toString());
-                    if(sCaExt == null) {
+                    SubjectKeyIdentifierExtension caAKIExt = (SubjectKeyIdentifierExtension) caCert.getExtension(PKIXExtensions.SubjectKey_Id.toString());
+                    if(caAKIExt == null) {
                         logger.error("CRLLdapValidator: signing certificate missing Subject Key Identifier. Skip CA " + caCert.getName());
                         continue;
                     }
 
-                    KeyIdentifier sCaKeyId = (KeyIdentifier) sCaExt.get(SubjectKeyIdentifierExtension.KEY_ID);
-                    KeyIdentifier aPeerKeyId = (KeyIdentifier) aPeeExt.get(AuthorityKeyIdentifierExtension.KEY_ID);
-                    if(Arrays.equals(sCaKeyId.getIdentifier(), aPeerKeyId.getIdentifier())) {
+                    KeyIdentifier caSKIId = (KeyIdentifier) caAKIExt.get(SubjectKeyIdentifierExtension.KEY_ID);
+                    KeyIdentifier peerAKIId = (KeyIdentifier) peerAKIExt.get(AuthorityKeyIdentifierExtension.KEY_ID);
+                    if(Arrays.equals(caSKIId.getIdentifier(), peerAKIId.getIdentifier())) {
                         pt = tPt;
                     }
                 } catch (IOException e) {

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/CRLLdapValidator.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/CRLLdapValidator.java
@@ -1,0 +1,81 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2007 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+package com.netscape.cms.ocsp;
+
+import java.security.cert.X509CRLEntry;
+import java.util.Enumeration;
+
+import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.netscape.security.x509.X509CRLImpl;
+import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
+
+import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.dbs.crldb.ICRLIssuingPointRecord;
+
+public class CRLLdapValidator implements SSLCertificateApprovalCallback {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CRLLdapValidator.class);
+
+    private LDAPStore crlStore;
+
+
+
+    public CRLLdapValidator(LDAPStore crlStore) {
+        super();
+        this.crlStore = crlStore;
+    }
+
+
+    @Override
+    public boolean approve(X509Certificate certificate, ValidityStatus currentStatus) {
+        logger.info("CRLLdapValidator: validate of peer's certificate for the connection " + certificate.getSubjectDN().toString());
+        ICRLIssuingPointRecord pt = null;
+        try {
+            Enumeration<ICRLIssuingPointRecord> eCRL = crlStore.searchAllCRLIssuingPointRecord(-1);
+            while (eCRL.hasMoreElements() && pt == null) {
+                ICRLIssuingPointRecord tPt = eCRL.nextElement();
+                logger.debug("CRLLdapValidator: CRL check issuer  " + tPt.getId());
+                if(tPt.getId().equals(certificate.getIssuerDN().toString())) {
+                    pt = tPt;
+                }
+            }
+        } catch (EBaseException e) {
+            logger.error("CRLLdapValidator: problem find CRL issuing point for " + certificate.getIssuerDN().toString());
+            return false;
+        }
+        if (pt == null) {
+            logger.error("CRLLdapValidator: CRL issuing point not found for " + certificate.getIssuerDN().toString());
+            return false;
+        }
+        try {
+            X509CRLImpl crl = new X509CRLImpl(pt.getCRL());
+            X509CRLEntry crlentry = crl.getRevokedCertificate(certificate.getSerialNumber());
+
+            if (crlentry == null) {
+                if (crlStore.isNotFoundGood()) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            logger.error("CRLLdapValidator: crl check error. " + e.getMessage());
+        }
+        logger.info("CRLLdapValidator: peer certificate not valid");
+        return false;
+    }
+
+}

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/CRLLdapValidator.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/CRLLdapValidator.java
@@ -12,7 +12,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 //
-// (C) 2007 Red Hat, Inc.
+// (C) 2023 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cms.ocsp;

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/CRLLdapValidator.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/CRLLdapValidator.java
@@ -43,7 +43,7 @@ public class CRLLdapValidator implements SSLCertificateApprovalCallback {
 
     @Override
     public boolean approve(X509Certificate certificate, ValidityStatus currentStatus) {
-        logger.info("CRLLdapValidator: validate of peer's certificate for the connection " + certificate.getSubjectDN().toString());
+        logger.info("CRLLdapValidator: validate of peer's certificate for the connection " + certificate.getSubjectDN());
         ICRLIssuingPointRecord pt = null;
         try {
             Enumeration<ICRLIssuingPointRecord> eCRL = crlStore.searchAllCRLIssuingPointRecord(-1);
@@ -55,11 +55,11 @@ public class CRLLdapValidator implements SSLCertificateApprovalCallback {
                 }
             }
         } catch (EBaseException e) {
-            logger.error("CRLLdapValidator: problem find CRL issuing point for " + certificate.getIssuerDN().toString());
+            logger.error("CRLLdapValidator: problem find CRL issuing point. " + e.getMessage(), e);
             return false;
         }
         if (pt == null) {
-            logger.error("CRLLdapValidator: CRL issuing point not found for " + certificate.getIssuerDN().toString());
+            logger.error("CRLLdapValidator: CRL issuing point not found for " + certificate.getIssuerDN());
             return false;
         }
         try {
@@ -72,7 +72,7 @@ public class CRLLdapValidator implements SSLCertificateApprovalCallback {
                 }
             }
         } catch (Exception e) {
-            logger.error("CRLLdapValidator: crl check error. " + e.getMessage());
+            logger.error("CRLLdapValidator: crl check error. " + e.getMessage(), e);
         }
         logger.info("CRLLdapValidator: peer certificate not valid");
         return false;

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
@@ -81,7 +81,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
     private static final String DEF_CA_CERT_ATTR = "cACertificate;binary";
     private static final String PROP_HOST = "host";
     private static final String PROP_PORT = "port";
-    private static final String PROP_CHECK_SUBSYSTEM_CONNECTION = "checkSubsystemConnection";
+    private static final String PROP_VALIDATE_CONNECTION_WITH_CRL = "validateConnCertWithCRL";
 
     private final static String PROP_NOT_FOUND_GOOD = "notFoundAsGood";
     private final static String PROP_INCLUDE_NEXT_UPDATE =
@@ -94,7 +94,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
     private String mCACertAttr = null;
     protected Hashtable<String, Long> mReqCounts = new Hashtable<>();
     private Hashtable<X509CertImpl, X509CRLImpl> mCRLs = new Hashtable<>();
-    private boolean mCheckConnection = false;
+    private boolean mValidateConnection = true;
 
 
     /**
@@ -139,7 +139,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
                     DEF_CA_CERT_ATTR);
         mByName = mConfig.getBoolean(PROP_BY_NAME, true);
 
-        mCheckConnection = mConfig.getBoolean(PROP_CHECK_SUBSYSTEM_CONNECTION, true);
+        mValidateConnection = mConfig.getBoolean(PROP_VALIDATE_CONNECTION_WITH_CRL, true);
     }
 
     /**
@@ -241,7 +241,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
 
             updater.start();
         }
-        if(mCheckConnection) {
+        if(mValidateConnection) {
             CMS.getCMSEngine().setApprovalCallback(new CRLLdapValidator(this));
         }
     }
@@ -498,7 +498,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
     }
 
     public boolean isCRLCheckAvailable() {
-        return mCheckConnection;
+        return mValidateConnection;
     }
 
 }

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
@@ -94,6 +94,8 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
     private String mCACertAttr = null;
     protected Hashtable<String, Long> mReqCounts = new Hashtable<>();
     private Hashtable<X509CertImpl, X509CRLImpl> mCRLs = new Hashtable<>();
+    private boolean mCheckConnection = false;
+
 
     /**
      * Constructs the default store.
@@ -137,6 +139,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
                     DEF_CA_CERT_ATTR);
         mByName = mConfig.getBoolean(PROP_BY_NAME, true);
 
+        mCheckConnection = mConfig.getBoolean(PROP_CHECK_SUBSYSTEM_CONNECTION, false);
     }
 
     /**
@@ -238,7 +241,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
 
             updater.start();
         }
-        if(mConfig.getBoolean(PROP_CHECK_SUBSYSTEM_CONNECTION, false)) {
+        if(mCheckConnection) {
             CMS.setApprovalCallbask(new CRLLdapValidator(this));
         }
     }
@@ -493,6 +496,11 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
             mConfig.put(key, pairs.get(key));
         }
     }
+
+    public boolean isCRLCheckAvailable() {
+        return mCheckConnection;
+    }
+
 }
 
 class CRLUpdater extends Thread {

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
@@ -242,7 +242,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
             updater.start();
         }
         if(mCheckConnection) {
-            CMS.setApprovalCallbask(new CRLLdapValidator(this));
+            CMS.getCMSEngine().setApprovalCallback(new CRLLdapValidator(this));
         }
     }
 

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
@@ -17,7 +17,6 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cms.ocsp;
 
-import java.lang.Integer;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.cert.X509CRL;
@@ -238,6 +237,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
 
             updater.start();
         }
+        CMS.setApprovalCallbask(new CRLLdapValidator(this));
     }
 
     @Override

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
@@ -81,6 +81,10 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
     private static final String DEF_CA_CERT_ATTR = "cACertificate;binary";
     private static final String PROP_HOST = "host";
     private static final String PROP_PORT = "port";
+
+    // This option enables the revocation verification of peer certificates using the CRL stored in the LDAP.
+    // Peer certificate of all the outcome connections from the OCSP subsystem are verified with the CRL.
+    // If also auths.revocationChecking.is set to true the peer certificate og all the income connections to the OCSP subsystem are verified with the CRL.
     private static final String PROP_VALIDATE_CONNECTION_WITH_CRL = "validateConnCertWithCRL";
 
     private final static String PROP_NOT_FOUND_GOOD = "notFoundAsGood";

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
@@ -81,6 +81,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
     private static final String DEF_CA_CERT_ATTR = "cACertificate;binary";
     private static final String PROP_HOST = "host";
     private static final String PROP_PORT = "port";
+    private static final String PROP_CHECK_SUBSYSTEM_CONNECTION = "checkSubsystemConnection";
 
     private final static String PROP_NOT_FOUND_GOOD = "notFoundAsGood";
     private final static String PROP_INCLUDE_NEXT_UPDATE =
@@ -237,7 +238,9 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
 
             updater.start();
         }
-        CMS.setApprovalCallbask(new CRLLdapValidator(this));
+        if(mConfig.getBoolean(PROP_CHECK_SUBSYSTEM_CONNECTION, false)) {
+            CMS.setApprovalCallbask(new CRLLdapValidator(this));
+        }
     }
 
     @Override

--- a/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/ocsp/LDAPStore.java
@@ -139,7 +139,7 @@ public class LDAPStore implements IDefStore, IExtendedPluginInfo {
                     DEF_CA_CERT_ATTR);
         mByName = mConfig.getBoolean(PROP_BY_NAME, true);
 
-        mCheckConnection = mConfig.getBoolean(PROP_CHECK_SUBSYSTEM_CONNECTION, false);
+        mCheckConnection = mConfig.getBoolean(PROP_CHECK_SUBSYSTEM_CONNECTION, true);
     }
 
     /**

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
@@ -164,8 +164,8 @@ public class OCSPEngine extends CMSEngine {
         try {
             X509CertImpl peerCert = new X509CertImpl(certificate.getEncoded());
             Enumeration<ICRLIssuingPointRecord> eCRL = crlStore.searchAllCRLIssuingPointRecord(-1);
-            AuthorityKeyIdentifierExtension aPeeExt = (AuthorityKeyIdentifierExtension) peerCert.getExtension(PKIXExtensions.AuthorityKey_Id.toString());
-            if(aPeeExt == null) {
+            AuthorityKeyIdentifierExtension peerAKIExt = (AuthorityKeyIdentifierExtension) peerCert.getExtension(PKIXExtensions.AuthorityKey_Id.toString());
+            if(peerAKIExt == null) {
                 logger.error("OCSPEngine: the certificate has not Authority Key Identifier Extension. CRL verification cannot be done.");
                 return false;
             }
@@ -175,15 +175,15 @@ public class OCSPEngine extends CMSEngine {
                 X509CertImpl caCert = new X509CertImpl(tPt.getCACert());
 
                 try {
-                    SubjectKeyIdentifierExtension sCaExt = (SubjectKeyIdentifierExtension) caCert.getExtension(PKIXExtensions.SubjectKey_Id.toString());
-                    if(sCaExt == null) {
+                    SubjectKeyIdentifierExtension caSKIExt = (SubjectKeyIdentifierExtension) caCert.getExtension(PKIXExtensions.SubjectKey_Id.toString());
+                    if(caSKIExt == null) {
                         logger.error("OCSPEngine: signing certificate missing Subject Key Identifier. Skip CA " + caCert.getName());
                         continue;
                     }
 
-                    KeyIdentifier sCaKeyId = (KeyIdentifier) sCaExt.get(SubjectKeyIdentifierExtension.KEY_ID);
-                    KeyIdentifier aPeerKeyId = (KeyIdentifier) aPeeExt.get(AuthorityKeyIdentifierExtension.KEY_ID);
-                    if(Arrays.equals(sCaKeyId.getIdentifier(), aPeerKeyId.getIdentifier())) {
+                    KeyIdentifier caSKIId = (KeyIdentifier) caSKIExt.get(SubjectKeyIdentifierExtension.KEY_ID);
+                    KeyIdentifier peerAKIId = (KeyIdentifier) peerAKIExt.get(AuthorityKeyIdentifierExtension.KEY_ID);
+                    if(Arrays.equals(caSKIId.getIdentifier(), peerAKIId.getIdentifier())) {
                         pt = tPt;
                     }
                 } catch (IOException e) {

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
@@ -63,5 +63,54 @@ public class OCSPEngine extends CMSEngine {
         }
 
         super.initSubsystem(subsystem, subsystemConfig);
+        if (subsystem instanceof OCSPAuthority) {
+            subsystem.startup();
+        }
     }
+
+    protected void startupSubsystems() throws Exception {
+
+        for (ISubsystem subsystem : subsystems.values()) {
+            logger.info("CMSEngine: Starting " + subsystem.getId() + " subsystem");
+            if (!(subsystem instanceof OCSPAuthority))
+                subsystem.startup();
+        }
+
+        // global admin servlet. (anywhere else more fit for this ?)
+    }
+    @Override
+    protected void initSequence() throws Exception {
+
+        initDebug();
+        init();
+        initPasswordStore();
+        initSubsystemListeners();
+        initSecurityProvider();
+        initPluginRegistry();
+        initLogSubsystem();
+        initDatabase();
+        initJssSubsystem();
+        initDBSubsystem();
+        initUGSubsystem();
+        initOIDLoaderSubsystem();
+        initX500NameSubsystem();
+        // skip TP subsystem;
+        // problem in needing dbsubsystem in constructor. and it's not used.
+        initRequestSubsystem();
+
+
+        startupSubsystems();
+
+        initAuthSubsystem();
+        initAuthzSubsystem();
+        initJobsScheduler();
+
+        configureAutoShutdown();
+        configureServerCertNickname();
+        configureExcludedLdapAttrs();
+
+        initSecurityDomain();
+    }
+
+
 }

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
@@ -142,11 +142,11 @@ public class OCSPEngine extends CMSEngine {
         }
 
         for (X509Certificate cert: certificates) {
-            if(crlCertValid(crlStore, cert, null)) {
-                return false;
+            if(!crlCertValid(crlStore, cert, null)) {
+                return true;
             }
         }
-        return true;
+        return false;
 
     }
 

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
@@ -68,6 +68,7 @@ public class OCSPEngine extends CMSEngine {
         }
     }
 
+
     protected void startupSubsystems() throws Exception {
 
         for (ISubsystem subsystem : subsystems.values()) {

--- a/base/server/cmsbundle/src/LogMessages.properties
+++ b/base/server/cmsbundle/src/LogMessages.properties
@@ -68,7 +68,7 @@ CMSCORE_AUTH_AUTH_FAILED=Failed to authenticate as admin UID={0}. Error: {1}
 CMSCORE_AUTH_UID_NOT_FOUND=UID {0} is not a user in the internal usr/grp database. Error {1}
 CMSCORE_AUTH_MISSING_CERT=Agent authentication missing certificate credential.
 CMSCORE_AUTH_NO_CERT=No Client Certificate Found
-CMSCORE_AUTH_REVOKED_CERT=Cannot authenticate agent.  Agent certificate has been revoked.
+CMSCORE_AUTH_REVOKED_CERT=Cannot authenticate user. Role user certificate has been revoked.
 CMSCORE_AUTH_AGENT_AUTH_FAILED=Cannot authenticate agent with certificate Serial 0x{0} Subject DN {1}. Error: {2}
 CMSCORE_AUTH_CANNOT_AGENT_AUTH=Cannot authenticate agent. LDAP Error: {0}
 CMSCORE_AUTH_AGENT_USER_NOT_FOUND=Cannot authenticate agent. Could not find a user for the agent cert. Check errors from UGSubsystem.

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
@@ -23,6 +23,7 @@ import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,12 +54,22 @@ public final class CMS {
 
     private static CMSEngine engine;
 
+    private static SSLCertificateApprovalCallback approvalCallback;
+
     public static CMSEngine getCMSEngine() {
         return engine;
     }
 
     public static void setCMSEngine(CMSEngine engine) {
         CMS.engine = engine;
+    }
+
+    public static SSLCertificateApprovalCallback getApprovalCallback() {
+        return approvalCallback;
+    }
+
+    public static void setApprovalCallbask(SSLCertificateApprovalCallback approvalCallback) {
+        CMS.approvalCallback = approvalCallback;
     }
 
     /**

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
@@ -23,7 +23,6 @@ import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,22 +53,12 @@ public final class CMS {
 
     private static CMSEngine engine;
 
-    private static SSLCertificateApprovalCallback approvalCallback;
-
     public static CMSEngine getCMSEngine() {
         return engine;
     }
 
     public static void setCMSEngine(CMSEngine engine) {
         CMS.engine = engine;
-    }
-
-    public static SSLCertificateApprovalCallback getApprovalCallback() {
-        return approvalCallback;
-    }
-
-    public static void setApprovalCallbask(SSLCertificateApprovalCallback approvalCallback) {
-        CMS.approvalCallback = approvalCallback;
     }
 
     /**

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -1102,6 +1102,28 @@ public class CMSEngine implements ServletContextListener {
 
         CMS.setCMSEngine(this);
 
+        initSequence();
+
+        // Register realm for this subsystem
+        ProxyRealm.registerRealm(id, new PKIRealm());
+
+        ready = true;
+        isStarted = true;
+
+        mStartupTime = System.currentTimeMillis();
+
+        logger.info(name + " engine started");
+        // Register TomcatJSS socket listener
+        TomcatJSS tomcatJss = TomcatJSS.getInstance();
+        if(serverSocketListener == null) {
+            serverSocketListener = new PKIServerSocketListener();
+        }
+        tomcatJss.addSocketListener(serverSocketListener);
+
+        notifySubsystemStarted();
+    }
+
+    protected void initSequence() throws Exception {
         initDebug();
         initPasswordStore();
         initSubsystemListeners();
@@ -1131,24 +1153,6 @@ public class CMSEngine implements ServletContextListener {
         configureExcludedLdapAttrs();
 
         initSecurityDomain();
-
-        // Register realm for this subsystem
-        ProxyRealm.registerRealm(id, new PKIRealm());
-
-        ready = true;
-        isStarted = true;
-
-        mStartupTime = System.currentTimeMillis();
-
-        logger.info(name + " engine started");
-        // Register TomcatJSS socket listener
-        TomcatJSS tomcatJss = TomcatJSS.getInstance();
-        if(serverSocketListener == null) {
-            serverSocketListener = new PKIServerSocketListener();
-        }
-        tomcatJss.addSocketListener(serverSocketListener);
-
-        notifySubsystemStarted();
     }
 
     public boolean isInRunningState() {

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -50,6 +50,7 @@ import org.mozilla.jss.crypto.Signature;
 import org.mozilla.jss.crypto.SignatureAlgorithm;
 import org.mozilla.jss.netscape.security.util.Cert;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 
 import com.netscape.certsrv.authentication.ISharedToken;
 import com.netscape.certsrv.base.EBaseException;
@@ -151,6 +152,8 @@ public class CMSEngine implements ServletContextListener {
     protected LogSubsystem logSubsystem = LogSubsystem.getInstance();
     protected JssSubsystem jssSubsystem = JssSubsystem.getInstance();
     protected DBSubsystem dbSubsystem = new DBSubsystem();
+    protected SSLCertificateApprovalCallback approvalCallback;
+
 
 
     protected RequestRepository requestRepository;
@@ -299,6 +302,14 @@ public class CMSEngine implements ServletContextListener {
 
     public void registerPendingListener(String name, IRequestListener listener) {
         pendingNotifier.registerListener(name, listener);
+    }
+
+    public SSLCertificateApprovalCallback getApprovalCallback() {
+        return approvalCallback;
+    }
+
+    public void setApprovalCallback(SSLCertificateApprovalCallback approvalCallback) {
+        this.approvalCallback = approvalCallback;
     }
 
     public void loadConfig(String path) throws Exception {

--- a/base/server/src/main/java/com/netscape/cmscore/ldapconn/PKISocketFactory.java
+++ b/base/server/src/main/java/com/netscape/cmscore/ldapconn/PKISocketFactory.java
@@ -151,7 +151,7 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
         SSLSocket s;
 
         if (mClientAuthCertNickname == null) {
-            s = new SSLSocket(host, port);
+            s = new SSLSocket(host, port, null, 0, CMS.getApprovalCallback(), null);
 
         } else {
             // Let's create a selection callback in the case the client auth
@@ -161,7 +161,7 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
 
             Socket js = new Socket(InetAddress.getByName(host), port);
             s = new SSLSocket(js, host,
-                    null,
+                    CMS.getApprovalCallback(),
                     new SSLClientCertificateSelectionCB(mClientAuthCertNickname));
         }
 

--- a/base/server/src/main/java/com/netscape/cmscore/ldapconn/PKISocketFactory.java
+++ b/base/server/src/main/java/com/netscape/cmscore/ldapconn/PKISocketFactory.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.dogtagpki.server.PKIClientSocketListener;
+import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 import org.mozilla.jss.ssl.SSLClientCertificateSelectionCallback;
 import org.mozilla.jss.ssl.SSLHandshakeCompletedEvent;
 import org.mozilla.jss.ssl.SSLHandshakeCompletedListener;
@@ -149,9 +150,14 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
          */
 
         SSLSocket s;
+        SSLCertificateApprovalCallback callback = null;
+
+        if (CMS.getCMSEngine() != null) {
+            callback = CMS.getCMSEngine().getApprovalCallback();
+        }
 
         if (mClientAuthCertNickname == null) {
-            s = new SSLSocket(host, port, null, 0, CMS.getApprovalCallback(), null);
+            s = new SSLSocket(host, port, null, 0, callback, null);
 
         } else {
             // Let's create a selection callback in the case the client auth
@@ -161,7 +167,7 @@ public class PKISocketFactory implements LDAPSSLSocketFactoryExt {
 
             Socket js = new Socket(InetAddress.getByName(host), port);
             s = new SSLSocket(js, host,
-                    CMS.getApprovalCallback(),
+                    callback,
                     new SSLClientCertificateSelectionCB(mClientAuthCertNickname));
         }
 


### PR DESCRIPTION
Modify OCSP responder to perform peer certificate checks with the CRL instead of using OCSP, avoiding the chicken and egg issue.

Solve RHCS-4262