### PR TITLE
Bug2228209-pkidbuser-wrong-o-in-pkispawn

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -525,8 +525,8 @@ pki_ds_base_dn=o=%(pki_instance_name)s-KRA
 pki_ds_database=%(pki_instance_name)s-KRA
 pki_ds_hostname=%(pki_hostname)s
 pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
-pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+pki_share_db=False
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 # Key ID generator: legacy, random
 pki_key_id_generator=legacy
@@ -610,8 +610,8 @@ pki_ds_base_dn=o=%(pki_instance_name)s-OCSP
 pki_ds_database=%(pki_instance_name)s-OCSP
 pki_ds_hostname=%(pki_hostname)s
 pki_subsystem_name=OCSP %(pki_hostname)s %(pki_https_port)s
-pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+pki_share_db=False
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 
 ###############################################################################
@@ -642,8 +642,8 @@ pki_ds_base_dn=o=%(pki_instance_name)s-TKS
 pki_ds_database=%(pki_instance_name)s-TKS
 pki_ds_hostname=%(pki_hostname)s
 pki_subsystem_name=TKS %(pki_hostname)s %(pki_https_port)s
-pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+pki_share_db=False
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 ###############################################################################
 ##  TPS Configuration:                                                       ##
@@ -672,6 +672,6 @@ pki_kra_uri=https://%(pki_hostname)s:%(pki_https_port)s
 pki_tks_uri=https://%(pki_hostname)s:%(pki_https_port)s
 pki_enable_server_side_keygen=False
 pki_import_shared_secret=False
-pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA
+pki_share_db=False
+pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 pki_source_phone_home_xml=/usr/share/pki/%(pki_subsystem_type)s/conf/phoneHome.xml


### PR DESCRIPTION
Ths patch addresses the issue where by default non-CA instances are created with hardcoded ending "-CA":
pki_share_dbuser_dn=uid=pkidbuser,ou=people,o=%(pki_instance_name)s-CA and
pki_ds_base_dn=o=%(pki_instance_name)s-<subsystem type>

where subsystem type is TKS, OCSP, TKS, or KRA,
which effictive makes the 'o' component of pki_share_dbuser_dn not matching with that of the pki_ds_base_dn.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2228209