### PR TITLE
For unknown certificates OCSP should have unknown CertStatus (part 2)

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -107,6 +107,7 @@ import com.netscape.certsrv.ca.CATypeException;
 import com.netscape.certsrv.ca.ECAException;
 import com.netscape.certsrv.ca.IssuerUnavailableException;
 import com.netscape.certsrv.cert.CertEnrollmentRequest;
+import com.netscape.certsrv.dbs.EDBRecordNotFoundException;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.logging.event.CRLSigningInfoEvent;
@@ -1557,25 +1558,27 @@ public class CertificateAuthority
          *    Otherwise, we move forward to generate and sign the
          *    aggregate OCSP response.
          */
-        CertificateAuthority ocspCA = this;
-        if (engine.getCAs().size() > 0 && tbsReq.getRequestCount() > 0) {
+        for (CertificateAuthority ocspCA: engine.getCAs()) {
             Request req = tbsReq.getRequestAt(0);
-            BigInteger serialNo = req.getCertID().getSerialNumber();
-
-            try {
-                CertificateRepository certificateRepository = engine.getCertificateRepository();
-                X509CertImpl cert = certificateRepository.getX509Certificate(serialNo);
-
-                X500Name certIssuerDN = (X500Name) cert.getIssuerDN();
-                ocspCA = engine.getCA(certIssuerDN);
-            } catch (EBaseException e) {
-                // If we don't know the issuer allow this CA to validate
-                // and report the CertStatus as Unknown
+            CertID cid = req.getCertID();
+            byte[] nameHash = null;
+            String digestName = cid.getDigestName();
+            if (digestName != null) {
+                try {
+                    MessageDigest md = MessageDigest.getInstance(digestName);
+                    nameHash = md.digest(ocspCA.getSubjectObj().getX500Name().getEncoded());
+                } catch (NoSuchAlgorithmException | IOException e) {
+                    logger.info("CertificateAuthority: OCSP request hash algorithm " + digestName + " not recognised - ");
+                }
+            }
+            if(Arrays.equals(nameHash, cid.getIssuerNameHash().toByteArray())) {
+                if(ocspCA != this) {
+                    return ((IOCSPService) ocspCA).validate(request);
+                }
+                break;
             }
         }
 
-        if (ocspCA != this)
-            return ((IOCSPService) ocspCA).validate(request);
 
         logger.debug("CertificateAuthority: validating OCSP request");
 
@@ -1734,10 +1737,13 @@ public class CertificateAuthority
         }
     }
 
-    private SingleResponse processRequest(Request req) {
+    public SingleResponse processRequest(Request req) {
 
         CAEngine engine = CAEngine.getInstance();
         CertificateRepository certificateRepository = engine.getCertificateRepository();
+
+        X509CertImpl caCert = mSigningUnit.getCertImpl();
+        X509Key key = (X509Key) caCert.getPublicKey();
 
         CertID cid = req.getCertID();
         INTEGER serialNo = cid.getSerialNumber();
@@ -1747,15 +1753,18 @@ public class CertificateAuthority
         GeneralizedTime thisUpdate = new GeneralizedTime(new Date());
 
         byte[] nameHash = null;
+        byte[] keyHash = null;
         String digestName = cid.getDigestName();
         if (digestName != null) {
             try {
                 MessageDigest md = MessageDigest.getInstance(digestName);
                 nameHash = md.digest(mName.getEncoded());
+                keyHash = md.digest(key.getKey());
             } catch (NoSuchAlgorithmException | IOException e) {
             }
         }
-        if (!Arrays.equals(cid.getIssuerNameHash().toByteArray(), nameHash)) {
+        if (!Arrays.equals(cid.getIssuerNameHash().toByteArray(), nameHash) ||
+                !Arrays.equals(cid.getIssuerKeyHash().toByteArray(), keyHash)) {
             // issuer of cert is not this CA (or we couldn't work
             // out whether it is or not due to unknown hash alg);
             // do not return status information for this cert
@@ -1834,9 +1843,12 @@ public class CertificateAuthority
             } else {
                 certStatus = new UnknownInfo();
             }
-        } catch (Exception e) {
+        } catch (EDBRecordNotFoundException e) {
             // not found
-            certStatus = new UnknownInfo(); // not issued not all
+            certStatus = new GoodInfo(); // not issued not all
+        } catch (EBaseException e) {
+            // internal error
+            certStatus = new UnknownInfo();
         }
 
         return new SingleResponse(


### PR DESCRIPTION
The CA's internal OCSP fails to handle certs issued by an unknown CA.
There is code in the CA's validation to handle that scenario but that
validation is never triggered as the request handling code that wraps it
considers not knowing the origin CA to be an error condition.

The code is changed to allow the validating CA to proceed even if the
origin CA is unknown, reporting Unknown for the CertStatus, while
delegating to the origin CA if it is found.

This finishes what was started with #4532 