### PR TITLE
Add pki-server <subsystem>-user-mod --password

### DIFF
--- a/.github/workflows/ca-admin-user-test.yml
+++ b/.github/workflows/ca-admin-user-test.yml
@@ -75,45 +75,100 @@ jobs:
           sed -n 's/^ *Type: *\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check CA admin certs
+      - name: Check auth with CA admin password
+        run: |
+          # import CA signing cert
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+
+          # correct password should work
+          docker exec pki pki -u caadmin -w Secret.123 ca-user-find
+
+          # wrong password should not work
+          docker exec pki pki -u caadmin -w wrong ca-user-find \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          echo "PKIException: Unauthorized" > expected
+          diff expected stderr
+
+      - name: Change CA admin password
+        run: |
+          docker exec pki pki-server ca-user-mod --password new caadmin
+
+          # original password should no longer work
+          docker exec pki pki -u caadmin -w Secret.123 ca-user-find \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          echo "PKIException: Unauthorized" > expected
+          diff expected stderr
+
+          # new password should work
+          docker exec pki pki -u caadmin -w new ca-user-find
+
+      - name: Change CA admin password with file
+        run: |
+          echo secret > secret.txt
+          docker exec pki pki-server ca-user-mod --password-file $SHARED/secret.txt caadmin
+
+          # password file should work
+          docker exec pki pki -u caadmin -w secret ca-user-find
+
+      - name: Remove CA admin password
+        run: |
+          docker exec pki pki-server ca-user-mod --password "" caadmin
+
+          # old password should no longer work
+          docker exec pki pki -u caadmin -w secret ca-user-find \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          echo "PKIException: Unauthorized" > expected
+          diff expected stderr
+
+          # blank password should not work
+          docker exec pki pki -u caadmin -w "" ca-user-find \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          echo "PKIException: Unauthorized" > expected
+          diff expected stderr
+
+      - name: Check certs assigned to CA admin user
         run: |
           docker exec pki pki-server ca-user-cert-find caadmin | tee output
 
+          # get admin cert ID
           sed -n 's/^ *Cert ID: *\(.*\)$/\1/p' output > cert.id
           CERT_ID=$(cat cert.id)
           echo "CERT_ID: $CERT_ID"
 
-      - name: Authentication and authorization with CA admin cert should work
+      - name: Check auth with CA admin cert
         run: |
-          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
-          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
-
+          # import admin cert
           docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
+          # admin cert should work
           docker exec pki pki -n caadmin ca-user-find
 
-      - name: Remove CA admin cert
+      - name: Unassign certs from CA admin user
         run: |
           CERT_ID=$(cat cert.id)
           echo "CERT_ID: $CERT_ID"
 
           docker exec pki pki-server ca-user-cert-del caadmin "$CERT_ID"
 
-          # admin should have no certs
+          # admin user should have no certs
           docker exec pki pki-server ca-user-cert-find caadmin | tee actual
           diff /dev/null actual
 
-      - name: Authentication with CA admin cert should not work
-        run: |
+          # admin cert should no longer work
           docker exec pki pki -n caadmin ca-user-find \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
           echo "PKIException: Unauthorized" > expected
           diff expected stderr
 
-      - name: Restore CA admin cert
+      - name: Reassign certs to CA admin user
         run: |
           CERT_ID=$(cat cert.id)
           echo "CERT_ID: $CERT_ID"
@@ -126,8 +181,7 @@ jobs:
           sed -n 's/^ *Cert ID: *\(.*\)$/\1/p' output > actual
           diff cert.id actual
 
-      - name: Authentication with CA admin cert should work again
-        run: |
+          # admin cert should work again
           docker exec pki pki -n caadmin ca-user-find
 
       - name: Check CA admin roles

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -285,6 +285,8 @@ class UserModifyCLI(pki.cli.CLI):
         print('Usage: pki-server %s-user-mod [OPTIONS] <user ID>' % self.parent.parent.name)
         print()
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('      --password <password>          User password')
+        print('      --password-file <path>         User password file')
         print('      --add-see-also <subject DN>    Link user to a certificate.')
         print('      --del-see-also <subject DN>    Unlink user from a certificate.')
         print('  -v, --verbose                      Run in verbose mode.')
@@ -295,7 +297,8 @@ class UserModifyCLI(pki.cli.CLI):
     def execute(self, argv):
         try:
             opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'add-see-also=', 'del-see-also=',
+                'instance=', 'password=', 'password-file=',
+                'add-see-also=', 'del-see-also=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -305,12 +308,20 @@ class UserModifyCLI(pki.cli.CLI):
 
         instance_name = 'pki-tomcat'
         subsystem_name = self.parent.parent.name
+        password = None
+        password_file = None
         add_see_also = None
         del_see_also = None
 
         for o, a in opts:
             if o in ('-i', '--instance'):
                 instance_name = a
+
+            elif o == '--password':
+                password = a
+
+            elif o == '--password-file':
+                password_file = a
 
             elif o == '--add-see-also':
                 add_see_also = a
@@ -356,6 +367,8 @@ class UserModifyCLI(pki.cli.CLI):
 
         subsystem.modify_user(
             user_id,
+            password=password,
+            password_file=password_file,
             add_see_also=add_see_also,
             del_see_also=del_see_also)
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1825,10 +1825,22 @@ class PKISubsystem(object):
         finally:
             shutil.rmtree(tmpdir)
 
-    def modify_user(self, user_id, add_see_also=None, del_see_also=None,
-                    as_current_user=False):
+    def modify_user(
+            self,
+            user_id,
+            password=None,
+            password_file=None,
+            add_see_also=None,
+            del_see_also=None,
+            as_current_user=False):
 
         cmd = [self.name + '-user-mod']
+
+        if password is not None:
+            cmd.extend(['--password', password])
+
+        if password_file is not None:
+            cmd.extend(['--password-file', password_file])
 
         if add_see_also:
             cmd.append('--add-see-also')

--- a/base/server/src/main/java/com/netscape/cmscore/usrgrp/UGSubsystem.java
+++ b/base/server/src/main/java/com/netscape/cmscore/usrgrp/UGSubsystem.java
@@ -1134,9 +1134,12 @@ public class UGSubsystem {
 
                 attrs.add(LDAPModification.REPLACE, ld);
             }
-            if ((st = user.getPassword()) != null && (!st.equals(""))) {
-                attrs.add(LDAPModification.REPLACE,
-                        new LDAPAttribute("userpassword", st));
+            if ((st = user.getPassword()) != null) {
+                if (st.equals("")) {
+                    attrs.add(LDAPModification.DELETE, new LDAPAttribute("userPassword"));
+                } else {
+                    attrs.add(LDAPModification.REPLACE, new LDAPAttribute("userPassword", st));
+                }
             }
             if ((st = user.getPhone()) != null) {
                 if (!st.equals("")) {


### PR DESCRIPTION
The `pki-server <subsystem>-user-mod` has been updated to provide a way to change the user password. This could be used to restore access to PKI server in case the current password is lost or the user cert has expired.

The `UGSubsystem.modifyUser()` has been modified to remove the `userPassword` attribute from the user record if the password is blank.

The test for admin user has been updated to validate password change and password removal.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Subsystem-User-CLI