### PR TITLE
Add dependency to java-devel for pki-server package

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -123,6 +123,10 @@ jobs:
         run: |
           docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
+      - name: Check CA audit events
+        run: |
+          docker exec pki pki-server ca-audit-event-find
+
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only
 

--- a/pki.spec
+++ b/pki.spec
@@ -428,6 +428,8 @@ Requires:         openldap-clients
 Requires:         openssl
 Requires:         %{product_id}-tools = %{version}-%{release}
 
+Requires:         %{java_devel}
+
 Requires:         keyutils
 
 Requires:         policycoreutils-python-utils


### PR DESCRIPTION
The CLI `pki-server ca-audit-event-find` fails because it requires the `jar` command provided by the java devel package which is not in the dependency list. A direct dependency added.

Additionally,, a check to get the audit-event has been included in the basic CA workflow.