### PR TITLE
Use standard logs dir

### DIFF
--- a/.github/workflows/ca-admin-user-test.yml
+++ b/.github/workflows/ca-admin-user-test.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -148,7 +148,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/alias
           lrwxrwxrwx pkiuser pkiuser conf -> /var/lib/pki/pki-tomcat/conf/ca
           lrwxrwxrwx pkiuser pkiuser emails -> /var/lib/pki/pki-tomcat/conf/ca/emails
-          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat/ca
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/lib/pki/pki-tomcat/logs/ca
           lrwxrwxrwx pkiuser pkiuser profiles -> /var/lib/pki/pki-tomcat/conf/ca/profiles
           lrwxrwxrwx pkiuser pkiuser registry -> /etc/sysconfig/pki/tomcat/pki-tomcat
           EOF
@@ -415,7 +415,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-cert-revocation-test.yml
+++ b/.github/workflows/ca-cert-revocation-test.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-cmc-shared-token-test.yml
+++ b/.github/workflows/ca-cmc-shared-token-test.yml
@@ -337,7 +337,7 @@ jobs:
         run: |
           docker exec pki grep \
               "\[AuditEvent=CMC_USER_SIGNED_REQUEST_SIG_VERIFY\]" \
-              /var/log/pki/pki-tomcat/ca/signedAudit/ca_audit | tee output
+              /var/lib/pki/pki-tomcat/logs/ca/signedAudit/ca_audit | tee output
 
           # there should be 1 event from user cert enrollment
           echo "1" > expected
@@ -349,7 +349,7 @@ jobs:
         run: |
           docker exec pki grep \
               "\[AuditEvent=CERT_STATUS_CHANGE_REQUEST_PROCESSED\]" \
-              /var/log/pki/pki-tomcat/ca/signedAudit/ca_audit | tee output
+              /var/lib/pki/pki-tomcat/logs/ca/signedAudit/ca_audit | tee output
 
           # there should be 1 event from user cert revocation
           echo "1" > expected
@@ -361,7 +361,7 @@ jobs:
         run: |
           docker exec pki grep \
               "\[AuditEvent=CMC_REQUEST_RECEIVED\]" \
-              /var/log/pki/pki-tomcat/ca/signedAudit/ca_audit | tee output
+              /var/lib/pki/pki-tomcat/logs/ca/signedAudit/ca_audit | tee output
 
           # there should be 3 events from issuance protection cert enrollment,
           # user cert enrollment, user cert revocation
@@ -374,7 +374,7 @@ jobs:
         run: |
           docker exec pki grep \
               "\[AuditEvent=CMC_RESPONSE_SENT\]" \
-              /var/log/pki/pki-tomcat/ca/signedAudit/ca_audit | tee output
+              /var/lib/pki/pki-tomcat/logs/ca/signedAudit/ca_audit | tee output
 
           # there should be 3 events from issuance protection cert enrollment,
           # user cert enrollment, user cert revocation
@@ -403,7 +403,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -739,7 +739,7 @@ jobs:
       - name: Check CA debug logs
         if: always()
         run: |
-          docker exec ca bash -c "cat /var/log/pki/pki-tomcat/ca/debug.*"
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -397,7 +397,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-custom-user-test.yml
+++ b/.github/workflows/ca-custom-user-test.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-ecc-test.yml
+++ b/.github/workflows/ca-ecc-test.yml
@@ -273,7 +273,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -386,7 +386,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -441,7 +441,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -442,7 +442,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-existing-nssdb-test.yml
+++ b/.github/workflows/ca-existing-nssdb-test.yml
@@ -329,7 +329,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-hsm-operation-test.yml
+++ b/.github/workflows/ca-hsm-operation-test.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-hsm-test.yml
+++ b/.github/workflows/ca-hsm-test.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-nuxwdog-test.yml
+++ b/.github/workflows/ca-nuxwdog-test.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-profile-caDirPinUserCert-test.yml
+++ b/.github/workflows/ca-profile-caDirPinUserCert-test.yml
@@ -307,7 +307,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-profile-caDirUserCert-test.yml
+++ b/.github/workflows/ca-profile-caDirUserCert-test.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-profile-caServerCert-test.yml
+++ b/.github/workflows/ca-profile-caServerCert-test.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-pruning-test.yml
+++ b/.github/workflows/ca-pruning-test.yml
@@ -446,7 +446,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-publishing-ca-cert-test.yml
+++ b/.github/workflows/ca-publishing-ca-cert-test.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -637,7 +637,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -301,7 +301,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-publishing-user-cert-test.yml
+++ b/.github/workflows/ca-publishing-user-cert-test.yml
@@ -442,7 +442,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-renewal-system-certs-hsm-test.yml
+++ b/.github/workflows/ca-renewal-system-certs-hsm-test.yml
@@ -503,9 +503,9 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check CA selftests log
         if: always()
         run: |
-          docker exec pki cat /var/log/pki/pki-tomcat/ca/selftests.log
+          docker exec pki cat /var/lib/pki/pki-tomcat/logs/ca/selftests.log

--- a/.github/workflows/ca-renewal-system-certs-test.yml
+++ b/.github/workflows/ca-renewal-system-certs-test.yml
@@ -457,9 +457,9 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check CA selftests log
         if: always()
         run: |
-          docker exec pki cat /var/log/pki/pki-tomcat/ca/selftests.log
+          docker exec pki cat /var/lib/pki/pki-tomcat/logs/ca/selftests.log

--- a/.github/workflows/ca-rsa-pss-test.yml
+++ b/.github/workflows/ca-rsa-pss-test.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-rsa-test.yml
+++ b/.github/workflows/ca-rsa-test.yml
@@ -281,7 +281,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-rsnv1-test.yml
+++ b/.github/workflows/ca-rsnv1-test.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ipa find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ipa find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -393,12 +393,12 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ipa find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ipa find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec ipa find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec ipa find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -593,7 +593,7 @@ jobs:
       - name: Check CA debug log in primary container
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts from primary container
         if: always()
@@ -678,7 +678,7 @@ jobs:
       - name: Check CA debug log in secondary container
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts from secondary container
         if: always()

--- a/.github/workflows/ipa-subca-test.yml
+++ b/.github/workflows/ipa-subca-test.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ipa find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ipa find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -197,7 +197,7 @@ jobs:
           cat > expected << EOF
           lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/alias
           lrwxrwxrwx pkiuser pkiuser conf -> /var/lib/pki/pki-tomcat/conf/kra
-          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat/kra
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/lib/pki/pki-tomcat/logs/kra
           lrwxrwxrwx pkiuser pkiuser registry -> /etc/sysconfig/pki/tomcat/pki-tomcat
           EOF
 
@@ -517,12 +517,12 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-clone-hsm-test.yml
+++ b/.github/workflows/kra-clone-hsm-test.yml
@@ -546,12 +546,12 @@ jobs:
       - name: Check primary CA debug log
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check primary KRA debug log
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in secondary container
         if: always()
@@ -561,12 +561,12 @@ jobs:
       - name: Check secondary CA debug log
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check secondary KRA debug log
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in tertiary container
         if: always()
@@ -576,12 +576,12 @@ jobs:
       - name: Check tertiary CA debug log
         if: always()
         run: |
-          docker exec tertiary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec tertiary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check tertiary KRA debug log
         if: always()
         run: |
-          docker exec tertiary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec tertiary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-clone-replicated-ds-test.yml
+++ b/.github/workflows/kra-clone-replicated-ds-test.yml
@@ -607,12 +607,12 @@ jobs:
       - name: Check primary CA debug log
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check primary KRA debug log
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in secondary container
         if: always()
@@ -622,12 +622,12 @@ jobs:
       - name: Check secondary CA debug log
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check secondary KRA debug log
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-clone-shared-ds-test.yml
+++ b/.github/workflows/kra-clone-shared-ds-test.yml
@@ -251,12 +251,12 @@ jobs:
       - name: Check primary CA debug log
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check primary KRA debug log
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in secondary container
         if: always()
@@ -266,12 +266,12 @@ jobs:
       - name: Check secondary CA debug log
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check secondary KRA debug log
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -218,12 +218,12 @@ jobs:
       - name: Check primary CA debug log
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check primary KRA debug log
         if: always()
         run: |
-          docker exec primary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in secondary container
         if: always()
@@ -233,12 +233,12 @@ jobs:
       - name: Check secondary CA debug log
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check secondary KRA debug log
         if: always()
         run: |
-          docker exec secondary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in tertiary container
         if: always()
@@ -248,12 +248,12 @@ jobs:
       - name: Check tertiary CA debug log
         if: always()
         run: |
-          docker exec tertiary find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec tertiary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check tertiary KRA debug log
         if: always()
         run: |
-          docker exec tertiary find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec tertiary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-cmc-test.yml
+++ b/.github/workflows/kra-cmc-test.yml
@@ -303,7 +303,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()
@@ -313,7 +313,7 @@ jobs:
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec kra find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-ecc-test.yml
+++ b/.github/workflows/kra-ecc-test.yml
@@ -372,12 +372,12 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-existing-certs-test.yml
+++ b/.github/workflows/kra-existing-certs-test.yml
@@ -441,7 +441,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()
@@ -451,7 +451,7 @@ jobs:
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec kra find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-existing-ds-test.yml
+++ b/.github/workflows/kra-existing-ds-test.yml
@@ -632,7 +632,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()
@@ -642,7 +642,7 @@ jobs:
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec kra find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-existing-hsm-test.yml
+++ b/.github/workflows/kra-existing-hsm-test.yml
@@ -521,7 +521,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()
@@ -531,7 +531,7 @@ jobs:
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec kra find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-existing-nssdb-test.yml
+++ b/.github/workflows/kra-existing-nssdb-test.yml
@@ -457,7 +457,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()
@@ -467,7 +467,7 @@ jobs:
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec kra find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()
@@ -227,7 +227,7 @@ jobs:
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec kra find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -243,12 +243,12 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-migration-test.yml
+++ b/.github/workflows/kra-migration-test.yml
@@ -407,22 +407,22 @@ jobs:
       - name: Check first CA debug log
         if: always()
         run: |
-          docker exec pki1 find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki1 find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check first KRA debug log
         if: always()
         run: |
-          docker exec pki1 find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec pki1 find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Check second CA debug log
         if: always()
         run: |
-          docker exec pki2 find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki2 find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check second KRA debug log
         if: always()
         run: |
-          docker exec pki2 find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec pki2 find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-oaep-test.yml
+++ b/.github/workflows/kra-oaep-test.yml
@@ -159,10 +159,10 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -319,7 +319,7 @@ jobs:
       - name: Check root CA debug log
         if: always()
         run: |
-          docker exec rootca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec rootca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in sub CA container
         if: always()
@@ -329,7 +329,7 @@ jobs:
       - name: Check sub CA debug log
         if: always()
         run: |
-          docker exec subca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec subca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()
@@ -339,7 +339,7 @@ jobs:
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec kra find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-sequential-test.yml
+++ b/.github/workflows/kra-sequential-test.yml
@@ -171,12 +171,12 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -273,7 +273,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec ca find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()
@@ -283,7 +283,7 @@ jobs:
       - name: Check KRA debug log
         if: always()
         run: |
-          docker exec kra find /var/log/pki/pki-tomcat/kra -name "debug.*" -exec cat {} \;
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -197,7 +197,7 @@ jobs:
           cat > expected << EOF
           lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/alias
           lrwxrwxrwx pkiuser pkiuser conf -> /var/lib/pki/pki-tomcat/conf/ocsp
-          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat/ocsp
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/lib/pki/pki-tomcat/logs/ocsp
           lrwxrwxrwx pkiuser pkiuser registry -> /etc/sysconfig/pki/tomcat/pki-tomcat
           EOF
 

--- a/.github/workflows/scep-test.yml
+++ b/.github/workflows/scep-test.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Check CA debug log
         if: always()
         run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/subca-lightweight-hsm-test.yml
+++ b/.github/workflows/subca-lightweight-hsm-test.yml
@@ -376,7 +376,7 @@ jobs:
       - name: Check CA debug logs
         if: always()
         run: |
-          docker exec pki bash -c "cat /var/log/pki/pki-tomcat/ca/debug.*"
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/subca-lightweight-test.yml
+++ b/.github/workflows/subca-lightweight-test.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Check CA debug logs
         if: always()
         run: |
-          docker exec pki bash -c "cat /var/log/pki/pki-tomcat/ca/debug.*"
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -160,7 +160,7 @@ jobs:
           cat > expected << EOF
           lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/alias
           lrwxrwxrwx pkiuser pkiuser conf -> /var/lib/pki/pki-tomcat/conf/tks
-          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat/tks
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/lib/pki/pki-tomcat/logs/tks
           lrwxrwxrwx pkiuser pkiuser registry -> /etc/sysconfig/pki/tomcat/pki-tomcat
           EOF
 

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -189,7 +189,7 @@ jobs:
           cat > expected << EOF
           lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/alias
           lrwxrwxrwx pkiuser pkiuser conf -> /var/lib/pki/pki-tomcat/conf/tps
-          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat/tps
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/lib/pki/pki-tomcat/logs/tps
           lrwxrwxrwx pkiuser pkiuser registry -> /etc/sysconfig/pki/tomcat/pki-tomcat
           EOF
 

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -4781,7 +4781,7 @@ class PKIDeployer:
             self.user_config.write(f)
 
         # For debugging/auditing purposes, store user's deployment.cfg into
-        # /var/log/pki/<instance>/<subsystem>/archive/spawn_deployment.cfg.<timestamp>
+        # /var/lib/pki/<instance>/logs/<subsystem>/archive/spawn_deployment.cfg.<timestamp>
 
         deployment_cfg_archive = os.path.join(
             subsystem.log_archive_dir,
@@ -4807,7 +4807,7 @@ class PKIDeployer:
         self.file.modify(manifest_file, silent=True)
 
         # For debugging/auditing purposes, store installation manifest into
-        # /var/log/pki/<instance>/<subsystem>/archive/spawn_manifest.<timestamp>
+        # /var/lib/pki/<instance>/logs/<subsystem>/archive/spawn_manifest.<timestamp>
 
         manifest_archive = os.path.join(
             subsystem.log_archive_dir,
@@ -4820,7 +4820,7 @@ class PKIDeployer:
 
         selinux.restorecon(self.instance.base_dir, True)
         selinux.restorecon(config.PKI_DEPLOYMENT_LOG_ROOT, True)
-        selinux.restorecon(self.instance.log_dir, True)
+        selinux.restorecon(self.instance.actual_logs_dir, True)
         selinux.restorecon(self.instance.actual_conf_dir, True)
 
     def selinux_context_exists(self, records, context_value):
@@ -4858,9 +4858,9 @@ class PKIDeployer:
             self.instance.base_dir + suffix,
             config.PKI_INSTANCE_SELINUX_CONTEXT, '', 's0', '')
 
-        logger.info('Adding SELinux fcontext "%s"', self.instance.log_dir + suffix)
+        logger.info('Adding SELinux fcontext "%s"', self.instance.actual_logs_dir + suffix)
         fcon.add(
-            self.instance.log_dir + suffix,
+            self.instance.actual_logs_dir + suffix,
             config.PKI_LOG_SELINUX_CONTEXT, '', 's0', '')
 
         port_records = seobject.portRecords(trans)
@@ -4891,9 +4891,9 @@ class PKIDeployer:
         fcon = seobject.fcontextRecords(trans)
         file_records = fcon.get_all()
 
-        if self.selinux_context_exists(file_records, self.instance.log_dir + suffix):
-            logger.info('Removing SELinux fcontext "%s"', self.instance.log_dir + suffix)
-            fcon.delete(self.instance.log_dir + suffix, '')
+        if self.selinux_context_exists(file_records, self.instance.actual_logs_dir + suffix):
+            logger.info('Removing SELinux fcontext "%s"', self.instance.actual_logs_dir + suffix)
+            fcon.delete(self.instance.actual_logs_dir + suffix, '')
 
         if self.selinux_context_exists(file_records, self.instance.base_dir + suffix):
             logger.info('Removing SELinux fcontext "%s"', self.instance.base_dir + suffix)

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -64,18 +64,14 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         instance.with_maven_deps = deployer.with_maven_deps
         instance.create_libs(force=True)
 
-        # Create /var/log/pki/<instance>
-        instance.makedirs(instance.log_dir, exist_ok=True)
+        # Create /var/log/pki/<instance> and /var/lib/pki/<instance>/logs
+        instance.create_logs_dir(exist_ok=True)
 
         # Create /var/lib/pki/<instance>/temp
         instance.makedirs(instance.temp_dir, exist_ok=True)
 
         # Create /var/lib/pki/<instance>/work
         instance.makedirs(instance.work_dir, exist_ok=True)
-
-        # Link /var/lib/pki/<instance>/logs to /var/log/pki/<instance>
-        logs_link = os.path.join(instance.base_dir, 'logs')
-        instance.symlink(instance.log_dir, logs_link, exist_ok=True)
 
         # Create /var/lib/pki/<instance>/conf/certs
         instance.makedirs(instance.certs_dir, exist_ok=True)

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -71,6 +71,10 @@ class PKIInstance(pki.server.PKIServer):
         # will be a link to the actual folder at /etc/pki/<instance>.
         self.actual_conf_dir = os.path.join(pki.server.PKIServer.CONFIG_DIR, self.name)
 
+        # The standard conf dir at /var/lib/pki/<instance>/logs
+        # will be a link to the actual folder at /var/log/pki/<instance>.
+        self.actual_logs_dir = os.path.join(pki.server.PKIServer.LOG_DIR, self.name)
+
         self.default_root_doc_base = os.path.join(
             pki.SHARE_DIR,
             'server',
@@ -142,10 +146,6 @@ class PKIInstance(pki.server.PKIServer):
         if self.version < 10:
             return os.path.join(pki.BASE_DIR, self.name)
         return os.path.join(pki.server.PKIServer.BASE_DIR, self.name)
-
-    @property
-    def log_dir(self):
-        return os.path.join(pki.server.PKIServer.LOG_DIR, self.name)
 
     @property
     def service_conf(self):
@@ -252,7 +252,7 @@ class PKIInstance(pki.server.PKIServer):
         super().create(force=force)
 
         logs_link = os.path.join(self.base_dir, 'logs')
-        self.symlink(self.log_dir, logs_link, exist_ok=True)
+        self.symlink(self.logs_dir, logs_link, exist_ok=True)
 
         self.create_registry()
 
@@ -400,11 +400,6 @@ class PKIInstance(pki.server.PKIServer):
         pki.util.unlink(self.unit_file, force=force)
 
         self.remove_registry(force=force)
-
-        if remove_logs:
-            logs_link = os.path.join(self.base_dir, 'logs')
-            logger.info('Removing %s', logs_link)
-            pki.util.unlink(logs_link, force=force)
 
         super().remove(remove_logs=remove_logs, force=force)
 

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -593,12 +593,12 @@ def main(argv):
 
         print()
 
-        subsystem_log_dir = os.path.join(
-            deployer.instance.log_dir,
+        subsystem_logs_dir = os.path.join(
+            deployer.instance.logs_dir,
             deployer.mdict['pki_subsystem_type'])
 
         print('Please check the %s logs in %s.' %
-              (deployer.subsystem_type, subsystem_log_dir))
+              (deployer.subsystem_type, subsystem_logs_dir))
 
         sys.exit(1)
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -122,16 +122,16 @@ class PKISubsystem(object):
         return os.path.join(self.instance.conf_dir, self.name)
 
     @property
-    def log_dir(self):
-        return os.path.join(self.instance.log_dir, self.name)
+    def logs_dir(self):
+        return os.path.join(self.instance.logs_dir, self.name)
 
     @property
     def log_archive_dir(self):
-        return os.path.join(self.log_dir, 'archive')
+        return os.path.join(self.logs_dir, 'archive')
 
     @property
     def log_signed_audit_dir(self):
-        return os.path.join(self.log_dir, 'signedAudit')
+        return os.path.join(self.logs_dir, 'signedAudit')
 
     @property
     def registry_dir(self):
@@ -213,22 +213,22 @@ class PKISubsystem(object):
 
     def create_logs(self, exist_ok=False):
 
-        # Create /var/log/pki/<instance>/<subsystem>
-        self.instance.makedirs(self.log_dir, exist_ok=exist_ok)
+        # Create /var/lib/pki/<instance>/logs/<subsystem>
+        self.instance.makedirs(self.logs_dir, exist_ok=exist_ok)
 
         # Link /var/lib/pki/<instance>/<subsystem>/logs
-        # to /var/log/pki/<instance>/<subsystem>
+        # to /var/lib/pki/<instance>/logs/<subsystem>
 
         logs_link = os.path.join(self.base_dir, 'logs')
         self.instance.symlink(
-            self.log_dir,
+            self.logs_dir,
             logs_link,
             exist_ok=exist_ok)
 
-        # Create /var/log/pki/<instance>/<subsystem>/archive
+        # Create /var/lib/pki/<instance>/logs/<subsystem>/archive
         self.instance.makedirs(self.log_archive_dir, exist_ok=exist_ok)
 
-        # Create /var/log/pki/<instance>/<subsystem>/signedAudit
+        # Create /var/lib/pki/<instance>/logs/<subsystem>/signedAudit
         self.instance.makedirs(self.log_signed_audit_dir, exist_ok=exist_ok)
 
     def create_registry(self, exist_ok=False):
@@ -281,17 +281,17 @@ class PKISubsystem(object):
 
     def remove_logs(self, force=False):
 
-        # Remove /var/log/pki/<instance>/<subsystem>/signedAudit
+        # Remove /var/lib/pki/<instance>/logs/<subsystem>/signedAudit
         logger.info('Removing %s', self.log_signed_audit_dir)
         pki.util.rmtree(self.log_signed_audit_dir, force=force)
 
-        # Remove /var/log/pki/<instance>/<subsystem>/archive
+        # Remove /var/lib/pki/<instance>/logs/<subsystem>/archive
         logger.info('Removing %s', self.log_archive_dir)
         pki.util.rmtree(self.log_archive_dir, force=force)
 
-        # Remove /var/log/pki/<instance>/<subsystem>
-        logger.info('Removing %s', self.log_dir)
-        pki.util.rmtree(self.log_dir, force=force)
+        # Remove /var/lib/pki/<instance>/logs/<subsystem>
+        logger.info('Removing %s', self.logs_dir)
+        pki.util.rmtree(self.logs_dir, force=force)
 
     def remove_conf(self, force=False):
 

--- a/base/server/python/pki/server/upgrade.py
+++ b/base/server/python/pki/server/upgrade.py
@@ -40,7 +40,7 @@ class PKIServerUpgradeScriptlet(pki.upgrade.PKIUpgradeScriptlet):
         self.instance = None
 
     def get_backup_dir(self):
-        return self.instance.log_dir + '/backup/' + str(self.version) + '/' + str(self.index)
+        return self.instance.logs_dir + '/backup/' + str(self.version) + '/' + str(self.index)
 
     def upgrade_subsystem(self, instance, subsystem):
         # Callback method to upgrade a subsystem.

--- a/base/server/upgrade/10.0.99/04-FixLogFileOwnership.py
+++ b/base/server/upgrade/10.0.99/04-FixLogFileOwnership.py
@@ -19,7 +19,6 @@
 #
 
 from __future__ import absolute_import
-import os
 import pki.server.upgrade
 
 
@@ -31,5 +30,4 @@ class FixLogFileOwnership(pki.server.upgrade.PKIServerUpgradeScriptlet):
 
     def upgrade_instance(self, instance):
 
-        log_dir = os.path.join('/var/log/pki', instance.name)
-        pki.util.chown(log_dir, instance.uid, instance.gid)
+        pki.util.chown(instance.actual_logs_dir, instance.uid, instance.gid)

--- a/docs/manuals/man1/AuditVerify.1.md
+++ b/docs/manuals/man1/AuditVerify.1.md
@@ -94,9 +94,9 @@ The name of this file is referenced in the **AuditVerify** command.
 For example, this file could be logListFile.txt:
 
 ```
-/var/log/pki/pki-tomcat/ca/signedAudit/ca_audit.20030227102711
-/var/log/pki/pki-tomcat/ca/signedAudit/ca_audit.20030226094015
-/var/log/pki/pki-tomcat/ca/signedAudit/ca_audit
+/var/lib/pki/pki-tomcat/logs/ca/signedAudit/ca_audit.20030227102711
+/var/lib/pki/pki-tomcat/logs/ca/signedAudit/ca_audit.20030226094015
+/var/lib/pki/pki-tomcat/logs/ca/signedAudit/ca_audit
 ```
 
 Assuming the audit databases do not contain prefixes and are located in the user home directory,

--- a/docs/manuals/man8/pkispawn.8.md
+++ b/docs/manuals/man8/pkispawn.8.md
@@ -312,7 +312,7 @@ To access this CA, simply point a browser to https://*hostname*:8443.
 
 The instance name (defined by **pki_instance_name**) is pki-tomcat, and it is
 located at /var/lib/pki/pki-tomcat. Logs for the instance are located
-at /var/log/pki/pki-tomcat, and an installation log is written to
+at /var/lib/pki/pki-tomcat/logs, and an installation log is written to
 /var/log/pki/pki-*subsystem*-spawn.*timestamp*.log.
 
 A PKCS #12 file containing the administrator certificate is created in


### PR DESCRIPTION
The code, the tests, and the docs have been updated to use the standard `logs` dir at `/var/lib/pki/<instance>/logs` to ensure that they are valid in all deployment scenarios.

`PKIServer.log_dir()` has been renamed into `logs_dir()` to match the standard `logs` dir name.