### PR TITLE
Bug2229930-crlCertValid-leaf-only

### DIFF
--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/OCSPEngine.java
@@ -44,6 +44,7 @@ import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.apps.EngineConfig;
 import com.netscape.cmscore.base.ConfigStorage;
+import com.netscape.cmscore.cert.CertUtils;
 import com.netscape.ocsp.OCSPAuthority;
 
 @WebListener
@@ -149,9 +150,13 @@ public class OCSPEngine extends CMSEngine {
         }
 
         for (X509Certificate cert: certificates) {
+            // validateConnCertWithCRL only handles leaf certs
+            if (CertUtils.isCACert(cert))
+                continue;
+
             if(!crlCertValid(crlStore, cert, null)) {
                 return true;
-            }
+            } else break;
         }
         return false;
 

--- a/base/server/src/main/java/com/netscape/cmscore/cert/CertUtils.java
+++ b/base/server/src/main/java/com/netscape/cmscore/cert/CertUtils.java
@@ -56,6 +56,7 @@ import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.util.ObjectIdentifier;
 import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.x509.AlgorithmId;
+import org.mozilla.jss.netscape.security.x509.BasicConstraintsExtension;
 import org.mozilla.jss.netscape.security.x509.CertificateExtensions;
 import org.mozilla.jss.netscape.security.x509.Extension;
 import org.mozilla.jss.netscape.security.x509.X500Name;
@@ -1337,6 +1338,43 @@ public class CertUtils {
         exts.set(CT_POISON_OID, ct_poison_ext);
         certinfo.delete(X509CertInfo.EXTENSIONS);
         certinfo.set(X509CertInfo.EXTENSIONS, exts);
+    }
+
+    public static boolean isCACert(X509Certificate cert) {
+        String method = "CertUtils.isCACert: ";
+        try {
+            X509CertImpl impl = new X509CertImpl(cert.getEncoded());
+            X509CertInfo certinfo = (X509CertInfo) impl.get(
+                    X509CertImpl.NAME + "." + X509CertImpl.INFO);
+            if (certinfo == null)
+                return false;
+            else {
+                CertificateExtensions exts = (CertificateExtensions) certinfo.get(X509CertInfo.EXTENSIONS);
+
+                if (exts == null)
+                    return false;
+                else {
+                    try {
+                        BasicConstraintsExtension ext = (BasicConstraintsExtension) exts
+                                .get(BasicConstraintsExtension.NAME);
+
+                        if (ext == null)
+                            return false;
+                        else {
+                            Boolean bool = (Boolean) ext.get(BasicConstraintsExtension.IS_CA);
+
+                            return bool.booleanValue();
+                        }
+                    } catch (IOException ee) {
+                        return false;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn(method + CMS.getLogMessage("CMSCORE_SECURITY_IS_CA_CERT", e.toString()), e);
+            return false;
+            //throw new EBaseException(CMS.getUserMessage("CMS_BASE_DECODE_CERT_FAILED"));
+        }
     }
 
     /*


### PR DESCRIPTION
This patch addresses the issue where OCSPEngine:crlCertValid attempts to verify up the chain and failed because when using CRL to validate certs, the CAs up the chain are issued by different CAs.
OCSPEngine:crlCertValid should be limited to leaf certs validation only.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=2229930