### PR TITLE
Add Buildrequires for fontawesome

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -383,6 +383,14 @@ find_file(IDM_CONSOLE_FRAMEWORK_JAR
         /usr/share/java
 )
 
+find_file(FONTAWESOME_WEBFONT
+    NAMES
+        fontawesome-webfont.woff
+    PATHS
+        /usr/share/fonts/fontawesome/
+        /usr/share/fonts/fontawesome4/
+)
+
 add_subdirectory(common)
 add_subdirectory(tools)
 

--- a/pki.spec
+++ b/pki.spec
@@ -748,8 +748,10 @@ Obsoletes:        %{product_id}-server-theme < %{version}-%{release}
 Provides:         %{product_id}-server-theme = %{version}-%{release}
 
 %if 0%{?fedora} > 38
+BuildRequires:    fontawesome4-fonts-web
 Requires:         fontawesome4-fonts-web
 %else
+BuildRequires:    fontawesome-fonts-web
 Requires:         fontawesome-fonts-web
 %endif
 
@@ -955,17 +957,6 @@ ln -sf ../../..%{_javadir}/%{name}/pki-console.jar
 %endif
 
 popd
-%endif
-
-%if %{with theme}
-# create links to FontAwesome fonts
-%if 0%{?fedora} > 38
-ln -s ../../../fonts/fontawesome4/fontawesome-webfont.woff \
-    %{buildroot}%{_datadir}/pki/common-ui/fonts/fontawesome-webfont.woff
-%else
-ln -s ../../../fonts/fontawesome/fontawesome-webfont.woff \
-    %{buildroot}%{_datadir}/pki/common-ui/fonts/fontawesome-webfont.woff
-%endif
 %endif
 
 %if %{with server}

--- a/themes/dogtag/common-ui/CMakeLists.txt
+++ b/themes/dogtag/common-ui/CMakeLists.txt
@@ -15,6 +15,8 @@ add_custom_command(
     COMMAND ln -sf ../../../../../..${DATA_INSTALL_DIR}/common-ui/ocsp links/
     COMMAND ln -sf ../../../../../..${DATA_INSTALL_DIR}/common-ui/pki.properties links/pki.properties
     COMMAND ln -sf ../../../../../..${DATA_INSTALL_DIR}/common-ui/tks links/
+    COMMAND ${CMAKE_COMMAND} -E make_directory fonts
+    COMMAND ln -sf ../../../../..${DATA_INSTALL_DIR}/common-ui/fonts/${FONTAWESOME_WEBFONT} fonts/fontawesome-webfont.woff
 )
 
 install(
@@ -22,6 +24,13 @@ install(
         ${CMAKE_CURRENT_BINARY_DIR}/links/
     DESTINATION
         ${DATA_INSTALL_DIR}/server/webapps/pki
+)
+
+install(
+    DIRECTORY
+        ${CMAKE_CURRENT_BINARY_DIR}/fonts/
+    DESTINATION
+        ${DATA_INSTALL_DIR}/common-ui/fonts
 )
 
 install(


### PR DESCRIPTION
This resolves a disparity in installed files between Maven and CMake now that fontawesome is not bundled in the CMake build anymore.

This happens because `font-awesome` is not available at build time so there is no file to link to for the comparison.