### PR TITLE
Remove preop.admin.group param

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -16,7 +16,6 @@ agent.interface.uri=ca/agent/ca
 machineName=[pki_hostname]
 instanceId=[pki_instance_name]
 pidDir=/var/run/pki/tomcat
-preop.admin.group=Certificate Manager Agents, Administrators
 preop.pin=[pki_one_time_pin]
 ca.cert.list=signing,ocsp_signing,sslserver,subsystem,audit_signing
 ca.cert.signing.certusage=SSLCA

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -11,7 +11,6 @@ authType=pwd
 machineName=[pki_hostname]
 instanceId=[pki_instance_name]
 pidDir=/var/run/pki/tomcat
-preop.admin.group=Data Recovery Manager Agents, Administrators
 preop.pin=[pki_one_time_pin]
 kra.cert.list=transport,storage,sslserver,subsystem,audit_signing
 kra.cert.transport.certusage=SSLClient

--- a/base/ocsp/shared/conf/CS.cfg
+++ b/base/ocsp/shared/conf/CS.cfg
@@ -6,7 +6,6 @@ installDate=[pki_install_time]
 cs.type=OCSP
 admin.interface.uri=ocsp/admin/console/config/wizard
 agent.interface.uri=ocsp/agent/ocsp
-preop.admin.group=Online Certificate Status Manager Agents, Administrators
 cms.product.version=@APPLICATION_VERSION@
 cms.passwordlist=internaldb,replicationdb
 preop.module.token=Internal Key Storage Token

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3904,8 +3904,23 @@ class PKIDeployer:
             tps_profiles=tps_profiles,
             as_current_user=True)
 
-        admin_groups = subsystem.config['preop.admin.group']
-        groups = [x.strip() for x in admin_groups.split(',')]
+        groups = ['Administrators']
+
+        if subsystem.type == 'CA':
+            groups.append('Certificate Manager Agents')
+
+        elif subsystem.type == 'KRA':
+            groups.append('Data Recovery Manager Agents')
+
+        elif subsystem.type == 'OCSP':
+            groups.append('Online Certificate Status Manager Agents')
+
+        elif subsystem.type == 'TKS':
+            groups.append('Token Key Service Manager Agents')
+
+        elif subsystem.type == 'TPS':
+            groups.append('TPS Agents')
+            groups.append('TPS Operators')
 
         if subsystem.config.get('securitydomain.select') == 'new':
 

--- a/base/tks/shared/conf/CS.cfg
+++ b/base/tks/shared/conf/CS.cfg
@@ -5,7 +5,6 @@ pidDir=/var/run/pki/tomcat
 installDate=[pki_install_time]
 cs.type=TKS
 admin.interface.uri=tks/admin/console/config/wizard
-preop.admin.group=Token Key Service Manager Agents, Administrators
 cms.product.version=@APPLICATION_VERSION@
 cms.passwordlist=internaldb,replicationdb
 tks.cert.list=sslserver,subsystem,audit_signing

--- a/base/tps/shared/conf/CS.cfg
+++ b/base/tps/shared/conf/CS.cfg
@@ -1994,7 +1994,6 @@ op.pinReset.userKey.update.symmetricKeys.requiredVersion=1
 passwordClass=com.netscape.cmsutil.password.PlainPasswordFile
 passwordFile=[pki_instance_path]/conf/password.conf
 pidDir=/var/run/pki/tomcat
-preop.admin.group=TPS Agents,TPS Operators,Administrators
 preop.cert.admin.defaultSigningAlgorithm=SHA256withRSA
 preop.cert.admin.dn=uid=admin,cn=admin
 preop.cert.admin.keysize.custom_size=2048


### PR DESCRIPTION
The `preop.admin.group` param defines the list of admin user's default groups and provides an undocumented way to customize the groups during installation, but this param can only be used under certain installation scenarios. Instead of that, it's better to use the CLI to change the groups after the installation is done.

The param has been removed and the list of admin user's default groups has been moved into `PKIDeployer.setup_admin_user()`.