### PR TITLE
Move pki nss-cert-find --cert option to pki nss-cert-show

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertFindCLI.java
@@ -5,29 +5,15 @@
 //
 package com.netscape.cmstools.nss;
 
-import java.io.ByteArrayInputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
 import org.dogtagpki.cli.CommandCLI;
-import org.mozilla.jss.CryptoManager;
-import org.mozilla.jss.asn1.ASN1Util;
-import org.mozilla.jss.asn1.INTEGER;
 import org.mozilla.jss.crypto.CryptoStore;
 import org.mozilla.jss.crypto.CryptoToken;
-import org.mozilla.jss.crypto.ObjectNotFoundException;
 import org.mozilla.jss.crypto.X509Certificate;
-import org.mozilla.jss.netscape.security.util.Cert;
-import org.mozilla.jss.pkix.cert.Certificate;
-import org.mozilla.jss.pkix.cert.CertificateInfo;
-import org.mozilla.jss.pkix.primitive.Name;
 
-import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
@@ -45,43 +31,6 @@ public class NSSCertFindCLI extends CommandCLI {
         formatter.printHelp(getFullName() + " [OPTIONS...]", options);
     }
 
-    @Override
-    public void createOptions() {
-        Option option = new Option(null, "cert", true, "Certificate to find");
-        option.setArgName("path");
-        options.addOption(option);
-
-        option = new Option(null, "format", true, "Certificate format: PEM (default), DER");
-        option.setArgName("format");
-        options.addOption(option);
-    }
-
-    public X509Certificate findCertByDERCert(byte[] derCert) throws Exception {
-
-        Certificate pkixCert;
-        try (ByteArrayInputStream is = new ByteArrayInputStream(derCert)) {
-            pkixCert = (Certificate) Certificate.getTemplate().decode(is);
-        }
-
-        CertificateInfo certInfo = pkixCert.getInfo();
-        Name issuer = certInfo.getIssuer();
-        INTEGER serialNumber = certInfo.getSerialNumber();
-
-        logger.info("Searching for cert with:");
-        logger.info("- issuer: " + issuer.getRFC1485());
-        logger.info("- serial number: " + new CertId(serialNumber).toHexString());
-
-        CryptoManager cm = CryptoManager.getInstance();
-
-        // CryptoManager doesn't have a method that calls CERT_FindCertByDERCert()
-        // in NSS so for now just use findCertByIssuerAndSerialNumber().
-        // TODO: Add CryptoManager.findCertByDERCert() to call CERT_FindCertByDERCert().
-
-        return cm.findCertByIssuerAndSerialNumber(
-                ASN1Util.encode(issuer),
-                serialNumber);
-    }
-
     public Collection<X509Certificate> findAllCerts() throws Exception {
 
         logger.info("Searching for all certs");
@@ -95,45 +44,12 @@ public class NSSCertFindCLI extends CommandCLI {
     @Override
     public void execute(CommandLine cmd) throws Exception {
 
-        String filename = cmd.getOptionValue("cert");
-        String format = cmd.getOptionValue("format");
-
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
 
-        Collection<X509Certificate> certs;
-
-        if (filename != null) {
-
-            // load cert from file
-            byte[] bytes = Files.readAllBytes(Paths.get(filename));
-
-            if (format == null || "PEM".equalsIgnoreCase(format)) {
-                bytes = Cert.parseCertificate(new String(bytes));
-
-            } else if ("DER".equalsIgnoreCase(format)) {
-                // nothing to do
-
-            } else {
-                throw new Exception("Unsupported format: " + format);
-            }
-
-            certs = new ArrayList<>();
-            try {
-                X509Certificate x509cert = findCertByDERCert(bytes);
-                certs.add(x509cert);
-
-            } catch (ObjectNotFoundException e) {
-                logger.info("Cert not found");
-            }
-
-        } else {
-            certs = findAllCerts();
-        }
-
         boolean first = true;
 
-        for (X509Certificate cert : certs) {
+        for (X509Certificate cert : findAllCerts()) {
 
             if (first) {
                 first = false;

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertShowCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertShowCLI.java
@@ -5,11 +5,25 @@
 //
 package com.netscape.cmstools.nss;
 
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.cli.CommandCLI;
 import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.asn1.ASN1Util;
+import org.mozilla.jss.asn1.INTEGER;
+import org.mozilla.jss.crypto.ObjectNotFoundException;
 import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.netscape.security.util.Cert;
+import org.mozilla.jss.pkix.cert.Certificate;
+import org.mozilla.jss.pkix.cert.CertificateInfo;
+import org.mozilla.jss.pkix.primitive.Name;
 
+import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.cmstools.cli.MainCLI;
 
 public class NSSCertShowCLI extends CommandCLI {
@@ -22,26 +36,104 @@ public class NSSCertShowCLI extends CommandCLI {
 
     @Override
     public void printHelp() {
-        formatter.printHelp(getFullName() + " [OPTIONS...] <nickname>", options);
+        formatter.printHelp(getFullName() + " [OPTIONS...] [nickname]", options);
+    }
+
+    @Override
+    public void createOptions() {
+        Option option = new Option(null, "cert-file", true, "Certificate to show");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "cert-format", true, "Certificate format: PEM (default), DER");
+        option.setArgName("format");
+        options.addOption(option);
+    }
+
+    public X509Certificate findCertByNickname(String nickname) throws Exception {
+
+        logger.info("Searching for cert " + nickname);
+
+        try {
+            CryptoManager cm = CryptoManager.getInstance();
+            return cm.findCertByNickname(nickname);
+
+        } catch (ObjectNotFoundException e) {
+            throw new CLIException("Certificate not found: " + nickname);
+        }
+    }
+
+    public X509Certificate findCertByCertFile(String certFile, String certFormat) throws Exception {
+
+        logger.info("Loading cert from " + certFile);
+
+        byte[] bytes = Files.readAllBytes(Paths.get(certFile));
+
+        if ("PEM".equalsIgnoreCase(certFormat)) {
+            bytes = Cert.parseCertificate(new String(bytes));
+
+        } else if ("DER".equalsIgnoreCase(certFormat)) {
+            // nothing to do
+
+        } else {
+            throw new CLIException("Unsupported certificate format: " + certFormat);
+        }
+
+        Certificate pkixCert;
+        try (ByteArrayInputStream is = new ByteArrayInputStream(bytes)) {
+            pkixCert = (Certificate) Certificate.getTemplate().decode(is);
+        }
+
+        CertificateInfo certInfo = pkixCert.getInfo();
+        Name issuer = certInfo.getIssuer();
+        INTEGER serialNumber = certInfo.getSerialNumber();
+
+        logger.info("Searching for cert with:");
+        logger.info("- issuer: " + issuer.getRFC1485());
+        logger.info("- serial number: " + new CertId(serialNumber).toHexString());
+
+        // CryptoManager doesn't have a method that calls CERT_FindCertByDERCert()
+        // in NSS so for now just use findCertByIssuerAndSerialNumber().
+        // TODO: Add CryptoManager.findCertByDERCert() to call CERT_FindCertByDERCert().
+
+        try {
+            CryptoManager cm = CryptoManager.getInstance();
+            return cm.findCertByIssuerAndSerialNumber(
+                    ASN1Util.encode(issuer),
+                    serialNumber);
+
+        } catch (ObjectNotFoundException e) {
+            throw new CLIException("Certificate not found");
+        }
     }
 
     @Override
     public void execute(CommandLine cmd) throws Exception {
 
+        String certFile = cmd.getOptionValue("cert-file");
+        String certFormat = cmd.getOptionValue("cert-format", "PEM");
+
         String[] cmdArgs = cmd.getArgs();
         String nickname = null;
 
-        if (cmdArgs.length < 1) {
-            throw new Exception("Missing certificate nickname");
+        if (cmdArgs.length >= 1) {
+            nickname = cmdArgs[0];
         }
-
-        nickname = cmdArgs[0];
 
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
 
-        CryptoManager cm = CryptoManager.getInstance();
-        X509Certificate cert = cm.findCertByNickname(nickname);
+        X509Certificate cert;
+
+        if (certFile != null) {
+            cert = findCertByCertFile(certFile, certFormat);
+
+        } else if (nickname != null) {
+            cert = findCertByNickname(nickname);
+
+        } else {
+            throw new CLIException("Missing certificate nickname or certificate file");
+        }
 
         NSSCertCLI.printCertInfo(cert);
     }


### PR DESCRIPTION
The `pki nss-cert-find --cert` option has been moved into `pki nss-cert-show` (and renamed to `--cert-file`) since it can only find a single cert instead of a collection. If the cert is not found the command will return a non-zero code, so it will be easier to use for automation.