### PR TITLE
Update pki nss-cert-import

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -658,7 +658,7 @@ class NSSDatabase(object):
             cert_format='pem',
             token=None,
             trust_attributes=None,
-            use_jss=False):
+            use_jss=True):
 
         logger.debug('NSSDatabase.add_cert(%s)', nickname)
 
@@ -751,6 +751,12 @@ class NSSDatabase(object):
         '''
         check = True
 
+        if cert_file and not cert_data:
+            with open(cert_file, 'r', encoding='utf-8') as f:
+                cert_data = f.read()
+
+        cert_data = convert_cert(cert_data, cert_format, 'pem')
+
         cmd = [
             'pki',
             '-d', self.directory
@@ -771,14 +777,10 @@ class NSSDatabase(object):
             # Trust is most likely ,, anyway so there is no loss.
             check = False
 
-        cmd.extend(['nss-cert-import'])
-
-        if cert_file:
-            cmd.extend(['--cert', cert_file])
-
-        if cert_data:
-            cert_data = convert_cert(cert_data, cert_format, 'pem')
-            cmd.extend(['--format', 'PEM'])
+        cmd.extend([
+            'nss-cert-import',
+            '--format', 'PEM'
+        ])
 
         if trust_attributes:
             cmd.extend(['--trust', trust_attributes])

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3049,9 +3049,7 @@ class PKIDeployer:
                 nickname=nickname,
                 cert_file=cert_file,
                 token=token,
-                trust_attributes=trust_attributes,
-                use_jss=True
-            )
+                trust_attributes=trust_attributes)
 
         finally:
             nssdb.close()
@@ -3250,8 +3248,7 @@ class PKIDeployer:
             nickname=request.systemCert.nickname,
             cert_data=system_cert['data'],
             cert_format='base64',
-            token=request.systemCert.token,
-            use_jss=False)
+            token=request.systemCert.token)
 
     def setup_system_certs(self, nssdb, subsystem):
 

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertImportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertImportCLI.java
@@ -93,9 +93,20 @@ public class NSSCertImportCLI extends CommandCLI {
         X509CertImpl cert = new X509CertImpl(bytes);
 
         ClientConfig clientConfig = mainCLI.getConfig();
-        NSSDatabase nssdb = mainCLI.getNSSDatabase();
 
-        String tokenName = clientConfig.getTokenName();
+        String tokenName = null;
+        int i = nickname.indexOf(':');
+
+        if (i < 0) {
+            // use token name specified in --token option
+            tokenName = clientConfig.getTokenName();
+        } else {
+            // use token name specified in nickname
+            tokenName = nickname.substring(0, i);
+            nickname = nickname.substring(i + 1);
+        }
+
+        NSSDatabase nssdb = mainCLI.getNSSDatabase();
 
         if (nickname == null) {
             nssdb.addCertificate(cert, trustFlags);


### PR DESCRIPTION
The `pki nss-cert-import` has been updated to use the token name in the nickname if specified, otherwise it will use the token name specified in the `--token` option.

The `NSSDatabase.addCertificate()` in Java (which is used by `pki nss-cert-import`) has been modified to call the new `PK11Store.importCert()` instead of `addPEMCertificate()` which depends on `certutil -A`.

The `NSSDatabase.add_cert()` in Python has been updated to use JSS (via `pki nss-cert-import`) by default. It has also been updated to provide the input cert via standard input instead of file to avoid permission issues.