### PR TITLE
Implement v2 of  AgentCertRequestService witout VLV and resteasy

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAServlet.java
@@ -18,6 +18,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class CAServlet extends HttpServlet {
     public static final long serialVersionUID = 1L;
+    public static final int DEFAULT_MAXTIME = 0;
+    public static final int DEFAULT_SIZE = 20;
 
 
     public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestACLFilter.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestACLFilter.java
@@ -1,0 +1,24 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ca.v2;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebFilter;
+
+import org.dogtagpki.server.v2.ACLFilter;
+
+@WebFilter(servletNames = "caCertRequest-agent")
+public class AgentCertRequestACLFilter extends ACLFilter {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        setAcl("certrequests");
+    }
+
+}

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestAuthMethodFilter.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestAuthMethodFilter.java
@@ -1,0 +1,24 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ca.v2;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebFilter;
+
+import org.dogtagpki.server.v2.AuthMethodFilter;
+
+@WebFilter(servletNames = "caCertRequest-agent")
+public class AgentCertRequestAuthMethodFilter extends AuthMethodFilter {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        setAuthMethod("certrequests");
+    }
+
+}

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestServlet.java
@@ -1,0 +1,36 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ca.v2;
+
+import java.io.PrintWriter;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.dogtagpki.server.ca.CAServlet;
+
+import com.netscape.certsrv.cert.CertRequestInfos;
+import com.netscape.certsrv.request.RequestId;
+
+@WebServlet(
+        name = "caCertRequest-agent",
+        urlPatterns = "/v2/agent/certrequests")
+public class AgentCertRequestServlet extends CAServlet {
+
+    @Override
+    public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.setContentType("application/json");
+        PrintWriter out = response.getWriter();
+        out.print("...");
+    }
+
+    public CertRequestInfos listRequests(String requestState, String requestType,
+            RequestId start, Integer pageSize, Integer maxResults, Integer maxTime) {
+        return null;
+    }
+
+}

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestServlet.java
@@ -6,31 +6,176 @@
 package org.dogtagpki.server.ca.v2;
 
 import java.io.PrintWriter;
+import java.security.SecureRandom;
+import java.util.Iterator;
+import java.util.Map;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.dogtagpki.server.ca.CAEngine;
 import org.dogtagpki.server.ca.CAServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.cert.CertRequestInfos;
+import com.netscape.certsrv.cert.CertReviewResponse;
 import com.netscape.certsrv.request.RequestId;
+import com.netscape.certsrv.request.RequestNotFoundException;
+import com.netscape.cms.profile.common.Profile;
+import com.netscape.cms.servlet.cert.CertRequestInfoFactory;
+import com.netscape.cms.servlet.cert.CertReviewResponseFactory;
+import com.netscape.cmscore.profile.ProfileSubsystem;
+import com.netscape.cmscore.request.Request;
+import com.netscape.cmscore.request.RequestRecord;
+import com.netscape.cmscore.request.RequestRepository;
+import com.netscape.cmscore.security.JssSubsystem;
+import com.netscape.cmsutil.ldap.LDAPUtil;
 
 @WebServlet(
         name = "caCertRequest-agent",
-        urlPatterns = "/v2/agent/certrequests")
+        urlPatterns = "/v2/agent/certrequests/*")
 public class AgentCertRequestServlet extends CAServlet {
+    private static final long serialVersionUID = 1L;
+    private static Logger logger = LoggerFactory.getLogger(AgentCertRequestServlet.class);
 
     @Override
     public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
         response.setContentType("application/json");
         PrintWriter out = response.getWriter();
-        out.print("...");
+        if(request.getPathInfo() != null) {
+            try {
+                RequestId id = new RequestId(request.getPathInfo().substring(1));
+                CertReviewResponse req = getRequestData(request, id);
+                if(req != null) {
+                    out.println(req.toJSON());
+                }
+            } catch (Exception e) {
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND, request.getRequestURI());
+            }
+            return;
+        }
+        int maxTime = request.getParameter("maxTime") == null ?
+                DEFAULT_MAXTIME : Integer.parseInt(request.getParameter("maxTime"));
+        int size = request.getParameter("pageSize") == null ?
+                DEFAULT_SIZE : Integer.parseInt(request.getParameter("pageSize"));
+        int start = request.getParameter("start") == null ? 0 : Integer.parseInt(request.getParameter("start"));
+        String requestType = request.getParameter("requestType");
+        String requestState = request.getParameter("requestState");
+        CertRequestInfos requests = null;
+        try {
+            requests =  listRequests(requestState, requestType, start, size, maxTime);
+            out.println(requests.toJSON());
+        } catch (EBaseException e) {
+            String message = "Unable to list cert requests: " + e.getMessage();
+            logger.error(message, e);
+            throw new PKIException(message, e);
+        }
+    }
+
+    private CertReviewResponse getRequestData(HttpServletRequest servletRequest, RequestId id) throws EBaseException {
+        CertReviewResponse info = null;
+        CAEngine engine = getCAEngine();
+        RequestRepository requestRepository = engine.getRequestRepository();
+        ProfileSubsystem ps = engine.getProfileSubsystem();
+        SecureRandom random = null;
+        if (engine.getEnableNonces()) {
+            JssSubsystem jssSubsystem = engine.getJSSSubsystem();
+            random = jssSubsystem.getRandomNumberGenerator();
+        }
+
+
+        Request request = requestRepository.readRequest(id);
+
+        if (request == null) {
+            return null;
+        }
+
+        String profileId = request.getExtDataInString(Request.PROFILE_ID);
+
+        Profile profile = ps.getProfile(profileId);
+        info = CertReviewResponseFactory.create(request, profile, null, servletRequest.getLocale());
+
+        if (random != null) {
+            // generate nonce
+            long n = random.nextLong();
+            logger.info("AgentCertRequestServlet: Nonce: {}", n);
+
+            // store nonce in session
+            Map<Object, Long> nonces = engine.getNonces(servletRequest, "cert-request");
+            nonces.put(info.getRequestId().toBigInteger(), n);
+
+            // return nonce to client
+            info.setNonce(Long.toString(n));
+        }
+        if (info == null) {
+            // request does not exist
+            throw new RequestNotFoundException(id);
+        }
+
+        logger.info("AgentCertRequestServlet: - profile: {}", info.getProfileName());
+        logger.info("AgentCertRequestServlet: - type: {}", info.getRequestType());
+        logger.info("AgentCertRequestServlet: - status: {}", info.getRequestStatus());
+
+        return info;
     }
 
     public CertRequestInfos listRequests(String requestState, String requestType,
-            RequestId start, Integer pageSize, Integer maxResults, Integer maxTime) {
-        return null;
+            int start, int pageSize, int maxTime) throws EBaseException {
+        logger.info("AgentCertRequestServlet: performing requests search");
+
+        CAEngine engine = getCAEngine();
+        RequestRepository requestRepository = engine.getRequestRepository();
+        CertRequestInfos reqInfos = new CertRequestInfos();
+
+        String filter = createSearchFilter(requestState, requestType);
+        logger.debug("AgentCertRequestServlet: performing paged search");
+
+        Iterator<RequestRecord> reqs = requestRepository.searchRequest(
+                filter,
+                maxTime,
+                start,
+                pageSize + 1);
+
+        while(reqs.hasNext()) {
+            Request request = reqs.next().toRequest();
+            logger.debug("- {}", request.getRequestId().toHexString());
+            try {
+                reqInfos.addEntry(CertRequestInfoFactory.create(request));
+            } catch (NoSuchMethodException e) {
+                logger.warn("Error in creating certrequestinfo - no such method: " + e.getMessage(), e);
+            }
+        }
+        reqInfos.setTotal(requestRepository.getTotalRequestsByFilter(filter));
+
+        // builder for search links
+        return reqInfos;
+    }
+
+    private String createSearchFilter(String requestState, String requestType) {
+        String filter = "";
+        int matches = 0;
+
+        if ((requestState == null) && (requestType == null)) {
+            filter = "(requeststate=*)";
+            return filter;
+        }
+        if (requestState != null) {
+            filter += "(requeststate=" + LDAPUtil.escapeFilter(requestState) + ")";
+            matches++;
+        }
+        if (requestType != null) {
+            filter += "(requesttype=" + LDAPUtil.escapeFilter(requestType) + ")";
+            matches++;
+        }
+        if (matches > 1) {
+            filter = "(&" + filter + ")";
+        }
+
+        return filter;
     }
 
 }

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/v2/CertServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/v2/CertServlet.java
@@ -59,9 +59,6 @@ import com.netscape.cmscore.dbs.RevocationInfo;
  */
 @WebServlet("/v2/certs/*")
 public class CertServlet extends CAServlet {
-    public static final int DEFAULT_MAXTIME = 0;
-    public static final int DEFAULT_SIZE = 20;
-
     private static final long serialVersionUID = 1L;
     private static Logger logger = LoggerFactory.getLogger(CertServlet.class);
 

--- a/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
@@ -362,6 +362,7 @@ public class RequestRepository extends Repository {
                 s.close();
         }
     }
+
     /**
      * Finds a list of request records that satisfies the filter.
      *

--- a/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.Set;
 
 import com.netscape.certsrv.base.EBaseException;
@@ -360,6 +361,34 @@ public class RequestRepository extends Repository {
             if (s != null)
                 s.close();
         }
+    }
+    /**
+     * Finds a list of request records that satisfies the filter.
+     *
+     * The filter should follow RFC1558 LDAP filter syntax.
+     * For example,
+     *
+     * {@Code (&(certRecordId=5)(x509Cert.notBefore=934398398))}
+     *
+     * @param filter search filter
+     * @param timeLimit timeout value
+     * @param start first entry to return from the list
+     * @param size max size to return
+     * @return a list of certificates
+     * @exception EBaseException failed to search
+     */
+    public Iterator<RequestRecord> searchRequest(String filter, int timeLimit, int start, int size)
+            throws EBaseException {
+
+        ArrayList<RequestRecord> records = new ArrayList<>();
+        logger.debug("searchRequest: filter {filter}, start {start} and size {size}", filter, start, size);
+        try (DBSSession s = dbSubsystem.createSession()) {
+            DBSearchResults sr  = s.pagedSearch(mBaseDN, filter, start, size, timeLimit);
+            while (sr.hasMoreElements()) {
+                records.add((RequestRecord) sr.nextElement());
+            }
+        }
+        return records.iterator();
     }
 
     public Collection<RequestRecord> listRequestsByFilter(String filter) throws EBaseException {

--- a/base/server/src/main/java/org/dogtagpki/server/v2/ACLFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/v2/ACLFilter.java
@@ -41,12 +41,6 @@ import com.netscape.cmscore.apps.CMSEngine;
 import com.netscape.cmscore.authorization.AuthzSubsystem;
 import com.netscape.cmscore.logging.Auditor;
 
-/**
- *
- */
-/**
- *
- */
 public abstract class ACLFilter extends GenericFilter {
 
     private static final long serialVersionUID = 1L;
@@ -325,5 +319,4 @@ public abstract class ACLFilter extends GenericFilter {
     public void setAcl(String acl) {
         this.acl = acl;
     }
-
 }

--- a/base/server/src/main/java/org/dogtagpki/server/v2/ACLFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/v2/ACLFilter.java
@@ -1,0 +1,329 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.v2;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.Principal;
+import java.util.Properties;
+
+import javax.servlet.FilterChain;
+import javax.servlet.GenericFilter;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.catalina.realm.GenericPrincipal;
+import org.dogtagpki.server.authentication.AuthToken;
+import org.dogtagpki.server.authorization.AuthzToken;
+import org.jboss.resteasy.spi.Failure;
+
+import com.netscape.certsrv.authentication.ExternalAuthToken;
+import com.netscape.certsrv.authorization.EAuthzAccessDenied;
+import com.netscape.certsrv.authorization.EAuthzUnknownRealm;
+import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.base.ForbiddenException;
+import com.netscape.certsrv.logging.ILogger;
+import com.netscape.certsrv.logging.event.AuthzEvent;
+import com.netscape.certsrv.logging.event.RoleAssumeEvent;
+import com.netscape.cms.realm.PKIPrincipal;
+import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.CMSEngine;
+import com.netscape.cmscore.authorization.AuthzSubsystem;
+import com.netscape.cmscore.logging.Auditor;
+
+/**
+ *
+ */
+/**
+ *
+ */
+public abstract class ACLFilter extends GenericFilter {
+
+    private static final long serialVersionUID = 1L;
+    public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ACLFilter.class);
+    private static final String LOGGING_ACL_PARSING_ERROR = "internal error: ACL parsing error";
+    private static final String LOGGING_NO_ACL_ACCESS_ALLOWED = "no ACL configured; OK";
+    private static final String LOGGING_MISSING_AUTH_TOKEN = "auth token not found";
+    private static final String LOGGING_MISSING_ACL_MAPPING = "ACL mapping not found; OK";
+    private static final String LOGGING_INVALID_ACL_MAPPING = "internal error: invalid ACL mapping";
+    private Properties aclProperties;
+    private String acl;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        if(request instanceof HttpServletRequest req &&
+                response instanceof HttpServletResponse resp) {
+            try {
+                checkACL(req, acl);
+            } catch (ForbiddenException fe) {
+                resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    private CMSEngine getCMSEngine() {
+        ServletContext servletContext = getServletContext();
+        return (CMSEngine) servletContext.getAttribute("engine");
+    }
+
+    private synchronized void loadACLProperties() throws IOException {
+
+        if (aclProperties != null)
+            return;
+
+        aclProperties = new Properties();
+
+        String context = getServletContext().getContextPath();
+        String subsystem = context.startsWith("/") ? context.substring(1) : context;
+
+        // load default mapping
+        Path defaultMappingACL = Paths.get("/usr/share/pki", subsystem, "conf", "acl.properties");
+        File defaultMapping = defaultMappingACL.toFile();
+        logger.debug("AgentCertRequestACLFilter: loading {}", defaultMappingACL);
+        try (FileReader in = new FileReader(defaultMapping)) {
+            aclProperties.load(in);
+        }
+
+        // load custom mapping
+        Path customMappingACL = Paths.get(CMS.getInstanceDir(), subsystem, "conf", "acl.properties");
+        File customMapping = customMappingACL.toFile();
+        logger.debug("AgentCertRequestACLFilter: checking {}", customMapping);
+        if (customMapping.exists()) {
+            logger.debug("AgentCertRequestACLFilter: loading {}",   customMappingACL);
+            try (FileReader in = new FileReader(customMapping)) {
+                aclProperties.load(in);
+            }
+        }
+    }
+
+    protected void checkACL(HttpServletRequest request, String name) throws ForbiddenException {
+        String auditInfo =  request.getMethod() + ":" + request.getPathInfo();
+
+        logger.debug("ACLFilter: {}", auditInfo);
+        String auditSubjectID = ILogger.UNIDENTIFIED;
+
+        /*
+         * when aclMapping is null, it's either of the following :
+         *   - only authentication needed
+         *   - allows anonymous, i.e. no authentication or authorization needed
+         * use authzRequired to track when aclMapping is not null for ease of following the code
+         */
+        boolean authzRequired = true;
+        if (name == null || name.isEmpty()) {
+            logger.debug("ACLFilter: no authorization required");
+            authzRequired = false;
+        }
+
+        Principal principal = request.getUserPrincipal();
+
+        // If unauthenticated, reject request.
+        if (principal == null && authzRequired) {
+            logger.debug("ACLFilter: No user principal provided.");
+            // audit comment: no Principal, no one to blame here
+            throw new ForbiddenException("No user principal provided.");
+        }
+        if (principal != null)
+            logger.debug("ACLFilter: principal: {}", principal.getName());
+
+        CMSEngine engine = getCMSEngine();
+        Auditor auditor = engine.getAuditor();
+        AuthzSubsystem authzSubsystem = engine.getAuthzSubsystem();
+
+        AuthToken authToken = null;
+        String authzMgrName = null;
+        if (principal != null) {
+            if (principal instanceof PKIPrincipal pkiPrincipal) {
+                authzMgrName = "DirAclAuthz";
+                authToken = pkiPrincipal.getAuthToken();
+            }
+            else {
+                String realm = null;
+                String[] parts = principal.getName().split("@", 2);
+                if (parts.length == 2) {
+                    realm = parts[1];
+                }
+                try {
+                    authzMgrName = authzSubsystem.getAuthzManagerNameByRealm(realm);
+                } catch (EAuthzUnknownRealm e) {
+                    throw new ForbiddenException(
+                        "Cannot find AuthzManager for external principal " + principal.getName(),
+                        e
+                    );
+                }
+                authToken = new ExternalAuthToken((GenericPrincipal) principal);
+            }
+            logger.debug("ACLFilter: will use authz manager {}", authzMgrName);
+        }
+
+        // If missing auth token, reject request.
+        if (authToken == null && authzRequired) {
+            logger.debug("ACLFilter: No authentication token present.");
+            // store a message in the signed audit log file
+            // although if it didn't pass authentication, it should not have gotten here
+            auditor.log(AuthzEvent.createFailureEvent(
+                        auditSubjectID,
+                        null, // resource
+                        null, // operation
+                        LOGGING_MISSING_AUTH_TOKEN + ":" + auditInfo));
+
+            throw new ForbiddenException("No authorization token present.");
+        }
+        if (authToken != null)
+            auditSubjectID = authToken.getInString(AuthToken.USER_ID);
+
+        // If still not available, it's unprotected, allow request.
+        if (!authzRequired) {
+            logger.debug("ACLFilter: Unprotected resource; access granted");
+
+            auditor.log(AuthzEvent.createSuccessEvent(
+                        auditSubjectID,
+                        null, //resource
+                        null, //operation
+                        LOGGING_MISSING_ACL_MAPPING + ":" + auditInfo)); //info
+
+            // unprotected resource -> do not generate ROLE_ASSUME event
+
+            return;
+        }
+
+        // we know aclMapping is not null now (!noAuthzRequired); authz game on...
+        logger.debug("ACLFilter: mapping: {}", name);
+
+        String[] values = null;
+        String value = null;
+        try {
+            loadACLProperties();
+
+            value = aclProperties.getProperty(name);
+
+        } catch (IOException e) {
+
+            auditor.log(AuthzEvent.createFailureEvent(
+                        auditSubjectID,
+                        null, //resource
+                        null, //operation
+                        LOGGING_ACL_PARSING_ERROR + ":" + auditInfo));
+
+            e.printStackTrace();
+            throw new Failure(e);
+        }
+
+        // If no property defined, allow request.
+        if (value == null) {
+            logger.debug("ACLFilter: Unprotected resource; access granted");
+
+            auditor.log(AuthzEvent.createSuccessEvent(
+                    auditSubjectID,
+                    null, //resource
+                    null, //operation
+                    LOGGING_NO_ACL_ACCESS_ALLOWED + ":" + auditInfo));
+
+            // unprotected resource -> do not generate ROLE_ASSUME event
+
+            return;
+        }
+
+        // accessing protected resource
+
+        values = value.split(",");
+
+        // If invalid mapping, reject request.
+        if (values.length != 2) {
+            logger.error("ACLFilter: Invalid ACL mapping: {}", value);
+
+            auditor.log(AuthzEvent.createFailureEvent(
+                    auditSubjectID,
+                    null, //resource
+                    null, //operation
+                    LOGGING_INVALID_ACL_MAPPING + ":" + auditInfo));
+
+            throw new ForbiddenException("Invalid ACL mapping.");
+        }
+
+        logger.debug("ACLFilter: ACL: {}", value);
+
+        try {
+            // Check authorization.
+            AuthzToken authzToken = authzSubsystem.authorize(
+                    authzMgrName,
+                    authToken,
+                    values[0], // resource
+                    values[1]); // operation
+
+            // If not authorized, reject request.
+            if (authzToken == null) {
+                String info = "No authorization token present.";
+                logger.debug("ACLFilter: {}", info);
+
+                auditor.log(AuthzEvent.createFailureEvent(
+                            auditSubjectID,
+                            values[0], // resource
+                            values[1], // operation
+                            info));
+
+                throw new ForbiddenException("No authorization token present.");
+            }
+
+            logger.debug("ACLFilter: access granted");
+
+        } catch (EAuthzAccessDenied e) {
+            String info = e.getMessage();
+            logger.debug("ACLFilter: {}", info);
+
+            auditor.log(AuthzEvent.createFailureEvent(
+                        auditSubjectID,
+                        values[0], // resource
+                        values[1], // operation
+                        info));
+
+            throw new ForbiddenException(e.toString());
+
+        } catch (EBaseException e) {
+            String info = e.getMessage();
+            logger.error("ACLFilter: " + info, e);
+
+            auditor.log(AuthzEvent.createFailureEvent(
+                        auditSubjectID,
+                        values[0], // resource
+                        values[1], // operation
+                        info));
+
+            throw new Failure(e);
+        }
+
+        logger.debug("ACLFilter: Protected resource; access granted");
+
+        auditor.log(AuthzEvent.createSuccessEvent(
+                    auditSubjectID,
+                    values[0], // resource
+                    values[1], // operation
+                    auditInfo));
+
+        if (principal instanceof PKIPrincipal pkiPrincipal) {
+            String[] roles = pkiPrincipal.getRoles();
+            if (roles != null) {
+                auditor.log(RoleAssumeEvent.createSuccessEvent(
+                        auditSubjectID,
+                        String.join(",", roles)));
+            }
+        }
+
+    }
+
+    public void setAcl(String acl) {
+        this.acl = acl;
+    }
+
+}

--- a/base/server/src/main/java/org/dogtagpki/server/v2/AuthMethodFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/v2/AuthMethodFilter.java
@@ -150,5 +150,4 @@ public abstract class AuthMethodFilter extends GenericFilter {
     public void setAuthMethod(String authMethod) {
         this.authMethod = authMethod;
     }
-
 }

--- a/base/server/src/main/java/org/dogtagpki/server/v2/AuthMethodFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/v2/AuthMethodFilter.java
@@ -1,0 +1,154 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.v2;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Properties;
+
+import javax.servlet.FilterChain;
+import javax.servlet.GenericFilter;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.catalina.realm.GenericPrincipal;
+import org.dogtagpki.server.authentication.AuthToken;
+import org.jboss.resteasy.spi.Failure;
+
+import com.netscape.certsrv.authentication.ExternalAuthToken;
+import com.netscape.certsrv.base.ForbiddenException;
+import com.netscape.cms.realm.PKIPrincipal;
+import com.netscape.cmscore.apps.CMS;
+
+public abstract class AuthMethodFilter extends GenericFilter {
+
+    private static final long serialVersionUID = 1L;
+    public static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AuthMethodFilter.class);
+    private Properties authProperties;
+    private String authMethod;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if(request instanceof HttpServletRequest req &&
+                response instanceof HttpServletResponse resp) {
+            try {
+                checkAuthenticationMethod(req, authMethod);
+            } catch (ForbiddenException fe) {
+                resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    private synchronized void loadAuthProperties() throws IOException {
+        if (authProperties != null)
+            return;
+
+        authProperties = new Properties();
+        String context = getServletContext().getContextPath();
+        String subsystem = context.startsWith("/") ? context.substring(1) : context;
+
+        // load default mapping
+        Path defaultMappingAuth = Paths.get("/usr/share/pki", subsystem, "conf", "auth-method.properties");
+        File defaultMapping = defaultMappingAuth.toFile();
+        logger.debug("AuthMethodFilter: loading {}", defaultMapping);
+        try (FileReader in = new FileReader(defaultMapping)) {
+            authProperties.load(in);
+        }
+
+        // load custom mapping
+        Path customMappingAuth = Paths.get(CMS.getInstanceDir(), subsystem, "conf", "auth-method.properties");
+        File customMapping = customMappingAuth.toFile();
+        logger.debug("AuthMethodFilter: checking {}", customMapping);
+        if (customMapping.exists()) {
+            logger.debug("AuthMethodFilter: loading {}", customMapping);
+            try (FileReader in = new FileReader(customMapping)) {
+                authProperties.load(in);
+            }
+        }
+    }
+
+    protected void checkAuthenticationMethod(HttpServletRequest request, String name) throws ForbiddenException {
+        logger.debug("AuthMethodFilter: mapping: {}", name);
+
+        try {
+            loadAuthProperties();
+
+            String value = authProperties.getProperty(name);
+            Collection<String> authMethods = new HashSet<>();
+            if (value != null) {
+                for (String v : value.split(",")) {
+                    authMethods.add(v.trim());
+                }
+            }
+
+            logger.debug("AuthMethodFilter: required auth methods: {}", authMethods);
+
+            Principal principal = request.getUserPrincipal();
+
+            // If unauthenticated, reject request.
+            if (principal == null) {
+                if (authMethods.isEmpty() || authMethods.contains("anonymous") || authMethods.contains("*")) {
+                    logger.debug("AuthMethodFilter: anonymous access allowed");
+                    return;
+                }
+                logger.error("AuthMethodFilter: anonymous access not allowed");
+                throw new ForbiddenException("Anonymous access not allowed.");
+            }
+
+            AuthToken authToken = null;
+            if (principal instanceof PKIPrincipal pkPrincipal)
+                authToken = pkPrincipal.getAuthToken();
+            else if (principal instanceof GenericPrincipal genPrincipal)
+                authToken = new ExternalAuthToken(genPrincipal);
+
+            // If missing auth token, reject request.
+            if (authToken == null) {
+                logger.error("AuthMethodFilter: missing authentication token");
+                throw new ForbiddenException("Missing authentication token.");
+            }
+
+            String authManager = authToken.getInString(AuthToken.TOKEN_AUTHMGR_INST_NAME);
+
+            logger.debug("AuthMethodFilter: authentication manager: {}", authManager);
+
+            if (authManager == null) {
+                logger.error("AuthMethodFilter: missing authentication manager");
+                throw new ForbiddenException("Missing authentication manager.");
+            }
+
+            if (
+                authMethods.isEmpty()
+                || authManager.equals("external")
+                || authMethods.contains(authManager)
+                || authMethods.contains("*")
+            ) {
+                logger.debug("AuthMethodFilter: access granted");
+                return;
+            }
+
+            throw new ForbiddenException("Authentication method not allowed.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new Failure(e);
+        }
+    }
+
+    public void setAuthMethod(String authMethod) {
+        this.authMethod = authMethod;
+    }
+
+}


### PR DESCRIPTION
Implement the AgentCertRequestService using a plain servlet and without VLV. The interface is very similar but the start parameter when retrieving the list is not anymore the id to start from but the index to start. Using random indexes it is less  useful to start from a specific attribute.

The authN/authZ was performed using interceptor but in a plain servlet these have been converted in filters maintaining the same behaviour.