### PR TITLE
Fix support for cert bundle

### DIFF
--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -260,10 +260,18 @@ jobs:
 
       - name: Re-install CA in secondary PKI container
         run: |
+          # create cert bundle containing CA and DS signing certs
+          docker exec secondary sed \
+              -n wcert_bundle.pem \
+              $SHARED/ca_signing.crt \
+              ds_signing.crt
+          docker exec secondary cat cert_bundle.pem
+
+          # install secondary CA with cert bundle
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg \
               -s CA \
-              -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
+              -D pki_cert_chain_path=cert_bundle.pem \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_ds_url=ldaps://secondaryds.example.com:3636 \
               -v


### PR DESCRIPTION
The `NSSDatabase.import_cert_chain()` has been modified to import the cert bundle specified in `pki_cert_chain_path` as individual CA certs instead of as a single PKCS #7 cert chain. This allows the cert bundle to include multiple unrelated cert chains.

The `NSSDatabase.__convert_certs_into_pkcs7()` is no longer used so it has been removed.

The test for CA cloning with secure DS connection has been updated to include both CA and DS signing certs into a cert bundle to validate the above changes.

Resolves: https://issues.redhat.com/browse/RHCS-4746