### PR TITLE
Restart the instance when new subsystems are deployed

### DIFF
--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -268,14 +268,21 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             instance.set_sslserver_cert_nickname(nickname, token)
 
         else:
-            logger.info('Starting %s subsystem', subsystem.type)
-            subsystem.enable(
-                wait=True,
-                max_wait=deployer.startup_timeout,
-                timeout=deployer.request_timeout)
+            if config.str2bool(deployer.mdict['pki_hsm_enable']):
+                logger.info('Stopping PKI server')
+                instance.stop(
+                    wait=True,
+                    max_wait=deployer.startup_timeout,
+                    timeout=deployer.request_timeout)
+            else:
+                logger.info('Starting %s subsystem', subsystem.type)
+                subsystem.enable(
+                    wait=True,
+                    max_wait=deployer.startup_timeout,
+                    timeout=deployer.request_timeout)
 
-            logger.info('Waiting for %s subsystem', subsystem.type)
-            subsystem.wait_for_startup(deployer.startup_timeout, deployer.request_timeout)
+                logger.info('Waiting for %s subsystem', subsystem.type)
+                subsystem.wait_for_startup(deployer.startup_timeout, deployer.request_timeout)
 
     def destroy(self, deployer):
         pass

--- a/base/server/python/pki/server/deployment/scriptlets/finalization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/finalization.py
@@ -70,7 +70,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             else:
                 instance.enable()
 
-            if len(instance.get_subsystems()) == 1:
+            if (len(instance.get_subsystems()) == 1 or
+                    config.str2bool(deployer.mdict['pki_hsm_enable'])):
                 logger.info('Starting PKI server')
                 instance.start(
                     wait=True,


### PR DESCRIPTION
If a new subsystem is deployed in a existing instance this not restarted during the installation but the new web-app is just enabled.

When the subsystem are configured to work with an HSM this could generate problems because certificates added during the installation with external tools are recognised. The instance restart will clean the internal cache and reference to the HSM and all certificates are identified.

Fix the issue #4335