### PR TITLE
Add support for cloning with CSR files

### DIFF
--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -222,14 +222,37 @@ jobs:
 
       - name: Install CA in tertiary PKI container
         run: |
-          docker exec secondary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-          docker exec secondary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+          # export system certs and keys (except sslserver)
+          docker exec secondary pki-server ca-clone-prepare \
+              --pkcs12-file ${SHARED}/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
+          # export CA signing CSR
+          docker exec secondary pki-server cert-export ca_signing \
+              --csr-file ${SHARED}/ca_signing.csr
+
+          # export CA OCSP signing CSR
+          docker exec secondary pki-server cert-export ca_ocsp_signing \
+              --csr-file ${SHARED}/ca_ocsp_signing.csr
+
+          # export CA audit signing CSR
+          docker exec secondary pki-server cert-export ca_audit_signing \
+              --csr-file ${SHARED}/ca_audit_signing.csr
+
+          # export subsystem CSR
+          docker exec secondary pki-server cert-export subsystem \
+              --csr-file ${SHARED}/subsystem.csr
+
           docker exec tertiary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone-of-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_ca_signing_csr_path=${SHARED}/ca_signing.csr \
+              -D pki_ocsp_signing_csr_path=${SHARED}/ca_ocsp_signing.csr \
+              -D pki_audit_signing_csr_path=${SHARED}/ca_audit_signing.csr \
+              -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1398,7 +1398,17 @@ class PKIDeployer:
             for tag in tags:
                 if tag == 'sslserver':
                     continue
-                substores.append(subsystem.name + '.' + tag)
+
+                # check CSR in CS.cfg
+                param = '%s.%s.certreq' % (subsystem.name, tag)
+                csr = subsystem.config.get(param)
+
+                if csr:
+                    # CSR already exists
+                    continue
+
+                # CSR doesn't exist, import from master
+                names.append(param)
 
             if subsystem.name == 'ca':
                 substores.append('ca.connector.KRA')
@@ -1898,7 +1908,12 @@ class PKIDeployer:
         param = 'pki_%s_csr_path' % cert_id
         csr_path = self.mdict.get(param)
 
-        if not csr_path:
+        # IPA has a default value for pki_ca_signing_csr_path,
+        # so it's necessary to check whether the file actually exists.
+        # https://github.com/freeipa/freeipa/blob/master/install/share/ipaca_default.ini#L111
+        # TODO: remove the default value from IPA
+
+        if not csr_path or not os.path.exists(csr_path):
             # no CSR file to import
             return
 
@@ -1935,7 +1950,12 @@ class PKIDeployer:
         param = 'pki_ca_signing_cert_path'
         cert_file = self.mdict.get(param)
 
-        if not cert_file:
+        # IPA has a default value for pki_ca_signing_cert_path,
+        # so it's necessary to check whether the file actually exists.
+        # https://github.com/freeipa/freeipa/blob/master/install/share/ipaca_default.ini#L43
+        # TODO: remove the default value from IPA
+
+        if not cert_file or not os.path.exists(cert_file):
             # no CA signing cert file to import
             return
 
@@ -1966,7 +1986,12 @@ class PKIDeployer:
         param = 'pki_%s_cert_path' % cert_id
         cert_file = self.mdict.get(param)
 
-        if not cert_file:
+        # IPA has a default value for pki_ca_signing_cert_path,
+        # so it's necessary to check whether the file actually exists.
+        # https://github.com/freeipa/freeipa/blob/master/install/share/ipaca_default.ini#L43
+        # TODO: remove the default value from IPA
+
+        if not cert_file or not os.path.exists(cert_file):
             # no system cert to import
             return
 

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -61,20 +61,16 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             user=deployer.mdict['pki_user'],
             group=deployer.mdict['pki_group'])
 
-        existing = deployer.configuration_file.existing
-        step_two = deployer.configuration_file.external_step_two
         clone = deployer.configuration_file.clone
         master_url = deployer.mdict['pki_clone_uri']
 
         try:
-            if existing or (external or standalone) and step_two:
+            deployer.import_system_cert_requests(subsystem)
+            deployer.import_system_certs(nssdb, subsystem)
+            deployer.update_system_certs(nssdb, subsystem)
+            subsystem.save()
 
-                deployer.import_system_cert_requests(subsystem)
-                deployer.import_system_certs(nssdb, subsystem)
-                deployer.update_system_certs(nssdb, subsystem)
-                subsystem.save()
-
-            elif len(subsystems) > 1:
+            if len(subsystems) > 1:
 
                 for s in subsystems:
 

--- a/docs/installation/ca/Installing_CA_Clone.md
+++ b/docs/installation/ca/Installing_CA_Clone.md
@@ -49,6 +49,22 @@ $ pki -d /etc/pki/pki-tomcat/alias -f /etc/pki/pki-tomcat/password.conf \
     --append
 ```
 
+Optionally, the CSRs for the above certificates can be exported as well with the following commands:
+
+```
+$ pki-server cert-export ca_signing \
+    --csr-file ca_signing.csr
+
+$ pki-server cert-export ca_ocsp_signing \
+    --csr-file ca_ocsp_signing.csr
+
+$ pki-server cert-export ca_audit_signing \
+    --csr-file ca_audit_signing.csr
+
+$ pki-server cert-export subsystem \
+    --csr-file subsystem.csr
+```
+
 SELinux Permissions
 -------------------
 
@@ -77,6 +93,15 @@ the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate and key have been exported into `ca_admin_cert.p12`.
 The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 See [Installing CA](Installing_CA.md) for details.
+
+If the CSRs are available, they can be specified with the following parameters:
+
+```
+pki_ca_signing_csr_path=ca_signing.csr
+pki_ocsp_signing_csr_path=ca_ocsp_signing.csr
+pki_audit_signing_csr_path=ca_audit_signing.csr
+pki_subsystem_csr_path=subsystem.csr
+```
 
 To start the installation execute the following command:
 


### PR DESCRIPTION
Previously during cloning `pkispawn` would retrieve database params and system cert params (i.e. `<subsystem>.<tag>.*`) from the master. However, the clone actually already has most of these params (from `pkispawn` config file and PKCS #12 file) except for the CSRs (i.e. `<subsystem>.<tag>.certreq`).

The code in `PKIDeployer.setup_database()` that retrieves the params from the master has been modified to retrieve only the database params and the CSRs (unless the clone already has them). In the future it might be possible to not retrieve anything from the master at all.

The `configuration.py` has been modified such that the code that imports the certs and CSRs from files (if provided) will run in all cases including cloning instead of just in specific cases.

The installation doc has been updated to show the optional steps for installing CA clone with CSR files:
https://github.com/edewata/pki/blob/install/docs/installation/ca/Installing_CA_Clone.md

The test for CA clone has been updated to create the secondary subsystem without CSR files like before, then create the tertiary subsystem with CSR files.