### PR TITLE
Update pki-server cert-create

### DIFF
--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -80,22 +80,17 @@ jobs:
               --subject "CN=CA Signing Certificate" \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               ca_signing
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-create \
               --token HSM \
-              nss-cert-issue \
-              --csr /etc/pki/pki-tomcat/certs/ca_signing.csr \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
-              --cert /tmp/ca_signing.crt
+              ca_signing
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
               -f /etc/pki/pki-tomcat/password.conf \
               --token HSM \
               nss-cert-import \
-              --cert /tmp/ca_signing.crt \
+              --cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
               --trust CT,C,C \
               ca_signing
 
@@ -124,23 +119,18 @@ jobs:
               --subject "CN=OCSP Signing Certificate" \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
               ca_ocsp_signing
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-create \
               --token HSM \
-              nss-cert-issue \
               --issuer HSM:ca_signing \
-              --csr /etc/pki/pki-tomcat/certs/ca_ocsp_signing.csr \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
-              --cert /tmp/ca_ocsp_signing.crt
+              ca_ocsp_signing
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
               -f /etc/pki/pki-tomcat/password.conf \
               --token HSM \
               nss-cert-import \
-              --cert /tmp/ca_ocsp_signing.crt \
+              --cert /etc/pki/pki-tomcat/certs/ca_ocsp_signing.crt \
               ca_ocsp_signing
 
           # check original cert
@@ -168,23 +158,18 @@ jobs:
               --subject "CN=Audit Signing Certificate" \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               ca_audit_signing
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-create \
               --token HSM \
-              nss-cert-issue \
               --issuer HSM:ca_signing \
-              --csr /etc/pki/pki-tomcat/certs/ca_audit_signing.csr \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert /tmp/ca_audit_signing.crt
+              ca_audit_signing
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
               -f /etc/pki/pki-tomcat/password.conf \
               --token HSM \
               nss-cert-import \
-              --cert /tmp/ca_audit_signing.crt \
+              --cert /etc/pki/pki-tomcat/certs/ca_audit_signing.crt \
               --trust ,,P \
               ca_audit_signing
 
@@ -213,23 +198,18 @@ jobs:
               --subject "CN=Subsystem Certificate" \
               --ext /usr/share/pki/server/certs/subsystem.conf \
               subsystem
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-create \
               --token HSM \
-              nss-cert-issue \
               --issuer HSM:ca_signing \
-              --csr /etc/pki/pki-tomcat/certs/subsystem.csr \
               --ext /usr/share/pki/server/certs/subsystem.conf \
-              --cert /tmp/subsystem.crt
+              subsystem
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
               -f /etc/pki/pki-tomcat/password.conf \
               --token HSM \
               nss-cert-import \
-              --cert /tmp/subsystem.crt \
+              --cert /etc/pki/pki-tomcat/certs/subsystem.crt \
               subsystem
 
           # check original cert
@@ -256,22 +236,17 @@ jobs:
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               sslserver
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-create \
               --token HSM \
-              nss-cert-issue \
               --issuer HSM:ca_signing \
-              --csr /etc/pki/pki-tomcat/certs/sslserver.csr \
               --ext /usr/share/pki/server/certs/sslserver.conf \
-              --cert /tmp/sslserver.crt
+              sslserver
           docker exec pki runuser -u pkiuser -- \
               pki \
               -d /etc/pki/pki-tomcat/alias \
               -f /etc/pki/pki-tomcat/password.conf \
               nss-cert-import \
-              --cert /tmp/sslserver.crt \
+              --cert /etc/pki/pki-tomcat/certs/sslserver.crt \
               sslserver
 
           # check original cert
@@ -461,7 +436,9 @@ jobs:
 
       - name: Check CA admin cert
         run: |
-          docker exec pki pki client-cert-import ca_signing --ca-cert /tmp/ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --ca-cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
+              ca_signing
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Check CA certs and requests

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -58,16 +58,13 @@ jobs:
               --subject "CN=CA Signing Certificate" \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               ca_signing
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-issue \
-              --csr /etc/pki/pki-tomcat/certs/ca_signing.csr \
+          docker exec pki pki-server cert-create \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
-              --cert ca_signing.crt
+              ca_signing
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-import \
-              --cert ca_signing.crt \
+              --cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
               --trust CT,C,C \
               ca_signing
 
@@ -89,17 +86,14 @@ jobs:
               --subject "CN=OCSP Signing Certificate" \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
               ca_ocsp_signing
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-issue \
+          docker exec pki pki-server cert-create \
               --issuer ca_signing \
-              --csr /etc/pki/pki-tomcat/certs/ca_ocsp_signing.csr \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
-              --cert ca_ocsp_signing.crt
+              ca_ocsp_signing
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-import \
-              --cert ca_ocsp_signing.crt \
+              --cert /etc/pki/pki-tomcat/certs/ca_ocsp_signing.crt \
               ca_ocsp_signing
 
           # check original cert
@@ -120,17 +114,14 @@ jobs:
               --subject "CN=Audit Signing Certificate" \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               ca_audit_signing
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-issue \
+          docker exec pki pki-server cert-create \
               --issuer ca_signing \
-              --csr /etc/pki/pki-tomcat/certs/ca_audit_signing.csr \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert ca_audit_signing.crt
+              ca_audit_signing
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-import \
-              --cert ca_audit_signing.crt \
+              --cert /etc/pki/pki-tomcat/certs/ca_audit_signing.crt \
               --trust ,,P \
               ca_audit_signing
 
@@ -152,17 +143,14 @@ jobs:
               --subject "CN=Subsystem Certificate" \
               --ext /usr/share/pki/server/certs/subsystem.conf \
               subsystem
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-issue \
+          docker exec pki pki-server cert-create \
               --issuer ca_signing \
-              --csr /etc/pki/pki-tomcat/certs/subsystem.csr \
               --ext /usr/share/pki/server/certs/subsystem.conf \
-              --cert subsystem.crt
+              subsystem
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-import \
-              --cert subsystem.crt \
+              --cert /etc/pki/pki-tomcat/certs/subsystem.crt \
               subsystem
 
           # check original cert
@@ -183,17 +171,14 @@ jobs:
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               sslserver
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-issue \
+          docker exec pki pki-server cert-create \
               --issuer ca_signing \
-              --csr /etc/pki/pki-tomcat/certs/sslserver.csr \
               --ext /usr/share/pki/server/certs/sslserver.conf \
-              --cert sslserver.crt
+              sslserver
           docker exec pki pki \
               -d /etc/pki/pki-tomcat/alias \
               nss-cert-import \
-              --cert sslserver.crt \
+              --cert /etc/pki/pki-tomcat/certs/sslserver.crt \
               sslserver
 
           # check original cert
@@ -336,7 +321,9 @@ jobs:
 
       - name: Check CA admin cert
         run: |
-          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki client-cert-import \
+              --ca-cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
+              ca_signing
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Check CA certs and requests

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -41,3 +41,9 @@ Use `pki nss-cert-del` command instead.
 == New pki-server cert-request CLI ==
 
 The `pki-server cert-request` command has been added to generate a key pair and an enrollment request for a system certificate.
+
+== Update pki-server cert-create CLI ==
+
+The `pki-server cert-create` command has been updated to support
+creating permanent system certificate using the server's NSS database
+and RSNv3 serial numbers.


### PR DESCRIPTION
The `pki-server cert-create` has been updated to simplify creating a system cert. It will use the server's NSS database directly and RSNv3 serial numbers so it can be used before the CA subsystem is created or when the server is down. It will use the CSR in `/etc/pki/pki-tomcat/certs` and store the new cert in that folder as well.

The tests for installing CA with existing NSS database and HSM have been updated to use this command.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Certificate-CLI
https://github.com/edewata/pki/blob/cli/docs/changes/v11.5.0/Tools-Changes.adoc
