### PR TITLE
Fix Bug 2265180 - Add Support for Symmetric Key Rollover [RHCS 9.7.z].

### DIFF
--- a/base/common/src/org/dogtagpki/tps/apdu/APDU.java
+++ b/base/common/src/org/dogtagpki/tps/apdu/APDU.java
@@ -58,7 +58,8 @@ public abstract class APDU {
         APDU_GET_ISSUERINFO,
         APDU_GENERATE_KEY_ECC,
         APDU_GET_LIFECYCLE,
-        APDU_CLEAR_KEY_SLOTS
+        APDU_CLEAR_KEY_SLOTS,
+        APDU_DELETE_KEYS   // ** G&D 256 Key Rollover Support **
     }
 
     protected byte cla;

--- a/base/common/src/org/dogtagpki/tps/apdu/DeleteKeysAPDU.java
+++ b/base/common/src/org/dogtagpki/tps/apdu/DeleteKeysAPDU.java
@@ -1,0 +1,35 @@
+package org.dogtagpki.tps.apdu;
+
+/**
+ * ** G&D 256 Key Rollover Support **
+ */
+
+import org.dogtagpki.tps.main.TPSBuffer;
+import com.netscape.certsrv.apps.CMS;
+
+public class DeleteKeysAPDU extends APDU {
+
+    public DeleteKeysAPDU(TPSBuffer keyVersion) {
+        setCLA((byte) 0x84);
+        setINS((byte) 0xE4);
+        setP1((byte) 0x00);
+        setP2((byte) 0x00);
+
+        TPSBuffer keyData = new TPSBuffer();
+
+        keyData.add((byte) 0xD2);               // tag for deleting key version
+        keyData.add((byte) keyVersion.size());  // length of key version
+        keyData.add(keyVersion);                // key version
+
+        //CMS.debug("DeleteKeysAPDU: keyData = " + keyData.toHexString());
+        
+        setData(keyData);
+
+    }
+
+    @Override
+    public APDU.Type getType() {
+        return APDU.Type.APDU_DELETE_KEYS;
+
+    }
+}

--- a/base/common/src/org/dogtagpki/tps/msg/EndOpMsg.java
+++ b/base/common/src/org/dogtagpki/tps/msg/EndOpMsg.java
@@ -68,7 +68,8 @@ public class EndOpMsg extends TPSMessage {
         STATUS_ERROR_NOT_TOKEN_OWNER,
         STATUS_RENEWAL_IS_PROCESSED,
         STATUS_ERROR_RENEWAL_FAILED,
-        STATUS_ERROR_CANNOT_ESTABLISH_COMMUNICATION
+        STATUS_ERROR_CANNOT_ESTABLISH_COMMUNICATION,
+        STATUS_ERROR_SYMKEY_256_UPGRADE // ** G&D 256 Key Rollover Support **
     };
 
 
@@ -226,6 +227,9 @@ public class EndOpMsg extends TPSMessage {
             break;
         case STATUS_ERROR_CANNOT_ESTABLISH_COMMUNICATION:
             result = 45;
+            break;
+        case STATUS_ERROR_SYMKEY_256_UPGRADE: // ** G&D 256 Key Rollover Support **
+            result = 46;
             break;
         default:
             break;

--- a/base/kra/src/com/netscape/kra/NetkeyKeygenService.java
+++ b/base/kra/src/com/netscape/kra/NetkeyKeygenService.java
@@ -27,6 +27,7 @@ import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.SecureRandom;
 
+import org.dogtagpki.tps.main.TPSBuffer;
 import org.mozilla.jss.asn1.ASN1Util;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.EncryptionAlgorithm;

--- a/base/server/cms/src/com/netscape/cms/servlet/tks/SecureChannelProtocol.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/tks/SecureChannelProtocol.java
@@ -1818,14 +1818,15 @@ public class SecureChannelProtocol {
             byte[] CUIDValue,
             byte[] KDD,
             byte[] kekKeyArray, byte[] encKeyArray, byte[] macKeyArray,
-            String useSoftToken, String keySet, byte protocol, GPParams params) throws EBaseException {
+            String useSoftToken, String keySet, byte protocol, GPParams params, 
+            GPParams oldParams) throws EBaseException { // ** G&D 256 Key Rollover Support ** add oldParams parameter
 
         String method = "SecureChannelProtocol.diversifyKey:";
 
         CMS.debug(method + " Entering ... newTokenName: " + newTokenName + " protocol: " + protocol);
         CMS.debug(method + " oldMasterKeyName: " + oldMasterKeyName);
         CMS.debug(method + " newMasterKeyName: " + newMasterKeyName);
-
+        
         //SecureChannelProtocol.debugByteArray(encKeyArray, " Developer enc key array: ");
         //SecureChannelProtocol.debugByteArray(macKeyArray, " Developer mac key array: ");
         //SecureChannelProtocol.debugByteArray(kekKeyArray, " Developer kek key array: ");
@@ -1965,11 +1966,12 @@ public class SecureChannelProtocol {
                 }
 
             } else { // Protocol 3
-
+                // ** G&D 256 Key Rollover Support **
+                // use the oldParams to compute the old_kek_sym_key
                 old_kek_sym_key = this.computeSessionKey_SCP03(tokenName, oldMasterKeyName,
-                        oldKeyInfo, SecureChannelProtocol.kekType, kekKeyArray, keySet,
-                        CUIDValue, KDD, null, null, transportKeyName, params);
-
+                      oldKeyInfo, SecureChannelProtocol.kekType, kekKeyArray, keySet,
+                      CUIDValue, KDD, null, null, transportKeyName, oldParams);
+                
                 CMS.debug(method + " Moving back to the developer key set case, protocol 3");
             }
         }
@@ -2042,10 +2044,11 @@ public class SecureChannelProtocol {
 
                 // Generate an old kek key to do the encrypting of the new static keys
 
+                // ** G&D 256 Key Rollover Support **
+                // use the oldParams to compute the old_kek_sym_key
                 old_kek_sym_key = this.computeSessionKey_SCP03(tokenName, oldMasterKeyName, oldKeyInfo,
                         SecureChannelProtocol.kekType, kekKeyArray,
-                        keySet, CUIDValue, KDD, null, null, transportKeyName, params);
-
+                        keySet, CUIDValue, KDD, null, null, transportKeyName, oldParams);
             }
 
             if (encKey == null || macKey == null || kekKey == null) {

--- a/base/server/cms/src/org/dogtagpki/server/connector/IRemoteRequest.java
+++ b/base/server/cms/src/org/dogtagpki/server/connector/IRemoteRequest.java
@@ -48,6 +48,7 @@ public interface IRemoteRequest {
     public static final String TOKEN_NEW_KEYINFO = "newKeyInfo";
     public static final String TOKEN_DATA = "data";
     public static final String WRAPPED_DEK_SESSION_KEY = "wrappedDekKey";
+    public static final String TOKEN_OLD_KEYSET = "oldKeySet";  // ** G&D 256 Key Rollover Support **
 
     // TKS response params
     /* computeSessionKey responses */
@@ -60,6 +61,7 @@ public interface IRemoteRequest {
     public static final String TKS_RESPONSE_DRM_Trans_DesKey = "drm_trans_desKey";
     public static final String TKS_RESPONSE_DRM_Trans_AesKey = "drm_trans_aesKey";
     public static final String TKS_RESPONSE_KeyCheck = "keycheck";
+    public static final String TKS_RESPONSE_KeyCheck_Des = "keycheck_des";          // Applet and Alg Selection by Token Range Support
     public static final String TKS_RESPONSE_HostCryptogram = "hostCryptogram";
 
     /* createKeySetData response */

--- a/base/tps/src/org/dogtagpki/server/tps/cms/TKSComputeSessionKeyResponse.java
+++ b/base/tps/src/org/dogtagpki/server/tps/cms/TKSComputeSessionKeyResponse.java
@@ -59,6 +59,11 @@ public class TKSComputeSessionKeyResponse extends RemoteResponse
         return (TPSBuffer) nameValTable.get(IRemoteRequest.TKS_RESPONSE_KeyCheck);
     }
 
+    // Applet and Alg Selection by Token Range Support
+    public TPSBuffer getKeyCheckDes() {
+        return (TPSBuffer) nameValTable.get(IRemoteRequest.TKS_RESPONSE_KeyCheck_Des);
+    }
+
     public TPSBuffer getHostCryptogram() {
         return (TPSBuffer) nameValTable.get(IRemoteRequest.TKS_RESPONSE_HostCryptogram);
     }

--- a/base/tps/src/org/dogtagpki/server/tps/cms/TKSRemoteRequestHandler.java
+++ b/base/tps/src/org/dogtagpki/server/tps/cms/TKSRemoteRequestHandler.java
@@ -315,6 +315,9 @@ public class TKSRemoteRequestHandler extends RemoteRequestHandler
                 + Util.specialURLEncode(card_cryptogram.toBytesArray()) +
                 "&" + IRemoteRequest.TOKEN_KEYSET + "=" + keySet;
 
+        //CMS.debug(method + " request to TKS: " + requestString);
+        CMS.debug(method + " sending request to TKS...");
+        
         HttpResponse resp =
                 conn.send("computeSessionKey",
                         requestString
@@ -420,6 +423,19 @@ public class TKSRemoteRequestHandler extends RemoteRequestHandler
                 CMS.debug(method + " got IRemoteRequest.TKS_RESPONSE_KeyCheck");
                 response.put(IRemoteRequest.TKS_RESPONSE_KeyCheck, Util.specialDecode(value));
             }
+            
+            // Applet and Alg Selection by Token Range Support - begin
+            value = (String) response.get(IRemoteRequest.TKS_RESPONSE_KeyCheck_Des);
+
+            if (value == null) {
+                CMS.debug(method + "response missing name-value pair for: " +
+                        IRemoteRequest.TKS_RESPONSE_KeyCheck_Des);
+
+            } else {
+                CMS.debug(method + " got IRemoteRequest.TKS_RESPONSE_KeyCheck_Des");
+                response.put(IRemoteRequest.TKS_RESPONSE_KeyCheck_Des, Util.specialDecode(value));
+            }
+            // Applet and Alg Selection by Token Range Support - end
 
             value = (String) response.get(IRemoteRequest.TKS_RESPONSE_HostCryptogram);
             if ( value == null ) {
@@ -618,7 +634,7 @@ public class TKSRemoteRequestHandler extends RemoteRequestHandler
     public TKSCreateKeySetDataResponse createKeySetData (
             TPSBuffer NewMasterVer,
             TPSBuffer version,
-            TPSBuffer cuid, TPSBuffer kdd, int protocol, TPSBuffer wrappedDekSessionKey)
+            TPSBuffer cuid, TPSBuffer kdd, int protocol, TPSBuffer wrappedDekSessionKey, String oldKeySet)  // ** G&D 256 Key Rollover Support ** add oldKeySet parameter
             throws EBaseException {
         CMS.debug("TKSRemoteRequestHandler: createKeySetData(): begins.");
         if (cuid == null || NewMasterVer == null || version == null) {
@@ -645,7 +661,14 @@ public class TKSRemoteRequestHandler extends RemoteRequestHandler
         if (wrappedDekSessionKey != null) { // We have secure channel protocol 02 trying to upgrade the key set.
             command += "&" + IRemoteRequest.WRAPPED_DEK_SESSION_KEY + "=" + Util.specialURLEncode(wrappedDekSessionKey);
         }
-
+        
+        // ** G&D 256 Key Rollover Support **
+        // include oldKeySet name in the request TKS if provided
+        if (oldKeySet != null) {
+            command += "&" + IRemoteRequest.TOKEN_OLD_KEYSET + "=" + oldKeySet;
+        }
+        CMS.debug("TKSRemoteRequestHandler: createKeySetData(): request to TKS: " + command); 
+        
         HttpResponse resp =
                 conn.send("createKeySetData",
                         command);

--- a/base/tps/src/org/dogtagpki/server/tps/engine/TPSEngine.java
+++ b/base/tps/src/org/dogtagpki/server/tps/engine/TPSEngine.java
@@ -429,7 +429,9 @@ public class TPSEngine {
 
     }
 
-    public TPSBuffer createKeySetData(TPSBuffer newMasterVersion, TPSBuffer oldVersion, int protocol, TPSBuffer cuid, TPSBuffer kdd, TPSBuffer wrappedDekSessionKey, String connId, String inKeyset)
+    // ** G&D 256 Key Rollover Support **
+    // Add oldKeySet parameter
+    public TPSBuffer createKeySetData(TPSBuffer newMasterVersion, TPSBuffer oldVersion, int protocol, TPSBuffer cuid, TPSBuffer kdd, TPSBuffer wrappedDekSessionKey, String connId, String inKeyset, String oldKeySet)
             throws TPSException {
 
         String method = "TPSEngine.createKeySetData:";
@@ -440,13 +442,17 @@ public class TPSEngine {
                     TPSStatus.STATUS_ERROR_UPGRADE_APPLET);
         }
 
+        CMS.debug(method + " cuid: " + cuid.toHexStringPlain() + " newMasterVersion: " + newMasterVersion.toHexString()
+                + "  oldVersion: " + oldVersion.toHexString() + "  protocol: " + protocol + " inKeyset: " + inKeyset
+                + "  oldKeySet: " + oldKeySet);
+        
         TKSRemoteRequestHandler tks = null;
 
         TKSCreateKeySetDataResponse resp = null;
 
         try {
             tks = new TKSRemoteRequestHandler(connId, inKeyset);
-            resp = tks.createKeySetData(newMasterVersion, oldVersion, cuid, kdd, protocol,wrappedDekSessionKey);
+            resp = tks.createKeySetData(newMasterVersion, oldVersion, cuid, kdd, protocol,wrappedDekSessionKey, oldKeySet);  // ** G&D 256 Key Rollover Support ** pass oldKeySet to TKS
         } catch (EBaseException e) {
 
             throw new TPSException(method + " failure to get key set data from TKS",

--- a/base/tps/src/org/dogtagpki/server/tps/mapping/BaseMappingResolver.java
+++ b/base/tps/src/org/dogtagpki/server/tps/mapping/BaseMappingResolver.java
@@ -38,5 +38,8 @@ public abstract class BaseMappingResolver {
 
     public abstract String getResolvedMapping(FilterMappingParams mappingParams, String nameToMap)
             throws TPSException;
-
+    
+    // ** G&D 256 Key Rollover Support **
+    public abstract String getResolvedMapping(FilterMappingParams mappingParams, String nameToMap, Integer symKeySize)
+            throws TPSException;
 }

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSPinResetProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSPinResetProcessor.java
@@ -244,7 +244,13 @@ public class TPSPinResetProcessor extends TPSProcessor {
                             (TPSSubsystem) CMS.getSubsystem(TPSSubsystem.ID);
                     BaseMappingResolver resolverInst =
                             subsystem.getMappingResolverManager().getResolverInstance(resolverInstName);
-                    String keySet = resolverInst.getResolvedMapping(mappingParams, "keySet");
+                    
+                    // ** G&D 256 Key Rollover Support **
+                    // Get the key size on card and pass it in to getResolvedMapping
+                    Integer symKeySize = getCardSymKeyLength(appletInfo.getCUIDhexStringPlain());
+                    CMS.debug(method + " symKeySize on card: " + symKeySize);
+                    
+                    String keySet = resolverInst.getResolvedMapping(mappingParams, "keySet", symKeySize);
                     setSelectedKeySet(keySet);
                     CMS.debug(method + " resolved keySet: " + keySet);
                 }


### PR DESCRIPTION
The purpose of this fix is two fold, based on external code contributions.

1. Implement the feature that allows certain 128 bit AES tokens to be upgraded to be 256 bit AES tokens.
2. Implement the feature that allows certain legacy scp03 tokens to have private keys injected with the legacy DES based unrapping algorithm.

Feature 1 works ONLY for external registration based enrollments. This requires the use of new key mappings that allow us to map the incoming token to a given keyset. Examples of this configuration will be provided in the bug testing instructions, which consists of keyset mapping entries in the TPS config, which then map to actual keyset config entries in the TKS.

Feature 2 was originally designed to work only for external reg. Redhat has added some minor mods to allow this to be configured in the non external reg case if desired, using the existing config variable per token profile. The key mapping resolver configurations for this feature has been upgraded to handle the desired wrapping algorithm and desired applet file version. Note once again this keyset mapping resolver feature is only available for external registration enrollment.

Rollover feature tested in dev for the g&d 7.0, while the legacy wrapping feature has been dev tested for the safenet sc650 scp03 token with both external reg and non external reg.