### PR TITLE
Refactor RequestRepository.listRequestsByFilter()

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/Monitor.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/Monitor.java
@@ -19,6 +19,7 @@ package com.netscape.cms.servlet.cert;
 
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Locale;
@@ -48,7 +49,7 @@ import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.base.ArgBlock;
 import com.netscape.cmscore.dbs.CertRecord;
 import com.netscape.cmscore.dbs.CertificateRepository;
-import com.netscape.cmscore.request.RequestList;
+import com.netscape.cmscore.request.Request;
 import com.netscape.cmscore.request.RequestRecord;
 import com.netscape.cmscore.request.RequestRepository;
 
@@ -318,19 +319,16 @@ public class Monitor extends CMSServlet {
             if (requestRepository != null) {
                 filter = Filter(RequestRecord.ATTR_CREATE_TIME, startTime, endTime);
 
-                RequestList reqList = requestRepository.listRequestsByFilter(filter);
+                Collection<RequestRecord> records = requestRepository.listRequestsByFilter(filter);
 
                 int count = 0;
 
-                while (reqList != null && reqList.hasMoreElements()) {
-                    RequestRecord rec = (RequestRecord) reqList.nextRequest();
-
-                    if (rec != null) {
-                        if (count == 0) {
-                            arg.addStringValue("firstRequest", rec.getRequestId().toString());
-                        }
-                        count++;
+                for (RequestRecord record : records) {
+                    Request request = record.toRequest();
+                    if (count == 0) {
+                        arg.addStringValue("firstRequest", request.getRequestId().toString());
                     }
+                    count++;
                 }
                 arg.addIntegerValue("numberOfRequests", count);
                 mTotalReqs += count;

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/job/PruningJob.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/job/PruningJob.java
@@ -6,6 +6,7 @@
 package org.dogtagpki.server.ca.job;
 
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
 
@@ -25,7 +26,6 @@ import com.netscape.cmscore.dbs.Repository.IDGenerator;
 import com.netscape.cmscore.jobs.JobConfig;
 import com.netscape.cmscore.jobs.JobsScheduler;
 import com.netscape.cmscore.request.Request;
-import com.netscape.cmscore.request.RequestList;
 import com.netscape.cmscore.request.RequestRecord;
 import com.netscape.cmscore.request.RequestRepository;
 
@@ -219,14 +219,13 @@ public class PruningJob extends Job implements IExtendedPluginInfo {
                 "(!(" + RequestRecord.ATTR_MODIFY_TIME + "=" + time + ")))";
         logger.info("PruningJob: - filter: " + filter);
 
-        RequestList requestRecords = requestRepository.listRequestsByFilter(
+        Collection<RequestRecord> records = requestRepository.listRequestsByFilter(
                 filter, requestSearchSizeLimit, requestSearchTimeLimit);
 
-        while (requestRecords.hasMoreElements()) {
-            RequestId requestID = requestRecords.nextElement();
+        for (RequestRecord record : records) {
+            Request request = record.toRequest();
+            RequestId requestID = request.getRequestId();
             logger.info("PruningJob: Pruning request " + requestID.toHexString());
-
-            Request request = requestRepository.readRequest(requestID);
             logger.info("PruningJob: - status: " + request.getRequestStatus());
             logger.info("PruningJob: - last modified: " + request.getModificationTime());
 

--- a/base/server/src/main/java/com/netscape/cms/servlet/request/CMSRequestDAO.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/request/CMSRequestDAO.java
@@ -17,6 +17,8 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cms.servlet.request;
 
+import java.util.Collection;
+
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
@@ -27,8 +29,8 @@ import com.netscape.certsrv.request.CMSRequestInfos;
 import com.netscape.certsrv.request.IRequestVirtualList;
 import com.netscape.certsrv.request.RequestId;
 import com.netscape.cmscore.request.Request;
-import com.netscape.cmscore.request.RequestList;
 import com.netscape.cmscore.request.RequestQueue;
+import com.netscape.cmscore.request.RequestRecord;
 import com.netscape.cmscore.request.RequestRepository;
 
 /**
@@ -120,20 +122,13 @@ public abstract class CMSRequestDAO {
             // The non-vlv requests are indexed, but are not paginated.
             // We should think about whether they should be, or if we need to
             // limit the number of results returned.
-            RequestList requests = requestRepository.listRequestsByFilter(filter, maxResults, maxTime);
-
-            if (requests == null) {
-                return ret;
-            }
+            Collection<RequestRecord> records = requestRepository.listRequestsByFilter(filter, maxResults, maxTime);
 
             logger.debug("CMSRequestDAO: records:");
-            while (requests.hasMoreElements()) {
-                RequestId rid = requests.nextElement();
-                Request request = requestRepository.readRequest(rid);
-                if (request != null) {
-                    logger.debug("- " + request.getRequestId().toHexString());
-                    ret.addEntry(createCMSRequestInfo(request, uriInfo));
-                }
+            for (RequestRecord record : records) {
+                Request request = record.toRequest();
+                logger.debug("- " + request.getRequestId().toHexString());
+                ret.addEntry(createCMSRequestInfo(request, uriInfo));
             }
             ret.setTotal(ret.getEntries().size());
         }

--- a/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
@@ -19,6 +19,8 @@ package com.netscape.cmscore.request;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.Set;
@@ -357,61 +359,64 @@ public class RequestRepository extends Repository {
         }
     }
 
-    public RequestList listRequestsByFilter(String filter) throws EBaseException {
+    public Collection<RequestRecord> listRequestsByFilter(String filter) throws EBaseException {
 
+        Collection<RequestRecord> records = new ArrayList<>();
         DBSSession s = dbSubsystem.createSession();
-        DBSearchResults results = null;
 
         try {
-            results = s.search(mBaseDN, filter);
+            DBSearchResults sr = s.search(mBaseDN, filter);
+
+            while (sr.hasMoreElements()) {
+                RequestRecord record = (RequestRecord) sr.nextElement();
+                records.add(record);
+            }
 
         } finally {
             s.close();
         }
 
-        if (results == null) {
-            return null;
-        }
-
-        return new SearchEnumeration(results);
+        return records;
     }
 
-    public RequestList listRequestsByFilter(String filter, int maxSize) throws EBaseException {
+    public Collection<RequestRecord> listRequestsByFilter(String filter, int maxSize) throws EBaseException {
 
+        Collection<RequestRecord> records = new ArrayList<>();
         DBSSession dbs = dbSubsystem.createSession();
-        DBSearchResults results = null;
 
         try {
-            results = dbs.search(mBaseDN, filter, maxSize);
+            DBSearchResults sr = dbs.search(mBaseDN, filter, maxSize);
+
+            while (sr.hasMoreElements()) {
+                RequestRecord record = (RequestRecord) sr.nextElement();
+                records.add(record);
+            }
 
         } finally {
             dbs.close();
         }
 
-        if (results == null) {
-            return null;
-        }
-
-        return new SearchEnumeration(results);
+        return records;
     }
 
-    public RequestList listRequestsByFilter(String filter, int maxSize, int timeLimit) throws EBaseException {
+    public Collection<RequestRecord> listRequestsByFilter(String filter, int maxSize, int timeLimit) throws EBaseException {
 
+        Collection<RequestRecord> records = new ArrayList<>();
         DBSSession dbs = dbSubsystem.createSession();
-        DBSearchResults results = null;
 
         try {
-            results = dbs.search(mBaseDN, filter, maxSize, timeLimit);
+            DBSearchResults sr = dbs.search(mBaseDN, filter, maxSize, timeLimit);
+
+            while (sr.hasMoreElements()) {
+                RequestRecord record = (RequestRecord) sr.nextElement();
+                records.add(record);
+            }
 
         } finally {
             dbs.close();
         }
 
-        if (results == null) {
-            return null;
-        }
-
-        return new SearchEnumeration(results);
+        return records;
     }
 
     /**


### PR DESCRIPTION
Previously the `RequestRepository.listRequestsByFilter()` would create a `DBSession` object, perform a search operation, close the session, then return the `DBSearchResults` in a `RequestList` object to the caller.

The problem is the `DBSearchResults` can only be used by the caller as long as the database connection is still open, which is not guaranteed once the session is closed.

To avoid potential issues, all variants of the method have been updated to store the search results into a `Collection` while the session is still active.