### PR TITLE
ACMEAccountService fixes/enhancements

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAccountService.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEAccountService.java
@@ -17,6 +17,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import org.dogtagpki.acme.ACMEAccount;
 import org.dogtagpki.acme.ACMEHeader;
 import org.dogtagpki.acme.ACMENonce;
@@ -74,7 +76,12 @@ public class ACMEAccountService {
         String payload = new String(jws.getPayloadAsBytes(), "UTF-8");
         logger.info("Payload: " + payload);
 
-        ACMEAccount update = ACMEAccount.fromJSON(payload);
+        ACMEAccount update;
+        try {
+            update = ACMEAccount.fromJSON(payload);
+        } catch (JsonProcessingException e) {
+            throw engine.createMalformedException(e.toString());
+        }
 
         String newStatus = update.getStatus();
         if (newStatus != null) {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -728,6 +728,18 @@ public class ACMEEngine {
         return new WebApplicationException(builder.build());
     }
 
+    public Exception createMalformedException(String desc) {
+        ResponseBuilder builder = Response.status(Response.Status.BAD_REQUEST);
+        builder.type("application/problem+json");
+
+        ACMEError error = new ACMEError();
+        error.setType("urn:ietf:params:acme:error:malformed");
+        error.setDetail("Malformed request: " + desc);
+        builder.entity(error);
+
+        return new WebApplicationException(builder.build());
+    }
+
     public void updateAccount(ACMEAccount account) throws Exception {
         database.updateAccount(account);
     }


### PR DESCRIPTION
```
e2046ef87c (Fraser Tweedale, 7 minutes ago)
   acme: implement POST-as-GET for accounts

   Some ACME clients including mod_md POST-as-GET the account resource
   (for an existing account), expected to read the account info.  In 
   particular, mod_md does this and certificate renewal fails because it
   cannot read or verify the account information.

   The ACME protocol does not explicitly require this behaviour.  But on the
   other hand, it is not surprising that clients assume they can do it, and it
   arguably is surprising if an ACME server does not provide it.

   So let's implement it.  The change itself is trivial: when payload is
   empty, POST-as-GET is implied (RFC 8555 section 6.3).  In this case, return
   the ACMEAccount object (which we already have at hand) unchanged.

48a385fcc4 (Fraser Tweedale, 28 minutes ago)
   acme: return proper error on malformed account payload

   ACMEAccountService currently throws an uncaught exception if decode the
   account object payload fails.  This results in the server responding 500
   Internal Server Error.  Respond with status 400 and a proper problem
   document instead.
```