### PR TITLE
Fix pki-server subsystem-show

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -67,6 +67,10 @@ jobs:
           sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
           diff expected actual
 
+          docker exec pki pki-server webapp-show ROOT
+          docker exec pki pki-server webapp-show ca
+          docker exec pki pki-server webapp-show pki
+
       - name: Check CA certs and keys
         run: |
           # check certs

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -71,6 +71,22 @@ jobs:
           docker exec pki pki-server webapp-show ca
           docker exec pki pki-server webapp-show pki
 
+      - name: Check subsystems
+        run: |
+          docker exec pki pki-server subsystem-find | tee output
+
+          # CA instance should have CA subsystem
+          echo "ca" > expected
+          sed -n 's/^ *Subsystem ID: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          docker exec pki pki-server subsystem-show ca | tee output
+
+          # CA subsystem should be enabled
+          echo "True" > expected
+          sed -n 's/^ *Enabled: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Check CA certs and keys
         run: |
           # check certs

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -56,6 +56,17 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
+      - name: Check webapps
+        run: |
+          docker exec pki pki-server webapp-find | tee output
+
+          # CA instance should have ROOT, ca, and pki webapps
+          echo "ROOT" > expected
+          echo "ca" >> expected
+          echo "pki" >> expected
+          sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Check CA certs and keys
         run: |
           # check certs

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -47,6 +47,18 @@ jobs:
 
           docker exec ipa pki-server cert-export ca_signing --cert-file ca_signing.crt
 
+      - name: Check webapps
+        run: |
+          docker exec ipa pki-server webapp-find | tee output
+
+          # IPA server should have ROOT, acme, ca, and pki webapps
+          echo "ROOT" > expected
+          echo "acme" >> expected
+          echo "ca" >> expected
+          echo "pki" >> expected
+          sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Check DS certs and keys
         run: |
           docker exec ipa ls -la /etc/dirsrv/slapd-EXAMPLE-COM
@@ -130,6 +142,19 @@ jobs:
           docker exec ipa ipa-kra-install -p Secret.123
           docker exec ipa pki-server ca-config-find | grep ca.connector.KRA
 
+      - name: Check webapps
+        run: |
+          docker exec ipa pki-server webapp-find | tee output
+
+          # IPA server should now have ROOT, acme, ca, kra, and pki webapps
+          echo "ROOT" > expected
+          echo "acme" >> expected
+          echo "ca" >> expected
+          echo "kra" >> expected
+          echo "pki" >> expected
+          sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Run PKI healthcheck
         run: docker exec ipa pki-healthcheck --failures-only
 
@@ -169,6 +194,16 @@ jobs:
           docker exec ipa ipa-run-tests -x --verbose \
               test_xmlrpc/test_vault_plugin.py
 
+      - name: Check IPA CA install log
+        if: always()
+        run: |
+          docker exec ipa cat /var/log/ipaserver-install.log
+
+      - name: Check IPA KRA install log
+        if: always()
+        run: |
+          docker exec ipa cat /var/log/ipaserver-kra-install.log
+
       - name: Gather artifacts
         if: always()
         run: |
@@ -185,5 +220,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ipa-basic-test
-          path: |
-            /tmp/artifacts/ipa
+          path: /tmp/artifacts

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -59,6 +59,11 @@ jobs:
           sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
           diff expected actual
 
+          docker exec ipa pki-server webapp-show ROOT
+          docker exec ipa pki-server webapp-show acme
+          docker exec ipa pki-server webapp-show ca
+          docker exec ipa pki-server webapp-show pki
+
       - name: Check DS certs and keys
         run: |
           docker exec ipa ls -la /etc/dirsrv/slapd-EXAMPLE-COM
@@ -154,6 +159,8 @@ jobs:
           echo "pki" >> expected
           sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
           diff expected actual
+
+          docker exec ipa pki-server webapp-show kra
 
       - name: Run PKI healthcheck
         run: docker exec ipa pki-healthcheck --failures-only

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -64,6 +64,22 @@ jobs:
           docker exec ipa pki-server webapp-show ca
           docker exec ipa pki-server webapp-show pki
 
+      - name: Check subsystems
+        run: |
+          docker exec ipa pki-server subsystem-find | tee output
+
+          # IPA server should have CA subsystem
+          echo "ca" > expected
+          sed -n 's/^ *Subsystem ID: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          docker exec ipa pki-server subsystem-show ca | tee output
+
+          # CA subsystem should be enabled
+          echo "True" > expected
+          sed -n 's/^ *Enabled: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Check DS certs and keys
         run: |
           docker exec ipa ls -la /etc/dirsrv/slapd-EXAMPLE-COM
@@ -161,6 +177,23 @@ jobs:
           diff expected actual
 
           docker exec ipa pki-server webapp-show kra
+
+      - name: Check subsystems
+        run: |
+          docker exec ipa pki-server subsystem-find | tee output
+
+          # IPA server should now have CA and KRA subsystems
+          echo "ca" > expected
+          echo "kra" >> expected
+          sed -n 's/^ *Subsystem ID: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          docker exec ipa pki-server subsystem-show kra | tee output
+
+          # KRA subsystem should be enabled
+          echo "True" > expected
+          sed -n 's/^ *Enabled: *\(.*\)$/\1/p' output > actual
+          diff expected actual
 
       - name: Run PKI healthcheck
         run: docker exec ipa pki-healthcheck --failures-only

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -45,6 +45,14 @@ jobs:
         run: |
           docker exec pki pki-server start
 
+      - name: Check webapps
+        run: |
+          docker exec pki pki-server webapp-find | tee output
+
+          # basic PKI server should have no webapps
+          sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
+          diff /dev/null actual
+
       - name: Set up client container
         run: |
           tests/bin/runner-init.sh client

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -53,6 +53,34 @@ jobs:
           sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
           diff /dev/null actual
 
+      - name: Check subsystems
+        run: |
+          docker exec pki pki-server subsystem-find | tee output
+
+          # basic PKI server should have no subsystems
+          sed -n 's/^ *Subsystem ID: *\(.*\)$/\1/p' output > actual
+          diff /dev/null actual
+
+          # CA subsystem should not exist
+          docker exec pki pki-server subsystem-show ca \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          echo "ERROR: No ca subsystem in instance pki-tomcat." > expected
+          diff expected stderr
+
+          # create empty CA subsystem folder
+          docker exec pki mkdir -p /var/lib/pki/pki-tomcat/ca
+
+          # CA subsystem should not exist
+          docker exec pki pki-server subsystem-show ca \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          echo "ERROR: No ca subsystem in instance pki-tomcat." > expected
+          diff expected stderr
+
+          # remove CA subsystem folder
+          docker exec pki rm -rf /var/lib/pki/pki-tomcat/ca
+
       - name: Set up client container
         run: |
           tests/bin/runner-init.sh client

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1222,8 +1222,15 @@ grant codeBase "file:%s" {
         for subsystem_name in SUBSYSTEM_TYPES:
 
             subsystem_dir = os.path.join(self.base_dir, subsystem_name)
+
+            # ensure /var/lib/pki/<instance>/<subsystem> exists
             if not os.path.exists(subsystem_dir):
-                # Directory does not exist
+                continue
+
+            # ensure /var/lib/pki/<instance>/<subsystem> is not empty
+            # https://issues.redhat.com/browse/RHEL-21568
+            if not os.listdir(subsystem_dir):
+                # Directory exists but it is empty
                 continue
 
             subsystem = pki.server.subsystem.PKISubsystemFactory.create(self, subsystem_name)

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -189,7 +189,7 @@ class SubsystemShowCLI(pki.cli.CLI):
 
         subsystem = instance.get_subsystem(subsystem_name)
         if not subsystem:
-            logger.error('ERROR: No %s subsystem in instance %s.',
+            logger.error('No %s subsystem in instance %s.',
                          subsystem_name, instance_name)
             sys.exit(1)
 
@@ -944,7 +944,7 @@ class SubsystemCertShowCLI(pki.cli.CLI):
 
         subsystem = instance.get_subsystem(subsystem_name)
         if not subsystem:
-            logger.error('ERROR: No %s subsystem in instance %s.',
+            logger.error('No %s subsystem in instance %s.',
                          subsystem_name, instance_name)
             sys.exit(1)
         cert = subsystem.get_subsystem_cert(cert_id)


### PR DESCRIPTION
The `PKIServer.load_subsystems()` has been modified to skip loading a subsystem if the subsystem folder doesn't exist or is empty. This will restore `pki-server subsystem-show` to work more consistently as in the previous PKI version.

The code in `PKIServer.get_webapps()` that gathers the info of a webapp has been moved into `PKIServer.get_webapp()`. Some tests have been updated to use `pki-server webapp-find` to list the webapps deployed in the instance.

The `pki-server webapp-show` has been added to show the info of a deployed webapp. Some tests have been updated to use this command.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Webapp-CLI
https://github.com/dogtagpki/pki/wiki/PKI-Server-Subsystem-CLI

Resolves: https://issues.redhat.com/browse/RHEL-21568
