### PR TITLE
Skip importing certs and requests when pki_ds_setup=False

### DIFF
--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -395,6 +395,78 @@ jobs:
           echo "0" > expected
           diff expected nsTaskExitCode
 
+      - name: Import CA signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/ca_signing.crt \
+              --profile /usr/share/pki/ca/conf/caCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA OCSP signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/ocsp_signing.crt \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA audit signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/audit_signing.crt \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import subsystem cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/subsystem.crt \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import SSL server cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/sslserver.crt \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import admin cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/admin.crt \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --request $REQUEST_ID
+
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add admin user
         run: |
@@ -659,10 +731,10 @@ jobs:
         run: |
           docker exec ca bash -c "cat /var/log/pki/pki-tomcat/ca/debug.*"
 
-      - name: Gather artifacts from CA container
+      - name: Gather artifacts
         if: always()
         run: |
-          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/ca ds
+          tests/bin/ds-artifacts-save.sh ds
 
           docker exec ca ls -la /etc/pki
           mkdir -p /tmp/artifacts/ca/etc/pki
@@ -674,24 +746,13 @@ jobs:
           docker cp ca:/var/log/pki /tmp/artifacts/ca/var/log
 
           docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
-        continue-on-error: true
 
-      - name: Gather artifacts from client container
-        if: always()
-        run: |
           mkdir -p /tmp/artifacts/client
           docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
 
-      - name: Upload artifacts from CA container
+      - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: ca-container-ca
-          path: /tmp/artifacts/ca
-
-      - name: Upload artifacts from client container
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: ca-container-client
-          path: /tmp/artifacts/client
+          name: ca-container
+          path: /tmp/artifacts

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -160,8 +160,16 @@ jobs:
               --maxConns 15 \
               --minConns 3
 
-          # configure user/group subsystem to use DS
+          # configure CA user/group subsystem
           docker exec pki pki-server ca-config-set usrgrp.ldap internaldb
+
+          # configure CA database subsystem
+          docker exec pki pki-server ca-config-set dbs.ldap internaldb
+          docker exec pki pki-server ca-config-set dbs.newSchemaEntryAdded true
+          docker exec pki pki-server ca-config-set dbs.requestDN ou=ca,ou=requests
+          docker exec pki pki-server ca-config-set dbs.request.id.generator random
+          docker exec pki pki-server ca-config-set dbs.serialDN ou=certificateRepository,ou=ca
+          docker exec pki pki-server ca-config-set dbs.cert.id.generator random
 
       - name: Check connection to CA database
         run: |
@@ -187,6 +195,78 @@ jobs:
       - name: Rebuild CA VLV indexes
         run: |
           docker exec pki pki-server ca-db-vlv-reindex -v
+
+      - name: Import CA signing cert into CA database
+        run: |
+          docker exec pki pki-server ca-cert-request-import \
+              --csr /etc/pki/pki-tomcat/certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec pki pki-server ca-cert-import \
+              --cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
+              --profile /usr/share/pki/ca/conf/caCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA OCSP signing cert into CA database
+        run: |
+          docker exec pki pki-server ca-cert-request-import \
+              --csr /etc/pki/pki-tomcat/certs/ca_ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec pki pki-server ca-cert-import \
+              --cert /etc/pki/pki-tomcat/certs/ca_ocsp_signing.crt \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA audit signing cert into CA database
+        run: |
+          docker exec pki pki-server ca-cert-request-import \
+              --csr /etc/pki/pki-tomcat/certs/ca_audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec pki pki-server ca-cert-import \
+              --cert /etc/pki/pki-tomcat/certs/ca_audit_signing.crt \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import subsystem cert into CA database
+        run: |
+          docker exec pki pki-server ca-cert-request-import \
+              --csr /etc/pki/pki-tomcat/certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec pki pki-server ca-cert-import \
+              --cert /etc/pki/pki-tomcat/certs/subsystem.crt \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import SSL server cert into CA database
+        run: |
+          docker exec pki pki-server ca-cert-request-import \
+              --csr /etc/pki/pki-tomcat/certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec pki pki-server ca-cert-import \
+              --cert /etc/pki/pki-tomcat/certs/sslserver.crt \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import admin cert into CA database
+        run: |
+          docker exec pki pki-server ca-cert-request-import \
+              --csr admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec pki pki-server ca-cert-import \
+              --cert admin.crt \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --request $REQUEST_ID
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database-User
       - name: Add database user
@@ -365,6 +445,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ca-existing-ds
-          path: |
-            /tmp/artifacts/ds
-            /tmp/artifacts/pki
+          path: /tmp/artifacts

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -33,8 +33,9 @@ echo "##########################################################################
 rc=0
 pki \
     -d /etc/pki/pki-tomcat/alias \
-    nss-cert-show \
-    ca_signing > /dev/null 2>&1 || rc=$?
+    nss-cert-export \
+    --output-file /certs/ca_signing.crt \
+    ca_signing || rc=$?
 
 if [ $rc -ne 0 ]
 then
@@ -76,8 +77,9 @@ echo "##########################################################################
 rc=0
 pki \
     -d /etc/pki/pki-tomcat/alias \
-    nss-cert-show \
-    ocsp_signing > /dev/null 2>&1 || rc=$?
+    nss-cert-export \
+    --output-file /certs/ocsp_signing.crt \
+    ocsp_signing || rc=$?
 
 if [ $rc -ne 0 ]
 then
@@ -117,8 +119,9 @@ echo "##########################################################################
 rc=0
 pki \
     -d /etc/pki/pki-tomcat/alias \
-    nss-cert-show \
-    audit_signing > /dev/null 2>&1 || rc=$?
+    nss-cert-export \
+    --output-file /certs/audit_signing.crt \
+    audit_signing || rc=$?
 
 if [ $rc -ne 0 ]
 then
@@ -159,8 +162,9 @@ echo "##########################################################################
 rc=0
 pki \
     -d /etc/pki/pki-tomcat/alias \
-    nss-cert-show \
-    subsystem > /dev/null 2>&1 || rc=$?
+    nss-cert-export \
+    --output-file /certs/subsystem.crt \
+    subsystem || rc=$?
 
 if [ $rc -ne 0 ]
 then
@@ -200,7 +204,8 @@ rc=0
 pki \
     -d /etc/pki/pki-tomcat/alias \
     nss-cert-show \
-    sslserver > /dev/null 2>&1 || rc=$?
+    --output-file /certs/sslserver.crt \
+    sslserver || rc=$?
 
 if [ $rc -ne 0 ]
 then
@@ -238,7 +243,9 @@ echo "##########################################################################
 
 # check if admin cert exists
 rc=0
-pki nss-cert-show admin > /dev/null 2>&1 || rc=$?
+pki nss-cert-export \
+    --output-file /certs/admin.crt \
+    admin || rc=$?
 
 if [ $rc -ne 0 ]
 then


### PR DESCRIPTION
If `pki_ds_setup` is set to `False` `pkispawn` should not modify the DS during installation, so the `PKIDeployer.setup_system_cert()` has been modified to skip importing the certs and the requests into CA database in that scenario. With this change the certs and the requests need to be imported separately.

The CA installation test with existing DS has been modified to import the certs and the requests into CA database before calling `pkispawn`.

The CA container test has been modified to export the certs and requests provided to the container during startup such that they can be imported into CA database after startup.

https://github.com/dogtagpki/pki/wiki/Installing-CA-with-Existing-DS-Database