### PR TITLE
Remove AuthorityMonitor tracking update

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/AuthorityMonitor.java
+++ b/base/ca/src/main/java/com/netscape/ca/AuthorityMonitor.java
@@ -378,28 +378,6 @@ public class AuthorityMonitor implements Runnable {
         nsUniqueIds.remove(aid);
     }
 
-    public synchronized void trackUpdate(AuthorityID aid, LDAPControl[] responseControls) {
-
-        LDAPPostReadControl control = (LDAPPostReadControl)
-            LDAPUtil.getControl(LDAPPostReadControl.class, responseControls);
-
-        LDAPEntry entry = control.getEntry();
-
-        LDAPAttribute attr = entry.getAttribute("entryUSN");
-        if (attr != null) {
-            BigInteger entryUSN = new BigInteger(attr.getStringValueArray()[0]);
-            logger.debug("AuthorityMonitor: tracking entryUSN: " + entryUSN);
-            entryUSNs.put(aid, entryUSN);
-        }
-
-        attr = entry.getAttribute("nsUniqueId");
-        if (attr != null) {
-            String nsUniqueId = attr.getStringValueArray()[0];
-            logger.info("AuthorityMonitor: tracking nsUniqueId: " + nsUniqueId);
-            nsUniqueIds.put(aid, nsUniqueId);
-        }
-    }
-
     /**
      * Stop the activityMonitor thread
      *

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -1723,8 +1723,6 @@ public class CAEngine extends CMSEngine {
         } finally {
             connectionFactory.returnConn(conn);
         }
-
-        authorityMonitor.trackUpdate(authorityID, responseControls);
     }
 
     public synchronized void modifyAuthorityEntry(AuthorityID aid, LDAPModificationSet mods) throws EBaseException {
@@ -1743,8 +1741,6 @@ public class CAEngine extends CMSEngine {
         } finally {
             connectionFactory.returnConn(conn);
         }
-
-        authorityMonitor.trackUpdate(aid, responseControls);
     }
 
     public synchronized void deleteAuthorityEntry(AuthorityID aid) throws EBaseException {


### PR DESCRIPTION
The tracking update allows to avoid reloading an authority if no changes have been done to the record. To verify the changes it is used the LDAP attribute `entryUSN` which is updated by DS server on any change.

The tracker update mechanism has a race condition when an entry is modified by the `CAEngine`. When the method `modifyAuthorityEntry()` is invoked, this will update the tracker and no CA are reloaded by the `AuthorityMonitor` thread because the tracker is already to the newest value. However, in case of CA clones, when a sub CA is created in the primary CA, the clone will get the record but there is no serial. The CA is registered and when the related keys are retrieved the record is update with the serial. The update is done by the `modifyAuthorityEntry()` which will update the trackers. As a result the `AuthorityMonitor` will not update the CA object and when used it will miss the serial so some operations will fails.

Since, the `trackerUpdate` method has not other impact has been removed so all trackers are managed by the `AuthorityMonitor`.

Fix #4669