### PR TITLE
Remove token password from destroy logs

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2454,6 +2454,7 @@ class SecurityDomain:
             logger.warning(
                 log.PKIHELPER_SECURITY_DOMAIN_UNREACHABLE_1,
                 secname)
+            exc.cmd[4] = '******'
             logger.error(log.PKI_SUBPROCESS_ERROR_1, exc)
             if critical_failure:
                 raise


### PR DESCRIPTION
In case of failure of the `sslget` command, during `pkidestroy`, the log will contain the full list of option including the token password. This has been obfuscated before the failure is logged.

Solve RHCS-4547