### PR TITLE
Remove CrlIssuer from template with CRLDP

### DIFF
--- a/base/ca/shared/profiles/ca/caCMCECserverCertWithCRLDP.cfg
+++ b/base/ca/shared/profiles/ca/caCMCECserverCertWithCRLDP.cfg
@@ -88,13 +88,9 @@ policyset.serverCertSet.9.constraint.name=No Constraint
 policyset.serverCertSet.9.default.class_id=commonNameToSANDefaultImpl
 policyset.serverCertSet.9.default.name=copy CN to SAN Default
 # The CRL Distribution Points extension describes where a CRL
-# can be accessed. This extension requires:
-#
-# 1. setting the crlDistPointsPointName_0 parameter to the URL of the CRL
-#    e.g. http://host.example.com:8081/crl/ServerCertCRL.crl
-# 2. setting the crlDistPointsIssuerName_0 parameter to the string
-#    representation of the Distinguised Name of the CRL issuer
-#    e.g. CN=CA Signing Certificate,O=Example-rhcs-ECC-RootCA
+# can be accessed. This extension requires setting the
+# crlDistPointsPointName_0 parameter to the URL of the CRL.
+# E.g.: http://host.example.com:8081/crl/ServerCertCRL.crl
 #
 # Note: The crlDisPointsPointName example below is assuming that a CRL Distribution Point
 #       is set up for a smaller set of certificates, e.g. server certs used for a specific purpose,
@@ -106,8 +102,8 @@ policyset.serverCertSet.10.default.class_id=crlDistributionPointsExtDefaultImpl
 policyset.serverCertSet.10.default.name=CRL Distribution Points Extension Default
 policyset.serverCertSet.10.default.params.crlDistPointsCritical=false
 policyset.serverCertSet.10.default.params.crlDistPointsEnable_0=true
-policyset.serverCertSet.10.default.params.crlDistPointsIssuerName_0=SET_ME_TO_DN_OF_CRL_ISSUER
-policyset.serverCertSet.10.default.params.crlDistPointsIssuerType_0=DirectoryName
+policyset.serverCertSet.10.default.params.crlDistPointsIssuerName_0=
+policyset.serverCertSet.10.default.params.crlDistPointsIssuerType_0=
 policyset.serverCertSet.10.default.params.crlDistPointsNum=1
 policyset.serverCertSet.10.default.params.crlDistPointsPointName_0=http://LOCATION_OF_CRL
 policyset.serverCertSet.10.default.params.crlDistPointsPointType_0=URIName

--- a/base/ca/shared/profiles/ca/caCMCserverCertWithCRLDP.cfg
+++ b/base/ca/shared/profiles/ca/caCMCserverCertWithCRLDP.cfg
@@ -78,13 +78,9 @@ policyset.serverCertSet.9.constraint.name=No Constraint
 policyset.serverCertSet.9.default.class_id=commonNameToSANDefaultImpl
 policyset.serverCertSet.9.default.name=copy CN to SAN Default
 # The CRL Distribution Points extension describes where a CRL
-# can be accessed. This extension requires:
-#
-# 1. setting the crlDistPointsPointName_0 parameter to the URL of the CRL
-#    e.g. http://host.example.com:8081/crl/ServerCertCRL.crl
-# 2. setting the crlDistPointsIssuerName_0 parameter to the string
-#    representation of the Distinguised Name of the CRL issuer
-#    e.g. CN=CA Signing Certificate,O=Example-rhcs-RSA-RootCA
+# can be accessed. This extension requires setting the
+# crlDistPointsPointName_0 parameter to the URL of the CRL.
+# E.g.: http://host.example.com:8081/crl/ServerCertCRL.crl
 #
 # Note: The crlDisPointsPointName example below is assuming that a CRL Distribution Point
 #       is set up for a smaller set of certificates, e.g. server certs used for a specific purpose,
@@ -96,8 +92,8 @@ policyset.serverCertSet.10.default.class_id=crlDistributionPointsExtDefaultImpl
 policyset.serverCertSet.10.default.name=CRL Distribution Points Extension Default
 policyset.serverCertSet.10.default.params.crlDistPointsCritical=false
 policyset.serverCertSet.10.default.params.crlDistPointsEnable_0=true
-policyset.serverCertSet.10.default.params.crlDistPointsIssuerName_0=SET_ME_TO_DN_OF_CRL_ISSUER
-policyset.serverCertSet.10.default.params.crlDistPointsIssuerType_0=DirectoryName
+policyset.serverCertSet.10.default.params.crlDistPointsIssuerName_0=
+policyset.serverCertSet.10.default.params.crlDistPointsIssuerType_0=
 policyset.serverCertSet.10.default.params.crlDistPointsNum=1
 policyset.serverCertSet.10.default.params.crlDistPointsPointName_0=http://LOCATION_OF_CRL
 policyset.serverCertSet.10.default.params.crlDistPointsPointType_0=URIName

--- a/base/ca/shared/profiles/ca/caECServerCertWithCRLDP.cfg
+++ b/base/ca/shared/profiles/ca/caECServerCertWithCRLDP.cfg
@@ -74,13 +74,9 @@ policyset.serverCertSet.8.default.class_id=signingAlgDefaultImpl
 policyset.serverCertSet.8.default.name=Signing Alg
 policyset.serverCertSet.8.default.params.signingAlg=-
 # The CRL Distribution Points extension describes where a CRL
-# can be accessed. This extension requires:
-#
-# 1. setting the crlDistPointsPointName_0 parameter to the URL of the CRL
-#    e.g. http://host.example.com:8081/crl/ServerCertCRL.crl
-# 2. setting the crlDistPointsIssuerName_0 parameter to the string
-#    representation of the Distinguised Name of the CRL issuer
-#    e.g. CN=CA Signing Certificate,O=Example-rhcs-ECC-RootCA
+# can be accessed. This extension requires setting the
+# crlDistPointsPointName_0 parameter to the URL of the CRL.
+# E.g.: http://host.example.com:8081/crl/ServerCertCRL.crl
 #
 # Note: The crlDisPointsPointName example below is assuming that a CRL Distribution Point
 #       is set up for a smaller set of certificates, e.g. server certs used for a specific purpose,
@@ -92,8 +88,8 @@ policyset.serverCertSet.9.default.class_id=crlDistributionPointsExtDefaultImpl
 policyset.serverCertSet.9.default.name=CRL Distribution Points Extension Default
 policyset.serverCertSet.9.default.params.crlDistPointsCritical=false
 policyset.serverCertSet.9.default.params.crlDistPointsEnable_0=true
-policyset.serverCertSet.9.default.params.crlDistPointsIssuerName_0=SET_ME_TO_DN_OF_CRL_ISSUER
-policyset.serverCertSet.9.default.params.crlDistPointsIssuerType_0=DirectoryName
+policyset.serverCertSet.9.default.params.crlDistPointsIssuerName_0=
+policyset.serverCertSet.9.default.params.crlDistPointsIssuerType_0=
 policyset.serverCertSet.9.default.params.crlDistPointsNum=1
 policyset.serverCertSet.9.default.params.crlDistPointsPointName_0=http://LOCATION_OF_CRL
 policyset.serverCertSet.9.default.params.crlDistPointsPointType_0=URIName

--- a/base/ca/shared/profiles/ca/caServerCertWithCRLDP.cfg
+++ b/base/ca/shared/profiles/ca/caServerCertWithCRLDP.cfg
@@ -74,13 +74,9 @@ policyset.serverCertSet.8.default.class_id=signingAlgDefaultImpl
 policyset.serverCertSet.8.default.name=Signing Alg
 policyset.serverCertSet.8.default.params.signingAlg=-
 # The CRL Distribution Points extension describes where a CRL
-# can be accessed. This extension requires:
-#
-# 1. setting the crlDistPointsPointName_0 parameter to the URL of the CRL
-#    e.g. http://host.example.com:8081/crl/ServerCertCRL.crl
-# 2. setting the crlDistPointsIssuerName_0 parameter to the string
-#    representation of the Distinguised Name of the CRL issuer
-#    e.g. CN=CA Signing Certificate,O=Example-rhcs-RSA-RootCA
+# can be accessed. This extension requires setting the
+# crlDistPointsPointName_0 parameter to the URL of the CRL.
+# E.g.: http://host.example.com:8081/crl/ServerCertCRL.crl
 #
 # Note: The crlDisPointsPointName example below is assuming that a CRL Distribution Point
 #       is set up for a smaller set of certificates, e.g. server certs used for a specific purpose,
@@ -92,8 +88,8 @@ policyset.serverCertSet.9.default.class_id=crlDistributionPointsExtDefaultImpl
 policyset.serverCertSet.9.default.name=CRL Distribution Points Extension Default
 policyset.serverCertSet.9.default.params.crlDistPointsCritical=false
 policyset.serverCertSet.9.default.params.crlDistPointsEnable_0=true
-policyset.serverCertSet.9.default.params.crlDistPointsIssuerName_0=SET_ME_TO_DN_OF_CRL_ISSUER
-policyset.serverCertSet.9.default.params.crlDistPointsIssuerType_0=DirectoryName
+policyset.serverCertSet.9.default.params.crlDistPointsIssuerName_0=
+policyset.serverCertSet.9.default.params.crlDistPointsIssuerType_0=
 policyset.serverCertSet.9.default.params.crlDistPointsNum=1
 policyset.serverCertSet.9.default.params.crlDistPointsPointName_0=http://LOCATION_OF_CRL
 policyset.serverCertSet.9.default.params.crlDistPointsPointType_0=URIName


### PR DESCRIPTION
CRLIssuer MUST not be included if the issuer is the same issuer of the certificate. Therefore it is removed from the template.

See: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13