### PR TITLE
Fix Bug 2233158 - Make key wrapping algorithm configurable between AE…

### DIFF
--- a/base/common/src/com/netscape/certsrv/request/IRequest.java
+++ b/base/common/src/com/netscape/certsrv/request/IRequest.java
@@ -162,6 +162,7 @@ public interface IRequest extends Serializable {
     public final static String NETKEY_ATTR_USERID = "USERID";
     public final static String NETKEY_ATTR_DRMTRANS_DES_KEY = "drm_trans_desKey";
     public static final String NETKEY_ATTR_DRMTRANS_AES_KEY = "drm_trans_aesKey";
+    public static final String NETKEY_ATTR_SSKEYGEN_AES_KEY_WRAP_ALG = "drm_aes_wrapAlg";
 
     public final static String NETKEY_ATTR_ARCHIVE_FLAG = "archive";
     public final static String NETKEY_ATTR_SERVERSIDE_MUSCLE_FLAG = "serverSideMuscle";

--- a/base/kra/src/com/netscape/kra/NetkeyKeygenService.java
+++ b/base/kra/src/com/netscape/kra/NetkeyKeygenService.java
@@ -176,6 +176,11 @@ public class NetkeyKeygenService implements IService {
         String method = "NetkeyKeygenService: serviceRequest: ";
 
         byte iv[] = { 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1 };
+        int ivLength = EncryptionAlgorithm.AES_128_CBC.getIVLength();
+
+        CMS.debug(method + " cbc iv len: " + ivLength);
+
+        byte iv_cbc[] = new byte[ivLength];
         String iv_s = "";
         try {
             JssSubsystem jssSubsystem = (JssSubsystem) CMS.getSubsystem(JssSubsystem.ID);
@@ -188,6 +193,7 @@ public class NetkeyKeygenService implements IService {
 
         IVParameterSpec algParam = null;
         IVParameterSpec desAlgParam =	new IVParameterSpec(iv);
+        IVParameterSpec aesCBCAlgParam =   new IVParameterSpec(iv_cbc);
 
         IConfigStore configStore = CMS.getConfigStore();
         boolean allowEncDecrypt_archival = configStore.getBoolean("kra.allowEncDecrypt.archival", false);
@@ -228,6 +234,15 @@ public class NetkeyKeygenService implements IService {
 
         String rWrappedDesKeyString = request.getExtDataInString(IRequest.NETKEY_ATTR_DRMTRANS_DES_KEY);
         String rWrappedAesKeyString = request.getExtDataInString(IRequest.NETKEY_ATTR_DRMTRANS_AES_KEY);
+        String aesKeyWrapAlg        = request.getExtDataInString(IRequest.NETKEY_ATTR_SSKEYGEN_AES_KEY_WRAP_ALG);
+
+        CMS.debug(method + " IRequest.NETKEY_ATTR_SSKEYGEN_AES_KEY_WRAP_ALG: " + IRequest.NETKEY_ATTR_SSKEYGEN_AES_KEY_WRAP_ALG);
+
+        if(aesKeyWrapAlg != null) {
+            CMS.debug(method + " aesKeyWrapAlg: " + aesKeyWrapAlg);
+        } else {
+            CMS.debug(method + " no aesKeyWrapAlg provided.");
+        }
 
         boolean useAesTransWrapped = false;
 
@@ -396,10 +411,23 @@ public class NetkeyKeygenService implements IService {
 
                 KeyWrapAlgorithm symWrapAlg = KeyWrapAlgorithm.DES3_CBC_PAD;
                 if(useAesTransWrapped == true) {
-                    //Here we must use AES KWP because it's the only common AES key wrap to be supoprted on hsm, nss, and soon the coolkey applet.
-		    //Should make this configurable at some point.
-                    symWrapAlg = KeyWrapAlgorithm.AES_KEY_WRAP_PAD_KWP;
-		    algParam =  null;
+                    //Here we recomment to use AES KWP because it's the only common AES key wrap to be supoprted on hsm, nss, and soon the coolkey applet.
+		    //But now we are going to make it configurable to AES CBC based on interest in doing so. KWP is the one that is assured to work
+		    //with the applet and nss / hsm envorinments. CBC can be chosen at the admin's discretion.
+                   
+                    if(aesKeyWrapAlg != null && "CBC".equalsIgnoreCase(aesKeyWrapAlg)) {
+                    // We want CBC
+                        CMS.debug(method + " TPS has selected CBC for AES key wrap method.");
+                        symWrapAlg = KeyWrapAlgorithm.AES_CBC_PAD;
+
+                        algParam =  aesCBCAlgParam;
+                        iv_s = org.mozilla.jss.netscape.security.util.Utils.SpecialEncode(iv_cbc);
+
+                    } else { 
+                        symWrapAlg = KeyWrapAlgorithm.AES_KEY_WRAP_PAD_KWP;
+		        algParam =  null;
+                        iv_s = org.mozilla.jss.netscape.security.util.Utils.SpecialEncode(iv);
+                    }
                     CMS.debug(method + " attemptedAesKeyWrap = true ");
                 } else {
                     algParam = desAlgParam;
@@ -453,7 +481,7 @@ public class NetkeyKeygenService implements IService {
                             PubKey));
                 }
 
-                iv_s = org.mozilla.jss.netscape.security.util.Utils.SpecialEncode(iv);
+                //iv_s = org.mozilla.jss.netscape.security.util.Utils.SpecialEncode(iv);
                 request.setExtData("iv_s", iv_s);
 
             } catch (Exception e) {

--- a/base/server/cms/src/com/netscape/cms/servlet/connector/GenerateKeyPairServlet.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/connector/GenerateKeyPairServlet.java
@@ -143,6 +143,11 @@ public class GenerateKeyPairServlet extends CMSServlet {
         String rKeysize = req.getParameter(IRemoteRequest.KRA_KEYGEN_KeySize);
         String rKeytype = req.getParameter(IRemoteRequest.KRA_KEYGEN_KeyType);
         String rKeycurve = req.getParameter(IRemoteRequest.KRA_KEYGEN_EC_KeyCurve);
+
+        //Optional AES key wrap alg, default KWP anyway.
+        String rAesWrapAlg = req.getParameter(IRemoteRequest.KRA_Aes_Wrap_Alg);
+        CMS.debug("GenerateKeyPairServlet: processServerSideKeygen():  rAesWrapAlg: " + rAesWrapAlg);
+
         //Get trans wrapped aes session key if provided.
         String raesKeyString = req.getParameter(IRemoteRequest.KRA_Trans_AesKey);
         if ((rCUID == null) || (rCUID.equals(""))) {
@@ -220,6 +225,10 @@ public class GenerateKeyPairServlet extends CMSServlet {
             thisreq.setExtData(IRequest.NETKEY_ATTR_KEY_SIZE, rKeysize);
             thisreq.setExtData(IRequest.NETKEY_ATTR_KEY_TYPE, rKeytype);
             thisreq.setExtData(IRequest.NETKEY_ATTR_KEY_EC_CURVE, rKeycurve);
+
+            if((rAesWrapAlg != null) && (rAesWrapAlg.length() >0)) {
+                thisreq.setExtData(IRequest.NETKEY_ATTR_SSKEYGEN_AES_KEY_WRAP_ALG,rAesWrapAlg);
+            }
 
             queue.processRequest(thisreq);
             Integer result = thisreq.getExtDataInInteger(IRequest.RESULT);

--- a/base/server/cms/src/org/dogtagpki/server/connector/IRemoteRequest.java
+++ b/base/server/cms/src/org/dogtagpki/server/connector/IRemoteRequest.java
@@ -107,6 +107,7 @@ public interface IRemoteRequest {
     public static final String KRA_UserId = "userid";
     public static final String KRA_Trans_DesKey = "drm_trans_desKey";
     public static final String KRA_Trans_AesKey = "drm_trans_aesKey";
+    public static final String KRA_Aes_Wrap_Alg = "drm_aes_wrapAlg";
     public static final String KRA_KEYGEN_Archive = "archive";
     public static final String KRA_KEYGEN_KeyType = "keytype";
     public static final String KRA_KEYGEN_EC_KeyCurve = "eckeycurve";

--- a/base/tps/src/org/dogtagpki/server/tps/cms/KRARemoteRequestHandler.java
+++ b/base/tps/src/org/dogtagpki/server/tps/cms/KRARemoteRequestHandler.java
@@ -66,12 +66,20 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
             String userid,
             String sDesKey,
             String sAesKey,
-            boolean archive)
+            boolean archive,
+            String aesKeyWrapAlg)
             throws EBaseException {
 
         CMS.debug("KRARemoteRequestHandler: serverSideKeyGen(): begins.");
         if (cuid == null || userid == null || sDesKey == null) {
             throw new EBaseException("KRARemoteRequestHandler: serverSideKeyGen(): input parameter null.");
+        }
+
+        String aesWrapAlg = aesKeyWrapAlg;
+
+        //Just check for unsupported values that are not CBC or KWP and give default.
+        if(aesWrapAlg == null || aesWrapAlg.length() != 3) {
+            aesWrapAlg = "KWP";
         }
 
         TPSSubsystem subsystem =
@@ -109,7 +117,9 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
                     "&" + IRemoteRequest.KRA_Trans_DesKey + "=" +
                     sDesKey +
                     "&" + IRemoteRequest.KRA_Trans_AesKey + "=" +
-                    sAesKey; 
+                    sAesKey +
+                    "&" + IRemoteRequest.KRA_Aes_Wrap_Alg + "=" + 
+                    aesWrapAlg; 
 
             //CMS.debug("KRARemoteRequestHandler: outgoing request for ECC: " + request);
 
@@ -131,7 +141,10 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
                     "&" + IRemoteRequest.KRA_Trans_DesKey + "=" +
                     sDesKey +
                     "&" + IRemoteRequest.KRA_Trans_AesKey + "=" +
-                    sAesKey; ;
+                    sAesKey +  
+                    "&" + IRemoteRequest.KRA_Aes_Wrap_Alg + "=" +
+                    aesWrapAlg;
+
 
             //CMS.debug("KRARemoteRequestHandler: outgoing request for RSA: " + request);
 
@@ -237,9 +250,10 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
             String userid,
             String sDesKey,
             String sAesKey,
-            String b64cert)
+            String b64cert,
+            String aesKeyWrapAlg)
             throws EBaseException {
-        return recoverKey(cuid, userid, sDesKey,sAesKey, b64cert, BigInteger.valueOf(0));
+        return recoverKey(cuid, userid, sDesKey,sAesKey, b64cert, BigInteger.valueOf(0),aesKeyWrapAlg);
     }
 
     public KRARecoverKeyResponse recoverKey(
@@ -248,7 +262,8 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
             String sDesKey,
             String sAesKey,
             String b64cert,
-            BigInteger keyid)
+            BigInteger keyid,
+            String aesKeyWrapAlg)
             throws EBaseException {
 
         CMS.debug("KRARemoteRequestHandler: recoverKey(): begins.");
@@ -257,6 +272,13 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
         }
         if (cuid == null || userid == null) {
             throw new EBaseException("KRARemoteRequestHandler: recoverKey(): input parameter null.");
+        }
+
+        String aesWrapAlg = aesKeyWrapAlg;
+
+        //Just check for unsupported values that are not CBC or KWP and give default.
+        if(aesWrapAlg == null || aesWrapAlg.length() != 3) {
+            aesWrapAlg = "KWP";
         }
 
         TPSSubsystem subsystem =
@@ -289,7 +311,10 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
                         "&" + IRemoteRequest.KRA_UserId + "=" +
                         userid +
                         "&" + IRemoteRequest.KRA_RECOVERY_CERT + "=" +
-                        b64cert  + desPart + aesPart;
+                        b64cert  + desPart + aesPart +
+                        "&" + IRemoteRequest.KRA_Aes_Wrap_Alg + "=" +
+                        aesWrapAlg;
+ 
 
             } else if (keyid != BigInteger.valueOf(0)) { // recover by keyid ... keyid != BigInteger.valueOf(0)
                 CMS.debug("KRARemoteRequestHandler: recoverKey(): keyid = " + keyid);
@@ -298,7 +323,10 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
                         "&" + IRemoteRequest.KRA_UserId + "=" +
                         userid +
                         "&" + IRemoteRequest.KRA_RECOVERY_KEYID + "=" +
-                        keyid.toString() + desPart + aesPart;
+                        keyid.toString() + desPart + aesPart +
+                        "&" + IRemoteRequest.KRA_Aes_Wrap_Alg + "=" +
+                        aesWrapAlg;
+
 
             }
         } catch (Exception e) {

--- a/base/tps/src/org/dogtagpki/server/tps/engine/TPSEngine.java
+++ b/base/tps/src/org/dogtagpki/server/tps/engine/TPSEngine.java
@@ -202,6 +202,7 @@ public class TPSEngine {
     public static final String ENROLL_MODE_RECOVERY = RECOVERY_OP;
     public static final String ERNOLL_MODE_RENEWAL = RENEWAL_OP;
     public static final String CFG_ALLOW_MULTI_TOKENS_USER = "allowMultiActiveTokensUser";
+    public static final String CFG_AES_KEY_WRAP_ALG = "aesKeyWrapAlg";
 
     public void init() {
         //ToDo
@@ -524,17 +525,17 @@ public class TPSEngine {
     public KRARecoverKeyResponse recoverKey(String cuid,
             String userid,
             TPSBuffer drmWrappedDesKey, TPSBuffer drmWrappedAesKey,
-            String b64cert, String drmConnId) throws TPSException {
+            String b64cert, String drmConnId,String aesKeyWrapAlg) throws TPSException {
 
         return this.recoverKey(cuid, userid, drmWrappedDesKey, drmWrappedAesKey,
-             b64cert, drmConnId, BigInteger.valueOf(0));
+             b64cert, drmConnId, BigInteger.valueOf(0),aesKeyWrapAlg);
 
     }
 
     public KRARecoverKeyResponse recoverKey(String cuid,
             String userid,
             TPSBuffer drmWrappedDesKey,TPSBuffer drmWrappedAesKey,
-            String b64cert, String drmConnId,BigInteger keyid) throws TPSException {
+            String b64cert, String drmConnId,BigInteger keyid,String aesKeyWrapAlg) throws TPSException {
         String method = "TPSEngine.recoverKey";
         CMS.debug("TPSEngine.recoverKey");
         if (cuid == null)
@@ -570,7 +571,7 @@ public class TPSEngine {
 
             resp = kra.recoverKey(cuid, userid, encodedDes,
                 encodedAes, 
-                (b64cert != null) ? Util.uriEncode(b64cert) : b64cert,keyid);
+                (b64cert != null) ? Util.uriEncode(b64cert) : b64cert,keyid,aesKeyWrapAlg);
         } catch (EBaseException e) {
             throw new TPSException("TPSEngine.recoverKey: Problem creating or using KRARemoteRequestHandler! "
                     + e.toString(), TPSStatus.STATUS_ERROR_RECOVERY_FAILED);
@@ -610,7 +611,7 @@ public class TPSEngine {
     public KRAServerSideKeyGenResponse serverSideKeyGen(int keySize, String cuid, String userid, String drmConnId,
             TPSBuffer wrappedDesKey, TPSBuffer drmWrappedAesKey,
             boolean archive,
-            boolean isECC) throws TPSException {
+            boolean isECC,String aesKeyWrapAlg) throws TPSException {
 
 /*
         CMS.debug("TPSEngine.serverSideKeyGen entering... keySize: " + keySize + " cuid: " + cuid + " userid: "
@@ -632,7 +633,7 @@ public class TPSEngine {
             resp = kra.serverSideKeyGen(isECC, keySize, cuid, userid,
                     (wrappedDesKey != null) ? Util.specialURLEncode(wrappedDesKey) :  "",
                     (drmWrappedAesKey != null) ? Util.specialURLEncode(drmWrappedAesKey) : "",
-                    archive);
+                    archive,aesKeyWrapAlg);
 
         } catch (EBaseException e) {
             throw new TPSException("TPSEngine.serverSideKeyGen: Problem creating  or using KRARemoteRequestHandler! "

--- a/base/tps/src/org/dogtagpki/server/tps/processor/CertEnrollInfo.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/CertEnrollInfo.java
@@ -36,6 +36,7 @@ public class CertEnrollInfo {
     private String publisherId;
     private String keyType;
     private String keyTypePrefix;
+    private String aesKeyWrapAlg;
 
     private CARetrieveCertResponse recoveredCertData;
     private KRARecoverKeyResponse  recoveredKeyData;
@@ -199,6 +200,14 @@ public class CertEnrollInfo {
         return publicKeyNumber;
     }
 
+    public void setAesKeyWrapAlg(String alg) {
+        aesKeyWrapAlg = alg;
+    }
+
+    public String getAesKeyWrapAlg() {
+        return aesKeyWrapAlg;
+    }
+    
     public void setKeyType(String keyType) {
         this.keyType = keyType;
     }

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
@@ -1311,6 +1311,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                 session.getExternalRegAttrs().getCertsToRecoverCount());
         ArrayList<ExternalRegCertToRecover> erCertsToRecover = session.getExternalRegAttrs().getCertsToRecover();
 
+        String aesKeyWrapAlg = getAESKeyWrapAlgSSKeyGen();
         for (ExternalRegCertToRecover erCert : erCertsToRecover) {
             BigInteger keyid = erCert.getKeyid();
             BigInteger serial = erCert.getSerial();
@@ -1416,7 +1417,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                         userid,
                         drmDesKey,drmAesKey,
                         getExternalRegRecoverByKeyID() ? null : b64cert,
-                        kraConn, keyid);
+                        kraConn, keyid,aesKeyWrapAlg);
 
                 if (keyResp == null) {
                     auditInfo = "recovering key not found";
@@ -1437,6 +1438,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
             cEnrollInfo.setTokenToBeRecovered(tokenRecord);
             cEnrollInfo.setRecoveredCertData(certResp);
             cEnrollInfo.setRecoveredKeyData(keyResp);
+            cEnrollInfo.setAesKeyWrapAlg(aesKeyWrapAlg);
+
             preRecoveredCerts.add(cEnrollInfo);
 
         }
@@ -1667,6 +1670,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
 
         boolean recoverOldEncCerts = tokenPolicy.isAllowdRenewSaveOldEncCerts();
         CMS.debug(method + " Recover Old Encryption Certs for Renewed Certs: " + recoverOldEncCerts);
+
+        String aesKeyWrapAlg = getAESKeyWrapAlgSSKeyGen();
         if (oldEncCertsToRecover.size() > 0 && recoverOldEncCerts == true) {
             CMS.debug("About to attempt to recover old encryption certs just renewed.");
 
@@ -1692,7 +1697,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                             toBeRecovered.getUserID(),
                             drmDesKey,
                             drmAesKey,
-                            b64cert, getDRMConnectorID(toBeRecovered.getKeyType()));
+                            b64cert, getDRMConnectorID(toBeRecovered.getKeyType()),aesKeyWrapAlg);
 
                     //Try to write recovered cert to token
 
@@ -1701,6 +1706,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                     cEnrollInfo.setTokenToBeRecovered(tokenRecord);
                     cEnrollInfo.setRecoveredCertData(certResponse);
                     cEnrollInfo.setRecoveredKeyData(keyResponse);
+                    cEnrollInfo.setAesKeyWrapAlg(aesKeyWrapAlg);
 
                     PKCS11Obj pkcs11obj = certsInfo.getPKCS11Obj();
                     int newCertId = pkcs11obj.getNextFreeCertIdNumber();
@@ -1955,6 +1961,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
         int actualCertIndex = 0;
         boolean legalScheme = false;
 
+        String aesKeyWrapAlg = getAESKeyWrapAlgSSKeyGen();
         //Go through again and do the recoveries/enrollments
 
         certsInfo.setNumCertsToEnroll(totalNumCerts);
@@ -1974,6 +1981,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
             if (scheme.equals(TPSEngine.RECOVERY_GENERATE_NEW_KEY) || isGenerateAndRecover) {
                 legalScheme = true;
                 CertEnrollInfo cEnrollInfo = new CertEnrollInfo();
+                cEnrollInfo.setAesKeyWrapAlg(aesKeyWrapAlg);
                 generateCertificate(certsInfo, channel, aInfo, keyTypeValue, TPSEngine.ENROLL_MODES.MODE_ENROLL,
                         actualCertIndex, cEnrollInfo);
 
@@ -2040,13 +2048,14 @@ public class TPSEnrollProcessor extends TPSProcessor {
                     KRARecoverKeyResponse keyResponse = tps.getEngine().recoverKey(toBeRecovered.getId(),
                             toBeRecovered.getUserID(),
                             drmDesKey,drmAesKey,
-                            b64cert, getDRMConnectorID(certToRecover.getKeyType()));
+                            b64cert, getDRMConnectorID(certToRecover.getKeyType()),aesKeyWrapAlg);
 
                     CertEnrollInfo cEnrollInfo = new CertEnrollInfo();
 
                     cEnrollInfo.setTokenToBeRecovered(toBeRecovered);
                     cEnrollInfo.setRecoveredCertData(certResponse);
                     cEnrollInfo.setRecoveredKeyData(keyResponse);
+                    cEnrollInfo.setAesKeyWrapAlg(aesKeyWrapAlg);
 
                     generateCertificate(certsInfo, channel, aInfo, keyTypeValue, TPSEngine.ENROLL_MODES.MODE_RECOVERY,
                             actualCertIndex, cEnrollInfo);
@@ -2451,6 +2460,9 @@ public class TPSEnrollProcessor extends TPSProcessor {
         boolean isRecovery = false;
         boolean isRenewal = false;
 
+        String aesKeyWrapAlg = getAESKeyWrapAlgSSKeyGen();
+        cEnrollInfo.setAesKeyWrapAlg(aesKeyWrapAlg);
+
         if (mode == ENROLL_MODES.MODE_RECOVERY) {
             isRecovery = true;
 
@@ -2492,7 +2504,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                 ssKeyGenResponse = getTPSEngine()
                         .serverSideKeyGen(cEnrollInfo.getKeySize(),
                                 aInfo.getCUIDhexStringPlain(), userid, kraConnId, drmDesKey,drmAesKey,
-                                archive, isECC);
+                                archive, isECC, aesKeyWrapAlg);
 
                 publicKeyStr = ssKeyGenResponse.getPublicKey();
                 //CMS.debug("TPSEnrollProcessor.enrollOneCertificate: public key string from server: " + publicKeyStr);
@@ -3164,7 +3176,17 @@ public class TPSEnrollProcessor extends TPSProcessor {
 
         //Give preference to AES kek wrapped key for SCP03, otherwise go with DES for SCP01
 	if(kekWrappedAESKey != null && kekWrappedAESKey.size() > 0 && channel.isSCP03()) {
-            alg = (byte) 0x88;
+
+            String aesKeyWrapAlg = cEnrollInfo.getAesKeyWrapAlg();
+
+            if(aesKeyWrapAlg != null && "CBC".equalsIgnoreCase(aesKeyWrapAlg)) { //CBC
+                CMS.debug("TPSEnrollProcessor.importPrivateKeyPKCS8: unwrap the priv key with AES CBC ");
+                alg = (byte) 0x89;
+            } else { // KWP
+                CMS.debug("TPSEnrollProcessor.importPrivateKeyPKCS8: unwrap the priv key with AES KWP ");
+                alg = (byte) 0x88;
+            }
+
             kekWrappedKey = kekWrappedAESKey;
         }
 
@@ -3181,7 +3203,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
         }
         data.add((byte) ivParamsBuff.size());
         data.add(ivParamsBuff);
-//        CMS.debug("TPSEnrollProcessor.importprivateKeyPKCS8: key data outgoing: " + data.toHexString());
+        //CMS.debug("TPSEnrollProcessor.importprivateKeyPKCS8: key data outgoing: " + data.toHexString());
 
         int pe1 = (cEnrollInfo.getKeyUser() << 4) + cEnrollInfo.getPrivateKeyNumber();
         int pe2 = (cEnrollInfo.getKeyUsage() << 4) + cEnrollInfo.getPublicKeyNumber();
@@ -3454,6 +3476,30 @@ public class TPSEnrollProcessor extends TPSProcessor {
         return parsedPubKey;
     }
 
+    public String getAESKeyWrapAlgSSKeyGen() {
+
+        String aesKeyWrapAlg = "KWP";
+
+        IConfigStore configStore = CMS.getConfigStore();
+
+        // op.enroll.userKey.keyGen.aesKeyWrapAlg 
+        try {
+            String configValue = TPSEngine.OP_ENROLL_PREFIX + "." + selectedTokenType + "." + TPSEngine.CFG_KEYGEN +
+                   "." +  TPSEngine.CFG_AES_KEY_WRAP_ALG;
+
+            CMS.debug("TPSEnrollProcessor::getAESKeyWrapAlgSSKeyGen: configValue . " + configValue);
+            aesKeyWrapAlg = configStore.getString(
+                    configValue, "KWP");
+            CMS.debug("TPSEnrollProcessor::getAESKeyWrapAlgSSKeyGen: value " + aesKeyWrapAlg);
+
+        } catch (EBaseException e) {
+            //return default
+            return aesKeyWrapAlg;
+        }
+
+        return aesKeyWrapAlg;
+
+    }
     private boolean checkForServerSideKeyGen(CertEnrollInfo cInfo) throws TPSException {
 
         if (cInfo == null) {


### PR DESCRIPTION
…S-KWP and AES-CBC [RHCS 9.7.z].

This fix allows the TPS adminsitrator to configure the aesKeyWrap alg when the KRA wraps a private key to be injected onto the smart card. This operation is done in server side keygen and key recovery scenarios. As of the latest code, only the AES_KWP wrap alg is supported. Users requested the ability to choose either KWP or AES_CBC_PAD. The caveat here is that CBC_PAD is not assured compatibility between the token and certain hsm based setups. The default is to use the currently supported KWP alg. The reason to allow CBC is due to the fact that this alg is supported directly in the token and is much quicker than the hand coded KWP algorithm currently supported.

The choice is very simply configured in the TPS's CS.cfg and can be configured separately for various token profiles. Also the default is KWP if the following setting is not present:

ex: op.enroll.userKey.keyGen.aesKeyWrapAlg=CBC

The two choices here are "KWP" or "CBC".

Another example for recovery when the original token is marked as temporarilly lost:

op.enroll.userKeyTemporary.keyGen.aesKeyWrapAlg=CBC

Once this is set, subsequent calls from the TPS to the KRA for server side keygen will send this choice to the KRA. From there the KRA will wrap the private key blob using the required alg and send it back to TPS.

From there the TPS will send the blob down to the coolkey applet to be unwrapped. A different byte code for KWP (0x88) or CBC (0x89) will be sent to a new coolkey applet. The new applet will be able to detect which alg to use and attempt.

There will be a subsequent addition to this PR to include the new applet which is still being finalized.

Once the user gets the new rpm's there will be a new applet to choose within the TPS config for ex:

op.format.userKey.update.applet.requiredVersion.prot.3=1.5.651f3902 op.enroll.userKey.update.applet.requiredVersion.prot.3=1.5.651f3902

The applet number here is just an example it will be different.