### PR TITLE
Add fontawesome dependency to Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>font-awesome</artifactId>
+            <version>4.7.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
This resolves a disparity in installed files between Maven and CMake now that fontawesome is not bundled in the CMake build anymore.