### PR TITLE
Update docs to use standard conf dir

### DIFF
--- a/docs/admin/Nuxwdog.md
+++ b/docs/admin/Nuxwdog.md
@@ -36,13 +36,13 @@ $ pki-server instance-nuxwdog-enable <instance>
 ```
 
 If any of the system certificates reside on a cryptographic token other than the
-internal NSS database, you will see entries like this in `/etc/pki/<instance>/password.conf`:
+internal NSS database, you will see entries like this in `/var/lib/pki/<instance>/conf/password.conf`:
 
 ```
 hardware-<token>=<password>
 ```
 
-In that case, add the following parameter to `/etc/pki/<instance>/<subsystem>/CS.cfg`:
+In that case, add the following parameter to `/var/lib/pki/<instance>/conf/<subsystem>/CS.cfg`:
 
 ```
 cms.tokenList=<token>
@@ -51,7 +51,7 @@ cms.tokenList=<token>
 Remove the password file or move it somewhere else:
 
 ```
-$ mv /etc/pki/<instance>/password.conf /path/to/password.conf
+$ mv /var/lib/pki/<instance>/conf/password.conf /path/to/password.conf
 ```
 
 Restart the server with the following command:
@@ -88,7 +88,7 @@ $ pki-server instance-nuxwdog-disable <instance>
 Finally, restart the instance:
 
 ```
-$ mv /path/to/password.conf /etc/pki/<instance>/password.conf
+$ mv /path/to/password.conf /var/lib/pki/<instance>/conf/password.conf
 $ systemctl start pki-tomcatd@<instance>.service
 ```
 

--- a/docs/admin/Offline_System_Certificate_Renewal.md
+++ b/docs/admin/Offline_System_Certificate_Renewal.md
@@ -61,11 +61,11 @@ due to expired system certificates. In an IPA environment, LDAPI is used for the
     --extra-cert $HTTPD_SERIAL
     ````
 
-4. Verify that there is no `internaldb` field in `/etc/pki/pki-tomcat/password.conf`
+4. Verify that there is no `internaldb` field in `/var/lib/pki/pki-tomcat/conf/password.conf`
 
 5. Verify that `CS.cfg` has `internaldb.ldapauth.authtype=SslClientAuth`
 
-6. Copy `/etc/pki/pki-tomcat/certs/$IPA_RA_SERIAL-renewed.crt` to `/var/lib/ipa/ra-agent.pem`
+6. Copy `/var/lib/pki/pki-tomcat/conf/certs/$IPA_RA_SERIAL-renewed.crt` to `/var/lib/ipa/ra-agent.pem`
 
 7. Remove old DS cert and import DS renewed cert into DS NSSDB and provide the pin from `/etc/dirsrv/slapd-REALM/pin.txt`
     ````
@@ -75,9 +75,9 @@ due to expired system certificates. In an IPA environment, LDAPI is used for the
     # certutil -A -n Server-Cert \
     -d /etc/dirsrv/slapd-REALM/ \
     -t ',,' \
-    -a -i /etc/pki/pki-tomcat/certs/${DS_SERIAL}-renewed.crt
+    -a -i /var/lib/pki/pki-tomcat/conf/certs/${DS_SERIAL}-renewed.crt
     ````
-8. Copy `/etc/pki/pki-tomcat/certs/$HTTPD_SERIAL` to `/var/lib/ipa/certs/httpd.crt`
+8. Copy `/var/lib/pki/pki-tomcat/conf/certs/$HTTPD_SERIAL` to `/var/lib/ipa/certs/httpd.crt`
 
 9. `ipactl restart` should succeed
 
@@ -157,12 +157,12 @@ There are 2 different scenarios based on value of `internaldb.ldapauth.authtype`
 
 3. Set the LDAP password in `password.conf`:
     ````
-    # echo internaldb=<LDAP password> >> /etc/pki/pki-tomcat/password.conf
+    # echo internaldb=<LDAP password> >> /var/lib/pki/pki-tomcat/conf/password.conf
     ````
 
 ### Bringing up the PKI server
 
-1. Create temp SSL certificate. The temp cert will be created in `/etc/pki/<instance>/certs/sslserver.crt`
+1. Create temp SSL certificate. The temp cert will be created in `/var/lib/pki/<instance>/conf/certs/sslserver.crt`
     ````
     # pki-server cert-create sslserver --temp
     ````

--- a/docs/admin/Session_Timeout.md
+++ b/docs/admin/Session_Timeout.md
@@ -24,7 +24,7 @@ If the connection is successfully created, the server will generate an ACCESS_SE
 If the connection fails to be created, the server will generate an ACCESS_SESSION_ESTABLISH audit event with Outcome=Failure.
 When the connection is closed, the server will generate an ACCESS_SESSION_TERMINATED audit event.
 
-TLS session timeout (i.e. TLS connection timeout) can be configured in the **keepAliveTimeout** parameter in the **Secure** &lt;Connector&gt; element in /etc/pki/&lt;instance&gt;/server.xml:
+TLS session timeout (i.e. TLS connection timeout) can be configured in the **keepAliveTimeout** parameter in the **Secure** &lt;Connector&gt; element in /var/lib/pki/&lt;instance&gt;/conf/server.xml:
 
 <pre>
 &lt;Server&gt;
@@ -54,7 +54,7 @@ See also [Tomcat HTTP Connector](https://tomcat.apache.org/tomcat-9.0-doc/config
 HTTP session is a mechanism to track a user across multiple HTTP requests using HTTP cookies.
 PKI server does not generate audit events for HTTP sessions.
 
-HTTP session timeout can be configured in the **&lt;session-timeout&gt;** element in /etc/pki/&lt;instance&gt;/web.xml:
+HTTP session timeout can be configured in the **&lt;session-timeout&gt;** element in /var/lib/pki/&lt;instance&gt;/conf/web.xml:
 
 <pre>
 &lt;web-app&gt;

--- a/docs/admin/TPS_Token_Lifecycle.md
+++ b/docs/admin/TPS_Token_Lifecycle.md
@@ -22,7 +22,7 @@ In TPS Web UI the token states will be displayed by their labels.
 
 Token state can be changed via PKI CLI or TPS Web UI.
 The transitions that can be done via PKI CLI or TPS Web UI are defined in the following property in
-/etc/pki/&lt;instance&gt;/tps/CS.cfg:
+/var/lib/pki/&lt;instance&gt;/conf/tps/CS.cfg:
 
 ```
 tokendb.allowedTransitions=0:1,0:2,0:3,0:6,3:2,3:6,4:1,4:2,4:3,4:6,6:7
@@ -57,14 +57,14 @@ If a token was originally ACTIVE then became SUSPENDED, it can only return to th
 | 3:2        | SUSPENDED     | FORMATTED  | This suspended (temporarily lost) token has been found. |
 | 3:4        | SUSPENDED     | ACTIVE     | This suspended (temporarily lost) token has been found. |
 
-To customize the tokendb.allowedTransitions property, edit the property in /etc/pki/&lt;instance&gt;/tps/CS.cfg,
+To customize the tokendb.allowedTransitions property, edit the property in /var/lib/pki/&lt;instance&gt;/conf/tps/CS.cfg,
 then restart the server.
 
 ## Token State Transitions via Token Operations
 
 Token states can also be changed via token operations (e.g. format, enroll).
 The transitions that can be done via token operations are defined in the following property in
-/etc/pki/&lt;instance&gt;/tps/CS.cfg:
+/var/lib/pki/&lt;instance&gt;/conf/tps/CS.cfg:
 
 ```
 tps.operations.allowedTransitions=0:0,0:4,4:4,4:0,7:0
@@ -85,7 +85,7 @@ The above list represents the following transitions:
 | 4:0        | ACTIVE        | FORMATTED  | This allows formatting an active token.                               |
 | 7:0        | UNFORMATTED   | FORMATTED  | This allows formatting a blank or previously used token.              |
 
-To customize the tps.operations.allowedTransitions property, edit the property in /etc/pki/&lt;instance&gt;/tps/CS.cfg,
+To customize the tps.operations.allowedTransitions property, edit the property in /var/lib/pki/&lt;instance&gt;/conf/tps/CS.cfg,
 then restart the server.
 
 This property can only be customized to remove transitions from the original list.

--- a/docs/changes/v11.1.0/Server-Changes.adoc
+++ b/docs/changes/v11.1.0/Server-Changes.adoc
@@ -4,8 +4,8 @@
 
 The following folders have been relocated:
 
-* `/var/lib/pki/<instance>/ca/emails` -> `/etc/pki/<instance>/ca/emails`
-* `/var/lib/pki/<instance>/ca/profiles` -> `/etc/pki/<instance>/ca/profiles`
+* `/var/lib/pki/<instance>/ca/emails` -> `/var/lib/pki/<instance>/conf/ca/emails`
+* `/var/lib/pki/<instance>/ca/profiles` -> `/var/lib/pki/<instance>/conf/ca/profiles`
 
 The following folders have been removed:
 

--- a/docs/installation/acme/Configuring-ACME-Metadata.adoc
+++ b/docs/installation/acme/Configuring-ACME-Metadata.adoc
@@ -4,7 +4,7 @@
 
 This document describes the process to configure ACME metadata.
 
-The metadata configuration is located at `/etc/pki/pki-tomcat/acme/metadata.conf`.
+The metadata configuration is located at `/var/lib/pki/pki-tomcat/conf/acme/metadata.conf`.
 If the file does not exist, the server will use the default metadata configuration at
 link:../../../base/acme/conf/metadata.conf[/usr/share/pki/acme/conf/metadata.conf].
 

--- a/docs/installation/acme/Configuring-ACME-with-DS-Database.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-DS-Database.adoc
@@ -56,7 +56,7 @@ $ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
 A sample database configuration is available at
 link:../../../base/acme/database/ds/database.conf[/usr/share/pki/acme/database/ds/database.conf].
 
-To use the DS database, copy the sample `database.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To use the DS database, copy the sample `database.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command to customize some of the parameters:
 
 ----

--- a/docs/installation/acme/Configuring-ACME-with-DS-Realm.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-DS-Realm.adoc
@@ -21,7 +21,7 @@ $ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
 A sample realm configuration is available at
 link:../../../base/acme/realm/ds/realm.conf[/usr/share/pki/acme/realm/ds/realm.conf].
 
-To use the DS realm, copy the sample `realm.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To use the DS realm, copy the sample `realm.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command to customize some of the parameters:
 
 ----

--- a/docs/installation/acme/Configuring-ACME-with-InMemory-Database.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-InMemory-Database.adoc
@@ -9,7 +9,7 @@ This document describes the process to configure ACME responder to use an in-mem
 A sample in-memory database configuration is available at
 link:../../../base/acme/database/in-memory/database.conf[/usr/share/pki/acme/database/in-memory/database.conf].
 
-To use an in-memory database, copy the sample `database.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To use an in-memory database, copy the sample `database.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command:
 
 ----

--- a/docs/installation/acme/Configuring-ACME-with-InMemory-Realm.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-InMemory-Realm.adoc
@@ -9,7 +9,7 @@ This document describes the process to configure ACME responder to use an in-mem
 A sample in-memory realm configuration is available at
 link:../../../base/acme/realm/in-memory/realm.conf[/usr/share/pki/acme/realm/in-memory/realm.conf].
 
-To use an in-memory realm, copy the sample `realm.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To use an in-memory realm, copy the sample `realm.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command:
 
 ----

--- a/docs/installation/acme/Configuring-ACME-with-NSS-Issuer.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-NSS-Issuer.adoc
@@ -10,7 +10,7 @@ to issue certificates using a local NSS database.
 A sample NSS issuer configuration is available at
 link:../../../base/acme/issuer/nss/issuer.conf[/usr/share/pki/acme/issuer/nss/issuer.conf].
 
-To configure an NSS issuer, copy the sample `issuer.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To configure an NSS issuer, copy the sample `issuer.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command to customize some of the parameters:
 
 ----

--- a/docs/installation/acme/Configuring-ACME-with-OpenLDAP-Database.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-OpenLDAP-Database.adoc
@@ -30,7 +30,7 @@ $ ldapadd -H ldap://$HOSTNAME -x -D "cn=Manager,dc=example,dc=com" -w Secret.123
 A sample database configuration is available at
 link:../../../base/acme/database/openldap/database.conf[/usr/share/pki/acme/database/openldap/database.conf].
 
-To use the OpenLDAP database, copy the sample `database.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To use the OpenLDAP database, copy the sample `database.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command to customize some of the parameters:
 
 ----

--- a/docs/installation/acme/Configuring-ACME-with-PKI-Issuer.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-PKI-Issuer.adoc
@@ -12,7 +12,7 @@ link:../ca/Installing_CA.md[Installing CA].
 A sample PKI issuer configuration is available at
 link:../../../base/acme/issuer/pki/issuer.conf[/usr/share/pki/acme/issuer/pki/issuer.conf].
 
-To configure a PKI issuer, copy the sample `issuer.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To configure a PKI issuer, copy the sample `issuer.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command to customize some of the parameters:
 
 ----

--- a/docs/installation/acme/Configuring-ACME-with-PostgreSQL-Database.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-PostgreSQL-Database.adoc
@@ -25,7 +25,7 @@ $ ln -s /usr/share/java/postgresql-jdbc/postgresql.jar /usr/share/pki/server/com
 A sample PostgreSQL database configuration is available at
 link:../../../base/acme/database/postgresql/database.conf[/usr/share/pki/acme/database/postgresql/database.conf].
 
-To use the PostgreSQL database, copy the sample `database.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To use the PostgreSQL database, copy the sample `database.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command to customize some of the parameters:
 
 ----

--- a/docs/installation/acme/Configuring-ACME-with-PostgreSQL-Realm.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-PostgreSQL-Realm.adoc
@@ -25,7 +25,7 @@ $ ln -s /usr/share/java/postgresql-jdbc/postgresql.jar /usr/share/pki/server/com
 A sample PostgreSQL realm configuration is available at
 link:../../../base/acme/realm/postgresql/realm.conf[/usr/share/pki/acme/realm/postgresql/realm.conf].
 
-To use the PostgreSQL realm, copy the sample `realm.conf` into the `/etc/pki/pki-tomcat/acme` folder,
+To use the PostgreSQL realm, copy the sample `realm.conf` into the `/var/lib/pki/pki-tomcat/conf/acme` folder,
 or execute the following command to customize some of the parameters:
 
 ----

--- a/docs/installation/acme/Configuring_ACME_Database.md
+++ b/docs/installation/acme/Configuring_ACME_Database.md
@@ -4,7 +4,7 @@ Configuring ACME Database
 ## Overview
 
 This document describes the process to configure a database for ACME responder.
-The database configuration is located at /etc/pki/pki-tomcat/acme/database.conf.
+The database configuration is located at /var/lib/pki/pki-tomcat/conf/acme/database.conf.
 
 The `pki-server acme-database-mod` can be used to configure the database via command-line.
 If the command is invoked without any parameters, it will enter an interactive mode, for example:

--- a/docs/installation/acme/Configuring_ACME_Issuer.md
+++ b/docs/installation/acme/Configuring_ACME_Issuer.md
@@ -4,7 +4,7 @@ Configuring ACME Issuer
 ## Overview
 
 This document describes the process to configure an issuer for ACME responder.
-The issuer configuration is located at /etc/pki/pki-tomcat/acme/issuer.conf.
+The issuer configuration is located at /var/lib/pki/pki-tomcat/conf/acme/issuer.conf.
 
 The `pki-server acme-issuer-mod` can be used to configure the issuer via command-line.
 If the command is invoked without any parameters, it will enter an interactive mode, for example:

--- a/docs/installation/acme/Configuring_ACME_Realm.md
+++ b/docs/installation/acme/Configuring_ACME_Realm.md
@@ -4,7 +4,7 @@ Configuring ACME Realm
 ## Overview
 
 This document describes the process to configure a realm for ACME responder.
-The realm configuration is located at /etc/pki/pki-tomcat/acme/realm.conf.
+The realm configuration is located at /var/lib/pki/pki-tomcat/conf/acme/realm.conf.
 
 The `pki-server acme-realm-mod` can be used to configure the realm via command-line.
 If the command is invoked without any parameters, it will enter an interactive mode, for example:

--- a/docs/installation/acme/Installing_PKI_ACME_Responder.md
+++ b/docs/installation/acme/Installing_PKI_ACME_Responder.md
@@ -20,7 +20,7 @@ To create PKI ACME responder in a PKI server instance, execute the following com
 $ pki-server acme-create
 ```
 
-The command will create the initial configuration files in `/etc/pki/pki-tomcat/acme` folder.
+The command will create the initial configuration files in `/var/lib/pki/pki-tomcat/conf/acme` folder.
 
 ## Configuring ACME Responder
 
@@ -39,7 +39,7 @@ Once everything is ready, deploy the ACME responder with the following command:
 $ pki-server acme-deploy
 ```
 
-The command will create a deployment descriptor at `/etc/pki/pki-tomcat/Catalina/localhost/acme.xml`.
+The command will create a deployment descriptor at `/var/lib/pki/pki-tomcat/conf/Catalina/localhost/acme.xml`.
 
 The server will start the ACME responder automatically in a few seconds.
 It is not necessary to restart PKI server.
@@ -72,7 +72,7 @@ To undeploy the ACME responder, execute the following command:
 $ pki-server acme-undeploy
 ```
 
-The command will remove the deployment descriptor at `/etc/pki/pki-tomcat/Catalina/localhost/acme.xml`.
+The command will remove the deployment descriptor at `/var/lib/pki/pki-tomcat/conf/Catalina/localhost/acme.xml`.
 
 The server will stop the ACME responder automatically in a few seconds.
 It is not necessary to restart PKI server.

--- a/docs/installation/ca/Installing_CA.md
+++ b/docs/installation/ca/Installing_CA.md
@@ -30,10 +30,10 @@ CA System Certificates
 ----------------------
 
 After installation the CA system certificates and keys will be stored
-in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`):
+in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`):
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_Clone.md
+++ b/docs/installation/ca/Installing_CA_Clone.md
@@ -42,7 +42,7 @@ Note that the existing SSL server certificate will not be exported.
 If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
 
 ```
-$ pki -d /etc/pki/pki-tomcat/alias -f /etc/pki/pki-tomcat/password.conf \
+$ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
     --pkcs12-file ca-certs.p12 \
     --pkcs12-password Secret.123 \
@@ -113,11 +113,11 @@ CA System Certificates
 ----------------------
 
 After installation the existing CA system certificates (including the certificate chain)
-and their keys will be stored in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`),
+and their keys will be stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`),
 and a new SSL server certificate will be created for the new instance:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.md
@@ -90,7 +90,7 @@ $ pkispawn -f ca.cfg -s CA
 ```
 
 It will install CA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
 Verifying System Certificates
@@ -99,7 +99,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -111,7 +111,7 @@ ca_audit_signing                                             ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.md
+++ b/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.md
@@ -64,7 +64,7 @@ Note that the existing SSL server certificate will not be exported.
 If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
 
 ```
-$ pki -d /etc/pki/pki-tomcat/alias -f /etc/pki/pki-tomcat/password.conf \
+$ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
     --pkcs12-file ca-certs.p12 \
     --pkcs12-password Secret.123 \
@@ -109,11 +109,11 @@ CA System Certificates
 ----------------------
 
 After installation the existing CA system certificates (including the certificate chain)
-and their keys will be stored in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`),
+and their keys will be stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`),
 and a new SSL server certificate will be created for the new instance:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
+++ b/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.md
@@ -47,7 +47,7 @@ $ pkispawn -f ca-step1.cfg -s CA
 ```
 
 It will install CA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
 Since there is no CSR path parameter specified, it will not generate the CA signing key by default.
@@ -110,7 +110,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_with_ECC.md
+++ b/docs/installation/ca/Installing_CA_with_ECC.md
@@ -42,10 +42,10 @@ CA System Certificates
 ----------------------
 
 After installation the CA system certificates and keys will be stored
-in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`):
+in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`):
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.md
@@ -57,7 +57,7 @@ $ pkispawn -f ca-step1.cfg -s CA
 ```
 
 It will install CA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
 Since there are no CSR path parameters specified, it will not generate CA system and admin keys.
@@ -68,24 +68,24 @@ Exporting Existing System Certificates and CSRs
 Export the system certificates from the existing CA with the following commands:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd -n "HSM:ca_signing" -a > ca_signing.crt
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd -n "HSM:ca_ocsp_signing" -a > ca_ocsp_signing.crt
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd -n "HSM:ca_audit_signing" -a > ca_audit_signing.crt
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd -n "HSM:ca_signing" -a > ca_signing.crt
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd -n "HSM:ca_ocsp_signing" -a > ca_ocsp_signing.crt
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd -n "HSM:ca_audit_signing" -a > ca_audit_signing.crt
 ```
 
 Export the CSRs from the existing CA with the following commands:
 
 ```
 $ echo "-----BEGIN CERTIFICATE REQUEST-----" > ca_signing.csr
-$ sed -n "/^ca.signing.certreq=/ s/^[^=]*=// p" < /etc/pki/pki-tomcat/ca/CS.cfg >> ca_signing.csr
+$ sed -n "/^ca.signing.certreq=/ s/^[^=]*=// p" < /var/lib/pki/pki-tomcat/conf/ca/CS.cfg >> ca_signing.csr
 $ echo "-----END CERTIFICATE REQUEST-----" >> ca_signing.csr
 
 $ echo "-----BEGIN CERTIFICATE REQUEST-----" > ca_ocsp_signing.csr
-$ sed -n "/^ca.ocsp_signing.certreq=/ s/^[^=]*=// p" < /etc/pki/pki-tomcat/ca/CS.cfg >> ca_ocsp_signing.csr
+$ sed -n "/^ca.ocsp_signing.certreq=/ s/^[^=]*=// p" < /var/lib/pki/pki-tomcat/conf/ca/CS.cfg >> ca_ocsp_signing.csr
 $ echo "-----END CERTIFICATE REQUEST-----" >> ca_ocsp_signing.csr
 
 $ echo "-----BEGIN CERTIFICATE REQUEST-----" > ca_audit_signing.csr
-$ sed -n "/^ca.audit_signing.certreq=/ s/^[^=]*=// p" < /etc/pki/pki-tomcat/ca/CS.cfg >> ca_audit_signing.csr
+$ sed -n "/^ca.audit_signing.certreq=/ s/^[^=]*=// p" < /var/lib/pki/pki-tomcat/conf/ca/CS.cfg >> ca_audit_signing.csr
 $ echo "-----END CERTIFICATE REQUEST-----" >> ca_audit_signing.csr
 ```
 
@@ -135,7 +135,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -147,7 +147,7 @@ ca_audit_signing                                             ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.md
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.md
@@ -24,7 +24,7 @@ $ pkispawn -f ca-existing-certs-step1.cfg -s CA
 ```
 
 It will install CA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
 Since there are no CSR path parameters specified, it will not generate CA system and admin keys.
@@ -35,7 +35,7 @@ Exporting Existing System Keys, CSRs, Certificates
 Export the system keys and certificates from the existing CA into a PKCS #12 file with the following command:
 
 ```
-$ pki -d /etc/pki/pki-tomcat/alias -c Secret.123 pkcs12-export \
+$ pki -d /var/lib/pki/pki-tomcat/conf/alias -c Secret.123 pkcs12-export \
   --pkcs12 ca-certs.p12 \
   --password Secret.123
 $ pki pkcs12-cert-del --pkcs12-file ca-certs.p12 --pkcs12-password Secret.123 sslserver
@@ -46,15 +46,15 @@ Export the CSRs from the existing CA with the following commands:
 
 ```
 $ echo "-----BEGIN CERTIFICATE REQUEST-----" > ca_signing.csr
-$ sed -n "/^ca.signing.certreq=/ s/^[^=]*=// p" < /etc/pki/pki-tomcat/ca/CS.cfg >> ca_signing.csr
+$ sed -n "/^ca.signing.certreq=/ s/^[^=]*=// p" < /var/lib/pki/pki-tomcat/conf/ca/CS.cfg >> ca_signing.csr
 $ echo "-----END CERTIFICATE REQUEST-----" >> ca_signing.csr
 
 $ echo "-----BEGIN CERTIFICATE REQUEST-----" > ca_ocsp_signing.csr
-$ sed -n "/^ca.ocsp_signing.certreq=/ s/^[^=]*=// p" < /etc/pki/pki-tomcat/ca/CS.cfg >> ca_ocsp_signing.csr
+$ sed -n "/^ca.ocsp_signing.certreq=/ s/^[^=]*=// p" < /var/lib/pki/pki-tomcat/conf/ca/CS.cfg >> ca_ocsp_signing.csr
 $ echo "-----END CERTIFICATE REQUEST-----" >> ca_ocsp_signing.csr
 
 $ echo "-----BEGIN CERTIFICATE REQUEST-----" > ca_audit_signing.csr
-$ sed -n "/^ca.audit_signing.certreq=/ s/^[^=]*=// p" < /etc/pki/pki-tomcat/ca/CS.cfg >> ca_audit_signing.csr
+$ sed -n "/^ca.audit_signing.certreq=/ s/^[^=]*=// p" < /var/lib/pki/pki-tomcat/conf/ca/CS.cfg >> ca_audit_signing.csr
 $ echo "-----END CERTIFICATE REQUEST-----" >> ca_audit_signing.csr
 ```
 
@@ -103,7 +103,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
+++ b/docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.md
@@ -20,7 +20,7 @@ $ pkispawn -f ca-external-cert-step1.cfg -s CA
 ```
 
 It will install CA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
 It will also generate the CA signing key in the server NSS database and the CSR in the specified path.
@@ -80,7 +80,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_with_HSM.md
+++ b/docs/installation/ca/Installing_CA_with_HSM.md
@@ -51,7 +51,7 @@ $ pkispawn -f ca.cfg -s CA
 ```
 
 It will install CA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
 Verifying System Certificates
@@ -60,7 +60,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -72,7 +72,7 @@ ca_audit_signing                                             ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
+++ b/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.md
@@ -35,11 +35,11 @@ CA System Certificates
 ----------------------
 
 After installation the CA system certificates with their keys will be
-generated and stored in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`),
+generated and stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`),
 and the DS signing certificate will be imported into the same NSS database:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ca/Installing_Subordinate_CA.md
+++ b/docs/installation/ca/Installing_Subordinate_CA.md
@@ -30,7 +30,7 @@ $ pkispawn -f subca.cfg -s CA
 ```
 
 It will install subordinate CA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
 Verifying System Certificates
@@ -39,7 +39,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/est/Installing_EST.md
+++ b/docs/installation/est/Installing_EST.md
@@ -67,7 +67,7 @@ Configure the issuance backend. The class `org.dogtagpki.est.DogtagRABackend` is
 
 
 ```
-# cat >/etc/pki/pki-tomcat/est/backend.conf <<EOF
+# cat >/var/lib/pki/pki-tomcat/conf/est/backend.conf <<EOF
 class=org.dogtagpki.est.DogtagRABackend
 url=https://$(hostname):8443
 profile=estServiceCert
@@ -79,7 +79,7 @@ EOF
 Configure request authorization. The class `org.dogtagpki.est.ExternalProcessRequestAuthorizer` allows to delegate the authorization to an external process configured with the paramter **executable**:
 
 ```
-# cat >/etc/pki/pki-tomcat/est/authorizer.conf <<EOF
+# cat >/var/lib/pki/pki-tomcat/conf/est/authorizer.conf <<EOF
 class=org.dogtagpki.est.ExternalProcessRequestAuthorizer
 executable=/usr/local/libexec/estauthz
 EOF
@@ -110,7 +110,7 @@ Deploy the EST application:
 Configure the authentication. The authentication is build on `com.netscape.cms.tomcat.ProxyRealm` class which allows to use realms from *tomcat* or developed for dogtag. As an example we use an in memory realm:
 
 ```
-# cat >/etc/pki/pki-tomcat/est/realm.conf <<EOF
+# cat >/var/lib/pki/pki-tomcat/conf/est/realm.conf <<EOF
 class=com.netscape.cms.realm.PKIInMemoryRealm
 username=alice
 password=4me2Test

--- a/docs/installation/kra/Installing_KRA.md
+++ b/docs/installation/kra/Installing_KRA.md
@@ -19,7 +19,7 @@ $ pkispawn -f kra.cfg -s KRA
 ```
 
 It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
 **Note**: When KRA is installed on a new system without any other subsystems,
@@ -35,7 +35,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/kra/Installing_KRA_Clone.md
+++ b/docs/installation/kra/Installing_KRA_Clone.md
@@ -35,7 +35,7 @@ Note that the existing SSL server certificate will not be exported.
 If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
 
 ```
-$ pki -d /etc/pki/pki-tomcat/alias -f /etc/pki/pki-tomcat/password.conf \
+$ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
     --pkcs12-file kra-certs.p12 \
     --pkcs12-password Secret.123 \
@@ -65,11 +65,11 @@ KRA System Certificates
 -----------------------
 
 After installation the existing KRA system certificates (including the certificate chain)
-and their keys will be stored in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`),
+and their keys will be stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`),
 and a new SSL server certificate will be created for the new instance:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.md
@@ -61,7 +61,7 @@ $ pkispawn -f kra.cfg -s KRA
 ```
 
 It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
 Verifying System Certificates
@@ -70,7 +70,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -82,7 +82,7 @@ kra_audit_signing                                            ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/kra/Installing_KRA_on_Separate_Instance.md
+++ b/docs/installation/kra/Installing_KRA_on_Separate_Instance.md
@@ -23,7 +23,7 @@ $ pkispawn -f kra-separate.cfg -s KRA
 ```
 
 It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
 **Note**: When KRA is installed on a new system without any other subsystems,
@@ -39,7 +39,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
+++ b/docs/installation/kra/Installing_KRA_with_Custom_Keys.md
@@ -49,7 +49,7 @@ $ pkispawn -f kra-step1.cfg -s KRA
 ```
 
 It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/dogtag/pki-tomcat/kra/alias
 
 Since there are no CSR path parameters specified, it will not generate KRA system and admin keys.
@@ -137,7 +137,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/kra/Installing_KRA_with_ECC.md
+++ b/docs/installation/kra/Installing_KRA_with_ECC.md
@@ -80,7 +80,7 @@ $ pkispawn -f kra.cfg -s KRA
 ```
 
 It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
 Verifying System Certificates
@@ -89,7 +89,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/kra/Installing_KRA_with_External_Certificates.md
+++ b/docs/installation/kra/Installing_KRA_with_External_Certificates.md
@@ -22,7 +22,7 @@ $ pkispawn -f kra-external-certs-step1.cfg -s KRA
 ```
 
 It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/dogtag/pki-tomcat/kra/alias
 
 It will also generate the system keys in the server NSS database and the CSRs in the specified paths.
@@ -84,7 +84,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/kra/Installing_KRA_with_HSM.md
+++ b/docs/installation/kra/Installing_KRA_with_HSM.md
@@ -54,7 +54,7 @@ $ pkispawn -f kra.cfg -s KRA
 ```
 
 It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
 Verifying System Certificates
@@ -63,7 +63,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -75,7 +75,7 @@ kra_audit_signing                                            ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.md
@@ -55,7 +55,7 @@ $ pkispawn -f kra.cfg -s KRA
 ```
 
 It will install KRA subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
 Verifying System Certificates
@@ -64,7 +64,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ocsp/Installing_OCSP.md
+++ b/docs/installation/ocsp/Installing_OCSP.md
@@ -19,7 +19,7 @@ $ pkispawn -f ocsp.cfg -s OCSP
 ```
 
 It will install OCSP subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ocsp/alias
 
 **Note**: When OCSP is installed on a new system without any other subsystems,
@@ -35,7 +35,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -98,7 +98,7 @@ Verify that the OCSPClient can be used to validate a certificate:
 
 ```
 $ OCSPClient \
- -d /etc/pki/pki-tomcat/alias \
+ -d /var/lib/pki/pki-tomcat/conf/alias \
  -h pki.example.com \
  -p 8080 \
  -t /ocsp/ee/ocsp \

--- a/docs/installation/ocsp/Installing_OCSP_Clone.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone.md
@@ -34,7 +34,7 @@ Note that the existing SSL server certificate will not be exported.
 If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
 
 ```
-$ pki -d /etc/pki/pki-tomcat/alias -f /etc/pki/pki-tomcat/password.conf \
+$ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
     --pkcs12-file ocsp-certs.p12 \
     --pkcs12-password Secret.123 \
@@ -64,11 +64,11 @@ OCSP System Certificates
 ------------------------
 
 After installation the existing OCSP system certificates (including the certificate chain)
-and their keys will be stored in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`),
+and their keys will be stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`),
 and a new SSL server certificate will be created for the new instance:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.md
@@ -59,7 +59,7 @@ $ pkispawn -f ocsp.cfg -s OCSP
 ```
 
 It will install OCSP subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ocsp/alias
 
 Verifying System Certificates
@@ -68,7 +68,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -80,7 +80,7 @@ ocsp_audit_signing                                           ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -142,7 +142,7 @@ Verify that the OCSPClient can be used to validate a certificate:
 
 ```
 $ OCSPClient \
- -d /etc/pki/pki-tomcat/alias \
+ -d /var/lib/pki/pki-tomcat/conf/alias \
  -h pki.example.com \
  -p 8080 \
  -t /ocsp/ee/ocsp \

--- a/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.md
@@ -48,7 +48,7 @@ $ pkispawn -f ocsp-step1.cfg -s OCSP
 ```
 
 It will install OCSP subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ocsp/alias
 
 Since there are no CSR path parameters specified, it will not generate the OCSP system and admin keys.
@@ -131,7 +131,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ocsp/Installing_OCSP_with_ECC.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_ECC.md
@@ -73,7 +73,7 @@ $ pkispawn -f ocsp.cfg -s OCSP
 ```
 
 It will install OCSP subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
 Verifying System Certificates
@@ -82,7 +82,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_External_Certificates.md
@@ -22,7 +22,7 @@ $ pkispawn -f ocsp-external-certs-step1.cfg -s OCSP
 ```
 
 It will install OCSP subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ocsp/alias
 
 It will also generate the system keys in the server NSS database and the CSRs in the specified paths.
@@ -82,7 +82,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.md
@@ -53,7 +53,7 @@ $ pkispawn -f ocsp.cfg -s OCSP
 ```
 
 It will install OCSP subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ocsp/alias
 
 Verifying System Certificates
@@ -62,7 +62,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -74,7 +74,7 @@ ocsp_audit_signing                                           ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -136,7 +136,7 @@ Verify that the OCSPClient can be used to validate a certificate:
 
 ```
 $ OCSPClient \
- -d /etc/pki/pki-tomcat/alias \
+ -d /var/lib/pki/pki-tomcat/conf/alias \
  -h pki.example.com \
  -p 8080 \
  -t /ocsp/ee/ocsp \

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.md
@@ -54,7 +54,7 @@ $ pkispawn -f ocsp.cfg -s OCSP
 ```
 
 It will install OCSP subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ocsp/alias
 
 Verifying System Certificates
@@ -63,7 +63,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -147,7 +147,7 @@ Verify that the OCSPClient can be used to validate a certificate:
 
 ```
 $ OCSPClient \
- -d /etc/pki/pki-tomcat/alias \
+ -d /var/lib/pki/pki-tomcat/conf/alias \
  -h pki.example.com \
  -p 8080 \
  -t /ocsp/ee/ocsp \

--- a/docs/installation/server/Installing_PKI_Server_with_Custom_NSS_Databases.md
+++ b/docs/installation/server/Installing_PKI_Server_with_Custom_NSS_Databases.md
@@ -5,7 +5,7 @@
 This page describes the process to create a PKI server with custom NSS databases.
 
 Normally, when installing a PKI subsystem (e.g. CA) some NSS databases will be created by default, for example:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
 Under some circumstances the admin may want to use custom NSS databases (e.g. with trust policy).
@@ -23,7 +23,7 @@ To create a basic PKI server, execute the following command:
 $ pki-server create
 ```
 
-This will create a server in /var/lib/pki/pki-tomcat with configuration files in /etc/pki/pki-tomcat.
+This will create a server in /var/lib/pki/pki-tomcat with configuration files in /var/lib/pki/pki-tomcat/conf.
 
 See also [PKI Server CLI](https://github.com/dogtagpki/pki/wiki/PKI-Server-CLI).
 
@@ -39,7 +39,7 @@ To enable trust policy:
 
 ```
 $ modutil \
-    -dbdir /etc/pki/pki-tomcat/alias \
+    -dbdir /var/lib/pki/pki-tomcat/conf/alias \
     -add p11-kit-trust \
     -libfile /usr/share/pki/lib/p11-kit-trust.so
 ```

--- a/docs/installation/tks/Installing_TKS.md
+++ b/docs/installation/tks/Installing_TKS.md
@@ -19,7 +19,7 @@ $ pkispawn -f tks.cfg -s TKS
 ```
 
 It will install TKS subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/tks/alias
 
 **Note**: When TKS is installed on a new system without any other subsystems,
@@ -35,7 +35,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/tks/Installing_TKS_Clone.md
+++ b/docs/installation/tks/Installing_TKS_Clone.md
@@ -33,7 +33,7 @@ Note that the existing SSL server certificate will not be exported.
 If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
 
 ```
-$ pki -d /etc/pki/pki-tomcat/alias -f /etc/pki/pki-tomcat/password.conf \
+$ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
     --pkcs12-file tks-certs.p12 \
     --pkcs12-password Secret.123 \
@@ -63,11 +63,11 @@ TKS System Certificates
 -----------------------
 
 After installation the existing TKS system certificates (including the certificate chain)
-and their keys will be stored in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`),
+and their keys will be stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`),
 and a new SSL server certificate will be created for the new instance:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/tks/Installing_TKS_with_ECC.md
+++ b/docs/installation/tks/Installing_TKS_with_ECC.md
@@ -70,7 +70,7 @@ $ pkispawn -f tks.cfg -s TKS
 ```
 
 It will install TKS subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/kra/alias
 
 Verifying System Certificates
@@ -79,7 +79,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/tks/Installing_TKS_with_HSM.md
+++ b/docs/installation/tks/Installing_TKS_with_HSM.md
@@ -52,7 +52,7 @@ $ pkispawn -f tks.cfg -s TKS
 ```
 
 It will install TKS subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/tks/alias
 
 Verifying System Certificates
@@ -61,7 +61,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -73,7 +73,7 @@ tks_audit_signing                                            ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.md
@@ -53,7 +53,7 @@ $ pkispawn -f tks.cfg -s TKS
 ```
 
 It will install TKS subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/tks/alias
 
 Verifying System Certificates
@@ -62,7 +62,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/tps/Installing_TPS.md
+++ b/docs/installation/tps/Installing_TPS.md
@@ -19,7 +19,7 @@ $ pkispawn -f tps.cfg -s TPS
 ```
 
 It will install TPS subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/tps/alias
 
 **Note**: When TPS is installed on a new system without any other subsystems,
@@ -35,7 +35,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/tps/Installing_TPS_Clone.md
+++ b/docs/installation/tps/Installing_TPS_Clone.md
@@ -34,7 +34,7 @@ Note that the existing SSL server certificate will not be exported.
 If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
 
 ```
-$ pki -d /etc/pki/pki-tomcat/alias -f /etc/pki/pki-tomcat/password.conf \
+$ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
     --pkcs12-file tps-certs.p12 \
     --pkcs12-password Secret.123 \
@@ -64,11 +64,11 @@ TPS System Certificates
 -----------------------
 
 After installation the existing TPS system certificates (including the certificate chain)
-and their keys will be stored in the server NSS database (i.e. `/etc/pki/pki-tomcat/alias`),
+and their keys will be stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`),
 and a new SSL server certificate will be created for the new instance:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/tps/Installing_TPS_with_HSM.md
+++ b/docs/installation/tps/Installing_TPS_with_HSM.md
@@ -52,7 +52,7 @@ $ pkispawn -f tps.cfg -s TPS
 ```
 
 It will install TPS subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/tps/alias
 
 Verifying System Certificates
@@ -61,7 +61,7 @@ Verifying System Certificates
 Verify that the internal token contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI
@@ -73,7 +73,7 @@ tps_audit_signing                                            ,,P
 Verify that the HSM contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias -h HSM -f HSM.pwd
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.md
@@ -53,7 +53,7 @@ $ pkispawn -f tps.cfg -s TPS
 ```
 
 It will install TPS subsystem in a Tomcat instance (default is pki-tomcat) and create the following NSS databases:
-* server NSS database: /etc/pki/pki-tomcat/alias
+* server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/tps/alias
 
 Verifying System Certificates
@@ -62,7 +62,7 @@ Verifying System Certificates
 Verify that the server NSS database contains the following certificates:
 
 ```
-$ certutil -L -d /etc/pki/pki-tomcat/alias
+$ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
 Certificate Nickname                                         Trust Attributes
                                                              SSL,S/MIME,JAR/XPI

--- a/docs/manuals/man5/pki-server-logging.5.md
+++ b/docs/manuals/man5/pki-server-logging.5.md
@@ -6,7 +6,7 @@ pki-server-logging - PKI Server Logging Configuration
 
 ## LOCATION
 
-/etc/pki/*instance*/logging.properties, /etc/pki/*instance*/*subsystem*/CS.cfg
+/var/lib/pki/*instance*/conf/logging.properties, /var/lib/pki/*instance*/conf/*subsystem*/CS.cfg
 
 ## DESCRIPTION
 
@@ -21,7 +21,7 @@ Tomcat uses java.util.logging (JUL) as the default logging framework.
 The configuration is described in [Tomcat Logging](http://tomcat.apache.org/tomcat-9.0-doc/logging.html).
 
 The default configuration is located at /usr/share/pki/server/conf/logging.properties.
-During server deployment a link will be created at /etc/pki/*instance*/logging.properties.
+During server deployment a link will be created at /var/lib/pki/*instance*/conf/logging.properties.
 
 By default only log messages with level WARNING or higher will be logged on the console (i.e. systemd journal).
 
@@ -52,7 +52,7 @@ For more information see the following documents:
 
 Each PKI subsystem uses an internal logging framework for debugging purposes.
 
-The logging configuration is stored in /etc/pki/*instance*/*subsystem*/CS.cfg.
+The logging configuration is stored in /var/lib/pki/*instance*/conf/*subsystem*/CS.cfg.
 
 ```
 debug.level=10
@@ -69,9 +69,9 @@ The default value is 10.
 To customize JUL configuration, replace the link with a copy of the default configuration:
 
 ```
-$ rm -f /etc/pki/<instance>/logging.properties
-$ cp /usr/share/pki/server/conf/logging.properties /etc/pki/<instance>
-$ chown pkiuser.pkiuser /etc/pki/<instance>/logging.properties
+$ rm -f /var/lib/pki/<instance>/conf/logging.properties
+$ cp /usr/share/pki/server/conf/logging.properties /var/lib/pki/<instance>/conf
+$ chown pkiuser.pkiuser /var/lib/pki/<instance>/conf/logging.properties
 ```
 
 Then edit the file as needed.

--- a/docs/manuals/man5/pki_default.cfg.5.md
+++ b/docs/manuals/man5/pki_default.cfg.5.md
@@ -224,7 +224,7 @@ For a CA, this defaults to **ca_admin_cert.p12** in the **pki_client_dir** direc
 
 **pki_backup_keys**, **pki_backup_file**, **pki_backup_password**  
 Set **pki_backup_keys** to True to back up the subsystem certificates and keys to a PKCS #12 file
-specified in **pki_backup_file** (default is /etc/pki/*instance_name*/alias/*subsystem*_backup_keys.p12).
+specified in **pki_backup_file** (default is /var/lib/pki/*instance_name*/conf/alias/*subsystem*_backup_keys.p12).
 **pki_backup_password** is the password of the PKCS#12 file.
 
 **Important:**
@@ -533,7 +533,7 @@ Defaults to False.
 **pki_cert_chain_path**  
 Required for the second step of a stand-alone PKI process.
 This is the location of the file containing the external CA signing certificate (as issued by the external CA).
-Defaults to /etc/pki/*instance_name*/external_ca.cert.
+Defaults to /var/lib/pki/*instance_name*/conf/external_ca.cert.
 
 **pki_ca_signing_cert_path**  
 Required for the second step of a stand-alone PKI process.

--- a/docs/manuals/man8/pki-server-nuxwdog.8.md
+++ b/docs/manuals/man8/pki-server-nuxwdog.8.md
@@ -13,7 +13,7 @@ pki-server-nuxwdog - Command-line interface for enabling PKI server instances to
 ## DESCRIPTION
 
 When a PKI server instance starts, it reads a plain text configuration file
-(i.e. /etc/pki/*instance_name*/password.conf) to obtain passwords needed to initialize the server.
+(i.e. /var/lib/pki/*instance_name*/conf/password.conf) to obtain passwords needed to initialize the server.
 This could include passwords needed to access server keys in hardware or software cryptographic modules,
 or passwords to establish database connections.
 

--- a/docs/manuals/man8/pkispawn.8.md
+++ b/docs/manuals/man8/pkispawn.8.md
@@ -990,7 +990,7 @@ and setting the relevant SELinux and file permissions is shown below.
 **pkcs12_password_file** is a text file containing the password selected for the generated PKCS12 file.
 
 ```
-master# PKCS12Export -d /etc/pki/pki-tomcat/alias -p pwfile \
+master# PKCS12Export -d /var/lib/pki/pki-tomcat/conf/alias -p pwfile \
         -w pkcs12_password_file -o backup_keys.p12
 master# scp backup_keys.p12 clone:/backup_keys.p12
 
@@ -1014,7 +1014,7 @@ master# pki-server ca-clone-prepare -i pki-tomcat \
         --pkcs12-password Secret123
 
 master# scp backup_keys.p12 clone:/backup_keys.p12
-master# scp /etc/pki/pki-tomcat/external_certs.conf \
+master# scp /var/lib/pki/pki-tomcat/conf/external_certs.conf \
          clone:/external_certs.conf
 ```
 


### PR DESCRIPTION
Similar to commit 13c25e507b1e7ee7fd69cac79c048d4ac73543b2, the docs have been updated to use the standard Tomcat `conf` dir instead of Fedora-specific dir such that the docs will be valid for all deployment scenarios.