### PR TITLE
Configuration free certs

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -1036,10 +1036,13 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
             return caCertImpl;
         }
 
-        String certnickname = mConfig.getString("signing.certnickname");
-        String tokennickname = mConfig.getString("signing.tokenname");
+        String certName = mConfig.getString("signing.certnickname");
+        String tokenName = mConfig.getString("signing.tokenname");
 
-        String certName = tokennickname + ":" + certnickname;
+        if(!CryptoUtil.isInternalToken(tokenName)) {
+            certName = tokenName + ":" + certName;
+        }
+
         logger.debug("CertificateAuthority: Getting CA signing cert: " + certName);
 
         CryptoManager manager;
@@ -1048,8 +1051,8 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
             manager= CryptoManager.getInstance();
             caCert = manager.findCertByNickname(certName);
         } catch (ObjectNotFoundException | NotInitializedException | TokenException e) {
-            logger.error("CertificateAuthority: Missing CA signing certificate");
-            throw new EBaseException("Missing CA signing certificate", e);
+            logger.error("CertificateAuthority: Unable to find CA signing certificate: " + e.getMessage(), e);
+            throw new EBaseException("Unable to find CA signing certificate: " + e.getMessage(), e);
         }
 
         try {

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3964,8 +3964,9 @@ class PKIDeployer:
         kra_url = 'https://%s:%s/kra/agent/kra/connector' % (hostname, securePort)
 
         subsystem_cert = subsystem.get_subsystem_cert('subsystem').get('data')
-        transport_cert = subsystem.config.get('kra.transport.cert')
-        transport_nickname = subsystem.config.get('kra.cert.transport.nickname')
+        transport_cert_info = subsystem.get_subsystem_cert('transport')
+        transport_cert = transport_cert_info.get('data')
+        transport_nickname = transport_cert_info.get('nickname')
 
         tmpdir = tempfile.mkdtemp()
         try:

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2169,7 +2169,7 @@ class PKIDeployer:
 
         self.import_cert_chain(nssdb)
 
-    def update_system_cert(self, nssdb, subsystem, tag):
+    def update_system_cert(self, subsystem, tag):
 
         logger.info('Updating %s cert', tag)
 
@@ -2181,15 +2181,6 @@ class PKIDeployer:
         if pki.nssdb.internal_token(tokenname):
             tokenname = pki.nssdb.INTERNAL_TOKEN_NAME
         subsystem.config['%s.%s.tokenname' % (subsystem.name, tag)] = tokenname
-
-        cert_data = nssdb.get_cert(
-            nickname=nickname,
-            token=self.mdict['pki_%s_token' % cert_id],
-            output_format='base64',
-            output_text=True,
-        )
-
-        subsystem.config['%s.%s.cert' % (subsystem.name, tag)] = cert_data
 
     def update_admin_cert(self, subsystem):
 
@@ -2212,12 +2203,12 @@ class PKIDeployer:
         finally:
             client_nssdb.close()
 
-    def update_system_certs(self, nssdb, subsystem):
+    def update_system_certs(self, subsystem):
 
         logger.info('Updating system certs')
 
         if subsystem.name == 'ca':
-            self.update_system_cert(nssdb, subsystem, 'signing')
+            self.update_system_cert(subsystem, 'signing')
 
             nickname = self.mdict['pki_ca_signing_nickname']
             subsystem.config['ca.signing.cacertnickname'] = nickname
@@ -2225,27 +2216,27 @@ class PKIDeployer:
             subsystem.config['ca.signing.defaultSigningAlgorithm'] = \
                 self.mdict['pki_ca_signing_signing_algorithm']
 
-            self.update_system_cert(nssdb, subsystem, 'ocsp_signing')
+            self.update_system_cert(subsystem, 'ocsp_signing')
 
             subsystem.config['ca.ocsp_signing.defaultSigningAlgorithm'] = \
                 self.mdict['pki_ocsp_signing_signing_algorithm']
 
         if subsystem.name == 'kra':
-            self.update_system_cert(nssdb, subsystem, 'storage')
-            self.update_system_cert(nssdb, subsystem, 'transport')
+            self.update_system_cert(subsystem, 'storage')
+            self.update_system_cert(subsystem, 'transport')
             self.update_admin_cert(subsystem)
 
         if subsystem.name == 'ocsp':
-            self.update_system_cert(nssdb, subsystem, 'signing')
+            self.update_system_cert(subsystem, 'signing')
 
             subsystem.config['ocsp.signing.defaultSigningAlgorithm'] = \
                 self.mdict['pki_ocsp_signing_signing_algorithm']
 
             self.update_admin_cert(subsystem)
 
-        self.update_system_cert(nssdb, subsystem, 'sslserver')
-        self.update_system_cert(nssdb, subsystem, 'subsystem')
-        self.update_system_cert(nssdb, subsystem, 'audit_signing')
+        self.update_system_cert(subsystem, 'sslserver')
+        self.update_system_cert(subsystem, 'subsystem')
+        self.update_system_cert(subsystem, 'audit_signing')
 
         subsystem.config['%s.audit_signing.defaultSigningAlgorithm' % subsystem.name] = \
             self.mdict['pki_audit_signing_signing_algorithm']

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -66,7 +66,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         try:
             deployer.import_system_cert_requests(subsystem)
             deployer.import_system_certs(nssdb, subsystem)
-            deployer.update_system_certs(nssdb, subsystem)
+            deployer.update_system_certs(subsystem)
             subsystem.save()
 
             deployer.update_sslserver_cert_nickname(subsystem)
@@ -79,16 +79,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                     if s.name == subsystem.name:
                         continue
 
-                    # import cert/request data from the existing subsystem
+                    # import request data from the existing subsystem
                     # into the new subsystem being installed
-
-                    logger.info('Importing sslserver cert data from %s', s.type)
-                    subsystem.config['%s.sslserver.cert' % subsystem.name] = \
-                        s.config['%s.sslserver.cert' % s.name]
-
-                    logger.info('Importing subsystem cert data from %s', s.type)
-                    subsystem.config['%s.subsystem.cert' % subsystem.name] = \
-                        s.config['%s.subsystem.cert' % s.name]
 
                     logger.info('Importing sslserver request data from %s', s.type)
                     subsystem.config['%s.sslserver.certreq' % subsystem.name] = \

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -330,7 +330,6 @@ class PKISubsystem(object):
         cert_id = cert['id']
         self.config['%s.%s.nickname' % (self.name, cert_id)] = cert.get('nickname')
         self.config['%s.%s.tokenname' % (self.name, cert_id)] = cert.get('token')
-        self.config['%s.%s.cert' % (self.name, cert_id)] = cert.get('data')
         self.config['%s.%s.certreq' % (self.name, cert_id)] = cert.get('request')
 
     def validate_system_cert(self, tag):


### PR DESCRIPTION
Subsystem certificates were stored in the `CS.cfg` configuration file  and NSSDB storage. This is useless and could create problem is they are not synced.

Therefore the certificates will not be stored in CS.cfg during the installation and all the requests will read the certificate from the NSSDB.

This partially implemented https://issues.redhat.com/browse/RHCS-3451, the certreq has the same problem and need to be removed from configuration files.

Fix #2157 