### PR TITLE
Convert CertStatusUpdate from VLV to paged search

### DIFF
--- a/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
@@ -765,10 +765,10 @@ public class CertificateRepository extends Repository {
         }
     }
 
-    public void updateStatus(Vector<CertId> list, String status) throws EBaseException {
+    public void updateStatus(ArrayList<CertId> list, String status) throws EBaseException {
 
         for (int i = 0; i < list.size(); i++) {
-            CertId certID = list.elementAt(i);
+            CertId certID = list.get(i);
             updateStatus(certID, status);
         }
     }
@@ -1877,97 +1877,97 @@ public class CertificateRepository extends Repository {
     }
 
     /**
-     * Gets Invalid certs orderes by noAfter date, jumps to records
-     * where notAfter date is greater than current.
+     * Gets Invalid certs by notBefore date
+     *
+     * The certificate are still invalid but the notBefore date has been reached.
      *
      * @param date reference date
-     * @param pageSize page size
      * @return a list of certificate records
      * @exception EBaseException failed to retrieve
      */
-    public CertRecordList getInvalidCertsByNotBeforeDate(Date date, int pageSize)
+    public RecordPagedList<CertRecord> getInvalidCertsByNotBeforeDate(Date date)
             throws EBaseException {
 
-        CertRecordList list = null;
+        RecordPagedList<CertRecord>  list = null;
 
-        String ldapfilter = "(" + CertRecord.ATTR_CERT_STATUS + "=" + CertRecord.STATUS_INVALID + ")";
-
+        StringBuilder ldapfilter = new StringBuilder();
+        ldapfilter.append("(&");
+        ldapfilter.append("(").append(CertRecord.ATTR_CERT_STATUS).append("=").append(CertRecord.STATUS_INVALID).append(")");
+        ldapfilter.append("(").append(CertificateValidity.NOT_BEFORE).append("<=").append(DateMapper.dateToDB(date)).append(")");
+        ldapfilter.append(")");
         String[] attrs = null;
 
-        if (mConsistencyCheck == false) {
+        if (!mConsistencyCheck) {
             attrs = new String[] { "objectclass", CertRecord.ATTR_ID, CertRecord.ATTR_X509CERT };
         }
 
-        logger.debug("getInvalidCertificatesByNotBeforeDate filter " + ldapfilter);
+        logger.debug("getInvalidCertificatesByNotBeforeDate filter {}", ldapfilter);
 
         logger.debug("getInvalidCertificatesByNotBeforeDate: about to call findCertRecordsInList");
 
-        list = findCertRecordsInListRawJumpto(ldapfilter, attrs,
-                    DateMapper.dateToDB(date), "notBefore", pageSize);
-
-
+        list = findPagedCertRecords(ldapfilter.toString(), attrs, null);
         return list;
 
     }
 
     /**
-     * Gets valid certs orderes by noAfter date, jumps to records
-     * where notAfter date is greater than current.
+     * Gets valid certs orderes where notAfter date has been reached.
      *
      * @param date reference date
-     * @param pageSize page size
      * @return a list of certificate records
      * @exception EBaseException failed to retrieve
      */
-    public CertRecordList getValidCertsByNotAfterDate(Date date, int pageSize)
+    public RecordPagedList<CertRecord> getValidCertsByNotAfterDate(Date date)
             throws EBaseException {
 
-        CertRecordList list = null;
-
-        String ldapfilter = "(" + CertRecord.ATTR_CERT_STATUS + "=" + CertRecord.STATUS_VALID + ")";
+        RecordPagedList<CertRecord>  list = null;
+        StringBuilder ldapfilter = new StringBuilder();
+        ldapfilter.append("(&");
+        ldapfilter.append("(").append(CertRecord.ATTR_CERT_STATUS).append("=").append(CertRecord.STATUS_VALID).append(")");
+        ldapfilter.append("(").append(CertificateValidity.NOT_AFTER).append("<=").append(DateMapper.dateToDB(date)).append(")");
+        ldapfilter.append(")");
 
         String[] attrs = null;
 
-        if (mConsistencyCheck == false) {
+        if (!mConsistencyCheck) {
             attrs = new String[] { "objectclass", CertRecord.ATTR_ID, CertRecord.ATTR_X509CERT };
         }
 
-        logger.debug("getValidCertsByNotAfterDate filter " + ldapfilter);
+        logger.debug("getValidCertsByNotAfterDate filter {}", ldapfilter);
 
-        list = findCertRecordsInListRawJumpto(ldapfilter, attrs, DateMapper.dateToDB(date), "notAfter", pageSize);
+        list = findPagedCertRecords(ldapfilter.toString(), attrs, null);
 
         return list;
     }
 
     /**
-     * Gets Revoked certs orderes by noAfter date, jumps to records
-     * where notAfter date is greater than current.
+     * Gets Revoked certs orderes by noAfter date has been reached.
      *
      * @param date reference date
-     * @param pageSize page size
      * @return a list of certificate records
      * @exception EBaseException failed to retrieve
      */
-    public CertRecordList getRevokedCertsByNotAfterDate(Date date, int pageSize)
+    public RecordPagedList<CertRecord> getRevokedCertsByNotAfterDate(Date date)
             throws EBaseException {
 
-        CertRecordList list = null;
-
-        String ldapfilter = "(" + CertRecord.ATTR_CERT_STATUS + "=" + CertRecord.STATUS_REVOKED + ")";
+        RecordPagedList<CertRecord> list = null;
+        StringBuilder ldapfilter = new StringBuilder();
+        ldapfilter.append("(&");
+        ldapfilter.append("(").append(CertRecord.ATTR_CERT_STATUS).append("=").append(CertRecord.STATUS_REVOKED).append(")");
+        ldapfilter.append("(").append(CertificateValidity.NOT_AFTER).append("<=").append(DateMapper.dateToDB(date)).append(")");
+        ldapfilter.append(")");
 
         String[] attrs = null;
 
-        if (mConsistencyCheck == false) {
+        if (!mConsistencyCheck) {
             attrs = new String[] { "objectclass", CertRecord.ATTR_REVOKED_ON, CertRecord.ATTR_ID,
                         CertRecord.ATTR_REVO_INFO, CertificateValidity.NOT_AFTER, CertRecord.ATTR_X509CERT };
         }
 
-        logger.debug("getRevokedCertificatesByNotAfterDate filter " + ldapfilter);
+        logger.debug("getRevokedCertificatesByNotAfterDate filter {}", ldapfilter);
 
         logger.debug("getRevokedCertificatesByNotAfterDate: about to call findCertRecordsInList");
-
-        list = findCertRecordsInListRawJumpto(ldapfilter, attrs,
-                    DateMapper.dateToDB(date), "notafter", pageSize);
+        list = findPagedCertRecords(ldapfilter.toString(), attrs, null);
 
         return list;
 

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
@@ -35,7 +35,7 @@ import com.netscape.certsrv.base.SessionContext;
  */
 public final class CMS {
 
-    public static Logger logger = LoggerFactory.getLogger(CMS.class);
+    public static final Logger logger = LoggerFactory.getLogger(CMS.class);
 
     // product name is provided by the server theme package
     private static final String PRODUCT_NAME_FILE = "/usr/share/pki/CS_SERVER_VERSION";
@@ -146,12 +146,12 @@ public final class CMS {
 
         MessageFormat mf = new MessageFormat(msg);
 
-        Object escapedParams[] = new Object[params.length];
+        Object[] escapedParams = new Object[params.length];
         for (int i = 0; i < params.length; i++) {
             Object param = params[i];
 
-            if (param instanceof String) {
-                escapedParams[i] = escapeLogMessageParam((String) param);
+            if (param instanceof String p) {
+                escapedParams[i] = escapeLogMessageParam(p);
             } else {
                 escapedParams[i] = param;
             }
@@ -166,7 +166,7 @@ public final class CMS {
         if (s == null)
             return null;
         if (s.contains("{") || s.contains("}"))
-            return "'" + s.replaceAll("'", "''") + "'";
+            return "'" + s.replace("'", "''") + "'";
         return s;
     }
 


### PR DESCRIPTION
Note: the VLV update was done on ordered elements. With the paged search elements are not ordered to avoid extra work since the order it is not relevant for the update.