### PR TITLE
Remove unnecessary workaround for certutil bug

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -749,7 +749,6 @@ class NSSDatabase(object):
         Import certificate using pki nss-cert-import command.
         In the future this will replace add_cert().
         '''
-        check = True
 
         if cert_file and not cert_data:
             with open(cert_file, 'r', encoding='utf-8') as f:
@@ -772,11 +771,6 @@ class NSSDatabase(object):
         if token:
             cmd.extend(['--token', token])
 
-            # Don't check the return value as a workaround for NSS upstream
-            # BZ https://bugzilla.mozilla.org/show_bug.cgi?id=1782980
-            # Trust is most likely ,, anyway so there is no loss.
-            check = False
-
         cmd.extend([
             'nss-cert-import',
             '--format', 'PEM'
@@ -793,7 +787,7 @@ class NSSDatabase(object):
 
         cmd.append(nickname)
 
-        self.run(cmd, input=cert_data, text=True, check=check, runas=True)
+        self.run(cmd, input=cert_data, text=True, check=True, runas=True)
 
     def add_ca_cert(self, cert_file, trust_attributes='CT,C,C'):
 


### PR DESCRIPTION
The `NSSDatabase.__add_cert()` was modified recently in 6dcca7e9279db9e5e295705168ebb8340b64d9e0 to use JSS via `pki nss-cert-import` instead of `certutil`, so the workaround for Mozilla Bug #1782980 is no longer needed.

Resolves: https://issues.redhat.com/browse/RHCS-4601