### PR TITLE
Add KRA and OCSP containers

### DIFF
--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -28,6 +28,18 @@ jobs:
       - name: Create network
         run: docker network create example
 
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Install dependencies in client container
+        run: docker exec client dnf install -y certbot
+
       - name: Create shared folders
         run: |
           mkdir certs
@@ -53,20 +65,7 @@ jobs:
               --detach \
               pki-acme
 
-      - name: Set up client container
-        run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client.example.com
-
-      - name: Install dependencies in client container
-        run: docker exec client dnf install -y certbot
-
-      - name: Wait for ACME container to start
-        run: |
+          # wait for ACME to start
           docker exec client curl \
               --retry 60 \
               --retry-delay 0 \
@@ -166,6 +165,20 @@ jobs:
 
           diff expected output
 
+      - name: Install CA signing cert
+        run: |
+          docker exec client pki \
+              nss-cert-import \
+              --cert $SHARED/certs/ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+      - name: Check ACME status
+        run: |
+          docker exec client pki \
+              -U https://acme.example.com:8443 \
+              acme-info
+
       - name: Verify certbot in client container
         run: |
           docker exec client certbot register \
@@ -203,6 +216,27 @@ jobs:
           docker exec client certbot unregister \
               --server http://acme.example.com:8080/acme/directory \
               --non-interactive
+
+      - name: Restart ACME
+        run: |
+          docker restart acme
+          sleep 5
+
+          # wait for ACME to restart
+          docker exec client curl \
+              --retry 60 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              http://acme.example.com:8080/acme/directory
+
+      - name: Check ACME status again
+        run: |
+          docker exec client pki \
+              -U https://acme.example.com:8443 \
+              acme-info
 
       - name: Check ACME container logs
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,18 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker
 
+      - name: Build pki-ocsp image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=${{ env.BASE_IMAGE }}
+            COPR_REPO=${{ env.COPR_REPO }}
+          tags: pki-ocsp
+          target: pki-ocsp
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker
+
       - name: Save PKI images
         run: |
           docker images
@@ -135,7 +147,8 @@ jobs:
               pki-runner \
               pki-server \
               pki-ca \
-              pki-kra
+              pki-kra \
+              pki-ocsp
 
       - name: Store PKI images
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,10 +115,27 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           outputs: type=docker
 
+      - name: Build pki-kra image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=${{ env.BASE_IMAGE }}
+            COPR_REPO=${{ env.COPR_REPO }}
+          tags: pki-kra
+          target: pki-kra
+          cache-from: type=local,src=/tmp/.buildx-cache
+          outputs: type=docker
+
       - name: Save PKI images
         run: |
           docker images
-          docker save -o pki-images.tar pki-dist pki-runner pki-server pki-ca
+          docker save -o pki-images.tar \
+              pki-dist \
+              pki-runner \
+              pki-server \
+              pki-ca \
+              pki-kra
 
       - name: Store PKI images
         uses: actions/cache@v4

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -211,8 +211,7 @@ jobs:
               --detach \
               pki-ca
 
-      - name: Wait for CA container to start
-        run: |
+          # wait for CA to start
           docker exec client curl \
               --retry 180 \
               --retry-delay 0 \
@@ -443,20 +442,20 @@ jobs:
               --request $REQUEST_ID
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
-      - name: Add admin user
+      - name: Add CA admin user
         run: |
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
               admin
 
-      - name: Assign admin cert to admin user
+      - name: Assign admin cert to CA admin user
         run: |
           docker exec ca pki-server ca-user-cert-add \
               --cert /certs/admin.crt \
               admin
 
-      - name: Add admin user into CA groups
+      - name: Add CA admin user into CA groups
         run: |
           docker exec ca pki-server ca-user-role-add admin "Administrators"
           docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
@@ -468,7 +467,7 @@ jobs:
 
       - name: Check admin operations from CA container
         run: |
-          # check admin user
+          # check CA admin user
           docker exec ca pki \
               -n admin \
               ca-user-show \
@@ -496,7 +495,7 @@ jobs:
 
       - name: Check admin operations from client container
         run: |
-          # check admin user
+          # check CA admin user
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n admin \
@@ -517,6 +516,29 @@ jobs:
               ca-cert-request-approve \
               $REQUEST_ID \
               --force
+
+      - name: Restart CA
+        run: |
+          docker restart ca
+          sleep 5
+
+          # wait for CA to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ca.example.com:8443
+
+      - name: Check CA admin user again
+        run: |
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-user-show \
+              admin
 
       - name: Check DS server systemd journal
         if: always()

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -1,0 +1,764 @@
+name: KRA container
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # https://github.com/dogtagpki/pki/wiki/Deploying-KRA-Container
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Create shared folders
+        run: |
+          mkdir -p ca/certs
+          mkdir -p ca/data
+          mkdir -p kra/certs
+          mkdir -p kra/data
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Set up CA container
+        run: |
+          docker run \
+              --name ca \
+              --hostname ca.example.com \
+              --network example \
+              --network-alias ca.example.com \
+              -v $PWD/ca/certs:/certs \
+              -v $PWD/ca/data:/data \
+              -e PKI_DS_URL=ldap://cads.example.com:3389 \
+              -e PKI_DS_PASSWORD=Secret.123 \
+              --detach \
+              pki-ca
+
+          # wait for CA to start
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ca.example.com:8443
+
+      - name: Set up CA DS container
+        run: |
+          tests/bin/ds-container-create.sh cads
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: cads.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect CA DS container to network
+        run: docker network connect example cads --alias cads.example.com
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
+      - name: Initialize CA database
+        run: |
+          docker exec ca pki-server ca-db-init -v
+          docker exec ca pki-server ca-db-index-add -v
+          docker exec ca pki-server ca-db-index-rebuild -v
+          docker exec ca pki-server ca-db-vlv-add -v
+          docker exec ca pki-server ca-db-vlv-reindex -v
+
+      - name: Import CA signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/ca_signing.crt \
+              --profile /usr/share/pki/ca/conf/caCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA OCSP signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/ocsp_signing.crt \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA audit signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/audit_signing.crt \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA subsystem cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/subsystem.crt \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import SSL server cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/sslserver.crt \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import admin cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/admin.crt \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --request $REQUEST_ID
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
+      - name: Add CA admin user
+        run: |
+          docker exec ca pki-server ca-user-add \
+              --full-name Administrator \
+              --type adminType \
+              admin
+
+      - name: Assign admin cert to CA admin user
+        run: |
+          docker exec ca pki-server ca-user-cert-add \
+              --cert /certs/admin.crt \
+              admin
+
+      - name: Add admin user into CA groups
+        run: |
+          docker exec ca pki-server ca-user-role-add admin "Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
+
+      - name: Install admin cert
+        run: |
+          docker exec client pki pkcs12-import \
+              --pkcs12 $SHARED/ca/certs/admin.p12 \
+              --password Secret.123
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-user-show \
+              admin
+
+      - name: Create KRA storage cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=DRM Storage Certificate" \
+              --ext /usr/share/pki/server/certs/kra_storage.conf \
+              --csr $SHARED/kra/certs/kra_storage.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/kra/certs/kra_storage.csr \
+              --ext /usr/share/pki/server/certs/kra_storage.conf \
+              --cert $SHARED/kra/certs/kra_storage.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/kra/certs/kra_storage.crt \
+              kra_storage
+          docker exec client pki nss-cert-show kra_storage
+
+      - name: Create KRA transport cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=DRM Transport Certificate" \
+              --ext /usr/share/pki/server/certs/kra_transport.conf \
+              --csr $SHARED/kra/certs/kra_transport.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/kra/certs/kra_transport.csr \
+              --ext /usr/share/pki/server/certs/kra_transport.conf \
+              --cert $SHARED/kra/certs/kra_transport.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/kra/certs/kra_transport.crt \
+              kra_transport
+          docker exec client pki nss-cert-show kra_transport
+
+      - name: Create KRA audit signing cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --csr $SHARED/kra/certs/audit_signing.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/kra/certs/audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert $SHARED/kra/certs/audit_signing.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/kra/certs/audit_signing.crt \
+              --trust ,,P \
+              audit_signing
+          docker exec client pki nss-cert-show audit_signing
+
+      - name: Create KRA subsystem cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=Subsystem Certificate" \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --csr $SHARED/kra/certs/subsystem.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/kra/certs/subsystem.csr \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --cert $SHARED/kra/certs/subsystem.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/kra/certs/subsystem.crt \
+              subsystem
+          docker exec client pki nss-cert-show subsystem
+
+      - name: Create KRA SSL server cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=kra.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr $SHARED/kra/certs/sslserver.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/kra/certs/sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --cert $SHARED/kra/certs/sslserver.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/kra/certs/sslserver.crt \
+              sslserver
+          docker exec client pki nss-cert-show sslserver
+
+      - name: Prepare KRA certs and keys
+        run: |
+          # export CA signing cert
+          docker exec client cp $SHARED/ca/certs/ca_signing.crt $SHARED/kra/certs
+
+          docker exec client pki nss-cert-find
+
+          # export KRA system certs and keys
+          docker exec client pki pkcs12-export \
+              --pkcs12 $SHARED/kra/certs/server.p12 \
+              --password Secret.123 \
+              kra_storage \
+              kra_transport \
+              audit_signing \
+              subsystem \
+              sslserver
+
+          docker exec client pki pkcs12-cert-find \
+              --pkcs12 $SHARED/kra/certs/server.p12 \
+              --password Secret.123 \
+
+          # export admin cert and key
+          docker exec client cp $SHARED/ca/certs/admin.p12 $SHARED/kra/certs
+
+          docker exec client pki pkcs12-cert-find \
+              --pkcs12 $SHARED/kra/certs/admin.p12 \
+              --password Secret.123 \
+
+          ls -la kra/certs
+
+      - name: Set up KRA container
+        run: |
+          docker run \
+              --name kra \
+              --hostname kra.example.com \
+              --network example \
+              --network-alias kra.example.com \
+              -v $PWD/kra/certs:/certs \
+              -v $PWD/kra/data:/data \
+              -e PKI_DS_URL=ldap://krads.example.com:3389 \
+              -e PKI_DS_PASSWORD=Secret.123 \
+              --detach \
+              pki-kra
+
+      - name: Wait for KRA container to start
+        run: |
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://kra.example.com:8443
+
+      - name: Check KRA data dir
+        if: always()
+        run: |
+          ls -l kra/data \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx 17 root conf
+          drwxrwxrwx 17 root logs
+          EOF
+
+          diff expected output
+
+      - name: Check KRA data/conf dir
+        if: always()
+        run: |
+          ls -l kra/data/conf \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx 17 root Catalina
+          drwxrwx--- 17 root alias
+          -rw-rw-rw- 17 root catalina.policy
+          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx 17 root certs
+          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- 17 root jss.conf
+          drwxrwxrwx 17 root kra
+          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw---- 17 root password.conf
+          -rw-rw-rw- 17 root server.xml
+          -rw-rw---- 17 root serverCertNick.conf
+          -rw-rw-rw- 17 root tomcat.conf
+          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check KRA data/conf/kra dir
+        if: always()
+        run: |
+          ls -l kra/data/conf/kra \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          -rw-rw-rw- 17 root CS.cfg
+          drwxrwxrwx 17 root archives
+          -rw-rw-r-- 17 root registry.cfg
+          EOF
+
+          diff expected output
+
+      - name: Check KRA data/logs dir
+        if: always()
+        run: |
+          ls -l kra/data/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwx--- 17 root backup
+          -rw-rw-r-- 17 root catalina.$DATE.log
+          -rw-rw-r-- 17 root host-manager.$DATE.log
+          drwxrwx--- 17 root kra
+          -rw-rw-r-- 17 root localhost.$DATE.log
+          -rw-rw-rw- 17 root localhost_access_log.$DATE.txt
+          -rw-rw-r-- 17 root manager.$DATE.log
+          drwxrwxrwx 17 root pki
+          EOF
+
+          diff expected output
+
+      - name: Check basic operations from KRA container
+        run: |
+          # check PKI server info
+          docker exec kra pki info
+
+      - name: Check basic operations from client container
+        run: |
+          # check PKI server info
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              info
+
+      - name: Set up KRA DS container
+        run: |
+          tests/bin/ds-container-create.sh krads
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: krads.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect KRA DS container to network
+        run: docker network connect example krads --alias krads.example.com
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-KRA-Database
+      - name: Set up KRA database
+        run: |
+          docker exec kra pki-server kra-db-init -v
+          docker exec kra pki-server kra-db-index-add -v
+          docker exec kra pki-server kra-db-index-rebuild  -v
+          docker exec kra pki-server kra-db-vlv-add -v
+          docker exec kra pki-server kra-db-vlv-reindex -v
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-KRA-Admin-User
+      - name: Add KRA admin user
+        run: |
+          docker exec kra pki-server kra-user-add \
+              --full-name Administrator \
+              --type adminType \
+              admin
+
+      - name: Assign admin cert to KRA admin user
+        run: |
+          docker exec kra pki-server kra-user-cert-add \
+              --cert /certs/admin.crt \
+              admin
+
+      - name: Add KRA admin user into KRA groups
+        run: |
+          docker exec kra pki-server kra-user-role-add admin "Administrators"
+          docker exec kra pki-server kra-user-role-add admin "Data Recovery Manager Agents"
+
+      - name: Check KRA admin user
+        run: |
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n admin \
+              kra-user-show \
+              admin
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-Subsystem-User
+      - name: Add CA subsystem user in KRA
+        run: |
+          docker exec kra pki-server kra-user-add \
+              --full-name CA-ca.example.com-8443 \
+              --type agentType \
+              CA-ca.example.com-8443
+
+      - name: Assign CA subsystem cert to CA subsystem user
+        run: |
+          docker cp ca/certs/subsystem.crt kra:ca_subsystem.crt
+          docker exec kra ls -la
+          docker exec kra pki-server kra-user-cert-add \
+              --cert ca_subsystem.crt \
+              CA-ca.example.com-8443
+
+      - name: Assign roles to CA subsystem user
+        run: |
+          docker exec kra pki-server kra-user-role-add CA-ca.example.com-8443 "Trusted Managers"
+
+      - name: Configure KRA connector in CA
+        run: |
+          docker exec ca pki-server ca-config-set ca.connector.KRA.enable true
+          docker exec ca pki-server ca-config-set ca.connector.KRA.host kra.example.com
+          docker exec ca pki-server ca-config-set ca.connector.KRA.local false
+          docker exec ca pki-server ca-config-set ca.connector.KRA.nickName subsystem
+          docker exec ca pki-server ca-config-set ca.connector.KRA.port 8443
+          docker exec ca pki-server ca-config-set ca.connector.KRA.timeout 30
+          docker exec ca pki-server ca-config-set ca.connector.KRA.uri /kra/agent/kra/connector
+
+          TRANSPORT_CERT=$(openssl x509 -outform der -in kra/certs/kra_transport.crt | base64 --wrap=0)
+          echo "Transport cert: $TRANSPORT_CERT"
+          docker exec ca pki-server ca-config-set ca.connector.KRA.transportCert $TRANSPORT_CERT
+
+      - name: Restart CA
+        run: |
+          docker restart ca
+          sleep 5
+
+          # wait for CA to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ca.example.com:8443
+
+      - name: Request cert with key archival
+        run: |
+          # generate key and submit cert request
+          # https://github.com/dogtagpki/pki/wiki/Submitting-Certificate-Request-with-Key-Archival
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              client-cert-request \
+              --profile caUserCert \
+              --type crmf \
+              --algorithm rsa \
+              --permanent \
+              --transport $SHARED/kra/certs/kra_transport.crt \
+              UID=testuser | tee output
+
+          REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" output)
+          echo "Request ID: $REQUEST_ID"
+          echo "$REQUEST_ID" > request.id
+
+      - name: Issue cert with key archival
+        run: |
+          REQUEST_ID=$(cat request.id)
+
+          # issue cert
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-cert-request-approve \
+              --force \
+              $REQUEST_ID | tee output
+
+          CERT_ID=$(sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" output)
+          echo "Cert ID: $CERT_ID"
+
+          # import cert into NSS database
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              ca-cert-export \
+              --output-file testuser.crt \
+              $CERT_ID
+          docker exec client pki nss-cert-import --cert testuser.crt testuser
+
+          # the cert should match the key (trust flags must be u,u,u)
+          echo "u,u,u" > expected
+          docker exec client pki nss-cert-show testuser | tee output
+          sed -n "s/^\s*Trust Flags:\s*\(\S*\)$/\1/p" output > actual
+          diff expected actual
+
+      - name: Check archived key
+        run: |
+          # find archived key by owner
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n admin \
+              kra-key-find --owner UID=testuser | tee output
+
+          KEY_ID=$(sed -n "s/^\s*Key ID:\s*\(\S*\)$/\1/p" output)
+          echo "Key ID: $KEY_ID"
+          echo $KEY_ID > key.id
+
+          DEC_KEY_ID=$(python -c "print(int('$KEY_ID', 16))")
+          echo "Dec Key ID: $DEC_KEY_ID"
+
+      - name: Check key retrieval
+        run: |
+          KEY_ID=$(cat key.id)
+          echo "Key ID: $KEY_ID"
+
+          BASE64_CERT=$(docker exec client pki nss-cert-export --format DER testuser | base64 --wrap=0)
+          echo "Cert: $BASE64_CERT"
+
+          cat > request.json <<EOF
+          {
+            "ClassName" : "com.netscape.certsrv.key.KeyRecoveryRequest",
+            "Attributes" : {
+              "Attribute" : [ {
+                "name" : "keyId",
+                "value" : "$KEY_ID"
+              }, {
+                "name" : "certificate",
+                "value" : "$BASE64_CERT"
+              }, {
+                "name" : "passphrase",
+                "value" : "Secret.123"
+              } ]
+            }
+          }
+          EOF
+
+          docker cp request.json client:.
+
+          # retrieve archived cert and key into PKCS #12 file
+          # https://github.com/dogtagpki/pki/wiki/Retrieving-Archived-Key
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n admin \
+              kra-key-retrieve \
+              --input request.json \
+              --output-data archived.p12
+
+          # import PKCS #12 file into NSS database
+          docker exec client pki \
+              -d nssdb \
+              pkcs12-import \
+              --pkcs12 archived.p12 \
+              --password Secret.123
+
+          docker exec client pki -d nssdb nss-cert-find
+
+          # remove archived cert from NSS database
+          docker exec client pki -d nssdb nss-cert-del UID=testuser
+
+          # import original cert into NSS database
+          docker exec client pki -d nssdb nss-cert-import --cert testuser.crt testuser
+
+          # the original cert should match the archived key (trust flags must be u,u,u)
+          echo "u,u,u" > expected
+          docker exec client pki -d nssdb nss-cert-show testuser | tee output
+          sed -n "s/^\s*Trust Flags:\s*\(\S*\)$/\1/p" output > actual
+          diff expected actual
+
+      - name: Restart KRA
+        run: |
+          docker restart kra
+          sleep 5
+
+          # wait for KRA to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://kra.example.com:8443
+
+      - name: Check KRA admin user again
+        run: |
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n admin \
+              kra-user-show \
+              admin
+
+      - name: Check CA DS server systemd journal
+        if: always()
+        run: |
+          docker exec cads journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check CA DS container logs
+        if: always()
+        run: |
+          docker logs cads
+
+      - name: Check CA container logs
+        if: always()
+        run: |
+          docker logs ca 2>&1
+
+      - name: Check CA debug logs
+        if: always()
+        run: |
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check KRA DS server systemd journal
+        if: always()
+        run: |
+          docker exec krads journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check KRA DS container logs
+        if: always()
+        run: |
+          docker logs krads
+
+      - name: Check KRA container logs
+        if: always()
+        run: |
+          docker logs kra 2>&1
+
+      - name: Check KRA debug logs
+        if: always()
+        run: |
+          docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Check client container logs
+        if: always()
+        run: |
+          docker logs client
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh cads
+
+          docker exec ca ls -la /etc/pki
+          mkdir -p /tmp/artifacts/ca/etc/pki
+          docker cp ca:/etc/pki/pki.conf /tmp/artifacts/ca/etc/pki
+
+          docker exec ca ls -la /var/log/pki
+          mkdir -p /tmp/artifacts/ca/var/log
+          docker cp ca:/var/log/pki /tmp/artifacts/ca/var/log
+
+          docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
+
+          tests/bin/ds-artifacts-save.sh krads
+
+          docker exec kra ls -la /etc/pki
+          mkdir -p /tmp/artifacts/kra/etc/pki
+          docker cp kra:/etc/pki/pki.conf /tmp/artifacts/kra/etc/pki
+
+          docker exec kra ls -la /var/log/pki
+          mkdir -p /tmp/artifacts/kra/var/log
+          docker cp kra:/var/log/pki /tmp/artifacts/kra/var/log
+
+          docker logs kra > /tmp/artifacts/kra/container.out 2> /tmp/artifacts/kra/container.err
+
+          mkdir -p /tmp/artifacts/client
+          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kra-container
+          path: /tmp/artifacts

--- a/.github/workflows/kra-tests.yml
+++ b/.github/workflows/kra-tests.yml
@@ -82,3 +82,8 @@ jobs:
     name: KRA migration
     needs: build
     uses: ./.github/workflows/kra-migration-test.yml
+
+  kra-container-test:
+    name: KRA container
+    needs: build
+    uses: ./.github/workflows/kra-container-test.yml

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -1,0 +1,786 @@
+name: OCSP container
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # https://github.com/dogtagpki/pki/wiki/Deploying-OCSP-Container
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libxml2-utils
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Create shared folders
+        run: |
+          mkdir -p ca/certs
+          mkdir -p ca/data
+          mkdir -p ocsp/certs
+          mkdir -p ocsp/data
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh client
+        env:
+          HOSTNAME: client.example.com
+
+      - name: Connect client container to network
+        run: docker network connect example client --alias client.example.com
+
+      - name: Set up CA container
+        run: |
+          docker run \
+              --name ca \
+              --hostname ca.example.com \
+              --network example \
+              --network-alias ca.example.com \
+              -v $PWD/ca/certs:/certs \
+              -v $PWD/ca/data:/data \
+              -e PKI_DS_URL=ldap://cads.example.com:3389 \
+              -e PKI_DS_PASSWORD=Secret.123 \
+              --detach \
+              pki-ca
+
+          # wait for CA to start
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ca.example.com:8443
+
+      - name: Set up CA DS container
+        run: |
+          tests/bin/ds-container-create.sh cads
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: cads.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect CA DS container to network
+        run: docker network connect example cads --alias cads.example.com
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
+      - name: Initialize CA database
+        run: |
+          docker exec ca pki-server ca-db-init -v
+          docker exec ca pki-server ca-db-index-add -v
+          docker exec ca pki-server ca-db-index-rebuild -v
+          docker exec ca pki-server ca-db-vlv-add -v
+          docker exec ca pki-server ca-db-vlv-reindex -v
+
+      - name: Import CA signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/ca_signing.crt \
+              --profile /usr/share/pki/ca/conf/caCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA OCSP signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/ocsp_signing.crt \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA audit signing cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/audit_signing.crt \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import CA subsystem cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/subsystem.crt \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import SSL server cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/sslserver.crt \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
+              --request $REQUEST_ID
+
+      - name: Import admin cert into CA database
+        run: |
+          docker exec ca pki-server ca-cert-request-import \
+              --csr /certs/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
+          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
+
+          docker exec ca pki-server ca-cert-import \
+              --cert /certs/admin.crt \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --request $REQUEST_ID
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
+      - name: Add CA admin user
+        run: |
+          docker exec ca pki-server ca-user-add \
+              --full-name Administrator \
+              --type adminType \
+              admin
+
+      - name: Assign admin cert to CA admin user
+        run: |
+          docker exec ca pki-server ca-user-cert-add \
+              --cert /certs/admin.crt \
+              admin
+
+      - name: Add admin user into CA groups
+        run: |
+          docker exec ca pki-server ca-user-role-add admin "Administrators"
+          docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
+
+      - name: Install admin cert
+        run: |
+          docker exec client pki pkcs12-import \
+              --pkcs12 $SHARED/ca/certs/admin.p12 \
+              --password Secret.123
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-user-show \
+              admin
+
+      - name: Create OCSP signing cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=OCSP Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+              --csr $SHARED/ocsp/certs/ocsp_signing.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/ocsp/certs/ocsp_signing.csr \
+              --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+              --cert $SHARED/ocsp/certs/ocsp_signing.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/ocsp/certs/ocsp_signing.crt \
+              ocsp_signing
+          docker exec client pki nss-cert-show ocsp_signing
+
+      - name: Create OCSP audit signing cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --csr $SHARED/ocsp/certs/audit_signing.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/ocsp/certs/audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert $SHARED/ocsp/certs/audit_signing.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/ocsp/certs/audit_signing.crt \
+              --trust ,,P \
+              audit_signing
+          docker exec client pki nss-cert-show audit_signing
+
+      - name: Create OCSP subsystem cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=Subsystem Certificate" \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --csr $SHARED/ocsp/certs/subsystem.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/ocsp/certs/subsystem.csr \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --cert $SHARED/ocsp/certs/subsystem.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/ocsp/certs/subsystem.crt \
+              subsystem
+          docker exec client pki nss-cert-show subsystem
+
+      - name: Create OCSP SSL server cert
+        run: |
+          docker exec client pki nss-cert-request \
+              --subject "CN=ocsp.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr $SHARED/ocsp/certs/sslserver.csr
+          docker exec client pki \
+              -d $SHARED/ca/data/conf/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/ocsp/certs/sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --cert $SHARED/ocsp/certs/sslserver.crt
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/ocsp/certs/sslserver.crt \
+              sslserver
+          docker exec client pki nss-cert-show sslserver
+
+      - name: Prepare OCSP certs and keys
+        run: |
+          # export CA signing cert
+          docker exec client cp $SHARED/ca/certs/ca_signing.crt $SHARED/ocsp/certs
+
+          docker exec client pki nss-cert-find
+
+          # export OCSP system certs and keys
+          docker exec client pki pkcs12-export \
+              --pkcs12 $SHARED/ocsp/certs/server.p12 \
+              --password Secret.123 \
+              ocsp_signing \
+              audit_signing \
+              subsystem \
+              sslserver
+
+          docker exec client pki pkcs12-cert-find \
+              --pkcs12 $SHARED/ocsp/certs/server.p12 \
+              --password Secret.123 \
+
+          # export admin cert and key
+          docker exec client cp $SHARED/ca/certs/admin.p12 $SHARED/ocsp/certs
+
+          docker exec client pki pkcs12-cert-find \
+              --pkcs12 $SHARED/ocsp/certs/admin.p12 \
+              --password Secret.123 \
+
+          ls -la ocsp/certs
+
+      - name: Set up OCSP container
+        run: |
+          docker run \
+              --name ocsp \
+              --hostname ocsp.example.com \
+              --network example \
+              --network-alias ocsp.example.com \
+              -v $PWD/ocsp/certs:/certs \
+              -v $PWD/ocsp/data:/data \
+              -e PKI_DS_URL=ldap://ocspds.example.com:3389 \
+              -e PKI_DS_PASSWORD=Secret.123 \
+              --detach \
+              pki-ocsp
+
+      - name: Wait for OCSP container to start
+        run: |
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ocsp.example.com:8443
+
+      - name: Check OCSP data dir
+        if: always()
+        run: |
+          ls -l ocsp/data \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx 17 root conf
+          drwxrwxrwx 17 root logs
+          EOF
+
+          diff expected output
+
+      - name: Check OCSP data/conf dir
+        if: always()
+        run: |
+          ls -l ocsp/data/conf \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx 17 root Catalina
+          drwxrwx--- 17 root alias
+          -rw-rw-rw- 17 root catalina.policy
+          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx 17 root certs
+          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- 17 root jss.conf
+          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
+          drwxrwxrwx 17 root ocsp
+          -rw-rw---- 17 root password.conf
+          -rw-rw-rw- 17 root server.xml
+          -rw-rw---- 17 root serverCertNick.conf
+          -rw-rw-rw- 17 root tomcat.conf
+          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check OCSP data/conf/ocsp dir
+        if: always()
+        run: |
+          ls -l ocsp/data/conf/ocsp \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
+              | tee output
+
+          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          -rw-rw-rw- 17 root CS.cfg
+          drwxrwxrwx 17 root archives
+          -rw-rw-r-- 17 root registry.cfg
+          EOF
+
+          diff expected output
+
+      - name: Check OCSP data/logs dir
+        if: always()
+        run: |
+          ls -l ocsp/data/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwx--- 17 root backup
+          -rw-rw-rw- 17 root catalina.$DATE.log
+          -rw-rw-rw- 17 root host-manager.$DATE.log
+          -rw-rw-rw- 17 root localhost.$DATE.log
+          -rw-rw-rw- 17 root localhost_access_log.$DATE.txt
+          -rw-rw-rw- 17 root manager.$DATE.log
+          drwxrwx--- 17 root ocsp
+          drwxrwxrwx 17 root pki
+          EOF
+
+          diff expected output
+
+      - name: Check basic operations from OCSP container
+        run: |
+          # check PKI server info
+          docker exec ocsp pki info
+
+      - name: Check basic operations from client container
+        run: |
+          # check PKI server info
+          docker exec client pki \
+              -U https://ocsp.example.com:8443 \
+              info
+
+      - name: Set up OCSP DS container
+        run: |
+          tests/bin/ds-container-create.sh ocspds
+        env:
+          IMAGE: ${{ env.DB_IMAGE }}
+          HOSTNAME: ocspds.example.com
+          PASSWORD: Secret.123
+
+      - name: Connect OCSP DS container to network
+        run: docker network connect example ocspds --alias ocspds.example.com
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-OCSP-Database
+      - name: Set up OCSP database
+        run: |
+          docker exec ocsp pki-server ocsp-db-init -v
+          docker exec ocsp pki-server ocsp-db-index-add -v
+          docker exec ocsp pki-server ocsp-db-index-rebuild  -v
+          docker exec ocsp pki-server ocsp-db-vlv-add -v
+          docker exec ocsp pki-server ocsp-db-vlv-reindex -v
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-OCSP-Admin-User
+      - name: Add OCSP admin user
+        run: |
+          docker exec ocsp pki-server ocsp-user-add \
+              --full-name Administrator \
+              --type adminType \
+              admin
+
+      - name: Assign admin cert to OCSP admin user
+        run: |
+          docker exec ocsp pki-server ocsp-user-cert-add \
+              --cert /certs/admin.crt \
+              admin
+
+      - name: Add OCSP admin user into OCSP groups
+        run: |
+          docker exec ocsp pki-server ocsp-user-role-add admin "Administrators"
+
+      - name: Check OCSP admin user
+        run: |
+          docker exec client pki \
+              -U https://ocsp.example.com:8443 \
+              -n admin \
+              ocsp-user-show \
+              admin
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-Subsystem-User
+      - name: Add CA subsystem user in OCSP
+        run: |
+          docker exec ocsp pki-server ocsp-user-add \
+              --full-name CA-ca.example.com-8443 \
+              --type agentType \
+              CA-ca.example.com-8443
+
+      - name: Assign CA subsystem cert to CA subsystem user
+        run: |
+          docker cp ca/certs/subsystem.crt ocsp:ca_subsystem.crt
+          docker exec ocsp pki-server ocsp-user-cert-add \
+              --cert ca_subsystem.crt \
+              CA-ca.example.com-8443
+
+      - name: Assign roles to CA subsystem user
+        run: |
+          docker exec ocsp pki-server ocsp-user-role-add CA-ca.example.com-8443 "Trusted Managers"
+
+      - name: Add CRL issuing point
+        run: |
+          # convert CA signing cert into PKCS #7 chain
+          docker exec ocsp pki pkcs7-cert-import --pkcs7 /certs/ca_signing.p7 --input-file /certs/ca_signing.crt
+          docker exec ocsp pki pkcs7-cert-find --pkcs7 /certs/ca_signing.p7
+
+          # create CRL issuing point with the PKCS #7 chain
+          docker exec ocsp pki-server ocsp-crl-issuingpoint-add --cert-chain /certs/ca_signing.p7
+
+      - name: Configure OCSP connector in CA
+        run: |
+          # configure OCSP publisher
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.enableClientAuth true
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.host ocsp.example.com
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.nickName subsystem
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.path /ocsp/agent/ocsp/addCRL
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.pluginName OCSPPublisher
+          docker exec ca pki-server ca-config-set ca.publish.publisher.instance.OCSPPublisher.port 8443
+
+          # configure CRL publishing rule
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.enable true
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.mapper NoMap
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.pluginName Rule
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.publisher OCSPPublisher
+          docker exec ca pki-server ca-config-set ca.publish.rule.instance.OCSPRule.type crl
+
+          # enable CRL publishing
+          docker exec ca pki-server ca-config-set ca.publish.enable true
+
+          # set buffer size to 0 so that revocation will take effect immediately
+          docker exec ca pki-server ca-config-set auths.revocationChecking.bufferSize 0
+
+          # update CRL immediately after each cert revocation
+          docker exec ca pki-server ca-crl-ip-mod -D alwaysUpdate=true MasterCRL
+
+      - name: Restart CA
+        run: |
+          docker restart ca
+          sleep 5
+
+          # wait for CA to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ca.example.com:8443
+
+      - name: Create user cert
+        run: |
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              client-cert-request \
+              uid=testuser | tee output
+
+          REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" output)
+          echo "Request ID: $REQUEST_ID"
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-cert-request-approve \
+              --force \
+              $REQUEST_ID | tee output
+
+          CERT_ID=$(sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" output)
+          echo "Cert ID: $CERT_ID"
+          echo "$CERT_ID" > cert.id
+
+      - name: Check OCSP responder with initial CRL
+        run: |
+          CERT_ID=$(cat cert.id)
+
+          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
+          docker exec client curl \
+              --cert-type P12 \
+              --cert $SHARED/ca/certs/admin.p12:Secret.123 \
+              -sk \
+              -d "xml=true" \
+              https://ca.example.com:8443/ca/agent/ca/updateCRL \
+              | xmllint --format -
+
+          # wait for CRL update
+          sleep 10
+
+          # check cert status using OCSPClient
+          docker exec client OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID | tee output
+
+          # cert status should be good
+          sed -n "s/^CertStatus=\(.*\)$/\1/p" output > actual
+          echo Good > expected
+          diff expected actual
+
+      - name: Check OCSP responder with after revocation
+        run: |
+          CERT_ID=$(cat cert.id)
+
+          # place cert on-hold
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-cert-hold \
+              --force \
+              $CERT_ID | tee output
+
+          # cert should be revoked
+          echo "REVOKED" > expected
+          sed -n "s/^\s*Status:\s*\(\S*\)$/\1/p" output > actual
+          diff expected actual
+
+          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
+          docker exec client curl \
+              --cert-type P12 \
+              --cert $SHARED/ca/certs/admin.p12:Secret.123 \
+              -sk \
+              -d "xml=true" \
+              https://ca.example.com:8443/ca/agent/ca/updateCRL \
+              | xmllint --format -
+
+          # wait for CRL update
+          sleep 10
+
+          # check cert status using OCSPClient
+          docker exec client OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID | tee output
+
+          # cert status should be revoked
+          sed -n "s/^CertStatus=\(.*\)$/\1/p" output > actual
+          echo Revoked > expected
+          diff expected actual
+
+      - name: Check OCSP responder with after unrevocation
+        run: |
+          CERT_ID=$(cat cert.id)
+
+          # place cert off-hold
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-cert-release-hold \
+              --force \
+              $CERT_ID | tee output
+
+          # cert should be valid
+          echo "VALID" > expected
+          sed -n "s/^\s*Status:\s*\(\S*\)$/\1/p" output > actual
+          diff expected actual
+
+          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
+          docker exec client curl \
+              --cert-type P12 \
+              --cert $SHARED/ca/certs/admin.p12:Secret.123 \
+              -sk \
+              -d "xml=true" \
+              https://ca.example.com:8443/ca/agent/ca/updateCRL \
+              | xmllint --format -
+
+          # wait for CRL update
+          sleep 10
+
+          # check cert status using OCSPClient
+          docker exec client OCSPClient \
+              -d /root/.dogtag/nssdb \
+              -h ocsp.example.com \
+              -p 8080 \
+              -t /ocsp/ee/ocsp \
+              -c ca_signing \
+              --serial $CERT_ID | tee output
+
+          # cert status should be good
+          sed -n "s/^CertStatus=\(.*\)$/\1/p" output > actual
+          echo Good > expected
+          diff expected actual
+
+      - name: Restart OCSP
+        run: |
+          docker restart ocsp
+          sleep 5
+
+          # wait for OCSP to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ocsp.example.com:8443
+
+      - name: Check OCSP admin user again
+        run: |
+          docker exec client pki \
+              -U https://ocsp.example.com:8443 \
+              -n admin \
+              ocsp-user-show \
+              admin
+
+      - name: Check CA DS server systemd journal
+        if: always()
+        run: |
+          docker exec cads journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check CA DS container logs
+        if: always()
+        run: |
+          docker logs cads
+
+      - name: Check CA container logs
+        if: always()
+        run: |
+          docker logs ca 2>&1
+
+      - name: Check CA debug logs
+        if: always()
+        run: |
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check OCSP DS server systemd journal
+        if: always()
+        run: |
+          docker exec ocspds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check OCSP DS container logs
+        if: always()
+        run: |
+          docker logs ocspds
+
+      - name: Check OCSP container logs
+        if: always()
+        run: |
+          docker logs ocsp 2>&1
+
+      - name: Check OCSP debug logs
+        if: always()
+        run: |
+          docker exec ocsp find /var/lib/pki/pki-tomcat/logs/ocsp -name "debug.*" -exec cat {} \;
+
+      - name: Check client container logs
+        if: always()
+        run: |
+          docker logs client
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh cads
+
+          docker exec ca ls -la /etc/pki
+          mkdir -p /tmp/artifacts/ca/etc/pki
+          docker cp ca:/etc/pki/pki.conf /tmp/artifacts/ca/etc/pki
+
+          docker exec ca ls -la /var/log/pki
+          mkdir -p /tmp/artifacts/ca/var/log
+          docker cp ca:/var/log/pki /tmp/artifacts/ca/var/log
+
+          docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
+
+          tests/bin/ds-artifacts-save.sh ocspds
+
+          docker exec ocsp ls -la /etc/pki
+          mkdir -p /tmp/artifacts/ocsp/etc/pki
+          docker cp ocsp:/etc/pki/pki.conf /tmp/artifacts/ocsp/etc/pki
+
+          docker exec ocsp ls -la /var/log/pki
+          mkdir -p /tmp/artifacts/ocsp/var/log
+          docker cp ocsp:/var/log/pki /tmp/artifacts/ocsp/var/log
+
+          docker logs ocsp > /tmp/artifacts/ocsp/container.out 2> /tmp/artifacts/ocsp/container.err
+
+          mkdir -p /tmp/artifacts/client
+          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ocsp-container
+          path: /tmp/artifacts

--- a/.github/workflows/ocsp-tests.yml
+++ b/.github/workflows/ocsp-tests.yml
@@ -90,3 +90,8 @@ jobs:
         ansible-playbook  -e 'pki_subsystem="ocsp"' tests/ansible/pki-playbook.yml 
       env:
         ANSIBLE_CONFIG: ${{ github.workspace }}/tests/ansible/ansible.cfg
+
+  ocsp-container-test:
+    name: OCSP container
+    needs: build
+    uses: ./.github/workflows/ocsp-container-test.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,3 +108,8 @@ jobs:
         run: |
           docker tag pki-kra ${{ vars.REGISTRY }}/$NAMESPACE/pki-kra:latest
           docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-kra:latest
+
+      - name: Publish pki-ocsp image
+        run: |
+          docker tag pki-ocsp ${{ vars.REGISTRY }}/$NAMESPACE/pki-ocsp:latest
+          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-ocsp:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,3 +103,8 @@ jobs:
         run: |
           docker tag pki-ca ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest
           docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-ca:latest
+
+      - name: Publish pki-kra image
+        run: |
+          docker tag pki-kra ${{ vars.REGISTRY }}/$NAMESPACE/pki-kra:latest
+          docker push ${{ vars.REGISTRY }}/$NAMESPACE/pki-kra:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -230,6 +230,37 @@ RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
 CMD [ "/usr/share/pki/kra/bin/pki-kra-run" ]
 
 ################################################################################
+FROM pki-server AS pki-ocsp
+
+ARG SUMMARY="Dogtag PKI OCSP Responder"
+
+LABEL name="pki-ocsp" \
+      summary="$SUMMARY" \
+      license="$LICENSE" \
+      version="$VERSION" \
+      architecture="$ARCH" \
+      maintainer="$MAINTAINER" \
+      vendor="$VENDOR" \
+      usage="podman run -p 8080:8080 -p 8443:8443 pki-ocsp" \
+      com.redhat.component="$COMPONENT"
+
+# Create OCSP subsystem
+RUN pki-server ocsp-create
+
+# Deploy OCSP subsystem
+RUN pki-server ocsp-deploy
+
+# Store default config files
+RUN mv /data/conf /var/lib/pki/pki-tomcat/conf.default
+
+# Grant the root group the full access to PKI server files
+# https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+RUN chgrp -Rf root /var/lib/pki/pki-tomcat
+RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
+
+CMD [ "/usr/share/pki/ocsp/bin/pki-ocsp-run" ]
+
+################################################################################
 FROM pki-server AS pki-acme
 
 ARG SUMMARY="Dogtag PKI ACME Responder"

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,6 +199,37 @@ RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
 CMD [ "/usr/share/pki/ca/bin/pki-ca-run" ]
 
 ################################################################################
+FROM pki-server AS pki-kra
+
+ARG SUMMARY="Dogtag PKI Key Recovery Authority"
+
+LABEL name="pki-kra" \
+      summary="$SUMMARY" \
+      license="$LICENSE" \
+      version="$VERSION" \
+      architecture="$ARCH" \
+      maintainer="$MAINTAINER" \
+      vendor="$VENDOR" \
+      usage="podman run -p 8080:8080 -p 8443:8443 pki-kra" \
+      com.redhat.component="$COMPONENT"
+
+# Create KRA subsystem
+RUN pki-server kra-create
+
+# Deploy KRA subsystem
+RUN pki-server kra-deploy
+
+# Store default config files
+RUN mv /data/conf /var/lib/pki/pki-tomcat/conf.default
+
+# Grant the root group the full access to PKI server files
+# https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+RUN chgrp -Rf root /var/lib/pki/pki-tomcat
+RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
+
+CMD [ "/usr/share/pki/kra/bin/pki-kra-run" ]
+
+################################################################################
 FROM pki-server AS pki-acme
 
 ARG SUMMARY="Dogtag PKI ACME Responder"

--- a/base/acme/bin/pki-acme-run
+++ b/base/acme/bin/pki-acme-run
@@ -13,8 +13,10 @@ umask 000
 
 echo "################################################################################"
 
-if [ ! -d /data/conf ]
+if [ -d /data/conf ]
 then
+    echo "INFO: Reusing /data/conf"
+else
     echo "INFO: Creating /data/conf"
     cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
     chown -Rf pkiuser:root /data/conf
@@ -24,9 +26,14 @@ fi
 
 echo "################################################################################"
 
-echo "INFO: Creating /data/logs"
-mkdir -p /data/logs
-chown -Rf pkiuser:root /data/logs
+if [ -d /data/logs ]
+then
+    echo "INFO: Reusing /data/logs"
+else
+    echo "INFO: Creating /data/logs"
+    mkdir /data/logs
+    chown -Rf pkiuser:root /data/logs
+fi
 
 echo "################################################################################"
 

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -10,8 +10,10 @@ umask 000
 
 echo "################################################################################"
 
-if [ ! -d /data/conf ]
+if [ -d /data/conf ]
 then
+    echo "INFO: Reusing /data/conf"
+else
     echo "INFO: Creating /data/conf"
     cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
     chown -Rf pkiuser:root /data/conf
@@ -21,9 +23,14 @@ fi
 
 echo "################################################################################"
 
-echo "INFO: Creating /data/logs"
-mkdir -p /data/logs
-chown -Rf pkiuser:root /data/logs
+if [ -d /data/logs ]
+then
+    echo "INFO: Reusing /data/logs"
+else
+    echo "INFO: Creating /data/logs"
+    mkdir /data/logs
+    chown -Rf pkiuser:root /data/logs
+fi
 
 echo "################################################################################"
 

--- a/base/kra/CMakeLists.txt
+++ b/base/kra/CMakeLists.txt
@@ -82,6 +82,17 @@ endif(WITH_JAVA)
 # install directories
 install(
     DIRECTORY
+        bin/
+    DESTINATION
+        ${DATA_INSTALL_DIR}/kra/bin
+    FILE_PERMISSIONS
+        OWNER_EXECUTE OWNER_READ
+        GROUP_EXECUTE GROUP_READ
+        WORLD_EXECUTE WORLD_READ
+)
+
+install(
+    DIRECTORY
         database/
     DESTINATION
         ${DATA_INSTALL_DIR}/kra/database

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -1,0 +1,179 @@
+#!/bin/sh -e
+
+# TODO:
+# - parameterize hard-coded values
+# - support existing subsystem user
+
+# Allow the owner of the container (who might not be in the root group)
+# to manage the config and log files.
+umask 000
+
+echo "################################################################################"
+
+if [ -d /data/conf ]
+then
+    echo "INFO: Reusing /data/conf"
+else
+    echo "INFO: Creating /data/conf"
+    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    chown -Rf pkiuser:root /data/conf
+    find /data/conf -type f -exec chmod +rw -- {} +
+    find /data/conf -type d -exec chmod +rwx -- {} +
+fi
+
+echo "################################################################################"
+
+if [ -d /data/logs ]
+then
+    echo "INFO: Reusing /data/logs"
+else
+    echo "INFO: Creating /data/logs"
+    mkdir /data/logs
+    chown -Rf pkiuser:root /data/logs
+fi
+
+echo "################################################################################"
+
+if [ -f /certs/server.p12 ]
+then
+    echo "INFO: Importing system certs and keys"
+
+    pki \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
+        pkcs12-import \
+        --pkcs12 /certs/server.p12 \
+        --password Secret.123
+fi
+
+echo "################################################################################"
+
+echo "INFO: KRA storage cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    kra_storage
+
+echo "################################################################################"
+
+echo "INFO: KRA transport cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    kra_transport
+
+echo "################################################################################"
+
+echo "INFO: Audit signing cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    audit_signing
+
+echo "################################################################################"
+
+echo "INFO: Subsystem cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    subsystem
+
+if [ ! -f /certs/subsystem.crt ]
+then
+    echo "INFO: Exporting subsystem cert"
+
+    pki \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
+        nss-cert-export \
+        --output-file /certs/subsystem.crt \
+        subsystem
+fi
+
+echo "################################################################################"
+
+echo "INFO: SSL server cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    sslserver
+
+echo "################################################################################"
+
+if [ -f /certs/admin.p12 ]
+then
+    echo "INFO: Importing admin cert and key"
+
+    pki pkcs12-import \
+        --pkcs12 /certs/admin.p12 \
+        --password Secret.123
+fi
+
+echo "INFO: Admin cert:"
+pki nss-cert-show admin
+
+if [ ! -f /certs/admin.crt ]
+then
+    echo "INFO: Exporting admin cert"
+
+    pki nss-cert-export \
+        --output-file /certs/admin.crt \
+        admin
+fi
+
+echo "################################################################################"
+echo "INFO: Creating PKI KRA"
+
+# Create KRA with existing certs and keys, with existing database,
+# with existing database user, with RSNv3, without security manager,
+# and without systemd service.
+pkispawn \
+    --conf /data/conf \
+    --logs /data/logs \
+    -f /usr/share/pki/server/examples/installation/kra.cfg \
+    -s KRA \
+    -D pki_group=root \
+    -D pki_cert_chain_path=/certs/ca_signing.crt \
+    -D pki_ds_url=$PKI_DS_URL \
+    -D pki_ds_password=$PKI_DS_PASSWORD \
+    -D pki_ds_database=userroot \
+    -D pki_ds_setup=False \
+    -D pki_skip_ds_verify=True \
+    -D pki_share_db=True \
+    -D pki_issuing_ca= \
+    -D pki_import_system_certs=False \
+    -D pki_storage_nickname=kra_storage \
+    -D pki_storage_csr_path=/certs/kra_storage.csr \
+    -D pki_transport_nickname=kra_transport \
+    -D pki_transport_csr_path=/certs/kra_transport.csr \
+    -D pki_audit_signing_nickname=audit_signing \
+    -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
+    -D pki_subsystem_nickname=subsystem \
+    -D pki_subsystem_csr_path=/certs/subsystem.csr \
+    -D pki_sslserver_nickname=sslserver \
+    -D pki_sslserver_csr_path=/certs/sslserver.csr \
+    -D pki_admin_setup=False \
+    -D pki_security_domain_setup=False \
+    -D pki_security_manager=False \
+    -D pki_systemd_service_create=False \
+    -D pki_registry_enable=False \
+    -v
+
+echo "################################################################################"
+echo "INFO: Configuring PKI KRA"
+
+pki-server kra-config-set internaldb.minConns 0
+
+echo "################################################################################"
+echo "INFO: Starting PKI KRA"
+
+if [ "$UID" = "0" ]; then
+    # In Docker/Podman the server runs as pkiuser (UID=17) that
+    # belongs to the root group (GID=0).
+    pki-server run
+
+else
+    # In OpenShift the server runs as an OpenShift-assigned user
+    # (with a random UID) that belongs to the root group (GID=0).
+    #
+    # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+    pki-server run --as-current-user
+fi

--- a/base/ocsp/CMakeLists.txt
+++ b/base/ocsp/CMakeLists.txt
@@ -83,6 +83,17 @@ endif(WITH_JAVA)
 # install directories
 install(
     DIRECTORY
+        bin/
+    DESTINATION
+        ${DATA_INSTALL_DIR}/ocsp/bin
+    FILE_PERMISSIONS
+        OWNER_EXECUTE OWNER_READ
+        GROUP_EXECUTE GROUP_READ
+        WORLD_EXECUTE WORLD_READ
+)
+
+install(
+    DIRECTORY
         database/
     DESTINATION
         ${DATA_INSTALL_DIR}/ocsp/database

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -1,0 +1,176 @@
+#!/bin/sh -e
+
+# TODO:
+# - parameterize hard-coded values
+# - support existing subsystem user
+
+# Allow the owner of the container (who might not be in the root group)
+# to manage the config and log files.
+umask 000
+
+echo "################################################################################"
+
+if [ -d /data/conf ]
+then
+    echo "INFO: Reusing /data/conf"
+else
+    echo "INFO: Creating /data/conf"
+    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    chown -Rf pkiuser:root /data/conf
+    find /data/conf -type f -exec chmod +rw -- {} +
+    find /data/conf -type d -exec chmod +rwx -- {} +
+fi
+
+echo "################################################################################"
+
+if [ -d /data/logs ]
+then
+    echo "INFO: Reusing /data/logs"
+else
+    echo "INFO: Creating /data/logs"
+    mkdir /data/logs
+    chown -Rf pkiuser:root /data/logs
+fi
+
+echo "################################################################################"
+
+if [ -f /certs/server.p12 ]
+then
+    echo "INFO: Importing system certs and keys"
+
+    pki \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
+        pkcs12-import \
+        --pkcs12 /certs/server.p12 \
+        --password Secret.123
+fi
+
+echo "################################################################################"
+
+echo "INFO: OCSP signing cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    ocsp_signing
+
+echo "################################################################################"
+
+echo "INFO: Audit signing cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    audit_signing
+
+echo "################################################################################"
+
+echo "INFO: Subsystem cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    subsystem
+
+if [ ! -f /certs/subsystem.crt ]
+then
+    echo "INFO: Exporting subsystem cert"
+
+    pki \
+        -d /var/lib/pki/pki-tomcat/conf/alias \
+        nss-cert-export \
+        --output-file /certs/subsystem.crt \
+        subsystem
+fi
+
+echo "################################################################################"
+
+echo "INFO: SSL server cert:"
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-show \
+    sslserver
+
+pki \
+    -d /var/lib/pki/pki-tomcat/conf/alias \
+    nss-cert-find
+
+echo "################################################################################"
+
+if [ -f /certs/admin.p12 ]
+then
+    echo "INFO: Importing admin cert and key"
+
+    pki pkcs12-import \
+        --pkcs12 /certs/admin.p12 \
+        --password Secret.123
+fi
+
+echo "INFO: Admin cert:"
+pki nss-cert-show admin
+
+if [ ! -f /certs/admin.crt ]
+then
+    echo "INFO: Exporting admin cert"
+
+    pki nss-cert-export \
+        --output-file /certs/admin.crt \
+        admin
+fi
+
+pki nss-cert-find
+
+echo "################################################################################"
+echo "INFO: Creating OCSP Responder"
+
+# Create OCSP with existing certs and keys, with existing database,
+# with existing database user, without security manager,
+# and without systemd service.
+pkispawn \
+    --conf /data/conf \
+    --logs /data/logs \
+    -f /usr/share/pki/server/examples/installation/ocsp.cfg \
+    -s OCSP \
+    -D pki_group=root \
+    -D pki_cert_chain_path=/certs/ca_signing.crt \
+    -D pki_cert_chain_nickname=ca_signing \
+    -D pki_ds_url=$PKI_DS_URL \
+    -D pki_ds_password=$PKI_DS_PASSWORD \
+    -D pki_ds_database=userroot \
+    -D pki_ds_setup=False \
+    -D pki_skip_ds_verify=True \
+    -D pki_share_db=True \
+    -D pki_issuing_ca= \
+    -D pki_import_system_certs=False \
+    -D pki_ocsp_signing_nickname=ocsp_signing \
+    -D pki_ocsp_signing_csr_path=/certs/ocsp_signing.csr \
+    -D pki_audit_signing_nickname=audit_signing \
+    -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
+    -D pki_subsystem_nickname=subsystem \
+    -D pki_subsystem_csr_path=/certs/subsystem.csr \
+    -D pki_sslserver_nickname=sslserver \
+    -D pki_sslserver_csr_path=/certs/sslserver.csr \
+    -D pki_admin_setup=False \
+    -D pki_security_domain_setup=False \
+    -D pki_security_manager=False \
+    -D pki_systemd_service_create=False \
+    -D pki_registry_enable=False \
+    -v
+
+echo "################################################################################"
+echo "INFO: Configuring OCSP Responder"
+
+pki-server ocsp-config-set internaldb.minConns 0
+
+echo "################################################################################"
+echo "INFO: Starting OCSP Responder"
+
+if [ "$UID" = "0" ]; then
+    # In Docker/Podman the server runs as pkiuser (UID=17) that
+    # belongs to the root group (GID=0).
+    pki-server run
+
+else
+    # In OpenShift the server runs as an OpenShift-assigned user
+    # (with a random UID) that belongs to the root group (GID=0).
+    #
+    # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+    pki-server run --as-current-user
+fi

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -61,24 +61,21 @@ then
     pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-request \
         --subject "CN=CA Signing Certificate" \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
-        --csr /tmp/ca_signing.csr
+        --csr /certs/ca_signing.csr
 
     # issue self-signed CA signing cert
     pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-issue \
-        --csr /tmp/ca_signing.csr \
+        --csr /certs/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
         --validity-length 1 \
         --validity-unit year \
-        --cert /tmp/ca_signing.crt
+        --cert /certs/ca_signing.crt
 
     # import and trust CA signing cert into NSS database
     pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-import \
-        --cert /tmp/ca_signing.crt \
+        --cert /certs/ca_signing.crt \
         --trust CT,C,C \
         ca_signing
-
-    rm /tmp/ca_signing.crt
-    rm /tmp/ca_signing.csr
 fi
 
 echo "INFO: CA Signing Certificate:"
@@ -99,22 +96,19 @@ then
     pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-request \
         --subject "CN=$HOSTNAME" \
         --ext /usr/share/pki/server/certs/sslserver.conf \
-        --csr /tmp/sslserver.csr
+        --csr /certs/sslserver.csr
 
     # issue SSL server cert
     pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-issue \
         --issuer ca_signing \
-        --csr /tmp/sslserver.csr \
+        --csr /certs/sslserver.csr \
         --ext /usr/share/pki/server/certs/sslserver.conf \
-        --cert /tmp/sslserver.crt
+        --cert /certs/sslserver.crt
 
     # import SSL server cert into NSS database
     pki -d /var/lib/pki/pki-tomcat/conf/alias nss-cert-import \
-        --cert /tmp/sslserver.crt \
+        --cert /certs/sslserver.crt \
         sslserver
-
-    rm /tmp/sslserver.crt
-    rm /tmp/sslserver.csr
 fi
 
 echo "INFO: SSL Server Certificate:"


### PR DESCRIPTION
The `Dockerfile` has been updated to define new KRA and OCSP containers.

A new test has been added to create CA and KRA containers, then verify key archival and recovery. A new test has also been added to create CA and OCSP containers, then verify CRL publishing and revocation checking.

https://github.com/dogtagpki/pki/wiki/Deploying-KRA-on-Podman
https://github.com/dogtagpki/pki/wiki/Deploying-OCSP-on-Podman
