### PR TITLE
Update Java dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
 
 # Install PKI runtime dependencies
 RUN dnf install -y dogtag-pki \
-    && dnf remove -y dogtag-* --noautoremove \
+    && rpm -e --nodeps $(rpm -qa | grep -E "^java-|^dogtag-|^python3-dogtag-") \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
@@ -71,7 +71,7 @@ RUN dnf localinstall -y /tmp/RPMS/* \
 # Import PKI sources
 COPY . /root/pki/
 
-# Build and install PKI packages
+# Build PKI packages
 RUN ./build.sh --work-dir=build $BUILD_OPTS rpm
 
 ################################################################################

--- a/pki.spec
+++ b/pki.spec
@@ -63,9 +63,27 @@ ExcludeArch: i686
 # Java
 ################################################################################
 
-%global java_devel java-17-openjdk-devel
-%global java_headless java-17-openjdk-headless
-%global java_home %{_jvmdir}/jre-17-openjdk
+%if 0%{?rhel}
+
+%define java_devel java-17-openjdk-devel
+%define java_headless java-17-openjdk-headless
+%define java_home %{_jvmdir}/jre-17-openjdk
+
+%else
+
+# Use Java 21 on Fedora 40+, otherwise use Java 17.
+%global java_devel java-devel >= 1:17
+%global java_headless java-headless >= 1:17
+
+# Don't use find since it might not work well with local builds.
+#   find {_jvmdir} -maxdepth 1 | grep "jre-[0-9]\+$"
+%global java_home %(
+   source /usr/share/java-utils/java-functions;
+   _prefer_jre=true;
+   set_jvm;
+   echo $JAVA_HOME)
+
+%endif
 
 ################################################################################
 # Application Server


### PR DESCRIPTION
The RPM spec has been updated to use Java 21 on Fedora 40 or later and Java 17 on other platforms.

The `Dockerfile` has been modified to remove any Java packages pulled by the existing PKI package to ensure that the build will be done using the correct Java version.