### PR TITLE
Bug2221818-ocsp-unknownCA-addendum

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CASigningUnit.java
+++ b/base/ca/src/main/java/com/netscape/ca/CASigningUnit.java
@@ -174,7 +174,7 @@ public final class CASigningUnit extends SigningUnit {
         }
         */
 
-        logger.info("CASigningUnit: Signing Certificate");
+        logger.info("CASigningUnit: Signing ...");
 
         boolean testSignatureFailure = mConfig.getBoolean("testSignatureFailure", false);
         if (testSignatureFailure) {

--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -1739,6 +1739,7 @@ public class CertificateAuthority
 
     public SingleResponse processRequest(Request req) {
 
+        String name = "CertificateAuthority: processRequest: ";
         CAEngine engine = CAEngine.getInstance();
         CertificateRepository certificateRepository = engine.getCertificateRepository();
 
@@ -1747,7 +1748,7 @@ public class CertificateAuthority
 
         CertID cid = req.getCertID();
         INTEGER serialNo = cid.getSerialNumber();
-        logger.debug("CertificateAuthority: processing request for cert 0x" + serialNo.toString(16));
+        logger.debug( name + "for cert 0x" + serialNo.toString(16));
 
         CertStatus certStatus = null;
         GeneralizedTime thisUpdate = new GeneralizedTime(new Date());
@@ -1844,10 +1845,15 @@ public class CertificateAuthority
                 certStatus = new UnknownInfo();
             }
         } catch (EDBRecordNotFoundException e) {
-            // not found
-            certStatus = new GoodInfo(); // not issued not all
+            logger.debug(name + "cert record not found");
+            certStatus = new UnknownInfo(); // not issued by this CA
         } catch (EBaseException e) {
             // internal error
+            logger.debug(name + e.toString());
+            certStatus = new UnknownInfo();
+        } catch (Exception e) {
+            // safety net
+            logger.debug(name + e.toString());
             certStatus = new UnknownInfo();
         }
 

--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -1847,13 +1847,9 @@ public class CertificateAuthority
         } catch (EDBRecordNotFoundException e) {
             logger.debug(name + "cert record not found");
             certStatus = new UnknownInfo(); // not issued by this CA
-        } catch (EBaseException e) {
-            // internal error
-            logger.debug(name + e.toString());
-            certStatus = new UnknownInfo();
         } catch (Exception e) {
-            // safety net
-            logger.debug(name + e.toString());
+            // internal error
+            logger.debug(name + "failed on certificateRepository.readCertificateRecord " + e.toString());
             certStatus = new UnknownInfo();
         }
 


### PR DESCRIPTION
a couple things:
- respond with Unknown when CA can't find cert in its db
- added safety net Exception to return Unknown
- minor debug message when CA signs an object that's not a cert

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2221818