### PR TITLE
Ca certs ap iv2

### DIFF
--- a/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
@@ -19,10 +19,12 @@ package com.netscape.cmscore.dbs;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.Vector;
 
 import org.mozilla.jss.netscape.security.x509.CertificateValidity;
@@ -1110,6 +1112,33 @@ public class CertificateRepository extends Repository {
         }
         return v.elements();
 
+    }
+
+    /**
+     * Finds a list of certificate records that satisfies the filter.
+     *
+     * The filter should follow RFC1558 LDAP filter syntax.
+     * For example,
+     *
+     * {@Code (&(certRecordId=5)(x509Cert.notBefore=934398398))}
+     *
+     * @param filter search filter
+     * @param maxSize max size to return
+     * @return a list of certificates
+     * @exception EBaseException failed to search
+     */
+    public Iterator<CertRecord> searchCertificates(String filter, int timeLimit, int start, int size)
+            throws EBaseException {
+
+        ArrayList<CertRecord> records = new ArrayList<>();
+        logger.debug("searchCertificates filter {filter}, start {start} and size {size}", filter, start, size);
+        try (DBSSession s = dbSubsystem.createSession()) {
+            DBSearchResults sr  = s.pagedSearch(mBaseDN, filter, start, size);
+            while (sr.hasMoreElements()) {
+                records.add((CertRecord) sr.nextElement());
+            }
+        }
+        return records.iterator();
     }
 
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAServlet.java
@@ -13,6 +13,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * @author Marco Fargetta <mfargett@redhat.com>
+ */
 public class CAServlet extends HttpServlet {
     public static final long serialVersionUID = 1L;
 
@@ -20,10 +23,26 @@ public class CAServlet extends HttpServlet {
     public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
     }
 
+    public void post(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    }
+
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         try {
             get(request, response);
+
+        } catch (ServletException | IOException e) {
+            throw e;
+
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        try {
+            post(request, response);
 
         } catch (ServletException | IOException e) {
             throw e;

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAServlet.java
@@ -21,9 +21,11 @@ public class CAServlet extends HttpServlet {
 
 
     public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
     public void post(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
     @Override

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/v2/CAInfoServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/v2/CAInfoServlet.java
@@ -1,3 +1,8 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
 package org.dogtagpki.server.ca.v2;
 
 import java.io.PrintWriter;
@@ -13,11 +18,15 @@ import org.dogtagpki.server.ca.CAServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @author Marco Fargetta <mfargett@redhat.com>
+ */
 @WebServlet("/v2/info")
 public class CAInfoServlet extends CAServlet {
     private static final long serialVersionUID = 1L;
     private static Logger logger = LoggerFactory.getLogger(CAInfoServlet.class);
 
+    @Override
     public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
         HttpSession session = request.getSession();
         logger.debug("CAInfoServlet.get(): session: " + session.getId());

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/v2/CertServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/v2/CertServlet.java
@@ -1,0 +1,261 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ca.v2;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.security.InvalidKeyException;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.dogtagpki.server.ca.CAEngine;
+import org.dogtagpki.server.ca.CAServlet;
+import org.dogtagpki.util.cert.CertUtil;
+import org.mozilla.jss.netscape.security.pkcs.ContentInfo;
+import org.mozilla.jss.netscape.security.pkcs.PKCS7;
+import org.mozilla.jss.netscape.security.pkcs.SignerInfo;
+import org.mozilla.jss.netscape.security.provider.RSAPublicKey;
+import org.mozilla.jss.netscape.security.util.CertPrettyPrint;
+import org.mozilla.jss.netscape.security.util.Utils;
+import org.mozilla.jss.netscape.security.x509.AlgorithmId;
+import org.mozilla.jss.netscape.security.x509.CRLExtensions;
+import org.mozilla.jss.netscape.security.x509.CRLReasonExtension;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+import org.mozilla.jss.netscape.security.x509.X509ExtensionException;
+import org.mozilla.jss.netscape.security.x509.X509Key;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.base.PKIException;
+import com.netscape.certsrv.cert.CertData;
+import com.netscape.certsrv.cert.CertDataInfo;
+import com.netscape.certsrv.cert.CertDataInfos;
+import com.netscape.certsrv.dbs.certdb.CertId;
+import com.netscape.cmscore.dbs.CertRecord;
+import com.netscape.cmscore.dbs.CertificateRepository;
+import com.netscape.cmscore.dbs.RevocationInfo;
+import com.netscape.cmsutil.ldap.LDAPUtil;
+
+/**
+ * @author Marco Fargetta <mfargett@redhat.com>
+ */
+@WebServlet("/v2/certs/*")
+public class CertServlet extends CAServlet {
+    public static final int DEFAULT_MAXTIME = 0;
+    public static final int DEFAULT_MAXRESULTS = 20;
+    public final static int DEFAULT_SIZE = 20;
+
+    private static final long serialVersionUID = 1L;
+    private static Logger logger = LoggerFactory.getLogger(CertServlet.class);
+
+    @Override
+    public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        HttpSession session = request.getSession();
+        logger.debug("CertServlet.get(): session: {}", session.getId());
+
+        response.setContentType("application/json");
+        PrintWriter out = response.getWriter();
+        if(request.getPathInfo() != null) {
+            CertId id = new CertId(request.getPathInfo().substring(1));
+            CertData cert;
+            try {
+                cert = getCertData(id, request.getLocale());
+                out.println(cert.toJSON());
+            } catch (Exception e) {
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND, request.getRequestURI());
+            }
+            return;
+        }
+
+        int maxResults = request.getParameter("maxResults") == null ?
+                DEFAULT_MAXRESULTS : Integer.parseInt(request.getParameter("maxResults"));
+        int maxTime = request.getParameter("maxTime") == null ?
+                DEFAULT_MAXTIME : Integer.parseInt(request.getParameter("maxTime"));
+        int size = request.getParameter("size") == null ?
+                DEFAULT_SIZE : Integer.parseInt(request.getParameter("size"));
+        int start = request.getParameter("start") == null ? 0 : Integer.parseInt(request.getParameter("start"));
+
+        CertDataInfos infos = listCerts(request.getParameter("status"), maxResults, maxTime, start, size);
+        out.println(infos.toJSON());
+    }
+
+    @Override
+    public void post(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        HttpSession session = request.getSession();
+        logger.debug("CertServlet.post(): session: {}", session.getId());
+
+        response.setContentType("application/json");
+        PrintWriter out = response.getWriter();
+
+        if(request.getPathInfo() == null || !request.getPathInfo().equals("/search")) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, request.getRequestURI());
+            return;
+        }
+
+        CertDataInfos infos = new CertDataInfos();
+        out.println(infos.toString());
+    }
+
+    private CertData getCertData(CertId id, Locale loc) throws Exception {
+        CAEngine engine = getCAEngine();
+        CertificateRepository repo = engine.getCertificateRepository();
+
+         //find the cert in question
+        CertRecord record = repo.readCertificateRecord(id.toBigInteger());
+        X509CertImpl cert = record.getCertificate();
+
+        CertData certData = new CertData();
+        certData.setSerialNumber(id);
+
+        Principal issuerDN = cert.getIssuerName();
+        if (issuerDN != null) certData.setIssuerDN(issuerDN.toString());
+
+        Principal subjectDN = cert.getSubjectName();
+        if (subjectDN != null) certData.setSubjectDN(subjectDN.toString());
+
+        String base64 = CertUtil.toPEM(cert);
+        certData.setEncoded(base64);
+
+        CertPrettyPrint print = new CertPrettyPrint(cert);
+        certData.setPrettyPrint(print.toString(loc));
+
+        X509Certificate[] certChain = engine.getCertChain(cert);
+
+        PKCS7 pkcs7 = new PKCS7(
+                new AlgorithmId[0],
+                new ContentInfo(new byte[0]),
+                certChain,
+                new SignerInfo[0]);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        pkcs7.encodeSignedData(bos, false);
+        byte[] p7Bytes = bos.toByteArray();
+
+        String p7Str = Utils.base64encode(p7Bytes, true);
+        certData.setPkcs7CertChain(p7Str);
+
+        Date notBefore = cert.getNotBefore();
+        if (notBefore != null) certData.setNotBefore(notBefore.toString());
+
+        Date notAfter = cert.getNotAfter();
+        if (notAfter != null) certData.setNotAfter(notAfter.toString());
+
+        certData.setRevokedOn(record.getRevokedOn());
+        certData.setRevokedBy(record.getRevokedBy());
+
+        RevocationInfo revInfo = record.getRevocationInfo();
+        if (revInfo != null) {
+            CRLExtensions revExts = revInfo.getCRLEntryExtensions();
+            if (revExts != null) {
+                try {
+                    CRLReasonExtension ext = (CRLReasonExtension)
+                        revExts.get(CRLReasonExtension.NAME);
+                    certData.setRevocationReason(ext.getReason().getCode());
+                } catch (X509ExtensionException e) {
+                    // nothing to do
+                }
+            }
+        }
+
+        certData.setStatus(record.getStatus());
+
+        return certData;
+    }
+
+    private CertDataInfos listCerts(String status, int maxResults, int maxTime, int start, int size) {
+        CAEngine engine = getCAEngine();
+        CertificateRepository repo = engine.getCertificateRepository();
+
+        logger.info("Listing certificates");
+
+        String filter;
+        if (status == null) {
+            filter = "(certstatus=*)";
+
+        } else  {
+            filter = "(certStatus=" + LDAPUtil.escapeFilter(status) + ")";
+        }
+        logger.info("Search filter: " + filter);
+
+        CertDataInfos infos = new CertDataInfos();
+        try {
+            Enumeration<CertRecord> e = repo.searchCertificates(filter, maxResults, maxTime);
+            if (e == null) {
+                throw new EBaseException("search results are null");
+            }
+
+            // store non-null results in a list
+            List<CertDataInfo> results = new ArrayList<>();
+            while (e.hasMoreElements()) {
+                CertRecord rec = e.nextElement();
+                if (rec == null) continue;
+                results.add(createCertDataInfo(rec));
+            }
+
+            int total = results.size();
+            logger.info("Search results: " + total);
+            infos.setTotal(total);
+
+            // return entries in the requested page
+            for (int i = start; i < start + size && i < total ; i++) {
+                infos.addEntry(results.get(i));
+            }
+        } catch (Exception e) {
+            logger.error("Unable to list certificates: " + e.getMessage(), e);
+            throw new PKIException("Unable to list certificates: " + e.getMessage(), e);
+        }
+
+        return infos;
+    }
+
+    private CertDataInfo createCertDataInfo(CertRecord record) throws EBaseException, InvalidKeyException {
+        CertDataInfo info = new CertDataInfo();
+
+        CertId id = new CertId(record.getSerialNumber());
+        info.setID(id);
+
+        X509Certificate cert = record.getCertificate();
+        info.setIssuerDN(cert.getIssuerDN().toString());
+        info.setSubjectDN(cert.getSubjectDN().toString());
+        info.setStatus(record.getStatus());
+        info.setVersion(cert.getVersion());
+        info.setType(cert.getType());
+
+        PublicKey key = cert.getPublicKey();
+        if (key instanceof X509Key) {
+            X509Key x509Key = (X509Key)key;
+            info.setKeyAlgorithmOID(x509Key.getAlgorithmId().getOID().toString());
+
+            if (x509Key.getAlgorithmId().toString().equalsIgnoreCase("RSA")) {
+                RSAPublicKey rsaKey = new RSAPublicKey(x509Key.getEncoded());
+                info.setKeyLength(rsaKey.getKeySize());
+            }
+        }
+
+        info.setNotValidBefore(cert.getNotBefore());
+        info.setNotValidAfter(cert.getNotAfter());
+
+        info.setIssuedOn(record.getCreateTime());
+        info.setIssuedBy(record.getIssuedBy());
+
+        info.setRevokedOn(record.getRevokedOn());
+        info.setRevokedBy(record.getRevokedBy());
+
+        return info;
+    }
+}

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfos.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertDataInfos.java
@@ -38,10 +38,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.base.DataCollection;
+import com.netscape.certsrv.util.JSONSerializer;
 
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class CertDataInfos extends DataCollection<CertDataInfo> {
+public class CertDataInfos extends DataCollection<CertDataInfo> implements JSONSerializer {
 
     public Element toDOM(Document document) {
 

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertSearchRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertSearchRequest.java
@@ -22,6 +22,7 @@ package com.netscape.certsrv.cert;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -1104,4 +1105,147 @@ public class CertSearchRequest implements JSONSerializer {
         Element rootElement = document.getDocumentElement();
         return fromDOM(rootElement);
     }
+
+    public static CertSearchRequest fromMap(Map<String, String[]> elements) {
+
+        CertSearchRequest request = new CertSearchRequest();
+
+        elements.forEach((key, values) -> {
+            switch (key) {
+            case "issuerDN":
+                request.setIssuerDN(values[0]);
+                break;
+            case "serialNumberRangeInUse":
+                request.setSerialNumberRangeInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "serialTo":
+                request.setSerialTo(values[0]);
+                break;
+            case "serialFrom":
+                request.setSerialFrom(values[0]);
+                break;
+            case "subjectInUse":
+                request.setSubjectInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "eMail":
+                request.setEmail(values[0]);
+                break;
+            case "commonName":
+                request.setCommonName(values[0]);
+                break;
+            case "userID":
+                request.setUserID(values[0]);
+                break;
+            case "orgUnit":
+                request.setOrgUnit(values[0]);
+                break;
+            case "org":
+                request.setOrg(values[0]);
+                break;
+            case "locality":
+                request.setLocality(values[0]);
+                break;
+            case "state":
+                request.setState(values[0]);
+                break;
+            case "country":
+                request.setCountry(values[0]);
+                break;
+            case "matchExactly":
+                request.setMatchExactly(Boolean.parseBoolean(values[0]));
+                break;
+            case "status":
+                request.setStatus(values[0]);
+                break;
+            case "revokedBy":
+                request.setRevokedBy(values[0]);
+                break;
+            case "revokedOnFrom":
+                request.setRevokedOnFrom(values[0]);
+                break;
+            case "revokedOnTo":
+                request.setRevokedOnTo(values[0]);
+                break;
+            case "revocationReason":
+                request.setRevocationReason(values[0]);
+                break;
+            case "issuedBy":
+                request.setIssuedBy(values[0]);
+                break;
+            case "issuedOnFrom":
+                request.setIssuedOnFrom(values[0]);
+                break;
+            case "issuedOnTo":
+                request.setIssuedOnTo(values[0]);
+                break;
+            case "validNotBeforeFrom":
+                request.setValidNotBeforeFrom(values[0]);
+                break;
+            case "validNotBeforeTo":
+                request.setValidNotBeforeTo(values[0]);
+                break;
+            case "validNotAfterFrom":
+                request.setValidNotAfterFrom(values[0]);
+                break;
+            case "validNotAfterTo":
+                request.setValidNotAfterTo(values[0]);
+                break;
+            case "validityOperation":
+                request.setValidityOperation(values[0]);
+                break;
+            case "validityCount":
+                request.setValidityCount(Integer.valueOf(values[0]));
+                break;
+            case "validityUnit":
+                request.setValidityUnit(Long.valueOf(values[0]));
+                break;
+            case "certTypeSubEmailCA":
+                request.setCertTypeSubEmailCA(values[0]);
+                break;
+            case "certTypeSubSSLCA":
+                request.setCertTypeSubSSLCA(values[0]);
+                break;
+            case "certTypeSecureEmail":
+                request.setCertTypeSecureEmail(values[0]);
+                break;
+            case "certTypeSSLClient":
+                request.setCertTypeSSLClient(values[0]);
+                break;
+            case "certTypeSSLServer":
+                request.setCertTypeSSLServer(values[0]);
+                break;
+            case "revokedByInUse":
+                request.setRevokedByInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "revokedOnInUse":
+                request.setRevokedOnInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "revocationReasonInUse":
+                request.setRevocationReasonInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "issuedByInUse":
+                request.setIssuedByInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "issuedOnInUse":
+                request.setIssuedOnInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "validNotBeforeInUse":
+                request.setValidNotBeforeInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "validNotAfterInUse":
+                request.setValidNotAfterInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "validityLengthInUse":
+                request.setValidityLengthInUse(Boolean.parseBoolean(values[0]));
+                break;
+            case "certTypeInUse":
+                request.setCertTypeInUse(Boolean.parseBoolean(values[0]));
+                break;
+            default:
+            }
+        });
+
+        return request;
+    }
+
 }

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/DBSSession.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/DBSSession.java
@@ -18,9 +18,9 @@
 package com.netscape.cmscore.dbs;
 
 import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.dbs.DBVirtualList;
 import com.netscape.certsrv.dbs.EDBException;
 import com.netscape.certsrv.dbs.IDBObj;
-import com.netscape.certsrv.dbs.DBVirtualList;
 import com.netscape.certsrv.dbs.ModificationSet;
 
 import netscape.ldap.LDAPSearchResults;
@@ -207,6 +207,48 @@ public class DBSSession implements AutoCloseable {
             String base,
             String filter,
             String[] attrs
+            ) throws EBaseException {
+        return null;
+    }
+
+    /**
+     * Retrieves a list of object that satifies the given
+     * filter.
+     *
+     * @param base starting point of the search
+     * @param filter search filter
+     * @param start index of the first element
+     * @param size max number of element in the page
+     * @return search results
+     * @exception EBaseException failed to search
+     */
+    public DBSearchResults pagedSearch(
+            String base,
+            String filter,
+            int start,
+            int size
+            ) throws EBaseException {
+        return pagedSearch(base, filter, start, size, -1);
+    }
+
+    /**
+     * Retrieves a list of object that satifies the given
+     * filter.
+     *
+     * @param base starting point of the search
+     * @param filter search filter
+     * @param start index of the first element
+     * @param size max number of element in the page
+     * @param timeLimit timeout limit
+     * @return search results
+     * @exception EBaseException failed to search
+     */
+    public DBSearchResults pagedSearch(
+            String base,
+            String filter,
+            int start,
+            int size,
+            int timeLimit
             ) throws EBaseException {
         return null;
     }


### PR DESCRIPTION
Implement v2 REST end-point for /ca/v2/certs
    
Implement the REST operations:
- GET of  /ca/v2/certs/<id>
- GET of /ca/v2/certs
- POST to /ca/v2/certs/search.
    
 These implement the behaviour of the current REST operations (see [[1](https://github.com/dogtagpki/pki/wiki/CA-Retrieve-Certificate-REST-API), [2](https://github.com/dogtagpki/pki/wiki/CA-List-Certificates-REST-API) and [3](https://github.com/dogtagpki/pki/wiki/CA-Search-Certificates-REST-API)]). The new version is not based on RESTeasy framework for the REST operation and the DB searches have replaced VLV with paged queries.
    
The only differences with the previous implementation are:
- the total value now show the number of returned item;
- the number of returned entry is limited (this is hard-coded for now).
