### PR TITLE
Add pki nss-cert-show --output-format option

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertCLI.java
@@ -24,20 +24,34 @@ public class NSSCertCLI extends CLI {
         addModule(new NSSCertShowCLI(this));
     }
 
-    public static void printCertInfo(X509Certificate cert) throws Exception {
+    public static NSSCertInfo createCertInfo(X509Certificate cert) throws Exception {
 
-        System.out.println("  Nickname: " + cert.getNickname());
+        NSSCertInfo certInfo = new NSSCertInfo();
 
-        CertId serialNumber = new CertId(cert.getSerialNumber());
-        System.out.println("  Serial Number: " + serialNumber.toHexString());
+        certInfo.setNickname(cert.getNickname());
+        certInfo.setSerialNumber(new CertId(cert.getSerialNumber()));
 
-        System.out.println("  Subject DN: " + cert.getSubjectDN());
-        System.out.println("  Issuer DN: " + cert.getIssuerDN());
+        certInfo.setSubjectDN(cert.getSubjectDN().toString());
+        certInfo.setIssuerDN(cert.getIssuerDN().toString());
 
         PK11Cert pk11Cert = (PK11Cert) cert;
-        System.out.println("  Not Valid Before: " + pk11Cert.getNotBefore());
-        System.out.println("  Not Valid After: " + pk11Cert.getNotAfter());
 
-        System.out.println("  Trust Flags: " + pk11Cert.getTrustFlags());
+        certInfo.setNotBefore(pk11Cert.getNotBefore());
+        certInfo.setNotAfter(pk11Cert.getNotAfter());
+
+        certInfo.setTrustFlags(pk11Cert.getTrustFlags());
+
+        return certInfo;
+    }
+
+    public static void printCertInfo(NSSCertInfo cert) throws Exception {
+
+        System.out.println("  Nickname: " + cert.getNickname());
+        System.out.println("  Serial Number: " + cert.getSerialNumber().toHexString());
+        System.out.println("  Subject DN: " + cert.getSubjectDN());
+        System.out.println("  Issuer DN: " + cert.getIssuerDN());
+        System.out.println("  Not Valid Before: " + cert.getNotBefore());
+        System.out.println("  Not Valid After: " + cert.getNotAfter());
+        System.out.println("  Trust Flags: " + cert.getTrustFlags());
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertFindCLI.java
@@ -57,7 +57,8 @@ public class NSSCertFindCLI extends CommandCLI {
                 System.out.println();
             }
 
-            NSSCertCLI.printCertInfo(cert);
+            NSSCertInfo certInfo = NSSCertCLI.createCertInfo(cert);
+            NSSCertCLI.printCertInfo(certInfo);
         }
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertInfo.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertInfo.java
@@ -1,0 +1,112 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import java.util.Date;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.netscape.certsrv.dbs.certdb.CertId;
+import com.netscape.certsrv.util.JSONSerializer;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class NSSCertInfo implements JSONSerializer {
+
+    String nickname;
+    CertId serialNumber;
+    String subjectDN;
+    String issuerDN;
+    Date notBefore;
+    Date notAfter;
+    String trustFlags;
+
+    @JsonProperty
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    @JsonProperty
+    public CertId getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(CertId serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+    @JsonProperty
+    public String getSubjectDN() {
+        return subjectDN;
+    }
+
+    public void setSubjectDN(String subjectDN) {
+        this.subjectDN = subjectDN;
+    }
+
+    @JsonProperty
+    public String getIssuerDN() {
+        return issuerDN;
+    }
+
+    public void setIssuerDN(String issuerDN) {
+        this.issuerDN = issuerDN;
+    }
+
+    @JsonProperty
+    public Date getNotBefore() {
+        return notBefore;
+    }
+
+    public void setNotBefore(Date notBefore) {
+        this.notBefore = notBefore;
+    }
+
+    @JsonProperty
+    public Date getNotAfter() {
+        return notAfter;
+    }
+
+    public void setNotAfter(Date notAfter) {
+        this.notAfter = notAfter;
+    }
+
+    @JsonProperty
+    public String getTrustFlags() {
+        return trustFlags;
+    }
+
+    public void setTrustFlags(String type) {
+        this.trustFlags = type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(issuerDN, nickname, notAfter, notBefore, serialNumber, subjectDN, trustFlags);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        NSSCertInfo other = (NSSCertInfo) obj;
+        return Objects.equals(issuerDN, other.issuerDN) && Objects.equals(nickname, other.nickname)
+                && Objects.equals(notAfter, other.notAfter) && Objects.equals(notBefore, other.notBefore)
+                && Objects.equals(serialNumber, other.serialNumber) && Objects.equals(subjectDN, other.subjectDN)
+                && Objects.equals(trustFlags, other.trustFlags);
+    }
+}

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertShowCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertShowCLI.java
@@ -48,6 +48,10 @@ public class NSSCertShowCLI extends CommandCLI {
         option = new Option(null, "cert-format", true, "Certificate format: PEM (default), DER");
         option.setArgName("format");
         options.addOption(option);
+
+        option = new Option(null, "output-format", true, "Output format: text (default), json");
+        option.setArgName("format");
+        options.addOption(option);
     }
 
     public X509Certificate findCertByNickname(String nickname) throws Exception {
@@ -112,6 +116,7 @@ public class NSSCertShowCLI extends CommandCLI {
 
         String certFile = cmd.getOptionValue("cert-file");
         String certFormat = cmd.getOptionValue("cert-format", "PEM");
+        String outputFormat = cmd.getOptionValue("output-format", "text");
 
         String[] cmdArgs = cmd.getArgs();
         String nickname = null;
@@ -135,6 +140,16 @@ public class NSSCertShowCLI extends CommandCLI {
             throw new CLIException("Missing certificate nickname or certificate file");
         }
 
-        NSSCertCLI.printCertInfo(cert);
+        NSSCertInfo certInfo = NSSCertCLI.createCertInfo(cert);
+
+        if ("json".equalsIgnoreCase(outputFormat)) {
+            System.out.println(certInfo.toJSON());
+
+        } else if ("text".equalsIgnoreCase(outputFormat)) {
+            NSSCertCLI.printCertInfo(certInfo);
+
+        } else {
+            throw new CLIException("Unsupported output format: " + outputFormat);
+        }
     }
 }


### PR DESCRIPTION
The `pki nss-cert-show` has been modified to provide an option to return the cert info in JSON format to make it easier to parse using other tools/languages.

The `NSSCertInfo` has been added to define the mapping between POJO and JSON.

https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-CLI