### PR TITLE
CI updates for PKI 11.5

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:40' }}
-  COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
+  COPR_REPO: ${{ vars.COPR_REPO }}
 
 jobs:
   build:

--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -3,7 +3,7 @@ name: ACME Tests
 on: [push, pull_request]
 
 env:
-  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:latest' }}
+  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:40' }}
   COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
 
 jobs:

--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -113,7 +113,7 @@ jobs:
     uses: ./.github/workflows/acme-postgresql-test.yml
 
   publish:
-    if: github.event_name == 'push' && github.ref_name == 'master'
+    if: github.event_name == 'push' && github.ref_name == 'v11.5'
     name: Publishing ACME images
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -147,5 +147,5 @@ jobs:
 
       - name: Publish pki-acme image
         run: |
-          docker tag pki-acme ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:latest
-          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:latest
+          docker tag pki-acme ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:11.5
+          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-acme:11.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:40' }}
-  COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
+  COPR_REPO: ${{ vars.COPR_REPO }}
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || 'dogtagpki' }}
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build PKI
 on: [push, pull_request]
 
 env:
-  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:latest' }}
+  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:40' }}
   COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || 'dogtagpki' }}
 

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:40' }}
-  COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
+  COPR_REPO: ${{ vars.COPR_REPO }}
 
 jobs:
   build:

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -3,7 +3,7 @@ name: IPA Tests
 on: [push, pull_request]
 
 env:
-  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:latest' }}
+  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:40' }}
   COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish PKI
 on:
   push:
     branches:
-      - master
+      - v11.5
 
 env:
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || github.repository_owner }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,15 +91,15 @@ jobs:
 
       - name: Publish pki-dist image
         run: |
-          docker tag pki-dist ${{ vars.REGISTRY }}/$NAMESPACE/pki-dist:latest
-          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-dist:latest
+          docker tag pki-dist ${{ vars.REGISTRY }}/$NAMESPACE/pki-dist:11.5
+          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-dist:11.5
 
       - name: Publish pki-server image
         run: |
-          docker tag pki-server ${{ vars.REGISTRY }}/$NAMESPACE/pki-server:latest
-          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-server:latest
+          docker tag pki-server ${{ vars.REGISTRY }}/$NAMESPACE/pki-server:11.5
+          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-server:11.5
 
       - name: Publish pki-ca image
         run: |
-          docker tag pki-ca ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest
-          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest
+          docker tag pki-ca ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:11.5
+          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:11.5

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:40' }}
-  COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
+  COPR_REPO: ${{ vars.COPR_REPO }}
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || 'dogtagpki' }}
 
 jobs:

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -6,7 +6,7 @@ on:
       - completed
 
 env:
-  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:latest' }}
+  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:40' }}
   COPR_REPO: ${{ vars.COPR_REPO || '@pki/master' }}
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || 'dogtagpki' }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG COMPONENT="dogtag-pki"
 ARG LICENSE="GPLv2 and LGPLv2"
 ARG ARCH="x86_64"
 ARG VERSION="0"
-ARG BASE_IMAGE="registry.fedoraproject.org/fedora:latest"
+ARG BASE_IMAGE="registry.fedoraproject.org/fedora:40"
 ARG COPR_REPO=""
 ARG BUILD_OPTS=""
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
         import os
         import re
 
-        value = os.getenv('BASE_IMAGE', 'registry.fedoraproject.org/fedora:latest')
+        value = os.getenv('BASE_IMAGE', 'registry.fedoraproject.org/fedora:40')
         print('BASE_IMAGE: {value}'.format(value=value))
         print('##vso[task.setvariable variable=BASE_IMAGE]{value}'.format(value=value))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
       docker build \
           --build-arg BASE_IMAGE=$BASE_IMAGE \
           --target pki-base \
-          --tag pki-base:latest \
+          --tag pki-base:11.5 \
           .
 
       docker run \
@@ -38,7 +38,7 @@ jobs:
           -v $BUILD_SOURCESDIRECTORY:/root/src \
           --privileged \
           --detach \
-          pki-base:latest
+          pki-base:11.5
 
       while :
       do

--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -5,7 +5,7 @@
 #
 # https://docs.fedoraproject.org/en-US/containers/guidelines/guidelines/
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:40
 
 ARG NAME="pki-acme"
 ARG SUMMARY="Dogtag PKI ACME Responder"

--- a/base/acme/openshift/pki-acme-deployment.yaml
+++ b/base/acme/openshift/pki-acme-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: pki-acme
-          image: 'quay.io/dogtagpki/pki-acme:latest'
+          image: 'quay.io/dogtagpki/pki-acme:11.5'
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /var/lib/tomcats/pki/conf/certs
@@ -52,6 +52,6 @@ spec:
           - pki-acme
         from:
           kind: ImageStreamTag
-          name: 'pki-acme:latest'
+          name: 'pki-acme:11.5'
       type: ImageChange
     - type: ConfigChange

--- a/base/acme/openshift/pki-acme-is.yaml
+++ b/base/acme/openshift/pki-acme-is.yaml
@@ -10,7 +10,7 @@ spec:
   tags:
     - from:
         kind: DockerImage
-        name: quay.io/dogtagpki/pki-acme:latest
-      name: latest
+        name: quay.io/dogtagpki/pki-acme:11.5
+      name: 11.5
       referencePolicy:
         type: Source

--- a/base/ca/Dockerfile
+++ b/base/ca/Dockerfile
@@ -5,7 +5,7 @@
 #
 # https://docs.fedoraproject.org/en-US/containers/guidelines/guidelines/
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:40
 
 ARG NAME="pki-ca"
 ARG SUMMARY="Dogtag PKI Certificate Authority"


### PR DESCRIPTION
* The version numbers for PKI 11.5 container images have been changed to 11.5.
* The default BASE_IMAGE for PKI 11.5 has been changed to Fedora 40.
* The default COPR_REPO for PKI 11.5 has been removed since all dependencies should be available on Fedora 40.
