### PR TITLE
Remove hierarchy.select param

### DIFF
--- a/.github/workflows/subca-clone-test.yml
+++ b/.github/workflows/subca-clone-test.yml
@@ -229,7 +229,6 @@ jobs:
 
           # normalize actual result:
           # - remove params that cannot be compared
-          # - change hierarchy.select from Root to Subordinate (TODO: fix this)
           sed -e '/^installDate=/d' \
               -e '/^dbs.beginReplicaNumber=/d' \
               -e '/^dbs.endReplicaNumber=/d' \
@@ -237,7 +236,6 @@ jobs:
               -e '/^dbs.nextEndReplicaNumber=/d' \
               -e '/^ca.sslserver.cert=/d' \
               -e '/^ca.sslserver.certreq=/d' \
-              -e 's/^\(hierarchy.select\)=.*$/\1=Subordinate/' \
               CS.cfg.secondary \
               | sort > actual
 

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -174,7 +174,7 @@ class PKIServerCLI(pki.cli.CLI):
             print()
             print('  CA Subsystem:')
 
-            subsystem_type = ca.config['hierarchy.select'] + ' CA'
+            subsystem_type = 'CA'
             if ca.config['securitydomain.select'] == 'new':
                 subsystem_type += ' (Security Domain)'
             print('    Type:                %s' % subsystem_type)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1078,11 +1078,6 @@ class PKIDeployer:
         # configure CA
         if subsystem.type == 'CA':
 
-            if external or subordinate:
-                subsystem.config['hierarchy.select'] = 'Subordinate'
-            else:
-                subsystem.config['hierarchy.select'] = 'Root'
-
             if subordinate:
                 subsystem.config['preop.cert.signing.type'] = 'remote'
                 subsystem.config['preop.cert.signing.profile'] = 'caInstallCACert'

--- a/base/server/upgrade/11.5.0/01-RemoveUnusedParams.py
+++ b/base/server/upgrade/11.5.0/01-RemoveUnusedParams.py
@@ -26,4 +26,8 @@ class RemoveUnusedParams(pki.server.upgrade.PKIServerUpgradeScriptlet):
         logger.info('Removing subsystem.select')
         subsystem.config.pop('subsystem.select', None)
 
+        # remove hierarchy.select param
+        logger.info('Removing hierarchy.select')
+        subsystem.config.pop('hierarchy.select', None)
+
         subsystem.save()


### PR DESCRIPTION
The `hierarchy.select` param stores a static information about the CA hierarchy (root vs. subordinate) which was set during installation but there is no process to update it in case the CA is converted from root to subordinate or vice versa. Also, the param is incorrectly set to root when cloning a subordinate CA.

Because of these issues the param is unreliable, so it has been removed from new and existing instances. The `pki-server status` CLI has also been updated to no longer show the CA hierarchy.

If necessary, the CA hierarchy can be determined by checking the CA signing cert. If it is self-signed that means it is a root CA.