### PR TITLE
Fix CRMFPopClient on FIPS environment

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
@@ -484,7 +484,6 @@ public class CRMFPopClient {
 
             if (algorithm.equals("rsa")) {
 
-                boolean sens = false;
                 boolean extract = true;
 
                 Usage[] usages = CryptoUtil.RSA_KEYPAIR_USAGES;
@@ -494,7 +493,7 @@ public class CRMFPopClient {
                         token,
                         keySize,
                         temporary,
-                        sens,
+                        null,
                         extract,
                         usages,
                         usagesMask);


### PR DESCRIPTION
When FIPS is enabled RSA key generation cannot have both temporary and sensitive to false.

Since temporary is defined from a command option the sensitive is set to null so the default for the environment will be used (true if FIPS is enabled and false if FIPS is disabled).

Fix BZ Bug 2250716