### PR TITLE
Add InfoServlet with APIv2

### DIFF
--- a/base/common/python/pki/info.py
+++ b/base/common/python/pki/info.py
@@ -108,7 +108,7 @@ class InfoClient(object):
 
         self.connection = connection
 
-        self.info_url = '/pki/rest/info'
+        self.info_url = '/pki/v2/info'
 
     @pki.handle_exceptions()
     def get_info(self):

--- a/base/common/src/main/java/org/dogtagpki/common/InfoClient.java
+++ b/base/common/src/main/java/org/dogtagpki/common/InfoClient.java
@@ -27,7 +27,7 @@ import com.netscape.certsrv.client.PKIClient;
 public class InfoClient extends Client {
 
     public InfoClient(PKIClient client) throws Exception {
-        super(client, "pki", "info");
+        super(client, "pki", "v2", "info");
     }
 
     public Info getInfo() throws Exception {

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/PKIEngine.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/PKIEngine.java
@@ -1,0 +1,11 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server;
+
+public class PKIEngine {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIEngine.class);
+}

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/PKIEngine.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/PKIEngine.java
@@ -5,7 +5,76 @@
 //
 package org.dogtagpki.server;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.dogtagpki.common.Info;
+
+import com.netscape.certsrv.base.PKIException;
+import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.cmscore.apps.CMS;
+
 public class PKIEngine {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIEngine.class);
+
+    public static final Path bannerFile = Paths.get(CMS.getInstanceDir(), "conf", "banner.txt");
+
+    public static boolean isBannerEnabled() {
+        return Files.exists(bannerFile);
+    }
+
+    public static String getBanner() throws IOException {
+        return new String(Files.readAllBytes(bannerFile), "UTF-8").trim();
+    }
+
+    public Info getInfo(HttpServletRequest request) throws Exception {
+
+        logger.info("PKIEngine: Getting server info");
+
+        HttpSession session = request.getSession();
+        logger.info("PKIEngine: - session: " + session.getId());
+
+        Info info = new Info();
+
+        boolean bannerDisplayed = session.getAttribute("bannerDisplayed") != null;
+        boolean bannerEnabled = isBannerEnabled();
+
+        // if banner not yet displayed in this session and it's enabled, return banner
+        if (!bannerDisplayed && bannerEnabled) {
+
+            String banner = getBanner();
+            info.setBanner(banner);
+
+            // validate banner
+            try {
+                // converting Info object into JSON
+                String jsonInfo = info.toJSON();
+
+                // and parse it back into Info object
+                info = JSONSerializer.fromJSON(jsonInfo, Info.class);
+
+            } catch (Exception e) {
+                logger.error("PKIEngine: Invalid access banner: " + e.getMessage(), e);
+                throw new PKIException("Invalid access banner: " + e.getMessage(), e);
+            }
+        }
+
+        // add other info attributes after banner validation
+
+        String productName = CMS.getProductName();
+        logger.info("PKIEngine: - product name: " + productName);
+        info.setName(productName);
+
+        String productVersion = CMS.getProductVersion();
+        logger.info("PKIEngine: - product version: " + productName);
+        info.setVersion(productVersion);
+
+        return info;
+    }
 }

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/PKIServlet.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/PKIServlet.java
@@ -1,0 +1,40 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server;
+
+import java.io.IOException;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class PKIServlet extends HttpServlet {
+
+    public static final long serialVersionUID = 1L;
+
+    public PKIEngine getPKIEngine() {
+        ServletContext servletContext = getServletContext();
+        return (PKIEngine) servletContext.getAttribute("engine");
+    }
+
+    public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        try {
+            get(request, response);
+
+        } catch (ServletException | IOException e) {
+            throw e;
+
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+}

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/PKIWebListener.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/PKIWebListener.java
@@ -1,0 +1,30 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+@WebListener
+public class PKIWebListener implements ServletContextListener {
+
+    public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIWebListener.class);
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+
+        ServletContext servletContext = event.getServletContext();
+
+        PKIEngine engine = new PKIEngine();
+        servletContext.setAttribute("engine", engine);
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+    }
+}

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/rest/InfoService.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/rest/InfoService.java
@@ -18,61 +18,24 @@
 
 package org.dogtagpki.server.rest;
 
-import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
 
 import org.dogtagpki.common.Info;
 import org.dogtagpki.common.InfoResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.dogtagpki.server.PKIEngine;
 
-import com.netscape.certsrv.base.PKIException;
-import com.netscape.certsrv.util.JSONSerializer;
 import com.netscape.cms.servlet.base.PKIService;
-import com.netscape.cmscore.apps.CMS;
 
 /**
  * @author Endi S. Dewata
  */
 public class InfoService extends PKIService implements InfoResource {
 
-    private static Logger logger = LoggerFactory.getLogger(InfoService.class);
-
     @Override
     public Response getInfo() throws Exception {
 
-        HttpSession session = servletRequest.getSession();
-        logger.debug("InfoService.getInfo(): session: " + session.getId());
-
-        Info info = new Info();
-
-        boolean bannerDisplayed = session.getAttribute("bannerDisplayed") != null;
-        boolean bannerEnabled = isBannerEnabled();
-
-        // if banner not yet displayed in this session and it's enabled, return banner
-        if (!bannerDisplayed && bannerEnabled) {
-
-            String banner = getBanner();
-            info.setBanner(banner);
-
-            // validate banner
-            try {
-                // converting Info object into JSON
-                String jsonInfo = info.toJSON();
-
-                // and parse it back into Info object
-                info = JSONSerializer.fromJSON(jsonInfo, Info.class);
-
-            } catch (Exception e) {
-                logger.error("InfoService: Invalid access banner: " + e.getMessage(), e);
-                throw new PKIException("Invalid access banner: " + e.getMessage(), e);
-            }
-        }
-
-        // add other info attributes after banner validation
-
-        info.setName(CMS.getProductName());
-        info.setVersion(CMS.getProductVersion());
+        PKIEngine engine = (PKIEngine) servletContext.getAttribute("engine");
+        Info info = engine.getInfo(servletRequest);
 
         return createOKResponse(info);
     }

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/v2/InfoServlet.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/v2/InfoServlet.java
@@ -1,0 +1,37 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.v2;
+
+import java.io.PrintWriter;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+
+import org.dogtagpki.common.Info;
+import org.dogtagpki.server.PKIEngine;
+import org.dogtagpki.server.PKIServlet;
+
+/**
+ * @author Endi S. Dewata
+ */
+@WebServlet("/v2/info")
+public class InfoServlet extends PKIServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
+
+        PKIEngine engine = getPKIEngine();
+        Info info = engine.getInfo(request);
+
+        response.setContentType(MediaType.APPLICATION_JSON);
+
+        PrintWriter out = response.getWriter();
+        out.println(info.toJSON());
+    }
+}

--- a/base/server-webapp/webapps/pki/js/pki.js
+++ b/base/server-webapp/webapps/pki/js/pki.js
@@ -58,7 +58,7 @@ var PKI = {
     getInfo: function(options) {
         $.ajax({
             type: "GET",
-            url: "/pki/rest/info",
+            url: "/pki/v2/info",
             dataType: "json"
         }).done(function(data, textStatus, jqXHR) {
             if (options.success) options.success.call(self, data, textStatus, jqXHR);

--- a/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
@@ -17,12 +17,8 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cms.servlet.base;
 
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -44,7 +40,6 @@ import javax.ws.rs.core.UriInfo;
 
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.util.JSONSerializer;
-import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 
 /**
@@ -87,16 +82,6 @@ public class PKIService {
 
     @Context
     protected ServletContext servletContext;
-
-    public static final Path bannerFile = Paths.get(CMS.getInstanceDir(), "conf", "banner.txt");
-
-    public static boolean isBannerEnabled() {
-        return Files.exists(bannerFile);
-    }
-
-    public static String getBanner() throws IOException {
-        return new String(Files.readAllBytes(bannerFile), "UTF-8").trim();
-    }
 
     /**
      * Return a match for a candidate media type (which may be a wildcard)


### PR DESCRIPTION
This PR provides a lightweight framework for a APIv2 and an example showing that the same service can be provided via both APIv1 and APIv2 without duplicating a lot of code.

The `PKIEngine` has been added to store the main code of PKI web application. `PKIWebListener` has been added to initialize the `PKIEngine` when the web application is started. `PKIServlet` has been added as the base class for servlets that use `PKIEngine`.

The code that constructs the `Info` object in `InfoService` has been moved into `PKIEngine` such that it can be reused.

The `InfoServlet` has been added as a lightweight alternative to `InfoService` without dependency on RESTEasy.
    
All clients have been modified to call the `InfoServlet` instead.
