### PR TITLE
Update cms.password.skipLdapConnTest default value

### DIFF
--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -59,7 +59,6 @@ jobs:
               -D pki_cert_id_generator=random \
               -D pki_request_id_generator=random \
               -v
-          docker exec pki pki-server ca-config-set cms.password.skipLdapConnTest true
           docker exec pki pki-server ca-config-set internaldb.minConns 0
           docker exec pki pki-server restart --wait
           docker exec pki curl -s http://pki.example.com:8080/ca/admin/ca/getStatus
@@ -76,6 +75,7 @@ jobs:
 
       - name: Test request enrollment
         run: |
+          # enrollment should work
           docker exec pki pki ca-cert-request-submit --profile caServerCert --csr-file sslserver.csr  | tee output
           grep "Reason:" output | wc -l > actual
           echo "0" > expected
@@ -85,6 +85,8 @@ jobs:
         run: |
           docker stop ds
           sleep 10
+
+          # enrollment should fail
           docker exec pki pki ca-cert-request-submit --profile caServerCert --csr-file sslserver.csr  | tee output
           grep "Reason:" output | wc -l > actual
           echo "1" > expected
@@ -94,6 +96,8 @@ jobs:
         run: |
           docker start ds
           sleep 20
+
+          # enrollment should work
           docker exec pki pki ca-cert-request-submit --profile caServerCert --csr-file sslserver.csr  | tee output
           grep "Reason:" output | wc -l > actual
           echo "0" > expected
@@ -106,6 +110,8 @@ jobs:
           docker exec pki pki-server ca-config-set ca.authorityMonitor.enable false 
           docker exec pki pki-server restart --wait
           docker exec pki curl -s http://pki.example.com:8080/ca/admin/ca/getStatus
+
+          # enrollment should fail
           docker exec pki pki ca-cert-request-submit --profile caServerCert --csr-file sslserver.csr | tee output
           grep "Reason:" output | wc -l > actual
           echo "1" > expected
@@ -115,7 +121,24 @@ jobs:
         run: |
           docker start ds
           sleep 60
+
+          # enrollment should work
           docker exec pki pki ca-cert-request-submit --profile caServerCert --csr-file sslserver.csr | tee output
           grep "Reason:" output | wc -l > actual
           echo "0" > expected
           diff expected actual
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ca-ds-connection
+          path: |
+            /tmp/artifacts/pki

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -478,7 +478,7 @@ public class CMSEngine {
             return;
         }
 
-        boolean skipLdapConnectionTest = config.getBoolean("cms.password.skipLdapConnTest", false);
+        boolean skipLdapConnectionTest = config.getBoolean("cms.password.skipLdapConnTest", true);
         logger.debug("CMSEngine: skip LDAP connection test: " + skipLdapConnectionTest);
 
         if (skipLdapConnectionTest) {


### PR DESCRIPTION
Previously each PKI subsystem would check the DS connection on startup and fail to start if the DS is not available. To improve PKI service reliability the subsystem needs to start regardless of DS availability (since the subsystem can reconnect to the DS later when needed), so the `cms.password.skipLdapConnTest` param has been modified to be `true` by default such that it no longer checks the DS connection on startup.

The DS connection test has been updated to remove the command that configures the param since it's no longer needed.