### PR TITLE
Update tests for CA with non-default algorithms

### DIFF
--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -102,6 +102,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA512withEC"
+          echo "SHA512withEC" > expected
+          docker exec pki pki-server ca-config-show ca.signing.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check CA OCSP signing cert
         run: |
           # inspect cert with certutil
@@ -119,6 +124,11 @@ jobs:
           # signing algorithm should be "ecdsa-with-SHA512"
           echo "ecdsa-with-SHA512" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # default signing algorithm should be "SHA512withEC"
+          echo "SHA512withEC" > expected
+          docker exec pki pki-server ca-config-show ca.ocsp_signing.defaultSigningAlgorithm | tee actual
           diff expected actual
 
       - name: Check CA audit signing cert
@@ -140,6 +150,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA512withEC"
+          echo "SHA512withEC" > expected
+          docker exec pki pki-server ca-config-show ca.audit_signing.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check subsystem cert
         run: |
           # inspect cert with certutil
@@ -159,6 +174,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA512withEC"
+          echo "SHA512withEC" > expected
+          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check SSL server cert
         run: |
           # inspect cert with certutil
@@ -176,6 +196,11 @@ jobs:
           # signing algorithm should be "ecdsa-with-SHA512"
           echo "ecdsa-with-SHA512" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # default signing algorithm should be "SHA512withEC"
+          echo "SHA512withEC" > expected
+          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm | tee actual
           diff expected actual
 
       - name: Run PKI healthcheck

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -113,6 +113,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA512withRSA/PSS"
+          echo "SHA512withRSA/PSS" > expected
+          docker exec pki pki-server ca-config-show ca.signing.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check CA OCSP signing cert
         run: |
           # inspect cert with certutil
@@ -130,6 +135,11 @@ jobs:
           # signing algorithm should be "rsassaPss"
           echo "rsassaPss" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # default signing algorithm should be "SHA512withRSA/PSS"
+          echo "SHA512withRSA/PSS" > expected
+          docker exec pki pki-server ca-config-show ca.ocsp_signing.defaultSigningAlgorithm | tee actual
           diff expected actual
 
       - name: Check CA audit signing cert
@@ -151,6 +161,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA512withRSA/PSS"
+          echo "SHA512withRSA/PSS" > expected
+          docker exec pki pki-server ca-config-show ca.audit_signing.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check subsystem cert
         run: |
           # inspect cert with certutil
@@ -170,6 +185,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA512withRSA/PSS"
+          echo "SHA512withRSA/PSS" > expected
+          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check SSL server cert
         run: |
           # inspect cert with certutil
@@ -187,6 +207,11 @@ jobs:
           # signing algorithm should be "rsassaPss"
           echo "rsassaPss" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # default signing algorithm should be "SHA512withRSA/PSS"
+          echo "SHA512withRSA/PSS" > expected
+          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm | tee actual
           diff expected actual
 
       - name: Run PKI healthcheck

--- a/.github/workflows/ca-rsa-test.yml
+++ b/.github/workflows/ca-rsa-test.yml
@@ -112,6 +112,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA384withRSA"
+          echo "SHA384withRSA" > expected
+          docker exec pki pki-server ca-config-show ca.signing.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check CA OCSP signing cert
         run: |
           # inspect cert with certutil
@@ -129,6 +134,11 @@ jobs:
           # signing algorithm should be "sha384WithRSAEncryption"
           echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # default signing algorithm should be "SHA384withRSA"
+          echo "SHA384withRSA" > expected
+          docker exec pki pki-server ca-config-show ca.ocsp_signing.defaultSigningAlgorithm | tee actual
           diff expected actual
 
       - name: Check CA audit signing cert
@@ -150,6 +160,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA384withRSA"
+          echo "SHA384withRSA" > expected
+          docker exec pki pki-server ca-config-show ca.audit_signing.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check subsystem cert
         run: |
           # inspect cert with certutil
@@ -169,6 +184,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
+          # default signing algorithm should be "SHA384withRSA"
+          echo "SHA384withRSA" > expected
+          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm | tee actual
+          diff expected actual
+
       - name: Check SSL server cert
         run: |
           # inspect cert with certutil
@@ -186,6 +206,11 @@ jobs:
           # signing algorithm should be "sha384WithRSAEncryption"
           echo "sha384WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
+          diff expected actual
+
+          # default signing algorithm should be "SHA384withRSA"
+          echo "SHA384withRSA" > expected
+          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm | tee actual
           diff expected actual
 
       - name: Run PKI healthcheck


### PR DESCRIPTION
The tests for CA with non-default algorithms (i.e. RSA, RSA/PSS, ECC) have been modified to check the default signing algorithm params in `CS.cfg`.