### PR TITLE
Add test for caServerCert profile

### DIFF
--- a/.github/workflows/ca-profile-caServerCert-test.yml
+++ b/.github/workflows/ca-profile-caServerCert-test.yml
@@ -1,0 +1,192 @@
+name: CA with caServerCert profile
+
+on:
+  workflow_call:
+    inputs:
+      db-image:
+        required: false
+        type: string
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v3
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ inputs.db-image }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_cert_id_generator=random \
+              -D pki_request_id_generator=random \
+              -v
+
+      - name: Configure caServerCert profile
+        run: |
+          # allow user-specified SAN extension
+          docker exec pki sed -i \
+              -e "s/^\(policyset.serverCertSet.list\)=\(.*\)$/\1=\2,13/" \
+              -e '$ a policyset.serverCertSet.13.constraint.class_id=noConstraintImpl' \
+              -e '$ a policyset.serverCertSet.13.constraint.name=No Constraint' \
+              -e '$ a policyset.serverCertSet.13.default.class_id=userExtensionDefaultImpl' \
+              -e '$ a policyset.serverCertSet.13.default.name=User supplied extension in CSR' \
+              -e '$ a policyset.serverCertSet.13.default.params.userExtOID=2.5.29.17' \
+              /etc/pki/pki-tomcat/ca/profiles/ca/caServerCert.cfg
+
+          # require unique subject name
+          docker exec pki sed -i \
+              -e "s/^\(policyset.serverCertSet.list\)=\(.*\)$/\1=\2,14/" \
+              -e '$ a policyset.serverCertSet.14.constraint.class_id=uniqueSubjectNameConstraintImpl' \
+              -e '$ a policyset.serverCertSet.14.constraint.name=Unique Subject Name Constraint' \
+              -e '$ a policyset.serverCertSet.14.default.class_id=noDefaultImpl' \
+              -e '$ a policyset.serverCertSet.14.default.name=No Default' \
+              /etc/pki/pki-tomcat/ca/profiles/ca/caServerCert.cfg
+
+          # check updated profile
+          docker exec pki cat /etc/pki/pki-tomcat/ca/profiles/ca/caServerCert.cfg
+
+          docker exec pki pki-server ca-redeploy --wait
+
+      - name: Set up CA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Create SSL server cert
+        run: |
+          # generate cert request
+          docker exec pki pki \
+              nss-cert-request \
+              --subject "CN=server.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --subjectAltName "critical, DNS:www.example.com" \
+              --csr sslserver.csr
+
+          docker exec pki openssl req -text -noout -in sslserver.csr | tee output
+
+          # verfiy SAN extension in cert request
+          echo "X509v3 Subject Alternative Name: critical" > expected
+          echo "DNS:www.example.com" >> expected
+          sed -En 'N; s/^ *(X509v3 Subject Alternative Name: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # submit cert request
+          docker exec pki pki \
+              ca-cert-request-submit \
+              --profile caServerCert \
+              --csr-file sslserver.csr | tee output
+
+          REQUEST_ID=$(sed -n -e 's/^ *Request ID: *\(.*\)$/\1/p' output)
+          echo "REQUEST_ID: $REQUEST_ID"
+
+          # issue cert
+          docker exec pki pki \
+              -n caadmin \
+              ca-cert-request-approve \
+              --force \
+              $REQUEST_ID | tee output
+
+          CERT_ID=$(sed -n -e 's/^ *Certificate ID: *\(.*\)$/\1/p' output)
+          echo "CERT_ID: $CERT_ID"
+
+          # export cert
+          docker exec pki pki ca-cert-export $CERT_ID --output-file sslserver.crt
+
+          docker exec pki openssl x509 -text -noout -in sslserver.crt | tee output
+
+          # verfiy SAN extension in cert
+          echo "X509v3 Subject Alternative Name: critical" > expected
+          echo "DNS:www.example.com" >> expected
+          sed -En 'N; s/^ *(X509v3 Subject Alternative Name: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+      - name: Create SSL server cert with same subject name
+        run: |
+          # generate cert request
+          docker exec pki pki \
+              nss-cert-request \
+              --subject "CN=server.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --subjectAltName "critical, DNS:pki.example.com" \
+              --csr sslserver.csr
+
+          docker exec pki openssl req -text -noout -in sslserver.csr | tee output
+
+          # verfiy SAN extension
+          echo "X509v3 Subject Alternative Name: critical" > expected
+          echo "DNS:pki.example.com" >> expected
+          sed -En 'N; s/^ *(X509v3 Subject Alternative Name: .*)\n *(.*)$/\1\n\2/p; D' output | tee actual
+          diff actual expected
+
+          # submit cert request
+          docker exec pki pki \
+              ca-cert-request-submit \
+              --profile caServerCert \
+              --csr-file sslserver.csr | tee output
+
+          echo "Request Status: rejected" > expected
+          sed -n "s/^\s*\(Request Status:.*\)$/\1/p" output > actual
+          diff expected actual
+
+          echo "Reason: Subject Name Not Unique CN=server.example.com" > expected
+          sed -n "s/^\s*\(Reason:.*\)$/\1/p" output > actual
+          diff expected actual
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ca-profile-caServerCert
+          path: |
+            /tmp/artifacts/pki

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -21,6 +21,13 @@ jobs:
     with:
       db-image: ${{ needs.init.outputs.db-image }}
 
+  ca-profile-caServerCert-test:
+    name: CA with caServerCert profile
+    needs: [init, build]
+    uses: ./.github/workflows/ca-profile-caServerCert-test.yml
+    with:
+      db-image: ${{ needs.init.outputs.db-image }}
+
   ca-secure-ds-test:
     name: CA with secure DS
     needs: [init, build]


### PR DESCRIPTION
A new CI job has been added to test cert enrollments using a customized `caServerCert` profile. The first enrollment should successfully issue an SSL server cert with user-provided SAN extension. The second enrollment should fail to issue another SSL server cert with the same subject name.