### PR TITLE
Enable RSNv3 by default

### DIFF
--- a/.github/workflows/acme-certbot-test.yml
+++ b/.github/workflows/acme-certbot-test.yml
@@ -55,8 +55,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install CA admin cert

--- a/.github/workflows/acme-postgresql-test.yml
+++ b/.github/workflows/acme-postgresql-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install CA admin cert

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -55,8 +55,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Set up ACME database in DS container

--- a/.github/workflows/ca-admin-user-test.yml
+++ b/.github/workflows/ca-admin-user-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check CA users

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check CA certs and keys

--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -85,8 +85,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token
@@ -173,8 +171,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token
@@ -344,8 +340,6 @@ jobs:
               -D pki_subsystem_token=HSM \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/ca-clone-replicated-ds-test.yml
+++ b/.github/workflows/ca-clone-replicated-ds-test.yml
@@ -55,8 +55,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_client_admin_cert_p12=$SHARED/caadmin.p12 \
               -v
 
@@ -252,8 +250,6 @@ jobs:
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_ds_setup=False \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in primary CA and secondary CA

--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -105,8 +105,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca-secure-ds-primary.cfg \
               -s CA \
               -D pki_ds_url=ldaps://primaryds.example.com:3636 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -217,8 +215,6 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_url=ldaps://secondaryds.example.com:3636 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -270,8 +266,6 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_url=ldaps://secondaryds.example.com:3636 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Gather artifacts from primary containers

--- a/.github/workflows/ca-clone-shared-ds-test.yml
+++ b/.github/workflows/ca-clone-shared-ds-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Export certs and keys from primary CA
@@ -89,8 +87,6 @@ jobs:
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_ds_setup=False \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in primary CA and secondary CA

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -107,8 +105,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -256,8 +252,6 @@ jobs:
               -D pki_audit_signing_csr_path=${SHARED}/ca_audit_signing.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec tertiary pki-server cert-find

--- a/.github/workflows/ca-cmc-shared-token-test.yml
+++ b/.github/workflows/ca-cmc-shared-token-test.yml
@@ -277,7 +277,7 @@ jobs:
           HEX_SERIAL=$(cat testuser.serial)
           echo "Hex serial: $HEX_SERIAL"
 
-          DEC_SERIAL=$((16#${HEX_SERIAL:2}))
+          DEC_SERIAL=$(python -c "print(int('$HEX_SERIAL', 16))")
           echo "Dec serial: $DEC_SERIAL"
 
           SHARED_TOKEN=$(cat token.txt)

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -59,8 +59,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Configure caUserCert profile

--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
           docker exec pki pki-server ca-config-set internaldb.minConns 0
           docker exec pki pki-server restart --wait

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca-ecc.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_enable_access_log=False \
               -v
 

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -232,8 +232,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_external=True \
               -D pki_external_step_two=False \
               -v
@@ -242,8 +240,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_external=True \
               -D pki_external_step_two=True \
               -D pki_pkcs12_path=ca-certs.p12 \

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -221,8 +221,6 @@ jobs:
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_ds_setup=False \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Run PKI healthcheck

--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -345,8 +345,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_existing=True \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -246,8 +246,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_existing=True \
               -D pki_ca_signing_csr_path=ca_signing.csr \
               -D pki_ocsp_signing_csr_path=ca_ocsp_signing.csr \

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -83,8 +83,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/ca-non-default-user-test.yml
+++ b/.github/workflows/ca-non-default-user-test.yml
@@ -63,8 +63,6 @@ jobs:
               -D pki_user=pki \
               -D pki_group=pki \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check PKI server process

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -66,8 +66,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       # https://github.com/dogtagpki/pki/wiki/Configuring-Notifications

--- a/.github/workflows/ca-nuxwdog-test.yml
+++ b/.github/workflows/ca-nuxwdog-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check CA

--- a/.github/workflows/ca-profile-caDirUserCert-test.yml
+++ b/.github/workflows/ca-profile-caDirUserCert-test.yml
@@ -87,8 +87,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Configure UserDirEnrollment

--- a/.github/workflows/ca-profile-caServerCert-test.yml
+++ b/.github/workflows/ca-profile-caServerCert-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Configure caServerCert profile

--- a/.github/workflows/ca-pruning-test.yml
+++ b/.github/workflows/ca-pruning-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_request_id_generator=random \
-              -D pki_cert_id_generator=random \
               -v
 
       - name: Configure server cert profile

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Export CA cert

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -59,8 +59,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Configure file-based CRL publishing

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -59,8 +59,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Prepare CRL publishing subtree

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Prepare publishing subtree

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -64,8 +64,6 @@ jobs:
               -D pki_subsystem_key_algorithm=SHA384withRSA/PSS \
               -D pki_sslserver_key_algorithm=SHA384withRSA/PSS \
               -D pki_admin_key_algorithm=SHA384withRSA/PSS \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system cert keys

--- a/.github/workflows/ca-rsa-test.yml
+++ b/.github/workflows/ca-rsa-test.yml
@@ -62,8 +62,6 @@ jobs:
               -D pki_subsystem_key_algorithm=SHA384withRSA \
               -D pki_sslserver_key_algorithm=SHA384withRSA \
               -D pki_admin_key_algorithm=SHA384withRSA \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_enable_access_log=False \
               -v
 

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -54,6 +54,8 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_cert_id_generator=legacy \
+              -D pki_request_id_generator=legacy \
               -D pki_random_serial_numbers_enable=True \
               -v
 

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -104,8 +104,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca-secure-ds.cfg \
               -s CA \
               -D pki_ds_url=ldaps://ds.example.com:3636 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find
@@ -102,8 +100,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check KRA storage cert

--- a/.github/workflows/kra-clone-hsm-test.yml
+++ b/.github/workflows/kra-clone-hsm-test.yml
@@ -85,8 +85,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install KRA in primary PKI container
@@ -103,8 +101,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token
@@ -188,8 +184,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install KRA in secondary PKI container
@@ -211,8 +205,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token
@@ -384,8 +376,6 @@ jobs:
               -D pki_subsystem_token=HSM \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install KRA in tertiary PKI container
@@ -424,8 +414,6 @@ jobs:
               -D pki_subsystem_token=HSM \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
               -D pki_sslserver_token=internal \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/kra-clone-shared-ds-test.yml
+++ b/.github/workflows/kra-clone-shared-ds-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install KRA in primary PKI container
@@ -63,8 +61,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install admin cert in primary PKI container
@@ -112,8 +108,6 @@ jobs:
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_ds_setup=False \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install KRA in secondary PKI container
@@ -129,8 +123,6 @@ jobs:
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_ds_setup=False \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in primary KRA and secondary KRA

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -66,8 +64,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -103,8 +99,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -119,8 +113,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -165,8 +157,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec tertiary pki-server cert-find
@@ -181,8 +171,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec tertiary pki-server cert-find

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find
@@ -101,8 +99,6 @@ jobs:
               -D pki_sslserver_csr_path=$SHARED/sslserver.csr \
               -D pki_audit_signing_csr_path=$SHARED/kra_audit_signing.csr \
               -D pki_admin_csr_path=$SHARED/kra_admin.csr \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       # https://github.com/dogtagpki/pki/wiki/Issuing-KRA-Storage-Certificate-with-CMC
@@ -277,8 +273,6 @@ jobs:
               -D pki_sslserver_cert_path=$SHARED/sslserver.p7b \
               -D pki_audit_signing_cert_path=$SHARED/kra_audit_signing.p7b \
               -D pki_admin_cert_path=$SHARED/kra_admin.crt \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec kra pki-server cert-find

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find
@@ -101,8 +99,6 @@ jobs:
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
               -D pki_audit_signing_csr_path=${SHARED}/kra_audit_signing.csr \
               -D pki_admin_csr_path=${SHARED}/kra_admin.csr \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Issue KRA storage cert
@@ -184,8 +180,6 @@ jobs:
               -D pki_sslserver_cert_path=${SHARED}/sslserver.crt \
               -D pki_audit_signing_cert_path=${SHARED}/kra_audit_signing.crt \
               -D pki_admin_cert_path=${SHARED}/kra_admin.crt \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec kra pki-server cert-find

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -83,8 +83,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token
@@ -124,8 +122,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/kra-oaep-test.yml
+++ b/.github/workflows/kra-oaep-test.yml
@@ -54,7 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find
@@ -69,7 +68,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Verify oaep is not configured in KRA
@@ -88,7 +86,6 @@ jobs:
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_use_oaep_rsa_keywrap=True \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find
@@ -104,7 +101,6 @@ jobs:
               -s KRA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -D pki_use_oaep_rsa_keywrap=True \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Verify oaep is configured in KRA

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find
@@ -95,8 +93,6 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
               -D pki_ds_url=ldap://krads.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec kra pki-server cert-find

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_security_domain_setup=False \
               -v
 
@@ -111,8 +109,6 @@ jobs:
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
               -D pki_audit_signing_csr_path=${SHARED}/kra_audit_signing.csr \
               -D pki_admin_csr_path=${SHARED}/kra_admin.csr \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Issue KRA storage cert
@@ -194,8 +190,6 @@ jobs:
               -D pki_sslserver_cert_path=${SHARED}/sslserver.crt \
               -D pki_audit_signing_cert_path=${SHARED}/kra_audit_signing.crt \
               -D pki_admin_cert_path=${SHARED}/kra_admin.crt \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec kra pki-server cert-find

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -101,8 +99,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -161,8 +157,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec tertiary pki-server cert-find

--- a/.github/workflows/ocsp-cmc-test.yml
+++ b/.github/workflows/ocsp-cmc-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -60,8 +60,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install CA admin cert in CA container

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -61,8 +61,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install CA admin cert in CA container

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find

--- a/.github/workflows/ocsp-hsm-test.yml
+++ b/.github/workflows/ocsp-hsm-test.yml
@@ -83,8 +83,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_security_domain_setup=False \
               -v
 

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find

--- a/.github/workflows/server-backup-test.yml
+++ b/.github/workflows/server-backup-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Run PKI healthcheck before backup

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://rootds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec root pki-server cert-find
@@ -91,8 +89,6 @@ jobs:
               -s CA \
               -D pki_cert_chain_path=${SHARED}/root-ca_signing.crt \
               -D pki_ds_url=ldap://subds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Install banner in subordinate container

--- a/.github/workflows/subca-clone-hsm-test.yml
+++ b/.github/workflows/subca-clone-hsm-test.yml
@@ -108,8 +108,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_client_admin_cert_p12=$SHARED/caadmin.p12 \
               -v
 
@@ -139,8 +137,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_client_admin_cert_p12=$SHARED/caadmin.p12 \
               -v
 
@@ -346,8 +342,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_clone_uri=https://primary-subca.example.com:8443 \
               -v
 

--- a/.github/workflows/subca-clone-test.yml
+++ b/.github/workflows/subca-clone-test.yml
@@ -80,8 +80,6 @@ jobs:
               -s CA \
               -D pki_ds_url=ldap://primary-ds.example.com:3389 \
               -D pki_ca_signing_csr_path=$SHARED/subca_signing.csr \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_client_admin_cert_p12=$SHARED/caadmin.p12 \
               -v
 
@@ -102,8 +100,6 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/root-ca_signing.crt \
               -D pki_ca_signing_csr_path=$SHARED/subca_signing.csr \
               -D pki_ca_signing_cert_path=$SHARED/subca_signing.crt \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_client_admin_cert_p12=$SHARED/caadmin.p12 \
               -v
 
@@ -161,8 +157,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/subca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondary-ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_clone_uri=https://primary-subca.example.com:8443 \
               -v
 

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -55,8 +55,6 @@ jobs:
               -s CA \
               -D pki_ds_url=ldap://rootds.example.com:3389 \
               -D pki_security_domain_name=ROOT \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Update caCMCcaCert profile
@@ -111,8 +109,6 @@ jobs:
               -s CA \
               -D pki_ds_url=ldap://subds.example.com:3389 \
               -D pki_ca_signing_csr_path=$SHARED/ca_signing.csr \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       # https://github.com/dogtagpki/pki/wiki/Issuing-CA-Signing-Certificate-with-CMC
@@ -148,8 +144,6 @@ jobs:
               -D pki_cert_chain_path=$SHARED/root-ca_signing.crt \
               -D pki_ca_signing_csr_path=$SHARED/ca_signing.csr \
               -D pki_ca_signing_cert_path=$SHARED/ca_signing.p7b \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check subordinate CA signing cert

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -74,8 +74,6 @@ jobs:
               -D pki_req_ext_add=True \
               -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
               -D pki_req_ext_data=1E0A00530075006200430041 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki /usr/share/pki/tests/ca/bin/test-subca-signing-csr-ext.sh ca_signing.csr
@@ -99,8 +97,6 @@ jobs:
               -D pki_req_ext_add=True \
               -D pki_req_ext_oid=1.3.6.1.4.1.311.20.2 \
               -D pki_req_ext_data=1E0A00530075006200430041 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find

--- a/.github/workflows/subca-hsm-test.yml
+++ b/.github/workflows/subca-hsm-test.yml
@@ -103,8 +103,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Issue subordinate CA signing cert
@@ -129,8 +127,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/subca-lightweight-hsm-test.yml
+++ b/.github/workflows/subca-lightweight-hsm-test.yml
@@ -81,8 +81,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check admin user

--- a/.github/workflows/subca-lightweight-test.yml
+++ b/.github/workflows/subca-lightweight-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check admin user

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -56,8 +56,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -103,8 +101,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -163,8 +159,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec tertiary pki-server cert-find

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find

--- a/.github/workflows/tks-hsm-test.yml
+++ b/.github/workflows/tks-hsm-test.yml
@@ -83,8 +83,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -54,8 +54,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find
@@ -66,8 +64,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec pki pki-server cert-find

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -56,8 +56,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -68,8 +66,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec primary pki-server cert-find
@@ -128,8 +124,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find
@@ -144,8 +138,6 @@ jobs:
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec secondary pki-server cert-find

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec ca pki-server cert-find
@@ -98,8 +96,6 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
               -D pki_ds_url=ldap://krads.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
           docker exec kra pki-server cert-find

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -83,8 +83,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token
@@ -124,8 +122,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -v
 
       - name: Check system certs in internal token

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -53,8 +53,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_cert_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_http_enable=False \
               -v
 
@@ -103,8 +101,6 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
               -D pki_ds_url=ldap://krads.example.com:3389 \
-              -D pki_key_id_generator=random \
-              -D pki_request_id_generator=random \
               -D pki_http_enable=False \
               -v
 

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -307,8 +307,6 @@ pkispawn \
     -D pki_ds_url=ldap://ds.example.com:3389 \
     -D pki_ds_setup=False \
     -D pki_share_db=True \
-    -D pki_request_id_generator=random \
-    -D pki_cert_id_generator=random \
     -D pki_existing=True \
     -D pki_import_system_certs=False \
     -D pki_ca_signing_nickname=ca_signing \

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -342,13 +342,13 @@ pki_replica_number_range_start=
 pki_replica_number_range_end=
 
 # Cert cert ID generator: legacy, random
-pki_cert_id_generator=legacy
+pki_cert_id_generator=random
 
 # Cert cert ID length in bits
 pki_cert_id_length=128
 
 # Cert request ID generator: legacy, random
-pki_request_id_generator=legacy
+pki_request_id_generator=random
 
 # Cert request ID length in bits
 pki_request_id_length=128
@@ -438,13 +438,13 @@ pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 # Key ID generator: legacy, random
-pki_key_id_generator=legacy
+pki_key_id_generator=random
 
 # Key ID length in bits
 pki_key_id_length=128
 
 # Key request ID generator: legacy, random
-pki_request_id_generator=legacy
+pki_request_id_generator=random
 
 # Key request ID length in bits
 pki_request_id_length=128

--- a/docs/changes/v11.5.0/Server-Changes.adoc
+++ b/docs/changes/v11.5.0/Server-Changes.adoc
@@ -28,3 +28,29 @@ and `validityUnit` parameters to specify the certificate validity.
 The default is 3 months.
 
 The `monthsValid` parameter has been deprecated.
+
+== Enable Random Serial Numbers v3 by Default ==
+
+New CA and KRA installations will have Random Serial Numbers v3 enabled by default.
+Existing installations will not be affected.
+
+To migrate existing installations with the legacy sequential serial numbers or RandomSerial Numbers v1 to Random Serial Numbers v3 follow these instructions:
+
+* link:https://github.com/dogtagpki/pki/wiki/Configuring-CA-with-Random-Serial-Numbers-v3[Configuring CA with Random Serial Numbers v3]
+* link:https://github.com/dogtagpki/pki/wiki/Configuring-KRA-with-Random-Serial-Numbers-v3[Configuring KRA with Random Serial Numbers v3]
+
+To install a new CA with the legacy sequential serial numbers specify the following parameters:
+
+* `pki_cert_id_generator=legacy`
+* `pki_request_id_generator=legacy`
+
+To install a new CA with the legacy Random Serial Numbers v1 specify the following parameters:
+
+* `pki_cert_id_generator=legacy`
+* `pki_request_id_generator=legacy`
+* `pki_random_serial_numbers_enable=True`
+
+To install a new KRA with the legacy sequential serial numbers specify the following parameters:
+
+* `pki_key_id_generator=legacy`
+* `pki_request_id_generator=legacy`

--- a/docs/installation/ca/Installing-CA-with-Random-Serial-Numbers-v3.adoc
+++ b/docs/installation/ca/Installing-CA-with-Random-Serial-Numbers-v3.adoc
@@ -2,6 +2,8 @@
 
 This page describes the process to install a CA subsystem with link:https://github.com/dogtagpki/pki/wiki/Random-Certificate-Serial-Numbers-v3[Random Certificate Serial Numbers v3] in PKI 11.2 or later.
 
+NOTE: RSNv3 is enabled by default since PKI 11.5.
+
 = Installation Procedure =
 
 To install CA with random serial numbers v3, follow the normal link:Installing_CA.md[CA installation] procedure, then specify the parameters below.

--- a/docs/installation/kra/Installing-KRA-with-Random-Serial-Numbers-v3.adoc
+++ b/docs/installation/kra/Installing-KRA-with-Random-Serial-Numbers-v3.adoc
@@ -2,6 +2,8 @@
 
 This page describes the process to install a KRA subsystem with random serial numbers in PKI 11.2 or later.
 
+NOTE: RSNv3 is enabled by default since PKI 11.5.
+
 = Installation Procedure =
 
 To install KRA with random serial numbers, follow the normal link:Installing_KRA.md[KRA installation] procedure, then specify the following parameter:

--- a/tests/ansible/ocsp/tasks/certificate_self_validation_with_crl.yml
+++ b/tests/ansible/ocsp/tasks/certificate_self_validation_with_crl.yml
@@ -89,8 +89,6 @@
       pkispawn -f /usr/share/pki/server/examples/installation/ca.cfg
       -s CA
       -D pki_ds_url=ldap://{{ cads_hostname }}:3389
-      -D pki_cert_id_generator=random
-      -D pki_request_id_generator=random
       -v
 
 - name: Install CA admin cert in CA container


### PR DESCRIPTION
The `default.cfg` has been updated such that new CA and KRA installations will have RSNv3 enabled by default. Existing installations will not be affected.

The tests have been updated to no longer enable RSNv3 explicitly since it's redundant.

The test for CA with CMC shared token has been updated to handle large serial numbers.

The test for CA with RSNv1 has been updated to explicitly use the legacy ID generators.

https://github.com/edewata/pki/blob/random/docs/changes/v11.5.0/Server-Changes.adoc
https://github.com/edewata/pki/blob/random/docs/installation/ca/Installing-CA-with-Random-Serial-Numbers-v3.adoc
https://github.com/edewata/pki/blob/random/docs/installation/kra/Installing-KRA-with-Random-Serial-Numbers-v3.adoc

Resolves: https://issues.redhat.com/browse/RHCS-3689