### PR TITLE
Fix incorrect default signing algorithm

### DIFF
--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Connect PKI container to network
         run: docker network connect example pki --alias pki.example.com
 
-      - name: Install CA with SHA512withEC
+      - name: Install CA
         run: |
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-ecc.cfg \
@@ -88,8 +88,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_signing | tee output
 
-          # signing algorithm should be "X9.62 ECDSA signature with SHA512"
-          echo "X9.62 ECDSA signature with SHA512" > expected
+          # signing algorithm should be "X9.62 ECDSA signature with SHA384"
+          echo "X9.62 ECDSA signature with SHA384" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -97,8 +97,8 @@ jobs:
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_signing.crt | tee output
 
-          # signing algorithm should be "ecdsa-with-SHA512"
-          echo "ecdsa-with-SHA512" > expected
+          # signing algorithm should be "ecdsa-with-SHA384"
+          echo "ecdsa-with-SHA384" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -126,8 +126,8 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA512withEC"
-          echo "SHA512withEC" > expected
+          # default signing algorithm should be "SHA384withEC"
+          echo "SHA384withEC" > expected
           docker exec pki pki-server ca-config-show ca.ocsp_signing.defaultSigningAlgorithm | tee actual
           diff expected actual
 
@@ -150,8 +150,8 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA512withEC"
-          echo "SHA512withEC" > expected
+          # default signing algorithm should be "SHA384withEC"
+          echo "SHA384withEC" > expected
           docker exec pki pki-server ca-config-show ca.audit_signing.defaultSigningAlgorithm | tee actual
           diff expected actual
 
@@ -174,10 +174,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA512withEC"
-          echo "SHA512withEC" > expected
-          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm | tee actual
-          diff expected actual
+          # default signing algorithm should not exist
+          echo "ERROR: No such parameter: ca.subsystem.defaultSigningAlgorithm" > expected
+          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+          diff expected stderr
 
       - name: Check SSL server cert
         run: |
@@ -198,10 +199,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA512withEC"
-          echo "SHA512withEC" > expected
-          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm | tee actual
-          diff expected actual
+          # default signing algorithm should not exist
+          echo "ERROR: No such parameter: ca.sslserver.defaultSigningAlgorithm" > expected
+          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+          diff expected stderr
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -50,24 +50,22 @@ jobs:
       - name: Connect PKI container to network
         run: docker network connect example pki --alias pki.example.com
 
-      - name: Install CA with SHA512withRSA/PSS
+      - name: Install CA
         run: |
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_use_pss_rsa_signing_algorithm=True \
-              -D pki_ca_signing_key_algorithm=SHA512withRSA/PSS \
+              -D pki_ca_signing_key_algorithm=SHA384withRSA/PSS \
               -D pki_ca_signing_signing_algorithm=SHA512withRSA/PSS \
-              -D pki_ocsp_signing_key_algorithm=SHA512withRSA/PSS \
-              -D pki_ocsp_signing_signing_algorithm=SHA512withRSA/PSS \
-              -D pki_audit_signing_key_algorithm=SHA512withRSA/PSS \
-              -D pki_audit_signing_signing_algorithm=SHA512withRSA/PSS \
-              -D pki_subsystem_key_algorithm=SHA512withRSA/PSS \
-              -D pki_subsystem_signing_algorithm=SHA512withRSA/PSS \
-              -D pki_sslserver_key_algorithm=SHA512withRSA/PSS \
-              -D pki_sslserver_signing_algorithm=SHA512withRSA/PSS \
-              -D pki_admin_key_algorithm=SHA512withRSA/PSS \
+              -D pki_ocsp_signing_key_algorithm=SHA384withRSA/PSS \
+              -D pki_ocsp_signing_signing_algorithm=SHA384withRSA/PSS \
+              -D pki_audit_signing_key_algorithm=SHA384withRSA/PSS \
+              -D pki_audit_signing_signing_algorithm=SHA384withRSA/PSS \
+              -D pki_subsystem_key_algorithm=SHA384withRSA/PSS \
+              -D pki_sslserver_key_algorithm=SHA384withRSA/PSS \
+              -D pki_admin_key_algorithm=SHA384withRSA/PSS \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
@@ -137,8 +135,8 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA512withRSA/PSS"
-          echo "SHA512withRSA/PSS" > expected
+          # default signing algorithm should be "SHA384withRSA/PSS"
+          echo "SHA384withRSA/PSS" > expected
           docker exec pki pki-server ca-config-show ca.ocsp_signing.defaultSigningAlgorithm | tee actual
           diff expected actual
 
@@ -161,8 +159,8 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA512withRSA/PSS"
-          echo "SHA512withRSA/PSS" > expected
+          # default signing algorithm should be "SHA384withRSA/PSS"
+          echo "SHA384withRSA/PSS" > expected
           docker exec pki pki-server ca-config-show ca.audit_signing.defaultSigningAlgorithm | tee actual
           diff expected actual
 
@@ -185,10 +183,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA512withRSA/PSS"
-          echo "SHA512withRSA/PSS" > expected
-          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm | tee actual
-          diff expected actual
+          # default signing algorithm should not exist
+          echo "ERROR: No such parameter: ca.subsystem.defaultSigningAlgorithm" > expected
+          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+          diff expected stderr
 
       - name: Check SSL server cert
         run: |
@@ -209,10 +208,11 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA512withRSA/PSS"
-          echo "SHA512withRSA/PSS" > expected
-          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm | tee actual
-          diff expected actual
+          # default signing algorithm should not exist
+          echo "ERROR: No such parameter: ca.sslserver.defaultSigningAlgorithm" > expected
+          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+          diff expected stderr
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only

--- a/.github/workflows/ca-rsa-test.yml
+++ b/.github/workflows/ca-rsa-test.yml
@@ -49,22 +49,20 @@ jobs:
       - name: Connect PKI container to network
         run: docker network connect example pki --alias pki.example.com
 
-      - name: Install CA with SHA384withRSA
+      - name: Install CA
         run: |
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_ca_signing_key_algorithm=SHA384withRSA \
-              -D pki_ca_signing_signing_algorithm=SHA384withRSA \
+              -D pki_ca_signing_signing_algorithm=SHA512withRSA \
               -D pki_ocsp_signing_key_algorithm=SHA384withRSA \
               -D pki_ocsp_signing_signing_algorithm=SHA384withRSA \
               -D pki_audit_signing_key_algorithm=SHA384withRSA \
               -D pki_audit_signing_signing_algorithm=SHA384withRSA \
               -D pki_subsystem_key_algorithm=SHA384withRSA \
-              -D pki_subsystem_signing_algorithm=SHA384withRSA \
               -D pki_sslserver_key_algorithm=SHA384withRSA \
-              -D pki_sslserver_signing_algorithm=SHA384withRSA \
               -D pki_admin_key_algorithm=SHA384withRSA \
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
@@ -112,8 +110,8 @@ jobs:
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA384withRSA"
-          echo "SHA384withRSA" > expected
+          # default signing algorithm should be "SHA512withRSA"
+          echo "SHA512withRSA" > expected
           docker exec pki pki-server ca-config-show ca.signing.defaultSigningAlgorithm | tee actual
           diff expected actual
 
@@ -122,8 +120,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
 
-          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
-          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
+          # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
+          echo "PKCS #1 SHA-512 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -131,8 +129,8 @@ jobs:
           docker exec pki pki-server cert-export ca_ocsp_signing --cert-file ca_ocsp_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_ocsp_signing.crt | tee output
 
-          # signing algorithm should be "sha384WithRSAEncryption"
-          echo "sha384WithRSAEncryption" > expected
+          # signing algorithm should be "sha512WithRSAEncryption"
+          echo "sha512WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -146,8 +144,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
 
-          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
-          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
+          # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
+          echo "PKCS #1 SHA-512 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -155,8 +153,8 @@ jobs:
           docker exec pki pki-server cert-export ca_audit_signing --cert-file ca_audit_signing.crt
           docker exec pki openssl x509 -text -noout -in ca_audit_signing.crt | tee output
 
-          # signing algorithm should be "sha384WithRSAEncryption"
-          echo "sha384WithRSAEncryption" > expected
+          # signing algorithm should be "sha512WithRSAEncryption"
+          echo "sha512WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -170,8 +168,8 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n subsystem | tee output
 
-          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
-          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
+          # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
+          echo "PKCS #1 SHA-512 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -179,23 +177,24 @@ jobs:
           docker exec pki pki-server cert-export subsystem --cert-file subsystem.crt
           docker exec pki openssl x509 -text -noout -in subsystem.crt | tee output
 
-          # signing algorithm should be "sha384WithRSAEncryption"
-          echo "sha384WithRSAEncryption" > expected
+          # signing algorithm should be "sha512WithRSAEncryption"
+          echo "sha512WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA384withRSA"
-          echo "SHA384withRSA" > expected
-          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm | tee actual
-          diff expected actual
+          # default signing algorithm should not exist
+          echo "ERROR: No such parameter: ca.subsystem.defaultSigningAlgorithm" > expected
+          docker exec pki pki-server ca-config-show ca.subsystem.defaultSigningAlgorithm \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+          diff expected stderr
 
       - name: Check SSL server cert
         run: |
           # inspect cert with certutil
           docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n sslserver | tee output
 
-          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
-          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
+          # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
+          echo "PKCS #1 SHA-512 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -203,15 +202,16 @@ jobs:
           docker exec pki pki-server cert-export sslserver --cert-file sslserver.crt
           docker exec pki openssl x509 -text -noout -in sslserver.crt | tee output
 
-          # signing algorithm should be "sha384WithRSAEncryption"
-          echo "sha384WithRSAEncryption" > expected
+          # signing algorithm should be "sha512WithRSAEncryption"
+          echo "sha512WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
-          # default signing algorithm should be "SHA384withRSA"
-          echo "SHA384withRSA" > expected
-          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm | tee actual
-          diff expected actual
+          # default signing algorithm should not exist
+          echo "ERROR: No such parameter: ca.sslserver.defaultSigningAlgorithm" > expected
+          docker exec pki pki-server ca-config-show ca.sslserver.defaultSigningAlgorithm \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+          diff expected stderr
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only
@@ -230,16 +230,16 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /root/.dogtag/nssdb -n caadmin | tee output
 
-          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
-          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
+          # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
+          echo "PKCS #1 SHA-512 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
           # inspect cert with openssl
           docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert | tee output
 
-          # signing algorithm should be "sha384WithRSAEncryption"
-          echo "sha384WithRSAEncryption" > expected
+          # signing algorithm should be "sha512WithRSAEncryption"
+          echo "sha512WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
@@ -251,16 +251,16 @@ jobs:
           # inspect cert with certutil
           docker exec pki certutil -L -d /root/.dogtag/nssdb -n sslserver | tee output
 
-          # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
-          echo "PKCS #1 SHA-384 With RSA Encryption" > expected
+          # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
+          echo "PKCS #1 SHA-512 With RSA Encryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 
           # inspect cert with openssl
           docker exec pki openssl x509 -text -noout -in sslserver.crt | tee output
 
-          # signing algorithm should be "sha384WithRSAEncryption"
-          echo "sha384WithRSAEncryption" > expected
+          # signing algorithm should be "sha512WithRSAEncryption"
+          echo "sha512WithRSAEncryption" > expected
           sed -n -e "s/\s*$//" -e "s/^\s*Signature Algorithm:\s*\(.*\)$/\1/p" output | uniq > actual
           diff expected actual
 

--- a/base/server/examples/installation/ca-ecc.cfg
+++ b/base/server/examples/installation/ca-ecc.cfg
@@ -9,7 +9,7 @@ pki_admin_password=Secret.123
 pki_admin_uid=caadmin
 pki_admin_key_type=ecc
 pki_admin_key_size=nistp521
-pki_admin_key_algorithm=SHA512withEC
+pki_admin_key_algorithm=SHA384withEC
 
 pki_client_pkcs12_password=Secret.123
 
@@ -21,28 +21,28 @@ pki_security_domain_name=EXAMPLE
 
 pki_ca_signing_nickname=ca_signing
 pki_ca_signing_key_type=ecc
-pki_ca_signing_key_algorithm=SHA512withEC
+pki_ca_signing_key_algorithm=SHA384withEC
 pki_ca_signing_key_size=nistp521
 pki_ca_signing_signing_algorithm=SHA512withEC
 
 pki_ocsp_signing_nickname=ca_ocsp_signing
 pki_ocsp_signing_key_type=ecc
-pki_ocsp_signing_key_algorithm=SHA512withEC
+pki_ocsp_signing_key_algorithm=SHA384withEC
 pki_ocsp_signing_key_size=nistp521
-pki_ocsp_signing_signing_algorithm=SHA512withEC
+pki_ocsp_signing_signing_algorithm=SHA384withEC
 
 pki_audit_signing_nickname=ca_audit_signing
 pki_audit_signing_key_type=ecc
-pki_audit_signing_key_algorithm=SHA512withEC
+pki_audit_signing_key_algorithm=SHA384withEC
 pki_audit_signing_key_size=nistp521
-pki_audit_signing_signing_algorithm=SHA512withEC
+pki_audit_signing_signing_algorithm=SHA384withEC
 
 pki_sslserver_nickname=sslserver
 pki_sslserver_key_type=ecc
-pki_sslserver_key_algorithm=SHA512withEC
+pki_sslserver_key_algorithm=SHA384withEC
 pki_sslserver_key_size=nistp521
 
 pki_subsystem_nickname=subsystem
 pki_subsystem_key_type=ecc
-pki_subsystem_key_algorithm=SHA512withEC
+pki_subsystem_key_algorithm=SHA384withEC
 pki_subsystem_key_size=nistp521

--- a/base/server/python/pki/server/cli/config.py
+++ b/base/server/python/pki/server/cli/config.py
@@ -186,6 +186,7 @@ class SubsystemConfigShowCLI(pki.cli.CLI):
 
         else:
             logger.error('No such parameter: %s', name)
+            sys.exit(1)
 
 
 class SubsystemConfigSetCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2200,9 +2200,6 @@ class PKIDeployer:
             tokenname = pki.nssdb.INTERNAL_TOKEN_NAME
         subsystem.config['%s.%s.tokenname' % (subsystem.name, tag)] = tokenname
 
-        subsystem.config['%s.%s.defaultSigningAlgorithm' % (subsystem.name, tag)] = \
-            self.mdict['pki_%s_key_algorithm' % cert_id]
-
         cert_data = nssdb.get_cert(
             nickname=nickname,
             token=self.mdict['pki_%s_token' % cert_id],
@@ -2243,7 +2240,13 @@ class PKIDeployer:
             nickname = self.mdict['pki_ca_signing_nickname']
             subsystem.config['ca.signing.cacertnickname'] = nickname
 
+            subsystem.config['ca.signing.defaultSigningAlgorithm'] = \
+                self.mdict['pki_ca_signing_signing_algorithm']
+
             self.update_system_cert(nssdb, subsystem, 'ocsp_signing')
+
+            subsystem.config['ca.ocsp_signing.defaultSigningAlgorithm'] = \
+                self.mdict['pki_ocsp_signing_signing_algorithm']
 
         if subsystem.name == 'kra':
             self.update_system_cert(nssdb, subsystem, 'storage')
@@ -2252,11 +2255,18 @@ class PKIDeployer:
 
         if subsystem.name == 'ocsp':
             self.update_system_cert(nssdb, subsystem, 'signing')
+
+            subsystem.config['ocsp.signing.defaultSigningAlgorithm'] = \
+                self.mdict['pki_ocsp_signing_signing_algorithm']
+
             self.update_admin_cert(subsystem)
 
         self.update_system_cert(nssdb, subsystem, 'sslserver')
         self.update_system_cert(nssdb, subsystem, 'subsystem')
         self.update_system_cert(nssdb, subsystem, 'audit_signing')
+
+        subsystem.config['%s.audit_signing.defaultSigningAlgorithm' % subsystem.name] = \
+            self.mdict['pki_audit_signing_signing_algorithm']
 
     def validate_system_certs(self, subsystem):
 


### PR DESCRIPTION
The `PKIDeployer.update_system_cert()` was incorrectly setting the default signing algorithm param in `CS.cfg` for all certs using the key algorithm param in `pkispawn` which could cause a problem if the key algorithm and signing algorithm are not the same.

The code has been modified to set the param properly using the signing algorithm param in `pkispawn` for CA/OCSP/audit signing certs only. This param is not used by other certs so it does not need to be set for those certs.

The `pki-server ca-config-show` CLI has been updated to return a non-zero code if the param being requested doesn't exist.

The tests have been updated to use different key and signing algorithms.

Resolves: https://github.com/dogtagpki/pki/issues/4518