### PR TITLE
Add pki-server cert-request

### DIFF
--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -75,22 +75,18 @@ jobs:
 
       - name: Create CA signing cert in HSM
         run: |
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-request \
               --token HSM \
-              nss-cert-request \
               --subject "CN=CA Signing Certificate" \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
-              --csr /tmp/ca_signing.csr
+              ca_signing
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
               -f /etc/pki/pki-tomcat/password.conf \
               --token HSM \
               nss-cert-issue \
-              --csr /tmp/ca_signing.csr \
+              --csr /etc/pki/pki-tomcat/certs/ca_signing.csr \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               --cert /tmp/ca_signing.crt
           docker exec pki runuser -u pkiuser -- \
@@ -123,15 +119,11 @@ jobs:
 
       - name: Create CA OCSP signing cert in HSM
         run: |
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-request \
               --token HSM \
-              nss-cert-request \
               --subject "CN=OCSP Signing Certificate" \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
-              --csr /tmp/ca_ocsp_signing.csr
+              ca_ocsp_signing
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
@@ -139,7 +131,7 @@ jobs:
               --token HSM \
               nss-cert-issue \
               --issuer HSM:ca_signing \
-              --csr /tmp/ca_ocsp_signing.csr \
+              --csr /etc/pki/pki-tomcat/certs/ca_ocsp_signing.csr \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
               --cert /tmp/ca_ocsp_signing.crt
           docker exec pki runuser -u pkiuser -- \
@@ -171,15 +163,11 @@ jobs:
 
       - name: Create CA audit signing cert in HSM
         run: |
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-request \
               --token HSM \
-              nss-cert-request \
               --subject "CN=Audit Signing Certificate" \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr /tmp/ca_audit_signing.csr
+              ca_audit_signing
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
@@ -187,7 +175,7 @@ jobs:
               --token HSM \
               nss-cert-issue \
               --issuer HSM:ca_signing \
-              --csr /tmp/ca_audit_signing.csr \
+              --csr /etc/pki/pki-tomcat/certs/ca_audit_signing.csr \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               --cert /tmp/ca_audit_signing.crt
           docker exec pki runuser -u pkiuser -- \
@@ -220,15 +208,11 @@ jobs:
 
       - name: Create subsystem cert in HSM
         run: |
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-request \
               --token HSM \
-              nss-cert-request \
               --subject "CN=Subsystem Certificate" \
               --ext /usr/share/pki/server/certs/subsystem.conf \
-              --csr /tmp/subsystem.csr
+              subsystem
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
@@ -236,7 +220,7 @@ jobs:
               --token HSM \
               nss-cert-issue \
               --issuer HSM:ca_signing \
-              --csr /tmp/subsystem.csr \
+              --csr /etc/pki/pki-tomcat/certs/subsystem.csr \
               --ext /usr/share/pki/server/certs/subsystem.conf \
               --cert /tmp/subsystem.crt
           docker exec pki runuser -u pkiuser -- \
@@ -268,14 +252,10 @@ jobs:
 
       - name: Create SSL server cert in server's NSS database
         run: |
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
-              nss-cert-request \
+          docker exec pki pki-server cert-request \
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
-              --csr /tmp/sslserver.csr
+              sslserver
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
@@ -283,7 +263,7 @@ jobs:
               --token HSM \
               nss-cert-issue \
               --issuer HSM:ca_signing \
-              --csr /tmp/sslserver.csr \
+              --csr /etc/pki/pki-tomcat/certs/sslserver.csr \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --cert /tmp/sslserver.crt
           docker exec pki runuser -u pkiuser -- \
@@ -354,11 +334,6 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_ca_signing_csr_path=/tmp/ca_signing.csr \
-              -D pki_ocsp_signing_csr_path=/tmp/ca_ocsp_signing.csr \
-              -D pki_audit_signing_csr_path=/tmp/ca_audit_signing.csr \
-              -D pki_subsystem_csr_path=/tmp/subsystem.csr \
-              -D pki_sslserver_csr_path=/tmp/sslserver.csr \
               -D pki_admin_cert_path=/tmp/admin.crt \
               -D pki_admin_csr_path=/tmp/admin.csr \
               -v

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -54,13 +54,10 @@ jobs:
 
       - name: Create CA signing cert in server's NSS database
         run: |
-          docker exec pki mkdir -p /etc/pki/pki-tomcat/certs
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-request \
+          docker exec pki pki-server cert-request \
               --subject "CN=CA Signing Certificate" \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
-              --csr /etc/pki/pki-tomcat/certs/ca_signing.csr
+              ca_signing
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-issue \
@@ -88,12 +85,10 @@ jobs:
 
       - name: Create CA OCSP signing cert in server's NSS database
         run: |
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-request \
+          docker exec pki pki-server cert-request \
               --subject "CN=OCSP Signing Certificate" \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
-              --csr /etc/pki/pki-tomcat/certs/ca_ocsp_signing.csr
+              ca_ocsp_signing
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-issue \
@@ -121,12 +116,10 @@ jobs:
 
       - name: Create CA audit signing cert in server's NSS database
         run: |
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-request \
+          docker exec pki pki-server cert-request \
               --subject "CN=Audit Signing Certificate" \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr /etc/pki/pki-tomcat/certs/ca_audit_signing.csr
+              ca_audit_signing
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-issue \
@@ -155,12 +148,10 @@ jobs:
 
       - name: Create subsystem cert in server's NSS database
         run: |
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-request \
+          docker exec pki pki-server cert-request \
               --subject "CN=Subsystem Certificate" \
               --ext /usr/share/pki/server/certs/subsystem.conf \
-              --csr /etc/pki/pki-tomcat/certs/subsystem.csr
+              subsystem
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-issue \
@@ -188,12 +179,10 @@ jobs:
 
       - name: Create SSL server cert in server's NSS database
         run: |
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-request \
+          docker exec pki pki-server cert-request \
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
-              --csr /etc/pki/pki-tomcat/certs/sslserver.csr
+              sslserver
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-issue \
@@ -243,7 +232,6 @@ jobs:
 
       - name: Install CA with existing NSS database
         run: |
-          docker exec pki chown -R pkiuser:pkiuser /etc/pki/pki-tomcat/certs
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -155,6 +155,10 @@ class PKIServer(object):
         return os.path.join(self.base_dir, 'conf')
 
     @property
+    def certs_dir(self):
+        return os.path.join(self.conf_dir, 'certs')
+
+    @property
     def lib_dir(self):
         return os.path.join(self.base_dir, 'lib')
 
@@ -306,6 +310,18 @@ class PKIServer(object):
                 nssdb.close()
 
         # TODO: handle other types of HTTP connector
+
+    def cert_file(self, cert_id):
+        '''
+        Compute name of certificate under instance certs folder.
+        '''
+        return os.path.join(self.certs_dir, cert_id + '.crt')
+
+    def csr_file(self, cert_id):
+        '''
+        Compute name of CSR under instance certs folder.
+        '''
+        return os.path.join(self.certs_dir, cert_id + '.csr')
 
     def create_catalina_policy(self):
 
@@ -684,6 +700,8 @@ grant codeBase "file:%s" {
         self.symlink(bin_dir, self.bin_dir, exist_ok=True)
 
         self.create_conf_dir(exist_ok=True)
+
+        self.makedirs(self.certs_dir, exist_ok=True)
 
         catalina_policy = os.path.join(Tomcat.CONF_DIR, 'catalina.policy')
         self.copy(catalina_policy, self.catalina_policy, force=force)

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -54,6 +54,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         logger.info('Creating %s', instance.conf_dir)
         instance.makedirs(instance.conf_dir, exist_ok=True)
 
+        instance.makedirs(instance.certs_dir, exist_ok=True)
+
         # Configuring internal token password
 
         internal_token = deployer.mdict['pki_self_signed_token']

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -37,3 +37,7 @@ The `pki nss-cert-del` command has been added to delete a certificate from NSS d
 
 The `pki client-cert-del` command has been deprecated.
 Use `pki nss-cert-del` command instead.
+
+== New pki-server cert-request CLI ==
+
+The `pki-server cert-request` command has been added to generate a key pair and an enrollment request for a system certificate.


### PR DESCRIPTION
The `pki-server cert-request` has been added to simplify creating CSRs for system certs so it's no longer necessary to specify the NSS database path, password file, CSR path, and also to fix the file ownership.

The `cert_folder()`, `cert_file()`, and `csr_file()` in `PKIInstance` have been moved into `PKIServer` so they can be reused. The `cert_folder()` has been renamed to `certs_dir()` for consistency.

The `PKIServer.create()` and `instance_layout.py` have been updated to create the `certs` folder so it's guaranteed to exist.

The `RemoveCertCSRfromConfig` upgrade script has been updated to use the new methods in `PKIServer`.

The tests for installing CA with existing NSS database and existing HSM have been updated to use the new command.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Certificate-CLI
https://github.com/edewata/pki/blob/cli/docs/changes/v11.5.0/Tools-Changes.adoc
