### PR TITLE
Add pki-server ca-crl-* commands

### DIFF
--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -2378,6 +2378,27 @@ class CASubsystem(PKISubsystem):
             subsystem_number = m.group(1)
             self.config['subsystem.%s.enabled' % subsystem_number] = 'false'
 
+    def get_crl_config(self):
+
+        config = {}
+
+        # find ca.crl.* params
+        pattern = re.compile(r'^ca.crl\.([^\.]*)$')
+
+        for key, value in self.config.items():
+
+            m = pattern.match(key)
+            if not m:
+                continue
+
+            name = m.group(1)
+            if name.startswith('_'):
+                continue
+
+            config[name] = value
+
+        return config
+
 
 class KRASubsystem(PKISubsystem):
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -2399,6 +2399,42 @@ class CASubsystem(PKISubsystem):
 
         return config
 
+    def find_crl_issuing_point_ids(self):
+
+        ids = []
+
+        # find ca.crl.<id>.class params
+        pattern = re.compile(r'^ca.crl\.([^\.]*)\.class$')
+
+        for key in self.config.keys():
+
+            m = pattern.match(key)
+            if not m:
+                continue
+
+            ip_id = m.group(1)
+            ids.append(ip_id)
+
+        return ids
+
+    def get_crl_issuing_point_config(self, ip_id):
+
+        config = {}
+
+        # find ca.crl.<id>.* params
+        pattern = re.compile(r'^ca.crl\.%s\.([^\.]*)' % ip_id)
+
+        for key, value in self.config.items():
+
+            m = pattern.match(key)
+            if not m:
+                continue
+
+            name = m.group(1)
+            config[name] = value
+
+        return config
+
 
 class KRASubsystem(PKISubsystem):
 


### PR DESCRIPTION
The `pki-server ca-crl-show` command has been added to make it easier to inspect CRL configuration.

The `pki-server ca-crl-ip-find/show` commands have been added to make it easier to inspect CRL issuing point configuration.

https://github.com/dogtagpki/pki/wiki/PKI-Server-CA-CRL-CLI