### PR TITLE
Update test for CA clone with HSM

### DIFF
--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -157,6 +157,9 @@ jobs:
 
       - name: Install CA in secondary PKI container
         run: |
+          # get CS.cfg from primary CA before cloning
+          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+
           docker exec primary pki-server cert-export ca_signing \
               --cert-file ${SHARED}/ca_signing.crt
           docker exec secondary pkispawn \
@@ -201,6 +204,77 @@ jobs:
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
 
+      - name: Check CS.cfg in primary CA after cloning
+        run: |
+          # get CS.cfg from primary CA after cloning
+          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - set dbs.enableSerialManagement to true (automatically enabled when cloned)
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e 's/^\(dbs.enableSerialManagement\)=.*$/\1=true/' \
+              CS.cfg.primary \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.primary.after \
+              | sort > actual
+
+          diff expected actual
+
+      - name: Check CS.cfg in secondary CA
+        run: |
+          # get CS.cfg from secondary CA
+          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - replace primary.example.com with secondary.example.com
+          # - replace primaryds.example.com with secondaryds.example.com
+          # - set ca.crl.MasterCRL.enableCRLCache to false (automatically disabled in the clone)
+          # - set ca.crl.MasterCRL.enableCRLUpdates to false (automatically disabled in the clone)
+          # - add params for the clone
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              -e 's/primary.example.com/secondary.example.com/' \
+              -e 's/primaryds.example.com/secondaryds.example.com/' \
+              -e 's/^\(ca.crl.MasterCRL.enableCRLCache\)=.*$/\1=false/' \
+              -e 's/^\(ca.crl.MasterCRL.enableCRLUpdates\)=.*$/\1=false/' \
+              -e '$ a ca.certStatusUpdateInterval=0' \
+              -e '$ a ca.listenToCloneModifications=false' \
+              -e '$ a master.ca.agent.host=primary.example.com' \
+              -e '$ a master.ca.agent.port=8443' \
+              CS.cfg.primary.after \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              CS.cfg.secondary \
+              | sort > actual
+
+          diff expected actual
+
       - name: Set up tertiary DS container
         run: |
           tests/bin/ds-container-create.sh tertiaryds
@@ -239,6 +313,22 @@ jobs:
 
       - name: Install CA in tertiary PKI container
         run: |
+          # export CA signing CSR
+          docker exec secondary pki-server cert-export ca_signing \
+              --csr-file ${SHARED}/ca_signing.csr
+
+          # export CA OCSP signing CSR
+          docker exec secondary pki-server cert-export ca_ocsp_signing \
+              --csr-file ${SHARED}/ca_ocsp_signing.csr
+
+          # export CA audit signing CSR
+          docker exec secondary pki-server cert-export ca_audit_signing \
+              --csr-file ${SHARED}/ca_audit_signing.csr
+
+          # export subsystem CSR
+          docker exec secondary pki-server cert-export subsystem \
+              --csr-file ${SHARED}/subsystem.csr
+
           docker exec tertiary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone-of-clone.cfg \
               -s CA \
@@ -248,9 +338,13 @@ jobs:
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \
               -D pki_ca_signing_token=HSM \
+              -D pki_ca_signing_csr_path=${SHARED}/ca_signing.csr \
               -D pki_ocsp_signing_token=HSM \
+              -D pki_ocsp_signing_csr_path=${SHARED}/ca_ocsp_signing.csr \
               -D pki_audit_signing_token=HSM \
+              -D pki_audit_signing_csr_path=${SHARED}/ca_audit_signing.csr \
               -D pki_subsystem_token=HSM \
+              -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_token=internal \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
@@ -279,6 +373,68 @@ jobs:
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
+          diff expected actual
+
+      - name: Check CS.cfg in secondary CA after cloning
+        run: |
+          # get CS.cfg from secondary CA after cloning
+          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary.after
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.secondary \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.secondary.after \
+              | sort > actual
+
+          diff expected actual
+
+      - name: Check CS.cfg in tertiary CA
+        run: |
+          # get CS.cfg from tertiary CA
+          docker cp tertiary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.tertiary
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - replace secondary.example.com with tertiary.example.com
+          # - replace secondaryds.example.com with tertiaryds.example.com
+          # - set master.ca.agent.host to secondary.example.com
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              -e 's/secondary.example.com/tertiary.example.com/' \
+              -e 's/secondaryds.example.com/tertiaryds.example.com/' \
+              -e 's/^\(master.ca.agent.host\)=.*$/\1=secondary.example.com/' \
+              CS.cfg.secondary.after \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              CS.cfg.tertiary \
+              | sort > actual
+
           diff expected actual
 
       - name: Gather artifacts from primary containers
@@ -315,7 +471,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-primary
+          name: ca-clone-hsm-primary
           path: |
             /tmp/artifacts/primary
 
@@ -323,7 +479,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-secondary
+          name: ca-clone-hsm-secondary
           path: |
             /tmp/artifacts/secondary
 
@@ -331,6 +487,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-clone-tertiary
+          name: ca-clone-hsm-tertiary
           path: |
             /tmp/artifacts/tertiary

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.md
@@ -7,8 +7,28 @@ Overview
 This page describes the process to install a CA subsystem as a clone of an existing CA subsystem
 where the system certificates and their keys are stored in HSM.
 
-Since the certificates and the keys are already in HSM, it's not necessary to export them into a
+Exporting Existing System Certificates
+--------------------------------------
+
+Since the system certificates and the keys are already in HSM, it's not necessary to export them into a
 PKCS #12 file to create a clone.
+
+However, the CSRs for the system certificates are stored in `CS.cfg` instead of HSM.
+They can optionally be exported with the following commands:
+
+```
+$ pki-server cert-export ca_signing \
+    --csr-file ca_signing.csr
+
+$ pki-server cert-export ca_ocsp_signing \
+    --csr-file ca_ocsp_signing.csr
+
+$ pki-server cert-export ca_audit_signing \
+    --csr-file ca_audit_signing.csr
+
+$ pki-server cert-export subsystem \
+    --csr-file subsystem.csr
+```
 
 CA Subsystem Installation
 -------------------------
@@ -52,6 +72,15 @@ pki_subsystem_nickname=subsystem
 pki_clone=True
 pki_clone_replicate_schema=True
 pki_clone_uri=https://pki.example.com:8443
+```
+
+If the CSRs are available, they can be specified with the following parameters:
+
+```
+pki_ca_signing_csr_path=ca_signing.csr
+pki_ocsp_signing_csr_path=ca_ocsp_signing.csr
+pki_audit_signing_csr_path=ca_audit_signing.csr
+pki_subsystem_csr_path=subsystem.csr
 ```
 
 Then execute the following command:


### PR DESCRIPTION
The test for CA clone with HSM has been updated to compare the `CS.cfg` in the primary, secondary, and tertiary instances. The test will create the secondary subsystem without CSR files like before, then create the tertiary subsystem with CSR files.

https://github.com/edewata/pki/blob/install/docs/installation/ca/Installing_CA_Clone_with_HSM.md
