### PR TITLE
Remove cs.type param

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -8,7 +8,6 @@ cs.state._001=## cs.state=0 (pre-operational)
 cs.state._002=## cs.state=1 (running)
 cs.state._003=##
 cs.state=0
-cs.type=CA
 authType=pwd
 admin.interface.uri=ca/admin/console/config/wizard
 ee.interface.uri=ca/ee/ca

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -4,7 +4,6 @@ _002=##
 installDate=[pki_install_time]
 cms.product.version=@APPLICATION_VERSION@
 cs.state=0
-cs.type=KRA
 admin.interface.uri=kra/admin/console/config/wizard
 agent.interface.uri=kra/agent/kra
 authType=pwd

--- a/base/ocsp/shared/conf/CS.cfg
+++ b/base/ocsp/shared/conf/CS.cfg
@@ -3,7 +3,6 @@ _001=## Online Certificate Status Protocol (OCSP) Responder Configuration File
 _002=##
 pidDir=/var/run/pki/tomcat
 installDate=[pki_install_time]
-cs.type=OCSP
 admin.interface.uri=ocsp/admin/console/config/wizard
 agent.interface.uri=ocsp/agent/ocsp
 cms.product.version=@APPLICATION_VERSION@

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -185,9 +185,6 @@ class PKISubsystem(object):
         if os.path.exists(self.cs_conf):
             pki.util.load_properties(self.cs_conf, self.config)
 
-        if 'cs.type' not in self.config:
-            self.set_config('cs.type', self.type)
-
         logger.info('Storing subsystem config: %s', self.cs_conf)
         self.instance.store_properties(self.cs_conf, self.config)
 
@@ -253,8 +250,6 @@ class PKISubsystem(object):
         if os.path.exists(self.cs_conf):
             logger.info('Loading subsystem config: %s', self.cs_conf)
             pki.util.load_properties(self.cs_conf, self.config)
-
-            self.type = self.config['cs.type']
 
         self.registry.clear()
 

--- a/base/server/src/main/java/com/netscape/cms/logging/LogFile.java
+++ b/base/server/src/main/java/com/netscape/cms/logging/LogFile.java
@@ -420,7 +420,7 @@ public class LogFile extends LogEventListener implements IExtendedPluginInfo {
         mLevel = config.getLevel();
 
         try {
-            String subsystem = cs.getType().toLowerCase();
+            String subsystem = engine.getID();
             String instID = CMS.getInstanceID();
 
             // build the default signedAudit file name

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/Configurator.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/Configurator.java
@@ -84,7 +84,7 @@ public class Configurator {
 
     public String getInstallToken(String sdhost, int sdport, String user, String passwd) throws Exception {
 
-        String csType = cs.getType();
+        String csType = engine.getName();
 
         ClientConfig config = new ClientConfig();
         config.setServerURL("https://" + sdhost + ":" + sdport);
@@ -134,7 +134,7 @@ public class Configurator {
 
         String subca_url = "https://" + cs.getHostname() + ":"
                 + engine.getAdminPort() + "/ca/admin/console/config/wizard" +
-                "?p=5&subsystem=" + cs.getType();
+                "?p=5&subsystem=" + engine.getName();
 
         MultivaluedMap<String, String> content = new MultivaluedHashMap<>();
         content.putSingle("uid", user);

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/GetStatus.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/GetStatus.java
@@ -74,7 +74,7 @@ public class GetStatus extends CMSServlet {
         EngineConfig config = engine.getConfig();
 
         int state = config.getState();
-        String type = config.getType();
+        String type = engine.getName();
         String status = engine.isReady() ? "running" : "starting";
         String version = GetStatus.class.getPackage().getImplementationVersion();
 

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/UpdateNumberRange.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/UpdateNumberRange.java
@@ -110,7 +110,6 @@ public abstract class UpdateNumberRange extends CMSServlet {
 
             EngineConfig cs = engine.getConfig();
             DatabaseConfig dbConfig = cs.getDatabaseConfig();
-            String cstype = cs.getType();
 
             auditParams += "+type;;" + type;
 

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -432,8 +432,7 @@ public class CMSEngine {
             listenersConfig = config.getSubStore("startupNotifiers", ConfigStore.class);
 
             if (listenersConfig.size() > 0) {
-                String subsystem = config.getType().toLowerCase();
-                String configPath = instanceDir + "/conf/" + subsystem + "/CS.cfg";
+                String configPath = instanceDir + "/conf/" + id + "/CS.cfg";
                 logger.warn("The 'startupNotifiers' property in " + configPath + " has been deprecated. Use 'listeners' instead.");
             }
         }
@@ -683,8 +682,7 @@ public class CMSEngine {
 
     public void initPluginRegistry() throws Exception {
         ConfigStore pluginRegistryConfig = config.getSubStore(PluginRegistry.ID, ConfigStore.class);
-        String subsystem = config.getType().toLowerCase();
-        String defaultRegistryFile = instanceDir + "/conf/" + subsystem + "/registry.cfg";
+        String defaultRegistryFile = instanceDir + "/conf/" + id + "/registry.cfg";
         pluginRegistry.init(pluginRegistryConfig, defaultRegistryFile);
         pluginRegistry.startup();
     }
@@ -1072,8 +1070,6 @@ public class CMSEngine {
     }
 
     public void configureServerCertNickname() throws EBaseException {
-
-        String id = mConfig.getType().toLowerCase();
 
         if (id.equals("ca") || id.equals("ocsp") ||
                 id.equals("kra") || id.equals("tks")) {
@@ -1898,24 +1894,9 @@ public class CMSEngine {
         String auditMessage = null;
 
         try {
-            String subsysType = config.getType();
-            if (subsysType == null || subsysType.equals("")) {
-                logger.error("CMSEngine: Missing cs.type in CS.cfg");
-                auditMessage = CMS.getLogMessage(
-                            AuditEvent.CIMC_CERT_VERIFICATION,
-                            ILogger.SYSTEM_UID,
-                            ILogger.FAILURE,
-                            "");
-
-                auditor.log(auditMessage);
-                throw new Exception("Missing cs.type in CS.cfg");
-            }
-
-            subsysType = subsysType.toLowerCase();
-
-            String certlist = config.getString(subsysType + ".cert.list", "");
+            String certlist = config.getString(id + ".cert.list", "");
             if (certlist.equals("")) {
-                logger.error("CMSEngine: Missing " + subsysType + ".cert.list in CS.cfg");
+                logger.error("CMSEngine: Missing " + id + ".cert.list in CS.cfg");
                 auditMessage = CMS.getLogMessage(
                             AuditEvent.CIMC_CERT_VERIFICATION,
                             ILogger.SYSTEM_UID,
@@ -1923,7 +1904,7 @@ public class CMSEngine {
                             "");
 
                 auditor.log(auditMessage);
-                throw new Exception("Missing " + subsysType + ".cert.list in CS.cfg");
+                throw new Exception("Missing " + id + ".cert.list in CS.cfg");
             }
 
             StringTokenizer tokenizer = new StringTokenizer(certlist, ",");
@@ -1972,21 +1953,13 @@ public class CMSEngine {
         String auditMessage = null;
 
         try {
-            String subsysType = config.getType();
-            if (subsysType == null || subsysType.equals("")) {
-                logger.error("CMSEngine: Missing cs.type in CS.cfg");
-                throw new Exception("Missing cs.type in CS.cfg");
-            }
-
-            subsysType = subsysType.toLowerCase();
-
-            String nickname = config.getString(subsysType + ".cert." + tag + ".nickname", "");
+            String nickname = config.getString(id + ".cert." + tag + ".nickname", "");
             if (nickname.equals("")) {
                 logger.error("CMSEngine: verifySystemCertByTag() nickname for cert tag " + tag + " undefined in CS.cfg");
                 throw new Exception("Missing nickname for " + tag + " certificate");
             }
 
-            String certusage = config.getString(subsysType + ".cert." + tag + ".certusage", "");
+            String certusage = config.getString(id + ".cert." + tag + ".certusage", "");
             if (certusage.equals("")) {
                 logger.warn("CMSEngine: verifySystemCertByTag() certusage for cert tag "
                         + tag + " undefined in CS.cfg, getting current certificate usage");

--- a/base/server/src/main/java/com/netscape/cmscore/apps/EngineConfig.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/EngineConfig.java
@@ -64,14 +64,6 @@ public class EngineConfig extends ConfigStore {
         putString("passwordFile", passwordFile);
     }
 
-    public String getType() throws EBaseException {
-        return getString("cs.type");
-    }
-
-    public void setType(String type) throws EBaseException {
-        putString("cs.type", type);
-    }
-
     public int getState() throws EBaseException {
         return getInteger("cs.state");
     }

--- a/base/server/src/main/java/org/dogtagpki/server/rest/UserService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/UserService.java
@@ -211,7 +211,7 @@ public class UserService extends SubsystemService implements UserResource {
             if (!StringUtils.isEmpty(type)) userData.setType(type);
 
             // TODO: refactor into TPSUserService
-            String csType = cs.getType();
+            String csType = engine.getName();
             if (csType.equals("TPS")) {
 
                 List<String> profiles = user.getTpsProfiles();
@@ -348,7 +348,7 @@ public class UserService extends SubsystemService implements UserResource {
             }
 
             // TODO: refactor into TPSUserService
-            String csType = cs.getType();
+            String csType = engine.getName();
             if (csType.equals("TPS")) {
 
                 String tpsProfiles = userData.getAttribute(ATTR_TPS_PROFILES);
@@ -460,7 +460,7 @@ public class UserService extends SubsystemService implements UserResource {
             }
 
             // TODO: refactor into TPSUserService
-            String csType = cs.getType();
+            String csType = engine.getName();
             if (csType.equals("TPS")) {
 
                 String tpsProfiles = userData.getAttribute(ATTR_TPS_PROFILES);

--- a/base/server/upgrade/11.6.0/01-CleanUpSubsystemConfig.py
+++ b/base/server/upgrade/11.6.0/01-CleanUpSubsystemConfig.py
@@ -27,6 +27,10 @@ class CleanUpSubsystemConfig(pki.server.upgrade.PKIServerUpgradeScriptlet):
             logger.info('Removing instanceId')
             subsystem.config.pop('instanceId', None)
 
+        if subsystem.config.get('cs.type'):
+            logger.info('Removing cs.type')
+            subsystem.config.pop('cs.type', None)
+
         param = '%s.admin.cert' % subsystem.name
         if subsystem.config.get(param):
             logger.info('Removing %s', param)

--- a/base/tks/shared/conf/CS.cfg
+++ b/base/tks/shared/conf/CS.cfg
@@ -3,7 +3,6 @@ _001=## Token Key Service (TKS) Configuration File
 _002=##
 pidDir=/var/run/pki/tomcat
 installDate=[pki_install_time]
-cs.type=TKS
 admin.interface.uri=tks/admin/console/config/wizard
 cms.product.version=@APPLICATION_VERSION@
 cms.passwordlist=internaldb,replicationdb

--- a/base/tps/shared/conf/CS.cfg
+++ b/base/tps/shared/conf/CS.cfg
@@ -124,7 +124,6 @@ cms.passwordlist=internaldb
 config.Generals.General.state=Enabled
 config.Generals.General.timestamp=1280283607424406
 cs.state=0
-cs.type=TPS
 dbs.ldap=internaldb
 dbs.newSchemaEntryAdded=true
 debug.level=10

--- a/docs/changes/v11.6.0/Server-Changes.adoc
+++ b/docs/changes/v11.6.0/Server-Changes.adoc
@@ -6,6 +6,7 @@ The following parameters in `CS.cfg` are no longer used
 so they have been removed:
 
 * `instanceId`
+* `cs.type`
 * `<subsystem>.admin.cert`
 * `<subsystem>.standalone`
 


### PR DESCRIPTION
The `cs.type` param has been removed from `CS.cfg` since subsystem type is not actually changeable and this param might introduce configuration issues.

The code that uses the subsystem type has been modified to call `CMSEngine.getName()` (for uppercase subsystem type) and `getID()` for (for lower case subsystem type) instead.

The `PKISubsystem.create_conf()` has been modified to no longer add the param if it's missing. The `load()` has also been updated to no longer read the param.

The upgrade script has been modified to remove the param from existing instances.