### PR TITLE
Add pki-server <subsystem>-db-init

### DIFF
--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -168,56 +168,9 @@ jobs:
           docker exec pki pki-server ca-db-info
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
-      - name: Configure DS database
+      - name: Initialize CA database
         run: |
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/base/server/database/ds/config.ldif
-
-      - name: Add PKI schema
-        run: |
-          docker exec ds ldapmodify \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/base/server/database/ds/schema.ldif
-
-      - name: Add CA base entry
-        run: |
-          docker exec -i ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 << EOF
-          dn: dc=ca,dc=pki,dc=example,dc=com
-          objectClass: dcObject
-          dc: ca
-          EOF
-
-      - name: Add CA database entries
-        run: |
-          sed \
-              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
-              base/ca/database/ds/create.ldif \
-              | tee create.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/create.ldif
-
-      - name: Add CA ACL resources
-        run: |
-          sed \
-              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
-              base/ca/database/ds/acl.ldif \
-              | tee acl.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/acl.ldif
+          docker exec pki pki-server ca-db-init -v
 
       - name: Add CA search indexes
         run: |

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1532,27 +1532,27 @@ class PKIDeployer:
         # then we are assuming that replication is already taken care of,
         # and schema has already been replicated.
 
-        setup_schema = not config.str2bool(self.mdict['pki_clone']) or \
-            not config.str2bool(self.mdict['pki_clone_setup_replication']) or \
-            not config.str2bool(self.mdict['pki_clone_replicate_schema'])
+        skip_schema = config.str2bool(self.mdict['pki_clone']) and \
+            config.str2bool(self.mdict['pki_clone_setup_replication']) and \
+            config.str2bool(self.mdict['pki_clone_replicate_schema'])
 
-        create_database = config.str2bool(self.mdict['pki_ds_create_new_db'])
+        create_backend = config.str2bool(self.mdict['pki_ds_create_new_db'])
 
         # When cloning a subsystem without setting up the replication agreements,
         # the database is a subtree of an existing tree and is already replicated,
         # so there is no need to set up the base entry.
 
-        create_base = config.str2bool(self.mdict['pki_ds_create_new_db']) or \
-            not config.str2bool(self.mdict['pki_clone']) or \
-            config.str2bool(self.mdict['pki_clone_setup_replication'])
+        skip_base = not config.str2bool(self.mdict['pki_ds_create_new_db']) and \
+            config.str2bool(self.mdict['pki_clone']) and \
+            not config.str2bool(self.mdict['pki_clone_setup_replication'])
 
-        create_containers = not config.str2bool(self.mdict['pki_clone'])
+        skip_containers = config.str2bool(self.mdict['pki_clone'])
 
         subsystem.init_database(
-            setup_schema=setup_schema,
-            create_database=create_database,
-            create_base=create_base,
-            create_containers=create_containers)
+            skip_schema=skip_schema,
+            create_backend=create_backend,
+            skip_base=skip_base,
+            skip_containers=skip_containers)
 
         # always create indexes
         subsystem.add_indexes()

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1154,25 +1154,29 @@ class PKISubsystem(object):
 
     def init_database(
             self,
-            setup_schema=False,
-            create_database=False,
-            create_base=False,
-            create_containers=False,
+            skip_config=False,
+            skip_schema=False,
+            create_backend=False,
+            skip_base=False,
+            skip_containers=False,
             as_current_user=False):
 
         cmd = [self.name + '-db-init']
 
-        if setup_schema:
-            cmd.append('--setup-schema')
+        if skip_config:
+            cmd.append('--skip-config')
 
-        if create_database:
-            cmd.append('--create-database')
+        if skip_schema:
+            cmd.append('--skip-schema')
 
-        if create_base:
-            cmd.append('--create-base')
+        if create_backend:
+            cmd.append('--create-backend')
 
-        if create_containers:
-            cmd.append('--create-containers')
+        if skip_base:
+            cmd.append('--skip-base')
+
+        if skip_containers:
+            cmd.append('--skip-containers')
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
@@ -89,8 +89,8 @@ public class LDAPConfigurator {
         return params;
     }
 
-    public void initDatabase() throws Exception {
-        logger.info("Initialize database");
+    public void configureServer() throws Exception {
+        logger.info("Configuring DS server");
         importLDIF("/usr/share/pki/server/database/ds/config.ldif", true);
     }
 
@@ -333,7 +333,7 @@ public class LDAPConfigurator {
         logger.info("Task " + dn + " complete");
     }
 
-    public void createDatabaseEntry(String databaseDN, String database, String baseDN) throws Exception {
+    public void createBackendEntry(String databaseDN, String database, String baseDN) throws Exception {
 
         logger.info("Adding " + databaseDN);
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
@@ -46,10 +46,11 @@ public class SubsystemDBInitCLI extends SubsystemCLI {
         option.setArgName("password config");
         options.addOption(option);
 
-        options.addOption(null, "setup-schema", false, "Set up schema");
-        options.addOption(null, "create-database", false, "Create database");
-        options.addOption(null, "create-base", false, "Create base entry");
-        options.addOption(null, "create-containers", false, "Create container entries");
+        options.addOption(null, "skip-config", false, "Skip DS server configuration");
+        options.addOption(null, "skip-schema", false, "Skip DS schema setup");
+        options.addOption(null, "create-backend", false, "Create DS backend");
+        options.addOption(null, "skip-base", false, "Skip base entry setup");
+        options.addOption(null, "skip-containers", false, "Skip container entries setup");
 
         options.addOption("v", "verbose", false, "Run in verbose mode.");
         options.addOption(null, "debug", false, "Run in debug mode.");
@@ -91,25 +92,27 @@ public class SubsystemDBInitCLI extends SubsystemCLI {
         LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, ldapConfig);
 
         try {
-            ldapConfigurator.initDatabase();
+            if (!cmd.hasOption("skip-config")) {
+                ldapConfigurator.configureServer();
+            }
 
-            if (cmd.hasOption("setup-schema")) {
+            if (!cmd.hasOption("skip-schema")) {
                 ldapConfigurator.setupSchema();
             }
 
-            if (cmd.hasOption("create-database")) {
+            if (cmd.hasOption("create-backend")) {
                 String databaseDN = "cn=" + LDAPUtil.escapeRDNValue(database) + ",cn=ldbm database, cn=plugins, cn=config";
-                ldapConfigurator.createDatabaseEntry(databaseDN, database, baseDN);
+                ldapConfigurator.createBackendEntry(databaseDN, database, baseDN);
 
                 String mappingDN = "cn=\"" + baseDN + "\",cn=mapping tree, cn=config";
                 ldapConfigurator.createMappingEntry(mappingDN, database, baseDN);
             }
 
-            if (cmd.hasOption("create-base")) {
+            if (!cmd.hasOption("skip-base")) {
                 ldapConfigurator.createBaseEntry(baseDN);
             }
 
-            if (cmd.hasOption("create-containers")) {
+            if (!cmd.hasOption("skip-containers")) {
                 ldapConfigurator.createContainers(subsystem);
                 ldapConfigurator.setupACL(subsystem);
             }


### PR DESCRIPTION
The `pki-server <subsystem>-db-init` has been added to initialize the subsystem database in a single step. By default this will include configuring DS server, setting up the schema, creating the base entry, and creating the container entries. The command provides options to skip these steps if needed. The command also provides an option to create a new DS backend.

The `PKISubsystem.init_database()` and `SubsystemDBInitCLI.java` have been modified to match options in the CLI.

https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database