### PR TITLE
Use standard conf dir

### DIFF
--- a/base/acme/conf/configsources.conf
+++ b/base/acme/conf/configsources.conf
@@ -12,4 +12,4 @@ engine.class=org.dogtagpki.acme.server.ACMEEngineConfigFileSource
 
 # The 'filename' parameter tells the ACMEEngineConfigFileSource
 # where to read the engine configuration from.
-engine.filename=/etc/pki/pki-tomcat/acme/engine.conf
+engine.filename=/var/lib/pki/pki-tomcat/conf/acme/engine.conf

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -12,7 +12,7 @@ then
     echo "INFO: Importing system certs and keys"
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         pkcs12-import \
         --pkcs12 /certs/server.p12 \
         --password Secret.123
@@ -32,7 +32,7 @@ echo "##########################################################################
 # check if CA signing cert exists
 rc=0
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-export \
     --output-file /certs/ca_signing.crt \
     ca_signing || rc=$?
@@ -42,14 +42,14 @@ then
     echo "INFO: Creating CA signing cert"
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-request \
         --subject "CN=CA Signing Certificate" \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
         --csr /certs/ca_signing.csr
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-issue \
         --csr /certs/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
@@ -58,7 +58,7 @@ then
         --cert /certs/ca_signing.crt
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-import \
         --cert /certs/ca_signing.crt \
         --trust CT,C,C \
@@ -67,7 +67,7 @@ fi
 
 echo "INFO: CA signing cert:"
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
     ca_signing
 
@@ -76,7 +76,7 @@ echo "##########################################################################
 # check if OCSP signing cert exists
 rc=0
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-export \
     --output-file /certs/ocsp_signing.crt \
     ocsp_signing || rc=$?
@@ -86,14 +86,14 @@ then
     echo "INFO: Creating OCSP signing cert"
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-request \
         --subject "CN=OCSP Signing Certificate" \
         --ext /usr/share/pki/server/certs/ocsp_signing.conf \
         --csr /certs/ocsp_signing.csr
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-issue \
         --issuer ca_signing \
         --csr /certs/ocsp_signing.csr \
@@ -101,7 +101,7 @@ then
         --cert /certs/ocsp_signing.crt
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-import \
         --cert /certs/ocsp_signing.crt \
         ocsp_signing
@@ -109,7 +109,7 @@ fi
 
 echo "INFO: OCSP signing cert:"
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
     ocsp_signing
 
@@ -118,7 +118,7 @@ echo "##########################################################################
 # check if audit signing cert exists
 rc=0
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-export \
     --output-file /certs/audit_signing.crt \
     audit_signing || rc=$?
@@ -128,14 +128,14 @@ then
     echo "INFO: Creating audit signing cert"
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-request \
         --subject "CN=Audit Signing Certificate" \
         --ext /usr/share/pki/server/certs/audit_signing.conf \
         --csr /certs/audit_signing.csr
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-issue \
         --issuer ca_signing \
         --csr /certs/audit_signing.csr \
@@ -143,7 +143,7 @@ then
         --cert /certs/audit_signing.crt
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-import \
         --cert /certs/audit_signing.crt \
         --trust ,,P \
@@ -152,7 +152,7 @@ fi
 
 echo "INFO: Audit signing cert:"
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
     audit_signing
 
@@ -161,7 +161,7 @@ echo "##########################################################################
 # check if subsystem cert exists
 rc=0
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-export \
     --output-file /certs/subsystem.crt \
     subsystem || rc=$?
@@ -171,13 +171,13 @@ then
     echo "INFO: Creating subsystem cert"
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-request \
         --subject "CN=Subsystem Certificate" \
         --csr /certs/subsystem.csr
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-issue \
         --issuer ca_signing \
         --csr /certs/subsystem.csr \
@@ -185,7 +185,7 @@ then
         --cert /certs/subsystem.crt
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-import \
         --cert /certs/subsystem.crt \
         subsystem
@@ -193,7 +193,7 @@ fi
 
 echo "INFO: Subsystem cert:"
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
     subsystem
 
@@ -202,7 +202,7 @@ echo "##########################################################################
 # check if SSL server cert exists
 rc=0
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
     --output-file /certs/sslserver.crt \
     sslserver || rc=$?
@@ -212,14 +212,14 @@ then
     echo "INFO: Creating SSL server cert:"
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-request \
         --subject "CN=$HOSTNAME" \
         --ext /usr/share/pki/server/certs/sslserver.conf \
         --csr /certs/sslserver.csr
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-issue \
         --issuer ca_signing \
         --csr /certs/sslserver.csr \
@@ -227,7 +227,7 @@ then
         --cert /certs/sslserver.crt
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-import \
         --cert /certs/sslserver.crt \
         sslserver
@@ -235,7 +235,7 @@ fi
 
 echo "INFO: SSL server cert:"
 pki \
-    -d /etc/pki/pki-tomcat/alias \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
     sslserver
 
@@ -287,7 +287,7 @@ then
     echo "INFO: Exporting CA signing cert"
 
     pki \
-        -d /etc/pki/pki-tomcat/alias \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-export \
         --output-file /certs/ca_signing.crt \
         ca_signing

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -830,7 +830,7 @@ class PKIDeployer:
                 params=self.mdict,
                 force=True)
 
-            # Merge temporary CS.cfg into /etc/pki/<instance>/<subsystem>/CS.cfg
+            # Merge temporary CS.cfg into /var/lib/pki/<instance>/conf/<subsystem>/CS.cfg
             # to preserve params in existing CS.cfg
 
             pki.util.load_properties(tmp_cs_cfg, subsystem.config)
@@ -4809,10 +4809,11 @@ class PKIDeployer:
         self.file.copy(manifest_file, manifest_archive)
 
     def restore_selinux_contexts(self):
+
         selinux.restorecon(self.instance.base_dir, True)
         selinux.restorecon(config.PKI_DEPLOYMENT_LOG_ROOT, True)
         selinux.restorecon(self.instance.log_dir, True)
-        selinux.restorecon(self.instance.conf_dir, True)
+        selinux.restorecon(self.instance.actual_conf_dir, True)
 
     def selinux_context_exists(self, records, context_value):
         '''
@@ -4834,9 +4835,9 @@ class PKIDeployer:
 
         fcon = seobject.fcontextRecords(trans)
 
-        logger.info('Adding SELinux fcontext "%s"', self.instance.conf_dir + suffix)
+        logger.info('Adding SELinux fcontext "%s"', self.instance.actual_conf_dir + suffix)
         fcon.add(
-            self.instance.conf_dir + suffix,
+            self.instance.actual_conf_dir + suffix,
             config.PKI_CFG_SELINUX_CONTEXT, '', 's0', '')
 
         logger.info('Adding SELinux fcontext "%s"', self.instance.nssdb_dir + suffix)
@@ -4894,9 +4895,9 @@ class PKIDeployer:
             logger.info('Removing SELinux fcontext "%s"', self.instance.nssdb_dir + suffix)
             fcon.delete(self.instance.nssdb_dir + suffix, '')
 
-        if self.selinux_context_exists(file_records, self.instance.conf_dir + suffix):
-            logger.info('Removing SELinux fcontext "%s"', self.instance.conf_dir + suffix)
-            fcon.delete(self.instance.conf_dir + suffix, '')
+        if self.selinux_context_exists(file_records, self.instance.actual_conf_dir + suffix):
+            logger.info('Removing SELinux fcontext "%s"', self.instance.actual_conf_dir + suffix)
+            fcon.delete(self.instance.actual_conf_dir + suffix, '')
 
         trans.finish()
 

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -77,7 +77,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         deployer.create_cs_cfg(subsystem)
 
         # Copy /usr/share/pki/<subsystem>/conf/registry.cfg
-        # to /etc/pki/<instance>/<subsystem>/registry.cfg
+        # to /var/lib/pki/<instance>/conf/<subsystem>/registry.cfg
 
         pki_source_registry_cfg = os.path.join(
             pki.server.PKIServer.SHARE_DIR,
@@ -96,7 +96,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if deployer.subsystem_type == "CA":
 
             # Copy /usr/share/pki/ca/emails
-            # to /etc/pki/<instance>/ca/emails
+            # to /var/lib/pki/<instance>/conf/ca/emails
 
             pki_source_emails = os.path.join(
                 pki.server.PKIServer.SHARE_DIR,
@@ -108,14 +108,14 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 subsystem.conf_dir + '/emails')
 
             # Link /var/lib/pki/<instance>/ca/emails
-            # to /etc/pki/<instance>/ca/emails
+            # to /var/lib/pki/<instance>/conf/ca/emails
 
             emails_path = os.path.join(instance.conf_dir, 'ca', 'emails')
             emails_link = os.path.join(instance.base_dir, 'ca', 'emails')
             instance.symlink(emails_path, emails_link, exist_ok=True)
 
             # Copy /usr/share/pki/ca/profiles
-            # to /etc/pki/<instance>/ca/profiles
+            # to /var/lib/pki/<instance>/conf/ca/profiles
 
             pki_source_profiles = os.path.join(
                 pki.server.PKIServer.SHARE_DIR,
@@ -127,13 +127,13 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 subsystem.conf_dir + '/profiles')
 
             # Link /var/lib/pki/<instance>/ca/profiles
-            # to /etc/pki/<instance>/ca/profiles
+            # to /var/lib/pki/<instance>/conf/ca/profiles
             profiles_path = os.path.join(instance.conf_dir, 'ca', 'profiles')
             profiles_link = os.path.join(instance.base_dir, 'ca', 'profiles')
             instance.symlink(profiles_path, profiles_link, exist_ok=True)
 
             # Copy /usr/share/pki/<subsystem>/conf/flatfile.txt
-            # to /etc/pki/<instance>/<subsystem>/flatfile.txt
+            # to /var/lib/pki/<instance>/conf/<subsystem>/flatfile.txt
 
             pki_source_flatfile_txt = os.path.join(
                 pki.server.PKIServer.SHARE_DIR,
@@ -150,7 +150,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pki_target_flatfile_txt)
 
             # Copy /usr/share/pki/<subsystem>/conf/<type>AdminCert.profile
-            # to /etc/pki/<instance>/<subsystem>/adminCert.profile
+            # to /var/lib/pki/<instance>/conf/<subsystem>/adminCert.profile
 
             admin_key_type = deployer.mdict['pki_admin_key_type']
 
@@ -169,7 +169,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pki_target_admincert_profile)
 
             # Copy /usr/share/pki/<subsystem>/conf/caAuditSigningCert.profile
-            # to /etc/pki/<instance>/<subsystem>/caAuditSigningCert.profile
+            # to /var/lib/pki/<instance>/conf/<subsystem>/caAuditSigningCert.profile
 
             pki_source_caauditsigningcert_profile = os.path.join(
                 pki.server.PKIServer.SHARE_DIR,
@@ -186,7 +186,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pki_target_caauditsigningcert_profile)
 
             # Copy /usr/share/pki/<subsystem>/conf/caCert.profile
-            # to /etc/pki/<instance>/<subsystem>/caCert.profile
+            # to /var/lib/pki/<instance>/conf/<subsystem>/caCert.profile
 
             pki_source_cacert_profile = os.path.join(
                 pki.server.PKIServer.SHARE_DIR,
@@ -203,7 +203,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pki_target_cacert_profile)
 
             # Copy /usr/share/pki/<subsystem>/conf/caOCSPCert.profile
-            # to /etc/pki/<instance>/<subsystem>/caOCSPCert.profile
+            # to /var/lib/pki/<instance>/conf/<subsystem>/caOCSPCert.profile
 
             pki_source_caocspcert_profile = os.path.join(
                 pki.server.PKIServer.SHARE_DIR,
@@ -220,7 +220,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pki_target_caocspcert_profile)
 
             # Copy /usr/share/pki/<subsystem>/conf/<type>ServerCert.profile
-            # to /etc/pki/<instance>/<subsystem>/serverCert.profile
+            # to /var/lib/pki/<instance>/conf/<subsystem>/serverCert.profile
 
             sslserver_key_type = deployer.mdict['pki_sslserver_key_type']
 
@@ -239,7 +239,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pki_target_servercert_profile)
 
             # Copy /usr/share/pki/<subsystem>/conf/<type>SubsystemCert.profile
-            # to /etc/pki/<instance>/<subsystem>/subsystemCert.profile
+            # to /var/lib/pki/<instance>/conf/<subsystem>/subsystemCert.profile
 
             subsystem_key_type = deployer.mdict['pki_subsystem_key_type']
 
@@ -258,7 +258,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pki_target_subsystemcert_profile)
 
             # Copy /usr/share/pki/<subsystem>/conf/proxy.conf
-            # to /etc/pki/<instance>/<subsystem>/proxy.conf
+            # to /var/lib/pki/<instance>/conf/<subsystem>/proxy.conf
 
             pki_source_proxy_conf = os.path.join(
                 pki.server.PKIServer.SHARE_DIR,
@@ -278,7 +278,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         elif deployer.subsystem_type == "TPS":
 
             # Copy /usr/share/pki/<subsystem>/conf/phoneHome.xml
-            # to /etc/pki/<instance>/<subsystem>/phoneHome.xml
+            # to /var/lib/pki/<instance>/conf/<subsystem>/phoneHome.xml
 
             pki_target_phone_home_xml = os.path.join(
                 subsystem.conf_dir,

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -170,11 +170,11 @@ class PKISubsystem(object):
 
     def create_conf(self, exist_ok=False):
 
-        # Create /etc/pki/<instance>/<subsystem>
+        # Create /var/lib/pki/<instance>/conf/<subsystem>
         self.instance.makedirs(self.conf_dir, exist_ok=exist_ok)
 
         # Link /var/lib/pki/<instance>/<subsystem>/conf
-        # to /etc/pki/<instance>/<subsystem>
+        # to /var/lib/pki/<instance>/conf/<subsystem>
 
         conf_link = os.path.join(self.base_dir, 'conf')
         self.instance.symlink(
@@ -201,7 +201,7 @@ class PKISubsystem(object):
         self.instance.store_properties(self.cs_conf, self.config)
 
         # Copy /usr/share/pki/<subsystem>/conf/registry.cfg
-        # to /etc/pki/<instance>/<subsystem>/registry.cfg
+        # to /var/lib/pki/<instance>/conf/<subsystem>/registry.cfg
 
         registry_conf = os.path.join(
             pki.server.PKIServer.SHARE_DIR,
@@ -295,7 +295,7 @@ class PKISubsystem(object):
 
     def remove_conf(self, force=False):
 
-        # Remove /etc/pki/<instance>/<subsystem>
+        # Remove /var/lib/pki/<instance>/conf/<subsystem>
         logger.info('Removing %s', self.conf_dir)
         pki.util.rmtree(self.conf_dir, force=force)
 

--- a/base/server/upgrade/10.11.0/06-UpdateJavaHome.py
+++ b/base/server/upgrade/10.11.0/06-UpdateJavaHome.py
@@ -36,7 +36,7 @@ class UpdateJavaHome(pki.server.upgrade.PKIServerUpgradeScriptlet):
         result = self.update_java_home(instance.service_conf, java_home)
         self.store_config(instance.service_conf, result)
 
-        # Updating /etc/pki/<instance>/tomcat.conf
+        # Updating /var/lib/pki/<instance>/conf/tomcat.conf
         logger.info('Updating %s', instance.tomcat_conf)
         self.backup(instance.tomcat_conf)
 

--- a/base/server/upgrade/10.2.4/02-FixNuxwdogListenerClass.py
+++ b/base/server/upgrade/10.2.4/02-FixNuxwdogListenerClass.py
@@ -32,5 +32,5 @@ class FixNuxwdogListenerClass(pki.server.upgrade.PKIServerUpgradeScriptlet):
     def upgrade_instance(self, instance):
         subprocess.check_call([
             'sed', '-i', 's/NuxwdogPasswordStoreInitializer/PKIListener/',
-            '/etc/pki/{0}/server.xml'.format(instance.name)
+            instance.server_xml
         ])

--- a/base/server/upgrade/10.2.6/01-RemoveInaccessableURLsFromServerXML.py
+++ b/base/server/upgrade/10.2.6/01-RemoveInaccessableURLsFromServerXML.py
@@ -39,5 +39,5 @@ class RemoveInaccessableURLsFromServerXML(
             '-e', '\\|^.*Secure EE URL.*kra/ee/kra.*$|d',
             '-e', '\\|^.*Unsecure URL.*tks/ee/tks.*$|d',
             '-e', '\\|^.*Secure EE URL.*tks/ee/tks.*$|d',
-            '/etc/pki/{0}/server.xml'.format(instance.name)
+            instance.server_xml
         ])

--- a/base/server/upgrade/10.7.1/01-RemoveResteasyPath.py
+++ b/base/server/upgrade/10.7.1/01-RemoveResteasyPath.py
@@ -30,7 +30,7 @@ class RemoveResteasyPath(pki.server.upgrade.PKIServerUpgradeScriptlet):
         self.message = 'Remove RESTEASY_LIB from JAVA_OPTS'
 
     def upgrade_instance(self, instance):
-        self.fix_tomcat_config('/etc/pki/%s/tomcat.conf' % instance.name)
+        self.fix_tomcat_config(instance.tomcat_conf)
         self.fix_tomcat_config('/etc/sysconfig/%s' % instance.name)
 
     def fix_tomcat_config(self, filename):

--- a/base/server/upgrade/10.9.0/03-DisableOpenJDKFIPS.py
+++ b/base/server/upgrade/10.9.0/03-DisableOpenJDKFIPS.py
@@ -20,7 +20,7 @@ class DisableOpenJDKFIPS(pki.server.upgrade.PKIServerUpgradeScriptlet):
         self.message = 'Set -Dcom.redhat.fips=false in Tomcat configuration'
 
     def upgrade_instance(self, instance):
-        self.fix_tomcat_config('/etc/pki/%s/tomcat.conf' % instance.name)
+        self.fix_tomcat_config(instance.tomcat_conf)
         self.fix_tomcat_config('/etc/sysconfig/%s' % instance.name)
 
     def fix_tomcat_config(self, filename):


### PR DESCRIPTION
PKI server supports two directory layouts: the `PKIServer` class uses the standard Tomcat layout where the config files are stored under the instance folder, and the `PKIInstance` class uses the FHS layout where the config files are stored separately under `/etc`.

Previously the `conf_dir()` in these classes returned different values. The one in `PKIServer` returned the standard `conf` dir under the instance folder and the one in `PKIInstance` returned the config folder at `/etc/pki/<instance>`.

To ensure the code works consistently in all cases scenarios the `conf_dir()` has been modified such that it will always return the standard `conf` dir, then in `PKIServer` the `conf` dir will be the an actual folder, but in `PKIInstance` it will be a link to the actual folder at `/etc/pki/<instance>`.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Directory-Structure

Related changes:
* https://github.com/dogtagpki/pki/commit/8dca24dd68f64859a719281629f44612a087b296
* https://github.com/dogtagpki/pki/commit/13c25e507b1e7ee7fd69cac79c048d4ac73543b2