### PR TITLE
Add options for custom config and log folders

### DIFF
--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -186,7 +186,7 @@ jobs:
               --password Secret.123 \
               admin
 
-      - name: Set up CA container
+      - name: Prepare certs folder
         run: |
           mkdir certs
           docker cp client:server.p12 certs
@@ -199,12 +199,20 @@ jobs:
           docker cp client:admin.csr certs
           ls -la certs
 
+      - name: Prepare data folder
+        run: |
+          mkdir data
+          ls -la data
+
+      - name: Set up CA container
+        run: |
           docker run \
               --name ca \
               --hostname=ca.example.com \
               --network=example \
               --network-alias=ca.example.com \
               -v $PWD/certs:/certs \
+              -v $PWD/data:/data \
               --detach \
               pki-ca
 
@@ -218,6 +226,73 @@ jobs:
               -k \
               -o /dev/null \
               https://ca.example.com:8443
+
+      - name: Check data dir
+        run: |
+          ls -l data \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxr-xr-x root root conf
+          drwxr-xr-x root root logs
+          EOF
+
+          diff expected output
+
+      - name: Check data/conf dir
+        run: |
+          ls -l data/conf \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwx--- 17 root Catalina
+          drwxrwx--- 17 root alias
+          drwxrwx--- 17 root ca
+          -rw-r--r-- root root catalina.policy
+          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- 17 root certs
+          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- 17 root password.conf
+          -rw-rw---- 17 root server.xml
+          -rw-rw---- 17 root serverCertNick.conf
+          -rw-rw---- 17 root tomcat.conf
+          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check data/logs dir
+        run: |
+          ls -l data/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxr-x--- 17 root backup
+          drwxrwx--- 17 root ca
+          -rw-r--r-- root root catalina.$DATE.log
+          -rw-r--r-- root root host-manager.$DATE.log
+          -rw-r--r-- root root localhost.$DATE.log
+          -rw-r--r-- root root localhost_access_log.$DATE.txt
+          -rw-r--r-- root root manager.$DATE.log
+          drwxr-xr-x root root pki
+          EOF
+
+          diff expected output
 
       - name: Check basic operations from CA container
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,12 +166,16 @@ LABEL name="pki-ca" \
 EXPOSE 8080 8443
 
 # Create PKI server
-RUN pki-server create --group root
+RUN id
+RUN pki-server create \
+    --group root \
+    --conf /data/conf \
+    --logs /data/logs
 
 # Create NSS database
 RUN pki-server nss-create --no-password
 
-VOLUME [ "/certs" ]
+VOLUME [ "/certs", "/data" ]
 
 CMD [ "/usr/share/pki/ca/bin/pki-ca-run" ]
 

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -6,6 +6,9 @@
 # - support existing subsystem user
 
 echo "################################################################################"
+mkdir -p /data/conf
+mkdir -p /data/logs
+echo "################################################################################"
 
 if [ -f /certs/server.p12 ]
 then
@@ -309,8 +312,11 @@ echo "INFO: Creating PKI CA"
 # with existing database user, with RSNv3, without security manager,
 # and without systemd service.
 pkispawn \
+    --conf /data/conf \
+    --logs /data/logs \
     -f /usr/share/pki/server/examples/installation/ca.cfg \
     -s CA \
+    -D pki_group=root \
     -D pki_ds_url=ldap://ds.example.com:3389 \
     -D pki_ds_setup=False \
     -D pki_skip_ds_verify=True \

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -166,6 +166,10 @@ class PKIServer(object):
     def actual_conf_dir(self):
         return self._conf_dir if self._conf_dir else self.conf_dir
 
+    @actual_conf_dir.setter
+    def actual_conf_dir(self, value):
+        self._conf_dir = value
+
     @property
     def certs_dir(self):
         return os.path.join(self.conf_dir, 'certs')
@@ -189,6 +193,10 @@ class PKIServer(object):
     @property
     def actual_logs_dir(self):
         return self._logs_dir if self._logs_dir else self.logs_dir
+
+    @actual_logs_dir.setter
+    def actual_logs_dir(self, value):
+        self._logs_dir = value
 
     @property
     def temp_dir(self):

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -300,6 +300,8 @@ class CreateCLI(pki.cli.CLI):
         print()
         print('      --user <name>             User.')
         print('      --group <name>            Group.')
+        print('      --conf <path>             Config folder')
+        print('      --logs <path>             Logs folder')
         print('      --with-maven-deps         Install Maven dependencies.')
         print('      --force                   Force creation.')
         print('  -v, --verbose                 Run in verbose mode.')
@@ -311,7 +313,7 @@ class CreateCLI(pki.cli.CLI):
 
         try:
             opts, args = getopt.gnu_getopt(argv, 'v', [
-                'user=', 'group=',
+                'user=', 'group=', 'conf=', 'logs=',
                 'with-maven-deps', 'force',
                 'verbose', 'debug', 'help'])
 
@@ -323,6 +325,8 @@ class CreateCLI(pki.cli.CLI):
         instance_name = 'pki-tomcat'
         user = None
         group = None
+        conf_dir = None
+        logs_dir = None
         with_maven_deps = False
         force = False
 
@@ -332,6 +336,12 @@ class CreateCLI(pki.cli.CLI):
 
             elif o == '--group':
                 group = a
+
+            elif o == '--conf':
+                conf_dir = a
+
+            elif o == '--logs':
+                logs_dir = a
 
             elif o == '--with-maven-deps':
                 with_maven_deps = True
@@ -370,6 +380,12 @@ class CreateCLI(pki.cli.CLI):
 
         if group:
             instance.group = group
+
+        if conf_dir:
+            instance.actual_conf_dir = conf_dir
+
+        if logs_dir:
+            instance.actual_logs_dir = logs_dir
 
         instance.with_maven_deps = with_maven_deps
 

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -98,6 +98,18 @@ def main(argv):
         deployer=deployer)
 
     parser.optional.add_argument(
+        '--conf',
+        dest='conf_dir',
+        action='store',
+        help='Config folder')
+
+    parser.optional.add_argument(
+        '--logs',
+        dest='logs_dir',
+        action='store',
+        help='Logs folder')
+
+    parser.optional.add_argument(
         '-f',
         dest='user_deployment_cfg', action='store',
         nargs=1, metavar='<file>',
@@ -546,6 +558,12 @@ def main(argv):
     deployer.instance = pki.server.PKIServerFactory.create(instance_name)
     deployer.instance.user = deployer.mdict['pki_user']
     deployer.instance.group = deployer.mdict['pki_group']
+
+    if args.conf_dir:
+        deployer.instance.actual_conf_dir = args.conf_dir
+
+    if args.logs_dir:
+        deployer.instance.actual_logs_dir = args.logs_dir
 
     deployer.instance.load()
 


### PR DESCRIPTION
The `pkispawn` and `pki-server create` commands have been modified to provide options to create an instance using custom `conf` and `logs` folders.

The CA container has been modified to use these options to store the config and log files under `/data` folder. To ensure that the files can be accessed by the container right now they need to be owned by the `root` group. In the future it might be possible to create a root-less container.

The CA container test has been modified to create an empty `/data` folder then check the config and log files after installation.