### PR TITLE
Fix dangling link to jaxb-api.jar

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -170,6 +170,8 @@ else()
         NAMES
             jaxb-api.jar
         PATHS
+            /usr/share/java/jaxb-api4
+            /usr/share/java/jaxb-api
             /usr/share/java
     )
 endif(XMVN_RESOLVE)


### PR DESCRIPTION
The CMake script has been updated to use more specific paths to find the proper location of `jaxb-api.jar` on platforms that do not provide `xmvn-resolve`.

Resolves: https://issues.redhat.com/browse/RHCS-4602