### PR TITLE
Update ACME container

### DIFF
--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Set up ACME container
         run: |
           docker run \
-              --name server \
+              --name acme \
+              --hostname acme.example.com \
+              --network example \
+              --network-alias acme.example.com \
               --detach \
               pki-acme
-
-      - name: Connect ACME container to network
-        run: docker network connect example server --alias pki.example.com
 
       - name: Set up client container
         run: |
@@ -59,24 +59,24 @@ jobs:
               -s \
               -k \
               -o /dev/null \
-              http://pki.example.com:8080/acme/directory
+              http://acme.example.com:8080/acme/directory
 
       - name: Verify certbot in client container
         run: |
           docker exec client certbot register \
-              --server http://pki.example.com:8080/acme/directory \
+              --server http://acme.example.com:8080/acme/directory \
               --email user1@example.com \
               --agree-tos \
               --non-interactive
           docker exec client certbot certonly \
-              --server http://pki.example.com:8080/acme/directory \
+              --server http://acme.example.com:8080/acme/directory \
               -d client.example.com \
               --key-type rsa \
               --standalone \
               --non-interactive
           docker exec client openssl x509 -text -noout -in /etc/letsencrypt/live/client.example.com/fullchain.pem
           docker exec client certbot renew \
-              --server http://pki.example.com:8080/acme/directory \
+              --server http://acme.example.com:8080/acme/directory \
               --cert-name client.example.com \
               --force-renewal \
               --no-random-sleep-on-renew \
@@ -87,48 +87,47 @@ jobs:
           # revocation test is disabled.
           #
           # docker exec client certbot revoke \
-          #     --server http://pki.example.com:8080/acme/directory \
+          #     --server http://acme.example.com:8080/acme/directory \
           #     --cert-name client.example.com \
           #     --non-interactive
           #
           docker exec client certbot update_account \
-              --server http://pki.example.com:8080/acme/directory \
+              --server http://acme.example.com:8080/acme/directory \
               --email user2@example.com \
               --non-interactive
           docker exec client certbot unregister \
-              --server http://pki.example.com:8080/acme/directory \
+              --server http://acme.example.com:8080/acme/directory \
               --non-interactive
 
-      - name: Gather artifacts from server container
+      - name: Check ACME container logs
         if: always()
         run: |
-          mkdir -p /tmp/artifacts/server
-          docker logs server > /tmp/artifacts/server/container.out 2> /tmp/artifacts/server/container.err
-          mkdir -p /tmp/artifacts/server/var/lib
-          docker cp server:/var/lib/tomcats /tmp/artifacts/server/var/lib
-        continue-on-error: true
+          docker logs acme 2>&1
 
-      - name: Gather artifacts from client container
+      - name: Check client container logs
         if: always()
         run: |
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
+          docker logs client 2>&1
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          docker exec acme ls -la /var/lib/tomcats/pki
+          mkdir -p /tmp/artifacts/acme/var/lib/tomcats
+          docker cp acme:/var/lib/tomcats/pki /tmp/artifacts/acme/var/lib/tomcats
+
+          docker exec client ls -la /etc/letsencrypt/live
           mkdir -p /tmp/artifacts/client/etc/letsencrypt
           docker cp client:/etc/letsencrypt/live /tmp/artifacts/client/etc/letsencrypt
+
+          docker exec client ls -la /var/log/letsencrypt
           mkdir -p /tmp/artifacts/client/var/log/letsencrypt
           docker cp client:/var/log/letsencrypt/letsencrypt.log /tmp/artifacts/client/var/log/letsencrypt
         continue-on-error: true
 
-      - name: Upload artifacts from server container
+      - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: acme-container-server
-          path: /tmp/artifacts/server
-
-      - name: Upload artifacts from client container
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acme-container-client
-          path: /tmp/artifacts/client
+          name: acme-container
+          path: /tmp/artifacts

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -112,9 +112,13 @@ jobs:
       - name: Gather artifacts
         if: always()
         run: |
-          docker exec acme ls -la /var/lib/tomcats/pki
-          mkdir -p /tmp/artifacts/acme/var/lib/tomcats
-          docker cp acme:/var/lib/tomcats/pki /tmp/artifacts/acme/var/lib/tomcats
+          docker exec acme ls -la /etc/pki/pki-tomcat
+          mkdir -p /tmp/artifacts/acme/etc/pki
+          docker cp acme:/etc/pki/pki-tomcat /tmp/artifacts/acme/etc/pki
+
+          docker exec acme ls -la /var/log/pki/pki-tomcat
+          mkdir -p /tmp/artifacts/acme/var/log/pki
+          docker cp acme:/var/log/pki/pki-tomcat /tmp/artifacts/acme/var/log/pki
 
           docker exec client ls -la /etc/letsencrypt/live
           mkdir -p /tmp/artifacts/client/etc/letsencrypt

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,16 +117,16 @@ LABEL name="pki-server" \
 EXPOSE 8080 8443
 
 # Create PKI server
-RUN pki-server create tomcat@pki --user tomcat --group root
+RUN pki-server create --group root
 
 # Create NSS database
-RUN pki-server nss-create -i tomcat@pki --no-password
+RUN pki-server nss-create --no-password
 
 # Enable JSS
-RUN pki-server jss-enable -i tomcat@pki
+RUN pki-server jss-enable
 
 # Configure SSL connector
-RUN pki-server http-connector-add -i tomcat@pki \
+RUN pki-server http-connector-add \
   --port 8443 \
   --scheme https \
   --secure true \
@@ -136,15 +136,15 @@ RUN pki-server http-connector-add -i tomcat@pki \
   Secure
 
 # Configure SSL server certificate
-RUN pki-server http-connector-cert-add -i tomcat@pki \
+RUN pki-server http-connector-cert-add \
   --keyAlias sslserver \
   --keystoreType pkcs11 \
   --keystoreProvider Mozilla-JSS
 
 # Grant the root group the full access to PKI server files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-RUN chgrp -Rf root /var/lib/tomcats/pki
-RUN chmod -Rf g+rw /var/lib/tomcats/pki
+RUN chgrp -Rf root /var/lib/pki/pki-tomcat
+RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
 
 CMD [ "/usr/share/pki/server/bin/pki-server-run" ]
 
@@ -214,27 +214,27 @@ RUN dnf install -y bind-utils iputils abrt-java-connector postgresql postgresql-
 RUN ln -s /usr/share/java/postgresql-jdbc/postgresql.jar /usr/share/pki/server/common/lib/postgresql.jar
 
 # Create PKI ACME application
-RUN pki-server acme-create -i tomcat@pki
+RUN pki-server acme-create
 
 # Use in-memory database by default
-RUN cp /usr/share/pki/acme/database/in-memory/database.conf /var/lib/tomcats/pki/conf/acme
+RUN cp /usr/share/pki/acme/database/in-memory/database.conf /var/lib/pki/pki-tomcat/conf/acme
 
 # Use NSS issuer by default
-RUN cp /usr/share/pki/acme/issuer/nss/issuer.conf /var/lib/tomcats/pki/conf/acme
+RUN cp /usr/share/pki/acme/issuer/nss/issuer.conf /var/lib/pki/pki-tomcat/conf/acme
 
 # Use in-memory realm by default
-RUN cp /usr/share/pki/acme/realm/in-memory/realm.conf /var/lib/tomcats/pki/conf/acme
+RUN cp /usr/share/pki/acme/realm/in-memory/realm.conf /var/lib/pki/pki-tomcat/conf/acme
 
 # Remove PKI ACME web application logging.properties so the logs will appear on the console
 RUN rm -f /usr/share/pki/acme/webapps/acme/WEB-INF/classes/logging.properties
 
 # Deploy PKI ACME application
-RUN pki-server acme-deploy -i tomcat@pki
+RUN pki-server acme-deploy
 
 # Grant the root group the full access to PKI ACME files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-RUN chgrp -Rf root /var/lib/tomcats/pki
-RUN chmod -Rf g+rw /var/lib/tomcats/pki
+RUN chgrp -Rf root /var/lib/pki/pki-tomcat
+RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
 
 VOLUME [ \
     "/certs", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -237,11 +237,11 @@ RUN chgrp -Rf root /var/lib/tomcats/pki
 RUN chmod -Rf g+rw /var/lib/tomcats/pki
 
 VOLUME [ \
-    "/var/lib/tomcats/pki/conf/certs", \
-    "/var/lib/tomcats/pki/conf/acme/metadata", \
-    "/var/lib/tomcats/pki/conf/acme/database", \
-    "/var/lib/tomcats/pki/conf/acme/issuer", \
-    "/var/lib/tomcats/pki/conf/acme/realm" ]
+    "/certs", \
+    "/metadata", \
+    "/database", \
+    "/issuer", \
+    "/realm" ]
 
 CMD [ "/usr/share/pki/acme/bin/pki-acme-run" ]
 

--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -102,10 +102,10 @@ RUN chgrp -Rf root /var/lib/tomcats/pki
 RUN chmod -Rf g+rw /var/lib/tomcats/pki
 
 VOLUME [ \
-    "/var/lib/tomcats/pki/conf/certs", \
-    "/var/lib/tomcats/pki/conf/acme/metadata", \
-    "/var/lib/tomcats/pki/conf/acme/database", \
-    "/var/lib/tomcats/pki/conf/acme/issuer", \
-    "/var/lib/tomcats/pki/conf/acme/realm" ]
+    "/certs", \
+    "/metadata", \
+    "/database", \
+    "/issuer", \
+    "/realm" ]
 
 CMD [ "/usr/share/pki/acme/bin/pki-acme-run" ]

--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -54,16 +54,16 @@ RUN dnf install -y rpm-build bind-utils iputils abrt-java-connector postgresql p
 RUN ln -s /usr/share/java/postgresql-jdbc/postgresql.jar /usr/share/pki/server/common/lib/postgresql.jar
 
 # Create PKI server
-RUN pki-server create tomcat@pki --user tomcat --group root
+RUN pki-server create --group root
 
 # Create NSS database
-RUN pki-server nss-create -i tomcat@pki --no-password
+RUN pki-server nss-create --no-password
 
 # Enable JSS
-RUN pki-server jss-enable -i tomcat@pki
+RUN pki-server jss-enable
 
 # Configure SSL connector
-RUN pki-server http-connector-add -i tomcat@pki \
+RUN pki-server http-connector-add \
   --port 8443 \
   --scheme https \
   --secure true \
@@ -73,33 +73,33 @@ RUN pki-server http-connector-add -i tomcat@pki \
   Secure
 
 # Configure SSL server certificate
-RUN pki-server http-connector-cert-add -i tomcat@pki \
+RUN pki-server http-connector-cert-add \
   --keyAlias sslserver \
   --keystoreType pkcs11 \
   --keystoreProvider Mozilla-JSS
 
 # Create PKI ACME application
-RUN pki-server acme-create -i tomcat@pki
+RUN pki-server acme-create
 
 # Use in-memory database by default
-RUN cp /usr/share/pki/acme/database/in-memory/database.conf /var/lib/tomcats/pki/conf/acme
+RUN cp /usr/share/pki/acme/database/in-memory/database.conf /var/lib/pki/pki-tomcat/conf/acme
 
 # Use NSS issuer by default
-RUN cp /usr/share/pki/acme/issuer/nss/issuer.conf /var/lib/tomcats/pki/conf/acme
+RUN cp /usr/share/pki/acme/issuer/nss/issuer.conf /var/lib/pki/pki-tomcat/conf/acme
 
 # Use in-memory realm by default
-RUN cp /usr/share/pki/acme/realm/in-memory/realm.conf /var/lib/tomcats/pki/conf/acme
+RUN cp /usr/share/pki/acme/realm/in-memory/realm.conf /var/lib/pki/pki-tomcat/conf/acme
 
 # Remove PKI ACME web application logging.properties so the logs will appear on the console
 RUN rm -f /usr/share/pki/acme/webapps/acme/WEB-INF/classes/logging.properties
 
 # Deploy PKI ACME application
-RUN pki-server acme-deploy -i tomcat@pki
+RUN pki-server acme-deploy
 
 # Grant the root group the full access to PKI ACME files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-RUN chgrp -Rf root /var/lib/tomcats/pki
-RUN chmod -Rf g+rw /var/lib/tomcats/pki
+RUN chgrp -Rf root /var/lib/pki/pki-tomcat
+RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
 
 VOLUME [ \
     "/certs", \

--- a/base/acme/bin/pki-acme-run
+++ b/base/acme/bin/pki-acme-run
@@ -15,7 +15,7 @@ then
     echo "INFO: Importing metadata configuration"
 
     # empty current metadata configuration
-    > /var/lib/tomcats/pki/conf/acme/metadata.conf
+    > /var/lib/pki/pki-tomcat/conf/acme/metadata.conf
 
     # import metadata configuration parameters
     for filename in /metadata/*
@@ -23,7 +23,7 @@ then
         [ -e "$filename" ] || break
         name=$(basename $filename)
         value=$(cat $filename)
-        echo "$name=$value" >> /var/lib/tomcats/pki/conf/acme/metadata.conf
+        echo "$name=$value" >> /var/lib/pki/pki-tomcat/conf/acme/metadata.conf
     done
 else
     echo "INFO: Using default metadata configuration"
@@ -37,7 +37,7 @@ then
     echo "INFO: Importing database configuration"
 
     # empty current database configuration
-    > /var/lib/tomcats/pki/conf/acme/database.conf
+    > /var/lib/pki/pki-tomcat/conf/acme/database.conf
 
     # import database configuration parameters
     for filename in /database/*
@@ -45,7 +45,7 @@ then
         [ -e "$filename" ] || break
         name=$(basename $filename)
         value=$(cat $filename)
-        echo "$name=$value" >> /var/lib/tomcats/pki/conf/acme/database.conf
+        echo "$name=$value" >> /var/lib/pki/pki-tomcat/conf/acme/database.conf
     done
 else
     echo "INFO: Using default database configuration"
@@ -59,7 +59,7 @@ then
     echo "INFO: Importing issuer configuration"
 
     # empty current issuer configuration
-    > /var/lib/tomcats/pki/conf/acme/issuer.conf
+    > /var/lib/pki/pki-tomcat/conf/acme/issuer.conf
 
     # import issuer configuration parameters
     for filename in /issuer/*
@@ -67,7 +67,7 @@ then
         [ -e "$filename" ] || break
         name=$(basename $filename)
         value=$(cat $filename)
-        echo "$name=$value" >> /var/lib/tomcats/pki/conf/acme/issuer.conf
+        echo "$name=$value" >> /var/lib/pki/pki-tomcat/conf/acme/issuer.conf
     done
 else
     echo "INFO: Using default issuer configuration"
@@ -81,7 +81,7 @@ then
     echo "INFO: Importing realm configuration"
 
     # empty current realm configuration
-    > /var/lib/tomcats/pki/conf/acme/realm.conf
+    > /var/lib/pki/pki-tomcat/conf/acme/realm.conf
 
     # import realm configuration parameters
     for filename in /realm/*
@@ -89,7 +89,7 @@ then
         [ -e "$filename" ] || break
         name=$(basename $filename)
         value=$(cat $filename)
-        echo "$name=$value" >> /var/lib/tomcats/pki/conf/acme/realm.conf
+        echo "$name=$value" >> /var/lib/pki/pki-tomcat/conf/acme/realm.conf
     done
 else
     echo "INFO: Using default realm configuration"

--- a/base/acme/bin/pki-acme-run
+++ b/base/acme/bin/pki-acme-run
@@ -10,8 +10,7 @@
 echo "################################################################################"
 
 # import metadata configuration if available
-if [ -d /var/lib/tomcats/pki/conf/acme/metadata ] && \
-   [ "$(ls /var/lib/tomcats/pki/conf/acme/metadata)" ]
+if [ -d /metadata ] && [ "$(ls /metadata)" ]
 then
     echo "INFO: Importing metadata configuration"
 
@@ -19,7 +18,7 @@ then
     > /var/lib/tomcats/pki/conf/acme/metadata.conf
 
     # import metadata configuration parameters
-    for filename in /var/lib/tomcats/pki/conf/acme/metadata/*
+    for filename in /metadata/*
     do
         [ -e "$filename" ] || break
         name=$(basename $filename)
@@ -33,8 +32,7 @@ fi
 echo "################################################################################"
 
 # import database configuration if available
-if [ -d /var/lib/tomcats/pki/conf/acme/database ] && \
-   [ "$(ls /var/lib/tomcats/pki/conf/acme/database)" ]
+if [ -d /database ] && [ "$(ls /database)" ]
 then
     echo "INFO: Importing database configuration"
 
@@ -42,7 +40,7 @@ then
     > /var/lib/tomcats/pki/conf/acme/database.conf
 
     # import database configuration parameters
-    for filename in /var/lib/tomcats/pki/conf/acme/database/*
+    for filename in /database/*
     do
         [ -e "$filename" ] || break
         name=$(basename $filename)
@@ -56,8 +54,7 @@ fi
 echo "################################################################################"
 
 # import issuer configuration if available
-if [ -d /var/lib/tomcats/pki/conf/acme/issuer ] && \
-   [ "$(ls /var/lib/tomcats/pki/conf/acme/issuer)" ]
+if [ -d /issuer ] && [ "$(ls /issuer)" ]
 then
     echo "INFO: Importing issuer configuration"
 
@@ -65,7 +62,7 @@ then
     > /var/lib/tomcats/pki/conf/acme/issuer.conf
 
     # import issuer configuration parameters
-    for filename in /var/lib/tomcats/pki/conf/acme/issuer/*
+    for filename in /issuer/*
     do
         [ -e "$filename" ] || break
         name=$(basename $filename)
@@ -79,8 +76,7 @@ fi
 echo "################################################################################"
 
 # import realm configuration if available
-if [ -d /var/lib/tomcats/pki/conf/acme/realm ] && \
-   [ "$(ls /var/lib/tomcats/pki/conf/acme/realm)" ]
+if [ -d /realm ] && [ "$(ls /realm)" ]
 then
     echo "INFO: Importing realm configuration"
 
@@ -88,7 +84,7 @@ then
     > /var/lib/tomcats/pki/conf/acme/realm.conf
 
     # import realm configuration parameters
-    for filename in /var/lib/tomcats/pki/conf/acme/realm/*
+    for filename in /realm/*
     do
         [ -e "$filename" ] || break
         name=$(basename $filename)

--- a/base/acme/openshift/pki-acme-deployment.yaml
+++ b/base/acme/openshift/pki-acme-deployment.yaml
@@ -19,15 +19,15 @@ spec:
           image: 'quay.io/dogtagpki/pki-acme:latest'
           imagePullPolicy: Always
           volumeMounts:
-            - mountPath: /var/lib/tomcats/pki/conf/certs
+            - mountPath: /certs
               name: pki-acme-certs
-            - mountPath: /var/lib/tomcats/pki/conf/acme/metadata
+            - mountPath: /metadata
               name: pki-acme-metadata
-            - mountPath: /var/lib/tomcats/pki/conf/acme/database
+            - mountPath: /database
               name: pki-acme-database
-            - mountPath: /var/lib/tomcats/pki/conf/acme/issuer
+            - mountPath: /issuer
               name: pki-acme-issuer
-            - mountPath: /var/lib/tomcats/pki/conf/acme/realm
+            - mountPath: /realm
               name: pki-acme-realm
       volumes:
         - name: pki-acme-certs

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -26,12 +26,12 @@ then
         -passout file:/tmp/password
 
     # import PKCS #12 file into NSS database
-    pki -d /var/lib/tomcats/pki/conf/alias pkcs12-import \
+    pki -d /var/lib/pki/pki-tomcat/conf/alias pkcs12-import \
         --pkcs12 /tmp/certs.p12 \
         --password-file /tmp/password
 
     # trust imported CA signing cert
-    certutil -M -d /var/lib/tomcats/pki/conf/alias -n ca_signing -t CT,C,C
+    certutil -M -d /var/lib/pki/pki-tomcat/conf/alias -n ca_signing -t CT,C,C
 
     rm /tmp/certs.p12
     rm /tmp/password
@@ -43,14 +43,14 @@ then
     echo "INFO: Importing Certificates and Keys from PKCS #12 File"
 
     # import PKCS #12 file into NSS database
-    pki -d /var/lib/tomcats/pki/conf/alias pkcs12-import \
+    pki -d /var/lib/pki/pki-tomcat/conf/alias pkcs12-import \
         --pkcs12 /certs/certs.p12 \
         --password-file /certs/password
 fi
 
 # check whether CA signing certificate is available
 rc=0
-certutil -L -d /var/lib/tomcats/pki/conf/alias -n ca_signing -a > /dev/null 2>&1 || rc=$?
+certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -n ca_signing -a > /dev/null 2>&1 || rc=$?
 
 # generate a CA signing certificate if not available
 if [ $rc -ne 0 ]
@@ -58,13 +58,13 @@ then
     echo "INFO: Issuing Self-signed CA Signing Certificate"
 
     # generate CA signing CSR
-    pki -d /var/lib/tomcats/pki/conf/alias nss-cert-request \
+    pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-request \
         --subject "CN=CA Signing Certificate" \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
         --csr /tmp/ca_signing.csr
 
     # issue self-signed CA signing cert
-    pki -d /var/lib/tomcats/pki/conf/alias nss-cert-issue \
+    pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-issue \
         --csr /tmp/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
         --validity-length 1 \
@@ -72,7 +72,7 @@ then
         --cert /tmp/ca_signing.crt
 
     # import and trust CA signing cert into NSS database
-    pki -d /var/lib/tomcats/pki/conf/alias nss-cert-import \
+    pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-import \
         --cert /tmp/ca_signing.crt \
         --trust CT,C,C \
         ca_signing
@@ -82,13 +82,13 @@ then
 fi
 
 echo "INFO: CA Signing Certificate:"
-certutil -L -d /var/lib/tomcats/pki/conf/alias -n ca_signing
+certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -n ca_signing
 
 echo "################################################################################"
 
 # check whether SSL server certificate is available
 rc=0
-certutil -L -d /var/lib/tomcats/pki/conf/alias -n sslserver -a > /dev/null 2>&1 || rc=$?
+certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -n sslserver -a > /dev/null 2>&1 || rc=$?
 
 # generate a SSL server certificate if not available
 if [ $rc -ne 0 ]
@@ -96,20 +96,20 @@ then
     echo "INFO: Issuing SSL Server Certificate"
 
     # generate SSL server CSR
-    pki -d /var/lib/tomcats/pki/conf/alias nss-cert-request \
+    pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-request \
         --subject "CN=$HOSTNAME" \
         --ext /usr/share/pki/server/certs/sslserver.conf \
         --csr /tmp/sslserver.csr
 
     # issue SSL server cert
-    pki -d /var/lib/tomcats/pki/conf/alias nss-cert-issue \
+    pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-issue \
         --issuer ca_signing \
         --csr /tmp/sslserver.csr \
         --ext /usr/share/pki/server/certs/sslserver.conf \
         --cert /tmp/sslserver.crt
 
     # import SSL server cert into NSS database
-    pki -d /var/lib/tomcats/pki/conf/alias nss-cert-import \
+    pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-import \
         --cert /tmp/sslserver.crt \
         sslserver
 
@@ -118,9 +118,9 @@ then
 fi
 
 echo "INFO: SSL Server Certificate:"
-certutil -L -d /var/lib/tomcats/pki/conf/alias -n sslserver
+certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -n sslserver
 
 echo "################################################################################"
 echo "INFO: Starting PKI server"
 
-pki-server run tomcat@pki --as-current-user
+pki-server run --as-current-user

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -10,8 +10,7 @@
 echo "################################################################################"
 
 # import ca_signing.cert and ca_signing.key if available
-if [ -f /var/lib/tomcats/pki/conf/certs/ca_signing.crt ] && \
-   [ -f /var/lib/tomcats/pki/conf/certs/ca_signing.key ]
+if [ -f /certs/ca_signing.crt ] && [ -f /certs/ca_signing.key ]
 then
     echo "INFO: Importing CA Signing Certificate and Key"
 
@@ -20,8 +19,8 @@ then
 
     # import PEM cert and key into PKCS #12 file
     openssl pkcs12 -export \
-        -in /var/lib/tomcats/pki/conf/certs/ca_signing.crt \
-        -inkey /var/lib/tomcats/pki/conf/certs/ca_signing.key \
+        -in /certs/ca_signing.crt \
+        -inkey /certs/ca_signing.key \
         -out /tmp/certs.p12 \
         -name ca_signing \
         -passout file:/tmp/password
@@ -39,14 +38,14 @@ then
 fi
 
 # import certs.p12 if available
-if [ -f /var/lib/tomcats/pki/conf/certs/certs.p12 ]
+if [ -f /certs/certs.p12 ]
 then
     echo "INFO: Importing Certificates and Keys from PKCS #12 File"
 
     # import PKCS #12 file into NSS database
     pki -d /var/lib/tomcats/pki/conf/alias pkcs12-import \
-        --pkcs12 /var/lib/tomcats/pki/conf/certs/certs.p12 \
-        --password-file /var/lib/tomcats/pki/conf/certs/password
+        --pkcs12 /certs/certs.p12 \
+        --password-file /certs/password
 fi
 
 # check whether CA signing certificate is available

--- a/docs/changes/v11.6.0/Server-Changes.adoc
+++ b/docs/changes/v11.6.0/Server-Changes.adoc
@@ -22,3 +22,13 @@ since they have default values:
 
 The `pki_existing` parameter is no longer used by `pkispawn`
 so it has been removed.
+
+== Update ACME container volumes ==
+
+The paths of ACME container volumes have been updated as follows:
+
+* `/var/lib/tomcats/pki/conf/certs` -> `/certs`
+* `/var/lib/tomcats/pki/conf/acme/metadata` -> `/metadata`
+* `/var/lib/tomcats/pki/conf/acme/database` -> `/database`
+* `/var/lib/tomcats/pki/conf/acme/issuer` -> `/issuer`
+* `/var/lib/tomcats/pki/conf/acme/realm` -> `/realm`

--- a/docs/installation/podman/Deploying_PKI_ACME_Responder_on_Podman.md
+++ b/docs/installation/podman/Deploying_PKI_ACME_Responder_on_Podman.md
@@ -73,9 +73,9 @@ $ podman run \
     --hostname acme.example.com \
     --network example \
     --network-alias acme.example.com \
+    -v $PWD/certs:/certs \
     --rm \
     --privileged \
-    -v ./certs:/var/lib/tomcats/pki/conf/certs \
     -it \
     quay.io/dogtagpki/pki-acme
 ```
@@ -116,10 +116,10 @@ $ podman run \
     --hostname acme.example.com \
     --network example \
     --network-alias acme.example.com \
+    -v $PWD/certs:/certs \
+    -v $PWD/database:/database \
     --rm \
     --privileged \
-    -v ./certs:/var/lib/tomcats/pki/conf/certs \
-    -v ./database:/var/lib/tomcats/pki/conf/acme/database \
     -it \
     quay.io/dogtagpki/pki-acme
 ```
@@ -149,11 +149,11 @@ $ podman run \
     --hostname acme.example.com \
     --network example \
     --network-alias acme.example.com \
+    -v $PWD/certs:/certs \
+    -v $PWD/database:/database \
+    -v $PWD/realm:/realm \
     --rm \
     --privileged \
-    -v ./certs:/var/lib/tomcats/pki/conf/certs \
-    -v ./database:/var/lib/tomcats/pki/conf/acme/database \
-    -v ./realm:/var/lib/tomcats/pki/conf/acme/realm \
     -it \
     quay.io/dogtagpki/pki-acme
 ```


### PR DESCRIPTION
The ACME container has been updated to use the default instance (i.e. `pki-tomcat`) instead of `tomcat@pki` which will be more consistent with the CA container and will make it easier to migrate from a regular deployment.

The paths of ACME container volumes have been updated to simplify deployment and to avoid collisions with instance files/folders.

The deployment doc for ACME container has been updated to use a network instead of a pod.

https://github.com/edewata/pki/blob/acme/docs/installation/podman/Deploying_PKI_ACME_Responder_on_Podman.md
https://github.com/edewata/pki/blob/acme/docs/changes/v11.6.0/Server-Changes.adoc

