### PR TITLE
Fix servlet name for GetApprovalStatus

### DIFF
--- a/base/kra/src/main/java/com/netscape/cms/servlet/key/GetApprovalStatus.java
+++ b/base/kra/src/main/java/com/netscape/cms/servlet/key/GetApprovalStatus.java
@@ -52,7 +52,7 @@ import com.netscape.kra.KeyRecoveryAuthority;
  * Check to see if a Key Recovery Request has been approved
  */
 @WebServlet(
-        name = "kraGenerateKeyPair",
+        name = "kraKRAGetApprovalStatus",
         urlPatterns = "/agent/kra/getApprovalStatus",
         initParams = {
                 @WebInitParam(name="GetClientCert", value="true"),


### PR DESCRIPTION
In commit f91fc5c1ba8ff549f54c631db1c0e83ac5f01cb6 the `GetApprovalStatus` was updated to use `@WebServlet` (PR #4479) but the servlet name was not set correctly and conflicted with `GenerateKeyPairServlet` which was causing a problem for TPS token enrollment with server-side key generation, but for some reason the CI did not fail until recently.

Now the servlet name has been fixed so the problem should no longer happen.