### PR TITLE
Fix missing dnf builddep in Dockerfiles

### DIFF
--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -29,20 +29,21 @@ LABEL name="$NAME" \
 
 EXPOSE 8080 8443
 
-# Enable COPR repo if specified
-RUN if [ -n "$COPR_REPO" ]; then dnf install -y dnf-plugins-core; dnf copr enable -y $COPR_REPO; fi
-
 # Install packages
-RUN dnf install -y rpm-build bind-utils iputils abrt-java-connector postgresql postgresql-jdbc \
+RUN dnf install -y dnf-plugins-core \
     && dnf clean all \
     && rm -rf /var/cache/dnf
+
+# Enable COPR repo if specified
+RUN if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
 
 # Import PKI sources
 COPY . /tmp/pki/
 WORKDIR /tmp/pki
 
 # Build and install PKI packages
-RUN dnf builddep -y --spec pki.spec \
+RUN dnf install -y rpm-build bind-utils iputils abrt-java-connector postgresql postgresql-jdbc \
+    && dnf builddep -y --spec pki.spec \
     && ./build.sh --with-pkgs=base,server,acme --work-dir=build rpm \
     && dnf localinstall -y build/RPMS/* \
     && dnf clean all \

--- a/base/ca/Dockerfile
+++ b/base/ca/Dockerfile
@@ -29,20 +29,21 @@ LABEL name="$NAME" \
 
 EXPOSE 8080 8443
 
-# Enable COPR repo if specified
-RUN if [ -n "$COPR_REPO" ]; then dnf install -y dnf-plugins-core; dnf copr enable -y $COPR_REPO; fi
-
 # Install packages
-RUN dnf install -y rpm-build \
+RUN dnf install -y dnf-plugins-core \
     && dnf clean all \
     && rm -rf /var/cache/dnf
+
+# Enable COPR repo if specified
+RUN if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
 
 # Import PKI sources
 COPY . /tmp/pki/
 WORKDIR /tmp/pki
 
 # Build and install PKI packages
-RUN dnf builddep -y --spec pki.spec \
+RUN dnf install -y rpm-build \
+    && dnf builddep -y --spec pki.spec \
     && ./build.sh --with-pkgs=base,server,ca --work-dir=build rpm \
     && dnf localinstall -y build/RPMS/* \
     && dnf clean all \


### PR DESCRIPTION
The `Dockerfile`s have been modified to install `dnf-plugins-core` regardless of `COPR_REPO` value to ensure that the `dnf builddep` command will work.

Resolves: https://github.com/dogtagpki/pki/issues/4664