### PR TITLE
Add option to remove config folder

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -360,6 +360,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           EOF
 
@@ -369,13 +370,29 @@ jobs:
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /etc/pki/pki-tomcat \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
 
+          # TODO: review permissions
           cat > expected << EOF
-          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
           EOF
 
-          diff expected stderr
+          diff expected output
 
       - name: Check PKI server logs dir after removal
         run: |

--- a/.github/workflows/ca-existing-config-test.yml
+++ b/.github/workflows/ca-existing-config-test.yml
@@ -1,0 +1,141 @@
+name: CA with existing config
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check system certs
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.orig
+
+      - name: Check CA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki nss-cert-find | tee admin-cert.orig
+
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Remove CA
+        run: |
+          docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Install CA again
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check system certs again
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.new
+
+          # system certs should not change
+          diff system-certs.orig system-certs.new
+
+      - name: Check CA admin again
+        run: |
+          docker exec pki pki nss-cert-find | tee admin-cert.new
+
+          # admin cert should not change
+          diff admin-cert.orig admin-cert.new
+
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Remove CA again
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ca-existing-config
+          path: /tmp/artifacts

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -48,6 +48,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/ca-existing-ds-test.yml
 
+  ca-existing-config-test:
+    name: CA with existing config
+    needs: build
+    uses: ./.github/workflows/ca-existing-config-test.yml
+
   ca-cmc-shared-token-test:
     name: CA with CMC shared token
     needs: build

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -471,6 +471,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           EOF
 
@@ -480,13 +481,30 @@ jobs:
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /etc/pki/pki-tomcat \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
 
+          # TODO: review permissions
           cat > expected << EOF
-          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          drwxrwx--- pkiuser pkiuser kra
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
           EOF
 
-          diff expected stderr
+          diff expected output
 
       - name: Check PKI server logs dir after removal
         run: |

--- a/.github/workflows/kra-existing-config-test.yml
+++ b/.github/workflows/kra-existing-config-test.yml
@@ -1,0 +1,146 @@
+name: KRA with existing config
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Install KRA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra.cfg \
+              -s KRA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check system certs
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.orig
+
+      - name: Check KRA admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki nss-cert-find | tee admin-cert.orig
+
+          docker exec pki pki -n caadmin kra-user-show kraadmin
+
+      - name: Remove KRA
+        run: docker exec pki pkidestroy -i pki-tomcat -s KRA -v
+
+      - name: Install KRA again
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra.cfg \
+              -s KRA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check system certs again
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.new
+
+          # system certs should not change
+          diff system-certs.orig system-certs.new
+
+      - name: Check KRA admin again
+        run: |
+          docker exec pki pki nss-cert-find | tee admin-cert.new
+
+          # admin cert should not change
+          diff admin-cert.orig admin-cert.new
+
+          docker exec pki pki -n caadmin kra-user-show kraadmin
+
+      - name: Remove KRA again
+        run: docker exec pki pkidestroy -i pki-tomcat -s KRA -v
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check KRA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kra-existing-config
+          path: /tmp/artifacts

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -53,6 +53,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/kra-existing-ds-test.yml
 
+  kra-existing-config-test:
+    name: KRA with existing config
+    needs: build
+    uses: ./.github/workflows/kra-existing-config-test.yml
+
   kra-cmc-test:
     name: KRA with CMC
     needs: build

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -576,6 +576,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           EOF
 
@@ -585,13 +586,30 @@ jobs:
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /etc/pki/pki-tomcat \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
 
+          # TODO: review permissions
           cat > expected << EOF
-          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          drwxrwx--- pkiuser pkiuser ocsp
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
           EOF
 
-          diff expected stderr
+          diff expected output
 
       - name: Check PKI server logs dir after removal
         run: |

--- a/.github/workflows/ocsp-existing-config-test.yml
+++ b/.github/workflows/ocsp-existing-config-test.yml
@@ -1,0 +1,156 @@
+name: OCSP with existing config
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Install OCSP
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ocsp.cfg \
+              -s OCSP \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check system certs
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.orig
+
+      - name: Check OCSP admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki nss-cert-find | tee admin-cert.orig
+
+          docker exec pki pki -n caadmin ocsp-user-show ocspadmin
+
+      - name: Remove OCSP
+        run: docker exec pki pkidestroy -i pki-tomcat -s OCSP -v
+
+      - name: Install OCSP again
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ocsp.cfg \
+              -s OCSP \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check system certs again
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.new
+
+          # system certs should not change
+          diff system-certs.orig system-certs.new
+
+      - name: Check OCSP admin again
+        run: |
+          docker exec pki pki nss-cert-find | tee admin-cert.new
+
+          # admin cert should not change
+          diff admin-cert.orig admin-cert.new
+
+          docker exec pki pki -n caadmin ocsp-user-show ocspadmin
+
+      - name: Remove OCSP again
+        run: docker exec pki pkidestroy -i pki-tomcat -s OCSP -v
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check OCSP debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ocsp -name "debug.*" -exec cat {} \;
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ocsp-existing-config
+          path: /tmp/artifacts

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -23,6 +23,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/ocsp-external-certs-test.yml
 
+  ocsp-existing-config-test:
+    name: OCSP with existing config
+    needs: build
+    uses: ./.github/workflows/ocsp-existing-config-test.yml
+
   ocsp-cmc-test:
     name: OCSP with CMC
     needs: build

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -186,6 +186,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           EOF
 
@@ -195,13 +196,25 @@ jobs:
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /etc/pki/pki-tomcat \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
 
+          # TODO: review permissions
           cat > expected << EOF
-          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          drwxr-x--- pkiuser pkiuser Catalina
+          -rw-rw---- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxr-x--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
           EOF
 
-          diff expected stderr
+          diff expected output
 
       - name: Check pki-tomcat server logs dir after removal
         run: |
@@ -338,6 +351,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          drwxr-x--- tomcat tomcat conf
           drwxr-x--- tomcat tomcat logs
           EOF
 
@@ -347,13 +361,25 @@ jobs:
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/tomcats/pki/conf \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
 
+          # TODO: review permissions
           cat > expected << EOF
-          ls: cannot access '/var/lib/tomcats/pki/conf': No such file or directory
+          drwxr-x--- tomcat tomcat Catalina
+          -rw-rw---- tomcat tomcat catalina.policy
+          lrwxrwxrwx tomcat tomcat catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxr-x--- tomcat tomcat certs
+          lrwxrwxrwx tomcat tomcat context.xml -> /etc/tomcat/context.xml
+          -rw-rw---- tomcat tomcat logging.properties
+          -rw-rw---- tomcat tomcat server.xml
+          -rw-rw---- tomcat tomcat tomcat.conf
+          lrwxrwxrwx tomcat tomcat web.xml -> /etc/tomcat/web.xml
           EOF
 
-          diff expected stderr
+          diff expected output
 
       - name: Check tomcat@pki server logs dir after removal
         run: |

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -266,6 +266,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           EOF
 
@@ -275,13 +276,30 @@ jobs:
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /etc/pki/pki-tomcat \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
 
+          # TODO: review permissions
           cat > expected << EOF
-          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          drwxrwx--- pkiuser pkiuser tks
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
           EOF
 
-          diff expected stderr
+          diff expected output
 
       - name: Check PKI server logs dir after removal
         run: |

--- a/.github/workflows/tks-existing-config-test.yml
+++ b/.github/workflows/tks-existing-config-test.yml
@@ -1,0 +1,156 @@
+name: TKS with existing config
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name:  Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Install TKS
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/tks.cfg \
+              -s TKS \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check system certs
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.orig
+
+      - name: Check TKS admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki nss-cert-find | tee admin-cert.orig
+
+          docker exec pki pki -n caadmin tks-user-show tksadmin
+
+      - name: Remove TKS
+        run: docker exec pki pkidestroy -i pki-tomcat -s TKS -v
+
+      - name: Install TKS again
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/tks.cfg \
+              -s TKS \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check system certs again
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.new
+
+          # system certs should not change
+          diff system-certs.orig system-certs.new
+
+      - name: Check TKS admin again
+        run: |
+          docker exec pki pki nss-cert-find | tee admin-cert.new
+
+          # admin cert should not change
+          diff admin-cert.orig admin-cert.new
+
+          docker exec pki pki -n caadmin tks-user-show tksadmin
+
+      - name: Remove TKS again
+        run: docker exec pki pkidestroy -i pki-tomcat -s TKS -v
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check TKS debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/tks -name "debug.*" -exec cat {} \;
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tks-existing-config
+          path: /tmp/artifacts

--- a/.github/workflows/tks-tests.yml
+++ b/.github/workflows/tks-tests.yml
@@ -23,6 +23,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/tks-external-certs-test.yml
 
+  tks-existing-config-test:
+    name: TKS with existing config
+    needs: build
+    uses: ./.github/workflows/tks-existing-config-test.yml
+
   tks-clone-test:
     name: TKS clone
     needs: build

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -377,6 +377,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           EOF
 
@@ -386,13 +387,32 @@ jobs:
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /etc/pki/pki-tomcat \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
 
+          # TODO: review permissions
           cat > expected << EOF
-          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          drwxrwx--- pkiuser pkiuser kra
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          drwxrwx--- pkiuser pkiuser tks
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          drwxrwx--- pkiuser pkiuser tps
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
           EOF
 
-          diff expected stderr
+          diff expected output
 
       - name: Check PKI server logs dir after removal
         run: |

--- a/.github/workflows/tps-existing-config-test.yml
+++ b/.github/workflows/tps-existing-config-test.yml
@@ -1,0 +1,194 @@
+name: TPS with existing config
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh ds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: ds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Install KRA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra.cfg \
+              -s KRA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Install TKS
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/tks.cfg \
+              -s TKS \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Install TPS
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/tps.cfg \
+              -s TPS \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_authdb_hostname=ds.example.com \
+              -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
+              -v
+
+      - name: Check system certs
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.orig
+
+      - name: Check TPS admin
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki client-cert-import ca_signing --ca-cert ca_signing.crt
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki nss-cert-find | tee admin-cert.orig
+
+          docker exec pki pki -n caadmin tps-user-show tpsadmin
+
+      - name: Remove TPS
+        run: docker exec pki pkidestroy -i pki-tomcat -s TPS -v
+
+      - name: Install TPS again
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/tps.cfg \
+              -s TPS \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_authdb_hostname=ds.example.com \
+              -D pki_authdb_port=3389 \
+              -D pki_enable_server_side_keygen=True \
+              -v
+
+      - name: Check system certs again
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              nss-cert-find | tee system-certs.new
+
+          # system certs should not change
+          diff system-certs.orig system-certs.new
+
+      - name: Check TPS admin again
+        run: |
+          docker exec pki pki nss-cert-find | tee admin-cert.new
+
+          # admin cert should not change
+          diff admin-cert.orig admin-cert.new
+
+          docker exec pki pki -n caadmin tps-user-show tpsadmin
+
+      - name: Remove TPS again
+        run: docker exec pki pkidestroy -i pki-tomcat -s TPS -v
+
+      - name: Remove TKS
+        run: docker exec pki pkidestroy -i pki-tomcat -s TKS -v
+
+      - name: Remove KRA
+        run: docker exec pki pkidestroy -i pki-tomcat -s KRA -v
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check KRA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Check TKS debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/tks -name "debug.*" -exec cat {} \;
+
+      - name: Check TPS debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/tps -name "debug.*" -exec cat {} \;
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tps-existing-config
+          path: /tmp/artifacts

--- a/.github/workflows/tps-tests.yml
+++ b/.github/workflows/tps-tests.yml
@@ -23,6 +23,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/tps-external-certs-test.yml
 
+  tps-existing-config-test:
+    name: TPS with existing config
+    needs: build
+    uses: ./.github/workflows/tps-existing-config-test.yml
+
   tps-clone-test:
     name: TPS clone
     needs: build

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1268,7 +1268,7 @@ grant codeBase "file:%s" {
 
         logger.info('%s web application stopped', webapp_id)
 
-    def remove(self, remove_logs=False, force=False):
+    def remove(self, remove_conf=False, remove_logs=False, force=False):
 
         logger.info('Removing %s', self.service_conf)
         pki.util.remove(self.service_conf, force=force)
@@ -1287,7 +1287,8 @@ grant codeBase "file:%s" {
 
         self.remove_libs(force=force)
 
-        self.remove_conf_dir(force=force)
+        if remove_conf:
+            self.remove_conf_dir(force=force)
 
         logger.info('Removing %s', self.bin_dir)
         pki.util.unlink(self.bin_dir, force=force)

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -400,7 +400,8 @@ class RemoveCLI(pki.cli.CLI):
     def print_help(self):
         print('Usage: pki-server remove [OPTIONS] [<instance ID>]')
         print()
-        print('      --remove-logs             Remove logs.')
+        print('      --remove-conf             Remove config folder.')
+        print('      --remove-logs             Remove logs folder.')
         print('      --force                   Force removal.')
         print('  -v, --verbose                 Run in verbose mode.')
         print('      --debug                   Run in debug mode.')
@@ -411,7 +412,7 @@ class RemoveCLI(pki.cli.CLI):
 
         try:
             opts, args = getopt.gnu_getopt(argv, 'v', [
-                'remove-logs', 'force',
+                'remove-conf', 'remove-logs', 'force',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -420,11 +421,15 @@ class RemoveCLI(pki.cli.CLI):
             sys.exit(1)
 
         instance_name = 'pki-tomcat'
+        remove_conf = False
         remove_logs = False
         force = False
 
         for o, _ in opts:
-            if o == '--remove-logs':
+            if o == '--remove-conf':
+                remove_conf = True
+
+            elif o == '--remove-logs':
                 remove_logs = True
 
             elif o == '--force':
@@ -456,7 +461,10 @@ class RemoveCLI(pki.cli.CLI):
 
         logger.info('Removing instance: %s', instance_name)
 
-        instance.remove(remove_logs=remove_logs, force=force)
+        instance.remove(
+            remove_conf=remove_conf,
+            remove_logs=remove_logs,
+            force=force)
 
 
 class StatusCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -45,6 +45,7 @@ from cryptography.hazmat.backends import default_backend
 import pki.nssdb
 import pki.account
 import pki.client
+import pki.pkcs12
 import pki.server
 import pki.server.deployment.scriptlets.configuration
 import pki.server.deployment.scriptlets.fapolicy_setup
@@ -143,6 +144,7 @@ class PKIDeployer:
         self.request_timeout = None
 
         self.force = False
+        self.remove_conf = False
         self.remove_logs = False
 
     def set_property(self, key, value, section=None):
@@ -567,9 +569,6 @@ class PKIDeployer:
             pki.server.DEFAULT_DIR_MODE)
 
     def remove_server_nssdb(self):
-
-        logger.info('Removing %s', self.instance.nssdb_link)
-        pki.util.unlink(self.instance.nssdb_link, self.force)
 
         logger.info('Removing %s', self.instance.nssdb_dir)
         pki.util.rmtree(self.instance.nssdb_dir, self.force)
@@ -2673,7 +2672,8 @@ class PKIDeployer:
             subsystem.set_config('securitydomain.select', 'new')
             subsystem.set_config('securitydomain.name', sd_name)
 
-            subsystem.create_security_domain(name=sd_name)
+            if config.str2bool(self.mdict['pki_ds_setup']):
+                subsystem.create_security_domain(name=sd_name)
 
             domain_manager = True
 

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -191,7 +191,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             logger.info('Setting up admin user')
             deployer.setup_admin_user(subsystem, admin_cert)
 
-        if not config.str2bool(deployer.mdict['pki_share_db']) and not clone:
+        if not config.str2bool(deployer.mdict['pki_share_db']) \
+                and not clone \
+                and config.str2bool(deployer.mdict['pki_ds_setup']):
             logger.info('Setting up database user')
             deployer.setup_database_user(subsystem)
 

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -265,9 +265,6 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if config.str2bool(deployer.mdict['pki_registry_enable']):
             instance.remove_registry(force=deployer.force)
 
-        deployer.remove_server_nssdb()
-        instance.remove_passwords(force=deployer.force)
-
         logger.info('Removing %s', instance.service_conf)
         pki.util.remove(instance.service_conf, force=deployer.force)
 
@@ -281,18 +278,20 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         pki.util.rmtree(instance.temp_dir, force=deployer.force)
 
         if deployer.remove_logs:
-
             # Remove /var/log/pki/<instance> and /var/lib/pki/<instance>/logs
-            # if requested
             instance.remove_logs_dir(force=deployer.force)
 
         instance.remove_libs(force=deployer.force)
 
-        # Remove /etc/pki/<instance> and /var/lib/pki/<instance>/conf
-        instance.remove_conf_dir(force=deployer.force)
+        if deployer.remove_conf:
+            # Remove /etc/pki/<instance> and /var/lib/pki/<instance>/conf
+            instance.remove_conf_dir(force=deployer.force)
 
         logger.info('Removing %s', instance.bin_dir)
         pki.util.unlink(instance.bin_dir, force=deployer.force)
+
+        logger.info('Removing %s', instance.nssdb_link)
+        pki.util.unlink(instance.nssdb_link, deployer.force)
 
         if os.path.isdir(instance.base_dir) and not os.listdir(instance.base_dir):
 

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -18,14 +18,7 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
 import logging
-
-import pki.nssdb
-import pki.pkcs12
-import pki.server
-import pki.util
 
 # PKI Deployment Imports
 from .. import pkiconfig as config
@@ -48,16 +41,3 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         deployer.install_cert_chain()
         deployer.import_ds_ca_cert()
         deployer.init_client_nssdb()
-
-    def destroy(self, deployer):
-
-        instance = self.instance
-
-        # if this is not the last subsystem, skip
-        if instance.get_subsystems():
-            return
-
-        if deployer.directory.exists(deployer.mdict['pki_client_dir']):
-            logger.info('Removing %s', deployer.mdict['pki_client_dir'])
-            pki.util.rmtree(deployer.mdict['pki_client_dir'],
-                            deployer.force)

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -321,5 +321,7 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if deployer.remove_logs:
             subsystem.remove_logs(force=deployer.force)
 
-        subsystem.remove_conf(force=deployer.force)
+        if deployer.remove_conf:
+            subsystem.remove_conf(force=deployer.force)
+
         subsystem.remove(force=deployer.force)

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -394,14 +394,17 @@ class PKIInstance(pki.server.PKIServer):
         for external_cert in PKIInstance.read_external_certs(conf_file):
             self.external_certs.append(external_cert)
 
-    def remove(self, remove_logs=False, force=False):
+    def remove(self, remove_conf=False, remove_logs=False, force=False):
 
         logger.info('Removing %s', self.unit_file)
         pki.util.unlink(self.unit_file, force=force)
 
         self.remove_registry(force=force)
 
-        super().remove(remove_logs=remove_logs, force=force)
+        super().remove(
+            remove_conf=remove_conf,
+            remove_logs=remove_logs,
+            force=force)
 
     def remove_libs(self, force=False):
 

--- a/base/server/python/pki/server/pkidestroy.py
+++ b/base/server/python/pki/server/pkidestroy.py
@@ -91,10 +91,17 @@ def main(argv):
     )
 
     parser.optional.add_argument(
+        '--remove-conf',
+        dest='remove_conf',
+        action='store_true',
+        help='Remove config folder'
+    )
+
+    parser.optional.add_argument(
         '--remove-logs',
         dest='remove_logs',
         action='store_true',
-        help='remove subsystem logs'
+        help='Remove logs folder'
     )
 
     parser.optional.add_argument(
@@ -165,6 +172,9 @@ def main(argv):
 
     # --force
     deployer.force = args.force
+
+    # --remove-conf
+    deployer.remove_conf = args.remove_conf
 
     # --remove-logs
     deployer.remove_logs = args.remove_logs


### PR DESCRIPTION
The `pkidestroy` and `pki-server remove` commands have been modified to keep the config folder by default but provide an option to remove the folder. The `security_databases.py` has also been modified to no longer remove the client NSS database. This will allow the subsystem to be reinstalled with the same config files (including the certs).

The basic installation tests have been modified to verify that the config folder still exists after server removal.

New tests have been added to install PKI subsystems with existing config files from previous installation.