### PR TITLE
Update ACME and CA containers

### DIFF
--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -28,6 +28,15 @@ jobs:
       - name: Create network
         run: docker network create example
 
+      - name: Create shared folders
+        run: |
+          mkdir certs
+          mkdir metadata
+          mkdir database
+          mkdir issuer
+          mkdir realm
+          mkdir data
+
       - name: Set up ACME container
         run: |
           docker run \
@@ -35,6 +44,12 @@ jobs:
               --hostname acme.example.com \
               --network example \
               --network-alias acme.example.com \
+              -v $PWD/certs:/certs \
+              -v $PWD/metadata:/metadata \
+              -v $PWD/database:/database \
+              -v $PWD/issuer:/issuer \
+              -v $PWD/realm:/realm \
+              -v $PWD/data:/data \
               --detach \
               pki-acme
 
@@ -60,6 +75,96 @@ jobs:
               -k \
               -o /dev/null \
               http://acme.example.com:8080/acme/directory
+
+      - name: Check data dir
+        if: always()
+        run: |
+          ls -l data \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx 17 root conf
+          drwxrwxrwx 17 root logs
+          EOF
+
+          diff expected output
+
+      - name: Check data/conf dir
+        if: always()
+        run: |
+          ls -l data/conf \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx 17 root Catalina
+          drwxrwxrwx 17 root acme
+          drwxrwxrwx 17 root alias
+          -rw-rw-rw- 17 root catalina.policy
+          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx 17 root certs
+          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- 17 root jss.conf
+          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- 17 root password.conf
+          -rw-rw-rw- 17 root server.xml
+          -rw-rw-rw- 17 root tomcat.conf
+          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check data/conf/acme dir
+        if: always()
+        run: |
+          ls -l data/conf/acme \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          -rw-rw-rw- 17 root database.conf
+          -rw-rw-rw- 17 root issuer.conf
+          -rw-rw-rw- 17 root realm.conf
+          EOF
+
+          diff expected output
+
+      - name: Check data/logs dir
+        if: always()
+        run: |
+          ls -l data/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwx--- 17 root backup
+          -rw-rw-rw- root root catalina.$DATE.log
+          -rw-rw-rw- root root host-manager.$DATE.log
+          -rw-rw-rw- root root localhost.$DATE.log
+          -rw-rw-rw- root root localhost_access_log.$DATE.txt
+          -rw-rw-rw- root root manager.$DATE.log
+          EOF
+
+          diff expected output
 
       - name: Verify certbot in client container
         run: |

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -252,19 +252,50 @@ jobs:
           # everything should be owned by pkiuser:root (UID=17, GID=0)
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwx--- 17 root Catalina
+          drwxrwxrwx 17 root Catalina
           drwxrwx--- 17 root alias
-          drwxrwx--- 17 root ca
+          drwxrwxrwx 17 root ca
           -rw-rw-rw- 17 root catalina.policy
           lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwx--- 17 root certs
+          drwxrwxrwx 17 root certs
           lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- 17 root jss.conf
           lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
           -rw-rw---- 17 root password.conf
-          -rw-rw---- 17 root server.xml
+          -rw-rw-rw- 17 root server.xml
           -rw-rw---- 17 root serverCertNick.conf
-          -rw-rw---- 17 root tomcat.conf
+          -rw-rw-rw- 17 root tomcat.conf
           lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check data/conf/ca dir
+        if: always()
+        run: |
+          ls -l data/conf/ca \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          -rw-rw-rw- 17 root CS.cfg
+          -rw-rw---- 17 root adminCert.profile
+          drwxrwxrwx 17 root archives
+          -rw-rw---- 17 root caAuditSigningCert.profile
+          -rw-rw---- 17 root caCert.profile
+          -rw-rw---- 17 root caOCSPCert.profile
+          drwxrwx--- 17 root emails
+          -rw-rw---- 17 root flatfile.txt
+          drwxrwx--- 17 root profiles
+          -rw-rw---- 17 root proxy.conf
+          -rw-rw-rw- 17 root registry.cfg
+          -rw-rw---- 17 root serverCert.profile
+          -rw-rw---- 17 root subsystemCert.profile
           EOF
 
           diff expected output

--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -53,8 +53,25 @@ RUN dnf install -y rpm-build bind-utils iputils abrt-java-connector postgresql p
 # Install PostgreSQL JDBC driver
 RUN ln -s /usr/share/java/postgresql-jdbc/postgresql.jar /usr/share/pki/server/common/lib/postgresql.jar
 
+# In OpenShift the server runs as an OpenShift-assigned user
+# (with a random UID) that belongs to the root group (GID=0),
+# so the server instance needs to be owned by the root group.
+#
+# https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+
 # Create PKI server
-RUN pki-server create --group root
+RUN pki-server create \
+    --group root \
+    --conf /data/conf \
+    --logs /data/logs
+
+# In Docker/Podman the server runs as pkiuser (UID=17). To
+# ensure it generates files with the proper ownership the
+# pkiuser's primary group needs to be changed to the root
+# group (GID=0).
+
+# Change pkiuser's primary group to root group
+RUN usermod pkiuser -g root
 
 # Create NSS database
 RUN pki-server nss-create --no-password
@@ -96,6 +113,9 @@ RUN rm -f /usr/share/pki/acme/webapps/acme/WEB-INF/classes/logging.properties
 # Deploy PKI ACME application
 RUN pki-server acme-deploy
 
+# Store default config files
+RUN mv /data/conf /var/lib/pki/pki-tomcat/conf.default
+
 # Grant the root group the full access to PKI ACME files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
 RUN chgrp -Rf root /var/lib/pki/pki-tomcat
@@ -106,6 +126,7 @@ VOLUME [ \
     "/metadata", \
     "/database", \
     "/issuer", \
-    "/realm" ]
+    "/realm", \
+    "/data" ]
 
 CMD [ "/usr/share/pki/acme/bin/pki-acme-run" ]

--- a/base/acme/bin/pki-acme-run
+++ b/base/acme/bin/pki-acme-run
@@ -7,6 +7,27 @@
 
 . /usr/share/pki/scripts/config
 
+# Allow the owner of the container (who might not be in the root group)
+# to manage the config and log files.
+umask 000
+
+echo "################################################################################"
+
+if [ ! -d /data/conf ]
+then
+    echo "INFO: Creating /data/conf"
+    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    chown -Rf pkiuser:root /data/conf
+    find /data/conf -type f -exec chmod +rw -- {} +
+    find /data/conf -type d -exec chmod +rwx -- {} +
+fi
+
+echo "################################################################################"
+
+echo "INFO: Creating /data/logs"
+mkdir -p /data/logs
+chown -Rf pkiuser:root /data/logs
+
 echo "################################################################################"
 
 # import metadata configuration if available

--- a/base/ca/Dockerfile
+++ b/base/ca/Dockerfile
@@ -50,12 +50,43 @@ RUN dnf install -y rpm-build \
     && rm -rf /var/cache/dnf \
     && rm -rf build
 
+# In OpenShift the server runs as an OpenShift-assigned user
+# (with a random UID) that belongs to the root group (GID=0),
+# so the server instance needs to be owned by the root group.
+#
+# https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+
 # Create PKI server
-RUN pki-server create --group root
+RUN pki-server create \
+    --group root \
+    --conf /data/conf \
+    --logs /data/logs
+
+# In Docker/Podman the server runs as pkiuser (UID=17). To
+# ensure it generates files with the proper ownership the
+# pkiuser's primary group needs to be changed to the root
+# group (GID=0).
+
+# Change pkiuser's primary group to root group
+RUN usermod pkiuser -g root
 
 # Create NSS database
 RUN pki-server nss-create --no-password
 
-VOLUME [ "/certs" ]
+# Create CA subsystem
+RUN pki-server ca-create
+
+# Deploy CA subsystem
+RUN pki-server ca-deploy
+
+# Store default config files
+RUN mv /data/conf /var/lib/pki/pki-tomcat/conf.default
+
+# Grant the root group the full access to PKI server files
+# https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+RUN chgrp -Rf root /var/lib/pki/pki-tomcat
+RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
+
+VOLUME [ "/certs", "/data" ]
 
 CMD [ "/usr/share/pki/ca/bin/pki-ca-run" ]

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -10,9 +10,14 @@ umask 000
 
 echo "################################################################################"
 
-echo "INFO: Creating /data/conf"
-mkdir -p /data/conf
-chown -Rf pkiuser:root /data/conf
+if [ ! -d /data/conf ]
+then
+    echo "INFO: Creating /data/conf"
+    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    chown -Rf pkiuser:root /data/conf
+    find /data/conf -type f -exec chmod +rw -- {} +
+    find /data/conf -type d -exec chmod +rwx -- {} +
+fi
 
 echo "################################################################################"
 


### PR DESCRIPTION
The ACME container has been updated to support a `data` folder which can be used to store the config and log files generated by the server.

The ACME container has also been modified to store the default config files created during the build. If the container is started with an empty `data` folder the default config files will be installed automatically.

The CA container has been modified to extend `pki-server` instead of `pki-runner` such that it will be more consistent with the ACME container.

The CA container has also been modified to store the default config files created during the build. If the container is started with an empty `data` folder the default config files will be installed automatically.
