### PR TITLE
Add Implementation-Version to Manifests via pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,18 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The `/getStatus` endpoints in the web UI were returning a null version since the build was switched to Maven.

It is probably now possible to remove the individual manifest files but I have left them as they are for now so we can still build with cmake if we wish.