### PR TITLE
Refactor CAEngine.addAuthorityEntry()

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/AuthorityRecord.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/AuthorityRecord.java
@@ -108,6 +108,14 @@ public class AuthorityRecord {
         this.keyHosts.addAll(keyHosts);
     }
 
+    public void addKeyHost(String keyHost) {
+        keyHosts.add(keyHost);
+    }
+
+    public void removeKeyHost(String keyHost) {
+        keyHosts.remove(keyHost);
+    }
+
     public String getNSUniqueID() {
         return nsUniqueID;
     }


### PR DESCRIPTION
The code that creates the authority LDAP entry has been merged into `CAEngine.addAuthorityEntry()`. This method has also been renamed to `addAuthorityRecord()`.