### PR TITLE
Fix race condition during ACME authz polling

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
@@ -778,6 +778,10 @@ public class LDAPDatabase extends ACMEDatabase {
                         + "," + RDN_AUTHORIZATION + "," + baseDN;
         LDAPEntry entry = new LDAPEntry(dn, attrSet);
         ldapAdd(entry);
+
+        for (ACMEChallenge challenge : authorization.getChallenges()) {
+            addChallenge(authorization.getAccountID(), challenge);
+        }
     }
 
     public void addChallenge(String accountID, ACMEChallenge challenge)

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAuthorizationService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAuthorizationService.java
@@ -6,8 +6,6 @@
 package org.dogtagpki.acme.server;
 
 import java.net.URI;
-import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.Collection;
 
 import javax.ws.rs.POST;
@@ -20,14 +18,12 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.commons.codec.binary.Base64;
 import org.dogtagpki.acme.ACMEAccount;
 import org.dogtagpki.acme.ACMEAuthorization;
 import org.dogtagpki.acme.ACMEChallenge;
 import org.dogtagpki.acme.ACMEHeader;
 import org.dogtagpki.acme.ACMENonce;
 import org.dogtagpki.acme.JWS;
-import org.dogtagpki.acme.validator.ACMEValidator;
 
 /**
  * @author Endi S. Dewata
@@ -69,29 +65,7 @@ public class ACMEAuthorizationService {
         String authorizationStatus = authorization.getStatus();
         logger.info("Authorization status: " + authorizationStatus);
 
-        // generate 128-bit token with JSS
-        // TODO: make it configurable
-
-        byte[] bytes = new byte[16];
-        SecureRandom random = SecureRandom.getInstance("pkcs11prng", "Mozilla-JSS");
-        random.nextBytes(bytes);
-        String token = Base64.encodeBase64URLSafeString(bytes);
-        logger.info("Token: " + token);
-
         Collection<ACMEChallenge> challenges = authorization.getChallenges();
-
-        if (challenges == null || challenges.size() <= 0) {
-            logger.info("Creating new challenges");
-            challenges = new ArrayList<>();
-
-            for (ACMEValidator validator : engine.getValidators()) {
-                ACMEChallenge challenge = validator.createChallenge(authzID, token);
-                challenges.add(challenge);
-            }
-
-            authorization.setChallenges(challenges);
-            engine.updateAuthorization(account, authorization);
-        }
 
         logger.info("Challenges:");
         for (ACMEChallenge challenge : challenges) {


### PR DESCRIPTION
Previously after creating an ACME order the client would call `ACMEAuthorizationService` to poll the status of the authorization. Initially the authorization did not have any challenges, so this service would create the challenges for it. In subsequent calls this service would just return the status of the authorization.

When the client completes a challenge, the `ACMEChallengeProcessor` will update the authorization by removing the old challenges and adding the new ones. Since these operations are not atomic there is a risk that after the old challenges are removed the client will call the `ACMEAuthorizationService` and create new challenges which will never be completed by the client.

To avoid the problem, the code that creates the challenges has been moved from `ACMEAuthorizationService` into `ACMENewOrderService` so the challenges can only be created just once when the order is initially created.

The `LDAPDatabase.addAuthorization()` has also been updated to add the challenges after adding the authorization.