### PR TITLE
Add stack-clash protection to native code

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -1049,6 +1049,10 @@ C_FLAGS="$C_FLAGS -fno-lto"
 C_FLAGS="$C_FLAGS -D_FORTIFY_SOURCE=3"
 CXX_FLAGS="$CXX_FLAGS -D_FORTIFY_SOURCE=3"
 
+# https://sourceware.org/annobin/annobin.html/Test-stack-clash.html
+C_FLAGS="$C_FLAGS -fstack-clash-protection"
+CXX_FLAGS="$CXX_FLAGS -fstack-clash-protection"
+
 %endif
 
 pkgs=base\


### PR DESCRIPTION
Rpminspect is failing because the native code is compiled without the required `-fstack-clash-protection` flag. For details:

https://sourceware.org/annobin/annobin.html/Test-stack-clash.html