### PR TITLE
Add pki-server <subsystem>-db-repl-agmt-add

### DIFF
--- a/.github/workflows/ca-clone-replicated-ds-test.yml
+++ b/.github/workflows/ca-clone-replicated-ds-test.yml
@@ -194,18 +194,15 @@ jobs:
 
       - name: Create replication agreement on primary DS
         run: |
-          docker exec primaryds dsconf \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              ldap://primaryds.example.com:3389 \
-              repl-agmt create \
-              --suffix=dc=ca,dc=pki,dc=example,dc=com \
-              --host=secondaryds.example.com \
-              --port=3389 \
-              --conn-protocol=LDAP \
-              --bind-dn="cn=Replication Manager,cn=config" \
-              --bind-passwd=Secret.123 \
-              --bind-method=SIMPLE \
+          docker exec secondary pki-server ca-db-repl-agmt-add \
+              --url ldap://primaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-url ldap://secondaryds.example.com:3389 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --suffix dc=ca,dc=pki,dc=example,dc=com \
+              -v \
               primaryds-to-secondaryds
 
           # check replication agreement
@@ -219,18 +216,15 @@ jobs:
 
       - name: Create replication agreement on secondary DS
         run: |
-          docker exec secondaryds dsconf \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              ldap://secondaryds.example.com:3389 \
-              repl-agmt create \
-              --suffix=dc=ca,dc=pki,dc=example,dc=com \
-              --host=primaryds.example.com \
-              --port=3389 \
-              --conn-protocol=LDAP \
-              --bind-dn="cn=Replication Manager,cn=config" \
-              --bind-passwd=Secret.123 \
-              --bind-method=SIMPLE \
+          docker exec secondary pki-server ca-db-repl-agmt-add \
+              --url ldap://secondaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-url ldap://primaryds.example.com:3389 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --suffix dc=ca,dc=pki,dc=example,dc=com \
+              -v \
               secondaryds-to-primaryds
 
           # check replication agreement

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
@@ -898,7 +898,6 @@ public class LDAPConfigurator {
         logger.debug("- nsDS5ReplicaHost: " + replicaHostname);
         logger.debug("- nsDS5ReplicaPort: " + replicaPort);
         logger.debug("- nsDS5ReplicaBindDN: " + replicaBindDN);
-        logger.debug("- nsDS5ReplicaTransportInfo: " + replicationSecurity);
 
         LDAPAttributeSet attrs = new LDAPAttributeSet();
         attrs.add(new LDAPAttribute("objectclass", "top"));
@@ -913,6 +912,7 @@ public class LDAPConfigurator {
         attrs.add(new LDAPAttribute("nsDS5ReplicaCredentials", replicaPassword));
 
         if (replicationSecurity != null && !replicationSecurity.equalsIgnoreCase("None")) {
+            logger.debug("- nsDS5ReplicaTransportInfo: " + replicationSecurity);
             attrs.add(new LDAPAttribute("nsDS5ReplicaTransportInfo", replicationSecurity));
         }
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationAgreementAddCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationAgreementAddCLI.java
@@ -1,0 +1,123 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
+import org.dogtagpki.util.logging.PKILogger;
+import org.dogtagpki.util.logging.PKILogger.LogLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.base.ConfigStorage;
+import com.netscape.cmscore.base.FileConfigStorage;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LdapBoundConnFactory;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+
+import netscape.ldap.LDAPConnection;
+import netscape.ldap.LDAPUrl;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class SubsystemDBReplicationAgreementAddCLI extends SubsystemCLI {
+
+    public static final Logger logger = LoggerFactory.getLogger(SubsystemDBReplicationAgreementAddCLI.class);
+
+    public SubsystemDBReplicationAgreementAddCLI(CLI parent) {
+        super(
+            "add",
+            "Add " + parent.parent.parent.parent.getName().toUpperCase() + " replication agreement",
+            parent);
+    }
+
+    @Override
+    public void createOptions() {
+
+        options.addOption(null, "ldap-config", true, "LDAP configuration file");
+        options.addOption(null, "replica-url", true, "Replica URL");
+        options.addOption(null, "replica-bind-dn", true, "Replica bind DN");
+        options.addOption(null, "replica-bind-password-file", true, "Replica bind password file");
+        options.addOption(null, "replication-security", true, "Replication security: SSL, TLS, None");
+
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing replication agreement name");
+        }
+
+        String agreementName = cmdArgs[0];
+
+        if (cmd.hasOption("debug")) {
+            PKILogger.setLevel(LogLevel.DEBUG);
+
+        } else if (cmd.hasOption("verbose")) {
+            PKILogger.setLevel(LogLevel.INFO);
+        }
+
+        String ldapConfigFile = cmd.getOptionValue("ldap-config");
+
+        if (ldapConfigFile == null) {
+            throw new CLIException("Missing LDAP configuration file");
+        }
+
+        LDAPUrl replicaUrl = new LDAPUrl(cmd.getOptionValue("replica-url"));
+        String replicaBindDN = cmd.getOptionValue("replica-bind-dn");
+        String replicaBindPasswordFile = cmd.getOptionValue("replica-bind-password-file");
+        String replicationSecurity = cmd.getOptionValue("replication-security");
+
+        initializeTomcatJSS();
+        String subsystem = parent.parent.parent.parent.getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        logger.info("Loading {}", ldapConfigFile);
+        ConfigStorage masterConfigStorage = new FileConfigStorage(ldapConfigFile);
+        LDAPConfig ldapConfig = new LDAPConfig(masterConfigStorage);
+        ldapConfig.load();
+
+        String replicaHostname = replicaUrl.getHost();
+        int replicaPort = replicaUrl.getPort();
+
+        String replicaBindPassword = Files.readAllLines(Paths.get(replicaBindPasswordFile)).get(0);
+
+        LdapBoundConnFactory connFactory = new LdapBoundConnFactory("LDAPConfigurator");
+        connFactory.init(socketConfig, ldapConfig);
+        LDAPConnection conn = connFactory.getConn();
+
+        try {
+            LDAPConfigurator configurator = new LDAPConfigurator(conn, ldapConfig);
+
+            configurator.createReplicationAgreement(
+                    agreementName,
+                    replicaHostname,
+                    replicaPort,
+                    replicaBindDN,
+                    replicaBindPassword,
+                    replicationSecurity);
+
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationAgreementCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationAgreementCLI.java
@@ -18,6 +18,7 @@ public class SubsystemDBReplicationAgreementCLI extends CLI {
             parent.parent.parent.name.toUpperCase() + " replication agreement management commands",
             parent);
 
+        addModule(new SubsystemDBReplicationAgreementAddCLI(this));
         addModule(new SubsystemDBReplicationAgreementInitCLI(this));
     }
 }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationSetupCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBReplicationSetupCLI.java
@@ -112,7 +112,6 @@ public class SubsystemDBReplicationSetupCLI extends SubsystemCLI {
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
         LDAPConnectionConfig replicaConnConfig = ldapConfig.getConnectionConfig();
-        String replicaHostname = replicaConnConfig.getString("host", "");
         String replicaPort = replicaConnConfig.getString("port", "");
 
         if (replicaReplicationPort == null || replicaReplicationPort.equals("")) {
@@ -128,7 +127,6 @@ public class SubsystemDBReplicationSetupCLI extends SubsystemCLI {
         try {
             LDAPConfig masterDBConfig = masterConfig.getSubStore("internaldb", LDAPConfig.class);
             LDAPConnectionConfig masterConnConfig = masterDBConfig.getConnectionConfig();
-            String masterHostname = masterConnConfig.getString("host", "");
             String masterPort = masterConnConfig.getString("port", "");
 
             if (masterReplicationPort == null || masterReplicationPort.equals("")) {
@@ -183,21 +181,6 @@ public class SubsystemDBReplicationSetupCLI extends SubsystemCLI {
                 logger.info("New replica number range: " + beginReplicaNumber + "-" + endReplicaNumber);
                 dbConfig.putString("beginReplicaNumber", Integer.toString(beginReplicaNumber));
 
-                createReplicationAgreements(
-                        masterConfigurator,
-                        ldapConfigurator,
-                        masterAgreementName,
-                        replicaAgreementName,
-                        replicationSecurity,
-                        masterHostname,
-                        replicaHostname,
-                        Integer.parseInt(masterReplicationPort),
-                        Integer.parseInt(replicaReplicationPort),
-                        masterBindDN,
-                        replicaBindDN,
-                        masterReplicationPassword,
-                        replicaReplicationPassword);
-
             } finally {
                 if (masterConn != null) masterConn.disconnect();
             }
@@ -251,42 +234,5 @@ public class SubsystemDBReplicationSetupCLI extends SubsystemCLI {
         }
 
         return replicaID;
-    }
-
-    public void createReplicationAgreements(
-            LDAPConfigurator masterConfigurator,
-            LDAPConfigurator replicaConfigurator,
-            String masterAgreementName,
-            String replicaAgreementName,
-            String replicationSecurity,
-            String masterHostname,
-            String replicaHostname,
-            int masterReplicationPort,
-            int replicaReplicationPort,
-            String masterBindDN,
-            String replicaBindDN,
-            String masterReplicationPassword,
-            String replicaReplicationPassword)
-            throws Exception {
-
-        logger.info("Creating replication agreement on " + masterHostname);
-
-        masterConfigurator.createReplicationAgreement(
-                masterAgreementName,
-                replicaHostname,
-                replicaReplicationPort,
-                replicaBindDN,
-                replicaReplicationPassword,
-                replicationSecurity);
-
-        logger.info("Creating replication agreement on " + replicaHostname);
-
-        replicaConfigurator.createReplicationAgreement(
-                replicaAgreementName,
-                masterHostname,
-                masterReplicationPort,
-                masterBindDN,
-                masterReplicationPassword,
-                replicationSecurity);
     }
 }


### PR DESCRIPTION
The `pki-server <subsystem>-db-repl-agmt-add` has been added to create DS replication agreements prior to running `pkispawn`.

The `SubsystemDBReplicationSetupCLI` has been modified to no longer create the replication agreements.

The `PKIDeployer.setup_database()` has been modified to create the replication agreements in both the master and the replica.

The test for CA cloning with replicated DS has been modified to use the new command.

https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-PKI-Tools
