### PR TITLE
Make profile REST API provide same information then XML API

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertRequestService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/CertRequestService.java
@@ -265,7 +265,6 @@ public class CertRequestService extends PKIService implements CertRequestResourc
         }
 
         ProfileDataInfos infos = new ProfileDataInfos();
-        boolean visibleOnly = true;
 
         Enumeration<String> e = ps.getProfileIds();
         if (e == null) return createOKResponse(infos);
@@ -275,12 +274,13 @@ public class CertRequestService extends PKIService implements CertRequestResourc
         while (e.hasMoreElements()) {
             try {
                 String id = e.nextElement();
-                ProfileDataInfo info = ProfileService.createProfileDataInfo(id, visibleOnly, uriInfo, getLocale(headers));
-                if (info == null) continue;
+                ProfileDataInfo info = ProfileService.createProfileDataInfo(id, uriInfo, getLocale(headers));
+                if (info == null || !info.getProfileVisible().booleanValue()) {
+                    continue;
+                }
                 results.add(info);
             } catch (EBaseException ex) {
-                logger.warn("CertRequestService: " + ex.getMessage());
-                continue;
+                logger.warn("CertRequestService: {}",  ex.getMessage());
             }
         }
 

--- a/base/ca/src/test/java/com/netscape/cms/servlet/test/CATest.java
+++ b/base/ca/src/test/java/com/netscape/cms/servlet/test/CATest.java
@@ -275,7 +275,7 @@ public class CATest {
 
         //Get a list of Profiles
 
-        ProfileDataInfos pInfos = profileClient.listProfiles(null, null);
+        ProfileDataInfos pInfos = profileClient.listProfiles(null, null, null, null, null);
 
         printProfileInfos(pInfos);
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileClient.java
@@ -42,10 +42,13 @@ public class ProfileClient extends Client {
         return get(id + "/raw", byte[].class);
     }
 
-    public ProfileDataInfos listProfiles(Integer start, Integer size) throws Exception {
+    public ProfileDataInfos listProfiles(Integer start, Integer size, Boolean visible, Boolean enable, String enableBy) throws Exception {
         Map<String, Object> params = new HashMap<>();
         if (start != null) params.put("start", start);
         if (size != null) params.put("size", size);
+        if (visible != null) params.put("visible", visible);
+        if (enable != null) params.put("enable", enable);
+        if (enableBy != null) params.put("enableBy", enableBy);
         return get(null, params, ProfileDataInfos.class);
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileDataInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileDataInfo.java
@@ -56,6 +56,12 @@ public class ProfileDataInfo implements JSONSerializer {
 
     protected String profileDescription;
 
+    protected Boolean profileVisible;
+
+    protected Boolean profileEnable;
+
+    protected String profileEnableBy;
+
     public ProfileDataInfo() {
     }
 
@@ -98,6 +104,31 @@ public class ProfileDataInfo implements JSONSerializer {
 
     public void setProfileDescription(String profileDescription) {
         this.profileDescription = profileDescription;
+    }
+
+
+    public Boolean getProfileVisible() {
+        return profileVisible;
+    }
+
+    public void setProfileVisible(Boolean profileVisible) {
+        this.profileVisible = profileVisible;
+    }
+
+    public Boolean getProfileEnable() {
+        return profileEnable;
+    }
+
+    public void setProfileEnable(Boolean profileEnable) {
+        this.profileEnable = profileEnable;
+    }
+
+    public String getProfileEnableBy() {
+        return profileEnableBy;
+    }
+
+    public void setProfileEnableBy(String profileEnableBy) {
+        this.profileEnableBy = profileEnableBy;
     }
 
     @Override
@@ -143,6 +174,21 @@ public class ProfileDataInfo implements JSONSerializer {
             profileDescriptionElement.appendChild(document.createTextNode(profileDescription));
             profileDataInfoElement.appendChild(profileDescriptionElement);
         }
+        if (profileVisible != null) {
+            Element profileVisibleElement = document.createElement("profileVisible");
+            profileVisibleElement.appendChild(document.createTextNode(profileVisible.toString()));
+            profileDataInfoElement.appendChild(profileVisibleElement);
+        }
+        if (profileEnable != null) {
+            Element profileEnableElement = document.createElement("profileEnable");
+            profileEnableElement.appendChild(document.createTextNode(profileEnable.toString()));
+            profileDataInfoElement.appendChild(profileEnableElement);
+        }
+        if (profileEnableBy != null) {
+            Element profileEnableByElement = document.createElement("profileEnableBy");
+            profileEnableByElement.appendChild(document.createTextNode(profileEnableBy));
+            profileDataInfoElement.appendChild(profileEnableByElement);
+        }
         return profileDataInfoElement;
     }
 
@@ -165,6 +211,18 @@ public class ProfileDataInfo implements JSONSerializer {
         NodeList profileDescriptionList = profileDataInfoElement.getElementsByTagName("profileDescription");
         if (profileDescriptionList.getLength() > 0) {
             profileDataInfo.setProfileDescription(profileDescriptionList.item(0).getTextContent());
+        }
+        NodeList profileVisibleList = profileDataInfoElement.getElementsByTagName("profileVisible");
+        if (profileVisibleList.getLength() > 0) {
+            profileDataInfo.setProfileVisible(Boolean.valueOf(profileVisibleList.item(0).getTextContent()));
+        }
+        NodeList profileEnableList = profileDataInfoElement.getElementsByTagName("profileEnable");
+        if (profileEnableList.getLength() > 0) {
+            profileDataInfo.setProfileEnable(Boolean.valueOf(profileEnableList.item(0).getTextContent()));
+        }
+        NodeList profileEnableByList = profileDataInfoElement.getElementsByTagName("profileEnableBy");
+        if (profileEnableByList.getLength() > 0) {
+            profileDataInfo.setProfileEnableBy(profileEnableByList.item(0).getTextContent());
         }
         return profileDataInfo;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileResource.java
@@ -22,7 +22,8 @@ public interface ProfileResource {
             @QueryParam("start") Integer start,
             @QueryParam("size") Integer size,
             @QueryParam("visible") Boolean visible,
-            @QueryParam("enable") Boolean enable);
+            @QueryParam("enable") Boolean enable,
+            @QueryParam("enableBy") String enableBy);
 
     @GET
     @Path("{id}")

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileResource.java
@@ -20,7 +20,9 @@ public interface ProfileResource {
     @ACLMapping("profiles.list")
     public Response listProfiles(
             @QueryParam("start") Integer start,
-            @QueryParam("size") Integer size);
+            @QueryParam("size") Integer size,
+            @QueryParam("visible") Boolean visible,
+            @QueryParam("enable") Boolean enable);
 
     @GET
     @Path("{id}")

--- a/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileFindCLI.java
@@ -38,6 +38,18 @@ public class ProfileFindCLI extends CommandCLI {
         option = new Option(null, "size", true, "Page size");
         option.setArgName("size");
         options.addOption(option);
+
+        option = new Option(null, "visible", true, "Profile with visible value");
+        option.setArgName("true/false");
+        options.addOption(option);
+
+        option = new Option(null, "enable", true, "Profile with enable value");
+        option.setArgName("true/false");
+        options.addOption(option);
+
+        option = new Option(null, "enableBy", true, "Only enabled by the user");
+        option.setArgName("user");
+        options.addOption(option);
     }
 
     @Override
@@ -55,11 +67,15 @@ public class ProfileFindCLI extends CommandCLI {
         s = cmd.getOptionValue("size");
         Integer size = s == null ? null : Integer.valueOf(s);
 
+        Boolean visible = cmd.hasOption("visible") ? Boolean.valueOf(cmd.getOptionValue("visible")) : null;
+        Boolean enable = cmd.hasOption("enable") ? Boolean.valueOf(cmd.getOptionValue("enable")) : null;
+        String enableBy = cmd.getOptionValue("enableBy");
+
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
 
         ProfileClient profileClient = profileCLI.getProfileClient();
-        ProfileDataInfos response = profileClient.listProfiles(start, size);
+        ProfileDataInfos response = profileClient.listProfiles(start, size, visible, enable, enableBy);
 
         MainCLI.printMessage(response.getTotal() + " entries matched");
         if (response.getTotal() == 0) return;


### PR DESCRIPTION
Current profile REST API misses the information: visible, enable and enableBy. These are needed by IPA to improve the UI.

Additionally, a filter for visible and enable has been added.

Resolve RHCS-4375