### PR TITLE
Add test for key archival and retrieval in IPA

### DIFF
--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -109,13 +109,41 @@ jobs:
           grep "(orphan)" output | wc -l > actual
           diff expected actual
 
+      - name: Check CA users
+        run: |
+          docker exec ipa pki-server ca-user-find
+
+          # check CA subsystem user
+          docker exec ipa pki-server ca-user-show CA-ipa.example.com-8443
+          docker exec ipa pki-server ca-user-cert-find CA-ipa.example.com-8443
+          docker exec ipa pki-server ca-user-role-find CA-ipa.example.com-8443
+
+          # check CA admin user
+          docker exec ipa pki-server ca-user-show admin
+          docker exec ipa pki-server ca-user-cert-find admin
+          docker exec ipa pki-server ca-user-role-find admin
+
+          # check PKI database user
+          docker exec ipa pki-server ca-user-show pkidbuser
+          docker exec ipa pki-server ca-user-cert-find pkidbuser
+          docker exec ipa pki-server ca-user-role-find pkidbuser
+
+          # check IPA RA user
+          docker exec ipa pki-server ca-user-show ipara
+          docker exec ipa pki-server ca-user-cert-find ipara
+          docker exec ipa pki-server ca-user-role-find ipara
+
+          # check ACME subsystem user
+          docker exec ipa pki-server ca-user-show acme-ipa.example.com
+          docker exec ipa pki-server ca-user-cert-find acme-ipa.example.com
+          docker exec ipa pki-server ca-user-role-find acme-ipa.example.com
+
       - name: Check CA admin cert
         run: |
           docker exec ipa ls -la /root/.dogtag/pki-tomcat
           docker exec ipa openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
-      - name: "Check CA admin PKCS #12 file"
-        run: |
+          # import CA admin cert and key into the client's NSS database
           docker exec ipa pki client-cert-import --ca-cert ca_signing.crt ca_signing
           docker exec ipa pki pkcs12-import \
               --pkcs12 /root/ca-agent.p12 \
@@ -123,11 +151,8 @@ jobs:
           docker exec ipa pki nss-cert-find
           docker exec ipa pki nss-cert-show ipa-ca-agent
 
-      - name: Check CA admin user
-        run: |
+          # CA admin should be able to access PKI users
           docker exec ipa pki -n ipa-ca-agent ca-user-find
-          docker exec ipa pki -n ipa-ca-agent ca-user-show admin
-          docker exec ipa pki -n ipa-ca-agent ca-user-membership-find admin
 
       - name: Check RA agent cert
         run: |
@@ -148,10 +173,8 @@ jobs:
           docker exec ipa pki nss-cert-find
           docker exec ipa pki nss-cert-show ipa-ra-agent
 
-      - name: Check RA agent user
-        run: |
-          docker exec ipa pki -n ipa-ca-agent ca-user-show ipara
-          docker exec ipa pki -n ipa-ca-agent ca-user-membership-find ipara
+          # RA agent should be able to access cert requests
+          docker exec ipa pki -n ipa-ra-agent ca-cert-request-find
 
       - name: Check HTTPD certs
         run: |
@@ -162,6 +185,45 @@ jobs:
         run: |
           docker exec ipa ipa-kra-install -p Secret.123
           docker exec ipa pki-server ca-config-find | grep ca.connector.KRA
+
+      - name: Check PKI certs and keys
+        run: |
+          # check certs
+          docker exec ipa pki-server cert-find
+
+          # check keys
+          docker exec ipa certutil -K \
+              -d /etc/pki/pki-tomcat/alias \
+              -f /etc/pki/pki-tomcat/alias/pwdfile.txt | tee output
+
+          # there should be no orphaned keys
+          echo "0" > expected
+          grep "(orphan)" output | wc -l > actual
+          diff expected actual
+
+      - name: Check KRA users
+        run: |
+          docker exec ipa pki-server kra-user-find
+
+          # check KRA admin user
+          docker exec ipa pki-server kra-user-show admin
+          docker exec ipa pki-server kra-user-cert-find admin
+          docker exec ipa pki-server kra-user-role-find admin
+
+          # check KRA subsystem user
+          docker exec ipa pki-server kra-user-show CA-ipa.example.com-443
+          docker exec ipa pki-server kra-user-cert-find CA-ipa.example.com-443
+          docker exec ipa pki-server kra-user-role-find CA-ipa.example.com-443
+
+          # check IPA KRA user
+          docker exec ipa pki-server kra-user-show ipakra
+          docker exec ipa pki-server kra-user-cert-find ipakra
+          docker exec ipa pki-server kra-user-role-find ipakra
+
+      - name: Check RA agent cert
+        run: |
+          # RA agent should be able to access key requests
+          docker exec ipa pki -n ipa-ra-agent kra-key-request-find
 
       - name: Check webapps
         run: |
@@ -234,6 +296,65 @@ jobs:
           docker exec ipa ipa-run-tests -x --verbose \
               test_xmlrpc/test_vault_plugin.py
 
+      - name: Check key archival and retrieval
+        run: |
+          # create a vault
+          docker exec ipa ipa vault-add \
+              --type symmetric \
+              --password Secret.123 \
+              testvault
+
+          # there should be 1 active key record initially
+          echo "active" > expected
+          docker exec ipa pki \
+              -n ipa-ra-agent \
+              kra-key-find \
+              --clientKeyID ipa:/users/admin/testvault | tee output
+          sed -n 's/^\s*Status:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          # retrieve the vault content
+          docker exec ipa ipa vault-retrieve \
+              --password Secret.123 \
+              --out $SHARED/output \
+              testvault
+
+          # the vault should be empty initially
+          diff /dev/null output
+
+          # generate a private key
+          docker exec ipa openssl genrsa -out $SHARED/private.key 2048
+          docker exec ipa chmod go+r $SHARED/private.key
+          cat private.key
+
+          # archive the private key into the vault
+          docker exec ipa ipa vault-archive \
+              --password Secret.123 \
+              --in $SHARED/private.key \
+              testvault
+
+          # the initial key record should be inactive and the new one should be active
+          echo "inactive" > expected
+          echo "active" >> expected
+          docker exec ipa pki \
+              -n ipa-ra-agent \
+              kra-key-find \
+              --clientKeyID ipa:/users/admin/testvault | tee output
+          sed -n 's/^\s*Status:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          # retrieve the vault content
+          docker exec ipa ipa vault-retrieve \
+              --password Secret.123 \
+              --out $SHARED/output \
+              testvault
+
+          # the original private key should be identical to the archived one
+          diff private.key output
+
+      - name: Remove IPA server
+        run: docker exec ipa ipa-server-install --uninstall -U
+
       - name: Check IPA CA install log
         if: always()
         run: |
@@ -243,6 +364,9 @@ jobs:
         if: always()
         run: |
           docker exec ipa cat /var/log/ipaserver-kra-install.log
+
+      - name: Remove IPA server
+        run: docker exec ipa ipa-server-install --uninstall -U
 
       - name: Check PKI server systemd journal
         if: always()
@@ -254,6 +378,11 @@ jobs:
         run: |
           docker exec ipa find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
 
+      - name: Check KRA debug log
+        if: always()
+        run: |
+          docker exec ipa find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+
       - name: Gather artifacts
         if: always()
         run: |
@@ -261,9 +390,6 @@ jobs:
           tests/bin/pki-artifacts-save.sh ipa
           tests/bin/ipa-artifacts-save.sh ipa
         continue-on-error: true
-
-      - name: Remove IPA server
-        run: docker exec ipa ipa-server-install --uninstall -U
 
       - name: Upload artifacts
         if: always()


### PR DESCRIPTION
The basic IPA test has been modified to create a vault, verify that it is empty initially, archive a private key, retrieve the private key, and verify the archived key.