### PR TITLE
Remove unused <subsystem>.admin.cert param

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2350,27 +2350,6 @@ class PKIDeployer:
 
         self.import_cert_chain(nssdb)
 
-    def update_admin_cert(self, subsystem):
-
-        logger.info('Updating admin certificate')
-
-        client_nssdb = pki.nssdb.NSSDatabase(
-            directory=self.mdict['pki_client_database_dir'],
-            password=self.mdict['pki_client_database_password'])
-
-        try:
-            nickname = self.mdict['pki_admin_nickname']
-            cert_data = client_nssdb.get_cert(
-                nickname=nickname,
-                output_format='base64',
-                output_text=True,
-            )
-
-            subsystem.config['%s.admin.cert' % subsystem.name] = cert_data
-
-        finally:
-            client_nssdb.close()
-
     def update_system_certs(self, subsystem):
 
         logger.info('Updating system certs')
@@ -2385,14 +2364,9 @@ class PKIDeployer:
             subsystem.config['ca.ocsp_signing.defaultSigningAlgorithm'] = \
                 self.mdict['pki_ocsp_signing_signing_algorithm']
 
-        if subsystem.name == 'kra':
-            self.update_admin_cert(subsystem)
-
         if subsystem.name == 'ocsp':
             subsystem.config['ocsp.signing.defaultSigningAlgorithm'] = \
                 self.mdict['pki_ocsp_signing_signing_algorithm']
-
-            self.update_admin_cert(subsystem)
 
         subsystem.config['%s.audit_signing.defaultSigningAlgorithm' % subsystem.name] = \
             self.mdict['pki_audit_signing_signing_algorithm']

--- a/base/server/upgrade/11.6.0/01-RemoveUnusedParams.py
+++ b/base/server/upgrade/11.6.0/01-RemoveUnusedParams.py
@@ -1,0 +1,28 @@
+# Authors:
+#     Endi S. Dewata <edewata@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import logging
+
+import pki
+
+logger = logging.getLogger(__name__)
+
+
+class RemoveUnusedParams(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Remove unused params'
+
+    def upgrade_subsystem(self, instance, subsystem):
+
+        self.backup(subsystem.cs_conf)
+
+        logger.info('Removing %s.admin.cert', subsystem.name)
+        subsystem.config.pop('%s.admin.cert' % subsystem.name, None)
+
+        subsystem.save()

--- a/docs/changes/v11.6.0/Server-Changes.adoc
+++ b/docs/changes/v11.6.0/Server-Changes.adoc
@@ -1,0 +1,6 @@
+= Server Changes =
+
+== Remove <subsystem>.admin.cert from CS.cfg ==
+
+The `<subsystem>.admin.cert` parameter in `CS.cfg` is no longer used
+so it has been removed.


### PR DESCRIPTION
The `<subsystem>.admin.cert` param was originally used to store the admin cert for standalone subsystems but it's no longer used so it has been removed.

https://github.com/edewata/pki/blob/config/docs/changes/v11.6.0/Server-Changes.adoc
