### PR TITLE
Add HSM support for LWCA

### DIFF
--- a/.github/workflows/subca-lightweight-hsm-test.yml
+++ b/.github/workflows/subca-lightweight-hsm-test.yml
@@ -208,12 +208,9 @@ jobs:
               "(objectClass=*)" | tee output
 
           # check authorityKeyNickname
-          echo "ca_signing $LWCA_ID" > expected
+          echo "HSM:ca_signing $LWCA_ID" > expected
           sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
-        # TODO: remove continue-on-error once this issue is fixed:
-        # https://github.com/dogtagpki/pki/issues/2412
-        continue-on-error: true
 
       - name: Check certs and keys in internal token
         run: |
@@ -222,8 +219,8 @@ jobs:
               -f /etc/pki/pki-tomcat/password.conf \
               nss-cert-find | tee output
 
-          # there should be 6 certs now
-          echo "6" > expected
+          # there should still be 5 certs
+          echo "5" > expected
           sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -232,8 +229,8 @@ jobs:
               -f /etc/pki/pki-tomcat/password.conf \
               nss-key-find | tee output
 
-          # there should be 2 keys now
-          echo "2" > expected
+          # there should still be 1 key
+          echo "1" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -245,8 +242,8 @@ jobs:
               --token HSM \
               nss-cert-find | tee output
 
-          # there should be 4 certs now
-          echo "4" > expected
+          # there should be 5 certs now
+          echo "5" > expected
           sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -256,8 +253,8 @@ jobs:
               --token HSM \
               nss-key-find | tee output
 
-          # there should be 4 keys now
-          echo "4" > expected
+          # there should be 5 keys now
+          echo "5" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -293,10 +290,15 @@ jobs:
         # https://github.com/dogtagpki/pki/issues/2412
         continue-on-error: true
 
+      - name: Check CA debug logs
+        if: always()
+        run: |
+          docker exec pki bash -c "cat /var/log/pki/pki-tomcat/ca/debug.*"
+
       - name: Gather artifacts
         if: always()
         run: |
-          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/ds-artifacts-save.sh ds
           tests/bin/pki-artifacts-save.sh pki
         continue-on-error: true
 
@@ -313,5 +315,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ca-lightweight-hsm
-          path: |
-            /tmp/artifacts/pki
+          path: /tmp/artifacts

--- a/.github/workflows/subca-lightweight-test.yml
+++ b/.github/workflows/subca-lightweight-test.yml
@@ -212,10 +212,15 @@ jobs:
           sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
+      - name: Check CA debug logs
+        if: always()
+        run: |
+          docker exec pki bash -c "cat /var/log/pki/pki-tomcat/ca/debug.*"
+
       - name: Gather artifacts
         if: always()
         run: |
-          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
+          tests/bin/ds-artifacts-save.sh ds
           tests/bin/pki-artifacts-save.sh pki
         continue-on-error: true
 
@@ -227,5 +232,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ca-lightweight
-          path: |
-            /tmp/artifacts/pki
+          path: /tmp/artifacts

--- a/base/ca/src/main/java/com/netscape/ca/CASigningUnit.java
+++ b/base/ca/src/main/java/com/netscape/ca/CASigningUnit.java
@@ -70,19 +70,33 @@ public final class CASigningUnit extends SigningUnit {
             mManager = CryptoManager.getInstance();
 
             if (nickname == null) {
+                // use nickname from config
                 try {
                     mNickname = mConfig.getCertNickname();
                 } catch (EPropertyNotFound e) {
                     mNickname = mConfig.getCACertNickname();
                 }
-            } else {
-                mNickname = nickname;
-            }
 
-            tokenname = config.getTokenName();
-            mToken = CryptoUtil.getKeyStorageToken(tokenname);
-            if (!CryptoUtil.isInternalToken(tokenname)) {
-                mNickname = tokenname + ":" + mNickname;
+                // use token name from config
+                tokenname = config.getTokenName();
+                mToken = CryptoUtil.getKeyStorageToken(tokenname);
+
+                // prepend token name to nickname
+                if (!CryptoUtil.isInternalToken(tokenname)) {
+                    mNickname = tokenname + ":" + mNickname;
+                }
+
+            } else {
+                // use specified nickname (which might contain token name)
+                mNickname = nickname;
+
+                // get token name from nickname
+                int i = mNickname.indexOf(':');
+                if (i >= 0) {
+                    tokenname = mNickname.substring(0, i);
+                }
+
+                mToken = CryptoUtil.getKeyStorageToken(tokenname);
             }
 
             try {

--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -1703,13 +1703,9 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
 
     public X509CertImpl generateSigningCert(
             X500Name subjectX500Name,
-            AuthToken authToken)
+            AuthToken authToken,
+            CryptoToken token)
             throws Exception {
-
-        CryptoManager cryptoManager = CryptoManager.getInstance();
-
-        // TODO: read PROP_TOKEN_NAME config
-        CryptoToken token = cryptoManager.getInternalKeyStorageToken();
 
         logger.info("CertificateAuthority: generating RSA key");
 


### PR DESCRIPTION
The `CAEngine.createCA()` has been modified to get the token name from LWCA's `keyNickname`. If the token name exists, it will use that token to create the private key and store the cert. Otherwise, it will use the internal token.

The `CASigningUnit.init()` has been modified to get the token name from name from LWCA's `keyNickname`. If the token name exists, it will use that token to load the cert and the private key, and for signing and verification. Otherwise, it will use the internal token.

The LWCA test with HSM has been modified to verify that the LWCA cert and key will be created in HSM instead of internal token.

Resolves: https://github.com/dogtagpki/pki/issues/2412