### PR TITLE
Fix building flags for C++ code

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ SHARE_DIR="/usr/share"
 
 CMAKE="cmake"
 C_FLAGS=
+CXX_FLAGS=
 
 JNI_DIR="/usr/lib/java"
 UNIT_DIR="/usr/lib/systemd/system"
@@ -275,6 +276,9 @@ while getopts v-: arg ; do
         c-flags=?*)
             C_FLAGS="$LONG_OPTARG"
             ;;
+        cxx-flags=?*)
+            CXX_FLAGS="$LONG_OPTARG"
+            ;;
         java-home=?*)
             # Don't convert Java home into an absolute path since that
             # will prevent PKI from running with other OpenJDK releases.
@@ -416,6 +420,7 @@ if [ "$DEBUG" = true ] ; then
     echo "SHARE_DIR: $SHARE_DIR"
     echo "CMAKE: $CMAKE"
     echo "C_FLAGS: $C_FLAGS"
+    echo "CXX_FLAGS: $CXX_FLAGS"
     echo "JAVA_HOME: $JAVA_HOME"
     echo "JNI_DIR: $JNI_DIR"
     echo "PYTHON: $PYTHON"
@@ -638,6 +643,7 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
     OPTIONS+=(-DLIB_SUFFIX=64)
     OPTIONS+=(-DBUILD_SHARED_LIBS:BOOL=ON)
     OPTIONS+=(-DCMAKE_C_FLAGS:STRING="$C_FLAGS")
+    OPTIONS+=(-DCMAKE_CXX_FLAGS:STRING="$CXX_FLAGS")
 
     if [ "$VERBOSE" = true ] ; then
         OPTIONS+=(-DCMAKE_JAVA_COMPILE_FLAGS:STRING="-Xlint:deprecation")

--- a/pki.spec
+++ b/pki.spec
@@ -1025,6 +1025,7 @@ popd
 
 # Remove all symbol table and relocation information from the executable.
 C_FLAGS="-s"
+CXX_FLAGS="$CXX_FLAGS -g -fPIE -pie"
 
 %if 0%{?fedora}
 # https://sourceware.org/annobin/annobin.html/Test-gaps.html
@@ -1035,15 +1036,19 @@ C_FLAGS="$C_FLAGS -fcf-protection=full"
 
 # https://sourceware.org/annobin/annobin.html/Test-optimization.html
 C_FLAGS="$C_FLAGS -O2"
+CXX_FLAGS="$CXX_FLAGS -O2"
 
 # https://sourceware.org/annobin/annobin.html/Test-glibcxx-assertions.html
 C_FLAGS="$C_FLAGS -D_GLIBCXX_ASSERTIONS"
+CXX_FLAGS="$CXX_FLAGS -D_GLIBCXX_ASSERTIONS"
 
 # https://sourceware.org/annobin/annobin.html/Test-lto.html
 C_FLAGS="$C_FLAGS -fno-lto"
 
 # https://sourceware.org/annobin/annobin.html/Test-fortify.html
 C_FLAGS="$C_FLAGS -D_FORTIFY_SOURCE=3"
+CXX_FLAGS="$CXX_FLAGS -D_FORTIFY_SOURCE=3"
+
 %endif
 
 pkgs=base\
@@ -1077,6 +1082,7 @@ pkgs=base\
     --share-dir=%{_datadir} \
     --cmake=%{__cmake} \
     --c-flags="$C_FLAGS" \
+    --cxx-flags="$CXX_FLAGS" \
     --java-home=%{java_home} \
     --jni-dir=%{_jnidir} \
     --unit-dir=%{_unitdir} \


### PR DESCRIPTION
`tpsclient` is developed in C++ so some flags required by Fedora to compile were not properly applied.
This introduce  a new option for C++ code flags and add the one required by fedora.