### PR TITLE
Disable healthcheck CS.cfg certs match

### DIFF
--- a/base/server/healthcheck/setup.py
+++ b/base/server/healthcheck/setup.py
@@ -31,7 +31,8 @@ setup(
         ],
         # plugin modules for pkihealthcheck.meta registry
         'pkihealthcheck.meta': [
-            'pki_certs = pki.server.healthcheck.meta.csconfig',
+            # Temporary disabled untile certs from CS config will be completely removed
+            #'pki_certs = pki.server.healthcheck.meta.csconfig',
             'pki_connectivity = pki.server.healthcheck.meta.connectivity',
         ],
         # plugin modules for pkihealthcheck.certs registry


### PR DESCRIPTION
Cert and csr will be removed from CS.cfg and stored in DB or separate file so this check is not anymore valid. It is temporary disabled to verify if can be removed or it should be replaced with other checks.