### PR TITLE
Add pki-server ca-crl-ip-mod

### DIFF
--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -83,7 +83,7 @@ jobs:
           docker exec pki pki-server ca-config-set ca.certStatusUpdateInterval 60
 
           # update CRL immediately after each cert revocation
-          docker exec pki pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
+          docker exec pki pki-server ca-crl-ip-mod -D alwaysUpdate=true MasterCRL
 
       - name: Restart CA subsystem
         run: |

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -97,7 +97,7 @@ jobs:
           docker exec pki pki-server ca-config-set auths.revocationChecking.bufferSize 0
 
           # update CRL immediately after each cert revocation
-          docker exec pki pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
+          docker exec pki pki-server ca-crl-ip-mod -D alwaysUpdate=true MasterCRL
 
           # restart CA subsystem
           docker exec pki pki-server ca-redeploy --wait

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -113,7 +113,7 @@ jobs:
           docker exec pki pki-server ca-config-set auths.revocationChecking.bufferSize 0
 
           # update CRL immediately after each cert revocation
-          docker exec pki pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
+          docker exec pki pki-server ca-crl-ip-mod -D alwaysUpdate=true MasterCRL
 
           # restart CA subsystem
           docker exec pki pki-server ca-redeploy --wait

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -114,7 +114,7 @@ jobs:
           docker exec pki pki-server ca-config-set auths.revocationChecking.bufferSize 0
 
           # update CRL immediately after each cert revocation
-          docker exec pki pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
+          docker exec pki pki-server ca-crl-ip-mod -D alwaysUpdate=true MasterCRL
 
           # restart CA subsystem
           docker exec pki pki-server ca-redeploy --wait

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -234,7 +234,7 @@ jobs:
           docker exec ca pki-server ca-config-set auths.revocationChecking.bufferSize 0
 
           # update CRL immediately after each cert revocation
-          docker exec ca pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
+          docker exec ca pki-server ca-crl-ip-mod -D alwaysUpdate=true MasterCRL
 
           # restart CA subsystem
           docker exec ca pki-server ca-redeploy --wait

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -266,7 +266,7 @@ jobs:
           docker exec ca pki-server ca-config-set auths.revocationChecking.bufferSize 0
 
           # update CRL immediately after each cert revocation
-          docker exec ca pki-server ca-config-set ca.crl.MasterCRL.alwaysUpdate true
+          docker exec ca pki-server ca-crl-ip-mod -D alwaysUpdate=true MasterCRL
 
           # restart CA subsystem
           docker exec ca pki-server ca-redeploy --wait

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -2435,6 +2435,12 @@ class CASubsystem(PKISubsystem):
 
         return config
 
+    def update_crl_issuing_point_config(self, ip_id, config):
+
+        for key, value in config.items():
+            param = 'ca.crl.%s.%s' % (ip_id, key)
+            pki.util.set_property(self.config, param, value)
+
 
 class KRASubsystem(PKISubsystem):
 


### PR DESCRIPTION
The `pki-server ca-crl-ip-mod` has been added to allow updating multiple CRL issuing point params at once.

https://github.com/dogtagpki/pki/wiki/PKI-Server-CA-CRL-CLI
