### PR TITLE
New list requests using paged search

### DIFF
--- a/base/server/src/main/java/com/netscape/cmscore/dbs/RecordPagedList.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/RecordPagedList.java
@@ -34,6 +34,7 @@ public class RecordPagedList<T extends IDBObj> implements Iterable<T> {
 
     private DBPagedSearch<T> pages;
     private Iterator<T> pageEntries;
+
     /**
      * Constructs a request paged.
      */
@@ -44,6 +45,10 @@ public class RecordPagedList<T extends IDBObj> implements Iterable<T> {
         } catch (EBaseException e) {
             throw new RuntimeException("CertRecordPagedList: Error to get a new page", e);
         }
+    }
+
+    public Iterator<T> getCurrentPageEntries() {
+        return pageEntries;
     }
 
     @Override

--- a/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.SessionContext;
+import com.netscape.certsrv.dbs.DBPagedSearch;
 import com.netscape.certsrv.dbs.DBVirtualList;
 import com.netscape.certsrv.dbs.EDBRecordNotFoundException;
 import com.netscape.certsrv.dbs.IDBObj;
@@ -39,6 +40,7 @@ import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.dbs.DBSSession;
 import com.netscape.cmscore.dbs.DBSearchResults;
 import com.netscape.cmscore.dbs.DBSubsystem;
+import com.netscape.cmscore.dbs.RecordPagedList;
 import com.netscape.cmscore.dbs.Repository;
 import com.netscape.cmscore.dbs.RepositoryRecord;
 
@@ -418,6 +420,48 @@ public class RequestRepository extends Repository {
         }
 
         return records;
+    }
+
+    /**
+     * Gets a paginated list of Request entries in this queue.
+     *
+     * @param fromID request id to start with
+     * @param filter search filter
+     * @param pageSize page size
+     * @param sortKey the attributes to sort by
+     * @return request list
+     */
+    public RecordPagedList<RequestRecord> getPagedRequestsByFilter(
+            RequestId fromID,
+            String filter,
+            int pageSize,
+            String sortKey) throws EBaseException {
+        if (fromID != null) {
+            if(!filter.startsWith("(")) {
+                filter = "(" + filter + ")";
+            }
+            filter = "(& (requestID >= " + fromID.toString() + ")" + filter +")";
+        }
+        return getPagedRequestsByFilter(filter, pageSize, sortKey);
+    }
+
+    /**
+     * Gets a paginated list of Request entries in this queue.
+     *
+     * @param filter search filter
+     * @param pageSize page size
+     * @param sortKey the attributes to sort by
+     * @return request list
+     */
+    public RecordPagedList<RequestRecord> getPagedRequestsByFilter(
+            String filter,
+            int pageSize,
+            String sortKey) throws EBaseException {
+        try(DBSSession session = dbSubsystem.createSession()){
+            DBPagedSearch<RequestRecord> pages;
+            pages = session.createPagedSearch(RequestRecord.class, mBaseDN, filter, null, sortKey);
+            return new RecordPagedList<>(pages);
+        }
     }
 
     /**

--- a/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
@@ -465,6 +465,18 @@ public class RequestRepository extends Repository {
     }
 
     /**
+     * Gets the total number of request entries.
+     *
+     * @param filter search filter
+     * @return number of entries
+     */
+    public int getTotlaRequestsByFilter(
+            String filter) throws EBaseException {
+        try(DBSSession session = dbSubsystem.createSession()){
+            return session.countEntries(RequestRecord.class, mBaseDN, filter, -1);
+        }
+    }
+    /**
      * Gets a pageable list of Request entries in this queue. This
      * jumps right to the end of the list.
      *


### PR DESCRIPTION
Implementing a new `listCMSRequests()` method which is using paged search instead of VLV indexes.