### PR TITLE
Fix permission issue in pki-server ca-cert-request-import

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRequestImportCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertRequestImportCLI.java
@@ -114,10 +114,6 @@ public class CACertRequestImportCLI extends CommandCLI {
             throw new Exception("Missing profile ID");
         }
 
-        if (!cmd.hasOption("csr")) {
-            throw new Exception("Missing certificate request");
-        }
-
         String requestPath = cmd.getOptionValue("csr");
         String requestFormat = cmd.getOptionValue("format");
 


### PR DESCRIPTION
In some cases `pki-server ca-cert-request-import` fails to import a CSR since the Python code of the command runs as the current user but the Java code runs as PKI user which might not have the permission to read the input file.

To avoid the issue, the Python code has been modified to load the CSR into memory, then pass the CSR to Java via the standard input. The Java code has been updated not to throw an exception if the CSR is provided via the standard input instead of a file.