### PR TITLE
Drop pki_existing param

### DIFF
--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -272,7 +272,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_existing=True \
               -D pki_hsm_enable=True \
               -D pki_token_name=HSM \
               -D pki_token_password=Secret.HSM \

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -199,7 +199,6 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_existing=True \
               -D pki_admin_cert_path=admin.crt \
               -D pki_admin_csr_path=admin.csr \
               -v

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -315,7 +315,6 @@ pkispawn \
     -D pki_ds_setup=False \
     -D pki_skip_ds_verify=True \
     -D pki_share_db=True \
-    -D pki_existing=True \
     -D pki_import_system_certs=False \
     -D pki_ca_signing_nickname=ca_signing \
     -D pki_ca_signing_csr_path=/certs/ca_signing.csr \

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -149,7 +149,6 @@ pki_use_oaep_rsa_keywrap=False
 pki_token_name=
 pki_token_password=
 pki_user=pkiuser
-pki_existing=False
 
 # DEPRECATED: Use 'pki_cert_chain_path' instead.
 pki_external_ca_cert_chain_path=

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3245,8 +3245,7 @@ class PKIDeployer:
         #
         # A new SSL server cert will always be created separately later.
 
-        external = config.str2bool(self.mdict['pki_external']) or \
-            config.str2bool(self.mdict['pki_existing'])
+        external = config.str2bool(self.mdict['pki_external'])
 
         if subsystem.type == 'CA' and external and cert_info:
 
@@ -3391,7 +3390,6 @@ class PKIDeployer:
         num_subsystems = len(self.instance.get_subsystems())
 
         external = config.str2bool(self.mdict['pki_external']) or \
-            config.str2bool(self.mdict['pki_existing']) or \
             config.str2bool(self.mdict['pki_standalone'])
 
         tags = subsystem.config['%s.cert.list' % subsystem.name].split(',')

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -298,7 +298,6 @@ class ConfigurationFile:
         # include SKI extension in CSR - for external CA
         self.req_ski = self.mdict.get('pki_req_ski')
 
-        self.existing = config.str2bool(self.mdict['pki_existing'])
         self.external = config.str2bool(self.mdict['pki_external'])
         self.external_step_one = not config.str2bool(
             self.mdict['pki_external_step_two'])

--- a/base/server/python/pki/server/deployment/pkiparser.py
+++ b/base/server/python/pki/server/deployment/pkiparser.py
@@ -94,6 +94,8 @@ class PKIConfigParser:
          None, 'pki_ajp_host_ipv4'),
         (None, 'pki_restart_configured_instance',
          None, None),
+        (None, 'pki_existing',
+         None, None),
     ]
 
     DEPRECATED_CA_PARAMS = [

--- a/docs/changes/v11.6.0/Server-Changes.adoc
+++ b/docs/changes/v11.6.0/Server-Changes.adoc
@@ -4,3 +4,8 @@
 
 The `<subsystem>.admin.cert` parameter in `CS.cfg` is no longer used
 so it has been removed.
+
+== Remove pki_existing parameter ==
+
+The `pki_existing` parameter is no longer used by `pkispawn`
+so it has been removed.


### PR DESCRIPTION
The `pki_existing` param is actually redundant and can be removed safely. Remaining references to this param in `pkispawn` have been removed. The `pkiparser.py` has been modified to deprecate this param. The CI tests have been updated to no longer use it.

https://github.com/edewata/pki/blob/config/docs/changes/v11.6.0/Server-Changes.adoc