### PR TITLE
Fix config file owners and permissions for containers

### DIFF
--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -252,7 +252,7 @@ jobs:
           # TODO: review owners/permissions
           cat > expected << EOF
           drwxrwxrwx 17 root Catalina
-          drwxrwx--- 17 root alias
+          drwxrwxrwx 17 root alias
           drwxrwxrwx 17 root ca
           -rw-rw-rw- 17 root catalina.policy
           lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
@@ -260,9 +260,9 @@ jobs:
           lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
           -rw-rw-rw- 17 root jss.conf
           lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw---- 17 root password.conf
+          -rw-rw-rw- 17 root password.conf
           -rw-rw-rw- 17 root server.xml
-          -rw-rw---- 17 root serverCertNick.conf
+          -rw-rw-rw- 17 root serverCertNick.conf
           -rw-rw-rw- 17 root tomcat.conf
           lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
           EOF
@@ -283,18 +283,18 @@ jobs:
           # TODO: review owners/permissions
           cat > expected << EOF
           -rw-rw-rw- 17 root CS.cfg
-          -rw-rw---- 17 root adminCert.profile
+          -rw-rw-rw- 17 root adminCert.profile
           drwxrwxrwx 17 root archives
-          -rw-rw---- 17 root caAuditSigningCert.profile
-          -rw-rw---- 17 root caCert.profile
-          -rw-rw---- 17 root caOCSPCert.profile
-          drwxrwx--- 17 root emails
-          -rw-rw---- 17 root flatfile.txt
-          drwxrwx--- 17 root profiles
-          -rw-rw---- 17 root proxy.conf
+          -rw-rw-rw- 17 root caAuditSigningCert.profile
+          -rw-rw-rw- 17 root caCert.profile
+          -rw-rw-rw- 17 root caOCSPCert.profile
+          drwxrwxrwx 17 root emails
+          -rw-rw-rw- 17 root flatfile.txt
+          drwxrwxrwx 17 root profiles
+          -rw-rw-rw- 17 root proxy.conf
           -rw-rw-rw- 17 root registry.cfg
-          -rw-rw---- 17 root serverCert.profile
-          -rw-rw---- 17 root subsystemCert.profile
+          -rw-rw-rw- 17 root serverCert.profile
+          -rw-rw-rw- 17 root subsystemCert.profile
           EOF
 
           diff expected output

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -368,7 +368,7 @@ jobs:
           # TODO: review owners/permissions
           cat > expected << EOF
           drwxrwxrwx 17 root Catalina
-          drwxrwx--- 17 root alias
+          drwxrwxrwx 17 root alias
           -rw-rw-rw- 17 root catalina.policy
           lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
           drwxrwxrwx 17 root certs
@@ -376,9 +376,9 @@ jobs:
           -rw-rw-rw- 17 root jss.conf
           drwxrwxrwx 17 root kra
           lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw---- 17 root password.conf
+          -rw-rw-rw- 17 root password.conf
           -rw-rw-rw- 17 root server.xml
-          -rw-rw---- 17 root serverCertNick.conf
+          -rw-rw-rw- 17 root serverCertNick.conf
           -rw-rw-rw- 17 root tomcat.conf
           lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
           EOF
@@ -400,7 +400,7 @@ jobs:
           cat > expected << EOF
           -rw-rw-rw- 17 root CS.cfg
           drwxrwxrwx 17 root archives
-          -rw-rw-r-- 17 root registry.cfg
+          -rw-rw-rw- 17 root registry.cfg
           EOF
 
           diff expected output

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -354,7 +354,7 @@ jobs:
           # TODO: review owners/permissions
           cat > expected << EOF
           drwxrwxrwx 17 root Catalina
-          drwxrwx--- 17 root alias
+          drwxrwxrwx 17 root alias
           -rw-rw-rw- 17 root catalina.policy
           lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
           drwxrwxrwx 17 root certs
@@ -362,9 +362,9 @@ jobs:
           -rw-rw-rw- 17 root jss.conf
           lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
           drwxrwxrwx 17 root ocsp
-          -rw-rw---- 17 root password.conf
+          -rw-rw-rw- 17 root password.conf
           -rw-rw-rw- 17 root server.xml
-          -rw-rw---- 17 root serverCertNick.conf
+          -rw-rw-rw- 17 root serverCertNick.conf
           -rw-rw-rw- 17 root tomcat.conf
           lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
           EOF
@@ -386,7 +386,7 @@ jobs:
           cat > expected << EOF
           -rw-rw-rw- 17 root CS.cfg
           drwxrwxrwx 17 root archives
-          -rw-rw-r-- 17 root registry.cfg
+          -rw-rw-rw- 17 root registry.cfg
           EOF
 
           diff expected output

--- a/base/acme/bin/pki-acme-run
+++ b/base/acme/bin/pki-acme-run
@@ -19,9 +19,6 @@ then
 else
     echo "INFO: Creating /data/conf"
     cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
-    chown -Rf pkiuser:root /data/conf
-    find /data/conf -type f -exec chmod +rw -- {} +
-    find /data/conf -type d -exec chmod +rwx -- {} +
 fi
 
 echo "################################################################################"

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -16,9 +16,6 @@ then
 else
     echo "INFO: Creating /data/conf"
     cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
-    chown -Rf pkiuser:root /data/conf
-    find /data/conf -type f -exec chmod +rw -- {} +
-    find /data/conf -type d -exec chmod +rwx -- {} +
 fi
 
 echo "################################################################################"
@@ -385,6 +382,13 @@ echo "INFO: Configuring PKI CA"
 
 pki-server ca-config-set internaldb.minConns 0
 pki-server ca-config-set ca.authorityMonitor.enable false
+
+echo "################################################################################"
+echo "INFO: Updating owners and permissions"
+
+chown -Rf pkiuser:root /data/conf
+find /data/conf -type f -exec chmod +rw -- {} +
+find /data/conf -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 echo "INFO: Starting PKI CA"

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -16,9 +16,6 @@ then
 else
     echo "INFO: Creating /data/conf"
     cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
-    chown -Rf pkiuser:root /data/conf
-    find /data/conf -type f -exec chmod +rw -- {} +
-    find /data/conf -type d -exec chmod +rwx -- {} +
 fi
 
 echo "################################################################################"
@@ -161,6 +158,13 @@ echo "##########################################################################
 echo "INFO: Configuring PKI KRA"
 
 pki-server kra-config-set internaldb.minConns 0
+
+echo "################################################################################"
+echo "INFO: Updating owners and permissions"
+
+chown -Rf pkiuser:root /data/conf
+find /data/conf -type f -exec chmod +rw -- {} +
+find /data/conf -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 echo "INFO: Starting PKI KRA"

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -16,9 +16,6 @@ then
 else
     echo "INFO: Creating /data/conf"
     cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
-    chown -Rf pkiuser:root /data/conf
-    find /data/conf -type f -exec chmod +rw -- {} +
-    find /data/conf -type d -exec chmod +rwx -- {} +
 fi
 
 echo "################################################################################"
@@ -158,6 +155,13 @@ echo "##########################################################################
 echo "INFO: Configuring OCSP Responder"
 
 pki-server ocsp-config-set internaldb.minConns 0
+
+echo "################################################################################"
+echo "INFO: Updating owners and permissions"
+
+chown -Rf pkiuser:root /data/conf
+find /data/conf -type f -exec chmod +rw -- {} +
+find /data/conf -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 echo "INFO: Starting OCSP Responder"

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -19,9 +19,6 @@ then
 else
     echo "INFO: Creating /data/conf"
     cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
-    chown -Rf pkiuser:root /data/conf
-    find /data/conf -type f -exec chmod +rw -- {} +
-    find /data/conf -type d -exec chmod +rwx -- {} +
 fi
 
 echo "################################################################################"
@@ -192,6 +189,13 @@ then
         --trust CT,C,C \
         ca_signing
 fi
+
+echo "################################################################################"
+echo "INFO: Updating owners and permissions"
+
+chown -Rf pkiuser:root /data/conf
+find /data/conf -type f -exec chmod +rw -- {} +
+find /data/conf -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 echo "INFO: Starting PKI server"


### PR DESCRIPTION
The container startup scripts have been modified to update the owners and permissions after the configuration is done such that the config files will have the proper owners and permissions.

Note: Some files created at runtime (e.g. log files) still have inconsistent owners/permissions. These files will be fixed separately later.