### PR TITLE
Update pki-server status

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -56,6 +56,15 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
+      - name: Check CA server status
+        run: |
+          docker exec pki pki-server status | tee output
+
+          # CA should be a domain manager
+          echo "True" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Check webapps
         run: |
           docker exec pki pki-server webapp-find | tee output

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -56,6 +56,17 @@ jobs:
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
+      - name: Check primary CA server status
+        run: |
+          docker exec primary pki-server status | tee output
+
+          # primary CA should be a domain manager
+          echo "True" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check primary CA system certs
+        run: |
           docker exec primary pki-server cert-find
 
       - name: Verify users and SD hosts in primary PKI container
@@ -107,6 +118,17 @@ jobs:
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
+      - name: Check secondary CA server status
+        run: |
+          docker exec secondary pki-server status | tee output
+
+          # secondary CA should be a domain manager
+          echo "True" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check secondary CA system certs
+        run: |
           docker exec secondary pki-server cert-find
 
       - name: Check schema in primary DS and secondary DS

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -103,6 +103,16 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
+      - name: Check PKI server status
+        run: |
+          docker exec pki pki-server status | tee output
+
+          # CA should be a domain manager, but KRA should not
+          echo "True" > expected
+          echo "False" >> expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Check security domain config in KRA
         run: |
           # KRA should join security domain in CA

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -56,6 +56,15 @@ jobs:
               -D pki_ds_url=ldap://rootcads.example.com:3389 \
               -v
 
+      - name: Check root CA server status
+        run: |
+          docker exec rootca pki-server status | tee output
+
+          # root CA should be a domain manager
+          echo "True" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Check security domain config in root CA
         run: |
           # root CA should run security domain service
@@ -122,6 +131,16 @@ jobs:
               -D pki_subordinate_security_domain_name=SUBORDINATE \
               -D pki_issuing_ca_uri=https://rootca.example.com:8443 \
               -v
+
+      - name: Check sub CA server status
+        run: |
+          docker exec subca pki-server status | tee output
+
+          # this sub CA should be a domain manager since it's created with
+          # pki_subordinate_create_new_security_domain=True
+          echo "True" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
 
       - name: Check sub CA certs
         if: always()
@@ -218,6 +237,15 @@ jobs:
               -D pki_admin_cert_file=${SHARED}/ca_admin.cert \
               -D pki_ds_url=ldap://krads.example.com:3389 \
               -v
+
+      - name: Check KRA server status
+        run: |
+          docker exec kra pki-server status | tee output
+
+          # KRA should not be a domain manager
+          echo "False" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
 
       - name: Check security domain config in KRA
         run: |

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -186,24 +186,26 @@ jobs:
               -D pki_admin_cert_path=${SHARED}/kra_admin.crt \
               -v
 
+      - name: Check KRA server status
+        run: |
+          docker exec kra pki-server status | tee output
+
+          # standalone KRA should be a domain manager
+          echo "True" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check KRA system certs
+        run: |
           docker exec kra pki-server cert-find
 
       # TODO: Fix DogtagKRAConnectivityCheck to work without CA
       # - name: Run PKI healthcheck
       #   run: docker exec kra pki-healthcheck --failures-only
 
-      - name: Check KRA security domain
-        run: |
-          docker exec kra pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec kra pki securitydomain-show \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
-
-          # standalone KRA should not return security domain info
-          echo "PKIException: Not Found" > expected
-          diff expected stderr
-
       - name: Check KRA admin
         run: |
+          docker exec kra pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
           docker exec kra pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/kra_admin_cert.p12 \
               --pkcs12-password Secret.123
@@ -219,6 +221,30 @@ jobs:
           # standalone KRA should not have CA user
           echo "UserNotFoundException: User CA-ca.example.com-8443 not found" > expected
           diff expected stderr
+
+      - name: Check KRA security domain
+        run: |
+          # security domain should be enabled (i.e. securitydomain.select=new)
+          cat > expected << EOF
+          securitydomain.checkIP=false
+          securitydomain.checkinterval=300000
+          securitydomain.flushinterval=86400000
+          securitydomain.host=kra.example.com
+          securitydomain.httpport=8080
+          securitydomain.httpsadminport=8443
+          securitydomain.name=example.com Security Domain
+          securitydomain.select=new
+          securitydomain.source=ldap
+          EOF
+
+          docker exec kra pki-server kra-config-find | grep ^securitydomain. | sort | tee actual
+          diff expected actual
+
+          # TODO: Fix pki securitydomain-show to work with standalone KRA
+          # docker exec kra pki securitydomain-show \
+          #     > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # standalone KRA should return security domain info
 
       - name: Check KRA connector in CA
         run: |

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -103,6 +103,16 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
+      - name: Check PKI server status
+        run: |
+          docker exec pki pki-server status | tee output
+
+          # CA should be a domain manager, but OCSP should not
+          echo "True" > expected
+          echo "False" >> expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
       - name: Check security domain config in OCSP
         run: |
           # OCSP should join security domain in CA

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -174,24 +174,26 @@ jobs:
               -D pki_admin_cert_path=${SHARED}/ocsp_admin.crt \
               -v
 
+      - name: Check OCSP server status
+        run: |
+          docker exec ocsp pki-server status | tee output
+
+          # standalone OCSP should be a domain manager
+          echo "True" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check OCSP system certs
+        run: |
           docker exec ocsp pki-server cert-find
 
       # TODO: Fix DogtagOCSPConnectivityCheck to work without CA
       # - name: Run PKI healthcheck
       #   run: docker exec ocsp pki-healthcheck --failures-only
 
-      - name: Check OCSP security domain
-        run: |
-          docker exec ocsp pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
-          docker exec ocsp pki securitydomain-show \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
-
-          # standalone OCSP should not return security domain info
-          echo "PKIException: Not Found" > expected
-          diff expected stderr
-
       - name: Check OCSP admin cert
         run: |
+          docker exec ocsp pki client-cert-import ca_signing --ca-cert ${SHARED}/ca_signing.crt
           docker exec ocsp pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
               --pkcs12-password Secret.123
@@ -207,6 +209,30 @@ jobs:
           # standalone OCSP should not have CA user
           echo "UserNotFoundException: User CA-ca.example.com-8443 not found" > expected
           diff expected stderr
+
+      - name: Check OCSP security domain
+        run: |
+          # security domain should be enabled (i.e. securitydomain.select=new)
+          cat > expected << EOF
+          securitydomain.checkIP=false
+          securitydomain.checkinterval=300000
+          securitydomain.flushinterval=86400000
+          securitydomain.host=ocsp.example.com
+          securitydomain.httpport=8080
+          securitydomain.httpsadminport=8443
+          securitydomain.name=example.com Security Domain
+          securitydomain.select=new
+          securitydomain.source=ldap
+          EOF
+
+          docker exec ocsp pki-server ocsp-config-find | grep ^securitydomain. | sort | tee actual
+          diff expected actual
+
+          # TODO: Fix pki securitydomain-show to work with standalone OCSP
+          # docker exec ocsp pki securitydomain-show \
+          #     > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # standalone OCSP should return security domain info
 
       - name: Check OCSP publishing in CA
         run: |

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -56,6 +56,17 @@ jobs:
               -D pki_ds_url=ldap://rootds.example.com:3389 \
               -v
 
+      - name: Check root CA server status
+        run: |
+          docker exec root pki-server status | tee output
+
+          # root CA should be a domain manager
+          echo "True" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check root CA system certs
+        run: |
           docker exec root pki-server cert-find
 
       - name: Install banner in root container
@@ -90,6 +101,19 @@ jobs:
               -D pki_cert_chain_path=${SHARED}/root-ca_signing.crt \
               -D pki_ds_url=ldap://subds.example.com:3389 \
               -v
+
+      - name: Check sub CA server status
+        run: |
+          docker exec subordinate pki-server status | tee output
+
+          # sub CA should not be a domain manager
+          echo "False" > expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check sub CA system certs
+        run: |
+          docker exec subordinate pki-server cert-find
 
       - name: Install banner in subordinate container
         run: docker exec subordinate cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -66,6 +66,20 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
+      - name: Check TKS server status
+        run: |
+          docker exec pki pki-server status | tee output
+
+          # CA should be a domain manager, but TKS should not
+          echo "True" > expected
+          echo "False" >> expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check TKS system certs
+        run: |
+          docker exec pki pki-server cert-find
+
       - name: Check TKS audit signing cert
         run: |
           docker exec pki pki-server cert-export tks_audit_signing \

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -89,6 +89,22 @@ jobs:
               -D pki_enable_server_side_keygen=True \
               -v
 
+      - name: Check TPS server status
+        run: |
+          docker exec pki pki-server status | tee output
+
+          # CA should be a domain manager, but KRA, TKS, TPS should not
+          echo "True" > expected
+          echo "False" >> expected
+          echo "False" >> expected
+          echo "False" >> expected
+          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check TPS system certs
+        run: |
+          docker exec pki pki-server cert-find
+
       - name: Check TPS audit signing cert
         run: |
           docker exec pki pki-server cert-export tps_audit_signing \

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -173,11 +173,8 @@ class PKIServerCLI(pki.cli.CLI):
             print()
             print('  CA Subsystem:')
 
-            subsystem_type = 'CA'
-            if ca.config['securitydomain.select'] == 'new':
-                subsystem_type += ' (Security Domain)'
-            print('    Type:                %s' % subsystem_type)
-
+            domain_manager = ca.config.get('securitydomain.select') == 'new'
+            print('    SD Manager:          %s' % domain_manager)
             print('    SD Name:             %s' % ca.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 ca.config['securitydomain.host'],
@@ -202,11 +199,8 @@ class PKIServerCLI(pki.cli.CLI):
             print()
             print('  KRA Subsystem:')
 
-            subsystem_type = 'KRA'
-            if kra.config['kra.standalone'] == 'true':
-                subsystem_type += ' (Standalone)'
-            print('    Type:                %s' % subsystem_type)
-
+            domain_manager = kra.config.get('securitydomain.select') == 'new'
+            print('    SD Manager:          %s' % domain_manager)
             print('    SD Name:             %s' % kra.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 kra.config['securitydomain.host'],
@@ -227,11 +221,8 @@ class PKIServerCLI(pki.cli.CLI):
             print()
             print('  OCSP Subsystem:')
 
-            subsystem_type = 'OCSP'
-            if ocsp.config['ocsp.standalone'] == 'true':
-                subsystem_type += ' (Standalone)'
-            print('    Type:                %s' % subsystem_type)
-
+            domain_manager = ocsp.config.get('securitydomain.select') == 'new'
+            print('    SD Manager:          %s' % domain_manager)
             print('    SD Name:             %s' % ocsp.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 ocsp.config['securitydomain.host'],
@@ -256,9 +247,8 @@ class PKIServerCLI(pki.cli.CLI):
             print()
             print('  TKS Subsystem:')
 
-            subsystem_type = 'TKS'
-            print('    Type:                %s' % subsystem_type)
-
+            domain_manager = tks.config.get('securitydomain.select') == 'new'
+            print('    SD Manager:          %s' % domain_manager)
             print('    SD Name:             %s' % tks.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 tks.config['securitydomain.host'],
@@ -279,9 +269,8 @@ class PKIServerCLI(pki.cli.CLI):
             print()
             print('  TPS Subsystem:')
 
-            subsystem_type = 'TPS'
-            print('    Type:                %s' % subsystem_type)
-
+            domain_manager = tps.config.get('securitydomain.select') == 'new'
+            print('    SD Manager:          %s' % domain_manager)
             print('    SD Name:             %s' % tps.config['securitydomain.name'])
             url = 'https://%s:%s' % (
                 tps.config['securitydomain.host'],

--- a/docs/changes/v11.6.0/Tools-Changes.adoc
+++ b/docs/changes/v11.6.0/Tools-Changes.adoc
@@ -3,3 +3,11 @@
 == Drop sslget ==
 
 The `sslget` command has been moved from `pki-tools` into `jss-tools`.
+
+== Update pki-server status ==
+
+The `pki-server status` command has been updated to no longer show
+the subsystem `Type` field since it's redundant.
+
+Instead, it will show an `SD Manager` field which will indicate whether
+the subsystem is a security domain manager.


### PR DESCRIPTION
The `pki-server status` command has been modified to no longer show the subsystem `Type` field since it's redundant. Instead, it will show an `SD Manager` field which will indicate whether the subsystem is a security domain manager. Some CI tests have been updated to validate this command.

https://github.com/edewata/pki/blob/ci/docs/changes/v11.6.0/Tools-Changes.adoc
https://github.com/dogtagpki/pki/wiki/PKI-Server-Status-CLI
