### PR TITLE
Using cert from nssdb in cert-export

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -2009,6 +2009,8 @@ class NSSDatabase(object):
         cert = {}
         cert['object'] = cert_obj
 
+        cert['data'] = self.get_cert(nickname=nickname, token=token, output_format='base64')
+
         cert['serial_number'] = cert_obj.serial_number
 
         cert['issuer'] = pki.convert_x509_name_to_dn(cert_obj.issuer)

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -959,11 +959,17 @@ class CertExportCLI(pki.cli.CLI):
                 logger.info('Exporting %s certificate into %s.', cert_id, cert_file)
 
                 cert_data = cert.get('data')
-                if cert_data is None:
-                    logger.error('Unable to find certificate data for %s', cert_id)
-                    sys.exit(1)
+                if cert_data:
+                    cert_data = pki.nssdb.convert_cert(cert_data, 'base64', 'pem')
+                else:
+                    crt_path = os.path.join(instance.conf_dir, 'conf', 'certs', cert_id + '.crt')
+                    try:
+                        with open(crt_path, 'r', encoding='utf-8') as f:
+                            cert_data = ''.join(f.readlines())
+                    except FileNotFoundError:
+                        logger.error('Unable to find certificate data for %s', cert_id)
+                        sys.exit(1)
 
-                cert_data = pki.nssdb.convert_cert(cert_data, 'base64', 'pem')
                 with open(cert_file, 'w', encoding='utf-8') as f:
                     f.write(cert_data)
 
@@ -972,11 +978,17 @@ class CertExportCLI(pki.cli.CLI):
                 logger.info('Exporting %s CSR into %s.', cert_id, csr_file)
 
                 cert_request = cert.get('request')
-                if cert_request is None:
-                    logger.error('Unable to find certificate request for %s', cert_id)
-                    sys.exit(1)
+                if cert_request:
+                    csr_data = pki.nssdb.convert_csr(cert_request, 'base64', 'pem')
+                else:
+                    csr_path = os.path.join(instance.conf_dir, 'conf', 'certs', cert_id + '.csr')
+                    try:
+                        with open(csr_path, 'r', encoding='utf-8') as f:
+                            csr_data = ''.join(f.readlines())
+                    except FileNotFoundError:
+                        logger.error('Unable to find certificate request for %s', cert_id)
+                        sys.exit(1)
 
-                csr_data = pki.nssdb.convert_csr(cert_request, 'base64', 'pem')
                 with open(csr_file, 'w', encoding='utf-8') as f:
                     f.write(csr_data)
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -306,7 +306,6 @@ class PKISubsystem(object):
         cert['id'] = tag
         cert['nickname'] = self.config.get('%s.%s.nickname' % (self.name, tag))
         cert['token'] = self.config.get('%s.%s.tokenname' % (self.name, tag))
-        cert['data'] = self.config.get('%s.%s.cert' % (self.name, tag))
         cert['request'] = self.config.get('%s.%s.certreq' % (self.name, tag))
         cert['certusage'] = self.config.get('%s.cert.%s.certusage' % (self.name, tag))
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -306,6 +306,7 @@ class PKISubsystem(object):
         cert['id'] = tag
         cert['nickname'] = self.config.get('%s.%s.nickname' % (self.name, tag))
         cert['token'] = self.config.get('%s.%s.tokenname' % (self.name, tag))
+        cert['data'] = self.config.get('%s.%s.cert' % (self.name, tag))
         cert['request'] = self.config.get('%s.%s.certreq' % (self.name, tag))
         cert['certusage'] = self.config.get('%s.cert.%s.certusage' % (self.name, tag))
 


### PR DESCRIPTION
Certificate and relative CSR are stored in multiple places. The command `pki-server cert-export` was reading only from the `CS.cfg` file but has been modified to read from nssdb and from the folder `<instance>/conf/certs/<cert_id>.crt`.

