### PR TITLE
Update tests to use standard conf dir

### DIFF
--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -85,7 +85,7 @@ jobs:
           docker exec pki pki-server acme-realm-mod \
               --type ds \
               -D url=ldap://ds.example.com:3389
-          docker exec pki bash -c "echo baseURL=http://server1.example.com:8080/acme >> /etc/pki/pki-tomcat/acme/engine.conf"
+          docker exec pki bash -c "echo baseURL=http://server1.example.com:8080/acme >> /var/lib/pki/pki-tomcat/conf/acme/engine.conf"
           docker exec pki pki-server acme-deploy --wait
 
       - name: Set up client container
@@ -132,7 +132,7 @@ jobs:
         run: |
           docker exec pki pki-server acme-undeploy --wait
           docker network disconnect example pki
-          docker exec pki sed -i "s/server1.example.com/server2.example.com/g" /etc/pki/pki-tomcat/acme/engine.conf
+          docker exec pki sed -i "s/server1.example.com/server2.example.com/g" /var/lib/pki/pki-tomcat/conf/acme/engine.conf
           docker network connect example pki --alias pki.example.com --alias server2.example.com
           docker exec pki pki-server acme-deploy --wait
 

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -105,7 +105,7 @@ jobs:
           echo "Secret.123" > password.txt
           docker cp password.txt pki:password.txt
           docker exec pki certutil -K \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -f password.txt | tee output
 
           # there should be no orphaned keys
@@ -118,7 +118,7 @@ jobs:
           docker exec pki pki-server cert-export ca_signing \
               --cert-file ca_signing.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/ca_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_signing.csr
 
           # check CA signing cert extensions
           docker exec pki /usr/share/pki/tests/ca/bin/test-ca-signing-cert-ext.sh
@@ -128,7 +128,7 @@ jobs:
           docker exec pki pki-server cert-export ca_ocsp_signing \
               --cert-file ca_ocsp_signing.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/ca_ocsp_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr
           docker exec pki openssl x509 -text -noout -in ca_ocsp_signing.crt
 
       - name: Check CA audit signing cert
@@ -136,7 +136,7 @@ jobs:
           docker exec pki pki-server cert-export ca_audit_signing \
               --cert-file ca_audit_signing.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/ca_audit_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr
           docker exec pki openssl x509 -text -noout -in ca_audit_signing.crt
 
       - name: Check subsystem cert
@@ -144,7 +144,7 @@ jobs:
           docker exec pki pki-server cert-export subsystem \
               --cert-file subsystem.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/subsystem.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr
           docker exec pki openssl x509 -text -noout -in subsystem.crt
 
       - name: Check SSL server cert
@@ -152,7 +152,7 @@ jobs:
           docker exec pki pki-server cert-export sslserver \
               --cert-file sslserver.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/sslserver.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
       - name: Check CA admin cert

--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -92,7 +92,7 @@ jobs:
           # there should be 5 certs
           echo "5" > expected
           docker exec primary pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -102,8 +102,8 @@ jobs:
           # there should be 4 certs
           echo "4" > expected
           docker exec primary pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -154,7 +154,7 @@ jobs:
       - name: Install CA in secondary PKI container
         run: |
           # get CS.cfg from primary CA before cloning
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary
 
           docker exec primary pki-server cert-export ca_signing \
               --cert-file ${SHARED}/ca_signing.crt
@@ -181,7 +181,7 @@ jobs:
           # TODO: investigate the discrepancy
           echo "3" > expected
           docker exec secondary pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -191,8 +191,8 @@ jobs:
           # there should be 4 certs
           echo "4" > expected
           docker exec secondary pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -201,7 +201,7 @@ jobs:
       - name: Check CS.cfg in primary CA after cloning
         run: |
           # get CS.cfg from primary CA after cloning
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -228,7 +228,7 @@ jobs:
       - name: Check CS.cfg in secondary CA
         run: |
           # get CS.cfg from secondary CA
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -350,7 +350,7 @@ jobs:
           # TODO: investigate the discrepancy
           echo "3" > expected
           docker exec tertiary pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -360,8 +360,8 @@ jobs:
           # there should be 4 certs
           echo "4" > expected
           docker exec tertiary pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -370,7 +370,7 @@ jobs:
       - name: Check CS.cfg in secondary CA after cloning
         run: |
           # get CS.cfg from secondary CA after cloning
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary.after
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -395,7 +395,7 @@ jobs:
       - name: Check CS.cfg in tertiary CA
         run: |
           # get CS.cfg from tertiary CA
-          docker cp tertiary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.tertiary
+          docker cp tertiary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.tertiary
 
           # normalize expected result:
           # - remove params that cannot be compared

--- a/.github/workflows/ca-clone-replicated-ds-test.yml
+++ b/.github/workflows/ca-clone-replicated-ds-test.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Import system certs and keys into secondary CA
         run: |
           docker exec secondary pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               pkcs12-import \
               --pkcs12 $SHARED/ca-certs.p12 \
               --password Secret.123
@@ -339,7 +339,7 @@ jobs:
       - name: Install secondary CA
         run: |
           # get CS.cfg from primary CA before cloning
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary
 
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
@@ -375,14 +375,14 @@ jobs:
       - name: Check CS.cfg in primary CA after cloning
         run: |
           # get CS.cfg from primary CA after cloning
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.after
 
           diff CS.cfg.primary CS.cfg.primary.after
 
       - name: Check CS.cfg in secondary CA
         run: |
           # get CS.cfg from secondary CA
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary
 
           # normalize expected result:
           # - remove params that cannot be compared

--- a/.github/workflows/ca-clone-shared-ds-test.yml
+++ b/.github/workflows/ca-clone-shared-ds-test.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install secondary CA
         run: |
           # get CS.cfg from primary CA before cloning
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary
 
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
@@ -115,7 +115,7 @@ jobs:
       - name: Check CS.cfg in primary CA after cloning
         run: |
           # get CS.cfg from primary CA after cloning
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -140,7 +140,7 @@ jobs:
       - name: Check CS.cfg in secondary CA
         run: |
           # get CS.cfg from secondary CA
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary
 
           # normalize expected result:
           # - remove params that cannot be compared

--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install CA in secondary PKI container
         run: |
           # get CS.cfg from primary CA before cloning
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary
 
           docker exec primary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
           docker exec secondary pkispawn \
@@ -239,7 +239,7 @@ jobs:
       - name: Check CS.cfg in primary CA after cloning
         run: |
           # get CS.cfg from primary CA after cloning
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.after
 
           docker exec primary pki-server ca-config-find | grep ca.crl.MasterCRL
 
@@ -268,7 +268,7 @@ jobs:
       - name: Check CS.cfg in secondary CA
         run: |
           # get CS.cfg from secondary CA
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary
 
           docker exec secondary pki-server ca-config-find | grep ca.crl.MasterCRL
 
@@ -386,7 +386,7 @@ jobs:
       - name: Check CS.cfg in secondary CA after cloning
         run: |
           # get CS.cfg from secondary CA after cloning
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary.after
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary.after
 
           docker exec secondary pki-server ca-config-find | grep ca.crl.MasterCRL
 
@@ -413,7 +413,7 @@ jobs:
       - name: Check CS.cfg in tertiary CA
         run: |
           # get CS.cfg from tertiary CA
-          docker cp tertiary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.tertiary
+          docker cp tertiary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.tertiary
 
           docker exec tertiary pki-server ca-config-find | grep ca.crl.MasterCRL
 

--- a/.github/workflows/ca-cmc-shared-token-test.yml
+++ b/.github/workflows/ca-cmc-shared-token-test.yml
@@ -72,8 +72,8 @@ jobs:
         run: |
           # generate cert request
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-request \
               --subject "CN=CA Issuance Protection" \
               --csr ca_issuance_protection.csr
@@ -91,7 +91,7 @@ jobs:
 
           # convert CMC response (DER PKCS #7) into PEM PKCS #7 cert chain
           docker exec pki CMCResponse \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -i ca_issuance_protection.cmc-response \
               -o ca_issuance_protection.p7b | tee output
 
@@ -106,16 +106,16 @@ jobs:
 
           # import cert chain
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               pkcs7-import \
               --pkcs7 ca_issuance_protection.p7b \
               ca_issuance_protection
 
           # check imported cert chain
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find
 
           # configure issuance protection nickname
@@ -177,7 +177,7 @@ jobs:
         run: |
           # generate shared token
           docker exec pki CMCSharedToken \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -p Secret.123 \
               -n ca_issuance_protection \
               -s Secret.123 \

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -739,7 +739,10 @@ jobs:
           docker exec ca ls -la /etc/pki
           mkdir -p /tmp/artifacts/ca/etc/pki
           docker cp ca:/etc/pki/pki.conf /tmp/artifacts/ca/etc/pki
-          docker cp ca:/etc/pki/pki-tomcat /tmp/artifacts/ca/etc/pki
+
+          docker exec ca ls -la /var/lib/pki/pki-tomcat/conf/
+          mkdir -p /tmp/artifacts/ca/var/lib/pki/pki-tomcat/conf
+          docker cp ca:/var/lib/pki/pki-tomcat/conf/. /tmp/artifacts/ca/var/lib/pki/pki-tomcat/conf
 
           docker exec ca ls -la /var/log/pki
           mkdir -p /tmp/artifacts/ca/var/log

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -68,10 +68,10 @@ jobs:
           docker exec pki sed -i \
               -e "s/^$VALIDITY_DEFAULT.range=.*$/$VALIDITY_DEFAULT.range=1/" \
               -e "/^$VALIDITY_DEFAULT.range=.*$/a $VALIDITY_DEFAULT.rangeUnit=minute" \
-              /etc/pki/pki-tomcat/ca/profiles/ca/caUserCert.cfg
+              /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caUserCert.cfg
 
           # check updated profile
-          docker exec pki cat /etc/pki/pki-tomcat/ca/profiles/ca/caUserCert.cfg
+          docker exec pki cat /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caUserCert.cfg
 
       - name: Configure CRL
         run: |

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           # all keys should be "ec"
           echo Secret.123 > password.txt
-          docker exec pki certutil -K -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt | tee output
+          docker exec pki certutil -K -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt | tee output
           echo "ec" > expected
 
           grep ca_signing output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
@@ -82,7 +82,7 @@ jobs:
       - name: Check CA signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_signing | tee output
 
           # signing algorithm should be "X9.62 ECDSA signature with SHA384"
           echo "X9.62 ECDSA signature with SHA384" > expected
@@ -106,7 +106,7 @@ jobs:
       - name: Check CA OCSP signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
 
           # signing algorithm should be "X9.62 ECDSA signature with SHA512"
           echo "X9.62 ECDSA signature with SHA512" > expected
@@ -130,7 +130,7 @@ jobs:
       - name: Check CA audit signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
 
           # signing algorithm should be "X9.62 ECDSA signature with SHA512"
           echo "X9.62 ECDSA signature with SHA512" > expected
@@ -154,7 +154,7 @@ jobs:
       - name: Check subsystem cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n subsystem | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n subsystem | tee output
 
           # signing algorithm should be "X9.62 ECDSA signature with SHA512"
           echo "X9.62 ECDSA signature with SHA512" > expected
@@ -179,7 +179,7 @@ jobs:
       - name: Check SSL server cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n sslserver | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n sslserver | tee output
 
           # signing algorithm should be "X9.62 ECDSA signature with SHA512"
           echo "X9.62 ECDSA signature with SHA512" > expected

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -259,8 +259,8 @@ jobs:
       - name: Check CA signing cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               ca_signing | tee ca_signing.crt.after
 
@@ -268,8 +268,8 @@ jobs:
           diff ca_signing.crt.before ca_signing.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname ca_signing | tee ca_signing.key.after
 
@@ -279,8 +279,8 @@ jobs:
       - name: Check CA OCSP signing cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               ca_ocsp_signing | tee ca_ocsp_signing.crt.after
 
@@ -288,8 +288,8 @@ jobs:
           diff ca_ocsp_signing.crt.before ca_ocsp_signing.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname ca_ocsp_signing | tee ca_ocsp_signing.key.after
 
@@ -299,8 +299,8 @@ jobs:
       - name: Check CA audit signing cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               ca_audit_signing | tee ca_audit_signing.crt.after
 
@@ -308,8 +308,8 @@ jobs:
           diff ca_audit_signing.crt.before ca_audit_signing.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname ca_audit_signing | tee ca_audit_signing.key.after
 
@@ -319,8 +319,8 @@ jobs:
       - name: Check subsystem cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               subsystem | tee subsystem.crt.after
 
@@ -328,8 +328,8 @@ jobs:
           diff subsystem.crt.before subsystem.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname subsystem | tee subsystem.key.after
 
@@ -339,8 +339,8 @@ jobs:
       - name: Check SSL server cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.after
 
@@ -348,8 +348,8 @@ jobs:
           diff sslserver.crt.before sslserver.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.after
 

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -113,7 +113,7 @@ jobs:
               --ext /usr/share/pki/server/certs/admin.conf \
               --csr admin.csr
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr admin.csr \
@@ -199,60 +199,60 @@ jobs:
       - name: Import CA signing cert into CA database
         run: |
           docker exec pki pki-server ca-cert-request-import \
-              --csr /etc/pki/pki-tomcat/certs/ca_signing.csr \
+              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_signing.csr \
               --profile /usr/share/pki/ca/conf/caCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec pki pki-server ca-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
+              --cert /var/lib/pki/pki-tomcat/conf/certs/ca_signing.crt \
               --profile /usr/share/pki/ca/conf/caCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA OCSP signing cert into CA database
         run: |
           docker exec pki pki-server ca-cert-request-import \
-              --csr /etc/pki/pki-tomcat/certs/ca_ocsp_signing.csr \
+              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec pki pki-server ca-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_ocsp_signing.crt \
+              --cert /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.crt \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA audit signing cert into CA database
         run: |
           docker exec pki pki-server ca-cert-request-import \
-              --csr /etc/pki/pki-tomcat/certs/ca_audit_signing.csr \
+              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr \
               --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec pki pki-server ca-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/ca_audit_signing.crt \
+              --cert /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.crt \
               --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
               --request $REQUEST_ID
 
       - name: Import subsystem cert into CA database
         run: |
           docker exec pki pki-server ca-cert-request-import \
-              --csr /etc/pki/pki-tomcat/certs/subsystem.csr \
+              --csr /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr \
               --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec pki pki-server ca-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/subsystem.crt \
+              --cert /var/lib/pki/pki-tomcat/conf/certs/subsystem.crt \
               --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
               --request $REQUEST_ID
 
       - name: Import SSL server cert into CA database
         run: |
           docker exec pki pki-server ca-cert-request-import \
-              --csr /etc/pki/pki-tomcat/certs/sslserver.csr \
+              --csr /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec pki pki-server ca-cert-import \
-              --cert /etc/pki/pki-tomcat/certs/sslserver.crt \
+              --cert /var/lib/pki/pki-tomcat/conf/certs/sslserver.crt \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
               --request $REQUEST_ID
 
@@ -279,7 +279,7 @@ jobs:
       - name: Assign subsystem cert to database user
         run: |
           docker exec pki pki-server ca-user-cert-add \
-              --cert /etc/pki/pki-tomcat/certs/subsystem.crt \
+              --cert /var/lib/pki/pki-tomcat/conf/certs/subsystem.crt \
               pkidbuser
 
       - name: Assign roles to database user
@@ -331,7 +331,7 @@ jobs:
       - name: Assign subsystem cert to subsystem user
         run: |
           docker exec pki pki-server ca-user-cert-add \
-              --cert /etc/pki/pki-tomcat/certs/subsystem.crt \
+              --cert /var/lib/pki/pki-tomcat/conf/certs/subsystem.crt \
               CA-pki.example.com-8443
 
       - name: Assign roles to subsystem user

--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -71,7 +71,7 @@ jobs:
           docker exec pki pki-server nss-create --no-password
 
           docker exec pki pki-server password-add "hardware-HSM" --password "Secret.HSM"
-          docker exec pki cat /etc/pki/pki-tomcat/password.conf
+          docker exec pki cat /var/lib/pki/pki-tomcat/conf/password.conf
 
       - name: Create CA signing cert
         run: |
@@ -91,8 +91,8 @@ jobs:
           # check original cert
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_signing | tee ca_signing.crt.before
@@ -100,8 +100,8 @@ jobs:
           # check original key
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:ca_signing | tee ca_signing.key.before
@@ -125,8 +125,8 @@ jobs:
           # check original cert
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_ocsp_signing | tee ca_ocsp_signing.crt.before
@@ -134,8 +134,8 @@ jobs:
           # check original key
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:ca_ocsp_signing | tee ca_ocsp_signing.key.before
@@ -159,8 +159,8 @@ jobs:
           # check original cert
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_audit_signing | tee ca_audit_signing.crt.before
@@ -168,8 +168,8 @@ jobs:
           # check original key
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:ca_audit_signing | tee ca_audit_signing.key.before
@@ -193,8 +193,8 @@ jobs:
           # check original cert
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:subsystem | tee subsystem.crt.before
@@ -202,8 +202,8 @@ jobs:
           # check original key
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:subsystem | tee subsystem.key.before
@@ -224,16 +224,16 @@ jobs:
           # check original cert
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.before
 
           # check original key
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.before
 
@@ -246,8 +246,8 @@ jobs:
               --csr /tmp/admin.csr
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-issue \
               --issuer HSM:ca_signing \
@@ -291,8 +291,8 @@ jobs:
         run: |
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_signing | tee ca_signing.crt.after
@@ -302,8 +302,8 @@ jobs:
 
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:ca_signing | tee ca_signing.key.after
@@ -315,8 +315,8 @@ jobs:
         run: |
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_ocsp_signing | tee ca_ocsp_signing.crt.after
@@ -326,8 +326,8 @@ jobs:
 
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:ca_ocsp_signing | tee ca_ocsp_signing.key.after
@@ -339,8 +339,8 @@ jobs:
         run: |
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_audit_signing | tee ca_audit_signing.crt.after
@@ -350,8 +350,8 @@ jobs:
 
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:ca_audit_signing | tee ca_audit_signing.key.after
@@ -363,8 +363,8 @@ jobs:
         run: |
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:subsystem | tee subsystem.cert.actual
@@ -374,8 +374,8 @@ jobs:
 
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:subsystem | tee subsystem.key.after
@@ -387,8 +387,8 @@ jobs:
         run: |
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.after
 
@@ -397,8 +397,8 @@ jobs:
 
           docker exec pki runuser -u pkiuser -- \
               pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.after
 
@@ -408,7 +408,7 @@ jobs:
       - name: Check CA admin cert
         run: |
           docker exec pki pki client-cert-import \
-              --ca-cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
+              --ca-cert /var/lib/pki/pki-tomcat/conf/certs/ca_signing.crt \
               ca_signing
           docker exec pki pki -n caadmin ca-user-show caadmin
 

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -65,13 +65,13 @@ jobs:
 
           # check original cert
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_signing | tee ca_signing.crt.before
 
           # check original key
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname ca_signing | tee ca_signing.key.before
 
@@ -89,13 +89,13 @@ jobs:
 
           # check original cert
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_ocsp_signing | tee ca_ocsp_signing.crt.before
 
           # check original key
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname ca_ocsp_signing | tee ca_ocsp_signing.key.before
 
@@ -113,13 +113,13 @@ jobs:
 
           # check original cert
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_audit_signing | tee ca_audit_signing.crt.before
 
           # check original key
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname ca_audit_signing | tee ca_audit_signing.key.before
 
@@ -137,13 +137,13 @@ jobs:
 
           # check original cert
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               subsystem | tee subsystem.crt.before
 
           # check original key
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname subsystem | tee subsystem.key.before
 
@@ -161,13 +161,13 @@ jobs:
 
           # check original cert
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               sslserver | tee sslserver.crt.before
 
           # check original key
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.before
 
@@ -179,7 +179,7 @@ jobs:
               --ext /usr/share/pki/server/certs/admin.conf \
               --csr admin.csr
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr admin.csr \
@@ -209,7 +209,7 @@ jobs:
       - name: Check CA signing cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_signing | tee ca_signing.crt.after
 
@@ -217,7 +217,7 @@ jobs:
           diff ca_signing.crt.before ca_signing.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname ca_signing | tee ca_signing.key.after
 
@@ -227,7 +227,7 @@ jobs:
       - name: Check CA OCSP signing cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_ocsp_signing | tee ca_ocsp_signing.crt.after
 
@@ -235,7 +235,7 @@ jobs:
           diff ca_ocsp_signing.crt.before ca_ocsp_signing.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname ca_ocsp_signing | tee ca_ocsp_signing.key.after
 
@@ -245,7 +245,7 @@ jobs:
       - name: Check CA audit signing cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_audit_signing | tee ca_audit_signing.crt.after
 
@@ -253,7 +253,7 @@ jobs:
           diff ca_audit_signing.crt.before ca_audit_signing.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname ca_audit_signing | tee ca_audit_signing.key.after
 
@@ -263,7 +263,7 @@ jobs:
       - name: Check subsystem cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               subsystem | tee subsystem.crt.after
 
@@ -271,7 +271,7 @@ jobs:
           diff subsystem.crt.before subsystem.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname subsystem | tee subsystem.key.after
 
@@ -281,7 +281,7 @@ jobs:
       - name: Check SSL server cert
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               sslserver | tee sslserver.crt.after
 
@@ -289,7 +289,7 @@ jobs:
           diff sslserver.crt.before sslserver.crt.after
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.after
 
@@ -299,7 +299,7 @@ jobs:
       - name: Check CA admin cert
         run: |
           docker exec pki pki client-cert-import \
-              --ca-cert /etc/pki/pki-tomcat/certs/ca_signing.crt \
+              --ca-cert /var/lib/pki/pki-tomcat/conf/certs/ca_signing.crt \
               ca_signing
           docker exec pki pki -n caadmin ca-user-show caadmin
 

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -90,7 +90,7 @@ jobs:
           # there should be 5 certs
           echo "5" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -99,7 +99,7 @@ jobs:
         run: |
           echo "CT,C,C" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -109,7 +109,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_ocsp_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -119,7 +119,7 @@ jobs:
         run: |
           echo ",,P" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_audit_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -129,7 +129,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               subsystem | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -139,7 +139,7 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               sslserver | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -150,7 +150,7 @@ jobs:
           echo Secret.HSM > password.txt
           echo "4" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -C ${SHARED}/password.txt \
               --token HSM \
               nss-cert-find | tee output
@@ -161,7 +161,7 @@ jobs:
         run: |
           echo "CTu,Cu,Cu" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -C ${SHARED}/password.txt \
               --token HSM \
               nss-cert-show \
@@ -173,7 +173,7 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -C ${SHARED}/password.txt \
               --token HSM \
               nss-cert-show \
@@ -185,7 +185,7 @@ jobs:
         run: |
           echo "u,u,Pu" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -C ${SHARED}/password.txt \
               --token HSM \
               nss-cert-show \
@@ -197,7 +197,7 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -C ${SHARED}/password.txt \
               --token HSM \
               nss-cert-show \

--- a/.github/workflows/ca-nuxwdog-test.yml
+++ b/.github/workflows/ca-nuxwdog-test.yml
@@ -76,24 +76,24 @@ jobs:
       - name: Enable Nuxwdog
         run: |
           # add internal password into keyring
-          PASSWORD=$(docker exec pki grep '^internal=' /etc/pki/pki-tomcat/password.conf | cut -d= -f2)
+          PASSWORD=$(docker exec pki grep '^internal=' /var/lib/pki/pki-tomcat/conf/password.conf | cut -d= -f2)
           docker exec pki runuser -u pkiuser -- \
               keyctl add user pki-tomcat/internal $PASSWORD @u
 
           # add internal database password into keyring
-          PASSWORD=$(docker exec pki grep '^internaldb=' /etc/pki/pki-tomcat/password.conf | cut -d= -f2)
+          PASSWORD=$(docker exec pki grep '^internaldb=' /var/lib/pki/pki-tomcat/conf/password.conf | cut -d= -f2)
           docker exec pki runuser -u pkiuser -- \
               keyctl add user pki-tomcat/internaldb $PASSWORD @u
 
           # add replication database password into keyring
-          PASSWORD=$(docker exec pki grep '^replicationdb=' /etc/pki/pki-tomcat/password.conf | cut -d= -f2)
+          PASSWORD=$(docker exec pki grep '^replicationdb=' /var/lib/pki/pki-tomcat/conf/password.conf | cut -d= -f2)
           docker exec pki runuser -u pkiuser -- \
               keyctl add user pki-tomcat/replicationdb $PASSWORD @u
 
           docker exec pki runuser -u pkiuser -- keyctl show @u
 
           # remove password.conf temporarily
-          docker exec pki mv /etc/pki/pki-tomcat/password.conf /tmp
+          docker exec pki mv /var/lib/pki/pki-tomcat/conf/password.conf /tmp
 
           # install setfacl tool needed for Nuxwdog
           docker exec pki dnf install -y acl
@@ -134,7 +134,7 @@ jobs:
           docker exec pki pki-server nuxwdog-disable
 
           # restore password.conf
-          docker exec pki mv /tmp/password.conf /etc/pki/pki-tomcat
+          docker exec pki mv /tmp/password.conf /var/lib/pki/pki-tomcat/conf
 
           # remove all passwords from keyring
           docker exec pki runuser -u pkiuser -- keyctl clear @u

--- a/.github/workflows/ca-profile-caServerCert-test.yml
+++ b/.github/workflows/ca-profile-caServerCert-test.yml
@@ -65,7 +65,7 @@ jobs:
               -e '$ a policyset.serverCertSet.13.default.class_id=userExtensionDefaultImpl' \
               -e '$ a policyset.serverCertSet.13.default.name=User supplied extension in CSR' \
               -e '$ a policyset.serverCertSet.13.default.params.userExtOID=2.5.29.17' \
-              /etc/pki/pki-tomcat/ca/profiles/ca/caServerCert.cfg
+              /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caServerCert.cfg
 
           # require unique subject name
           docker exec pki sed -i \
@@ -74,10 +74,10 @@ jobs:
               -e '$ a policyset.serverCertSet.14.constraint.name=Unique Subject Name Constraint' \
               -e '$ a policyset.serverCertSet.14.default.class_id=noDefaultImpl' \
               -e '$ a policyset.serverCertSet.14.default.name=No Default' \
-              /etc/pki/pki-tomcat/ca/profiles/ca/caServerCert.cfg
+              /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caServerCert.cfg
 
           # check updated profile
-          docker exec pki cat /etc/pki/pki-tomcat/ca/profiles/ca/caServerCert.cfg
+          docker exec pki cat /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caServerCert.cfg
 
           docker exec pki pki-server ca-redeploy --wait
 

--- a/.github/workflows/ca-pruning-test.yml
+++ b/.github/workflows/ca-pruning-test.yml
@@ -62,10 +62,10 @@ jobs:
           docker exec pki sed -i \
               -e "s/^$VALIDITY_DEFAULT.range=.*$/$VALIDITY_DEFAULT.range=1/" \
               -e "/^$VALIDITY_DEFAULT.range=.*$/a $VALIDITY_DEFAULT.rangeUnit=minute" \
-              /etc/pki/pki-tomcat/ca/profiles/ca/caServerCert.cfg
+              /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caServerCert.cfg
 
           # check updated profile
-          docker exec pki cat /etc/pki/pki-tomcat/ca/profiles/ca/caServerCert.cfg
+          docker exec pki cat /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caServerCert.cfg
 
       - name: Configure user cert profile
         run: |
@@ -74,10 +74,10 @@ jobs:
           docker exec pki sed -i \
               -e "s/^$VALIDITY_DEFAULT.range=.*$/$VALIDITY_DEFAULT.range=4/" \
               -e "/^$VALIDITY_DEFAULT.range=.*$/a $VALIDITY_DEFAULT.rangeUnit=minute" \
-              /etc/pki/pki-tomcat/ca/profiles/ca/caUserCert.cfg
+              /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caUserCert.cfg
 
           # check updated profile
-          docker exec pki cat /etc/pki/pki-tomcat/ca/profiles/ca/caUserCert.cfg
+          docker exec pki cat /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caUserCert.cfg
 
       - name: Configure cert status update task
         run: |

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -120,10 +120,10 @@ jobs:
           docker exec pki sed -i \
               -e "s/^$VALIDITY_DEFAULT.range=.*$/$VALIDITY_DEFAULT.range=1/" \
               -e "/^$VALIDITY_DEFAULT.range=.*$/a $VALIDITY_DEFAULT.rangeUnit=minute" \
-              /etc/pki/pki-tomcat/ca/profiles/ca/caUserCert.cfg
+              /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caUserCert.cfg
 
           # check updated profile
-          docker exec pki cat /etc/pki/pki-tomcat/ca/profiles/ca/caUserCert.cfg
+          docker exec pki cat /var/lib/pki/pki-tomcat/conf/ca/profiles/ca/caUserCert.cfg
 
       - name: Configure cert status update task
         run: |

--- a/.github/workflows/ca-renewal-system-certs-hsm-test.yml
+++ b/.github/workflows/ca-renewal-system-certs-hsm-test.yml
@@ -149,13 +149,13 @@ jobs:
           echo "Secret.123" > password.internal
           docker exec pki certutil \
               -K \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -f $SHARED/password.internal | tee keys.internal.orig
 
           echo "Secret.HSM" > password.HSM
           docker exec pki certutil \
               -K \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -f $SHARED/password.HSM \
               -h HSM | tee keys.HSM.orig
 
@@ -469,13 +469,13 @@ jobs:
 
           # the keys should not change
           docker exec pki certutil \
-              -K -d /etc/pki/pki-tomcat/alias \
+              -K -d /var/lib/pki/pki-tomcat/conf/alias \
               -f $SHARED/password.internal | tee keys.internal.after
           diff keys.internal.orig keys.internal.after
 
           # the keys should not change
           docker exec pki certutil \
-              -K -d /etc/pki/pki-tomcat/alias \
+              -K -d /var/lib/pki/pki-tomcat/conf/alias \
               -f $SHARED/password.HSM \
               -h HSM | tee keys.HSM.after
           diff keys.HSM.orig keys.HSM.after

--- a/.github/workflows/ca-renewal-system-certs-test.yml
+++ b/.github/workflows/ca-renewal-system-certs-test.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           echo "Secret.123" > password.txt
           docker exec pki certutil \
-              -K -d /etc/pki/pki-tomcat/alias \
+              -K -d /var/lib/pki/pki-tomcat/conf/alias \
               -f $SHARED/password.txt | tee keys.orig
 
       - name: Run PKI healthcheck
@@ -430,7 +430,7 @@ jobs:
         run: |
           # the keys should not change
           docker exec pki certutil \
-              -K -d /etc/pki/pki-tomcat/alias \
+              -K -d /var/lib/pki/pki-tomcat/conf/alias \
               -f $SHARED/password.txt | tee keys.after
           diff keys.orig keys.after
 

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           # all keys should be "rsa"
           echo Secret.123 > password.txt
-          docker exec pki certutil -K -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt | tee output
+          docker exec pki certutil -K -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt | tee output
           echo "rsa" > expected
 
           grep ca_signing output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
@@ -91,7 +91,7 @@ jobs:
       - name: Check CA signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_signing | tee output
 
           # signing algorithm should be "PKCS #1 RSA-PSS Signature"
           echo "PKCS #1 RSA-PSS Signature" > expected
@@ -115,7 +115,7 @@ jobs:
       - name: Check CA OCSP signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
 
           # signing algorithm should be "PKCS #1 RSA-PSS Signature"
           echo "PKCS #1 RSA-PSS Signature" > expected
@@ -139,7 +139,7 @@ jobs:
       - name: Check CA audit signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
 
           # signing algorithm should be "PKCS #1 RSA-PSS Signature"
           echo "PKCS #1 RSA-PSS Signature" > expected
@@ -163,7 +163,7 @@ jobs:
       - name: Check subsystem cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n subsystem | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n subsystem | tee output
 
           # signing algorithm should be "PKCS #1 RSA-PSS Signature"
           echo "PKCS #1 RSA-PSS Signature" > expected
@@ -188,7 +188,7 @@ jobs:
       - name: Check SSL server cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n sslserver | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n sslserver | tee output
 
           # signing algorithm should be "PKCS #1 RSA-PSS Signature"
           echo "PKCS #1 RSA-PSS Signature" > expected

--- a/.github/workflows/ca-rsa-test.yml
+++ b/.github/workflows/ca-rsa-test.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           # all keys should be "rsa"
           echo Secret.123 > password.txt
-          docker exec pki certutil -K -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt | tee output
+          docker exec pki certutil -K -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt | tee output
           echo "rsa" > expected
 
           grep ca_signing output | sed -n 's/<.*>\s\(\S\+\)\s.*/\1/p' > actual
@@ -90,7 +90,7 @@ jobs:
       - name: Check CA signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_signing | tee output
 
           # signing algorithm should be "PKCS #1 SHA-384 With RSA Encryption"
           echo "PKCS #1 SHA-384 With RSA Encryption" > expected
@@ -114,7 +114,7 @@ jobs:
       - name: Check CA OCSP signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_ocsp_signing | tee output
 
           # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
           echo "PKCS #1 SHA-512 With RSA Encryption" > expected
@@ -138,7 +138,7 @@ jobs:
       - name: Check CA audit signing cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n ca_audit_signing | tee output
 
           # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
           echo "PKCS #1 SHA-512 With RSA Encryption" > expected
@@ -162,7 +162,7 @@ jobs:
       - name: Check subsystem cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n subsystem | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n subsystem | tee output
 
           # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
           echo "PKCS #1 SHA-512 With RSA Encryption" > expected
@@ -187,7 +187,7 @@ jobs:
       - name: Check SSL server cert
         run: |
           # inspect cert with certutil
-          docker exec pki certutil -L -d /etc/pki/pki-tomcat/alias -f ${SHARED}/password.txt -n sslserver | tee output
+          docker exec pki certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -f ${SHARED}/password.txt -n sslserver | tee output
 
           # signing algorithm should be "PKCS #1 SHA-512 With RSA Encryption"
           echo "PKCS #1 SHA-512 With RSA Encryption" > expected

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -68,7 +68,7 @@ jobs:
           echo "Secret.123" > password.txt
           docker cp password.txt pki:password.txt
           docker exec pki certutil -K \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -f password.txt | tee output
 
           # there should be no orphaned keys

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -66,7 +66,7 @@ jobs:
           echo "Secret.123" > password.txt
           docker cp password.txt pki:password.txt
           docker exec pki certutil -K \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               -f password.txt | tee output
 
           # there should be no orphaned keys

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -101,8 +101,8 @@ jobs:
 
           # check keys
           docker exec ipa certutil -K \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/alias/pwdfile.txt | tee output
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/alias/pwdfile.txt | tee output
 
           # there should be no orphaned keys
           echo "0" > expected
@@ -193,8 +193,8 @@ jobs:
 
           # check keys
           docker exec ipa certutil -K \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/alias/pwdfile.txt | tee output
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/alias/pwdfile.txt | tee output
 
           # there should be no orphaned keys
           echo "0" > expected

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -410,8 +410,8 @@ jobs:
       - name: Change renewal master
         run: |
           # get CS.cfg before renewal update
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.orig
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary.orig
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.orig
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary.orig
 
           # move renewal master to secondary server
           docker exec primary ipa config-mod \
@@ -426,22 +426,22 @@ jobs:
 
       - name: Check primary CA config
         run: |
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after-renewal-update
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.after-renewal-update
 
           # renewal config is maintained by IPA, so there should be no change in PKI
           diff CS.cfg.primary.orig CS.cfg.primary.after-renewal-update
 
       - name: Check secondary CA config
         run: |
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary.after-renewal-update
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary.after-renewal-update
 
           # renewal config is maintained by IPA, so there should be no change in PKI
           diff CS.cfg.secondary.orig CS.cfg.secondary.after-renewal-update
 
       - name: Check CA CSR copied correctly 
         run: |
-          docker cp primary:/etc/pki/pki-tomcat/certs primary-certs
-          docker cp secondary:/etc/pki/pki-tomcat/certs secondary-certs
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/certs primary-certs
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/certs secondary-certs
 
           diff primary-certs/ca_audit_signing.csr secondary-certs/ca_audit_signing.csr
           diff primary-certs/ca_ocsp_signing.csr secondary-certs/ca_ocsp_signing.csr
@@ -486,7 +486,7 @@ jobs:
       - name: Check CRL generation config in primary CA
         run: |
           # get CS.cfg from primary CA after CRL generation update
-          docker cp primary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after-crl-update
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.after-crl-update
 
           docker exec primary pki-server ca-config-find | grep ca.crl.MasterCRL
 
@@ -511,7 +511,7 @@ jobs:
       - name: Check CRL generation config in secondary CA
         run: |
           # get CS.cfg from secondary CA after CRL generation update
-          docker cp secondary:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary.after-crl-update
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary.after-crl-update
 
           docker exec secondary pki-server ca-config-find | grep ca.crl.MasterCRL
 

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -132,7 +132,7 @@ jobs:
           docker exec pki pki-server cert-export kra_storage \
               --cert-file kra_storage.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/kra_storage.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/kra_storage.csr
           docker exec pki openssl x509 -text -noout -in kra_storage.crt
 
       - name: Check KRA transport cert
@@ -140,7 +140,7 @@ jobs:
           docker exec pki pki-server cert-export kra_transport \
               --cert-file kra_transport.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/kra_transport.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr
           docker exec pki openssl x509 -text -noout -in kra_transport.crt
 
       - name: Check KRA audit signing cert
@@ -148,7 +148,7 @@ jobs:
           docker exec pki pki-server cert-export kra_audit_signing \
               --cert-file kra_audit_signing.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/kra_audit_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr
           docker exec pki openssl x509 -text -noout -in kra_audit_signing.crt
 
       - name: Check subsystem cert
@@ -156,7 +156,7 @@ jobs:
           docker exec pki pki-server cert-export subsystem \
               --cert-file subsystem.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/subsystem.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr
           docker exec pki openssl x509 -text -noout -in subsystem.crt
 
       - name: Check SSL server cert
@@ -164,7 +164,7 @@ jobs:
           docker exec pki pki-server cert-export sslserver \
               --cert-file sslserver.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/sslserver.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
       - name: Check KRA admin cert

--- a/.github/workflows/kra-clone-hsm-test.yml
+++ b/.github/workflows/kra-clone-hsm-test.yml
@@ -108,7 +108,7 @@ jobs:
           # there should be 8 certs
           echo "8" > expected
           docker exec primary pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -118,8 +118,8 @@ jobs:
           # there should be 7 certs
           echo "7" > expected
           docker exec primary pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -189,7 +189,7 @@ jobs:
       - name: Install KRA in secondary PKI container
         run: |
           # get CS.cfg from primary KRA before cloning
-          docker cp primary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.primary
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.primary
 
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra-clone.cfg \
@@ -215,7 +215,7 @@ jobs:
           # TODO: investigate the discrepancy
           echo "4" > expected
           docker exec secondary pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -225,8 +225,8 @@ jobs:
           # there should be 7 certs
           echo "7" > expected
           docker exec secondary pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -235,7 +235,7 @@ jobs:
       - name: Check CS.cfg in primary KRA after cloning
         run: |
           # get CS.cfg from primary KRA after cloning
-          docker cp primary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.primary.after
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.primary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -262,7 +262,7 @@ jobs:
       - name: Check CS.cfg in secondary KRA
         run: |
           # get CS.cfg from secondary KRA
-          docker cp secondary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.secondary
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.secondary
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -424,7 +424,7 @@ jobs:
           # TODO: investigate the discrepancy
           echo "4" > expected
           docker exec tertiary pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -434,8 +434,8 @@ jobs:
           # there should be 7 certs
           echo "7" > expected
           docker exec tertiary pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -444,7 +444,7 @@ jobs:
       - name: Check CS.cfg in secondary KRA after cloning
         run: |
           # get CS.cfg from secondary KRA after cloning
-          docker cp secondary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.secondary.after
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.secondary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -469,7 +469,7 @@ jobs:
       - name: Check CS.cfg in tertiary KRA
         run: |
           # get CS.cfg from tertiary KRA
-          docker cp tertiary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.tertiary
+          docker cp tertiary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.tertiary
 
           # normalize expected result:
           # - remove params that cannot be compared

--- a/.github/workflows/kra-clone-replicated-ds-test.yml
+++ b/.github/workflows/kra-clone-replicated-ds-test.yml
@@ -124,8 +124,8 @@ jobs:
       - name: Import system certs and keys into secondary CA
         run: |
           docker exec secondary pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               pkcs12-import \
               --pkcs12 $SHARED/ca-certs.p12 \
               --password Secret.123
@@ -250,8 +250,8 @@ jobs:
       - name: Import KRA system certs and keys into secondary KRA
         run: |
           docker exec secondary pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               pkcs12-import \
               --pkcs12 $SHARED/kra-certs.p12 \
               --password Secret.123
@@ -469,7 +469,7 @@ jobs:
       - name: Install KRA in secondary PKI container
         run: |
           # get CS.cfg from primary KRA before cloning
-          docker cp primary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.primary
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.primary
 
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra-clone.cfg \
@@ -505,7 +505,7 @@ jobs:
       - name: Check CS.cfg in primary KRA after cloning
         run: |
           # get CS.cfg from primary KRA after cloning
-          docker cp primary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.primary.after
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.primary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -530,7 +530,7 @@ jobs:
       - name: Check CS.cfg in secondary KRA
         run: |
           # get CS.cfg from secondary KRA
-          docker cp secondary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.secondary
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.secondary
 
           # normalize expected result:
           # - remove params that cannot be compared

--- a/.github/workflows/kra-clone-shared-ds-test.yml
+++ b/.github/workflows/kra-clone-shared-ds-test.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Install KRA in secondary PKI container
         run: |
           # get CS.cfg from primary KRA before cloning
-          docker cp primary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.primary
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.primary
 
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra-clone.cfg \
@@ -151,7 +151,7 @@ jobs:
       - name: Check CS.cfg in primary KRA after cloning
         run: |
           # get CS.cfg from primary KRA after cloning
-          docker cp primary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.primary.after
+          docker cp primary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.primary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -176,7 +176,7 @@ jobs:
       - name: Check CS.cfg in secondary KRA
         run: |
           # get CS.cfg from secondary KRA
-          docker cp secondary:/etc/pki/pki-tomcat/kra/CS.cfg CS.cfg.secondary
+          docker cp secondary:/var/lib/pki/pki-tomcat/conf/kra/CS.cfg CS.cfg.secondary
 
           # normalize expected result:
           # - remove params that cannot be compared

--- a/.github/workflows/kra-ecc-test.yml
+++ b/.github/workflows/kra-ecc-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Check KRA storage cert
         run: |
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/kra_storage.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/kra_storage.csr
 
           docker exec pki pki-server cert-export kra_storage \
               --cert-file kra_storage.crt
@@ -92,7 +92,7 @@ jobs:
       - name: Check KRA transport cert
         run: |
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/kra_transport.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr
 
           docker exec pki pki-server cert-export kra_transport \
               --cert-file kra_transport.crt
@@ -117,7 +117,7 @@ jobs:
       - name: Check KRA audit signing cert
         run: |
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/kra_audit_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr
 
           docker exec pki pki-server cert-export kra_audit_signing \
               --cert-file kra_audit_signing.crt
@@ -141,7 +141,7 @@ jobs:
       - name: Check subsystem cert
         run: |
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/subsystem.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr
 
           docker exec pki pki-server cert-export subsystem \
               --cert-file subsystem.crt
@@ -166,7 +166,7 @@ jobs:
       - name: Check SSL server cert
         run: |
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/sslserver.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr
 
           docker exec pki pki-server cert-export sslserver \
               --cert-file sslserver.crt

--- a/.github/workflows/kra-existing-certs-test.yml
+++ b/.github/workflows/kra-existing-certs-test.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Install CA admin cert
         run: |
           docker exec ca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-export \
               --output-file $SHARED/cert_chain.pem \
               --with-chain \
@@ -315,8 +315,8 @@ jobs:
       - name: Check KRA storage cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_storage | tee kra_storage.crt.after
 
@@ -324,8 +324,8 @@ jobs:
           diff kra_storage.crt.before kra_storage.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_storage | tee kra_storage.key.after
 
@@ -335,8 +335,8 @@ jobs:
       - name: Check KRA transport cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_transport | tee kra_transport.crt.after
 
@@ -344,8 +344,8 @@ jobs:
           diff kra_transport.crt.before kra_transport.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_transport | tee kra_transport.key.after
 
@@ -355,8 +355,8 @@ jobs:
       - name: Check KRA audit signing cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_audit_signing | tee kra_audit_signing.crt.after
 
@@ -364,8 +364,8 @@ jobs:
           diff kra_audit_signing.crt.before kra_audit_signing.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_audit_signing | tee kra_audit_signing.key.after
 
@@ -375,8 +375,8 @@ jobs:
       - name: Check subsystem cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               subsystem | tee subsystem.crt.after
 
@@ -384,8 +384,8 @@ jobs:
           diff subsystem.crt.before subsystem.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname subsystem | tee subsystem.key.after
 
@@ -395,8 +395,8 @@ jobs:
       - name: Check SSL server cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.after
 
@@ -404,8 +404,8 @@ jobs:
           diff sslserver.crt.before sslserver.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.after
 

--- a/.github/workflows/kra-existing-ds-test.yml
+++ b/.github/workflows/kra-existing-ds-test.yml
@@ -87,7 +87,7 @@ jobs:
               --subject "CN=DRM Storage Certificate" \
               --ext /usr/share/pki/server/certs/kra_storage.conf \
               kra_storage
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_storage.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_storage.csr $SHARED
           docker exec kra openssl req -text -noout -in $SHARED/kra_storage.csr
 
           # submit cert request
@@ -103,22 +103,22 @@ jobs:
           # retrieve cert
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_storage.crt
-          docker exec kra cp $SHARED/kra_storage.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_storage.crt /var/lib/pki/pki-tomcat/conf/certs
 
           # import cert
           docker exec kra pki-server cert-import kra_storage
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_storage | tee kra_storage.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_storage | tee kra_storage.key.before
 
@@ -129,7 +129,7 @@ jobs:
               --subject "CN=DRM Transport Certificate" \
               --ext /usr/share/pki/server/certs/kra_transport.conf \
               kra_transport
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_transport.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_transport.csr
 
           # submit cert request
@@ -145,22 +145,22 @@ jobs:
           # retrieve cert
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_transport.crt
-          docker exec kra cp $SHARED/kra_transport.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_transport.crt /var/lib/pki/pki-tomcat/conf/certs
 
           # import cert
           docker exec kra pki-server cert-import kra_transport
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_transport | tee kra_transport.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_transport | tee kra_transport.key.before
 
@@ -171,7 +171,7 @@ jobs:
               --subject "CN=Audit Signing Certificate" \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               kra_audit_signing
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_audit_signing.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_audit_signing.csr
 
           # submit cert request
@@ -187,22 +187,22 @@ jobs:
           # retrieve cert
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_audit_signing.crt
-          docker exec kra cp $SHARED/kra_audit_signing.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_audit_signing.crt /var/lib/pki/pki-tomcat/conf/certs
 
           # import cert
           docker exec kra pki-server cert-import kra_audit_signing
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_audit_signing | tee kra_audit_signing.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_audit_signing | tee kra_audit_signing.key.before
 
@@ -213,7 +213,7 @@ jobs:
               --subject "CN=Subsystem Certificate" \
               --ext /usr/share/pki/server/certs/subsystem.conf \
               subsystem
-          docker exec kra cp /etc/pki/pki-tomcat/certs/subsystem.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/subsystem.csr
 
           # submit cert request
@@ -229,22 +229,22 @@ jobs:
           # retrieve cert
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/subsystem.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/subsystem.crt
-          docker exec kra cp $SHARED/subsystem.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/subsystem.crt /var/lib/pki/pki-tomcat/conf/certs
 
           # import cert
           docker exec kra pki-server cert-import subsystem
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               subsystem | tee subsystem.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname subsystem | tee subsystem.key.before
 
@@ -255,7 +255,7 @@ jobs:
               --subject "CN=kra.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               sslserver
-          docker exec kra cp /etc/pki/pki-tomcat/certs/sslserver.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/sslserver.csr
 
           # submit cert request
@@ -271,22 +271,22 @@ jobs:
           # retrieve cert
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/sslserver.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/sslserver.crt
-          docker exec kra cp $SHARED/sslserver.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/sslserver.crt /var/lib/pki/pki-tomcat/conf/certs
 
           # import cert
           docker exec kra pki-server cert-import sslserver
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.before
 
@@ -446,15 +446,15 @@ jobs:
         if: always()
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find
 
       - name: Check KRA storage cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_storage | tee kra_storage.crt.after
 
@@ -462,8 +462,8 @@ jobs:
           diff kra_storage.crt.before kra_storage.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_storage | tee kra_storage.key.after
 
@@ -473,8 +473,8 @@ jobs:
       - name: Check KRA transport cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_transport | tee kra_transport.crt.after
 
@@ -482,8 +482,8 @@ jobs:
           diff kra_transport.crt.before kra_transport.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_transport | tee kra_transport.key.after
 
@@ -493,8 +493,8 @@ jobs:
       - name: Check KRA audit signing cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_audit_signing | tee kra_audit_signing.crt.after
 
@@ -502,8 +502,8 @@ jobs:
           diff kra_audit_signing.crt.before kra_audit_signing.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_audit_signing | tee kra_audit_signing.key.after
 
@@ -513,8 +513,8 @@ jobs:
       - name: Check subsystem cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               subsystem | tee subsystem.crt.after
 
@@ -522,8 +522,8 @@ jobs:
           diff subsystem.crt.before subsystem.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname subsystem | tee subsystem.key.after
 
@@ -533,8 +533,8 @@ jobs:
       - name: Check SSL server cert in server's NSS database
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.after
 
@@ -542,8 +542,8 @@ jobs:
           diff sslserver.crt.before sslserver.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.after
 

--- a/.github/workflows/kra-existing-hsm-test.yml
+++ b/.github/workflows/kra-existing-hsm-test.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Install CA admin cert
         run: |
           docker exec ca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-export \
               --output-file $SHARED/cert_chain.pem \
               --with-chain \
@@ -110,7 +110,7 @@ jobs:
           docker exec kra pki-server nss-create --password Secret.123
 
           docker exec kra pki-server password-add "hardware-HSM" --password "Secret.HSM"
-          docker exec kra cat /etc/pki/pki-tomcat/password.conf
+          docker exec kra cat /var/lib/pki/pki-tomcat/conf/password.conf
 
       - name: Issue KRA storage cert
         run: |
@@ -119,7 +119,7 @@ jobs:
               --subject "CN=DRM Storage Certificate" \
               --ext /usr/share/pki/server/certs/kra_storage.conf \
               kra_storage
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_storage.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_storage.csr $SHARED
           docker exec kra openssl req -text -noout -in $SHARED/kra_storage.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -132,7 +132,7 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_storage.crt
-          docker exec kra cp $SHARED/kra_storage.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_storage.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               --token HSM \
@@ -140,16 +140,16 @@ jobs:
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_storage | tee kra_storage.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:kra_storage | tee kra_storage.key.before
@@ -161,7 +161,7 @@ jobs:
               --subject "CN=DRM Transport Certificate" \
               --ext /usr/share/pki/server/certs/kra_transport.conf \
               kra_transport
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_transport.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_transport.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -174,7 +174,7 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_transport.crt
-          docker exec kra cp $SHARED/kra_transport.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_transport.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               --token HSM \
@@ -182,16 +182,16 @@ jobs:
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_transport | tee kra_transport.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:kra_transport | tee kra_transport.key.before
@@ -203,7 +203,7 @@ jobs:
               --subject "CN=Audit Signing Certificate" \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               kra_audit_signing
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_audit_signing.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_audit_signing.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -216,7 +216,7 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_audit_signing.crt
-          docker exec kra cp $SHARED/kra_audit_signing.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_audit_signing.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               --token HSM \
@@ -224,16 +224,16 @@ jobs:
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_audit_signing | tee kra_audit_signing.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:kra_audit_signing | tee kra_audit_signing.key.before
@@ -245,7 +245,7 @@ jobs:
               --subject "CN=Subsystem Certificate" \
               --ext /usr/share/pki/server/certs/subsystem.conf \
               subsystem
-          docker exec kra cp /etc/pki/pki-tomcat/certs/subsystem.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/subsystem.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -258,7 +258,7 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/subsystem.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/subsystem.crt
-          docker exec kra cp $SHARED/subsystem.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/subsystem.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               --token HSM \
@@ -266,16 +266,16 @@ jobs:
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:subsystem | tee subsystem.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:subsystem | tee subsystem.key.before
@@ -286,7 +286,7 @@ jobs:
               --subject "CN=kra.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               sslserver
-          docker exec kra cp /etc/pki/pki-tomcat/certs/sslserver.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/sslserver.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -299,22 +299,22 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/sslserver.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/sslserver.crt
-          docker exec kra cp $SHARED/sslserver.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/sslserver.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               sslserver
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.before
 
@@ -382,8 +382,8 @@ jobs:
       - name: Check KRA storage cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_storage | tee kra_storage.crt.after
@@ -392,8 +392,8 @@ jobs:
           diff kra_storage.crt.before kra_storage.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:kra_storage | tee kra_storage.key.after
@@ -404,8 +404,8 @@ jobs:
       - name: Check KRA transport cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_transport | tee kra_transport.crt.after
@@ -414,8 +414,8 @@ jobs:
           diff kra_transport.crt.before kra_transport.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:kra_transport | tee kra_transport.key.after
@@ -426,8 +426,8 @@ jobs:
       - name: Check KRA audit signing cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_audit_signing | tee kra_audit_signing.crt.after
@@ -436,8 +436,8 @@ jobs:
           diff kra_audit_signing.crt.before kra_audit_signing.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:kra_audit_signing | tee kra_audit_signing.key.after
@@ -448,8 +448,8 @@ jobs:
       - name: Check subsystem cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:subsystem | tee subsystem.crt.after
@@ -458,8 +458,8 @@ jobs:
           diff subsystem.crt.before subsystem.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find \
               --nickname HSM:subsystem | tee subsystem.key.after
@@ -470,8 +470,8 @@ jobs:
       - name: Check SSL server cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.after
 
@@ -479,8 +479,8 @@ jobs:
           diff sslserver.crt.before sslserver.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.after
 

--- a/.github/workflows/kra-existing-nssdb-test.yml
+++ b/.github/workflows/kra-existing-nssdb-test.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Install CA admin cert
         run: |
           docker exec ca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-export \
               --output-file $SHARED/cert_chain.pem \
               --with-chain \
@@ -95,7 +95,7 @@ jobs:
               --subject "CN=DRM Storage Certificate" \
               --ext /usr/share/pki/server/certs/kra_storage.conf \
               kra_storage
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_storage.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_storage.csr $SHARED
           docker exec kra openssl req -text -noout -in $SHARED/kra_storage.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -108,22 +108,22 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_storage.crt
-          docker exec kra cp $SHARED/kra_storage.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_storage.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               kra_storage
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_storage | tee kra_storage.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_storage | tee kra_storage.key.before
 
@@ -133,7 +133,7 @@ jobs:
               --subject "CN=DRM Transport Certificate" \
               --ext /usr/share/pki/server/certs/kra_transport.conf \
               kra_transport
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_transport.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_transport.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -146,22 +146,22 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_transport.crt
-          docker exec kra cp $SHARED/kra_transport.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_transport.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               kra_transport
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_transport | tee kra_transport.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_transport | tee kra_transport.key.before
 
@@ -171,7 +171,7 @@ jobs:
               --subject "CN=Audit Signing Certificate" \
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               kra_audit_signing
-          docker exec kra cp /etc/pki/pki-tomcat/certs/kra_audit_signing.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_audit_signing.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -184,22 +184,22 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_audit_signing.crt
-          docker exec kra cp $SHARED/kra_audit_signing.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/kra_audit_signing.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               kra_audit_signing
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_audit_signing | tee kra_audit_signing.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_audit_signing | tee kra_audit_signing.key.before
 
@@ -209,7 +209,7 @@ jobs:
               --subject "CN=Subsystem Certificate" \
               --ext /usr/share/pki/server/certs/subsystem.conf \
               subsystem
-          docker exec kra cp /etc/pki/pki-tomcat/certs/subsystem.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/subsystem.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -222,22 +222,22 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/subsystem.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/subsystem.crt
-          docker exec kra cp $SHARED/subsystem.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/subsystem.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               subsystem
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               subsystem | tee subsystem.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname subsystem | tee subsystem.key.before
 
@@ -247,7 +247,7 @@ jobs:
               --subject "CN=kra.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               sslserver
-          docker exec kra cp /etc/pki/pki-tomcat/certs/sslserver.csr $SHARED
+          docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/sslserver.csr
 
           docker exec ca pki ca-cert-request-submit \
@@ -260,22 +260,22 @@ jobs:
 
           docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/sslserver.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/sslserver.crt
-          docker exec kra cp $SHARED/sslserver.crt /etc/pki/pki-tomcat/certs
+          docker exec kra cp $SHARED/sslserver.crt /var/lib/pki/pki-tomcat/conf/certs
 
           docker exec kra pki-server cert-import \
               sslserver
 
           # check original cert
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.before
 
           # check original key
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.before
 
@@ -331,8 +331,8 @@ jobs:
       - name: Check KRA storage cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_storage | tee kra_storage.crt.after
 
@@ -340,8 +340,8 @@ jobs:
           diff kra_storage.crt.before kra_storage.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_storage | tee kra_storage.key.after
 
@@ -351,8 +351,8 @@ jobs:
       - name: Check KRA transport cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_transport | tee kra_transport.crt.after
 
@@ -360,8 +360,8 @@ jobs:
           diff kra_transport.crt.before kra_transport.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_transport | tee kra_transport.key.after
 
@@ -371,8 +371,8 @@ jobs:
       - name: Check KRA audit signing cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               kra_audit_signing | tee kra_audit_signing.crt.after
 
@@ -380,8 +380,8 @@ jobs:
           diff kra_audit_signing.crt.before kra_audit_signing.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname kra_audit_signing | tee kra_audit_signing.key.after
 
@@ -391,8 +391,8 @@ jobs:
       - name: Check subsystem cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               subsystem | tee subsystem.crt.after
 
@@ -400,8 +400,8 @@ jobs:
           diff subsystem.crt.before subsystem.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname subsystem | tee subsystem.key.after
 
@@ -411,8 +411,8 @@ jobs:
       - name: Check SSL server cert
         run: |
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-show \
               sslserver | tee sslserver.crt.after
 
@@ -420,8 +420,8 @@ jobs:
           diff sslserver.crt.before sslserver.crt.after
 
           docker exec kra pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find \
               --nickname sslserver | tee sslserver.key.after
 

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -90,7 +90,7 @@ jobs:
           # CA should create 5 certs in internal token
           echo "5" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -100,8 +100,8 @@ jobs:
           # CA should create 4 certs in HSM
           echo "4" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -129,7 +129,7 @@ jobs:
           # KRA should create 3 additional certs in internal token
           echo "8" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -138,7 +138,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               kra_storage | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -148,7 +148,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               kra_transport | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -158,7 +158,7 @@ jobs:
         run: |
           echo ",,P" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               kra_audit_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -169,8 +169,8 @@ jobs:
           # KRA should create 3 additional certs in HSM
           echo "7" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -180,8 +180,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_storage | tee output
@@ -192,8 +192,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_transport | tee output
@@ -204,8 +204,8 @@ jobs:
         run: |
           echo "u,u,Pu" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:kra_audit_signing | tee output

--- a/.github/workflows/kra-migration-test.yml
+++ b/.github/workflows/kra-migration-test.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Check first CA admin
         run: |
           docker exec pki1 pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-export \
               --output-file cert_chain.pem \
               --with-chain \
@@ -248,8 +248,8 @@ jobs:
       - name: Check second CA admin
         run: |
           docker exec pki2 pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-export \
               --output-file cert_chain.pem \
               --with-chain \
@@ -287,7 +287,7 @@ jobs:
           docker exec pki1 KRATool \
               -kratool_config_file /usr/share/pki/tools/KRATool.cfg \
               -source_kra_naming_context dc=kra,dc=pki1,dc=example,dc=com \
-              -source_pki_security_database_path /etc/pki/pki-tomcat/alias \
+              -source_pki_security_database_path /var/lib/pki/pki-tomcat/conf/alias \
               -source_pki_security_database_pwdfile $SHARED/password.txt \
               -source_storage_token_name "Internal Key Storage Token" \
               -source_storage_certificate_nickname kra_storage \

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check root CA certs
         if: always()
         run: |
-          docker exec rootca pki -d /etc/pki/pki-tomcat/alias nss-cert-find
+          docker exec rootca pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-find
 
           docker exec rootca pki-server cert-export \
               --cert-file ${SHARED}/root-ca_signing.crt \
@@ -145,7 +145,7 @@ jobs:
       - name: Check sub CA certs
         if: always()
         run: |
-          docker exec subca pki -d /etc/pki/pki-tomcat/alias nss-cert-find
+          docker exec subca pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-find
 
           docker exec subca pki-server cert-export \
               --cert-file ${SHARED}/ca_signing.crt \
@@ -184,7 +184,7 @@ jobs:
           cat cert_chain.crt
 
       - name: Install banner in sub CA container
-        run: docker exec subca cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec subca cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Verify sub CA admin
         run: |
@@ -264,7 +264,7 @@ jobs:
       - name: Check KRA certs
         if: always()
         run: |
-          docker exec kra pki -d /etc/pki/pki-tomcat/alias nss-cert-find
+          docker exec kra pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-find
 
       - name: Check KRA users
         if: always()
@@ -274,7 +274,7 @@ jobs:
           docker exec kra pki-server kra-user-role-find kraadmin
 
       - name: Install banner in KRA container
-        run: docker exec kra cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec kra cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       # TODO: Fix DogtagKRAConnectivityCheck to work without CA
       # - name: Run PKI healthcheck

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -132,7 +132,7 @@ jobs:
           docker exec pki pki-server cert-export ocsp_signing \
               --cert-file ocsp_signing.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/ocsp_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/ocsp_signing.csr
           docker exec pki openssl x509 -text -noout -in ocsp_signing.crt
 
       - name: Check OCSP audit signing cert
@@ -140,7 +140,7 @@ jobs:
           docker exec pki pki-server cert-export ocsp_audit_signing \
               --cert-file ocsp_audit_signing.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/ocsp_audit_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/ocsp_audit_signing.csr
           docker exec pki openssl x509 -text -noout -in ocsp_audit_signing.crt
 
       - name: Check subsystem cert
@@ -148,7 +148,7 @@ jobs:
           docker exec pki pki-server cert-export subsystem \
               --cert-file subsystem.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/subsystem.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr
           docker exec pki openssl x509 -text -noout -in subsystem.crt
 
       - name: Check SSL server cert
@@ -156,7 +156,7 @@ jobs:
           docker exec pki pki-server cert-export sslserver \
               --cert-file sslserver.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/sslserver.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
       - name: Check OCSP admin cert

--- a/.github/workflows/ocsp-hsm-test.yml
+++ b/.github/workflows/ocsp-hsm-test.yml
@@ -90,7 +90,7 @@ jobs:
           # CA should create 5 certs in internal token
           echo "5" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -100,8 +100,8 @@ jobs:
           # CA should create 4 certs in HSM
           echo "4" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -128,7 +128,7 @@ jobs:
           # OCSP should create 2 additional certs in internal token
           echo "7" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -137,7 +137,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ocsp_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -147,7 +147,7 @@ jobs:
         run: |
           echo ",,P" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ocsp_audit_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -158,8 +158,8 @@ jobs:
           # OCSP should create 2 additional certs in HSM
           echo "6" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -169,8 +169,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ocsp_signing | tee output
@@ -181,8 +181,8 @@ jobs:
         run: |
           echo "u,u,Pu" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ocsp_audit_signing | tee output

--- a/.github/workflows/ocsp-separate-test.yml
+++ b/.github/workflows/ocsp-separate-test.yml
@@ -76,7 +76,7 @@ jobs:
           diff expected actual
 
       - name: Install banner in CA container
-        run: docker exec ca cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec ca cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Set up OCSP DS container
         run: |
@@ -129,7 +129,7 @@ jobs:
           diff expected actual
 
       - name: Install banner in OCSP container
-        run: docker exec ocsp cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec ocsp cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Run PKI healthcheck
         run: docker exec ocsp pki-healthcheck --failures-only

--- a/.github/workflows/qe-tests.yml
+++ b/.github/workflows/qe-tests.yml
@@ -78,16 +78,33 @@ jobs:
         if: always()
         run: |
           tests/bin/ds-artifacts-save.sh pki1 --instance topology-02-testingmaster
-          mkdir -p /tmp/artifacts/pki1/etc/pki
-          mkdir -p /tmp/artifacts/pki1/var/log
+
           docker exec pki1 ls -la /etc/pki
+          mkdir -p /tmp/artifacts/pki1/etc/pki
           docker cp pki1:/etc/pki/pki.conf /tmp/artifacts/pki1/etc/pki
-          docker cp pki1:/etc/pki/topology-02-CA /tmp/artifacts/pki1/etc/pki
-          docker cp pki1:/etc/pki/topology-02-KRA /tmp/artifacts/pki1/etc/pki
-          docker cp pki1:/etc/pki/topology-02-OCSP /tmp/artifacts/pki1/etc/pki
-          docker cp pki1:/etc/pki/topology-02-TKS /tmp/artifacts/pki1/etc/pki
-          docker cp pki1:/etc/pki/topology-02-TPS /tmp/artifacts/pki1/etc/pki
+
+          docker exec pki1 ls -la /var/lib/pki/topology-02-CA/conf
+          mkdir -p /tmp/artifacts/pki1/var/lib/pki/conf
+          docker cp pki1:/var/lib/pki/topology-02-CA/conf/. /tmp/artifacts/pki1/var/lib/pki/conf
+
+          docker exec pki1 ls -la /var/lib/pki/topology-02-KRA/conf
+          mkdir -p /tmp/artifacts/pki1/var/lib/pki/conf
+          docker cp pki1:/var/lib/pki/topology-02-KRA/conf/. /tmp/artifacts/pki1/var/lib/pki/conf
+
+          docker exec pki1 ls -la /var/lib/pki/topology-02-OCSP/conf
+          mkdir -p /tmp/artifacts/pki1/var/lib/pki/conf
+          docker cp pki1:/var/lib/pki/topology-02-OCSP/conf/. /tmp/artifacts/pki1/var/lib/pki/conf
+
+          docker exec pki1 ls -la /var/lib/pki/topology-02-TKS/conf
+          mkdir -p /tmp/artifacts/pki1/var/lib/pki/conf
+          docker cp pki1:/var/lib/pki/topology-02-TKS/conf/. /tmp/artifacts/pki1/var/lib/pki/conf
+
+          docker exec pki1 ls -la /var/lib/pki/topology-02-TPS/conf
+          mkdir -p /tmp/artifacts/pki1/var/lib/pki/conf
+          docker cp pki1:/var/lib/pki/topology-02-TPS/conf/. /tmp/artifacts/pki1/var/lib/pki/conf
+
           docker exec pki1 ls -la /var/log/pki
+          mkdir -p /tmp/artifacts/pki1/var/log
           docker cp pki1:/var/log/pki /tmp/artifacts/pki1/var/log
           docker exec pki1 journalctl -u pki-tomcatd@topology-02-CA > /tmp/artifacts/pki1/var/log/pki/topology-02-CA/systemd.log
           docker exec pki1 journalctl -u pki-tomcatd@topology-02-KRA > /tmp/artifacts/pki1/var/log/pki/topology-02-KRA/systemd.log

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -78,8 +78,8 @@ jobs:
         run: |
           docker exec pki pki-server ca-config-set ca.scep.enable true
 
-          docker exec pki bash -c "echo UID:$(cat client.ip) > /etc/pki/pki-tomcat/ca/flatfile.txt"
-          docker exec pki bash -c "echo PWD:Secret.123 >> /etc/pki/pki-tomcat/ca/flatfile.txt"
+          docker exec pki bash -c "echo UID:$(cat client.ip) > /var/lib/pki/pki-tomcat/conf/ca/flatfile.txt"
+          docker exec pki bash -c "echo PWD:Secret.123 >> /var/lib/pki/pki-tomcat/conf/ca/flatfile.txt"
 
           # restart CA subsystem
           docker exec pki pki-server ca-redeploy --wait
@@ -110,8 +110,8 @@ jobs:
         run: |
           docker exec pki pki-server ca-config-set ca.scep.encryptionAlgorithm AES 
           docker exec pki pki-server ca-config-set ca.scep.allowedEncryptionAlgorithms DES3,AES 
-          docker exec pki bash -c "echo UID:$(cat client.ip) > /etc/pki/pki-tomcat/ca/flatfile.txt"
-          docker exec pki bash -c "echo PWD:Secret.123 >> /etc/pki/pki-tomcat/ca/flatfile.txt"
+          docker exec pki bash -c "echo UID:$(cat client.ip) > /var/lib/pki/pki-tomcat/conf/ca/flatfile.txt"
+          docker exec pki bash -c "echo PWD:Secret.123 >> /var/lib/pki/pki-tomcat/conf/ca/flatfile.txt"
           # restart CA subsystem
           docker exec pki pki-server ca-redeploy --wait
 

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -70,7 +70,7 @@ jobs:
           docker exec root pki-server cert-find
 
       - name: Install banner in root container
-        run: docker exec root cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec root cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Set up subordinate DS container
         run: |
@@ -116,14 +116,14 @@ jobs:
           docker exec subordinate pki-server cert-find
 
       - name: Install banner in subordinate container
-        run: docker exec subordinate cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec subordinate cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Check CA signing cert
         run: |
           docker exec subordinate pki-server cert-export ca_signing \
               --cert-file ca_signing.crt
           docker exec subordinate openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/ca_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_signing.csr
 
           # check sub CA signing cert extensions
           docker exec subordinate /usr/share/pki/tests/ca/bin/test-subca-signing-cert-ext.sh ca_signing.crt
@@ -133,7 +133,7 @@ jobs:
           docker exec subordinate pki-server cert-export ca_ocsp_signing \
               --cert-file ca_ocsp_signing.crt
           docker exec subordinate openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/ca_ocsp_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr
           docker exec subordinate openssl x509 -text -noout -in ca_ocsp_signing.crt
 
       - name: Check CA audit signing cert
@@ -141,7 +141,7 @@ jobs:
           docker exec subordinate pki-server cert-export ca_audit_signing \
               --cert-file ca_audit_signing.crt
           docker exec subordinate openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/ca_audit_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr
           docker exec subordinate openssl x509 -text -noout -in ca_audit_signing.crt
 
       - name: Check subsystem cert
@@ -149,7 +149,7 @@ jobs:
           docker exec subordinate pki-server cert-export subsystem \
               --cert-file subsystem.crt
           docker exec subordinate openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/subsystem.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr
           docker exec subordinate openssl x509 -text -noout -in subsystem.crt
 
       - name: Check SSL server cert
@@ -157,7 +157,7 @@ jobs:
           docker exec subordinate pki-server cert-export sslserver \
               --cert-file sslserver.crt
           docker exec subordinate openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/sslserver.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr
           docker exec subordinate openssl x509 -text -noout -in sslserver.crt
 
       - name: Check CA admin cert

--- a/.github/workflows/subca-clone-hsm-test.yml
+++ b/.github/workflows/subca-clone-hsm-test.yml
@@ -145,7 +145,7 @@ jobs:
           # there should be 6 certs
           echo "6" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -154,7 +154,7 @@ jobs:
         run: |
           echo "CT,C,C" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               root-ca_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -164,7 +164,7 @@ jobs:
         run: |
           echo "CT,C,C" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -174,7 +174,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_ocsp_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -184,7 +184,7 @@ jobs:
         run: |
           echo ",,P" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_audit_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -194,7 +194,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               subsystem | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -204,7 +204,7 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               sslserver | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -214,8 +214,8 @@ jobs:
         run: |
           echo "4" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -225,8 +225,8 @@ jobs:
         run: |
           echo "CTu,Cu,Cu" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_signing | tee output
@@ -237,8 +237,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_ocsp_signing | tee output
@@ -249,8 +249,8 @@ jobs:
         run: |
           echo "u,u,Pu" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_audit_signing | tee output
@@ -261,8 +261,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec primary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:subsystem | tee output
@@ -325,7 +325,7 @@ jobs:
       - name: Install secondary sub-CA
         run: |
           # get CS.cfg from primary sub-CA before cloning
-          docker cp primary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+          docker cp primary-subca:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary
 
           docker exec secondary-subca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
@@ -348,7 +348,7 @@ jobs:
       - name: Check CS.cfg in primary sub-CA after cloning
         run: |
           # get CS.cfg from primary sub-CA after cloning
-          docker cp primary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+          docker cp primary-subca:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -375,7 +375,7 @@ jobs:
       - name: Check CS.cfg in secondary sub-CA
         run: |
           # get CS.cfg from secondary sub-CA
-          docker cp secondary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+          docker cp secondary-subca:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -424,7 +424,7 @@ jobs:
           # TODO: fix pkispawn to import the missing certs
           echo "4" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -433,7 +433,7 @@ jobs:
         run: |
           echo "CT,C,C" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               root-ca_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -443,7 +443,7 @@ jobs:
         run: |
           echo "CT,C,C" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -456,7 +456,7 @@ jobs:
       #  run: |
       #    echo ",," > expected
       #    docker exec secondary-subca pki \
-      #        -d /etc/pki/pki-tomcat/alias \
+      #        -d /var/lib/pki/pki-tomcat/conf/alias \
       #        nss-cert-show \
       #        ca_ocsp_signing | tee output
       #    sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -466,7 +466,7 @@ jobs:
         run: |
           echo ",,P" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_audit_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -479,7 +479,7 @@ jobs:
       #  run: |
       #    echo ",," > expected
       #    docker exec secondary-subca pki \
-      #        -d /etc/pki/pki-tomcat/alias \
+      #        -d /var/lib/pki/pki-tomcat/conf/alias \
       #        nss-cert-show \
       #        subsystem | tee output
       #    sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -489,7 +489,7 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               sslserver | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -499,8 +499,8 @@ jobs:
         run: |
           echo "4" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -510,8 +510,8 @@ jobs:
         run: |
           echo "CTu,Cu,Cu" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_signing | tee output
@@ -522,8 +522,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_ocsp_signing | tee output
@@ -534,8 +534,8 @@ jobs:
         run: |
           echo "u,u,Pu" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_audit_signing | tee output
@@ -546,8 +546,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec secondary-subca pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:subsystem | tee output

--- a/.github/workflows/subca-clone-test.yml
+++ b/.github/workflows/subca-clone-test.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Install secondary sub-CA
         run: |
           # get CS.cfg from primary sub-CA before cloning
-          docker cp primary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary
+          docker cp primary-subca:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary
 
           docker exec secondary-subca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
@@ -165,7 +165,7 @@ jobs:
       - name: Check CS.cfg in primary sub-CA after cloning
         run: |
           # get CS.cfg from primary sub-CA after cloning
-          docker cp primary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.primary.after
+          docker cp primary-subca:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary.after
 
           # normalize expected result:
           # - remove params that cannot be compared
@@ -192,7 +192,7 @@ jobs:
       - name: Check CS.cfg in secondary sub-CA
         run: |
           # get CS.cfg from secondary sub-CA
-          docker cp secondary-subca:/etc/pki/pki-tomcat/ca/CS.cfg CS.cfg.secondary
+          docker cp secondary-subca:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.secondary
 
           # normalize expected result:
           # - remove params that cannot be compared

--- a/.github/workflows/subca-hsm-test.yml
+++ b/.github/workflows/subca-hsm-test.yml
@@ -134,7 +134,7 @@ jobs:
           # there should be 6 certs
           echo "6" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -143,7 +143,7 @@ jobs:
         run: |
           echo "CT,C,C" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               root-ca_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -153,7 +153,7 @@ jobs:
         run: |
           echo "CT,C,C" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -163,7 +163,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_ocsp_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -173,7 +173,7 @@ jobs:
         run: |
           echo ",,P" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               ca_audit_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -183,7 +183,7 @@ jobs:
         run: |
           echo ",," > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               subsystem | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -193,7 +193,7 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               sslserver | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -203,8 +203,8 @@ jobs:
         run: |
           echo "4" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -214,8 +214,8 @@ jobs:
         run: |
           echo "CTu,Cu,Cu" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_signing | tee output
@@ -226,8 +226,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_ocsp_signing | tee output
@@ -238,8 +238,8 @@ jobs:
         run: |
           echo "u,u,Pu" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:ca_audit_signing | tee output
@@ -250,8 +250,8 @@ jobs:
         run: |
           echo "u,u,u" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:subsystem | tee output

--- a/.github/workflows/subca-lightweight-hsm-test.yml
+++ b/.github/workflows/subca-lightweight-hsm-test.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Check certs and keys in internal token
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
           # there should be 5 certs
@@ -141,8 +141,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
           # there should be 1 key
@@ -153,8 +153,8 @@ jobs:
       - name: Check certs and keys in HSM
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
 
@@ -164,8 +164,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find | tee output
 
@@ -217,8 +217,8 @@ jobs:
       - name: Check certs and keys in internal token
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
           # there should still be 5 certs
@@ -227,8 +227,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
           # there should still be 1 key
@@ -239,8 +239,8 @@ jobs:
       - name: Check certs and keys in HSM
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
 
@@ -250,8 +250,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find | tee output
 
@@ -330,8 +330,8 @@ jobs:
       - name: Check certs and keys in internal token
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
           # there should be 5 certs
@@ -340,8 +340,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
           # there should be 1 key
@@ -352,8 +352,8 @@ jobs:
       - name: Check certs and keys in HSM
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
 
@@ -363,8 +363,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-key-find | tee output
 

--- a/.github/workflows/subca-lightweight-test.yml
+++ b/.github/workflows/subca-lightweight-test.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Check certs and keys in NSS database
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
           # there should be 5 certs
@@ -114,8 +114,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
           # there should be 5 keys
@@ -172,8 +172,8 @@ jobs:
       - name: Check certs and keys in NSS database
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
           # there should be 25 certs now
@@ -182,8 +182,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
           # there should be 25 keys now
@@ -267,8 +267,8 @@ jobs:
       - name: Check certs and keys in NSS database
         run: |
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
           # there should be 5 certs now
@@ -277,8 +277,8 @@ jobs:
           diff expected actual
 
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
           # there should be 5 keys now

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -85,7 +85,7 @@ jobs:
           docker exec pki pki-server cert-export tks_audit_signing \
               --cert-file tks_audit_signing.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/tks_audit_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/tks_audit_signing.csr
           docker exec pki openssl x509 -text -noout -in tks_audit_signing.crt
 
       - name: Check subsystem cert
@@ -93,7 +93,7 @@ jobs:
           docker exec pki pki-server cert-export subsystem \
               --cert-file subsystem.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/subsystem.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr
           docker exec pki openssl x509 -text -noout -in subsystem.crt
 
       - name: Check SSL server cert
@@ -101,7 +101,7 @@ jobs:
           docker exec pki pki-server cert-export sslserver \
               --cert-file sslserver.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/sslserver.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
       - name: Check TKS admin cert

--- a/.github/workflows/tks-hsm-test.yml
+++ b/.github/workflows/tks-hsm-test.yml
@@ -90,7 +90,7 @@ jobs:
           # CA should create 5 certs in internal token
           echo "5" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -100,8 +100,8 @@ jobs:
           # CA should create 4 certs in HSM
           echo "4" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -127,7 +127,7 @@ jobs:
           # TKS should create 1 additional cert in internal token
           echo "6" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -136,7 +136,7 @@ jobs:
         run: |
           echo ",,P" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               tks_audit_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -147,8 +147,8 @@ jobs:
           # TKS should create 1 additional certs in HSM
           echo "5" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -158,8 +158,8 @@ jobs:
         run: |
           echo "u,u,Pu" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:tks_audit_signing | tee output

--- a/.github/workflows/tks-separate-test.yml
+++ b/.github/workflows/tks-separate-test.yml
@@ -58,7 +58,7 @@ jobs:
           docker exec ca pki-server cert-find
 
       - name: Install banner in CA container
-        run: docker exec ca cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec ca cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Set up TKS DS container
         run: |
@@ -97,7 +97,7 @@ jobs:
           docker exec tks pki-server cert-find
 
       - name: Install banner in TKS container
-        run: docker exec tks cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec tks cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Run PKI healthcheck
         run: docker exec tks pki-healthcheck --failures-only

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -110,7 +110,7 @@ jobs:
           docker exec pki pki-server cert-export tps_audit_signing \
               --cert-file tps_audit_signing.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/tps_audit_signing.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/tps_audit_signing.csr
           docker exec pki openssl x509 -text -noout -in tps_audit_signing.crt
 
       - name: Check subsystem cert
@@ -118,7 +118,7 @@ jobs:
           docker exec pki pki-server cert-export subsystem \
               --cert-file subsystem.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/subsystem.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr
           docker exec pki openssl x509 -text -noout -in subsystem.crt
 
       - name: Check SSL server cert
@@ -126,7 +126,7 @@ jobs:
           docker exec pki pki-server cert-export sslserver \
               --cert-file sslserver.crt
           docker exec pki openssl req -text -noout \
-              -in /etc/pki/pki-tomcat/certs/sslserver.csr
+              -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
       - name: Check TPS admin cert

--- a/.github/workflows/tps-hsm-test.yml
+++ b/.github/workflows/tps-hsm-test.yml
@@ -90,7 +90,7 @@ jobs:
           # CA should create 5 certs in internal token
           echo "5" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -100,8 +100,8 @@ jobs:
           # CA should create 4 certs in HSM
           echo "4" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -129,7 +129,7 @@ jobs:
           # KRA should create 3 additional certs in internal token
           echo "8" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -139,8 +139,8 @@ jobs:
           # KRA should create 3 additional certs in HSM
           echo "7" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -166,7 +166,7 @@ jobs:
           # TKS should create 1 additional cert in internal token
           echo "9" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -176,8 +176,8 @@ jobs:
           # TKS should create 1 additional cert in HSM
           echo "8" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -206,7 +206,7 @@ jobs:
           # TPS should create 1 additional cert in internal token
           echo "10" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
@@ -215,7 +215,7 @@ jobs:
         run: |
           echo ",,P" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
               nss-cert-show \
               tps_audit_signing | tee output
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
@@ -226,8 +226,8 @@ jobs:
           # TPS should create 1 additional cert in HSM
           echo "9" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-find | tee output
           grep "Serial Number:" output | wc -l > actual
@@ -237,8 +237,8 @@ jobs:
         run: |
           echo "u,u,Pu" > expected
           docker exec pki pki \
-              -d /etc/pki/pki-tomcat/alias \
-              -f /etc/pki/pki-tomcat/password.conf \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
               --token HSM \
               nss-cert-show \
               HSM:tps_audit_signing | tee output

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -67,7 +67,7 @@ jobs:
           diff expected actual
 
       - name: Install banner in CA container
-        run: docker exec ca cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec ca cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Set up KRA DS container
         run: |
@@ -115,7 +115,7 @@ jobs:
           diff expected actual
 
       - name: Install banner in KRA container
-        run: docker exec kra cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec kra cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Set up TKS DS container
         run: |
@@ -161,7 +161,7 @@ jobs:
           diff expected actual
 
       - name: Install banner in TKS container
-        run: docker exec tks cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec tks cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Set up TPS DS container
         run: |
@@ -221,7 +221,7 @@ jobs:
           diff expected actual
 
       - name: Install banner in TPS container
-        run: docker exec tps cp /usr/share/pki/server/examples/banner/banner.txt /etc/pki/pki-tomcat
+        run: docker exec tps cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
 
       - name: Run PKI healthcheck
         run: docker exec tps pki-healthcheck --failures-only

--- a/tests/ansible/est/tasks/main.yml
+++ b/tests/ansible/est/tasks/main.yml
@@ -120,7 +120,7 @@
 - name: Configure EST backend
   community.docker.docker_container_copy_into:
     container: "{{ pki_container }}"
-    container_path: /etc/pki/pki-tomcat/est/backend.conf
+    container_path: /var/lib/pki/pki-tomcat/conf/est/backend.conf
     content: |
       class=org.dogtagpki.est.DogtagRABackend
       url=https://{{ pki_hostname }}:8443
@@ -133,7 +133,7 @@
 - name: Configurte EST authorization exec
   community.docker.docker_container_copy_into:
     container: "{{ pki_container }}"
-    container_path: /etc/pki/pki-tomcat/est/authorizer.conf
+    container_path: /var/lib/pki/pki-tomcat/conf/est/authorizer.conf
     content: |
       class=org.dogtagpki.est.ExternalProcessRequestAuthorizer
       executable=/usr/local/libexec/estauthz
@@ -156,7 +156,7 @@
 - name: Configurte EST authentication
   community.docker.docker_container_copy_into:
     container: "{{ pki_container }}"
-    container_path: /etc/pki/pki-tomcat/est/realm.conf
+    container_path: /var/lib/pki/pki-tomcat/conf/est/realm.conf
     content: |
       class=com.netscape.cms.realm.PKIInMemoryRealm
       username=alice

--- a/tests/bin/pki-artifacts-save.sh
+++ b/tests/bin/pki-artifacts-save.sh
@@ -47,7 +47,10 @@ fi
 docker exec $NAME ls -la /etc/pki
 mkdir -p $OUTPUT/etc/pki
 docker cp $NAME:/etc/pki/pki.conf $OUTPUT/etc/pki
-docker cp $NAME:/etc/pki/$INSTANCE $OUTPUT/etc/pki
+
+docker exec $NAME ls -la /var/lib/pki/$INSTANCE/conf
+mkdir -p $OUTPUT/var/lib/pki/$INSTANCE/conf
+docker cp $NAME:/var/lib/pki/$INSTANCE/conf/* $OUTPUT/var/lib/pki/$INSTANCE/conf
 
 docker exec $NAME ls -la /var/log/pki
 mkdir -p $OUTPUT/var/log

--- a/tests/ca/bin/test-ca-signing-cert.sh
+++ b/tests/ca/bin/test-ca-signing-cert.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # get CA signing cert using certutil
-certutil -L -d /etc/pki/pki-tomcat/alias -n ca_signing -r > /tmp/ca_signing.crt
+certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -n ca_signing -r > /tmp/ca_signing.crt
 
 # get CA signing cert using pki ca-cert-signing-export
 pki ca-cert-signing-export > /tmp/ca_signing.pem

--- a/tests/ca/bin/test-subsystem-cert.sh
+++ b/tests/ca/bin/test-subsystem-cert.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # get subsystem cert using certutil
-certutil -L -d /etc/pki/pki-tomcat/alias -n subsystem -r > /tmp/subsystem.crt
+certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -n subsystem -r > /tmp/subsystem.crt
 
 # get subsystem cert using pki ca-cert-subsystem-export
 pki ca-cert-subsystem-export > /tmp/subsystem.pem

--- a/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_shared.yml
+++ b/tests/dogtag/pytest-ansible/installation/roles/Test_Execution/tasks/configure_shared.yml
@@ -19,7 +19,7 @@
   - INC_CONSTANTS
 
 - name: Enable SignedAudit for ca and kra subsystem
-  replace: dest=/etc/pki/pki-tomcat/{{ item }}/CS.cfg regexp="log.instance.SignedAudit.logSigning=false" replace="log.instance.SignedAudit.logSigning=true"
+  replace: dest=/var/lib/pki/pki-tomcat/conf/{{ item }}/CS.cfg regexp="log.instance.SignedAudit.logSigning=false" replace="log.instance.SignedAudit.logSigning=true"
   with_items:
     - ca
     - kra


### PR DESCRIPTION
Normally the Tomcat `conf` dir is located immediately under the instance dir. For PKI server, which is based on Tomcat, the location is `/var/lib/pki/<instance>/conf`.

Depending on the deployment scenario the config files might be mounted from a different location (e.g. `/etc/pki/<instance>` on Fedora) and the standard `conf` dir will be just a link to the actual location.

To ensure that the tests are valid for all deployment scenarios they have been updated to use the standard `conf` dir instead of the Fedora-specific one.