### PR TITLE
Add test for subordinate CA clone

### DIFF
--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -112,6 +112,13 @@ jobs:
     with:
       db-image: ${{ needs.init.outputs.db-image }}
 
+  subca-clone-test:
+    name: Sub-CA clone
+    needs: [init, build]
+    uses: ./.github/workflows/subca-clone-test.yml
+    with:
+      db-image: ${{ needs.init.outputs.db-image }}
+
   scep-test:
     name: SCEP responder
     needs: [init, build]

--- a/.github/workflows/subca-clone-test.yml
+++ b/.github/workflows/subca-clone-test.yml
@@ -1,0 +1,307 @@
+name: Sub-CA clone
+# docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
+# https://github.com/dogtagpki/pki/blob/master/docs/installation/ca/Installing_CA_Clone.md
+
+on:
+  workflow_call:
+    inputs:
+      db-image:
+        required: false
+        type: string
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v3
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up root CA container
+        run: |
+          tests/bin/runner-init.sh root-ca
+        env:
+          HOSTNAME: root-ca.example.com
+
+      - name: Connect root CA container to network
+        run: docker network connect example root-ca --alias root-ca.example.com
+
+      - name: Create root CA in NSS database
+        run: |
+          docker exec root-ca pki nss-cert-request \
+              --subject "CN=Root CA Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr $SHARED/root-ca_signing.csr
+          docker exec root-ca pki nss-cert-issue \
+              --csr $SHARED/root-ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert $SHARED/root-ca_signing.crt
+          docker exec root-ca pki nss-cert-import \
+              --cert $SHARED/root-ca_signing.crt \
+              --trust CT,C,C \
+              root-ca_signing
+
+      - name: Set up primary DS container
+        run: |
+          tests/bin/ds-container-create.sh primary-ds
+        env:
+          IMAGE: ${{ inputs.db-image }}
+          HOSTNAME: primary-ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect primary DS container to network
+        run: docker network connect example primary-ds --alias primary-ds.example.com
+
+      - name: Set up primary sub-CA container
+        run: |
+          tests/bin/runner-init.sh primary-subca
+        env:
+          HOSTNAME: primary-subca.example.com
+
+      - name: Connect primary sub-CA container to network
+        run: docker network connect example primary-subca --alias primary-subca.example.com
+
+      - name: Install primary sub-CA (step 1)
+        run: |
+          docker exec primary-subca pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://primary-ds.example.com:3389 \
+              -D pki_ca_signing_csr_path=$SHARED/subca_signing.csr \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -D pki_client_admin_cert_p12=$SHARED/caadmin.p12 \
+              -v
+
+      - name: Issue primary sub-CA signing cert
+        run: |
+          docker exec root-ca pki nss-cert-issue \
+              --issuer root-ca_signing \
+              --csr $SHARED/subca_signing.csr \
+              --ext /usr/share/pki/server/certs/subca_signing.conf \
+              --cert $SHARED/subca_signing.crt
+
+      - name: Install primary sub-CA (step 2)
+        run: |
+          docker exec primary-subca pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca-external-cert-step2.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://primary-ds.example.com:3389 \
+              -D pki_cert_chain_path=${SHARED}/root-ca_signing.crt \
+              -D pki_ca_signing_csr_path=$SHARED/subca_signing.csr \
+              -D pki_ca_signing_cert_path=$SHARED/subca_signing.crt \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -D pki_client_admin_cert_p12=$SHARED/caadmin.p12 \
+              -v
+
+          docker exec primary-subca pki-server cert-find
+
+      - name: Run PKI healthcheck
+        run: docker exec primary-subca pki-healthcheck --failures-only
+
+      - name: Check primary sub-CA admin
+        run: |
+          docker exec primary-subca pki client-cert-import \
+              --ca-cert $SHARED/root-ca_signing.crt \
+              root-ca_signing
+          docker exec primary-subca pki pkcs12-import \
+              --pkcs12 $SHARED/caadmin.p12 \
+              --pkcs12-password Secret.123
+          docker exec primary-subca pki -n caadmin ca-user-show caadmin
+
+      - name: Export primary sub-CA certs
+        run: |
+          docker exec primary-subca pki-server ca-clone-prepare \
+              --pkcs12-file ${SHARED}/subca-certs.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Set up secondary DS container
+        run: |
+          tests/bin/ds-container-create.sh secondary-ds
+        env:
+          IMAGE: ${{ inputs.db-image }}
+          HOSTNAME: secondary-ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect secondary DS container to network
+        run: docker network connect example secondary-ds --alias secondary-ds.example.com
+
+      - name: Set up secondary sub-CA container
+        run: |
+          tests/bin/runner-init.sh secondary-subca
+        env:
+          HOSTNAME: secondary-subca.example.com
+
+      - name: Connect secondary sub-CA container to network
+        run: docker network connect example secondary-subca --alias secondary-subca.example.com
+
+      - name: Install secondary sub-CA
+        run: |
+          # get CS.cfg from primary sub-CA before cloning
+          docker cp primary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+
+          docker exec secondary-subca pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
+              -s CA \
+              -D pki_cert_chain_path=${SHARED}/root-ca_signing.crt \
+              -D pki_security_domain_hostname=primary-subca.example.com \
+              -D pki_clone_pkcs12_path=${SHARED}/subca-certs.p12 \
+              -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_ds_url=ldap://secondary-ds.example.com:3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -D pki_clone_uri=https://primary-subca.example.com:8443 \
+              -v
+
+          docker exec secondary-subca pki-server cert-find
+
+      - name: Check CS.cfg in primary sub-CA after cloning
+        run: |
+          # get CS.cfg from primary sub-CA after cloning
+          docker cp primary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - set dbs.enableSerialManagement to true (automatically enabled when cloned)
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e 's/^\(dbs.enableSerialManagement\)=.*$/\1=true/' \
+              CS.cfg.primary \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.primary.after \
+              | sort > actual
+
+          diff expected actual
+
+      - name: Check CS.cfg in secondary sub-CA
+        run: |
+          # get CS.cfg from secondary sub-CA
+          docker cp secondary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - replace primary-subca.example.com with secondary-subca.example.com
+          # - replace primary-ds.example.com with secondary-ds.example.com
+          # - set ca.crl.MasterCRL.enableCRLCache to false (automatically disabled in the clone)
+          # - set ca.crl.MasterCRL.enableCRLUpdates to false (automatically disabled in the clone)
+          # - add params for the clone
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              -e 's/primary-subca.example.com/secondary-subca.example.com/' \
+              -e 's/primary-ds.example.com/secondary-ds.example.com/' \
+              -e 's/^\(ca.crl.MasterCRL.enableCRLCache\)=.*$/\1=false/' \
+              -e 's/^\(ca.crl.MasterCRL.enableCRLUpdates\)=.*$/\1=false/' \
+              -e '$ a ca.certStatusUpdateInterval=0' \
+              -e '$ a ca.listenToCloneModifications=false' \
+              -e '$ a master.ca.agent.host=primary-subca.example.com' \
+              -e '$ a master.ca.agent.port=8443' \
+              CS.cfg.primary.after \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          # - change hierarchy.select from Root to Subordinate (TODO: fix this)
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^ca.sslserver.cert=/d' \
+              -e '/^ca.sslserver.certreq=/d' \
+              -e 's/^\(hierarchy.select\)=.*$/\1=Subordinate/' \
+              CS.cfg.secondary \
+              | sort > actual
+
+          diff expected actual
+
+      - name: Run PKI healthcheck
+        run: docker exec secondary-subca pki-healthcheck --failures-only
+
+      - name: Check secondary sub-CA admin
+        run: |
+          docker exec secondary-subca pki client-cert-import \
+              --ca-cert $SHARED/root-ca_signing.crt \
+              root-ca_signing
+          docker exec secondary-subca pki pkcs12-import \
+              --pkcs12 $SHARED/caadmin.p12 \
+              --pkcs12-password Secret.123
+          docker exec secondary-subca pki -n caadmin ca-user-show caadmin
+
+      - name: Check users in primary sub-CA and secondary sub-CA
+        run: |
+          docker exec primary-subca pki -n caadmin ca-user-find | tee subca-users.primary
+          docker exec secondary-subca pki -n caadmin ca-user-find > subca-users.secondary
+
+          diff subca-users.primary subca-users.secondary
+
+      - name: Check certs in primary sub-CA and secondary sub-CA
+        run: |
+          docker exec primary-subca pki ca-cert-find | tee subca-certs.primary
+          docker exec secondary-subca pki ca-cert-find > subca-certs.secondary
+
+          diff subca-certs.primary subca-certs.secondary
+
+      - name: Gather artifacts from primary sub-CA
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki primary-ds
+          tests/bin/pki-artifacts-save.sh primary-subca
+        continue-on-error: true
+
+      - name: Gather artifacts from secondary sub-CA
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki secondary-ds
+          tests/bin/pki-artifacts-save.sh secondary-subca
+        continue-on-error: true
+
+      - name: Remove secondary sub-CA
+        run: docker exec secondary-subca pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Remove primary sub-CA
+        run: docker exec primary-subca pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts from primary sub-CA
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: subca-clone-primary
+          path: |
+            /tmp/artifacts/primary-subca
+
+      - name: Upload artifacts from secondary sub-CA
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: subca-clone-secondary
+          path: |
+            /tmp/artifacts/secondary-subca


### PR DESCRIPTION
A new test has been added to test installing a subordinate CA (using external CA method) then clone it into another instance. The test will also compare the `CS.cfg`, the users, and the certs in these instances to ensure that they are (mostly) identical.

The `hierarchy.select` param is incorrectly set as `Root` instead of `Subordinate` in the clone. This will be addressed separately later.