### PR TITLE
Make CertRecordPagedList generic

### DIFF
--- a/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
@@ -1164,7 +1164,7 @@ public class CertificateRepository extends Repository {
         logger.debug("countCertificates filter {}", filter);
 
         try (DBSSession s = dbSubsystem.createSession()) {
-            return s.countCertificates(mBaseDN, filter, timeLimit);
+            return s.countEntries(CertRecord.class, mBaseDN, filter, timeLimit);
         }
     }
 
@@ -1252,7 +1252,7 @@ public class CertificateRepository extends Repository {
      * @return a list of certificates
      * @exception EBaseException failed to search
      */
-    public CertRecordPagedList findPagedCertRecords(String filter,
+    public RecordPagedList<CertRecord> findPagedCertRecords(String filter,
             String[] attrs, String sortKey)
             throws EBaseException {
 
@@ -1260,12 +1260,13 @@ public class CertificateRepository extends Repository {
 
         try (DBSSession session = dbSubsystem.createSession()) {
             DBPagedSearch<CertRecord> page = session.<CertRecord>createPagedSearch(
+                    CertRecord.class,
                     mBaseDN,
                     filter,
                     attrs,
                     sortKey);
 
-            return new CertRecordPagedList(page);
+            return new RecordPagedList<>(page);
         }
     }
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertFindCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertFindCLI.java
@@ -29,9 +29,9 @@ import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.base.ConfigStorage;
 import com.netscape.cmscore.base.FileConfigStorage;
 import com.netscape.cmscore.dbs.CertRecord;
-import com.netscape.cmscore.dbs.CertRecordPagedList;
 import com.netscape.cmscore.dbs.CertificateRepository;
 import com.netscape.cmscore.dbs.DBSubsystem;
+import com.netscape.cmscore.dbs.RecordPagedList;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
 import com.netscape.cmscore.ldapconn.PKISocketConfig;
 import com.netscape.cmscore.security.SecureRandomConfig;
@@ -118,7 +118,7 @@ public class CACertFindCLI extends CommandCLI {
             CertificateRepository certificateRepository = new CertificateRepository(secureRandom, dbSubsystem);
             certificateRepository.init();
 
-            CertRecordPagedList certPages = certificateRepository.findPagedCertRecords(filter, null, "serialno");
+            RecordPagedList<CertRecord> certPages = certificateRepository.findPagedCertRecords(filter, null, "serialno");
             boolean follow = false;
             for (CertRecord cRec: certPages) {
                 CertId id = new CertId(cRec.getSerialNumber());

--- a/base/server/src/main/java/com/netscape/certsrv/dbs/DBPagedSearch.java
+++ b/base/server/src/main/java/com/netscape/certsrv/dbs/DBPagedSearch.java
@@ -20,7 +20,6 @@ package com.netscape.certsrv.dbs;
 import java.util.List;
 
 import com.netscape.certsrv.base.EBaseException;
-import com.netscape.cmscore.dbs.CertRecord;
 
 /**
  * A class represents a paged search.
@@ -29,8 +28,8 @@ import com.netscape.cmscore.dbs.CertRecord;
  */
 public abstract class DBPagedSearch<E extends IDBObj> {
 
-    public abstract List<CertRecord> getPage() throws EBaseException;
+    public abstract List<E> getPage() throws EBaseException;
 
-    public abstract List<CertRecord> getPage(int size) throws EBaseException;
+    public abstract List<E> getPage(int size) throws EBaseException;
 
 }

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/DBSSession.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/DBSSession.java
@@ -258,13 +258,15 @@ public class DBSSession implements AutoCloseable {
      * Retrieves a list of object that satisfies the given
      * filter.
      *
+     * @param classResults the class representing the entries in the paged list
      * @param base starting point of the search
      * @param filter search filter
      * @param timeLimit timeout limit
      * @return the number of certificates
      * @exception EBaseException failed to search
      */
-    public int countCertificates(
+    public <T extends IDBObj> int countEntries(
+            Class<T> classResults,
             String base,
             String filter,
             int timeLimit
@@ -375,15 +377,15 @@ public class DBSSession implements AutoCloseable {
     /**
      * Retrieves a paged search of objects.
      *
+     * @param classResults the class representing the entries in the paged list
      * @param base starting point of the search
      * @param filter search filter
      * @param attrs selected attributes
-     * @param startFrom starting point
      * @param sortKey key used to sort the list
      * @return search results in virtual list
      * @exception EBaseException failed to search
      */
-    public <T extends IDBObj> DBPagedSearch<T> createPagedSearch(String base, String filter, String[] attrs,
+    public <T extends IDBObj> DBPagedSearch<T> createPagedSearch(Class<T> classResults, String base, String filter, String[] attrs,
             String sortKey)  throws EBaseException {
         return null;
     }

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/DBSearchResults.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/DBSearchResults.java
@@ -58,13 +58,11 @@ public class DBSearchResults implements Enumeration<Object> {
      */
     @Override
     public Object nextElement() {
-        LDAPEntry entry = null;
 
         try {
             Object o = mRes.nextElement();
 
-            if (o instanceof LDAPEntry) {
-                entry = (LDAPEntry) o;
+            if (o instanceof LDAPEntry entry) {
                 return mRegistry.createObject(entry.getAttributeSet());
             }
             if (o instanceof LDAPException)
@@ -72,7 +70,7 @@ public class DBSearchResults implements Enumeration<Object> {
             // doing nothing because the last object in the search
             // results is always LDAPException
             else
-                logger.warn("DBSearchResults: result format error class=" + o.getClass().getName());
+                logger.warn("DBSearchResults: result format error class={}", o.getClass().getName());
         } catch (Exception e) {
 
             /*LogDoc

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/LDAPSession.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/LDAPSession.java
@@ -535,13 +535,13 @@ public class LDAPSession extends DBSSession {
     }
 
     @Override
-    public int countCertificates(String base, String filter, int timeLimit)
+    public <T extends IDBObj> int countEntries(Class<T> classResults, String base, String filter, int timeLimit)
             throws EBaseException {
         String[] attrs = {"objectclass"};
-        DBPagedSearch<CertRecord> search = createPagedSearch(base, filter, attrs, null);
-        CertRecordPagedList list = new CertRecordPagedList(search);
+        DBPagedSearch<T> search = createPagedSearch(classResults,  base, filter, attrs, null);
+        RecordPagedList<T> list = new RecordPagedList<>(search);
         int count = 0;
-        for(CertRecord c: list) {
+        for(T c: list) {
             count++;
         }
 
@@ -688,11 +688,11 @@ public class LDAPSession extends DBSSession {
     }
 
     @Override
-    public <T extends IDBObj> DBPagedSearch<T> createPagedSearch(String base, String filter,
-            String attrs[], String sortKey) throws EBaseException {
+    public <T extends IDBObj> DBPagedSearch<T> createPagedSearch(Class<T> classResults, String base, String filter,
+            String[] attrs, String sortKey) throws EBaseException {
         logger.debug("LDAPSession: createPagedSearch({}, {})", base, filter);
 
-        return new LDAPPagedSearch<>(dbSubsystem.getRegistry(),mConn, base,
+        return new LDAPPagedSearch<>(classResults, dbSubsystem.getRegistry(),mConn, base,
                 filter, attrs, sortKey);
     }
 

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/RecordPagedList.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/RecordPagedList.java
@@ -22,21 +22,22 @@ import java.util.List;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.dbs.DBPagedSearch;
+import com.netscape.certsrv.dbs.IDBObj;
 
 /**
 * Contain all records in a page for a paged search.
 *
 * @author Marco Fargetta {@literal <mfargett@redhat.com>}
 */
-public class CertRecordPagedList implements Iterable<CertRecord> {
-    public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CertRecordPagedList.class);
+public class RecordPagedList<T extends IDBObj> implements Iterable<T> {
+    public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RecordPagedList.class);
 
-    private DBPagedSearch<CertRecord> pages;
-    private Iterator<CertRecord> pageEntries;
+    private DBPagedSearch<T> pages;
+    private Iterator<T> pageEntries;
     /**
      * Constructs a request paged.
      */
-    public CertRecordPagedList(DBPagedSearch<CertRecord> pages) {
+    public RecordPagedList(DBPagedSearch<T> pages) {
         this.pages = pages;
         try {
             pageEntries = pages.getPage().iterator();
@@ -46,17 +47,17 @@ public class CertRecordPagedList implements Iterable<CertRecord> {
     }
 
     @Override
-    public Iterator<CertRecord> iterator() {
-        return new CertRecordPageIterator();
+    public Iterator<T> iterator() {
+        return new RecordPageIterator();
     }
 
-    class CertRecordPageIterator implements Iterator<CertRecord> {
+    class RecordPageIterator implements Iterator<T> {
 
         @Override
         public boolean hasNext() {
             if (!pageEntries.hasNext()) {
                 try {
-                    List<CertRecord> newPage = pages.getPage();
+                    List<T> newPage = pages.getPage();
                     pageEntries = newPage.iterator();
                 } catch (EBaseException e) {
                     throw new RuntimeException("CertRecordPagedList: Error to get a new page", e);
@@ -66,7 +67,7 @@ public class CertRecordPagedList implements Iterable<CertRecord> {
         }
 
         @Override
-        public CertRecord next() {
+        public T next() {
             if (hasNext()) {
                 return pageEntries.next();
             }


### PR DESCRIPTION
The class `CertRecordPagedList` is renamed to `RecordPagedList` and made generic to be used with all type of entries available.