### PR TITLE
Fix the update to 11.5.0

### DIFF
--- a/base/server/upgrade/11.5.0/04-RemoveCertCSRfromConfig.py
+++ b/base/server/upgrade/11.5.0/04-RemoveCertCSRfromConfig.py
@@ -19,13 +19,9 @@ class RemoveCertCSRfromConfig(pki.server.upgrade.PKIServerUpgradeScriptlet):
         super().__init__()
         self.message = 'Removes certs data and CSR from CS.cfg'
 
-    def upgrade_instance(self, instance):
-
-        instance.makedirs(instance.certs_dir, exist_ok=True)
-
     def upgrade_subsystem(self, instance, subsystem):
-
         self.backup(subsystem.cs_conf)
+        instance.makedirs(instance.certs_dir, exist_ok=True)
 
         logger.info('Removing certs data')
         certs = subsystem.find_system_certs()


### PR DESCRIPTION
Check and create the folder for every subsystem update, beside the instance update.

During the update certs and csr are removed from CS.cfg file and stored in `<config>/certs` folder if they are not in the internaldb.

The folder creation for the instance was done after update the subsystem generating an error and stopping the update.