### PR TITLE
[Fix Bug 2251981] Part 2: opsFlag parameter

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/system/SystemCertData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/system/SystemCertData.java
@@ -61,6 +61,9 @@ public class SystemCertData {
     protected String subjectDN;
 
     @XmlElement
+    protected String opsFlag;
+
+    @XmlElement
     protected String opsFlagMask;
 
     @XmlElement
@@ -240,6 +243,20 @@ public class SystemCertData {
 
     public void setDNSNames(String[] dnsNames) {
         this.dnsNames = dnsNames;
+    }
+
+    /**
+     * @return the certificate operation flags
+     */
+    public String getOpsFlag() {
+        return opsFlag;
+    }
+
+    /**
+     * @param The certificate operation flags. It is a comma separated list of usages including: encrypt, decrypt, sign, sign_recover, verify, verify_recover, wrap, unwrap and derive.
+     */
+    public void setOpsFlag(String opsFlag) {
+        this.opsFlag = opsFlag;
     }
 
     /**

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -86,6 +86,7 @@ pki_audit_signing_key_size=2048
 pki_audit_signing_key_type=rsa
 pki_audit_signing_signing_algorithm=SHA256withRSA
 pki_audit_signing_token=
+pki_audit_signing_opsFlag=
 pki_audit_signing_opsFlagMask=
 
 pki_backup_keys=False
@@ -157,6 +158,7 @@ pki_sslserver_key_type=%(pki_ssl_server_key_type)s
 pki_sslserver_nickname=%(pki_ssl_server_nickname)s
 pki_sslserver_subject_dn=%(pki_ssl_server_subject_dn)s
 pki_sslserver_token=%(pki_ssl_server_token)s
+pki_sslserver_opsFlag=
 pki_sslserver_opsFlagMask=
 
 pki_subsystem_key_algorithm=SHA256withRSA
@@ -166,6 +168,7 @@ pki_subsystem_key_type=rsa
 pki_subsystem_nickname=subsystemCert cert-%(pki_instance_name)s
 pki_subsystem_subject_dn=cn=Subsystem Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_subsystem_token=
+pki_subsystem_opsFlag=
 pki_subsystem_opsFlagMask=
 
 #Set this if we want to use PSS signing when RSA is specified
@@ -356,6 +359,7 @@ pki_ca_signing_serial_number=1
 pki_ca_signing_signing_algorithm=SHA256withRSA
 pki_ca_signing_subject_dn=cn=CA Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ca_signing_token=
+pki_ca_signing_opsFlag=
 pki_ca_signing_opsFlagMask=
 
 # DEPRECATED: Use 'pki_ca_signing_csr_path' instead.
@@ -392,6 +396,7 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s CA
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=CA OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
+pki_ocsp_signing_opsFlag=
 pki_ocsp_signing_opsFlagMask=
 
 pki_profiles_in_ldap=False
@@ -505,6 +510,7 @@ pki_storage_nickname=storageCert cert-%(pki_instance_name)s KRA
 pki_storage_signing_algorithm=SHA256withRSA
 pki_storage_subject_dn=cn=DRM Storage Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_storage_token=
+pki_storage_opsFlag=
 pki_storage_opsFlagMask=
 
 pki_transport_key_algorithm=SHA256withRSA
@@ -514,6 +520,7 @@ pki_transport_nickname=transportCert cert-%(pki_instance_name)s KRA
 pki_transport_signing_algorithm=SHA256withRSA
 pki_transport_subject_dn=cn=DRM Transport Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_transport_token=
+pki_transport_opsFlag=
 pki_transport_opsFlagMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
@@ -588,6 +595,7 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s OCSP
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
+pki_ocsp_signing_opsFlag=
 pki_ocsp_signing_opsFlagMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -2890,6 +2890,7 @@ class ConfigClient:
         cert.nickname = self.mdict["pki_%s_nickname" % tag]
         cert.subjectDN = self.mdict["pki_%s_subject_dn" % tag]
         cert.token = self.mdict["pki_%s_token" % tag]
+        cert.opsFlag = self.mdict["pki_%s_opsFlag" % tag]
         cert.opsFlagMask = self.mdict["pki_%s_opsFlagMask" % tag]
         return cert
 


### PR DESCRIPTION
Add the second parameter to pkispawn in other to customise the key par generation in HSM. The new config parameter is `pki_<cert>_opsFlag`. The `<cert>` is the id as defined for the parameter `pki_<cert>_opsFlagMask` and they have the same values