### PR TITLE
Add test for CA with RSA algorithm

### DIFF
--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Connect PKI container to network
         run: docker network connect example pki --alias pki.example.com
 
-      - name: Install CA
+      - name: Install CA with SHA512withRSA/PSS
         run: |
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
@@ -74,6 +74,7 @@ jobs:
 
       - name: Check system cert keys
         run: |
+          # all keys should be "rsa"
           echo Secret.123 > password.txt
           docker exec pki certutil -K -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt | tee output
           echo "rsa" > expected
@@ -95,53 +96,103 @@ jobs:
 
       - name: Check CA signing cert
         run: |
+          # inspect cert with certutil
+          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_signing | tee output
+
+          # signing algorithm should be "PKCS #1 RSA-PSS Signature"
+          echo "PKCS #1 RSA-PSS Signature" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # inspect cert with openssl
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_signing.crt | tee output
 
+          # signing algorithm should be "rsassaPss"
           echo "rsassaPss" > expected
-          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
       - name: Check CA OCSP signing cert
         run: |
+          # inspect cert with certutil
+          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
+
+          # signing algorithm should be "PKCS #1 RSA-PSS Signature"
+          echo "PKCS #1 RSA-PSS Signature" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # inspect cert with openssl
           docker exec pki pki-server cert-export ca_ocsp_signing --cert-file ca_ocsp_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_ocsp_signing.crt | tee output
 
+          # signing algorithm should be "rsassaPss"
           echo "rsassaPss" > expected
-          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
       - name: Check CA audit signing cert
         run: |
+          # inspect cert with certutil
+          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
+
+          # signing algorithm should be "PKCS #1 RSA-PSS Signature"
+          echo "PKCS #1 RSA-PSS Signature" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # inspect cert with openssl
           docker exec pki pki-server cert-export ca_audit_signing --cert-file ca_audit_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_audit_signing.crt | tee output
 
+          # signing algorithm should be "rsassaPss"
           echo "rsassaPss" > expected
-          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
       - name: Check subsystem cert
         run: |
+          # inspect cert with certutil
+          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n subsystem | tee output
+
+          # signing algorithm should be "PKCS #1 RSA-PSS Signature"
+          echo "PKCS #1 RSA-PSS Signature" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # inspect cert with openssl
           docker exec pki pki-server cert-export subsystem --cert-file subsystem.crt
           docker exec pki openssl x509 -text -noout -in subsystem.crt | tee output
 
+          # signing algorithm should be "rsassaPss"
           echo "rsassaPss" > expected
-          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
       - name: Check SSL server cert
         run: |
+          # inspect cert with certutil
+          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n sslserver | tee output
+
+          # signing algorithm should be "PKCS #1 RSA-PSS Signature"
+          echo "PKCS #1 RSA-PSS Signature" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # inspect cert with openssl
           docker exec pki pki-server cert-export sslserver --cert-file sslserver.crt
           docker exec pki openssl x509 -text -noout -in sslserver.crt | tee output
 
+          # signing algorithm should be "rsassaPss"
           echo "rsassaPss" > expected
-          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only
 
-      - name: Verify CA admin
+      - name: Check authenticating as CA admin user
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
@@ -152,15 +203,42 @@ jobs:
 
       - name: Check CA admin cert
         run: |
-          docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert | tee output
+          # inspect cert with certutil
+          docker exec pki certutil -L -d /root/.dogtag/nssdb -n caadmin | tee output
 
-          echo "rsassaPss" > expected
-          sed -n "/^\s*Signature Algorithm:/ {s/^.*:\s*\(\S*\)\s*$/\1/p;q}" output > actual
+          # signing algorithm should be "PKCS #1 RSA-PSS Signature"
+          echo "PKCS #1 RSA-PSS Signature" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-      - name: Check cert requests in CA
+          # inspect cert with openssl
+          docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert | tee output
+
+          # signing algorithm should be "rsassaPss"
+          echo "rsassaPss" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+      - name: Check issuing SSL server cert
         run: |
-          docker exec pki pki -n caadmin ca-cert-request-find
+          # issue cert
+          docker exec pki /usr/share/pki/tests/ca/bin/sslserver-create.sh
+
+          # inspect cert with certutil
+          docker exec pki certutil -L -d /root/.dogtag/nssdb -n sslserver | tee output
+
+          # signing algorithm should be "PKCS #1 RSA-PSS Signature"
+          echo "PKCS #1 RSA-PSS Signature" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # inspect cert with openssl
+          docker exec pki openssl x509 -text -noout -in sslserver.crt | tee output
+
+          # signing algorithm should be "rsassaPss"
+          echo "rsassaPss" > expected
+          sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-rsa-test.yml
+++ b/.github/workflows/ca-rsa-test.yml
@@ -1,4 +1,4 @@
-name: CA with ECC
+name: CA with RSA
 
 on:
   workflow_call:
@@ -8,7 +8,6 @@ on:
         type: string
 
 jobs:
-  # docs/installation/ca/Installing_CA_with_ECC.md
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -50,23 +49,34 @@ jobs:
       - name: Connect PKI container to network
         run: docker network connect example pki --alias pki.example.com
 
-      - name: Install CA with SHA512withEC
+      - name: Install CA with SHA384withRSA
         run: |
           docker exec pki pkispawn \
-              -f /usr/share/pki/server/examples/installation/ca-ecc.cfg \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_ca_signing_key_algorithm=SHA384withRSA \
+              -D pki_ca_signing_signing_algorithm=SHA384withRSA \
+              -D pki_ocsp_signing_key_algorithm=SHA384withRSA \
+              -D pki_ocsp_signing_signing_algorithm=SHA384withRSA \
+              -D pki_audit_signing_key_algorithm=SHA384withRSA \
+              -D pki_audit_signing_signing_algorithm=SHA384withRSA \
+              -D pki_subsystem_key_algorithm=SHA384withRSA \
+              -D pki_subsystem_signing_algorithm=SHA384withRSA \
+              -D pki_sslserver_key_algorithm=SHA384withRSA \
+              -D pki_sslserver_signing_algorithm=SHA384withRSA \
+              -D pki_admin_key_algorithm=SHA384withRSA \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -D pki_enable_access_log=False \
               -v
 
-      - name: Check system cert keys
+      - name: Check system certs keys
         run: |
-          # all keys should be "ec"
+          # all keys should be "rsa"
           echo Secret.123 > password.txt
           docker exec pki certutil -K -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt | tee output
-          echo "ec" > expected
+          echo "rsa" > expected
 
           grep ca_signing output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
           diff expected actual
@@ -88,8 +98,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_signing | tee output
 
-          # signing algorithm should be "X9.62 ECDSA signature with SHA512"
-          echo "X9.62 ECDSA signature with SHA512" > expected
+          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
+          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -97,8 +107,8 @@ jobs:
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_signing.crt | tee output
 
-          # signing algorithm should be "ecdsa-with-SHA512"
-          echo "ecdsa-with-SHA512" > expected
+          # signing algorithm should be "sha384WithRSAEncryption"
+          echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -107,8 +117,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
 
-          # signing algorithm should be "X9.62 ECDSA signature with SHA512"
-          echo "X9.62 ECDSA signature with SHA512" > expected
+          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
+          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -116,8 +126,8 @@ jobs:
           docker exec pki pki-server cert-export ca_ocsp_signing --cert-file ca_ocsp_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_ocsp_signing.crt | tee output
 
-          # signing algorithm should be "ecdsa-with-SHA512"
-          echo "ecdsa-with-SHA512" > expected
+          # signing algorithm should be "sha384WithRSAEncryption"
+          echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -126,8 +136,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
 
-          # signing algorithm should be "X9.62 ECDSA signature with SHA512"
-          echo "X9.62 ECDSA signature with SHA512" > expected
+          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
+          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -135,8 +145,8 @@ jobs:
           docker exec pki pki-server cert-export ca_audit_signing --cert-file ca_audit_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_audit_signing.crt | tee output
 
-          # signing algorithm should be "ecdsa-with-SHA512"
-          echo "ecdsa-with-SHA512" > expected
+          # signing algorithm should be "sha384WithRSAEncryption"
+          echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -145,8 +155,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n subsystem | tee output
 
-          # signing algorithm should be "X9.62 ECDSA signature with SHA512"
-          echo "X9.62 ECDSA signature with SHA512" > expected
+          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
+          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -154,8 +164,8 @@ jobs:
           docker exec pki pki-server cert-export subsystem --cert-file subsystem.crt
           docker exec pki openssl x509 -text -noout -in subsystem.crt | tee output
 
-          # signing algorithm should be "ecdsa-with-SHA512"
-          echo "ecdsa-with-SHA512" > expected
+          # signing algorithm should be "sha384WithRSAEncryption"
+          echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -164,8 +174,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n sslserver | tee output
 
-          # signing algorithm should be "X9.62 ECDSA signature with SHA512"
-          echo "X9.62 ECDSA signature with SHA512" > expected
+          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
+          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -173,8 +183,8 @@ jobs:
           docker exec pki pki-server cert-export sslserver --cert-file sslserver.crt
           docker exec pki openssl x509 -text -noout -in sslserver.crt | tee output
 
-          # signing algorithm should be "ecdsa-with-SHA512"
-          echo "ecdsa-with-SHA512" > expected
+          # signing algorithm should be "sha384WithRSAEncryption"
+          echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -195,16 +205,16 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /root/.dogtag/nssdb -n caadmin | tee output
 
-          # signing algorithm should be "X9.62 ECDSA signature with SHA512"
-          echo "X9.62 ECDSA signature with SHA512" > expected
+          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
+          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
           # inspect cert with openssl
           docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert | tee output
 
-          # signing algorithm should be "ecdsa-with-SHA512"
-          echo "ecdsa-with-SHA512" > expected
+          # signing algorithm should be "sha384WithRSAEncryption"
+          echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -216,16 +226,16 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /root/.dogtag/nssdb -n sslserver | tee output
 
-          # signing algorithm should be "X9.62 ECDSA signature with SHA512"
-          echo "X9.62 ECDSA signature with SHA512" > expected
+          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
+          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
           # inspect cert with openssl
           docker exec pki openssl x509 -text -noout -in sslserver.crt | tee output
 
-          # signing algorithm should be "ecdsa-with-SHA512"
-          echo "ecdsa-with-SHA512" > expected
+          # signing algorithm should be "sha384WithRSAEncryption"
+          echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -243,6 +253,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-ecc
+          name: ca-rsa
           path: |
             /tmp/artifacts/pki

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -28,6 +28,13 @@ jobs:
     with:
       db-image: ${{ needs.init.outputs.db-image }}
 
+  ca-rsa-test:
+    name: CA with RSA
+    needs: [init, build]
+    uses: ./.github/workflows/ca-rsa-test.yml
+    with:
+      db-image: ${{ needs.init.outputs.db-image }}
+
   ca-rsa-pss-test:
     name: CA with RSA/PSS
     needs: [init, build]

--- a/tests/ca/bin/sslserver-create.sh
+++ b/tests/ca/bin/sslserver-create.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -ex
+
+# https://github.com/dogtagpki/pki/wiki/Generating-SSL-Server-CSR-with-PKI-NSS
+# https://github.com/dogtagpki/pki/wiki/Issuing-SSL-Server-Certificate-with-PKI-CA
+
+# submit a cert request and capture the request ID
+pki nss-cert-request \
+    --subject "CN=$HOSTNAME" \
+    --ext /usr/share/pki/server/certs/sslserver.conf \
+    --csr sslserver.csr
+
+pki ca-cert-request-submit --profile caServerCert --csr-file sslserver.csr | tee /tmp/output
+
+sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" /tmp/output > /tmp/request_id
+REQUEST_ID=$(cat /tmp/request_id)
+
+# approve the cert request and capture the cert ID
+pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee /tmp/output
+
+sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" /tmp/output > /tmp/cert_id
+CERT_ID=$(cat /tmp/cert_id)
+
+pki ca-cert-export $CERT_ID --output-file sslserver.crt
+
+pki nss-cert-import sslserver --cert sslserver.crt


### PR DESCRIPTION
A new test has been added to install CA with a non-default RSA algorithm verify that the system certs and admin cert use the same algorithm. The test will also issue an SSL server cert and verify that the cert uses the same algorithm.

The tests for CA with ECC and RSA/PSS algorithms have also been updated to perform the same validation.