### PR TITLE
Fix CA with secure ds CI failure

### DIFF
--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -97,7 +97,7 @@ jobs:
           docker cp primary:ds_server.p12 primaryds_server.p12
           tests/bin/ds-container-certs-import.sh primaryds primaryds_server.p12
           tests/bin/ds-container-stop.sh primaryds
-          tests/bin/ds-container-start.sh primaryds
+          tests/bin/ds-container-start.sh --image=pki-runner primaryds
 
       - name: Install CA in primary PKI container
         run: |
@@ -203,7 +203,7 @@ jobs:
           docker cp secondary:ds_server.p12 secondaryds_server.p12
           tests/bin/ds-container-certs-import.sh secondaryds secondaryds_server.p12
           tests/bin/ds-container-stop.sh secondaryds
-          tests/bin/ds-container-start.sh secondaryds
+          tests/bin/ds-container-start.sh --image=pki-runner secondaryds
 
       - name: Install CA in secondary PKI container
         run: |

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -96,7 +96,7 @@ jobs:
           docker cp pki:ds_server.p12 ds_server.p12
           tests/bin/ds-container-certs-import.sh ds ds_server.p12
           tests/bin/ds-container-stop.sh ds
-          tests/bin/ds-container-start.sh ds
+          tests/bin/ds-container-start.sh --image=pki-runner ds
 
       - name: Install CA
         run: |


### PR DESCRIPTION
DS container uses pki-runner image when configured with a certificate and this has to be specified with the start script otherwise the startup take in account the steps for quay.io ds image which is differently configured.

The CA clone with secure DS is still failing in my test but it is in a different place many step after the current error. I am investigating that issue and add to this PR or following PR.