### PR TITLE
Drop subsystem.select param

### DIFF
--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -98,6 +98,9 @@ jobs:
 
       - name: Install CA in secondary PKI container
         run: |
+          # get CS.cfg from primary CA before cloning
+          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+
           docker exec primary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
@@ -111,6 +114,77 @@ jobs:
               -v
 
           docker exec secondary pki-server cert-find
+
+      - name: Check CS.cfg in primary CA after cloning
+        run: |
+          # get CS.cfg from primary CA after cloning
+          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - set dbs.enableSerialManagement to true (automatically enabled when cloned)
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e 's/^\(dbs.enableSerialManagement\)=.*$/\1=true/' \
+              CS.cfg.primary \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.primary.after \
+              | sort > actual
+
+          diff expected actual
+
+      - name: Check CS.cfg in secondary CA
+        run: |
+          # get CS.cfg from secondary CA
+          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - replace primary.example.com with secondary.example.com
+          # - replace primaryds.example.com with secondaryds.example.com
+          # - set ca.crl.MasterCRL.enableCRLCache to false (automatically disabled in the clone)
+          # - set ca.crl.MasterCRL.enableCRLUpdates to false (automatically disabled in the clone)
+          # - add params for the clone
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              -e 's/primary.example.com/secondary.example.com/' \
+              -e 's/primaryds.example.com/secondaryds.example.com/' \
+              -e 's/^\(ca.crl.MasterCRL.enableCRLCache\)=.*$/\1=false/' \
+              -e 's/^\(ca.crl.MasterCRL.enableCRLUpdates\)=.*$/\1=false/' \
+              -e '$ a ca.certStatusUpdateInterval=0' \
+              -e '$ a ca.listenToCloneModifications=false' \
+              -e '$ a master.ca.agent.host=primary.example.com' \
+              -e '$ a master.ca.agent.port=8443' \
+              CS.cfg.primary.after \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              CS.cfg.secondary \
+              | sort > actual
+
+          diff expected actual
 
       - name: Verify users and SD hosts in secondary PKI container
         run: |
@@ -162,6 +236,68 @@ jobs:
               -v
 
           docker exec tertiary pki-server cert-find
+
+      - name: Check CS.cfg in secondary CA after cloning
+        run: |
+          # get CS.cfg from secondary CA after cloning
+          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary.after
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.secondary \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.secondary.after \
+              | sort > actual
+
+          diff expected actual
+
+      - name: Check CS.cfg in tertiary CA
+        run: |
+          # get CS.cfg from tertiary CA
+          docker cp tertiary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.tertiary
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - replace secondary.example.com with tertiary.example.com
+          # - replace secondaryds.example.com with tertiaryds.example.com
+          # - set master.ca.agent.host to secondary.example.com
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              -e 's/secondary.example.com/tertiary.example.com/' \
+              -e 's/secondaryds.example.com/tertiaryds.example.com/' \
+              -e 's/^\(master.ca.agent.host\)=.*$/\1=secondary.example.com/' \
+              CS.cfg.secondary.after \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              CS.cfg.tertiary \
+              | sort > actual
+
+          diff expected actual
 
       - name: Verify users and SD hosts in tertiary PKI container
         run: |

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -174,10 +174,7 @@ class PKIServerCLI(pki.cli.CLI):
             print()
             print('  CA Subsystem:')
 
-            if ca.config['subsystem.select'] == 'Clone':
-                subsystem_type = 'CA Clone'
-            else:
-                subsystem_type = ca.config['hierarchy.select'] + ' CA'
+            subsystem_type = ca.config['hierarchy.select'] + ' CA'
             if ca.config['securitydomain.select'] == 'new':
                 subsystem_type += ' (Security Domain)'
             print('    Type:                %s' % subsystem_type)
@@ -207,9 +204,7 @@ class PKIServerCLI(pki.cli.CLI):
             print('  KRA Subsystem:')
 
             subsystem_type = 'KRA'
-            if kra.config['subsystem.select'] == 'Clone':
-                subsystem_type += ' Clone'
-            elif kra.config['kra.standalone'] == 'true':
+            if kra.config['kra.standalone'] == 'true':
                 subsystem_type += ' (Standalone)'
             print('    Type:                %s' % subsystem_type)
 
@@ -234,9 +229,7 @@ class PKIServerCLI(pki.cli.CLI):
             print('  OCSP Subsystem:')
 
             subsystem_type = 'OCSP'
-            if ocsp.config['subsystem.select'] == 'Clone':
-                subsystem_type += ' Clone'
-            elif ocsp.config['ocsp.standalone'] == 'true':
+            if ocsp.config['ocsp.standalone'] == 'true':
                 subsystem_type += ' (Standalone)'
             print('    Type:                %s' % subsystem_type)
 
@@ -265,8 +258,6 @@ class PKIServerCLI(pki.cli.CLI):
             print('  TKS Subsystem:')
 
             subsystem_type = 'TKS'
-            if tks.config['subsystem.select'] == 'Clone':
-                subsystem_type += ' Clone'
             print('    Type:                %s' % subsystem_type)
 
             print('    SD Name:             %s' % tks.config['securitydomain.name'])
@@ -290,8 +281,6 @@ class PKIServerCLI(pki.cli.CLI):
             print('  TPS Subsystem:')
 
             subsystem_type = 'TPS'
-            if tps.config['subsystem.select'] == 'Clone':
-                subsystem_type += ' Clone'
             print('    Type:                %s' % subsystem_type)
 
             print('    SD Name:             %s' % tps.config['securitydomain.name'])

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1065,12 +1065,6 @@ class PKIDeployer:
 
             subsystem.config['preop.ca.type'] = 'sdca'
 
-        # configure cloning
-        if clone:
-            subsystem.config['subsystem.select'] = 'Clone'
-        else:
-            subsystem.config['subsystem.select'] = 'New'
-
         # configure CA
         if subsystem.type == 'CA':
 

--- a/base/server/upgrade/11.5.0/01-RemoveUnusedParams.py
+++ b/base/server/upgrade/11.5.0/01-RemoveUnusedParams.py
@@ -1,0 +1,29 @@
+# Authors:
+#     Endi S. Dewata <edewata@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import logging
+
+import pki
+
+logger = logging.getLogger(__name__)
+
+
+class RemoveUnusedParams(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Remove unused params'
+
+    def upgrade_subsystem(self, instance, subsystem):
+
+        self.backup(subsystem.cs_conf)
+
+        # remove subsystem.select param
+        logger.info('Removing subsystem.select')
+        subsystem.config.pop('subsystem.select', None)
+
+        subsystem.save()


### PR DESCRIPTION
The `subsystem.select` param in `CS.cfg` was used to record whether the subsystem was installed as a new subsystem or a clone of an existing subsystem, but it does not actually control any functionality.

Ideally a clone should be indistinguishable from a normal subsystem, so the param has been removed to minimize the differences in the `CS.cfg`.

The `pki-server status` CLI has been modified to no longer use the param. An upgrade script has also been added to remove the param from existing instances.

The CA clone test has been updated to compare the `CS.cfg` files in the primary, secondary, and tertiary subsystems. They should be mostly identical except for some params that do change when cloned.
