### PR TITLE
Update CA container

### DIFF
--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -228,6 +228,7 @@ jobs:
               https://ca.example.com:8443
 
       - name: Check data dir
+        if: always()
         run: |
           ls -l data \
               | sed \
@@ -235,15 +236,17 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
               | tee output
 
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxr-xr-x root root conf
-          drwxr-xr-x root root logs
+          drwxrwxrwx 17 root conf
+          drwxrwxrwx 17 root logs
           EOF
 
           diff expected output
 
       - name: Check data/conf dir
+        if: always()
         run: |
           ls -l data/conf \
               | sed \
@@ -251,12 +254,13 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
               | tee output
 
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
           # TODO: review owners/permissions
           cat > expected << EOF
           drwxrwx--- 17 root Catalina
           drwxrwx--- 17 root alias
           drwxrwx--- 17 root ca
-          -rw-r--r-- root root catalina.policy
+          -rw-rw-rw- 17 root catalina.policy
           lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
           drwxrwx--- 17 root certs
           lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
@@ -271,6 +275,7 @@ jobs:
           diff expected output
 
       - name: Check data/logs dir
+        if: always()
         run: |
           ls -l data/logs \
               | sed \
@@ -280,16 +285,17 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxr-x--- 17 root backup
+          drwxrwx--- 17 root backup
           drwxrwx--- 17 root ca
-          -rw-r--r-- root root catalina.$DATE.log
-          -rw-r--r-- root root host-manager.$DATE.log
-          -rw-r--r-- root root localhost.$DATE.log
-          -rw-r--r-- root root localhost_access_log.$DATE.txt
-          -rw-r--r-- root root manager.$DATE.log
-          drwxr-xr-x root root pki
+          -rw-rw-r-- 17 root catalina.$DATE.log
+          -rw-rw-r-- 17 root host-manager.$DATE.log
+          -rw-rw-r-- 17 root localhost.$DATE.log
+          -rw-rw-rw- 17 root localhost_access_log.$DATE.txt
+          -rw-rw-r-- 17 root manager.$DATE.log
+          drwxrwxrwx 17 root pki
           EOF
 
           diff expected output
@@ -318,157 +324,25 @@ jobs:
         run: docker network connect example ds --alias ds.example.com
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
-      - name: Configure DS database
+      - name: Initialize CA database
         run: |
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/base/server/database/ds/config.ldif
-
-      - name: Add PKI schema
-        run: |
-          docker exec ds ldapmodify \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/base/server/database/ds/schema.ldif
-
-      - name: Add CA base entry
-        run: |
-          docker exec -i ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 << EOF
-          dn: dc=ca,dc=pki,dc=example,dc=com
-          objectClass: dcObject
-          dc: ca
-          EOF
-
-      - name: Add CA database entries
-        run: |
-          sed \
-              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
-              base/ca/database/ds/create.ldif \
-              | tee create.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/create.ldif
-
-      - name: Add CA ACL resources
-        run: |
-          sed \
-              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
-              base/ca/database/ds/acl.ldif \
-              | tee acl.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/acl.ldif
+          docker exec ca pki-server ca-db-init -v
 
       - name: Add CA search indexes
         run: |
-          sed \
-              -e 's/{database}/userroot/g' \
-              base/ca/database/ds/index.ldif \
-              | tee index.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/index.ldif
+          docker exec ca pki-server ca-db-index-add -v
 
       - name: Rebuild CA search indexes
         run: |
-          # start rebuild task
-          sed \
-              -e 's/{database}/userroot/g' \
-              base/ca/database/ds/indextasks.ldif \
-              | tee indextasks.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/indextasks.ldif
-
-          # wait for task to complete
-          while true; do
-              sleep 1
-
-              docker exec ds ldapsearch \
-                  -H ldap://ds.example.com:3389 \
-                  -D "cn=Directory Manager" \
-                  -w Secret.123 \
-                  -b "cn=index1160589770, cn=index, cn=tasks, cn=config" \
-                  -LLL \
-                  nsTaskExitCode \
-                  | tee output
-
-              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
-              cat nsTaskExitCode
-
-              if [ -s nsTaskExitCode ]; then
-                  break
-              fi
-          done
-
-          echo "0" > expected
-          diff expected nsTaskExitCode
+          docker exec ca pki-server ca-db-index-rebuild -v
 
       - name: Add CA VLV indexes
         run: |
-          sed \
-              -e 's/{instanceId}/pki-tomcat/g' \
-              -e 's/{database}/userroot/g' \
-              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
-              base/ca/database/ds/vlv.ldif \
-              | tee vlv.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/vlv.ldif
+          docker exec ca pki-server ca-db-vlv-add -v
 
       - name: Rebuild CA VLV indexes
         run: |
-          # start rebuild task
-          sed \
-              -e 's/{database}/userroot/g' \
-              -e 's/{instanceId}/pki-tomcat/g' \
-              base/ca/database/ds/vlvtasks.ldif \
-              | tee vlvtasks.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/vlvtasks.ldif
-
-          # wait for task to complete
-          while true; do
-              sleep 1
-
-              docker exec ds ldapsearch \
-                  -H ldap://ds.example.com:3389 \
-                  -D "cn=Directory Manager" \
-                  -w Secret.123 \
-                  -b "cn=index1160589769, cn=index, cn=tasks, cn=config" \
-                  -LLL \
-                  nsTaskExitCode \
-                  | tee output
-
-              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
-              cat nsTaskExitCode
-
-              if [ -s nsTaskExitCode ]; then
-                  break
-              fi
-          done
-
-          echo "0" > expected
-          diff expected nsTaskExitCode
+          docker exec ca pki-server ca-db-vlv-reindex -v
 
       - name: Import CA signing cert into CA database
         run: |
@@ -545,199 +419,52 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add admin user
         run: |
-          docker exec -i ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 << EOF
-          dn: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          objectClass: person
-          objectClass: organizationalPerson
-          objectClass: inetOrgPerson
-          objectClass: cmsuser
-          cn: admin
-          sn: admin
-          uid: admin
-          mail: admin@example.com
-          userPassword: Secret.123
-          userState: 1
-          userType: adminType
-          EOF
+          docker exec ca pki-server ca-user-add \
+              --full-name Administrator \
+              --type adminType \
+              admin
 
       - name: Assign admin cert to admin user
         run: |
-          # convert cert from PEM to DER
-          docker cp client:admin.crt admin.crt
-          openssl x509 -outform der -in admin.crt -out admin.der
-          docker cp admin.der ds:admin.der
-
-          # get serial number
-          openssl x509 -text -noout -in admin.crt | tee output
-          SERIAL=$(sed -En 'N; s/^ *Serial Number:\n *(.*)$/\1/p; D' output)
-          echo "SERIAL: $SERIAL"
-          HEX_SERIAL=$(echo "$SERIAL" | tr -d ':')
-          echo "HEX_SERIAL: $HEX_SERIAL"
-          DEC_SERIAL=$(python -c "print(int('$HEX_SERIAL', 16))")
-          echo "DEC_SERIAL: $DEC_SERIAL"
-
-          docker exec -i ds ldapmodify \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 << EOF
-          dn: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: description
-          description: 2;$DEC_SERIAL;CN=CA Signing Certificate;CN=Administrator
-          -
-          add: userCertificate
-          userCertificate:< file:admin.der
-          -
-          EOF
+          docker exec ca pki-server ca-user-cert-add \
+              --cert /certs/admin.crt \
+              admin
 
       - name: Add admin user into CA groups
         run: |
-          docker exec -i ds ldapmodify \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 << EOF
-          dn: cn=Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Certificate Manager Agents,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Security Domain Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Enterprise CA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Enterprise KRA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Enterprise RA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Enterprise TKS Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Enterprise OCSP Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Enterprise TPS Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-          EOF
+          docker exec ca pki-server ca-user-role-add admin "Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
+          docker exec ca pki-server ca-user-role-add admin "Security Domain Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Enterprise CA Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Enterprise KRA Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Enterprise RA Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Enterprise TKS Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Enterprise OCSP Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Enterprise TPS Administrators"
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database-User
       - name: Add database user
         run: |
-          docker exec -i ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 << EOF
-          dn: uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          objectClass: person
-          objectClass: organizationalPerson
-          objectClass: inetOrgPerson
-          objectClass: cmsuser
-          cn: pkidbuser
-          sn: pkidbuser
-          uid: pkidbuser
-          userState: 1
-          userType: agentType
-          EOF
+          docker exec ca pki-server ca-user-add \
+              --full-name pkidbuser \
+              --type agentType \
+              pkidbuser
 
       - name: Assign subsystem cert to database user
         run: |
-          # convert cert from PEM to DER
-          docker cp client:subsystem.crt subsystem.crt
-          openssl x509 -outform der -in subsystem.crt -out subsystem.der
-          docker cp subsystem.der ds:subsystem.der
-
-          # get serial number
-          openssl x509 -text -noout -in subsystem.crt | tee output
-          SERIAL=$(sed -En 'N; s/^ *Serial Number:\n *(.*)$/\1/p; D' output)
-          echo "SERIAL: $SERIAL"
-          HEX_SERIAL=$(echo "$SERIAL" | tr -d ':')
-          echo "HEX_SERIAL: $HEX_SERIAL"
-          DEC_SERIAL=$(python -c "print(int('$HEX_SERIAL', 16))")
-          echo "DEC_SERIAL: $DEC_SERIAL"
-
-          docker exec -i ds ldapmodify \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 << EOF
-          dn: uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: description
-          description: 2;$DEC_SERIAL;CN=CA Signing Certificate;CN=Subsystem Certificate
-          -
-          add: seeAlso
-          seeAlso: CN=Subsystem Certificate
-          -
-          add: userCertificate
-          userCertificate:< file:subsystem.der
-          -
-          EOF
+          docker exec ca pki-server ca-user-cert-add \
+              --cert /certs/subsystem.crt \
+              pkidbuser
 
       - name: Add database user into CA groups
         run: |
-          docker exec -i ds ldapmodify \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 << EOF
-          dn: cn=Subsystem Group,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-
-          dn: cn=Certificate Manager Agents,ou=groups,dc=ca,dc=pki,dc=example,dc=com
-          changetype: modify
-          add: uniqueMember
-          uniqueMember: uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
-          -
-          EOF
+          docker exec ca pki-server ca-user-role-add pkidbuser "Subsystem Group"
+          docker exec ca pki-server ca-user-role-add pkidbuser "Certificate Manager Agents"
 
       - name: Grant database user access to CA database
         run: |
-          sed \
-              -e 's/{rootSuffix}/dc=example,dc=com/g' \
-              -e 's/{dbuser}/uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com/g' \
-              base/server/database/ds/db-access-grant.ldif \
-              | tee db-access-grant.ldif
-          docker exec ds ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f $SHARED/db-access-grant.ldif \
-              -c
+          docker exec ca pki-server ca-db-access-grant \
+              uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
 
       - name: Check public operations from CA container
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,12 +165,25 @@ LABEL name="pki-ca" \
 
 EXPOSE 8080 8443
 
+# In OpenShift the server runs as an OpenShift-assigned user
+# (with a random UID) that belongs to the root group (GID=0),
+# so the server instance needs to be owned by the root group.
+#
+# https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+
 # Create PKI server
-RUN id
 RUN pki-server create \
     --group root \
     --conf /data/conf \
     --logs /data/logs
+
+# In Docker/Podman the server runs as pkiuser (UID=17). To
+# ensure it generates files with the proper ownership the
+# pkiuser's primary group needs to be changed to the root
+# group (GID=0).
+
+# Change pkiuser's primary group to root group
+RUN usermod pkiuser -g root
 
 # Create NSS database
 RUN pki-server nss-create --no-password

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -5,9 +5,22 @@
 # - do not create security domain
 # - support existing subsystem user
 
+# Allow the owner of the container (who might not be in the root group)
+# to manage the config and log files.
+umask 000
+
 echo "################################################################################"
+
+echo "INFO: Creating /data/conf"
 mkdir -p /data/conf
+chown -Rf pkiuser:root /data/conf
+
+echo "################################################################################"
+
+echo "INFO: Creating /data/logs"
 mkdir -p /data/logs
+chown -Rf pkiuser:root /data/logs
+
 echo "################################################################################"
 
 if [ -f /certs/server.p12 ]
@@ -318,6 +331,7 @@ pkispawn \
     -s CA \
     -D pki_group=root \
     -D pki_ds_url=ldap://ds.example.com:3389 \
+    -D pki_ds_database=userroot \
     -D pki_ds_setup=False \
     -D pki_skip_ds_verify=True \
     -D pki_share_db=True \
@@ -348,4 +362,15 @@ pki-server ca-config-set ca.authorityMonitor.enable false
 echo "################################################################################"
 echo "INFO: Starting PKI CA"
 
-pki-server run --as-current-user
+if [ "$UID" = "0" ]; then
+    # In Docker/Podman the server runs as pkiuser (UID=17) that
+    # belongs to the root group (GID=0).
+    pki-server run
+
+else
+    # In OpenShift the server runs as an OpenShift-assigned user
+    # (with a random UID) that belongs to the root group (GID=0).
+    #
+    # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+    pki-server run --as-current-user
+fi


### PR DESCRIPTION
The CA container has been updated such that all files will be owned by `pkiuser:root` so that it will work in Docker/Podman as well as in OpenShift.

The test for CA container has been updated to use `pki-server` commands to set up the CA database in the default DS backend (i.e. `userroot`).