### PR TITLE
Add serial and issuer to SSL logs and audits

### DIFF
--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/AccessSessionEstablishEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/AccessSessionEstablishEvent.java
@@ -35,7 +35,9 @@ public class AccessSessionEstablishEvent extends SignedAuditEvent {
     public static AccessSessionEstablishEvent createSuccessEvent(
             String clientIP,
             String serverIP,
-            String subjectID) {
+            String subjectID,
+            String certID,
+            String issuerID) {
 
         AccessSessionEstablishEvent event = new AccessSessionEstablishEvent(
                 ACCESS_SESSION_ESTABLISH_SUCCESS);
@@ -43,6 +45,8 @@ public class AccessSessionEstablishEvent extends SignedAuditEvent {
         event.setAttribute("ClientIP", clientIP);
         event.setAttribute("ServerIP", serverIP);
         event.setAttribute("SubjectID", subjectID);
+        event.setAttribute("CertSerialNum", certID);
+        event.setAttribute("IssuerDN", issuerID);
         event.setAttribute("Outcome", ILogger.SUCCESS);
 
         return event;
@@ -52,6 +56,8 @@ public class AccessSessionEstablishEvent extends SignedAuditEvent {
             String clientIP,
             String serverIP,
             String subjectID,
+            String certID,
+            String issuerID,
             String info) {
 
         AccessSessionEstablishEvent event = new AccessSessionEstablishEvent(
@@ -60,6 +66,8 @@ public class AccessSessionEstablishEvent extends SignedAuditEvent {
         event.setAttribute("ClientIP", clientIP);
         event.setAttribute("ServerIP", serverIP);
         event.setAttribute("SubjectID", subjectID);
+        event.setAttribute("CertSerialNum", certID);
+        event.setAttribute("IssuerDN", issuerID);
         event.setAttribute("Outcome", ILogger.FAILURE);
         event.setAttribute("Info", info);
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/AccessSessionTerminatedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/AccessSessionTerminatedEvent.java
@@ -33,6 +33,8 @@ public class AccessSessionTerminatedEvent extends SignedAuditEvent {
             String clientIP,
             String serverIP,
             String subjectID,
+            String certID,
+            String issuerID,
             String info) {
 
         AccessSessionTerminatedEvent event = new AccessSessionTerminatedEvent(
@@ -41,6 +43,8 @@ public class AccessSessionTerminatedEvent extends SignedAuditEvent {
         event.setAttribute("ClientIP", clientIP);
         event.setAttribute("ServerIP", serverIP);
         event.setAttribute("SubjectID", subjectID);
+        event.setAttribute("CertSerialNum", certID);
+        event.setAttribute("IssuerDN", issuerID);
         event.setAttribute("Outcome", ILogger.SUCCESS);
         event.setAttribute("Info", info);
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ClientAccessSessionEstablishEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ClientAccessSessionEstablishEvent.java
@@ -38,6 +38,17 @@ public class ClientAccessSessionEstablishEvent extends SignedAuditEvent {
             String serverPort,
             String subjectID) {
 
+        return ClientAccessSessionEstablishEvent.createSuccessEvent(clientHost, serverHost, serverPort, subjectID, null, null);
+    }
+
+    public static ClientAccessSessionEstablishEvent createSuccessEvent(
+            String clientHost,
+            String serverHost,
+            String serverPort,
+            String subjectID,
+            String certID,
+            String issuerID) {
+
         ClientAccessSessionEstablishEvent event = new ClientAccessSessionEstablishEvent(
                 CLIENT_ACCESS_SESSION_ESTABLISH_SUCCESS);
 
@@ -45,6 +56,12 @@ public class ClientAccessSessionEstablishEvent extends SignedAuditEvent {
         event.setAttribute("ServerHost", serverHost);
         event.setAttribute("ServerPort", serverPort);
         event.setAttribute("SubjectID", subjectID);
+        if (certID != null) {
+            event.setAttribute("CertSerialNum", certID);
+        }
+        if (issuerID != null) {
+            event.setAttribute("IssuerDN", issuerID);
+        }
         event.setAttribute("Outcome", ILogger.SUCCESS);
 
         return event;
@@ -57,6 +74,19 @@ public class ClientAccessSessionEstablishEvent extends SignedAuditEvent {
             String subjectID,
             String info) {
 
+        return ClientAccessSessionEstablishEvent.createFailureEvent(clientHost, serverHost, serverPort, subjectID, null, null,
+                info);
+    }
+
+    public static ClientAccessSessionEstablishEvent createFailureEvent(
+            String clientHost,
+            String serverHost,
+            String serverPort,
+            String subjectID,
+            String certID,
+            String issuerID,
+            String info) {
+
         ClientAccessSessionEstablishEvent event = new ClientAccessSessionEstablishEvent(
                 CLIENT_ACCESS_SESSION_ESTABLISH_FAILURE);
 
@@ -64,6 +94,12 @@ public class ClientAccessSessionEstablishEvent extends SignedAuditEvent {
         event.setAttribute("ServerHost", serverHost);
         event.setAttribute("ServerPort", serverPort);
         event.setAttribute("SubjectID", subjectID);
+        if (certID != null) {
+            event.setAttribute("CertSerialNum", certID);
+        }
+        if (issuerID != null) {
+            event.setAttribute("IssuerDN", issuerID);
+        }
         event.setAttribute("Outcome", ILogger.FAILURE);
         event.setAttribute("Info", info);
 

--- a/base/server/src/main/java/com/netscape/certsrv/logging/event/ClientAccessSessionTerminatedEvent.java
+++ b/base/server/src/main/java/com/netscape/certsrv/logging/event/ClientAccessSessionTerminatedEvent.java
@@ -34,6 +34,8 @@ public class ClientAccessSessionTerminatedEvent extends SignedAuditEvent {
             String serverHost,
             String serverPort,
             String subjectID,
+            String certID,
+            String issuerID,
             String info) {
 
         ClientAccessSessionTerminatedEvent event = new ClientAccessSessionTerminatedEvent(
@@ -43,6 +45,12 @@ public class ClientAccessSessionTerminatedEvent extends SignedAuditEvent {
         event.setAttribute("ServerHost", serverHost);
         event.setAttribute("ServerPort", serverPort);
         event.setAttribute("SubjectID", subjectID);
+        if (certID != null) {
+            event.setAttribute("CertSerialNum", certID);
+        }
+        if (issuerID != null) {
+            event.setAttribute("IssuerDN", issuerID);
+        }
         event.setAttribute("Outcome", ILogger.SUCCESS);
         event.setAttribute("Info", info);
 

--- a/base/server/src/main/java/org/dogtagpki/server/PKIServerSocketListener.java
+++ b/base/server/src/main/java/org/dogtagpki/server/PKIServerSocketListener.java
@@ -17,6 +17,7 @@
 // --- END COPYRIGHT BLOCK ---
 package org.dogtagpki.server;
 
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.security.Principal;
 import java.security.cert.Certificate;
@@ -93,6 +94,8 @@ public class PKIServerSocketListener implements SSLSocketListener {
             String clientIP = defaultUnknown;
             String serverIP = defaultUnknown;
             String subjectID = defaultUnknown;
+            String certID = defaultUnknown;
+            String issuerID = defaultUnknown;
             String hostname = defaultUnknown;
             SSLSecurityStatus status = null;
 
@@ -104,8 +107,14 @@ public class PKIServerSocketListener implements SSLSocketListener {
 
                 status = socket.getStatus();
                 X509Certificate peerCertificate = status.getPeerCertificate();
-                Principal subjectDN = peerCertificate == null ? null : peerCertificate.getSubjectDN();
-                subjectID = subjectDN == null ? "" : subjectDN.toString();
+                if (peerCertificate != null){
+                    Principal subjectDN = peerCertificate.getSubjectDN();
+                    subjectID = subjectDN == null ? "" : subjectDN.toString();
+                    BigInteger serial = peerCertificate.getSerialNumber();
+                    certID = serial == null ? "" : serial.toString();
+                    Principal issuerDN = peerCertificate.getIssuerDN();
+                    issuerID = issuerDN == null ? "" : issuerDN.toString();
+                }
             } else {
                 if(sslEngine != null) {
                     JSSSession session = sslEngine.getSession();
@@ -115,6 +124,8 @@ public class PKIServerSocketListener implements SSLSocketListener {
                             X509Certificate cert = (X509Certificate) certs[0];
                             if(cert != null) {
                                 subjectID = cert.getSubjectDN().toString();
+                                certID = cert.getSerialNumber().toString();
+                                issuerID = cert.getIssuerDN().toString();
                             }
                         }
                         if(session.getRemoteAddr() != null) {
@@ -134,13 +145,16 @@ public class PKIServerSocketListener implements SSLSocketListener {
             logger.debug("- client: " + clientIP);
             logger.debug("- server: " + serverIP);
             logger.debug("- subject: " + subjectID);
+            logger.debug("- serial: " + certID);
+            logger.debug("- issuer: " + issuerID);
 
             auditor.log(AccessSessionTerminatedEvent.createEvent(
                     clientIP,
                     serverIP,
                     subjectID,
+                    certID,
+                    issuerID,
                     reason));
-
         } catch (Exception e) {
             logger.error("PKIServerSocketListener: " + e.getMessage(), e);
         }
@@ -166,6 +180,8 @@ public class PKIServerSocketListener implements SSLSocketListener {
             String clientIP = defaultUnknown;
             String serverIP = defaultUnknown;
             String subjectID = defaultUnknown;
+            String certID = defaultUnknown;
+            String issuerID = defaultUnknown;
 
             InetAddress clientAddress =  null;
             InetAddress serverAddress = null;
@@ -173,34 +189,40 @@ public class PKIServerSocketListener implements SSLSocketListener {
             if (description == SSLAlertDescription.CLOSE_NOTIFY.getID()) {
 
                 // get socket info from socketInfos map since socket has been closed
-            if(socket != null) {
-                Map<String,Object> info = socketInfos.get(socket);
-                clientIP = (String)info.get("clientIP");
-                serverIP = (String)info.get("serverIP");
-                subjectID = (String)info.get("subjectID");
-            } else {
-                if(sslEngine != null) {
-                    JSSSession session = sslEngine.getSession();
-                    if(session != null) {
-                        Certificate[] certs = session.getPeerCertificates();
-                        if(certs != null) {
-                             X509Certificate cert = (X509Certificate) certs[0];
-                             subjectID = cert.getSubjectDN().toString();
-                        }
-                        if(session.getRemoteAddr() != null) {
-                            clientIP = session.getRemoteAddr();
-                        }
-                        if(session.getLocalAddr() != null) {
-                            serverIP = session.getLocalAddr();
+                if(socket != null) {
+                    Map<String,Object> info = socketInfos.get(socket);
+                    clientIP = (String)info.get("clientIP");
+                    serverIP = (String)info.get("serverIP");
+                    subjectID = (String)info.get("subjectID");
+                    certID = (String)info.get("certID");
+                    issuerID = (String)info.get("issuerID");
+                } else {
+                    if(sslEngine != null) {
+                        JSSSession session = sslEngine.getSession();
+                        if(session != null) {
+                            Certificate[] certs = session.getPeerCertificates();
+                            if(certs != null) {
+                                X509Certificate cert = (X509Certificate) certs[0];
+                                subjectID = cert.getSubjectDN().toString();
+                                certID = cert.getSerialNumber().toString();
+                                issuerID = cert.getIssuerDN().toString();
+                            }
+                            if(session.getRemoteAddr() != null) {
+                                clientIP = session.getRemoteAddr();
+                            }
+                            if(session.getLocalAddr() != null) {
+                                serverIP = session.getLocalAddr();
+                            }
                         }
                     }
                 }
-            }
 
-            auditEvent = AccessSessionTerminatedEvent.createEvent(
+                auditEvent = AccessSessionTerminatedEvent.createEvent(
                     clientIP,
                     serverIP,
                     subjectID,
+                    certID,
+                    issuerID,
                     reason);
 
             } else {
@@ -213,9 +235,14 @@ public class PKIServerSocketListener implements SSLSocketListener {
 
                     SSLSecurityStatus status = socket.getStatus();
                     X509Certificate peerCertificate = status.getPeerCertificate();
-                    Principal subjectDN = peerCertificate == null ? null : peerCertificate.getSubjectDN();
-                    subjectID = subjectDN == null ? "" : subjectDN.toString();
-
+                    if (peerCertificate != null) {
+                        Principal subjectDN = peerCertificate.getSubjectDN();
+                        subjectID = subjectDN == null ? "" : subjectDN.toString();
+                        BigInteger serial = peerCertificate.getSerialNumber();
+                        certID = serial == null ? "" : serial.toString();
+                        Principal issuerDN = peerCertificate.getIssuerDN();
+                        issuerID = issuerDN == null ? "" : issuerDN.toString();
+                    }
                } else {
                    if(sslEngine != null) {
                         JSSSession session = sslEngine.getSession();
@@ -225,6 +252,8 @@ public class PKIServerSocketListener implements SSLSocketListener {
                                  X509Certificate cert = (X509Certificate) certs[0];
                                  if(cert != null) {
                                      subjectID = cert.getSubjectDN().toString();
+                                     certID = cert.getSerialNumber().toString();
+                                     issuerID = cert.getIssuerDN().toString();
                                  }
                             }
                             if(session.getRemoteAddr() != null) {
@@ -241,6 +270,8 @@ public class PKIServerSocketListener implements SSLSocketListener {
                         clientIP,
                         serverIP,
                         subjectID,
+                        certID,
+                        issuerID,
                         reason);
             }
 
@@ -249,6 +280,8 @@ public class PKIServerSocketListener implements SSLSocketListener {
             logger.debug("- client: " + clientIP);
             logger.debug("- server: " + serverIP);
             logger.debug("- subject: " + subjectID);
+            logger.debug("- serial: " + certID);
+            logger.debug("- issuer: " + issuerID);
 
             auditor.log(auditEvent);
 
@@ -278,6 +311,10 @@ public class PKIServerSocketListener implements SSLSocketListener {
             X509Certificate peerCertificate = null;
             Principal subjectDN = null;
             String subjectID = defaultUnknown;
+            BigInteger serial = null;
+            String certID = defaultUnknown;
+            Principal issuerDN = null;
+            String issuerID = defaultUnknown;
 
             if(socket != null) {
                 clientAddress = socket.getInetAddress();
@@ -287,13 +324,21 @@ public class PKIServerSocketListener implements SSLSocketListener {
 
                 status = socket.getStatus();
                 peerCertificate = status.getPeerCertificate();
-                subjectDN = peerCertificate == null ? null : peerCertificate.getSubjectDN();
-                subjectID = subjectDN == null ? "" : subjectDN.toString();
+                if (peerCertificate != null) {
+                    subjectDN = peerCertificate.getSubjectDN();
+                    subjectID = subjectDN == null ? "" : subjectDN.toString();
+                    serial = peerCertificate.getSerialNumber();
+                    certID = serial == null ? "" : serial.toString();
+                    issuerDN = peerCertificate.getIssuerDN();
+                    issuerID = issuerDN == null ? "" : issuerDN.toString();
+                }
                 // store socket info in socketInfos map
                 Map<String,Object> info = new HashMap<>();
                 info.put("clientIP", clientIP);
                 info.put("serverIP", serverIP);
                 info.put("subjectID", subjectID);
+                info.put("certID", certID);
+                info.put("issuerID", issuerID);
                 socketInfos.put(socket, info);
             } else {
                 if(sslEngine != null) {
@@ -303,7 +348,12 @@ public class PKIServerSocketListener implements SSLSocketListener {
                         if(certs != null) {
                             X509Certificate cert = (X509Certificate) certs[0];
                             if(cert != null) {
-                                subjectID = cert.getSubjectDN().toString();
+                                subjectDN = cert.getSubjectDN();
+                                subjectID = subjectDN == null ? "" : subjectDN.toString();
+                                serial = cert.getSerialNumber();
+                                certID = serial == null ? "" : serial.toString();
+                                issuerDN = cert.getIssuerDN();
+                                issuerID = issuerDN == null ? "" : issuerDN.toString();
                             }
                         }
                     }
@@ -319,11 +369,15 @@ public class PKIServerSocketListener implements SSLSocketListener {
             logger.debug("- client: " + clientIP);
             logger.debug("- server: " + serverIP);
             logger.debug("- subject: " + subjectID);
+            logger.debug("- serial: " + certID);
+            logger.debug("- issuer: " + issuerID);
 
             auditor.log(AccessSessionEstablishEvent.createSuccessEvent(
                     clientIP,
                     serverIP,
-                    subjectID));
+                    subjectID,
+                    certID,
+                    issuerID));
         } catch (Exception e) {
             logger.error("PKIServerSocketListener: " + e.getMessage(), e);
         }


### PR DESCRIPTION
When acting as server SSL logs where reporting in log and audit only the certificate subject. Since a client could use a certificate from other CAs to access, the issuer and the serial number of the certificate are included in the audit for a better identification.

To work properly in all condition this requires also https://github.com/dogtagpki/jss/pull/1008