### PR TITLE
Update PKI_VERSION in tomcat.conf

### DIFF
--- a/base/common/python/pki/upgrade.py
+++ b/base/common/python/pki/upgrade.py
@@ -43,7 +43,8 @@ class PKIUpgradeTracker(object):
 
     def __init__(self, name, filename, delimiter='=',
                  version_key='PKI_VERSION',
-                 index_key='PKI_UPGRADE_INDEX'):
+                 index_key='PKI_UPGRADE_INDEX',
+                 quote=None):
 
         self.name = name
         self.filename = filename
@@ -54,7 +55,7 @@ class PKIUpgradeTracker(object):
         # properties must be read and written immediately to avoid
         # interfering with scriptlets that update the same file
 
-        self.properties = pki.PropertyFile(filename, delimiter)
+        self.properties = pki.PropertyFile(filename, delimiter=delimiter, quote=quote)
 
         # run all scriptlets for each upgrade version
         self.remove_index()

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -694,7 +694,7 @@ grant codeBase "file:%s" {
         # copy /etc/tomcat/tomcat.conf
         self.copy(Tomcat.TOMCAT_CONF, self.tomcat_conf, force=force)
 
-        tomcat_conf = pki.PropertyFile(self.tomcat_conf)
+        tomcat_conf = pki.PropertyFile(self.tomcat_conf, quote='"')
         tomcat_conf.read()
 
         # store JAVA_HOME from /usr/share/pki/etc/pki.conf

--- a/base/server/python/pki/server/upgrade.py
+++ b/base/server/python/pki/server/upgrade.py
@@ -69,7 +69,8 @@ class PKIServerUpgrader(pki.upgrade.PKIUpgrader):
             '%s instance' % self.instance,
             INSTANCE_TRACKER % self.instance.conf_dir,
             version_key='PKI_VERSION',
-            index_key='PKI_UPGRADE_INDEX')
+            index_key='PKI_UPGRADE_INDEX',
+            quote='"')
 
         return self.tracker
 

--- a/base/server/share/conf/tomcat.conf
+++ b/base/server/share/conf/tomcat.conf
@@ -57,7 +57,7 @@ TOMCAT_LOG="/var/log/pki/[pki_instance_name]/tomcat-initd.log"
 # put your own definitions here
 # (i.e. LD_LIBRARY_PATH for some jdbc drivers)
 
-PKI_VERSION=[application_version]
+PKI_VERSION="[application_version]"
 
 # Debian settings
 TOMCAT_USER="[pki_user]"


### PR DESCRIPTION
The `PKI_VERSION` in `tomcat.conf` has been modified to use quotes like other properties in the file so they all can be processed more consistently.

The `PropertyFile` and `PKIUpgradeTracker` classes have been modified to support optional quotes.