### PR TITLE
Use gcc option _FORTIFY_SOURCE=3

### DIFF
--- a/cmake/Modules/DefineCompilerFlags.cmake
+++ b/cmake/Modules/DefineCompilerFlags.cmake
@@ -26,11 +26,6 @@ if (UNIX AND NOT WIN32)
         if (WITH_STACK_PROTECTOR)
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-strong")
         endif (WITH_STACK_PROTECTOR)
-
-        check_c_compiler_flag("-D_FORTIFY_SOURCE=2" WITH_FORTIFY_SOURCE)
-        if (WITH_FORTIFY_SOURCE)
-            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FORTIFY_SOURCE=2")
-        endif (WITH_FORTIFY_SOURCE)
     endif (${CMAKE_C_COMPILER_ID} MATCHES GNU)
 
     #

--- a/pki.spec
+++ b/pki.spec
@@ -1041,6 +1041,9 @@ C_FLAGS="$C_FLAGS -D_GLIBCXX_ASSERTIONS"
 
 # https://sourceware.org/annobin/annobin.html/Test-lto.html
 C_FLAGS="$C_FLAGS -fno-lto"
+
+# https://sourceware.org/annobin/annobin.html/Test-fortify.html
+C_FLAGS="$C_FLAGS -D_FORTIFY_SOURCE=3"
 %endif
 
 pkgs=base\


### PR DESCRIPTION
The RPM spec has been updated to use `gcc` option `_FORTIFY_SOURCE=3` since it's now required by `rpminspect`. The code that configures this option in CMake script has been removed to reduce dependency on CMake.

**Note:** For some reason `rpminspect` on `tpsclient` is still failing. That will require a separate investigation.