### PR TITLE
Update pki-server cert-import

### DIFF
--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -84,14 +84,8 @@ jobs:
               --token HSM \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               ca_signing
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-import \
               --token HSM \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
-              --trust CT,C,C \
               ca_signing
 
           # check original cert
@@ -124,13 +118,8 @@ jobs:
               --issuer HSM:ca_signing \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
               ca_ocsp_signing
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-import \
               --token HSM \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_ocsp_signing.crt \
               ca_ocsp_signing
 
           # check original cert
@@ -163,14 +152,8 @@ jobs:
               --issuer HSM:ca_signing \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               ca_audit_signing
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-import \
               --token HSM \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_audit_signing.crt \
-              --trust ,,P \
               ca_audit_signing
 
           # check original cert
@@ -203,13 +186,8 @@ jobs:
               --issuer HSM:ca_signing \
               --ext /usr/share/pki/server/certs/subsystem.conf \
               subsystem
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+          docker exec pki pki-server cert-import \
               --token HSM \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/subsystem.crt \
               subsystem
 
           # check original cert
@@ -241,13 +219,7 @@ jobs:
               --issuer HSM:ca_signing \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               sslserver
-          docker exec pki runuser -u pkiuser -- \
-              pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/sslserver.crt \
-              sslserver
+          docker exec pki pki-server cert-import sslserver
 
           # check original cert
           docker exec pki runuser -u pkiuser -- \

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -61,12 +61,7 @@ jobs:
           docker exec pki pki-server cert-create \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               ca_signing
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
-              --trust CT,C,C \
-              ca_signing
+          docker exec pki pki-server cert-import ca_signing
 
           # check original cert
           docker exec pki pki \
@@ -90,11 +85,7 @@ jobs:
               --issuer ca_signing \
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
               ca_ocsp_signing
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_ocsp_signing.crt \
-              ca_ocsp_signing
+          docker exec pki pki-server cert-import ca_ocsp_signing
 
           # check original cert
           docker exec pki pki \
@@ -118,12 +109,7 @@ jobs:
               --issuer ca_signing \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               ca_audit_signing
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_audit_signing.crt \
-              --trust ,,P \
-              ca_audit_signing
+          docker exec pki pki-server cert-import ca_audit_signing
 
           # check original cert
           docker exec pki pki \
@@ -147,11 +133,7 @@ jobs:
               --issuer ca_signing \
               --ext /usr/share/pki/server/certs/subsystem.conf \
               subsystem
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/subsystem.crt \
-              subsystem
+          docker exec pki pki-server cert-import subsystem
 
           # check original cert
           docker exec pki pki \
@@ -175,11 +157,7 @@ jobs:
               --issuer ca_signing \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               sslserver
-          docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              nss-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/sslserver.crt \
-              sslserver
+          docker exec pki pki-server cert-import sslserver
 
           # check original cert
           docker exec pki pki \

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -47,3 +47,8 @@ The `pki-server cert-request` command has been added to generate a key pair and 
 The `pki-server cert-create` command has been updated to support
 creating permanent system certificate using the server's NSS database
 and RSNv3 serial numbers.
+
+== Update pki-server cert-import CLI ==
+
+The `pki-server cert-import` command has been updated to provide
+options to specify the certificate nickname and token name.


### PR DESCRIPTION
The `pki-server cert-import` has been updated to provide options to specify the nickname and token so that the cert can be imported before creating any subsystem in the instance.

The tests for installing CA with existing NSS database and HSM have been updated to use this command.

https://github.com/edewata/pki/blob/cli/docs/changes/v11.5.0/Tools-Changes.adoc
https://github.com/dogtagpki/pki/wiki/PKI-Server-Certificate-CLI
