### PR TITLE
Fix ops flag mask master

### DIFF
--- a/.github/workflows/ca-hsm-operation-test.yml
+++ b/.github/workflows/ca-hsm-operation-test.yml
@@ -84,7 +84,7 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_ca_signing_opsFlagMask=sign \
+              -D pki_ca_signing_opFlagsMask=sign \
               -v
         continue-on-error: true
         id: hsm_no_sign
@@ -108,8 +108,8 @@ jobs:
               -D pki_audit_signing_token=HSM \
               -D pki_subsystem_token=HSM \
               -D pki_sslserver_token=internal \
-              -D pki_ca_signing_opsFlag=sign \
-              -D pki_ca_signing_opsFlagMask=sign \
+              -D pki_ca_signing_opFlags=sign \
+              -D pki_ca_signing_opFlagsMask=sign \
               -v
 
       - name: Gather artifacts

--- a/.github/workflows/ca-hsm-operation-test.yml
+++ b/.github/workflows/ca-hsm-operation-test.yml
@@ -1,0 +1,136 @@
+name: CA with HSM and custom operation key flags
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # docs/installation/ca/Installing_CA_with_HSM.md
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v3
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install dependencies
+        run: |
+          docker exec pki dnf install -y softhsm
+
+      - name: Create SoftHSM token
+        run: |
+          # allow PKI user to access SoftHSM files
+          docker exec pki usermod pkiuser -a -G ods
+
+          # create SoftHSM token for PKI server
+          docker exec pki runuser -u pkiuser -- \
+              softhsm2-util \
+              --init-token \
+              --label HSM \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
+              --free
+
+          docker exec pki ls -laR /var/lib/softhsm/tokens
+
+      - name: Install CA with HSM and no sign flag
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_instance_name=pki-failing-tomcat \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_hsm_enable=True \
+              -D pki_token_name=HSM \
+              -D pki_token_password=Secret.HSM \
+              -D pki_server_database_password=Secret.123 \
+              -D pki_ca_signing_token=HSM \
+              -D pki_ocsp_signing_token=HSM \
+              -D pki_audit_signing_token=HSM \
+              -D pki_subsystem_token=HSM \
+              -D pki_sslserver_token=internal \
+              -D pki_ca_signing_opsFlagMask=sign \
+              -v
+        continue-on-error: true
+        id: hsm_no_sign
+
+      - name: Check the install with no sign ops failed
+        if: job.steps.hsm_no_sign.status != failure()
+        run: exit 1
+        
+      - name: Install CA with HSM reintroducing sign flag
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_hsm_enable=True \
+              -D pki_token_name=HSM \
+              -D pki_token_password=Secret.HSM \
+              -D pki_server_database_password=Secret.123 \
+              -D pki_ca_signing_token=HSM \
+              -D pki_ocsp_signing_token=HSM \
+              -D pki_audit_signing_token=HSM \
+              -D pki_subsystem_token=HSM \
+              -D pki_sslserver_token=internal \
+              -D pki_ca_signing_opsFlag=sign \
+              -D pki_ca_signing_opsFlagMask=sign \
+              -v
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Remove SoftHSM token
+        run: |
+          docker exec pki ls -laR /var/lib/softhsm/tokens
+          docker exec pki runuser -u pkiuser -- softhsm2-util --delete-token --token HSM
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ca-hsm
+          path: |
+            /tmp/artifacts/pki

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -67,3 +67,8 @@ jobs:
     name: SCEP responder
     needs: build
     uses: ./.github/workflows/scep-test.yml
+
+  hsm-operation-test:
+    name: CA with HSM and custom operation key flags
+    needs: build
+    uses: ./.github/workflows/ca-hsm-operation-test.yml

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -646,7 +646,8 @@ class NSSDatabase(object):
             key_wrap=False,
             curve=None,
             ssl_ecdh=False,
-            opsFlagMask=None):
+            ops_flag=None,
+            ops_flag_mask=None):
 
         cmd = [
             'pki',
@@ -687,8 +688,11 @@ class NSSDatabase(object):
         if ssl_ecdh:
             cmd.append('--ssl-ecdh')
 
-        if opsFlagMask:
-            cmd.extend(['--ops-flag-mask', opsFlagMask])
+        if ops_flag:
+            cmd.extend(['--ops-flag', ops_flag])
+
+        if ops_flag_mask:
+            cmd.extend(['--ops-flag-mask', ops_flag_mask])
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -646,8 +646,8 @@ class NSSDatabase(object):
             key_wrap=False,
             curve=None,
             ssl_ecdh=False,
-            ops_flag=None,
-            ops_flag_mask=None):
+            op_flags=None,
+            op_flags_mask=None):
 
         cmd = [
             'pki',
@@ -688,11 +688,11 @@ class NSSDatabase(object):
         if ssl_ecdh:
             cmd.append('--ssl-ecdh')
 
-        if ops_flag:
-            cmd.extend(['--ops-flag', ops_flag])
+        if op_flags:
+            cmd.extend(['--op-flags', op_flags])
 
-        if ops_flag_mask:
-            cmd.extend(['--ops-flag-mask', ops_flag_mask])
+        if op_flags_mask:
+            cmd.extend(['--op-flags-mask', op_flags_mask])
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -645,7 +645,8 @@ class NSSDatabase(object):
             key_size=None,
             key_wrap=False,
             curve=None,
-            ssl_ecdh=False):
+            ssl_ecdh=False,
+            opsFlagMask=None):
 
         cmd = [
             'pki',
@@ -685,6 +686,9 @@ class NSSDatabase(object):
 
         if ssl_ecdh:
             cmd.append('--ssl-ecdh')
+
+        if opsFlagMask:
+            cmd.extend(['--ops-flag-mask', opsFlagMask])
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')

--- a/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -3047,6 +3047,12 @@ public class CryptoUtil {
 
         return desKey;
     }
+
+    public static KeyPairGeneratorSpi.Usage[] generateUsage(String usage) {
+        return Arrays.stream(usage.toUpperCase().split(",")).map(String::trim)
+                .map(KeyPairGeneratorSpi.Usage::valueOf).toArray(KeyPairGeneratorSpi.Usage[]::new);
+
+    }
 }
 
 // START ENABLE_ECC

--- a/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.Vector;
+import java.util.stream.Stream;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.SecretKeyFactory;
@@ -461,6 +462,10 @@ public class CryptoUtil {
             keygen.extractablePairs(extractable);
         }
 
+        String usageList = usages != null ? String.join(",", Stream.of(usages).map(org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage::name).toArray(String[]::new)) : "";
+        logger.debug("CryptoUtil: generateRSAKeyPair with key usage {}", usageList);
+        String usageMaskList = usagesMask != null ? String.join(",", Stream.of(usagesMask).map(org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage::name).toArray(String[]::new)) : "";
+        logger.debug("CryptoUtil: generateRSAKeyPair with key usage mask {}", usageMaskList);
         keygen.setKeyPairUsages(usages, usagesMask);
 
         logger.debug("CryptoUtil: - key size: " + keySize);
@@ -561,6 +566,10 @@ public class CryptoUtil {
             keygen.extractablePairs(extractable);
         }
 
+        String usageList = usages != null ? String.join(",", Stream.of(usages).map(org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage::name).toArray(String[]::new)) : "";
+        logger.debug("CryptoUtil: generateRSAKeyPair with key usage {}", usageList);
+        String usageMaskList = usagesMask != null ? String.join(",", Stream.of(usagesMask).map(org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage::name).toArray(String[]::new)) : "";
+        logger.debug("CryptoUtil: generateRSAKeyPair with key usage mask {}", usageMaskList);
         keygen.setKeyPairUsages(usages, usagesMask);
 
         keygen.initialize(curveCode);

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -56,8 +56,8 @@ pki_audit_signing_key_size=2048
 pki_audit_signing_key_type=rsa
 pki_audit_signing_signing_algorithm=SHA256withRSA
 pki_audit_signing_token=
-pki_audit_signing_opsFlag=
-pki_audit_signing_opsFlagMask=
+pki_audit_signing_opFlags=
+pki_audit_signing_opFlagsMask=
 
 pki_backup_keys=False
 pki_backup_file=
@@ -125,8 +125,8 @@ pki_sslserver_key_type=%(pki_ssl_server_key_type)s
 pki_sslserver_nickname=%(pki_ssl_server_nickname)s
 pki_sslserver_subject_dn=%(pki_ssl_server_subject_dn)s
 pki_sslserver_token=%(pki_ssl_server_token)s
-pki_sslserver_opsFlag=
-pki_sslserver_opsFlagMask=
+pki_sslserver_opFlags=
+pki_sslserver_opFlagsMask=
 
 pki_self_signed_nickname=temp %(pki_sslserver_nickname)s
 pki_self_signed_token=
@@ -138,8 +138,8 @@ pki_subsystem_key_type=rsa
 pki_subsystem_nickname=subsystemCert cert-%(pki_instance_name)s
 pki_subsystem_subject_dn=cn=Subsystem Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_subsystem_token=
-pki_subsystem_opsFlag=
-pki_subsystem_opsFlagMask=
+pki_subsystem_opFlags=
+pki_subsystem_opFlagsMask=
 
 #Set this if we want to use PSS signing when RSA is specified
 pki_use_pss_rsa_signing_algorithm=False
@@ -276,8 +276,8 @@ pki_ca_signing_serial_number=1
 pki_ca_signing_signing_algorithm=SHA256withRSA
 pki_ca_signing_subject_dn=cn=CA Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ca_signing_token=
-pki_ca_signing_opsFlag=
-pki_ca_signing_opsFlagMask=
+pki_ca_signing_opFlags=
+pki_ca_signing_opFlagsMask=
 
 # DEPRECATED: Use 'pki_ca_signing_csr_path' instead.
 pki_external_csr_path=
@@ -313,8 +313,8 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s CA
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=CA OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
-pki_ocsp_signing_opsFlag=
-pki_ocsp_signing_opsFlagMask=
+pki_ocsp_signing_opFlags=
+pki_ocsp_signing_opFlagsMask=
 
 pki_profiles_in_ldap=False
 pki_random_serial_numbers_enable=False
@@ -421,8 +421,8 @@ pki_storage_nickname=storageCert cert-%(pki_instance_name)s KRA
 pki_storage_signing_algorithm=SHA256withRSA
 pki_storage_subject_dn=cn=DRM Storage Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_storage_token=
-pki_storage_opsFlag=
-pki_storage_opsFlagMask=
+pki_storage_opFlags=
+pki_storage_opFlagsMask=
 
 pki_transport_key_algorithm=SHA256withRSA
 pki_transport_key_size=2048
@@ -431,8 +431,8 @@ pki_transport_nickname=transportCert cert-%(pki_instance_name)s KRA
 pki_transport_signing_algorithm=SHA256withRSA
 pki_transport_subject_dn=cn=DRM Transport Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_transport_token=
-pki_transport_opsFlag=
-pki_transport_opsFlagMask=
+pki_transport_opFlags=
+pki_transport_opFlagsMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
 pki_admin_name=%(pki_admin_uid)s
@@ -518,8 +518,8 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s OCSP
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
-pki_ocsp_signing_opsFlag=
-pki_ocsp_signing_opsFlagMask=
+pki_ocsp_signing_opFlags=
+pki_ocsp_signing_opFlagsMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
 pki_admin_name=%(pki_admin_uid)s

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -56,6 +56,7 @@ pki_audit_signing_key_size=2048
 pki_audit_signing_key_type=rsa
 pki_audit_signing_signing_algorithm=SHA256withRSA
 pki_audit_signing_token=
+pki_audit_signing_opsFlagMask=
 
 pki_backup_keys=False
 pki_backup_file=
@@ -123,6 +124,7 @@ pki_sslserver_key_type=%(pki_ssl_server_key_type)s
 pki_sslserver_nickname=%(pki_ssl_server_nickname)s
 pki_sslserver_subject_dn=%(pki_ssl_server_subject_dn)s
 pki_sslserver_token=%(pki_ssl_server_token)s
+pki_sslserver_opsFlagMask=
 
 pki_self_signed_nickname=temp %(pki_sslserver_nickname)s
 pki_self_signed_token=
@@ -134,6 +136,7 @@ pki_subsystem_key_type=rsa
 pki_subsystem_nickname=subsystemCert cert-%(pki_instance_name)s
 pki_subsystem_subject_dn=cn=Subsystem Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_subsystem_token=
+pki_subsystem_opsFlagMask=
 
 #Set this if we want to use PSS signing when RSA is specified
 pki_use_pss_rsa_signing_algorithm=False
@@ -270,6 +273,7 @@ pki_ca_signing_serial_number=1
 pki_ca_signing_signing_algorithm=SHA256withRSA
 pki_ca_signing_subject_dn=cn=CA Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ca_signing_token=
+pki_ca_signing_opsFlagMask=
 
 # DEPRECATED: Use 'pki_ca_signing_csr_path' instead.
 pki_external_csr_path=
@@ -305,6 +309,7 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s CA
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=CA OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
+pki_ocsp_signing_opsFlagMask=
 
 pki_profiles_in_ldap=False
 pki_random_serial_numbers_enable=False
@@ -411,6 +416,7 @@ pki_storage_nickname=storageCert cert-%(pki_instance_name)s KRA
 pki_storage_signing_algorithm=SHA256withRSA
 pki_storage_subject_dn=cn=DRM Storage Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_storage_token=
+pki_storage_opsFlagMask=
 
 pki_transport_key_algorithm=SHA256withRSA
 pki_transport_key_size=2048
@@ -419,6 +425,7 @@ pki_transport_nickname=transportCert cert-%(pki_instance_name)s KRA
 pki_transport_signing_algorithm=SHA256withRSA
 pki_transport_subject_dn=cn=DRM Transport Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_transport_token=
+pki_transport_opsFlagMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
 pki_admin_name=%(pki_admin_uid)s
@@ -504,6 +511,7 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s OCSP
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
+pki_ocsp_signing_opsFlagMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
 pki_admin_name=%(pki_admin_uid)s

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -56,6 +56,7 @@ pki_audit_signing_key_size=2048
 pki_audit_signing_key_type=rsa
 pki_audit_signing_signing_algorithm=SHA256withRSA
 pki_audit_signing_token=
+pki_audit_signing_opsFlag=
 pki_audit_signing_opsFlagMask=
 
 pki_backup_keys=False
@@ -124,6 +125,7 @@ pki_sslserver_key_type=%(pki_ssl_server_key_type)s
 pki_sslserver_nickname=%(pki_ssl_server_nickname)s
 pki_sslserver_subject_dn=%(pki_ssl_server_subject_dn)s
 pki_sslserver_token=%(pki_ssl_server_token)s
+pki_sslserver_opsFlag=
 pki_sslserver_opsFlagMask=
 
 pki_self_signed_nickname=temp %(pki_sslserver_nickname)s
@@ -136,6 +138,7 @@ pki_subsystem_key_type=rsa
 pki_subsystem_nickname=subsystemCert cert-%(pki_instance_name)s
 pki_subsystem_subject_dn=cn=Subsystem Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_subsystem_token=
+pki_subsystem_opsFlag=
 pki_subsystem_opsFlagMask=
 
 #Set this if we want to use PSS signing when RSA is specified
@@ -273,6 +276,7 @@ pki_ca_signing_serial_number=1
 pki_ca_signing_signing_algorithm=SHA256withRSA
 pki_ca_signing_subject_dn=cn=CA Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ca_signing_token=
+pki_ca_signing_opsFlag=
 pki_ca_signing_opsFlagMask=
 
 # DEPRECATED: Use 'pki_ca_signing_csr_path' instead.
@@ -309,6 +313,7 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s CA
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=CA OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
+pki_ocsp_signing_opsFlag=
 pki_ocsp_signing_opsFlagMask=
 
 pki_profiles_in_ldap=False
@@ -416,6 +421,7 @@ pki_storage_nickname=storageCert cert-%(pki_instance_name)s KRA
 pki_storage_signing_algorithm=SHA256withRSA
 pki_storage_subject_dn=cn=DRM Storage Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_storage_token=
+pki_storage_opsFlag=
 pki_storage_opsFlagMask=
 
 pki_transport_key_algorithm=SHA256withRSA
@@ -425,6 +431,7 @@ pki_transport_nickname=transportCert cert-%(pki_instance_name)s KRA
 pki_transport_signing_algorithm=SHA256withRSA
 pki_transport_subject_dn=cn=DRM Transport Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_transport_token=
+pki_transport_opsFlag=
 pki_transport_opsFlagMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s
@@ -511,6 +518,7 @@ pki_ocsp_signing_nickname=ocspSigningCert cert-%(pki_instance_name)s OCSP
 pki_ocsp_signing_signing_algorithm=SHA256withRSA
 pki_ocsp_signing_subject_dn=cn=OCSP Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_ocsp_signing_token=
+pki_ocsp_signing_opsFlag=
 pki_ocsp_signing_opsFlagMask=
 
 pki_admin_email=%(pki_admin_name)s@%(pki_dns_domainname)s

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2839,8 +2839,8 @@ class PKIDeployer:
         system_cert.nickname = self.mdict['pki_%s_nickname' % cert_id]
         system_cert.subjectDN = self.mdict['pki_%s_subject_dn' % cert_id]
         system_cert.token = self.mdict['pki_%s_token' % cert_id]
-        system_cert.ops_flag = self.mdict['pki_%s_opsFlag' % cert_id]
-        system_cert.ops_flag_mask = self.mdict['pki_%s_opsFlagMask' % cert_id]
+        system_cert.op_flags = self.mdict['pki_%s_opFlags' % cert_id]
+        system_cert.op_flags_mask = self.mdict['pki_%s_opFlagsMask' % cert_id]
 
         if not system_cert.token:
             if config.str2bool(self.mdict['pki_hsm_enable']):
@@ -2973,8 +2973,8 @@ class PKIDeployer:
 
         token = request.systemCert.token
         key_type = request.systemCert.keyType
-        ops_flag = request.systemCert.ops_flag
-        ops_flag_mask = request.systemCert.ops_flag_mask
+        op_flags = request.systemCert.op_flags
+        op_flags_mask = request.systemCert.op_flags_mask
         key_size = None
         key_wrap = False
         curve = None
@@ -3000,8 +3000,8 @@ class PKIDeployer:
                 key_wrap=key_wrap,
                 curve=curve,
                 ssl_ecdh=ssl_ecdh,
-                ops_flag=ops_flag,
-                ops_flag_mask=ops_flag_mask)
+                op_flags=op_flags,
+                op_flags_mask=op_flags_mask)
         finally:
             nssdb.close()
 

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2839,7 +2839,8 @@ class PKIDeployer:
         system_cert.nickname = self.mdict['pki_%s_nickname' % cert_id]
         system_cert.subjectDN = self.mdict['pki_%s_subject_dn' % cert_id]
         system_cert.token = self.mdict['pki_%s_token' % cert_id]
-        system_cert.opsFlagMask = self.mdict['pki_%s_opsFlagMask' % cert_id]
+        system_cert.ops_flag = self.mdict['pki_%s_opsFlag' % cert_id]
+        system_cert.ops_flag_mask = self.mdict['pki_%s_opsFlagMask' % cert_id]
 
         if not system_cert.token:
             if config.str2bool(self.mdict['pki_hsm_enable']):
@@ -2972,7 +2973,8 @@ class PKIDeployer:
 
         token = request.systemCert.token
         key_type = request.systemCert.keyType
-
+        ops_flag = request.systemCert.ops_flag
+        ops_flag_mask = request.systemCert.ops_flag_mask
         key_size = None
         key_wrap = False
         curve = None
@@ -2997,7 +2999,9 @@ class PKIDeployer:
                 key_size=key_size,
                 key_wrap=key_wrap,
                 curve=curve,
-                ssl_ecdh=ssl_ecdh)
+                ssl_ecdh=ssl_ecdh,
+                ops_flag=ops_flag,
+                ops_flag_mask=ops_flag_mask)
         finally:
             nssdb.close()
 

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2839,6 +2839,7 @@ class PKIDeployer:
         system_cert.nickname = self.mdict['pki_%s_nickname' % cert_id]
         system_cert.subjectDN = self.mdict['pki_%s_subject_dn' % cert_id]
         system_cert.token = self.mdict['pki_%s_token' % cert_id]
+        system_cert.opsFlagMask = self.mdict['pki_%s_opsFlagMask' % cert_id]
 
         if not system_cert.token:
             if config.str2bool(self.mdict['pki_hsm_enable']):

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
@@ -86,6 +86,10 @@ public class NSSKeyCreateCLI extends CommandCLI {
         option.setArgName("boolean");
         options.addOption(option);
 
+        option = new Option(null, "ops-flag", true, "Custom flags for key usage (empty for HSM default)");
+        option.setArgName("usage list");
+        options.addOption(option);
+
         option = new Option(null, "ops-flag-mask", true, "Custom flags mask for key usage (empty for HSM default)");
         option.setArgName("usage list");
         options.addOption(option);
@@ -133,7 +137,8 @@ public class NSSKeyCreateCLI extends CommandCLI {
             extractable = Boolean.valueOf(extractableStr);
         }
 
-        String opsFlagMask = cmd.getOptionValue("extractable");
+        String opsFlag = cmd.getOptionValue("ops-flag");
+        String opsFlagMask = cmd.getOptionValue("ops-flag-mask");
 
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
@@ -147,17 +152,19 @@ public class NSSKeyCreateCLI extends CommandCLI {
 
         logger.info("Creating " + keyType + " in token " + tokenName);
 
-        Usage[] usages;
-        Usage[] usagesMask;
+        Usage[] usages = null;
+        Usage[] usagesMask = null;
+
         if ("RSA".equalsIgnoreCase(keyType)) {
-
             if (keySize == null) keySize = "2048";
-            if (opsFlagMask != null && !opsFlagMask.isEmpty()) {
-                usages = CryptoUtil.generateUsage(opsFlagMask);
-                usagesMask = CryptoUtil.generateUsage(opsFlagMask);
-
+            if (opsFlag != null && !opsFlag.isEmpty()) {
+                usages = CryptoUtil.generateUsage(opsFlag);
             } else {
                 usages = keyWrap ? CryptoUtil.RSA_KEYPAIR_USAGES : null;
+            }
+            if (opsFlagMask != null && !opsFlagMask.isEmpty()) {
+                usagesMask = CryptoUtil.generateUsage(opsFlagMask);
+            } else {
                 usagesMask = keyWrap ? CryptoUtil.RSA_KEYPAIR_USAGES_MASK : null;
             }
 
@@ -178,13 +185,12 @@ public class NSSKeyCreateCLI extends CommandCLI {
             keyInfo.setAlgorithm(privateKey.getAlgorithm());
 
         } else if ("EC".equalsIgnoreCase(keyType)) {
-
-            if (opsFlagMask != null && !opsFlagMask.isEmpty()) {
+            if (opsFlag != null && !opsFlag.isEmpty()) {
                 usages = CryptoUtil.generateUsage(opsFlagMask);
+            }
+            if (opsFlagMask != null && !opsFlagMask.isEmpty()) {
                 usagesMask = CryptoUtil.generateUsage(opsFlagMask);
-
             } else {
-                usages = null;
                 usagesMask = sslECDH ? CryptoUtil.ECDH_USAGES_MASK : CryptoUtil.ECDHE_USAGES_MASK;
             }
 

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
@@ -86,11 +86,11 @@ public class NSSKeyCreateCLI extends CommandCLI {
         option.setArgName("boolean");
         options.addOption(option);
 
-        option = new Option(null, "ops-flag", true, "Custom flags for key usage (empty for HSM default)");
+        option = new Option(null, "op-flags", true, "Custom flags for key usage");
         option.setArgName("usage list");
         options.addOption(option);
 
-        option = new Option(null, "ops-flag-mask", true, "Custom flags mask for key usage (empty for HSM default)");
+        option = new Option(null, "op-flags-mask", true, "Custom flags mask for key usage");
         option.setArgName("usage list");
         options.addOption(option);
 
@@ -137,8 +137,8 @@ public class NSSKeyCreateCLI extends CommandCLI {
             extractable = Boolean.valueOf(extractableStr);
         }
 
-        String opsFlag = cmd.getOptionValue("ops-flag");
-        String opsFlagMask = cmd.getOptionValue("ops-flag-mask");
+        String opFlags = cmd.getOptionValue("op-flags");
+        String opFlagsMask = cmd.getOptionValue("op-flags-mask");
 
         MainCLI mainCLI = (MainCLI) getRoot();
         mainCLI.init();
@@ -157,13 +157,13 @@ public class NSSKeyCreateCLI extends CommandCLI {
 
         if ("RSA".equalsIgnoreCase(keyType)) {
             if (keySize == null) keySize = "2048";
-            if (opsFlag != null && !opsFlag.isEmpty()) {
-                usages = CryptoUtil.generateUsage(opsFlag);
+            if (opFlags != null && !opFlags.isEmpty()) {
+                usages = CryptoUtil.generateUsage(opFlags);
             } else {
                 usages = keyWrap ? CryptoUtil.RSA_KEYPAIR_USAGES : null;
             }
-            if (opsFlagMask != null && !opsFlagMask.isEmpty()) {
-                usagesMask = CryptoUtil.generateUsage(opsFlagMask);
+            if (opFlagsMask != null && !opFlagsMask.isEmpty()) {
+                usagesMask = CryptoUtil.generateUsage(opFlagsMask);
             } else {
                 usagesMask = keyWrap ? CryptoUtil.RSA_KEYPAIR_USAGES_MASK : null;
             }
@@ -185,11 +185,11 @@ public class NSSKeyCreateCLI extends CommandCLI {
             keyInfo.setAlgorithm(privateKey.getAlgorithm());
 
         } else if ("EC".equalsIgnoreCase(keyType)) {
-            if (opsFlag != null && !opsFlag.isEmpty()) {
-                usages = CryptoUtil.generateUsage(opsFlagMask);
+            if (opFlags != null && !opFlags.isEmpty()) {
+                usages = CryptoUtil.generateUsage(opFlagsMask);
             }
-            if (opsFlagMask != null && !opsFlagMask.isEmpty()) {
-                usagesMask = CryptoUtil.generateUsage(opsFlagMask);
+            if (opFlagsMask != null && !opFlagsMask.isEmpty()) {
+                usagesMask = CryptoUtil.generateUsage(opFlagsMask);
             } else {
                 usagesMask = sslECDH ? CryptoUtil.ECDH_USAGES_MASK : CryptoUtil.ECDHE_USAGES_MASK;
             }

--- a/docs/changes/v11.5.0/Server-Changes.adoc
+++ b/docs/changes/v11.5.0/Server-Changes.adoc
@@ -56,11 +56,11 @@ To install a new KRA with the legacy sequential serial numbers specify the follo
 * `pki_request_id_generator=legacy`
 
 
-== Add pki_<cert_id>_opsFlag and pki_<cert_id>_opsFlagMask parameters ==
+== Add pki_<cert_id>_opFlags and pki_<cert_id>_opFlagsMask parameters ==
 
 Two new parameters are added to pkispawn configuration for setting the key flags in HSM.
 The new parameters are available for all certificates created during the subsystem installation
-and their value is a comma separated list of the following flags: encrypt, decrypt, sign,
-sign_recover, verify, verify_recover, wrap, unwrap and derive. The first parameter add flags to
-the list identified by underneath module while the second remove them.
+and their value is a comma separated list of the following flags: `encrypt`, `decrypt`, `sign`,
+`sign_recover`, `verify`, `verify_recover`, `wrap`, `unwrap` and `derive`. The first parameter add
+flags to the list identified by underneath module while the second remove them.
 Default values are empty lists to get the HSM default key flags.

--- a/docs/changes/v11.5.0/Server-Changes.adoc
+++ b/docs/changes/v11.5.0/Server-Changes.adoc
@@ -56,10 +56,11 @@ To install a new KRA with the legacy sequential serial numbers specify the follo
 * `pki_request_id_generator=legacy`
 
 
-== Add pki_<cert_id>_opsFlagMask parameter ==
+== Add pki_<cert_id>_opsFlag and pki_<cert_id>_opsFlagMask parameters ==
 
-A new parameter is added to pkispawn configuration for setting the key flags in HSM.
-The new parameter is available for all certificates created during the subsystem installation
-and its value is a comma separated list of the following flags: encrypt, decrypt, sign,
-sign_recover, verify, verify_recover, wrap, unwrap and derive.
-Default value is an empty list.
+Two new parameters are added to pkispawn configuration for setting the key flags in HSM.
+The new parameters are available for all certificates created during the subsystem installation
+and their value is a comma separated list of the following flags: encrypt, decrypt, sign,
+sign_recover, verify, verify_recover, wrap, unwrap and derive. The first parameter add flags to
+the list identified by underneath module while the second remove them.
+Default values are empty lists to get the HSM default key flags.

--- a/docs/changes/v11.5.0/Server-Changes.adoc
+++ b/docs/changes/v11.5.0/Server-Changes.adoc
@@ -54,3 +54,12 @@ To install a new KRA with the legacy sequential serial numbers specify the follo
 
 * `pki_key_id_generator=legacy`
 * `pki_request_id_generator=legacy`
+
+
+== Add pki_<cert_id>_opsFlagMask parameter ==
+
+A new parameter is added to pkispawn configuration for setting the key flags in HSM.
+The new parameter is available for all certificates created during the subsystem installation
+and its value is a comma separated list of the following flags: encrypt, decrypt, sign,
+sign_recover, verify, verify_recover, wrap, unwrap and derive.
+Default value is an empty list.

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -59,7 +59,7 @@ The `pki-server status` command has been updated to no longer show
 whether a subsystem is a new subsystem or a clone since there is no
 distinction between them.
 
-== New opsFlagMask options for pki nss-key-create CLI ==
+== New ops-flag and ops-flag-mask options for pki nss-key-create CLI ==
 
-The `pki nss-key-create` command has been modified to support the option `--ops-flag-mask`
-to specify a list of flags to set for the new key.
+The `pki nss-key-create` command has been modified to support the option `--ops-flag` and `--ops-flag-mask`
+to specify a list of flags or masks to set for the new key.

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -59,7 +59,7 @@ The `pki-server status` command has been updated to no longer show
 whether a subsystem is a new subsystem or a clone since there is no
 distinction between them.
 
-== New ops-flag and ops-flag-mask options for pki nss-key-create CLI ==
+== New op-flags and op-flags-mask options for pki nss-key-create CLI ==
 
-The `pki nss-key-create` command has been modified to support the option `--ops-flag` and `--ops-flag-mask`
+The `pki nss-key-create` command has been modified to support the option `--op-flags` and `--op-flags-mask`
 to specify a list of flags or masks to set for the new key.

--- a/docs/changes/v11.5.0/Tools-Changes.adoc
+++ b/docs/changes/v11.5.0/Tools-Changes.adoc
@@ -58,3 +58,8 @@ options to specify the certificate nickname and token name.
 The `pki-server status` command has been updated to no longer show
 whether a subsystem is a new subsystem or a clone since there is no
 distinction between them.
+
+== New opsFlagMask options for pki nss-key-create CLI ==
+
+The `pki nss-key-create` command has been modified to support the option `--ops-flag-mask`
+to specify a list of flags to set for the new key.


### PR DESCRIPTION
@edewata  this PR add two flags `pki_*_opsFlag` and `pki_*_opsFlagMask`. These have been introduced in branch v10.13 with PRs #4643, #4645 and #4647 but the code in master is too different for cherry-picking so I have written from scratch and added test and doc.