### PR TITLE
[Fix Bug 2251981]

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/system/SystemCertData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/system/SystemCertData.java
@@ -61,6 +61,9 @@ public class SystemCertData {
     protected String subjectDN;
 
     @XmlElement
+    protected String opsFlagMask;
+
+    @XmlElement
     protected String cert;
 
     @XmlElement
@@ -237,6 +240,20 @@ public class SystemCertData {
 
     public void setDNSNames(String[] dnsNames) {
         this.dnsNames = dnsNames;
+    }
+
+    /**
+     * @return the certificate operation mask
+     */
+    public String getOpsFlagMask() {
+        return opsFlagMask;
+    }
+
+    /**
+     * @param The certificate operation mask. It is a comma separated list of usages including: encrypt, decrypt, sign, sign_recover, verify, verify_recover, wrap, unwrap and derive.
+     */
+    public void setOpsFlagMask(String opsFlagMask) {
+        this.opsFlagMask = opsFlagMask;
     }
 
     @Override

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -86,6 +86,7 @@ pki_audit_signing_key_size=2048
 pki_audit_signing_key_type=rsa
 pki_audit_signing_signing_algorithm=SHA256withRSA
 pki_audit_signing_token=
+pki_audit_signing_opsFlagMask=
 
 pki_backup_keys=False
 pki_backup_file=
@@ -156,6 +157,7 @@ pki_sslserver_key_type=%(pki_ssl_server_key_type)s
 pki_sslserver_nickname=%(pki_ssl_server_nickname)s
 pki_sslserver_subject_dn=%(pki_ssl_server_subject_dn)s
 pki_sslserver_token=%(pki_ssl_server_token)s
+pki_sslserver_opsFlagMask=
 
 pki_subsystem_key_algorithm=SHA256withRSA
 pki_subsystem_signing_algorithm=SHA256withRSA
@@ -164,6 +166,7 @@ pki_subsystem_key_type=rsa
 pki_subsystem_nickname=subsystemCert cert-%(pki_instance_name)s
 pki_subsystem_subject_dn=cn=Subsystem Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_subsystem_token=
+pki_subsystem_opsFlagMask=
 
 #Set this if we want to use PSS signing when RSA is specified
 pki_use_pss_rsa_signing_algorithm=False
@@ -353,6 +356,7 @@ pki_ca_signing_serial_number=1
 pki_ca_signing_signing_algorithm=SHA256withRSA
 pki_ca_signing_subject_dn=cn=CA Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ca_signing_token=
+pki_ca_signing_opsFlagMask=
 
 # DEPRECATED: Use 'pki_ca_signing_csr_path' instead.
 pki_external_csr_path=
@@ -388,6 +392,7 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s CA
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=CA OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
+pki_ocsp_signing_opsFlagMask=
 
 pki_profiles_in_ldap=False
 pki_random_serial_numbers_enable=False
@@ -500,6 +505,7 @@ pki_storage_nickname=storageCert cert-%(pki_instance_name)s KRA
 pki_storage_signing_algorithm=SHA256withRSA
 pki_storage_subject_dn=cn=DRM Storage Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_storage_token=
+pki_storage_opsFlagMask=
 
 pki_transport_key_algorithm=SHA256withRSA
 pki_transport_key_size=2048
@@ -508,6 +514,7 @@ pki_transport_nickname=transportCert cert-%(pki_instance_name)s KRA
 pki_transport_signing_algorithm=SHA256withRSA
 pki_transport_subject_dn=cn=DRM Transport Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_transport_token=
+pki_transport_opsFlagMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
 pki_admin_name=%(pki_admin_uid)s
@@ -581,6 +588,7 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s OCSP
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
+pki_ocsp_signing_opsFlagMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
 pki_admin_name=%(pki_admin_uid)s

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2890,6 +2890,7 @@ class ConfigClient:
         cert.nickname = self.mdict["pki_%s_nickname" % tag]
         cert.subjectDN = self.mdict["pki_%s_subject_dn" % tag]
         cert.token = self.mdict["pki_%s_token" % tag]
+        cert.opsFlagMask = self.mdict["pki_%s_opsFlagMask" % tag]
         return cert
 
     def retrieve_existing_server_cert(self, cfg_file):

--- a/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/util/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -69,18 +69,18 @@ import org.mozilla.jss.SecretDecoderRing.KeyManager;
 import org.mozilla.jss.asn1.ANY;
 import org.mozilla.jss.asn1.ASN1Value;
 import org.mozilla.jss.asn1.BIT_STRING;
-import org.mozilla.jss.asn1.INTEGER;
 import org.mozilla.jss.asn1.BMPString;
-import org.mozilla.jss.asn1.PrintableString;
-import org.mozilla.jss.asn1.TeletexString;
-import org.mozilla.jss.asn1.UTF8String;
-import org.mozilla.jss.asn1.UniversalString;
+import org.mozilla.jss.asn1.INTEGER;
 import org.mozilla.jss.asn1.InvalidBERException;
 import org.mozilla.jss.asn1.NULL;
 import org.mozilla.jss.asn1.OBJECT_IDENTIFIER;
 import org.mozilla.jss.asn1.OCTET_STRING;
+import org.mozilla.jss.asn1.PrintableString;
 import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.asn1.SET;
+import org.mozilla.jss.asn1.TeletexString;
+import org.mozilla.jss.asn1.UTF8String;
+import org.mozilla.jss.asn1.UniversalString;
 import org.mozilla.jss.crypto.Algorithm;
 import org.mozilla.jss.crypto.Cipher;
 import org.mozilla.jss.crypto.CryptoStore;
@@ -157,8 +157,8 @@ import org.mozilla.jss.pkix.crmf.CertTemplate;
 import org.mozilla.jss.pkix.crmf.EncryptedKey;
 import org.mozilla.jss.pkix.crmf.EncryptedValue;
 import org.mozilla.jss.pkix.crmf.PKIArchiveOptions;
-import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 import org.mozilla.jss.pkix.primitive.AVA;
+import org.mozilla.jss.pkix.primitive.AlgorithmIdentifier;
 import org.mozilla.jss.pkix.primitive.Name;
 import org.mozilla.jss.pkix.primitive.SubjectPublicKeyInfo;
 import org.mozilla.jss.ssl.SSLCipher;
@@ -3324,6 +3324,12 @@ public class CryptoUtil {
         }
 
         return desKey;
+    }
+
+    public static KeyPairGeneratorSpi.Usage[] generateUsage(String usage) {
+        return Arrays.stream(usage.toUpperCase().split(",")).map(String::trim)
+                .map(KeyPairGeneratorSpi.Usage::valueOf).toArray(KeyPairGeneratorSpi.Usage[]::new);
+
     }
 }
 


### PR DESCRIPTION
Default operation flags does not work for some HSM so a new mechanism is introduced to allow a custom flag list. The certificate generate in the hsm can be customised in pkispawn config file with `pki_<cert>_opsFlagMask` where `<cert> is one between:

- audit_signing
- sslserver
- subsystem
- ca_signing
- ocsp_signing
- storage
- transport
- ocsp_signing

The value is a comma sepated list of flags (case insensitive) which can be: encrypt, decrypt, sign, sign_recover, verify, verify_recover, wrap, unwrap AND derive.