### PR TITLE
Restore default value for pki_share_db

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -460,7 +460,7 @@ pki_ds_base_dn=o=%(pki_instance_name)s-KRA
 pki_ds_database=%(pki_instance_name)s-KRA
 pki_ds_hostname=%(pki_hostname)s
 pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
-pki_share_db=False
+pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 # Key ID generator: legacy, random
@@ -545,7 +545,7 @@ pki_ds_base_dn=o=%(pki_instance_name)s-OCSP
 pki_ds_database=%(pki_instance_name)s-OCSP
 pki_ds_hostname=%(pki_hostname)s
 pki_subsystem_name=OCSP %(pki_hostname)s %(pki_https_port)s
-pki_share_db=False
+pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 
@@ -577,7 +577,7 @@ pki_ds_base_dn=o=%(pki_instance_name)s-TKS
 pki_ds_database=%(pki_instance_name)s-TKS
 pki_ds_hostname=%(pki_hostname)s
 pki_subsystem_name=TKS %(pki_hostname)s %(pki_https_port)s
-pki_share_db=False
+pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 ###############################################################################
@@ -607,6 +607,6 @@ pki_kra_uri=https://%(pki_hostname)s:%(pki_https_port)s
 pki_tks_uri=https://%(pki_hostname)s:%(pki_https_port)s
 pki_enable_server_side_keygen=False
 pki_import_shared_secret=False
-pki_share_db=False
+pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 pki_source_phone_home_xml=/usr/share/pki/%(pki_subsystem_type)s/conf/phoneHome.xml


### PR DESCRIPTION
In commit 22a1b3dbbbf4003d50476a1bbf0629a5beae4405 the default values for `pki_share_db` for non-CA subsystems were changed to `False` since subsystems on separate instances will not share the same database user, but apparently it causes a problem during TPS installation with a shared instance.

To avoid changing the behavior, the default values have been restored to `True`. This param can still be overridden in `pkispawn` config as needed.

**Note:** There's a separate issue that causes token enrollment to fail, but the shared secret creation should work correctly now.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2228209
