### PR TITLE
Update test for CA clone with replicated DS

### DIFF
--- a/.github/workflows/ca-clone-replicated-ds-test.yml
+++ b/.github/workflows/ca-clone-replicated-ds-test.yml
@@ -329,6 +329,16 @@ jobs:
 
           diff primaryds.dn secondaryds.dn
 
+      - name: Create search indexes
+        run: |
+          docker exec secondary pki-server ca-db-index-add -v
+          docker exec secondary pki-server ca-db-index-rebuild -v
+
+      - name: Create VLV indexes
+        run: |
+          docker exec secondary pki-server ca-db-vlv-add -v
+          docker exec secondary pki-server ca-db-vlv-reindex -v
+
       # https://github.com/dogtagpki/pki/wiki/Installing-CA-Clone-with-Existing-DS
       - name: Install secondary CA
         run: |

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1557,15 +1557,6 @@ class PKIDeployer:
             skip_base=skip_base,
             skip_containers=skip_containers)
 
-        # always create indexes
-        subsystem.add_indexes()
-
-        # if the database is already replicated but not yet indexed, rebuild the indexes
-        if config.str2bool(self.mdict['pki_clone']) and \
-                not config.str2bool(self.mdict['pki_clone_setup_replication']) and \
-                config.str2bool(self.mdict['pki_clone_reindex_data']):
-            subsystem.rebuild_indexes()
-
         if config.str2bool(self.mdict['pki_clone']) and \
                 config.str2bool(self.mdict['pki_clone_setup_replication']):
             self.setup_replication(subsystem, master_config)
@@ -1585,6 +1576,15 @@ class PKIDeployer:
             dbuser = 'uid=pkidbuser,ou=people,' + self.mdict['pki_ds_base_dn']
 
         subsystem.grant_database_access(dbuser)
+
+        # Always create search and VLV indexes since they will not be replicated
+        subsystem.add_indexes()
+
+        # If the database is already replicated but not yet indexed, rebuild the indexes
+        if config.str2bool(self.mdict['pki_clone']) and \
+                not config.str2bool(self.mdict['pki_clone_setup_replication']) and \
+                config.str2bool(self.mdict['pki_clone_reindex_data']):
+            subsystem.rebuild_indexes()
 
         subsystem.add_vlv()
         subsystem.reindex_vlv()


### PR DESCRIPTION
The test for CA clone with replicated DS has been updated to create search and VLV indexes manually since it will call `pkispawn` with `pki_ds_setup=False` which will skip those steps.