### PR TITLE
Fix RSA key pairs generation in FIPS environment

### DIFF
--- a/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -423,9 +423,9 @@ public class CryptoUtil {
         return generateRSAKeyPair(
                 token,
                 keySize,
-                false,
-                false,
-                false,
+                null,
+                null,
+                null,
                 usages,
                 usagesMask);
     }

--- a/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
+++ b/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
@@ -972,9 +972,9 @@ public class NSSDatabase {
         return CryptoUtil.generateRSAKeyPair(
                 token,
                 keySize,
-                false,
-                false,
-                false,
+                null,
+                null,
+                null,
                 usages,
                 usagesMask);
     }
@@ -989,9 +989,9 @@ public class NSSDatabase {
         return CryptoUtil.generateRSAKeyPair(
                 token,
                 keySize,
-                false,
-                false,
-                false,
+                null,
+                null,
+                null,
                 null,
                 null);
     }


### PR DESCRIPTION
When FIPS is enabled and kay are not temporary then the sensitive flag has to be true.

Flags are assigned only if not `NULL` so to enable the default values they generator is invoked with `NULL` value instead of `false` value which was assigned.

NOTE: EC key pairs were working in FIPS because they were using `NULL` values (as visible few lines before the changes).

Fix:  RHCS-4595 and should fix RHCS-4566