### PR TITLE
Add pki-server <subsystem>-db-repl-agmt-init

### DIFF
--- a/.github/workflows/ca-clone-replicated-ds-test.yml
+++ b/.github/workflows/ca-clone-replicated-ds-test.yml
@@ -69,6 +69,15 @@ jobs:
               --pkcs12-password Secret.123
           docker exec primary pki -n caadmin ca-user-show caadmin
 
+      - name: Export system certs and keys from primary CA
+        run: |
+          docker exec primary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec primary pki-server cert-export ca_signing \
+              --cert-file $SHARED/ca_signing.crt
+
       - name: Set up secondary DS container
         run: |
           tests/bin/ds-container-create.sh secondaryds
@@ -79,6 +88,28 @@ jobs:
 
       - name: Connect secondary DS container to network
         run: docker network connect example secondaryds --alias secondaryds.example.com
+
+      - name: Set up secondary PKI container
+        run: |
+          tests/bin/runner-init.sh secondary
+        env:
+          HOSTNAME: secondary.example.com
+
+      - name: Connect secondary PKI container to network
+        run: docker network connect example secondary --alias secondary.example.com
+
+      - name: Create secondary PKI server
+        run: |
+          docker exec secondary pki-server create
+          docker exec secondary pki-server nss-create --no-password
+
+      - name: Import system certs and keys into secondary CA
+        run: |
+          docker exec secondary pki \
+              -d /etc/pki/pki-tomcat/alias \
+              pkcs12-import \
+              --pkcs12 $SHARED/ca-certs.p12 \
+              --password Secret.123
 
       # https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-DS-Tools
       - name: Preparing DS backend
@@ -218,24 +249,6 @@ jobs:
 
           diff primaryds.dn secondaryds.dn
 
-      - name: Export certs and keys from primary CA
-        run: |
-          docker exec primary pki-server ca-clone-prepare \
-              --pkcs12-file $SHARED/ca-certs.p12 \
-              --pkcs12-password Secret.123
-
-          docker exec primary pki-server cert-export ca_signing \
-              --cert-file $SHARED/ca_signing.crt
-
-      - name: Set up secondary PKI container
-        run: |
-          tests/bin/runner-init.sh secondary
-        env:
-          HOSTNAME: secondary.example.com
-
-      - name: Connect secondary PKI container to network
-        run: docker network connect example secondary --alias secondary.example.com
-
       # https://github.com/dogtagpki/pki/wiki/Installing-CA-Clone-with-Existing-DS
       - name: Install secondary CA
         run: |
@@ -246,8 +259,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=$SHARED/ca_signing.crt \
-              -D pki_clone_pkcs12_path=$SHARED/ca-certs.p12 \
-              -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_ds_setup=False \
               -v

--- a/.github/workflows/ca-clone-replicated-ds-test.yml
+++ b/.github/workflows/ca-clone-replicated-ds-test.yml
@@ -103,6 +103,10 @@ jobs:
           docker exec secondary pki-server create
           docker exec secondary pki-server nss-create --no-password
 
+      - name: Create secondary CA subsystem
+        run: |
+          docker exec secondary pki-server ca-create -v
+
       - name: Import system certs and keys into secondary CA
         run: |
           docker exec secondary pki \
@@ -143,6 +147,22 @@ jobs:
               --bind-dn="cn=Replication Manager,cn=config" \
               --bind-passwd=Secret.123
 
+          # check replication manager
+          docker exec primaryds ldapsearch \
+              -H ldap://primaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=Replication Manager,cn=config"
+
+          # check replica object
+          docker exec primaryds ldapsearch \
+              -H ldap://primaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=replica,cn=dc\3Dca\2Cdc\3Dpki\2Cdc\3Dexample\2Cdc\3Dcom,cn=mapping tree,cn=config"
+
       - name: Enable replication on secondary DS
         run: |
           docker exec secondaryds dsconf \
@@ -156,7 +176,23 @@ jobs:
               --bind-dn="cn=Replication Manager,cn=config" \
               --bind-passwd=Secret.123
 
-      - name: Create replication manager on primary DS
+          # check replication manager
+          docker exec secondaryds ldapsearch \
+              -H ldap://secondaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=Replication Manager,cn=config"
+
+          # check replica object
+          docker exec secondaryds ldapsearch \
+              -H ldap://secondaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=replica,cn=dc\3Dca\2Cdc\3Dpki\2Cdc\3Dexample\2Cdc\3Dcom,cn=mapping tree,cn=config"
+
+      - name: Create replication agreement on primary DS
         run: |
           docker exec primaryds dsconf \
               -D "cn=Directory Manager" \
@@ -172,7 +208,16 @@ jobs:
               --bind-method=SIMPLE \
               primaryds-to-secondaryds
 
-      - name: Create replication manager on secondary DS
+          # check replication agreement
+          docker exec primaryds ldapsearch \
+              -H ldap://primaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=primaryds-to-secondaryds,cn=replica,cn=dc\3Dca\2Cdc\3Dpki\2Cdc\3Dexample\2Cdc\3Dcom,cn=mapping tree,cn=config" \
+              dn
+
+      - name: Create replication agreement on secondary DS
         run: |
           docker exec secondaryds dsconf \
               -D "cn=Directory Manager" \
@@ -188,38 +233,24 @@ jobs:
               --bind-method=SIMPLE \
               secondaryds-to-primaryds
 
-      - name: Initializing replication agreement
-        run: |
-          # start initialization
-          docker exec primaryds dsconf \
+          # check replication agreement
+          docker exec secondaryds ldapsearch \
+              -H ldap://secondaryds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              ldap://primaryds.example.com:3389 \
-              repl-agmt init \
-              --suffix=dc=ca,dc=pki,dc=example,dc=com \
+              -x \
+              -b "cn=secondaryds-to-primaryds,cn=replica,cn=dc\3Dca\2Cdc\3Dpki\2Cdc\3Dexample\2Cdc\3Dcom,cn=mapping tree,cn=config" \
+              dn
+
+      - name: Initializing replication agreement
+        run: |
+          docker exec secondary pki-server ca-db-repl-agmt-init \
+              --url ldap://primaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --suffix dc=ca,dc=pki,dc=example,dc=com \
+              -v \
               primaryds-to-secondaryds
-
-          # wait for initialization to complete
-          counter=0
-          while [[ "$counter" -lt 30 ]]; do
-              sleep 1
-
-              docker exec primaryds dsconf \
-                  -D "cn=Directory Manager" \
-                  -w Secret.123 \
-                  ldap://primaryds.example.com:3389 \
-                  repl-agmt init-status \
-                  --suffix=dc=ca,dc=pki,dc=example,dc=com \
-                  primaryds-to-secondaryds \
-                  > >(tee stdout) 2> >(tee stderr >&2) || true
-
-              STDOUT=$(cat stdout)
-              if [ "$STDOUT" = "Agreement successfully initialized." ]; then
-                  break
-              fi
-
-              counter=$((counter+1))
-          done
 
       - name: Check entries in primary DS and secondary DS
         run: |

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -464,16 +464,6 @@ class ConfigurationFile:
             self.confirm_data_exists("pki_https_port")
             self.confirm_data_exists("pki_tomcat_server_port")
 
-            # Check clone parameters for non-HSM clone
-            if not config.str2bool(self.mdict['pki_hsm_enable']):
-
-                # If system certificates are already provided via
-                # pki_server_pkcs12, there's no need to provide
-                # pki_clone_pkcs12.
-                if not self.mdict['pki_server_pkcs12_path']:
-                    self.confirm_data_exists("pki_clone_pkcs12_path")
-                    self.confirm_file_exists("pki_clone_pkcs12_path")
-
             self.confirm_data_exists("pki_clone_replication_security")
 
         elif self.external:

--- a/base/server/python/pki/server/deployment/scriptlets/initialization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/initialization.py
@@ -73,19 +73,11 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
 
         if configuration_file.clone:
 
-            # Verify existence of PKCS #12 Password (ONLY for non-HSM Clones)
-            if not config.str2bool(deployer.mdict['pki_hsm_enable']):
-
-                # If system certificates are already provided via
-                # pki_server_pkcs12, there's no need to provide
-                # pki_clone_pkcs12.
-                if not deployer.mdict['pki_server_pkcs12_path']:
-                    configuration_file.confirm_data_exists('pki_clone_pkcs12_password')
-
             # Verify absence of all PKCS #12 clone parameters for HSMs
-            elif (os.path.exists(deployer.mdict['pki_clone_pkcs12_path']) or
-                    ('pki_clone_pkcs12_password' in deployer.mdict and
-                     len(deployer.mdict['pki_clone_pkcs12_password']))):
+            if config.str2bool(deployer.mdict['pki_hsm_enable']) and \
+                    (os.path.exists(deployer.mdict['pki_clone_pkcs12_path']) or
+                     ('pki_clone_pkcs12_password' in deployer.mdict and
+                      len(deployer.mdict['pki_clone_pkcs12_password']))):
                 logger.error(log.PKIHELPER_HSM_CLONES_MUST_SHARE_HSM_MASTER_PRIVATE_KEYS)
                 raise Exception(
                     log.PKIHELPER_HSM_CLONES_MUST_SHARE_HSM_MASTER_PRIVATE_KEYS)

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1326,6 +1326,35 @@ class PKISubsystem(object):
         finally:
             shutil.rmtree(tmpdir)
 
+    def init_replication_agreement(
+            self,
+            name,
+            ldap_config):
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            ldap_config_file = os.path.join(tmpdir, 'ldap.conf')
+            pki.util.store_properties(ldap_config_file, ldap_config)
+            pki.util.chown(tmpdir, self.instance.uid, self.instance.gid)
+
+            cmd = [self.name + '-db-repl-agmt-init']
+
+            if ldap_config_file:
+                cmd.extend(['--ldap-config', ldap_config_file])
+
+            if logger.isEnabledFor(logging.DEBUG):
+                cmd.append('--debug')
+
+            elif logger.isEnabledFor(logging.INFO):
+                cmd.append('--verbose')
+
+            cmd.append(name)
+
+            self.run(cmd)
+
+        finally:
+            shutil.rmtree(tmpdir)
+
     def find_vlv(self, as_current_user=False):
 
         cmd = [self.name + '-db-vlv-find']

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationAgreementCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationAgreementCLI.java
@@ -1,0 +1,23 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemDBReplicationAgreementCLI extends CLI {
+
+    public SubsystemDBReplicationAgreementCLI(CLI parent) {
+        super(
+            "agmt",
+            parent.parent.parent.name.toUpperCase() + " replication agreement management commands",
+            parent);
+
+        addModule(new SubsystemDBReplicationAgreementInitCLI(this));
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationAgreementInitCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationAgreementInitCLI.java
@@ -1,0 +1,98 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.dogtagpki.util.logging.PKILogger;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.base.ConfigStorage;
+import com.netscape.cmscore.base.FileConfigStorage;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LdapBoundConnFactory;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+
+import netscape.ldap.LDAPConnection;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemDBReplicationAgreementInitCLI extends SubsystemCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(SubsystemDBReplicationAgreementInitCLI.class);
+
+    public SubsystemDBReplicationAgreementInitCLI(CLI parent) {
+        super(
+            "init",
+            "Initialize " + parent.parent.parent.parent.getName().toUpperCase() + " replication agreement",
+            parent);
+    }
+
+    @Override
+    public void createOptions() {
+
+        options.addOption(null, "ldap-config", true, "LDAP configuration file");
+
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing replication agreement name");
+        }
+
+        String agreementName = cmdArgs[0];
+
+        if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(LogLevel.DEBUG);
+
+        } else if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(LogLevel.INFO);
+        }
+
+        String ldapConfigFile = cmd.getOptionValue("ldap-config");
+
+        if (ldapConfigFile == null) {
+            throw new Exception("Missing LDAP configuration file");
+        }
+
+        initializeTomcatJSS();
+        String subsystem = parent.parent.parent.parent.getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        logger.info("Loading {}", ldapConfigFile);
+        ConfigStorage configStorage = new FileConfigStorage(ldapConfigFile);
+        LDAPConfig ldapConfig = new LDAPConfig(configStorage);
+        ldapConfig.load();
+
+        LdapBoundConnFactory connFactory = new LdapBoundConnFactory("LDAPConfigurator");
+        connFactory.init(socketConfig, ldapConfig);
+        LDAPConnection conn = connFactory.getConn();
+
+        try {
+            LDAPConfigurator configurator = new LDAPConfigurator(conn, ldapConfig);
+            configurator.initializeReplicationAgreement(agreementName);
+
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationCLI.java
@@ -16,5 +16,6 @@ public class SubsystemDBReplicationCLI extends CLI {
         super("repl", parent.parent.name.toUpperCase() + " database replication management commands", parent);
 
         addModule(new SubsystemDBReplicationSetupCLI(this));
+        addModule(new SubsystemDBReplicationAgreementCLI(this));
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationSetupCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationSetupCLI.java
@@ -181,9 +181,6 @@ public class SubsystemDBReplicationSetupCLI extends SubsystemCLI {
                 logger.info("New replica number range: " + beginReplicaNumber + "-" + endReplicaNumber);
                 dbConfig.putString("beginReplicaNumber", Integer.toString(beginReplicaNumber));
 
-                logger.info("Initializing replication agreement");
-                masterConfigurator.initializeReplicationAgreement(masterAgreementName);
-
             } finally {
                 if (masterConn != null) masterConn.disconnect();
             }


### PR DESCRIPTION
The `pki-server <subsystem>-db-repl-agmt-init` has been added to start initializing the replication agreement and wait until it's complete.

The `SubsystemDBReplicationSetupCLI` has been modified to no longer include initializing the replication agreement.

The test for CA cloning with replicated DS has been updated to use the new command. The test has also been updated to
import the primary CA's system certs and keys into the secondary CA's NSS database prior to running `pkispawn` so it's no longer necessary to specify the PKCS #12 path and password for `pkispawn`.
    
The `ConfigurationFile.verify_predefined_configuration_file_data()` and `initialization.py` have been modified such that the PKCS #12 path and password are no longer mandatory for cloning.

https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-DS-Tools
https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-LDAP-Tools
https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-PKI-Tools
