### PR TITLE
Add pki_http_enable param

### DIFF
--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -57,9 +57,18 @@ jobs:
               -D pki_ds_url=ldap://cads.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
+              -D pki_http_enable=False \
               -v
 
           docker exec ca pki-server cert-find
+
+      - name: Verify there is no plain HTTP connectors in CA
+        run: |
+          docker exec ca pki-server http-connector-find | tee output
+
+          echo "Secure" > expected
+          sed -n -e "s/^ *Connector ID: *\(.*\)$/\1/p" output > actual
+          diff expected actual
 
       - name: Install banner in CA container
         run: docker exec ca cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
@@ -98,9 +107,18 @@ jobs:
               -D pki_ds_url=ldap://krads.example.com:3389 \
               -D pki_key_id_generator=random \
               -D pki_request_id_generator=random \
+              -D pki_http_enable=False \
               -v
 
           docker exec kra pki-server cert-find
+
+      - name: Verify there is no plain HTTP connectors in KRA
+        run: |
+          docker exec kra pki-server http-connector-find | tee output
+
+          echo "Secure" > expected
+          sed -n -e "s/^ *Connector ID: *\(.*\)$/\1/p" output > actual
+          diff expected actual
 
       - name: Install banner in KRA container
         run: docker exec kra cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
@@ -135,9 +153,18 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
               -D pki_ds_url=ldap://tksds.example.com:3389 \
+              -D pki_http_enable=False \
               -v
 
           docker exec tks pki-server cert-find
+
+      - name: Verify there is no plain HTTP connectors in TKS
+        run: |
+          docker exec tks pki-server http-connector-find | tee output
+
+          echo "Secure" > expected
+          sed -n -e "s/^ *Connector ID: *\(.*\)$/\1/p" output > actual
+          diff expected actual
 
       - name: Install banner in TKS container
         run: docker exec tks cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
@@ -178,9 +205,26 @@ jobs:
               -D pki_authdb_hostname=tpsds.example.com \
               -D pki_authdb_port=3389 \
               -D pki_enable_server_side_keygen=True \
+              -D pki_http_enable=False \
               -v
 
           docker exec tps pki-server cert-find
+
+      - name: Verify there is no plain HTTP connectors in TPS
+        run: |
+          docker exec tps pki-server http-connector-find | tee output
+
+          echo "Secure" > expected
+          sed -n -e "s/^ *Connector ID: *\(.*\)$/\1/p" output > actual
+          diff expected actual
+
+      - name: Verify there is no plain HTTP ports in security domain
+        run: |
+          docker exec ca pki-server sd-subsystem-find | tee output
+
+          echo -n "" > expected
+          sed -ne "/^ *Port:/p" output > actual
+          diff expected actual
 
       - name: Install banner in TPS container
         run: docker exec tps cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat

--- a/base/common/python/pki/system.py
+++ b/base/common/python/pki/system.py
@@ -81,7 +81,7 @@ class SecurityDomainHost(object):
         host.Hostname = json_value['Hostname']
         host.SecurePort = json_value['SecurePort']
         host.SubsystemName = json_value['SubsystemName']
-        host.Port = json_value['Port']
+        host.Port = json_value.get('Port')
 
         return host
 

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -258,6 +258,8 @@ pki_proxy_https_port=443
 pki_security_manager=true
 pki_tomcat_server_port=8005
 
+pki_http_enable=True
+
 # Paths
 # These are used in the processing of pkispawn and are not supposed
 # to be overwritten by user configuration files.

--- a/base/server/python/pki/server/cli/sd.py
+++ b/base/server/python/pki/server/cli/sd.py
@@ -176,7 +176,7 @@ class SDSubsystemAddCLI(pki.cli.CLI):
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
         print('      --subsystem <type>             Subsystem type')
         print('      --hostname <hostname>          Hostname')
-        print('      --unsecure-port <port>         Unsecure port (default: 8080)')
+        print('      --unsecure-port <port>         Unsecure port')
         print('      --secure-port <port>           Secure port (default: 8443)')
         print('      --domain-manager               Domain manager')
         print('      --clone                        Clone')
@@ -201,7 +201,7 @@ class SDSubsystemAddCLI(pki.cli.CLI):
         instance_name = 'pki-tomcat'
         subsystem_type = None
         hostname = None
-        unsecure_port = '8080'
+        unsecure_port = None
         secure_port = '8443'
         domain_manager = False
         clone = False

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1494,7 +1494,7 @@ class PKISubsystem(object):
             subsystem_id,
             subsystem_type,
             hostname,
-            unsecure_port='8080',
+            unsecure_port=None,
             secure_port='8443',
             domain_manager=False,
             clone=False,
@@ -1552,7 +1552,7 @@ class PKISubsystem(object):
             sd_url,
             host_id,
             hostname,
-            unsecure_port='8080',
+            unsecure_port=None,
             secure_port='8443',
             domain_manager=False,
             clone=False,
@@ -1576,9 +1576,11 @@ class PKISubsystem(object):
                 '--install-token', install_token,
                 '--type', self.type,
                 '--hostname', hostname,
-                '--unsecure-port', unsecure_port,
-                '--secure-port', secure_port
+                '--secure-port', secure_port,
             ]
+
+            if unsecure_port is not None:
+                cmd.extend(['--unsecure-port', unsecure_port])
 
             if domain_manager:
                 cmd.append('--domain-manager')

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SDSubsystemAddCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SDSubsystemAddCLI.java
@@ -54,7 +54,7 @@ public class SDSubsystemAddCLI extends CommandCLI {
         option.setArgName("hostname");
         options.addOption(option);
 
-        option = new Option(null, "unsecure-port", true, "Unsecure port (default: 8080)");
+        option = new Option(null, "unsecure-port", true, "Unsecure port");
         option.setArgName("port");
         options.addOption(option);
 
@@ -89,7 +89,7 @@ public class SDSubsystemAddCLI extends CommandCLI {
             throw new CLIException("Missing hostname");
         }
 
-        String unsecurePort = cmd.getOptionValue("unsecure-port", "8080");
+        String unsecurePort = cmd.getOptionValue("unsecure-port");
         String securePort = cmd.getOptionValue("secure-port", "8443");
         boolean domainManager = cmd.hasOption("domain-manager");
         boolean clone = cmd.hasOption("clone");
@@ -150,7 +150,11 @@ public class SDSubsystemAddCLI extends CommandCLI {
             attrs.add(new LDAPAttribute("cn", cn));
             attrs.add(new LDAPAttribute("SubsystemName", subsystemID));
             attrs.add(new LDAPAttribute("Host", hostname));
-            attrs.add(new LDAPAttribute("UnSecurePort", unsecurePort));
+
+            if (unsecurePort != null) {
+                attrs.add(new LDAPAttribute("UnSecurePort", unsecurePort));
+            }
+
             attrs.add(new LDAPAttribute("SecurePort", securePort));
             attrs.add(new LDAPAttribute("SecureAgentPort", securePort));
             attrs.add(new LDAPAttribute("SecureAdminPort", securePort));

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SDSubsystemCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SDSubsystemCLI.java
@@ -26,7 +26,12 @@ public class SDSubsystemCLI extends CLI {
 
         System.out.println("  Subsystem ID: " + host.getId());
         System.out.println("  Hostname: " + host.getHostname());
-        System.out.println("  Port: " + host.getPort());
+
+        String port = host.getPort();
+        if (port != null) {
+            System.out.println("  Port: " + port);
+        }
+
         System.out.println("  Secure Port: " + host.getSecurePort());
 
         if (host.getDomainManager() != null) {

--- a/base/tools/src/main/java/com/netscape/cmstools/system/SecurityDomainHostAddCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/system/SecurityDomainHostAddCLI.java
@@ -32,7 +32,7 @@ public class SecurityDomainHostAddCLI extends CommandCLI {
 
     @Override
     public void createOptions() {
-        Option option = new Option(null, "port", true, "Port (default: 8080)");
+        Option option = new Option(null, "port", true, "Port");
         option.setArgName("port");
         options.addOption(option);
 
@@ -63,7 +63,7 @@ public class SecurityDomainHostAddCLI extends CommandCLI {
         SecurityDomainHost host = new SecurityDomainHost();
         host.setId(hostID);
 
-        String port = cmd.getOptionValue("port", "8080");
+        String port = cmd.getOptionValue("port");
         host.setPort(port);
 
         String securePort = cmd.getOptionValue("securePort", "8443");

--- a/base/tools/src/main/java/com/netscape/cmstools/system/SecurityDomainJoinCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/system/SecurityDomainJoinCLI.java
@@ -57,7 +57,7 @@ public class SecurityDomainJoinCLI extends CommandCLI {
         option.setArgName("hostname");
         options.addOption(option);
 
-        option = new Option(null, "unsecure-port", true, "Unsecure port (default: 8080)");
+        option = new Option(null, "unsecure-port", true, "Unsecure port");
         option.setArgName("port");
         options.addOption(option);
 
@@ -103,7 +103,7 @@ public class SecurityDomainJoinCLI extends CommandCLI {
             throw new Exception("Missing hostname");
         }
 
-        String unsecurePort = cmd.getOptionValue("unsecure-port", "8080");
+        String unsecurePort = cmd.getOptionValue("unsecure-port");
         String securePort = cmd.getOptionValue("secure-port", "8443");
         boolean domainManager = cmd.hasOption("domain-manager");
         boolean clone = cmd.hasOption("clone");
@@ -114,7 +114,11 @@ public class SecurityDomainJoinCLI extends CommandCLI {
         content.putSingle("type", type);
         content.putSingle("name", hostID);
         content.putSingle("host", hostname);
-        content.putSingle("httpport", unsecurePort);
+
+        if (unsecurePort != null) {
+            content.putSingle("httpport", unsecurePort);
+        }
+
         content.putSingle("sport", securePort);
         content.putSingle("agentsport", securePort);
         content.putSingle("adminsport", securePort);

--- a/docs/changes/v11.5.0/Server-Changes.adoc
+++ b/docs/changes/v11.5.0/Server-Changes.adoc
@@ -8,3 +8,9 @@ A new `pki_ds_url` parameter has been added for `pkispawn` to replace the follow
 * `pki_ds_ldap_port`
 * `pki_ds_ldaps_port`
 * `pki_ds_secure_connection`
+
+== Add pki_http_enable parameter ==
+
+A new `pki_http_enable` parameter has been added for `pkispawn`
+to enable/disable the plain HTTP connector in `server.xml`.
+The default value is `True`.


### PR DESCRIPTION
A new `pki_http_enable` parameter has been added for `pkispawn` to enable/disable the plain HTTP connector in `server.xml`. Currently the plain HTTP connector is enabled by default, but in the future it might be disabled by default such that the server will only use the secure HTTP connector.

The security domain CLIs have been modified such that they work without the plain HTTP connector.

The TPS test with separate instances has been modified to verify that the system works without plain HTTP connectors.

https://github.com/edewata/pki/blob/install/docs/changes/v11.5.0/Server-Changes.adoc
