### PR TITLE
Refactor validateSyntaxDNS to support wildcard DNS entries

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEIdentifierValidator.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEIdentifierValidator.java
@@ -93,7 +93,12 @@ public class ACMEIdentifierValidator {
 
         /* Extra check that URI class is happy with it */
         try {
-            new URI("http", value, null, null);
+            if (value.startsWith("*.")) {
+                String domain = value.substring(2); // Remove the leading "*."
+                new URI("http", domain, null, null);
+            } else {
+                new URI("http", value, null, null);
+            }
         } catch (URISyntaxException e) {
             ACMEError error = new ACMEError();
             error.setType("urn:ietf:params:acme:error:malformed");


### PR DESCRIPTION
Previously, wildcard DNS entries like '*.example.com' were failing URI validation as they are not valid URIs. This commit separates the wildcard validation logic to handle such cases separately, ensuring accurate validation for wildcard DNS entries.

Fixes #4556