### PR TITLE
Add tests for adding multiple LWCAs

### DIFF
--- a/.github/workflows/ipa-subca-test.yml
+++ b/.github/workflows/ipa-subca-test.yml
@@ -98,6 +98,43 @@ jobs:
               --pkcs12-password Secret.123
           docker exec ipa pki -n ipa-ca-agent ca-user-show admin
 
+      - name: Check lightweight CAs
+        run: |
+          # there should be 1 authority initially
+          docker exec ipa pki -n ipa-ca-agent ca-authority-find | tee output
+          echo "1" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Create lightweight CAs
+        run: |
+          for i in {1..20}
+          do
+              docker exec ipa ipa ca-add "lwca$i" \
+                  --subject "cn=Lightweight CA $i" \
+                  --desc "Lightweight CA $i"
+          done
+
+          # there should be 21 authorities now
+          docker exec ipa pki -n ipa-ca-agent ca-authority-find | tee output
+          echo "21" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Remove lightweight CAs
+        run: |
+          for i in {1..20}
+          do
+              docker exec ipa ipa ca-disable "lwca$i"
+              docker exec ipa ipa ca-del "lwca$i"
+          done
+
+          # there should be 1 authority now
+          docker exec ipa pki -n ipa-ca-agent ca-authority-find | tee output
+          echo "1" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
       - name: Check PKI server systemd journal
         if: always()
         run: |

--- a/.github/workflows/subca-lightweight-test.yml
+++ b/.github/workflows/subca-lightweight-test.yml
@@ -123,30 +123,30 @@ jobs:
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
-      - name: Create lightweight CA
+      - name: Create lightweight CAs
         run: |
           HOSTCA_ID=$(cat hostca-id)
 
-          # create a LWCA under the host CA
-          docker exec pki pki -n caadmin ca-authority-create \
-              --parent $HOSTCA_ID \
-              CN="Lightweight CA" | tee output
+          # create 20 LWCAs under the host CA
+          for i in {1..20}
+          do
+              docker exec pki pki -n caadmin ca-authority-create \
+                  --parent $HOSTCA_ID \
+                  CN="Lightweight CA $i" | tee output
 
-          # store LWCA ID
-          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > lwca-id
-          LWCA_ID=$(cat lwca-id)
+              # store LWCA ID
+              sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output >> lwca-id
+          done
 
           docker exec pki pki -n caadmin ca-authority-find | tee output
 
-          # there should be 2 authorities now
-          echo -e "$HOSTCA_ID\n$LWCA_ID" | sort > expected
+          # there should be 21 authorities now
+          echo -e "$HOSTCA_ID\n$(cat lwca-id)" | sort > expected
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
-      - name: Check lightweight CA's LDAP entry
+      - name: Check authority LDAP entries
         run: |
-          LWCA_ID=$(cat lwca-id)
-
           docker exec pki ldapsearch \
               -H ldap://ds.example.com:3389 \
               -x \
@@ -158,8 +158,14 @@ jobs:
               -LLL \
               "(objectClass=*)" | tee output
 
-          # check authorityKeyNickname
-          echo -e "ca_signing\nca_signing $LWCA_ID" | sort > expected
+          # check authorityKeyNicknames
+          echo "ca_signing" > expected
+          for LWCA_ID in $(cat lwca-id)
+          do
+              echo -e "ca_signing $LWCA_ID" >> expected
+          done
+          sort -o expected expected
+
           sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
@@ -170,8 +176,8 @@ jobs:
               -f /etc/pki/pki-tomcat/password.conf \
               nss-cert-find | tee output
 
-          # there should be 6 certs now
-          echo "6" > expected
+          # there should be 25 certs now
+          echo "25" > expected
           sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -180,14 +186,19 @@ jobs:
               -f /etc/pki/pki-tomcat/password.conf \
               nss-key-find | tee output
 
-          # there should be 6 keys now
-          echo "6" > expected
+          # there should be 25 keys now
+          echo "25" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
       - name: Check enrollment against lightweight CA
         run: |
-          LWCA_ID=$(cat lwca-id)
+          # use the first LWCA
+          LWCA_ID=$(head -1 lwca-id)
+
+          # get LWCA's DN
+          docker exec pki pki -n caadmin ca-authority-show $LWCA_ID | tee output
+          sed -n -e 's/^\s*Authority DN:\s*\(.*\)$/\1/p' output > expected
 
           # submit enrollment request against LWCA
           docker exec pki pki client-cert-request \
@@ -210,20 +221,21 @@ jobs:
           docker exec pki pki ca-cert-show $CERT_ID | tee output
 
           # verify that it's signed by LWCA
-          echo "CN=Lightweight CA" > expected
           sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Remove lightweight CA
+      - name: Remove lightweight CAs
         run: |
           HOSTCA_ID=$(cat hostca-id)
-          LWCA_ID=$(cat lwca-id)
 
-          docker exec pki pki -n caadmin ca-authority-disable $LWCA_ID
+          for LWCA_ID in $(cat lwca-id)
+          do
+              docker exec pki pki -n caadmin ca-authority-disable $LWCA_ID
 
-          docker exec pki pki -n caadmin ca-authority-del \
-              --force \
-              $LWCA_ID | tee output
+              docker exec pki pki -n caadmin ca-authority-del \
+                  --force \
+                  $LWCA_ID
+          done
 
           docker exec pki pki -n caadmin ca-authority-find | tee output
 
@@ -232,7 +244,7 @@ jobs:
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check lightweight CA's LDAP entry
+      - name: Check authority LDAP entries
         run: |
           HOSTCA_ID=$(cat hostca-id)
 

--- a/base/ca/src/main/java/com/netscape/ca/CASigningUnit.java
+++ b/base/ca/src/main/java/com/netscape/ca/CASigningUnit.java
@@ -143,10 +143,6 @@ public final class CASigningUnit extends SigningUnit {
             logger.error(CMS.getLogMessage("CMSCORE_CA_SIGNING_TOKEN_NOT_FOUND", tokenname, e.toString()), e);
             throw new ECAException(CMS.getUserMessage("CMS_CA_TOKEN_NOT_FOUND", tokenname), e);
 
-        } catch (CAMissingCertException | CAMissingKeyException e) {
-            logger.error(CMS.getLogMessage("CMSCORE_CA_SIGNING_CERT_NOT_FOUND", e.toString()), e);
-            throw e;  // re-throw
-
         } catch (TokenException e) {
             logger.error(CMS.getLogMessage("OPERATION_ERROR", e.toString()), e);
             throw new ECAException(CMS.getUserMessage("CMS_CA_TOKEN_ERROR"), e);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AgentCertRequestService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AgentCertRequestService.java
@@ -159,6 +159,7 @@ public class AgentCertRequestService extends PKIService implements AgentCertRequ
             throw new ConflictingOperationException(message, e);
 
         } catch (CAMissingCertException | CAMissingKeyException e) {
+            logger.error(CMS.getLogMessage("CMSCORE_CA_SIGNING_CERT_NOT_FOUND", e.toString()), e);
             throw new ServiceUnavailableException(e.toString(), e);
 
         } catch (EPropertyException e) {

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AuthorityService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/AuthorityService.java
@@ -286,6 +286,7 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
             audit(ILogger.FAILURE, OpDef.OP_ADD, "<unknown>", auditParams);
             throw new ConflictingOperationException(e.toString());
         } catch (CAMissingCertException | CAMissingKeyException e) {
+            logger.error(CMS.getLogMessage("CMSCORE_CA_SIGNING_CERT_NOT_FOUND", e.toString()), e);
             throw new ServiceUnavailableException(e.toString());
         } catch (Exception e) {
             String message = "Error creating CA: " + e.getMessage();

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/v2/AgentCertRequestServlet.java
@@ -157,6 +157,7 @@ public class AgentCertRequestServlet extends CAServlet {
                 throw new ConflictingOperationException(message, e);
 
             } catch (CAMissingCertException | CAMissingKeyException e) {
+                logger.error(CMS.getLogMessage("CMSCORE_CA_SIGNING_CERT_NOT_FOUND", e.toString()), e);
                 throw new ServiceUnavailableException(e.toString(), e);
 
             } catch (EPropertyException e) {


### PR DESCRIPTION
New tests have been added to validate adding multiple LWCAs in plain PKI environment and in IPA environment.

The `CASigningUnit` has been updated to no longer log an exception if the cert or key is missing since in LWCA case the exception is used as a mechanism to trigger the key retriever so it is actually not a problem. Instead, the exception will only be logged by other code where the exception indicates a real problem.