### PR TITLE
Remove unconfigurable instanceId param

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -14,7 +14,6 @@ admin.interface.uri=ca/admin/console/config/wizard
 ee.interface.uri=ca/ee/ca
 agent.interface.uri=ca/agent/ca
 machineName=[pki_hostname]
-instanceId=[pki_instance_name]
 pidDir=/var/run/pki/tomcat
 preop.pin=[pki_one_time_pin]
 ca.cert.list=signing,ocsp_signing,sslserver,subsystem,audit_signing

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -9,7 +9,6 @@ admin.interface.uri=kra/admin/console/config/wizard
 agent.interface.uri=kra/agent/kra
 authType=pwd
 machineName=[pki_hostname]
-instanceId=[pki_instance_name]
 pidDir=/var/run/pki/tomcat
 preop.pin=[pki_one_time_pin]
 kra.cert.list=transport,storage,sslserver,subsystem,audit_signing

--- a/base/ocsp/shared/conf/CS.cfg
+++ b/base/ocsp/shared/conf/CS.cfg
@@ -63,7 +63,6 @@ preop.cert.subsystem.cncomponent.override=true
 cs.state=0
 authType=pwd
 machineName=[pki_hostname]
-instanceId=[pki_instance_name]
 preop.pin=[pki_one_time_pin]
 multiroles=true
 multiroles.false.groupEnforceList=Administrators,Auditors,Trusted Managers,Certificate Manager Agents,Registration Manager Agents,Data Recovery Manager Agents,Online Certificate Status Manager Agents,Token Key Service Manager Agents,Enterprise CA Administrators,Enterprise KRA Adminstrators,Enterprise OCSP Administrators,Enterprise RA Administrators,Enterprise TKS Administrators,Enterprise TPS Administrators,Security Domain Administrators,Subsystem Group

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -188,9 +188,6 @@ class PKISubsystem(object):
         if 'cs.type' not in self.config:
             self.set_config('cs.type', self.type)
 
-        if 'instanceId' not in self.config:
-            self.set_config('instanceId', self.instance.name)
-
         logger.info('Storing subsystem config: %s', self.cs_conf)
         self.instance.store_properties(self.cs_conf, self.config)
 

--- a/base/server/src/main/java/com/netscape/cms/logging/LogFile.java
+++ b/base/server/src/main/java/com/netscape/cms/logging/LogFile.java
@@ -421,7 +421,7 @@ public class LogFile extends LogEventListener implements IExtendedPluginInfo {
 
         try {
             String subsystem = cs.getType().toLowerCase();
-            String instID = cs.getInstanceID();
+            String instID = CMS.getInstanceID();
 
             // build the default signedAudit file name
             signedAuditDefaultFileName = subsystem + "_" + instID + "_" + "audit";

--- a/base/server/src/main/java/com/netscape/cms/servlet/admin/CMSAdminServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/admin/CMSAdminServlet.java
@@ -622,7 +622,7 @@ public class CMSAdminServlet extends AdminServlet {
         }
 
         try {
-            String instanceId = cs.getInstanceID();
+            String instanceId = CMS.getInstanceID();
             params.put(Constants.PR_STAT_INSTANCEID, instanceId);
         } catch (Exception e) {
         }

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMS.java
@@ -19,6 +19,8 @@ package com.netscape.cmscore.apps;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -74,6 +76,11 @@ public final class CMS {
 
     public static String getInstanceDir() {
         return System.getProperty("catalina.base");  // defined by Tomcat
+    }
+
+    public static String getInstanceID() {
+        Path instancePath = Paths.get(getInstanceDir());
+        return instancePath.getFileName().toString();
     }
 
     /**

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -395,7 +395,7 @@ public class CMSEngine {
         config = createConfig(storage);
         config.load();
 
-        instanceId = config.getInstanceID();
+        instanceId = CMS.getInstanceID();
 
         mConfig = config;
     }
@@ -528,7 +528,7 @@ public class CMSEngine {
                 connConfig = ldapConfig.getConnectionConfig();
 
                 binddn = "cn=Replication Manager masterAgreement1-" + config.getHostname() + "-" +
-                        config.getInstanceID() + ",cn=config";
+                        CMS.getInstanceID() + ",cn=config";
 
             } else if (tags.equals("CA LDAP Publishing")) {
 

--- a/base/server/src/main/java/com/netscape/cmscore/apps/EngineConfig.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/EngineConfig.java
@@ -49,14 +49,6 @@ public class EngineConfig extends ConfigStore {
         putString("machineName", hostname);
     }
 
-    public String getInstanceID() throws EBaseException {
-        return getString("instanceId");
-    }
-
-    public void setInstanceID(String instanceID) throws EBaseException {
-        putString("instanceId", instanceID);
-    }
-
     public String getPasswordClass() throws EBaseException {
         return getString("passwordClass", PlainPasswordFile.class.getName());
     }
@@ -135,7 +127,7 @@ public class EngineConfig extends ConfigStore {
     public PasswordStoreConfig getPasswordStoreConfig() throws EBaseException {
 
         PasswordStoreConfig config = new PasswordStoreConfig();
-        config.setID(getString("instanceId"));
+        config.setID(CMS.getInstanceID());
         config.setClassName(getPasswordClass());
         config.setFileName(getPasswordFile());
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexAddCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexAddCLI.java
@@ -43,7 +43,7 @@ public class SubsystemDBIndexAddCLI extends SubsystemCLI {
         cs.load();
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
-        String instanceId = cs.getInstanceID();
+        String instanceId = CMS.getInstanceID();
 
         PasswordStoreConfig psc = cs.getPasswordStoreConfig();
         PasswordStore passwordStore = CMS.createPasswordStore(psc);

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexRebuildCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBIndexRebuildCLI.java
@@ -43,7 +43,7 @@ public class SubsystemDBIndexRebuildCLI extends SubsystemCLI {
         cs.load();
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
-        String instanceId = cs.getInstanceID();
+        String instanceId = CMS.getInstanceID();
 
         PasswordStoreConfig psc = cs.getPasswordStoreConfig();
         PasswordStore passwordStore = CMS.createPasswordStore(psc);

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBVLVAddCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBVLVAddCLI.java
@@ -43,7 +43,7 @@ public class SubsystemDBVLVAddCLI extends SubsystemCLI {
         cs.load();
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
-        String instanceId = cs.getInstanceID();
+        String instanceId = CMS.getInstanceID();
 
         PasswordStoreConfig psc = cs.getPasswordStoreConfig();
         PasswordStore passwordStore = CMS.createPasswordStore(psc);

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBVLVDeleteCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBVLVDeleteCLI.java
@@ -43,7 +43,7 @@ public class SubsystemDBVLVDeleteCLI extends SubsystemCLI {
         cs.load();
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
-        String instanceId = cs.getInstanceID();
+        String instanceId = CMS.getInstanceID();
 
         PasswordStoreConfig psc = cs.getPasswordStoreConfig();
         PasswordStore passwordStore = CMS.createPasswordStore(psc);

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBVLVFindCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBVLVFindCLI.java
@@ -49,7 +49,7 @@ public class SubsystemDBVLVFindCLI extends SubsystemCLI {
         cs.load();
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
-        String instanceId = cs.getInstanceID();
+        String instanceId = CMS.getInstanceID();
 
         PasswordStoreConfig psc = cs.getPasswordStoreConfig();
         PasswordStore passwordStore = CMS.createPasswordStore(psc);

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBVLVReindexCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBVLVReindexCLI.java
@@ -43,7 +43,7 @@ public class SubsystemDBVLVReindexCLI extends SubsystemCLI {
         cs.load();
 
         LDAPConfig ldapConfig = cs.getInternalDBConfig();
-        String instanceId = cs.getInstanceID();
+        String instanceId = CMS.getInstanceID();
 
         PasswordStoreConfig psc = cs.getPasswordStoreConfig();
         PasswordStore passwordStore = CMS.createPasswordStore(psc);

--- a/base/server/upgrade/11.6.0/01-CleanUpSubsystemConfig.py
+++ b/base/server/upgrade/11.6.0/01-CleanUpSubsystemConfig.py
@@ -23,6 +23,10 @@ class CleanUpSubsystemConfig(pki.server.upgrade.PKIServerUpgradeScriptlet):
 
         self.backup(subsystem.cs_conf)
 
+        if subsystem.config.get('instanceId'):
+            logger.info('Removing instanceId')
+            subsystem.config.pop('instanceId', None)
+
         param = '%s.admin.cert' % subsystem.name
         if subsystem.config.get(param):
             logger.info('Removing %s', param)

--- a/base/tks/shared/conf/CS.cfg
+++ b/base/tks/shared/conf/CS.cfg
@@ -55,7 +55,6 @@ preop.module.token=Internal Key Storage Token
 cs.state=0
 authType=pwd
 machineName=[pki_hostname]
-instanceId=[pki_instance_name]
 preop.pin=[pki_one_time_pin]
 multiroles=true
 multiroles.false.groupEnforceList=Administrators,Auditors,Trusted Managers,Certificate Manager Agents,Registration Manager Agents,Data Recovery Manager Agents,Online Certificate Status Manager Agents,Token Key Service Manager Agents,Enterprise CA Administrators,Enterprise KRA Adminstrators,Enterprise OCSP Administrators,Enterprise RA Administrators,Enterprise TKS Administrators,Enterprise TPS Administrators,Security Domain Administrators,Subsystem Group

--- a/base/tomcat/src/main/java/com/netscape/cms/tomcat/NuxwdogPasswordStore.java
+++ b/base/tomcat/src/main/java/com/netscape/cms/tomcat/NuxwdogPasswordStore.java
@@ -3,6 +3,8 @@ package com.netscape.cms.tomcat;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -63,7 +65,9 @@ public class NuxwdogPasswordStore implements org.dogtagpki.jss.tomcat.PasswordSt
             }
         }
 
-        instanceId = props.getProperty("instanceId");
+        String instanceDir = System.getProperty("catalina.base");
+        Path instancePath = Paths.get(instanceDir);
+        instanceId = instancePath.getFileName().toString();
     }
 
     private void addTag(String tag) {

--- a/base/tps/shared/conf/CS.cfg
+++ b/base/tps/shared/conf/CS.cfg
@@ -181,7 +181,6 @@ general.search.timelimit.default=10
 general.search.timelimit.max=10
 general.verifyProof=1
 installDate=[pki_install_time]
-instanceId=[pki_instance_name]
 internaldb._000=##
 internaldb._001=## Internal Database
 internaldb._002=##

--- a/docs/changes/v11.6.0/Server-Changes.adoc
+++ b/docs/changes/v11.6.0/Server-Changes.adoc
@@ -5,6 +5,7 @@
 The following parameters in `CS.cfg` are no longer used
 so they have been removed:
 
+* `instanceId`
 * `<subsystem>.admin.cert`
 * `<subsystem>.standalone`
 


### PR DESCRIPTION
The `instanceId` param has been removed from `CS.cfg` since it's not actually changeable and also to prevent misconfiguration.

The code that uses the instance ID has been modified to call `CMS.getInstanceID()` instead which gets it from the instance dir (which comes from `catalina.base` property). Due to class loading issue the `NuxwdogPasswordStore` class cannot call this method so it has to get it directly from the `catalina.base` property.

The `PKISubsystem.create_conf()` has been modified to no longer add the param if it's missing.

The upgrade script has been modified to remove the param from existing instances.

https://github.com/edewata/pki/blob/config/docs/changes/v11.6.0/Server-Changes.adoc
