### PR TITLE
Add tests to check server files after removal

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -56,7 +56,7 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
-      - name: Check PKI server base dir
+      - name: Check PKI server base dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/pki/pki-tomcat \
@@ -81,10 +81,10 @@ jobs:
 
           diff expected output
 
-      - name: Check PKI server conf dir
+      - name: Check PKI server conf dir after installation
         run: |
           # check file types, owners, and permissions
-          docker exec pki ls -l /var/lib/pki/pki-tomcat/conf/ \
+          docker exec pki ls -l /etc/pki/pki-tomcat \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
@@ -105,6 +105,31 @@ jobs:
           -rw-rw---- pkiuser pkiuser serverCertNick.conf
           -rw-rw---- pkiuser pkiuser tomcat.conf
           lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -318,6 +343,55 @@ jobs:
 
       - name: Remove CA
         run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check PKI server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
 
       - name: Check DS server systemd journal
         if: always()

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -103,7 +103,7 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
-      - name: Check PKI server base dir
+      - name: Check PKI server base dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/pki/pki-tomcat \
@@ -129,10 +129,10 @@ jobs:
 
           diff expected output
 
-      - name: Check PKI server conf dir
+      - name: Check PKI server conf dir after installation
         run: |
           # check file types, owners, and permissions
-          docker exec pki ls -l /var/lib/pki/pki-tomcat/conf/ \
+          docker exec pki ls -l /etc/pki/pki-tomcat \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
@@ -154,6 +154,32 @@ jobs:
           -rw-rw---- pkiuser pkiuser serverCertNick.conf
           -rw-rw---- pkiuser pkiuser tomcat.conf
           lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -428,6 +454,56 @@ jobs:
 
       - name: Remove CA
         run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check PKI server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
 
       - name: Check PKI server systemd journal
         if: always()

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -103,7 +103,7 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
-      - name: Check PKI server base dir
+      - name: Check PKI server base dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/pki/pki-tomcat \
@@ -129,10 +129,10 @@ jobs:
 
           diff expected output
 
-      - name: Check PKI server conf dir
+      - name: Check PKI server conf dir after installation
         run: |
           # check file types, owners, and permissions
-          docker exec pki ls -l /var/lib/pki/pki-tomcat/conf/ \
+          docker exec pki ls -l /etc/pki/pki-tomcat \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
@@ -154,6 +154,32 @@ jobs:
           -rw-rw---- pkiuser pkiuser serverCertNick.conf
           -rw-rw---- pkiuser pkiuser tomcat.conf
           lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser ocsp
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -533,6 +559,56 @@ jobs:
 
       - name: Remove CA
         run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check PKI server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser ocsp
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -41,7 +41,11 @@ jobs:
         run: |
           docker exec pki pki-server create -v
 
-      - name: Check pki-tomcat server base dir
+      - name: Start pki-tomcat server
+        run: |
+          docker exec pki pki-server start --wait -v
+
+      - name: Check pki-tomcat server base dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/pki/pki-tomcat \
@@ -64,7 +68,7 @@ jobs:
 
           diff expected output
 
-      - name: Check pki-tomcat server conf dir
+      - name: Check pki-tomcat server conf dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /etc/pki/pki-tomcat \
@@ -88,9 +92,28 @@ jobs:
 
           diff expected output
 
-      - name: Start pki-tomcat server
+      - name: Check pki-tomcat server logs dir after installation
         run: |
-          docker exec pki pki-server start --wait -v
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          -rw-r--r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-r--r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-r--r-- pkiuser pkiuser manager.$DATE.log
+          EOF
+
+          diff expected output
 
       - name: Check pki-tomcat webapps
         run: |
@@ -147,11 +170,51 @@ jobs:
         run: |
           docker exec pki pki-server remove -v
 
+      - name: Check pki-tomcat server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check pki-tomcat server conf dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check pki-tomcat server logs dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/log/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
       - name: Create tomcat@pki server
         run: |
           docker exec pki pki-server create tomcat@pki -v
 
-      - name: Check tomcat@pki server base dir
+      - name: Start tomcat@pki server
+        run: |
+          docker exec pki pki-server start tomcat@pki --wait -v
+
+      - name: Check tomcat@pki server base dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/tomcats/pki \
@@ -174,7 +237,7 @@ jobs:
 
           diff expected output
 
-      - name: Check tomcat@pki server conf dir
+      - name: Check tomcat@pki server conf dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/tomcats/pki/conf \
@@ -198,9 +261,27 @@ jobs:
 
           diff expected output
 
-      - name: Start tomcat@pki server
+      - name: Check tomcat@pki server logs dir after installation
         run: |
-          docker exec pki pki-server start tomcat@pki --wait -v
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/tomcats/pki/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          -rw-r--r-- tomcat tomcat catalina.$DATE.log
+          -rw-r--r-- tomcat tomcat host-manager.$DATE.log
+          -rw-r--r-- tomcat tomcat localhost.$DATE.log
+          -rw-r--r-- tomcat tomcat localhost_access_log.$DATE.txt
+          -rw-r--r-- tomcat tomcat manager.$DATE.log
+          EOF
+
+          diff expected output
 
       - name: Check HTTP connection to tomcat@pki server
         run: |
@@ -220,6 +301,18 @@ jobs:
       - name: Remove tomcat@pki server
         run: |
           docker exec pki pki-server remove tomcat@pki -v
+
+      - name: Check tomcat@pki server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/tomcats/pki \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/tomcats/pki': No such file or directory
+          EOF
+
+          diff expected stderr
 
       - name: Gather artifacts from server container
         if: always()

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -66,7 +66,7 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
-      - name: Check PKI server base dir
+      - name: Check PKI server base dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/pki/pki-tomcat \
@@ -92,10 +92,10 @@ jobs:
 
           diff expected output
 
-      - name: Check PKI server conf dir
+      - name: Check PKI server conf dir after installation
         run: |
           # check file types, owners, and permissions
-          docker exec pki ls -l /var/lib/pki/pki-tomcat/conf/ \
+          docker exec pki ls -l /etc/pki/pki-tomcat \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
@@ -117,6 +117,32 @@ jobs:
           drwxrwx--- pkiuser pkiuser tks
           -rw-rw---- pkiuser pkiuser tomcat.conf
           lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
           EOF
 
           diff expected output
@@ -223,6 +249,56 @@ jobs:
 
       - name: Remove CA
         run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check PKI server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          EOF
+
+          diff expected output
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -89,7 +89,7 @@ jobs:
               -D pki_enable_server_side_keygen=True \
               -v
 
-      - name: Check PKI server base dir
+      - name: Check PKI server base dir after installation
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/pki/pki-tomcat \
@@ -117,10 +117,10 @@ jobs:
 
           diff expected output
 
-      - name: Check PKI server conf dir
+      - name: Check PKI server conf dir after installation
         run: |
           # check file types, owners, and permissions
-          docker exec pki ls -l /var/lib/pki/pki-tomcat/conf/ \
+          docker exec pki ls -l /etc/pki/pki-tomcat \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
@@ -144,6 +144,34 @@ jobs:
           -rw-rw---- pkiuser pkiuser tomcat.conf
           drwxrwx--- pkiuser pkiuser tps
           lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          drwxrwx--- pkiuser pkiuser tps
           EOF
 
           diff expected output
@@ -332,6 +360,58 @@ jobs:
 
       - name: Remove CA
         run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check PKI server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          drwxrwx--- pkiuser pkiuser tps
+          EOF
+
+          diff expected output
 
       - name: Upload artifacts
         if: always()


### PR DESCRIPTION
The CI tests have been updated to check the files left on the system after PKI server removal using `pkidestroy` and `pki-server remove` commands.

Currently their behavior is inconsistent:

- `pkidestroy` will leave PKI server and subsystem logs files under `/var/log/pki/<instance>` folder
- `pki-server remove` will remove all files

Ideally the behavior should be more consistent. That will be addressed separately later.