### PR TITLE
Update installation tests with existing config files

### DIFF
--- a/.github/workflows/ca-existing-config-test.yml
+++ b/.github/workflows/ca-existing-config-test.yml
@@ -77,6 +77,82 @@ jobs:
         run: |
           docker exec pki pkidestroy -i pki-tomcat -s CA -v
 
+      - name: Check PKI server base dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # Tomcat and CA should be removed leaving just the conf and logs folders
+          # TODO: review permissions
+          cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server conf dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # all config files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+          # save the original config
+          docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
+
+      - name: Check PKI server logs dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
       - name: Install CA again
         run: |
           docker exec pki pkispawn \
@@ -84,6 +160,35 @@ jobs:
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
+
+      - name: Check PKI server config after second installation
+        run: |
+          # server config should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/server.xml /etc/pki/pki-tomcat/server.xml
+
+          # passwords should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/password.conf /etc/pki/pki-tomcat/password.conf
+
+      - name: Check CA config after second installation
+        run: |
+          # TODO: remove timestamps from config files
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              /etc/pki/pki-tomcat.orig/ca/CS.cfg \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              /etc/pki/pki-tomcat/ca/CS.cfg \
+              | sort > actual
+
+          # CA config should not change
+          diff expected actual
 
       - name: Check system certs again
         run: |
@@ -103,8 +208,55 @@ jobs:
 
           docker exec pki pki -n caadmin ca-user-show caadmin
 
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
+
       - name: Remove CA again
-        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s CA \
+              --remove-conf \
+              --remove-logs \
+              -v
+
+      - name: Check PKI server base dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/log/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
 
       - name: Check DS server systemd journal
         if: always()
@@ -120,11 +272,6 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Check CA debug log
-        if: always()
-        run: |
-          docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/kra-existing-config-test.yml
+++ b/.github/workflows/kra-existing-config-test.yml
@@ -84,6 +84,92 @@ jobs:
       - name: Remove KRA
         run: docker exec pki pkidestroy -i pki-tomcat -s KRA -v
 
+      - name: Check PKI server base dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # KRA subsystem should be removed
+          # TODO: review permissions
+          cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/conf/alias
+          lrwxrwxrwx pkiuser pkiuser bin -> /usr/share/tomcat/bin
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser common
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
+          lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
+          drwxrwx--- pkiuser pkiuser temp
+          drwxr-xr-x pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser work
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server conf dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # all config files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          drwxrwx--- pkiuser pkiuser kra
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+          # save the original config
+          docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
+
+      - name: Check PKI server logs dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
       - name: Install KRA again
         run: |
           docker exec pki pkispawn \
@@ -91,6 +177,35 @@ jobs:
               -s KRA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
+
+      - name: Check PKI server config after second installation
+        run: |
+          # server config should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/server.xml /etc/pki/pki-tomcat/server.xml
+
+          # passwords should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/password.conf /etc/pki/pki-tomcat/password.conf
+
+      - name: Check KRA config after second installation
+        run: |
+          # TODO: remove timestamps from config files
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              /etc/pki/pki-tomcat.orig/kra/CS.cfg \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              /etc/pki/pki-tomcat/kra/CS.cfg \
+              | sort > actual
+
+          # KRA config should not change
+          diff expected actual
 
       - name: Check system certs again
         run: |
@@ -110,17 +225,6 @@ jobs:
 
           docker exec pki pki -n caadmin kra-user-show kraadmin
 
-      - name: Remove KRA again
-        run: docker exec pki pkidestroy -i pki-tomcat -s KRA -v
-
-      - name: Remove CA
-        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
-
-      - name: Check PKI server systemd journal
-        if: always()
-        run: |
-          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
       - name: Check CA debug log
         if: always()
         run: |
@@ -130,6 +234,65 @@ jobs:
         if: always()
         run: |
           docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Remove KRA again
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s KRA \
+              --remove-conf \
+              --remove-logs \
+              -v
+
+      - name: Remove CA
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s CA \
+              --remove-conf \
+              --remove-logs \
+              -v
+
+      - name: Check PKI server base dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/log/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/ocsp-existing-config-test.yml
+++ b/.github/workflows/ocsp-existing-config-test.yml
@@ -84,6 +84,92 @@ jobs:
       - name: Remove OCSP
         run: docker exec pki pkidestroy -i pki-tomcat -s OCSP -v
 
+      - name: Check PKI server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # OCSP subsystem should be removed
+          # TODO: review permissions
+          cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/conf/alias
+          lrwxrwxrwx pkiuser pkiuser bin -> /usr/share/tomcat/bin
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser common
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
+          lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
+          drwxrwx--- pkiuser pkiuser temp
+          drwxr-xr-x pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser work
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server conf dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # all config files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          drwxrwx--- pkiuser pkiuser ocsp
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+          # save the original config
+          docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
+
+      - name: Check PKI server logs dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser ocsp
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
       - name: Install OCSP again
         run: |
           docker exec pki pkispawn \
@@ -91,6 +177,35 @@ jobs:
               -s OCSP \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
+
+      - name: Check PKI server config after second installation
+        run: |
+          # server config should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/server.xml /etc/pki/pki-tomcat/server.xml
+
+          # passwords should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/password.conf /etc/pki/pki-tomcat/password.conf
+
+      - name: Check OCSP config after second installation
+        run: |
+          # TODO: remove timestamps from config files
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              /etc/pki/pki-tomcat.orig/ocsp/CS.cfg \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              /etc/pki/pki-tomcat/ocsp/CS.cfg \
+              | sort > actual
+
+          # OCSP config should not change
+          diff expected actual
 
       - name: Check system certs again
         run: |
@@ -110,11 +225,69 @@ jobs:
 
           docker exec pki pki -n caadmin ocsp-user-show ocspadmin
 
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check OCSP debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ocsp -name "debug.*" -exec cat {} \;
+
       - name: Remove OCSP again
-        run: docker exec pki pkidestroy -i pki-tomcat -s OCSP -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s OCSP \
+              --remove-conf \
+              --remove-logs \
+              -v
 
       - name: Remove CA
-        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s CA \
+              --remove-conf \
+              --remove-logs \
+              -v
+
+      - name: Check PKI server base dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/log/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
 
       - name: Check DS server systemd journal
         if: always()
@@ -130,16 +303,6 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Check CA debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Check OCSP debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/ocsp -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/tks-existing-config-test.yml
+++ b/.github/workflows/tks-existing-config-test.yml
@@ -84,6 +84,92 @@ jobs:
       - name: Remove TKS
         run: docker exec pki pkidestroy -i pki-tomcat -s TKS -v
 
+      - name: Check PKI server base dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # TKS subsystem should be removed
+          # TODO: review permissions
+          cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/conf/alias
+          lrwxrwxrwx pkiuser pkiuser bin -> /usr/share/tomcat/bin
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser common
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
+          lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
+          drwxrwx--- pkiuser pkiuser temp
+          drwxr-xr-x pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser work
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server conf dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # all config files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          drwxrwx--- pkiuser pkiuser tks
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+          # save the original config
+          docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
+
+      - name: Check PKI server logs dir after first removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          EOF
+
+          diff expected output
+
       - name: Install TKS again
         run: |
           docker exec pki pkispawn \
@@ -91,6 +177,35 @@ jobs:
               -s TKS \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
+
+      - name: Check PKI server config after second installation
+        run: |
+          # server config should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/server.xml /etc/pki/pki-tomcat/server.xml
+
+          # passwords should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/password.conf /etc/pki/pki-tomcat/password.conf
+
+      - name: Check TKS config after second installation
+        run: |
+          # TODO: remove timestamps from config files
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              /etc/pki/pki-tomcat.orig/tks/CS.cfg \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              /etc/pki/pki-tomcat/tks/CS.cfg \
+              | sort > actual
+
+          # TKS config should not change
+          diff expected actual
 
       - name: Check system certs again
         run: |
@@ -110,11 +225,57 @@ jobs:
 
           docker exec pki pki -n caadmin tks-user-show tksadmin
 
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check TKS debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/tks -name "debug.*" -exec cat {} \;
+
       - name: Remove TKS again
-        run: docker exec pki pkidestroy -i pki-tomcat -s TKS -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s TKS \
+              --remove-conf \
+              --remove-logs \
+              -v
 
       - name: Remove CA
-        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s CA \
+              --remove-conf \
+              --remove-logs \
+              -v
+
+      - name: Check PKI server base dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
 
       - name: Check DS server systemd journal
         if: always()
@@ -130,16 +291,6 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Check CA debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Check TKS debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/tks -name "debug.*" -exec cat {} \;
 
       - name: Gather artifacts
         if: always()

--- a/.github/workflows/tps-existing-config-test.yml
+++ b/.github/workflows/tps-existing-config-test.yml
@@ -103,6 +103,98 @@ jobs:
       - name: Remove TPS
         run: docker exec pki pkidestroy -i pki-tomcat -s TPS -v
 
+      - name: Check PKI server base dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # TPS subsystem should be removed
+          # TODO: review permissions
+          cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/conf/alias
+          lrwxrwxrwx pkiuser pkiuser bin -> /usr/share/tomcat/bin
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser common
+          lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
+          drwxrwx--- pkiuser pkiuser kra
+          lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
+          drwxrwx--- pkiuser pkiuser temp
+          drwxrwx--- pkiuser pkiuser tks
+          drwxr-xr-x pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser work
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server conf dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # all config files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser alias
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-r--r-- pkiuser pkiuser catalina.policy
+          lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwx--- pkiuser pkiuser certs
+          lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
+          drwxrwx--- pkiuser pkiuser kra
+          lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- pkiuser pkiuser password.conf
+          -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
+          drwxrwx--- pkiuser pkiuser tks
+          -rw-rw---- pkiuser pkiuser tomcat.conf
+          drwxrwx--- pkiuser pkiuser tps
+          lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+          # save the original config
+          docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
+
+      - name: Check PKI server logs dir after removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
+          -rw-rw-r-- pkiuser pkiuser host-manager.$DATE.log
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          drwxrwx--- pkiuser pkiuser tps
+          EOF
+
+          diff expected output
+
       - name: Install TPS again
         run: |
           docker exec pki pkispawn \
@@ -113,6 +205,37 @@ jobs:
               -D pki_authdb_port=3389 \
               -D pki_enable_server_side_keygen=True \
               -v
+
+      - name: Check PKI server config after second installation
+        run: |
+          # server config should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/server.xml /etc/pki/pki-tomcat/server.xml
+
+          # passwords should not change
+          docker exec pki diff /etc/pki/pki-tomcat.orig/password.conf /etc/pki/pki-tomcat/password.conf
+
+      - name: Check TPS config after second installation
+        run: |
+          # TODO: remove timestamps from config files
+
+          # normalize expected result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              -e '/^config\.Subsystem_Connections\..*\.timestamp=/d' \
+              /etc/pki/pki-tomcat.orig/tps/CS.cfg \
+              | sort > expected
+
+          # normalize actual result:
+          # - remove params that cannot be compared
+          docker exec pki sed \
+              -e '/^installDate=/d' \
+              -e '/^config\.Subsystem_Connections\..*\.timestamp=/d' \
+              /etc/pki/pki-tomcat/tps/CS.cfg \
+              | sort > actual
+
+          # TPS config should not change
+          diff expected actual
 
       - name: Check system certs again
         run: |
@@ -132,17 +255,97 @@ jobs:
 
           docker exec pki pki -n caadmin tps-user-show tpsadmin
 
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check KRA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Check TKS debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/tks -name "debug.*" -exec cat {} \;
+
+      - name: Check TPS debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/tps -name "debug.*" -exec cat {} \;
+
       - name: Remove TPS again
-        run: docker exec pki pkidestroy -i pki-tomcat -s TPS -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s TPS \
+              --remove-conf \
+              --remove-logs \
+              -v
 
       - name: Remove TKS
-        run: docker exec pki pkidestroy -i pki-tomcat -s TKS -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s TKS \
+              --remove-conf \
+              --remove-logs \
+              -v
 
       - name: Remove KRA
-        run: docker exec pki pkidestroy -i pki-tomcat -s KRA -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s KRA \
+              --remove-conf \
+              --remove-logs \
+              -v
 
       - name: Remove CA
-        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+        run: |
+          docker exec pki pkidestroy \
+              -i pki-tomcat \
+              -s CA \
+              --remove-conf \
+              --remove-logs \
+              -v
+
+      - name: Check PKI server base dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/lib/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server conf dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /etc/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/etc/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI server logs dir after second removal
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ls: cannot access '/var/log/pki/pki-tomcat': No such file or directory
+          EOF
+
+          diff expected stderr
 
       - name: Gather artifacts
         if: always()
@@ -165,26 +368,6 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Check CA debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Check KRA debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
-
-      - name: Check TKS debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/tks -name "debug.*" -exec cat {} \;
-
-      - name: Check TPS debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/tps -name "debug.*" -exec cat {} \;
 
       - name: Upload artifacts
         if: always()


### PR DESCRIPTION
The installation tests with existing config files have been updated to verify that the config files do not get altered by the second installation. Currently this is not entirely true since there are timestamps stored in the config files, but in the future these timestamps can be removed or moved into log files instead.

The tests have also been updated to remove the config and log files after the second installation.