### PR TITLE
Fix pki_cert_chain_path param

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -401,13 +401,6 @@ class PKIDeployer:
 
         self.import_certs_and_keys(nssdb)
 
-        # If provided, import cert chain into NSS database.
-        # Note: Cert chain must be imported after the system certs
-        # to ensure that the system certs are imported with
-        # the correct nicknames.
-
-        self.import_cert_chain(nssdb)
-
     def configure_system_cert(self, subsystem, tag):
 
         cert_id = self.get_cert_id(subsystem, tag)

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -405,6 +405,12 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 deployer.import_system_cert_requests(subsystem)
                 deployer.import_system_certs(nssdb, subsystem)
 
+                # If provided, import cert chain into NSS database.
+                # Note: Cert chain must be imported after the system certs
+                # to ensure that the system certs are imported with
+                # the correct nicknames.
+                deployer.import_cert_chain(nssdb)
+
                 deployer.configure_system_certs(subsystem)
 
                 deployer.update_system_certs(nssdb, subsystem)
@@ -413,6 +419,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 deployer.validate_system_certs(nssdb, subsystem)
 
             elif len(subsystems) > 1:
+
+                # If provided, import cert chain into NSS database.
+                deployer.import_cert_chain(nssdb)
 
                 for s in subsystems:
 
@@ -443,13 +452,14 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
             else:  # self-signed CA
 
+                # If provided, import cert chain into NSS database.
+                deployer.import_cert_chain(nssdb)
+
                 # To be implemented in ticket #1692.
 
                 # Generate CA cert request.
                 # Self sign CA cert.
                 # Import self-signed CA cert into NSS database.
-
-                pass
 
         finally:
             nssdb.close()


### PR DESCRIPTION
Previously the `pki_cert_chain_path` was only used to import the cert chain under certain cases:
- installation with existing certs/keys
- installation with external certs
- standalone installation

The `configuration.py` has been modified such that the cert chain will be imported in all cases.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2228922