### PR TITLE
Add pki-server <subsystem>-db-index-add/rebuild

### DIFF
--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -221,52 +221,11 @@ jobs:
 
       - name: Add CA search indexes
         run: |
-          sed \
-              -e 's/{database}/userroot/g' \
-              base/ca/database/ds/index.ldif \
-              | tee index.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/index.ldif
+          docker exec pki pki-server ca-db-index-add -v
 
       - name: Rebuild CA search indexes
         run: |
-          # start rebuild task
-          sed \
-              -e 's/{database}/userroot/g' \
-              base/ca/database/ds/indextasks.ldif \
-              | tee indextasks.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/indextasks.ldif
-
-          # wait for task to complete
-          while true; do
-              sleep 1
-
-              docker exec ds ldapsearch \
-                  -H ldap://ds.example.com:3389 \
-                  -D "cn=Directory Manager" \
-                  -w Secret.123 \
-                  -b "cn=index1160589770, cn=index, cn=tasks, cn=config" \
-                  -LLL \
-                  nsTaskExitCode \
-                  | tee output
-
-              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
-              cat nsTaskExitCode
-
-              if [ -s nsTaskExitCode ]; then
-                  break
-              fi
-          done
-
-          echo "0" > expected
-          diff expected nsTaskExitCode
+          docker exec pki pki-server ca-db-index-rebuild -v
 
       - name: Add CA VLV indexes
         run: |

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBCLI.java
@@ -21,6 +21,7 @@ package org.dogtagpki.server.ca.cli;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.server.cli.SubsystemDBAccessCLI;
 import org.dogtagpki.server.cli.SubsystemDBEmptyCLI;
+import org.dogtagpki.server.cli.SubsystemDBIndexCLI;
 import org.dogtagpki.server.cli.SubsystemDBInfoCLI;
 import org.dogtagpki.server.cli.SubsystemDBInitCLI;
 import org.dogtagpki.server.cli.SubsystemDBRemoveCLI;
@@ -42,6 +43,7 @@ public class CADBCLI extends CLI {
         addModule(new CADBUpgradeCLI(this));
 
         addModule(new SubsystemDBAccessCLI(this));
+        addModule(new SubsystemDBIndexCLI(this));
         addModule(new SubsystemDBReplicationCLI(this));
         addModule(new SubsystemDBVLVCLI(this));
     }

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1531,18 +1531,20 @@ class PKIDeployer:
 
         create_containers = not config.str2bool(self.mdict['pki_clone'])
 
-        # If the database is already replicated but not yet indexed, rebuild the indexes.
-
-        rebuild_indexes = config.str2bool(self.mdict['pki_clone']) and \
-            not config.str2bool(self.mdict['pki_clone_setup_replication']) and \
-            config.str2bool(self.mdict['pki_clone_reindex_data'])
-
         subsystem.init_database(
             setup_schema=setup_schema,
             create_database=create_database,
             create_base=create_base,
-            create_containers=create_containers,
-            rebuild_indexes=rebuild_indexes)
+            create_containers=create_containers)
+
+        # always create indexes
+        subsystem.add_indexes()
+
+        # if the database is already replicated but not yet indexed, rebuild the indexes
+        if config.str2bool(self.mdict['pki_clone']) and \
+                not config.str2bool(self.mdict['pki_clone_setup_replication']) and \
+                config.str2bool(self.mdict['pki_clone_reindex_data']):
+            subsystem.rebuild_indexes()
 
         if config.str2bool(self.mdict['pki_clone']) and \
                 config.str2bool(self.mdict['pki_clone_setup_replication']):

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1121,7 +1121,6 @@ class PKISubsystem(object):
             create_database=False,
             create_base=False,
             create_containers=False,
-            rebuild_indexes=False,
             as_current_user=False):
 
         cmd = [self.name + '-db-init']
@@ -1138,9 +1137,6 @@ class PKISubsystem(object):
         if create_containers:
             cmd.append('--create-containers')
 
-        if rebuild_indexes:
-            cmd.append('--rebuild-indexes')
-
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
 
@@ -1148,6 +1144,30 @@ class PKISubsystem(object):
             cmd.append('--verbose')
 
         self.run(cmd, as_current_user=as_current_user)
+
+    def add_indexes(self):
+
+        cmd = [self.name + '-db-index-add']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd)
+
+    def rebuild_indexes(self):
+
+        cmd = [self.name + '-db-index-rebuild']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd)
 
     def empty_database(self, force=False, as_current_user=False):
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBCLI.java
@@ -35,6 +35,7 @@ public class SubsystemDBCLI extends CLI {
         addModule(new SubsystemDBUpgradeCLI(this));
 
         addModule(new SubsystemDBAccessCLI(this));
+        addModule(new SubsystemDBIndexCLI(this));
         addModule(new SubsystemDBReplicationCLI(this));
         addModule(new SubsystemDBVLVCLI(this));
     }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexAddCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexAddCLI.java
@@ -1,0 +1,74 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapAuthInfo;
+import com.netscape.cmscore.ldapconn.LdapBoundConnection;
+import com.netscape.cmscore.ldapconn.LdapConnInfo;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemDBIndexAddCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemDBIndexAddCLI.class);
+
+    public SubsystemDBIndexAddCLI(CLI parent) {
+        super("add", "Add " + parent.parent.parent.getName().toUpperCase() + " indexes", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        initializeTomcatJSS();
+        String subsystem = parent.parent.parent.getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        LDAPConfig ldapConfig = cs.getInternalDBConfig();
+        String instanceId = cs.getInstanceID();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = PasswordStore.create(psc);
+
+        LDAPConnectionConfig connConfig = ldapConfig.getConnectionConfig();
+
+        LdapConnInfo connInfo = new LdapConnInfo(connConfig);
+        LdapAuthInfo authInfo = getAuthInfo(passwordStore, connInfo, ldapConfig);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PKISocketFactory socketFactory = new PKISocketFactory();
+        socketFactory.setSecure(connInfo.getSecure());
+        if (authInfo.getAuthType() == LdapAuthInfo.LDAP_AUTHTYPE_SSLCLIENTAUTH) {
+            socketFactory.setClientCertNickname(authInfo.getClientCertNickname());
+        }
+        socketFactory.init(socketConfig);
+
+        LdapBoundConnection conn = new LdapBoundConnection(socketFactory, connInfo, authInfo);
+        LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, ldapConfig, instanceId);
+
+        try {
+            ldapConfigurator.createIndexes(subsystem);
+
+        } finally {
+            conn.disconnect();
+        }
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexCLI.java
@@ -1,0 +1,21 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemDBIndexCLI extends CLI {
+
+    public SubsystemDBIndexCLI(CLI parent) {
+        super("index", parent.parent.name.toUpperCase() + " index management commands", parent);
+
+        addModule(new SubsystemDBIndexAddCLI(this));
+        addModule(new SubsystemDBIndexRebuildCLI(this));
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexRebuildCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexRebuildCLI.java
@@ -1,0 +1,74 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapAuthInfo;
+import com.netscape.cmscore.ldapconn.LdapBoundConnection;
+import com.netscape.cmscore.ldapconn.LdapConnInfo;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemDBIndexRebuildCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemDBIndexRebuildCLI.class);
+
+    public SubsystemDBIndexRebuildCLI(CLI parent) {
+        super("rebuild", "Rebuild " + parent.parent.parent.getName().toUpperCase() + " indexes", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        initializeTomcatJSS();
+        String subsystem = parent.parent.parent.getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        LDAPConfig ldapConfig = cs.getInternalDBConfig();
+        String instanceId = cs.getInstanceID();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = PasswordStore.create(psc);
+
+        LDAPConnectionConfig connConfig = ldapConfig.getConnectionConfig();
+
+        LdapConnInfo connInfo = new LdapConnInfo(connConfig);
+        LdapAuthInfo authInfo = getAuthInfo(passwordStore, connInfo, ldapConfig);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PKISocketFactory socketFactory = new PKISocketFactory();
+        socketFactory.setSecure(connInfo.getSecure());
+        if (authInfo.getAuthType() == LdapAuthInfo.LDAP_AUTHTYPE_SSLCLIENTAUTH) {
+            socketFactory.setClientCertNickname(authInfo.getClientCertNickname());
+        }
+        socketFactory.init(socketConfig);
+
+        LdapBoundConnection conn = new LdapBoundConnection(socketFactory, connInfo, authInfo);
+        LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, ldapConfig, instanceId);
+
+        try {
+            ldapConfigurator.rebuildIndexes(subsystem);
+
+        } finally {
+            conn.disconnect();
+        }
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
@@ -50,7 +50,6 @@ public class SubsystemDBInitCLI extends SubsystemCLI {
         options.addOption(null, "create-database", false, "Create database");
         options.addOption(null, "create-base", false, "Create base entry");
         options.addOption(null, "create-containers", false, "Create container entries");
-        options.addOption(null, "rebuild-indexes", false, "Rebuild indexes");
 
         options.addOption("v", "verbose", false, "Run in verbose mode.");
         options.addOption(null, "debug", false, "Run in debug mode.");
@@ -113,12 +112,6 @@ public class SubsystemDBInitCLI extends SubsystemCLI {
             if (cmd.hasOption("create-containers")) {
                 ldapConfigurator.createContainers(subsystem);
                 ldapConfigurator.setupACL(subsystem);
-            }
-
-            ldapConfigurator.createIndexes(subsystem);
-
-            if (cmd.hasOption("rebuild-indexes")) {
-                ldapConfigurator.rebuildIndexes(subsystem);
             }
 
         } finally {


### PR DESCRIPTION
The code that adds and rebuilds DS database search indexes in `SubsystemDBInitCLI` has been moved into `SubsystemDBIndexAddCLI` and `SubsystemDBIndexRebuildCLI`, respectively, such that they can be used more independently.

Similarly, the `PKISubsystem.init_database()` has been split into `add_indexes()` and `rebuild_indexes()`.

The `pki-server <subsystem>-db-index-add/rebuild` commands have been added to execute these operations from command line.

The test for installing CA with existing DS has been updated to use the new commands.

https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
