### PR TITLE
Add cert validity options/params for CLI and ACME

### DIFF
--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -48,7 +48,8 @@ jobs:
               nss-cert-issue \
               --csr ca_signing.csr \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
-              --months-valid 12 \
+              --validity-length 1 \
+              --validity-unit year \
               --cert ca_signing.crt
           docker exec client pki \
               nss-cert-import \

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -52,7 +52,8 @@ then
         nss-cert-issue \
         --csr /certs/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
-        --months-valid 12 \
+        --validity-length 1 \
+        --validity-unit year \
         --cert /certs/ca_signing.crt
 
     pki \

--- a/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
+++ b/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
@@ -1070,10 +1070,55 @@ public class NSSDatabase {
                 extensions);
     }
 
+    public static int validityUnitFromString(String validityUnit) throws Exception {
+
+        if (validityUnit.equalsIgnoreCase("year")) {
+            return Calendar.YEAR;
+
+        } else if (validityUnit.equalsIgnoreCase("month")) {
+            return Calendar.MONTH;
+
+        } else if (validityUnit.equalsIgnoreCase("day")) {
+            return Calendar.DAY_OF_YEAR;
+
+        } else if (validityUnit.equalsIgnoreCase("hour")) {
+            return Calendar.HOUR_OF_DAY;
+
+        } else if (validityUnit.equalsIgnoreCase("minute")) {
+            return Calendar.MINUTE;
+
+        } else {
+            throw new Exception("Invalid validity unit: " + validityUnit);
+        }
+    }
+
+    public static String validityUnitToString(int validityUnit) throws Exception {
+
+        if (validityUnit == Calendar.YEAR) {
+            return "year";
+
+        } else if (validityUnit == Calendar.MONTH) {
+            return "month";
+
+        } else if (validityUnit == Calendar.DAY_OF_YEAR) {
+            return "day";
+
+        } else if (validityUnit == Calendar.HOUR_OF_DAY) {
+            return "hour";
+
+        } else if (validityUnit == Calendar.MINUTE) {
+            return "minute";
+
+        } else {
+            throw new Exception("Invalid validity unit: " + validityUnit);
+        }
+    }
+
     public X509Certificate createCertificate(
             org.mozilla.jss.crypto.X509Certificate issuer,
             PKCS10 pkcs10,
-            Integer monthsValid,
+            int validityLength,
+            int validityUnit,
             String hash,
             Extensions extensions) throws Exception {
 
@@ -1081,7 +1126,8 @@ public class NSSDatabase {
                 issuer,
                 pkcs10,
                 null, // serial number
-                monthsValid,
+                validityLength,
+                validityUnit,
                 hash,
                 extensions);
     }
@@ -1090,7 +1136,8 @@ public class NSSDatabase {
             org.mozilla.jss.crypto.X509Certificate issuer,
             PKCS10 pkcs10,
             String serialNumber,
-            Integer monthsValid,
+            int validityLength,
+            int validityUnit,
             String hash,
             Extensions extensions) throws Exception {
 
@@ -1099,7 +1146,8 @@ public class NSSDatabase {
                 issuer,
                 pkcs10,
                 serialNumber,
-                monthsValid,
+                validityLength,
+                validityUnit,
                 hash,
                 extensions);
     }
@@ -1109,7 +1157,8 @@ public class NSSDatabase {
             org.mozilla.jss.crypto.X509Certificate issuer,
             PKCS10 pkcs10,
             String serialNumber,
-            Integer monthsValid,
+            int validityLength,
+            int validityUnit,
             String hash,
             Extensions extensions) throws Exception {
 
@@ -1150,7 +1199,7 @@ public class NSSDatabase {
         Date notBeforeDate = calendar.getTime();
         logger.debug("NSSDatabase: - not before: " + notBeforeDate);
 
-        calendar.add(Calendar.MONTH, monthsValid);
+        calendar.add(validityUnit, validityLength);
         Date notAfterDate = calendar.getTime();
         logger.debug("NSSDatabase: - not after: " + notAfterDate);
 

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -68,7 +68,8 @@ then
     pki -d /var/lib/tomcats/pki/conf/alias nss-cert-issue \
         --csr /tmp/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
-        --months-valid 12 \
+        --validity-length 1 \
+        --validity-unit year \
         --cert /tmp/ca_signing.crt
 
     # import and trust CA signing cert into NSS database

--- a/docs/changes/v11.5.0/Server-Changes.adoc
+++ b/docs/changes/v11.5.0/Server-Changes.adoc
@@ -20,3 +20,11 @@ The default value is `True`.
 The parameters `<subsystem_name>.<cert_id>.cert` and `<subsystem_name>.<cert_id>.certreq` are removed from `CS.cfg` files.
 Certificates are retrieved from the nssdb configured and they are not stored in other places.
 CSR are stored in the folder `<instance_config>/certs` as `<cert_nickname>.csr` and they are retrieved from this location.
+
+== New validity parameters for NSS Issuer in ACME ==
+
+The `NSSIssuer` in ACME has been modified to provide `validityLength`
+and `validityUnit` parameters to specify the certificate validity.
+The default is 3 months.
+
+The `monthsValid` parameter has been deprecated.

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -20,3 +20,11 @@ Use `pki` CLI or the `curl` command instead.
 
 The `DRMTool` command is no longer available.
 Use `KRATool` command instead.
+
+== New validity options for pki nss-cert-issue CLI ==
+
+The `pki nss-cert-issue` command has been modified to provide
+`--validity-length` and `--validity-unit` options to specify
+the certificate validity. The default is 3 months.
+
+The `--months-valid` option has been deprecated.


### PR DESCRIPTION
The `pki nss-cert-issue` command and the `NSSIssuer` in ACME have been modified to provide options/params to specify the cert validity in different units (e.g. minutes) which could be useful for testing and end-users as well.

The old option/param is limited to months only so it has been deprecated.

https://github.com/edewata/pki/blob/cli/docs/changes/v11.5.0/Server-Changes.adoc
https://github.com/edewata/pki/blob/cli/docs/changes/v11.5.0/Tools-Changes.adoc
