### PR TITLE
Add test for LWCA removal

### DIFF
--- a/.github/workflows/subca-lightweight-hsm-test.yml
+++ b/.github/workflows/subca-lightweight-hsm-test.yml
@@ -185,12 +185,13 @@ jobs:
 
           # store LWCA ID
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > lwca-id
+          LWCA_ID=$(cat lwca-id)
 
           docker exec pki pki -n caadmin ca-authority-find | tee output
 
           # there should be 2 authorities now
-          echo "2" > expected
-          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          echo -e "$HOSTCA_ID\n$LWCA_ID" | sort > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
       - name: Check lightweight CA's LDAP entry
@@ -202,14 +203,15 @@ jobs:
               -x \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -b "cn=$LWCA_ID, ou=authorities,ou=ca,dc=ca,dc=pki,dc=example,dc=com" \
+              -b "ou=authorities,ou=ca,dc=ca,dc=pki,dc=example,dc=com" \
+              -s one \
               -o ldif_wrap=no \
               -LLL \
               "(objectClass=*)" | tee output
 
           # check authorityKeyNickname
-          echo "HSM:ca_signing $LWCA_ID" > expected
-          sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output > actual
+          echo -e "HSM:ca_signing\nHSM:ca_signing $LWCA_ID" | sort > expected
+          sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
       - name: Check certs and keys in internal token
@@ -286,9 +288,90 @@ jobs:
           echo "CN=Lightweight CA" > expected
           sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
-        # TODO: remove continue-on-error once this issue is fixed:
-        # https://github.com/dogtagpki/pki/issues/2412
-        continue-on-error: true
+
+      - name: Remove lightweight CA
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+          LWCA_ID=$(cat lwca-id)
+
+          docker exec pki pki -n caadmin ca-authority-disable $LWCA_ID
+
+          docker exec pki pki -n caadmin ca-authority-del \
+              --force \
+              $LWCA_ID | tee output
+
+          docker exec pki pki -n caadmin ca-authority-find | tee output
+
+          # there should be 1 authority now
+          echo "$HOSTCA_ID" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check lightweight CA's LDAP entry
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+
+          docker exec pki ldapsearch \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -b "ou=authorities,ou=ca,dc=ca,dc=pki,dc=example,dc=com" \
+              -s one \
+              -o ldif_wrap=no \
+              -LLL \
+              "(objectClass=*)" | tee output
+
+          # there should be 1 entry now
+          echo "$HOSTCA_ID" > expected
+          sed -n 's/^\s*cn:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check certs and keys in internal token
+        run: |
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-cert-find | tee output
+
+          # there should be 5 certs
+          echo "5" > expected
+          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-key-find | tee output
+
+          # there should be 1 key
+          echo "1" > expected
+          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Check certs and keys in HSM
+        run: |
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              --token HSM \
+              nss-cert-find | tee output
+
+          # there should be 4 certs now
+          echo "4" > expected
+          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              --token HSM \
+              nss-key-find | tee output
+
+          # there should be 4 keys now
+          echo "4" > expected
+          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
 
       - name: Check CA debug logs
         if: always()

--- a/.github/workflows/subca-lightweight-test.yml
+++ b/.github/workflows/subca-lightweight-test.yml
@@ -134,12 +134,13 @@ jobs:
 
           # store LWCA ID
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > lwca-id
+          LWCA_ID=$(cat lwca-id)
 
           docker exec pki pki -n caadmin ca-authority-find | tee output
 
           # there should be 2 authorities now
-          echo "2" > expected
-          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          echo -e "$HOSTCA_ID\n$LWCA_ID" | sort > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
       - name: Check lightweight CA's LDAP entry
@@ -151,14 +152,15 @@ jobs:
               -x \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -b "cn=$LWCA_ID,ou=authorities,ou=ca,dc=ca,dc=pki,dc=example,dc=com" \
+              -b "ou=authorities,ou=ca,dc=ca,dc=pki,dc=example,dc=com" \
+              -s one \
               -o ldif_wrap=no \
               -LLL \
               "(objectClass=*)" | tee output
 
           # check authorityKeyNickname
-          echo "ca_signing $LWCA_ID" > expected
-          sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output > actual
+          echo -e "ca_signing\nca_signing $LWCA_ID" | sort > expected
+          sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
       - name: Check certs and keys in NSS database
@@ -210,6 +212,66 @@ jobs:
           # verify that it's signed by LWCA
           echo "CN=Lightweight CA" > expected
           sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Remove lightweight CA
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+          LWCA_ID=$(cat lwca-id)
+
+          docker exec pki pki -n caadmin ca-authority-disable $LWCA_ID
+
+          docker exec pki pki -n caadmin ca-authority-del \
+              --force \
+              $LWCA_ID | tee output
+
+          docker exec pki pki -n caadmin ca-authority-find | tee output
+
+          # there should be 1 authority now
+          echo "$HOSTCA_ID" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check lightweight CA's LDAP entry
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+
+          docker exec pki ldapsearch \
+              -H ldap://ds.example.com:3389 \
+              -x \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -b "ou=authorities,ou=ca,dc=ca,dc=pki,dc=example,dc=com" \
+              -s one \
+              -o ldif_wrap=no \
+              -LLL \
+              "(objectClass=*)" | tee output
+
+          # there should be 1 entry now
+          echo "$HOSTCA_ID" > expected
+          sed -n 's/^\s*cn:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check certs and keys in NSS database
+        run: |
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-cert-find | tee output
+
+          # there should be 5 certs now
+          echo "5" > expected
+          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/password.conf \
+              nss-key-find | tee output
+
+          # there should be 5 keys now
+          echo "5" > expected
+          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
       - name: Check CA debug logs

--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -1456,6 +1456,10 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
     /** Delete keys and certs of this authority from NSSDB.
      */
     public void deleteAuthorityNSSDB() throws ECAException {
+
+        X509Certificate cert = mSigningUnit.getCert();
+        logger.info("CertificateAuthority: Removing cert " + cert.getNickname());
+
         CryptoManager cryptoManager;
         try {
             cryptoManager = CryptoManager.getInstance();
@@ -1472,7 +1476,7 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
         CryptoStore cryptoStore =
             cryptoManager.getInternalKeyStorageToken().getCryptoStore();
         try {
-            cryptoStore.deleteCert(mSigningUnit.getCert());
+            cryptoStore.deleteCert(cert);
         } catch (NoSuchItemOnTokenException e) {
             logger.warn("deleteAuthority: cert is not on token: " + e);
             // if the cert isn't there, never mind

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -1675,6 +1675,8 @@ public class CAEngine extends CMSEngine {
     public synchronized void deleteAuthorityEntry(AuthorityID aid) throws EBaseException {
 
         String dn = "cn=" + aid + "," + getAuthorityBaseDN();
+        logger.info("CAEngine: Removing " + dn);
+
         LDAPConnection conn = connectionFactory.getConn();
 
         try {


### PR DESCRIPTION
The LWCA tests with internal NSS token and HSM have been updated to test LWCA removal and validate that the corresponding LDAP entry, NSS cert, and NSS key are also removed.