### PR TITLE
Fix cmake compilation warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-project(pki)
-
 # Required cmake version
 cmake_minimum_required(VERSION 3.0.0)
+
+project(pki)
 
 # global needed variables
 set(APPLICATION_NAME ${PROJECT_NAME})

--- a/cmake/Modules/DefinePythonSitePackages.cmake
+++ b/cmake/Modules/DefinePythonSitePackages.cmake
@@ -23,12 +23,7 @@ function(find_site_packages pythonexecutable targetname)
 endfunction(find_site_packages)
 
 # Find default Python
-set(Python_ADDITIONAL_VERSIONS 3)
-find_package(PythonInterp REQUIRED)
-# FindPythonInterp doesn't restrict version with ADDITIONAL_VERSIONS
-if (PYTHON_VERSION_STRING VERSION_LESS "3.5.0")
-    message(FATAL_ERROR "Detect Python interpreter < 3.5.0")
-endif()
+find_package(Python COMPONENTS Interpreter Development)
 message(STATUS "Building pki.server for ${PYTHON_VERSION_STRING}")
 
 if (NOT DEFINED PYTHON3_SITE_PACKAGES)


### PR DESCRIPTION
Move `cmake_minimum_required` before `project` to silence warning. This actually uncovers a new warning:
```
CMake Deprecation Warning at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```
...which will need to be addressed in the future.

Replace deprecated `FindPythonInterp` in `find_package`