### PR TITLE
Add test for KRA clone with replicated DS

### DIFF
--- a/.github/workflows/kra-clone-replicated-ds-test.yml
+++ b/.github/workflows/kra-clone-replicated-ds-test.yml
@@ -1,0 +1,617 @@
+name: KRA clone with replicated DS
+# https://github.com/dogtagpki/pki/wiki/Installing-KRA-Clone-with-Replicated-DS
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v3
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up primary DS container
+        run: |
+          tests/bin/ds-container-create.sh primaryds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: primaryds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect primary DS container to network
+        run: docker network connect example primaryds --alias primaryds.example.com
+
+      - name: Set up primary PKI container
+        run: |
+          tests/bin/runner-init.sh primary
+        env:
+          HOSTNAME: primary.example.com
+
+      - name: Connect primary PKI container to network
+        run: docker network connect example primary --alias primary.example.com
+
+      - name: Install primary CA
+        run: |
+          docker exec primary pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
+              -v
+
+      - name: Check primary CA admin user
+        run: |
+          # install CA signing cert
+          docker exec primary pki-server cert-export ca_signing \
+              --cert-file $SHARED/ca_signing.crt
+          docker exec primary pki client-cert-import ca_signing \
+              --ca-cert $SHARED/ca_signing.crt
+
+          # install admin cert
+          docker exec primary cp \
+              /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              $SHARED/ca_admin_cert.p12
+          docker exec primary pki pkcs12-import \
+              --pkcs12 $SHARED/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec primary pki -n caadmin ca-user-show caadmin
+
+      - name: Install primary KRA
+        run: |
+          docker exec primary pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra.cfg \
+              -s KRA \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
+              -v
+
+      - name: Check primary KRA admin user
+        run: |
+          docker exec primary pki -n caadmin kra-user-show kraadmin
+
+      - name: Set up secondary DS container
+        run: |
+          tests/bin/ds-container-create.sh secondaryds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: secondaryds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect secondary DS container to network
+        run: docker network connect example secondaryds --alias secondaryds.example.com
+
+      - name: Set up secondary PKI container
+        run: |
+          tests/bin/runner-init.sh secondary
+        env:
+          HOSTNAME: secondary.example.com
+
+      - name: Connect secondary PKI container to network
+        run: docker network connect example secondary --alias secondary.example.com
+
+      - name: Create secondary PKI server
+        run: |
+          docker exec secondary pki-server create
+          docker exec secondary pki-server nss-create --password Secret.123
+
+      - name: Create secondary CA subsystem
+        run: |
+          docker exec secondary pki-server ca-create -v
+
+      - name: Export CA certs and keys from primary CA
+        run: |
+          docker exec primary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Import system certs and keys into secondary CA
+        run: |
+          docker exec secondary pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              pkcs12-import \
+              --pkcs12 $SHARED/ca-certs.p12 \
+              --password Secret.123
+
+      - name: Configure connection to CA database
+        run: |
+          # store DS password
+          docker exec secondary pki-server password-add \
+              --password Secret.123 \
+              internaldb
+
+          # configure DS connection params
+          docker exec secondary pki-server ca-db-config-mod \
+              --hostname secondaryds.example.com \
+              --port 3389 \
+              --secure false \
+              --auth BasicAuth \
+              --bindDN "cn=Directory Manager" \
+              --bindPWPrompt internaldb \
+              --database ca \
+              --baseDN dc=ca,dc=pki,dc=example,dc=com \
+              --multiSuffix false \
+              --maxConns 15 \
+              --minConns 3
+
+      # https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-PKI-Tools
+      - name: Create backend for CA in secondary DS
+        run: |
+          docker exec secondary pki-server ca-db-create -v
+
+      - name: Enable replication on primary DS
+        run: |
+          docker exec primary pki-server ca-db-repl-enable \
+              --url ldap://primaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --replica-id 1 \
+              --suffix dc=ca,dc=pki,dc=example,dc=com \
+              -v
+
+      - name: Enable replication on secondary DS
+        run: |
+          docker exec secondary pki-server ca-db-repl-enable \
+              --url ldap://secondaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --replica-id 2 \
+              --suffix dc=ca,dc=pki,dc=example,dc=com \
+              -v
+
+      - name: Create replication agreement on primary DS
+        run: |
+          docker exec primary pki-server ca-db-repl-agmt-add \
+              --url ldap://primaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-url ldap://secondaryds.example.com:3389 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --suffix dc=ca,dc=pki,dc=example,dc=com \
+              -v \
+              primaryds-to-secondaryds
+
+      - name: Create replication agreement on secondary DS
+        run: |
+          docker exec secondary pki-server ca-db-repl-agmt-add \
+              --url ldap://secondaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-url ldap://primaryds.example.com:3389 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --suffix dc=ca,dc=pki,dc=example,dc=com \
+              -v \
+              secondaryds-to-primaryds
+
+      - name: Initializing replication agreement
+        run: |
+          docker exec primary pki-server ca-db-repl-agmt-init \
+              --url ldap://primaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --suffix dc=ca,dc=pki,dc=example,dc=com \
+              -v \
+              primaryds-to-secondaryds
+
+      - name: Create CA search indexes
+        run: |
+          docker exec secondary pki-server ca-db-index-add -v
+          docker exec secondary pki-server ca-db-index-rebuild -v
+
+      - name: Create CA VLV indexes
+        run: |
+          docker exec secondary pki-server ca-db-vlv-add -v
+          docker exec secondary pki-server ca-db-vlv-reindex -v
+
+      - name: Install secondary CA
+        run: |
+          docker exec secondary pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
+              -s CA \
+              -D pki_cert_chain_path=$SHARED/ca_signing.crt \
+              -D pki_clone_pkcs12_path=$SHARED/ca-certs.p12 \
+              -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
+              -v
+
+      - name: Create secondary KRA subsystem
+        run: |
+          docker exec secondary pki-server kra-create -v
+
+      - name: Export KRA certs and keys from primary PKI container
+        run: |
+          docker exec primary pki-server kra-clone-prepare \
+              --pkcs12-file $SHARED/kra-certs.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Import KRA system certs and keys into secondary KRA
+        run: |
+          docker exec secondary pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              pkcs12-import \
+              --pkcs12 $SHARED/kra-certs.p12 \
+              --password Secret.123
+
+      - name: Configure connection to KRA database
+        run: |
+          docker exec secondary pki-server kra-db-config-mod \
+              --hostname secondaryds.example.com \
+              --port 3389 \
+              --secure false \
+              --auth BasicAuth \
+              --bindDN "cn=Directory Manager" \
+              --bindPWPrompt internaldb \
+              --database kra \
+              --baseDN dc=kra,dc=pki,dc=example,dc=com \
+              --multiSuffix false \
+              --maxConns 15 \
+              --minConns 3
+
+      # https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replication-with-PKI-Tools
+      - name: Create backend for KRA in secondary DS
+        run: |
+          docker exec secondary pki-server kra-db-create -v
+
+      - name: Enable KRA replication on primary DS
+        run: |
+          docker exec primary pki-server kra-db-repl-enable \
+              --url ldap://primaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --replica-id 1 \
+              --suffix dc=kra,dc=pki,dc=example,dc=com \
+              -v
+
+          # check replication manager
+          docker exec primaryds ldapsearch \
+              -H ldap://primaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=Replication Manager,cn=config" \
+              -s base \
+              -o ldif_wrap=no \
+              -LLL
+
+          # check replica object
+          docker exec primaryds ldapsearch \
+              -H ldap://primaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=replica,cn=dc\3Dkra\2Cdc\3Dpki\2Cdc\3Dexample\2Cdc\3Dcom,cn=mapping tree,cn=config" \
+              -s base \
+              -o ldif_wrap=no \
+              -LLL
+
+      - name: Enable KRA replication on secondary DS
+        run: |
+          docker exec secondary pki-server kra-db-repl-enable \
+              --url ldap://secondaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --replica-id 2 \
+              --suffix dc=kra,dc=pki,dc=example,dc=com \
+              -v
+
+          # check replication manager
+          docker exec secondaryds ldapsearch \
+              -H ldap://secondaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=Replication Manager,cn=config" \
+              -s base \
+              -o ldif_wrap=no \
+              -LLL
+
+          # check replica object
+          docker exec secondaryds ldapsearch \
+              -H ldap://secondaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=replica,cn=dc\3Dkra\2Cdc\3Dpki\2Cdc\3Dexample\2Cdc\3Dcom,cn=mapping tree,cn=config" \
+              -s base \
+              -o ldif_wrap=no \
+              -LLL
+
+      - name: Create replication agreement on primary DS
+        run: |
+          docker exec primary pki-server kra-db-repl-agmt-add \
+              --url ldap://primaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-url ldap://secondaryds.example.com:3389 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --suffix dc=kra,dc=pki,dc=example,dc=com \
+              -v \
+              primaryds-to-secondaryds
+
+          # check replication agreement
+          docker exec primaryds ldapsearch \
+              -H ldap://primaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=primaryds-to-secondaryds,cn=replica,cn=dc\3Dkra\2Cdc\3Dpki\2Cdc\3Dexample\2Cdc\3Dcom,cn=mapping tree,cn=config" \
+              -s base \
+              -o ldif_wrap=no \
+              -LLL
+
+      - name: Create replication agreement on secondary DS
+        run: |
+          docker exec secondary pki-server kra-db-repl-agmt-add \
+              --url ldap://secondaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --replica-url ldap://primaryds.example.com:3389 \
+              --replica-bind-dn "cn=Replication Manager,cn=config" \
+              --replica-bind-password Secret.123 \
+              --suffix dc=kra,dc=pki,dc=example,dc=com \
+              -v \
+              secondaryds-to-primaryds
+
+          # check replication agreement
+          docker exec secondaryds ldapsearch \
+              -H ldap://secondaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b "cn=secondaryds-to-primaryds,cn=replica,cn=dc\3Dkra\2Cdc\3Dpki\2Cdc\3Dexample\2Cdc\3Dcom,cn=mapping tree,cn=config" \
+              -s base \
+              -o ldif_wrap=no \
+              -LLL
+
+      - name: Initializing replication agreement
+        run: |
+          docker exec primary pki-server kra-db-repl-agmt-init \
+              --url ldap://primaryds.example.com:3389 \
+              --bind-dn "cn=Directory Manager" \
+              --bind-password Secret.123 \
+              --suffix dc=kra,dc=pki,dc=example,dc=com \
+              -v \
+              primaryds-to-secondaryds
+
+      - name: Check schema in primary DS and secondary DS
+        run: |
+          docker exec primaryds ldapsearch \
+              -H ldap://primaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b cn=schema \
+              -o ldif_wrap=no \
+              -LLL \
+              objectClasses attributeTypes \
+              | grep "\-oid" | sort | tee primaryds.schema
+
+          docker exec secondaryds ldapsearch \
+              -H ldap://secondaryds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -x \
+              -b cn=schema \
+              -o ldif_wrap=no \
+              -LLL \
+              objectClasses attributeTypes \
+              | grep "\-oid" | sort | tee secondaryds.schema
+
+          diff primaryds.schema secondaryds.schema
+
+      - name: Check entries in primary KRA and secondary KRA
+        run: |
+          # get DNs from primary KRA
+          docker exec primaryds ldapsearch \
+              -H ldap://primaryds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -b "dc=kra,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -LLL \
+              dn \
+              | sed -ne 's/^dn: \(.*\)$/\1/p' | sort | tee primaryds.dn
+
+          # get DNs from secondary DS
+          docker exec secondaryds ldapsearch \
+              -H ldap://secondaryds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -b "dc=kra,dc=pki,dc=example,dc=com" \
+              -o ldif_wrap=no \
+              -LLL \
+              dn \
+              | sed -ne 's/^dn: \(.*\)$/\1/p' | sort > secondaryds.dn
+
+          diff primaryds.dn secondaryds.dn
+
+      - name: Create KRA search indexes
+        run: |
+          docker exec secondary pki-server kra-db-index-add -v
+          docker exec secondary pki-server kra-db-index-rebuild -v
+
+      - name: Create KRA VLV indexes
+        run: |
+          docker exec secondary pki-server kra-db-vlv-add -v
+          docker exec secondary pki-server kra-db-vlv-reindex -v
+
+      - name: Install KRA in secondary PKI container
+        run: |
+          # get CS.cfg from primary KRA before cloning
+          docker cp primary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.primary
+
+          docker exec secondary pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra-clone.cfg \
+              -s KRA \
+              -D pki_cert_chain_path=$SHARED/ca_signing.crt \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
+              -D pki_ds_setup=False \
+              -v
+
+      - name: Check system certs in primary KRA and secondary KRA
+        run: |
+          # get system certs from primary KRA (except sslserver)
+          docker exec primary pki-server cert-show kra_storage > system-certs.primary
+          echo >> system-certs.primary
+          docker exec primary pki-server cert-show kra_transport >> system-certs.primary
+          echo >> system-certs.primary
+          docker exec primary pki-server cert-show kra_audit_signing >> system-certs.primary
+          echo >> system-certs.primary
+          docker exec primary pki-server cert-show subsystem >> system-certs.primary
+
+          # get system certs from secondary KRA (except sslserver)
+          docker exec secondary pki-server cert-show kra_storage > system-certs.secondary
+          echo >> system-certs.secondary
+          docker exec secondary pki-server cert-show kra_transport >> system-certs.secondary
+          echo >> system-certs.secondary
+          docker exec secondary pki-server cert-show kra_audit_signing >> system-certs.secondary
+          echo >> system-certs.secondary
+          docker exec secondary pki-server cert-show subsystem >> system-certs.secondary
+
+          cat system-certs.primary
+          diff system-certs.primary system-certs.secondary
+
+      - name: Check CS.cfg in primary KRA after cloning
+        run: |
+          # get CS.cfg from primary KRA after cloning
+          docker cp primary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.primary.after
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.primary \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              CS.cfg.primary.after \
+              | sort > actual
+
+          diff expected actual
+
+      - name: Check CS.cfg in secondary KRA
+        run: |
+          # get CS.cfg from secondary KRA
+          docker cp secondary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.secondary
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          # - replace primary.example.com with secondary.example.com
+          # - replace primaryds.example.com with secondaryds.example.com
+          # - set securitydomain.host to primary.example.com
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^kra.sslserver.cert=/d' \
+              -e '/^kra.sslserver.certreq=/d' \
+              -e 's/primary.example.com/secondary.example.com/' \
+              -e 's/primaryds.example.com/secondaryds.example.com/' \
+              -e 's/^\(securitydomain.host\)=.*$/\1=primary.example.com/' \
+              CS.cfg.primary.after \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          sed -e '/^installDate=/d' \
+              -e '/^dbs.beginReplicaNumber=/d' \
+              -e '/^dbs.endReplicaNumber=/d' \
+              -e '/^dbs.nextBeginReplicaNumber=/d' \
+              -e '/^dbs.nextEndReplicaNumber=/d' \
+              -e '/^kra.sslserver.cert=/d' \
+              -e '/^kra.sslserver.certreq=/d' \
+              CS.cfg.secondary \
+              | sort > actual
+
+          diff expected actual
+
+      - name: Install admin cert in secondary PKI container
+        run: |
+          # install CA signing cert
+          docker exec secondary pki client-cert-import ca_signing \
+              --ca-cert $SHARED/ca_signing.crt
+
+          # install admin cert
+          docker exec secondary pki pkcs12-import \
+              --pkcs12 $SHARED/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Check users in primary KRA and secondary KRA
+        run: |
+          docker exec primary pki -n caadmin kra-user-find | tee kra-users.primary
+          docker exec secondary pki -n caadmin kra-user-find > kra-users.secondary
+          diff kra-users.primary kra-users.secondary
+
+      - name: Run PKI healthcheck in primary container
+        run: docker exec primary pki-healthcheck --failures-only
+
+      - name: Run PKI healthcheck in secondary container
+        run: docker exec secondary pki-healthcheck --failures-only
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh primaryds
+          tests/bin/ds-artifacts-save.sh secondaryds
+          tests/bin/pki-artifacts-save.sh primary
+          tests/bin/pki-artifacts-save.sh secondary
+        continue-on-error: true
+
+      - name: Remove KRA from secondary PKI container
+        run: docker exec secondary pkidestroy -i pki-tomcat -s KRA -v
+
+      - name: Remove CA from secondary PKI container
+        run: docker exec secondary pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Remove KRA from primary PKI container
+        run: docker exec primary pkidestroy -i pki-tomcat -s KRA -v
+
+      - name: Remove CA from primary PKI container
+        run: docker exec primary pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: kra-clone-replicated-ds
+          path: |
+            /tmp/artifacts

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -48,6 +48,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/kra-clone-shared-ds-test.yml
 
+  kra-clone-replicated-ds-test:
+    name: KRA clone with replicated DS
+    needs: build
+    uses: ./.github/workflows/kra-clone-replicated-ds-test.yml
+
   kra-standalone-test:
     name: Standalone KRA
     needs: build


### PR DESCRIPTION
A new test has been added to verify installing CA and KRA subsystem with DS, cloning the CA and KRA databases in DS, then installing CA and KRA clones using the cloned CA and KRA databases.

This process allows DS cloning to be done separately from CA and KRA cloning which could prevent `pkispawn` from timing out if the database is large.

https://github.com/dogtagpki/pki/wiki/Installing-CA-Clone-with-Replicated-DS
https://github.com/dogtagpki/pki/wiki/Installing-KRA-Clone-with-Replicated-DS