### PR TITLE
Adding useful OCSP debug messages

### DIFF
--- a/base/ocsp/src/main/java/com/netscape/cms/servlet/ocsp/AddCRLServlet.java
+++ b/base/ocsp/src/main/java/com/netscape/cms/servlet/ocsp/AddCRLServlet.java
@@ -415,14 +415,14 @@ public class AddCRLServlet extends CMSServlet {
                     (pt.getThisUpdate().getTime() >=
                     crl.getThisUpdate().getTime())) {
 
-                logger.warn("AddCRLServlet: no update, received CRL is older than current CRL");
+                logger.warn("AddCRLServlet: no update, received CRL is not newer than current CRL");
 
                 if (noUI) {
                     try {
                         resp.setContentType("application/text");
                         resp.getOutputStream().write("status=1\n".getBytes());
                         resp.getOutputStream().write(
-                                "error=Sent CRL is older than the current CRL\n".getBytes());
+                                "error=Sent CRL is not newer than the current CRL\n".getBytes());
                         resp.getOutputStream().flush();
                         cmsReq.setStatus(CMSRequest.SUCCESS);
 
@@ -435,7 +435,7 @@ public class AddCRLServlet extends CMSServlet {
                     } catch (Exception e) {
                     }
                 } else {
-                    logger.error("AddCRLServlet: CRL is older");
+                    logger.error("AddCRLServlet: CRL is not newer");
 
                     // NOTE:  The signed audit events
                     //        LOGGING_SIGNED_AUDIT_CRL_RETRIEVAL and


### PR DESCRIPTION
This patch fixed and added some useful information in the OCSP area. During investigation setup procedure for ticket RHCS-4264, some debug messages can be confusing.  In addition, more information should be shared for administrators to understand why things are not working as expected. It is also useful for RHCS-4261

for RHCS-4264 and RHCS-4261