### PR TITLE
Add pki-server <subsystem>-db-create

### DIFF
--- a/.github/workflows/ca-clone-replicated-ds-test.yml
+++ b/.github/workflows/ca-clone-replicated-ds-test.yml
@@ -115,6 +115,27 @@ jobs:
               --pkcs12 $SHARED/ca-certs.p12 \
               --password Secret.123
 
+      - name: Configure connection to CA database
+        run: |
+          # store DS password
+          docker exec secondary pki-server password-add \
+              --password Secret.123 \
+              internaldb
+
+          # configure DS connection params
+          docker exec secondary pki-server ca-db-config-mod \
+              --hostname secondaryds.example.com \
+              --port 3389 \
+              --secure false \
+              --auth BasicAuth \
+              --bindDN "cn=Directory Manager" \
+              --bindPWPrompt internaldb \
+              --database ca \
+              --baseDN dc=ca,dc=pki,dc=example,dc=com \
+              --multiSuffix false \
+              --maxConns 15 \
+              --minConns 3
+
       # https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-DS-Tools
       - name: Preparing DS backend
         run: |
@@ -126,13 +147,7 @@ jobs:
               backend suffix list
 
           # create backend for CA in secondary DS
-          docker exec secondaryds dsconf \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              ldap://secondaryds.example.com:3389 \
-              backend create \
-              --suffix=dc=ca,dc=pki,dc=example,dc=com \
-              --be-name=ca
+          docker exec secondary pki-server ca-db-create -v
 
       - name: Enable replication on primary DS
         run: |

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBCLI.java
@@ -20,6 +20,7 @@ package org.dogtagpki.server.ca.cli;
 
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.server.cli.SubsystemDBAccessCLI;
+import org.dogtagpki.server.cli.SubsystemDBCreateCLI;
 import org.dogtagpki.server.cli.SubsystemDBEmptyCLI;
 import org.dogtagpki.server.cli.SubsystemDBIndexCLI;
 import org.dogtagpki.server.cli.SubsystemDBInfoCLI;
@@ -37,6 +38,7 @@ public class CADBCLI extends CLI {
         super("db", "CA database management commands", parent);
 
         addModule(new SubsystemDBInfoCLI(this));
+        addModule(new SubsystemDBCreateCLI(this));
         addModule(new SubsystemDBInitCLI(this));
         addModule(new SubsystemDBEmptyCLI(this));
         addModule(new SubsystemDBRemoveCLI(this));

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1524,6 +1524,10 @@ class PKIDeployer:
             else:
                 logger.info('Reusing replicated database')
 
+        if config.str2bool(self.mdict['pki_ds_create_new_db']):
+            logger.info('Creating database')
+            subsystem.create_database()
+
         logger.info('Initializing database')
 
         # In most cases, we want to replicate the schema and therefore not add it here.
@@ -1538,8 +1542,6 @@ class PKIDeployer:
             config.str2bool(self.mdict['pki_clone_setup_replication']) and \
             config.str2bool(self.mdict['pki_clone_replicate_schema'])
 
-        create_backend = config.str2bool(self.mdict['pki_ds_create_new_db'])
-
         # When cloning a subsystem without setting up the replication agreements,
         # the database is a subtree of an existing tree and is already replicated,
         # so there is no need to set up the base entry.
@@ -1552,7 +1554,6 @@ class PKIDeployer:
 
         subsystem.init_database(
             skip_schema=skip_schema,
-            create_backend=create_backend,
             skip_base=skip_base,
             skip_containers=skip_containers)
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1160,11 +1160,22 @@ class PKISubsystem(object):
         logger.debug('Command: %s', ' '.join(cmd))
         subprocess.check_call(cmd)
 
+    def create_database(self):
+
+        cmd = [self.name + '-db-create']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd)
+
     def init_database(
             self,
             skip_config=False,
             skip_schema=False,
-            create_backend=False,
             skip_base=False,
             skip_containers=False,
             as_current_user=False):
@@ -1176,9 +1187,6 @@ class PKISubsystem(object):
 
         if skip_schema:
             cmd.append('--skip-schema')
-
-        if create_backend:
-            cmd.append('--create-backend')
 
         if skip_base:
             cmd.append('--skip-base')

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBCLI.java
@@ -29,6 +29,7 @@ public class SubsystemDBCLI extends CLI {
         super("db", parent.name.toUpperCase() + " database management commands", parent);
 
         addModule(new SubsystemDBInfoCLI(this));
+        addModule(new SubsystemDBCreateCLI(this));
         addModule(new SubsystemDBInitCLI(this));
         addModule(new SubsystemDBEmptyCLI(this));
         addModule(new SubsystemDBRemoveCLI(this));


### PR DESCRIPTION
The `pki-server <subsystem>-db-create` has been added to create a DS backend for the subsystem.

The `pki-server <subsystem>-db-init` has been updated to no longer provide a `--create-backend` option.

The test for CA cloning with replicated DS has been modified to use the new command.

https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-PKI-Tools