### PR TITLE
Update container tests to use Podman

### DIFF
--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -13,6 +13,15 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+
+          # Currently certbot fails to run inside podman.
+          # TODO: Replace docker with podman when the issue is resolved.
+          # sudo apt-get -y purge --auto-remove docker-ce-cli
+          # sudo apt-get -y install podman-docker
+
       - name: Clone repository
         uses: actions/checkout@v4
 
@@ -30,12 +39,10 @@ jobs:
 
       - name: Set up client container
         run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client.example.com
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              client
 
       - name: Install dependencies in client container
         run: docker exec client dnf install -y certbot
@@ -81,14 +88,14 @@ jobs:
           ls -l data \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by root group (GID=0)
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root conf
-          drwxrwxrwx 17 root logs
+          drwxrwxrwx root conf
+          drwxrwxrwx root logs
           EOF
 
           diff expected output
@@ -99,25 +106,25 @@ jobs:
           ls -l data/conf \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by root group (GID=0)
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root Catalina
-          drwxrwxrwx 17 root acme
-          drwxrwxrwx 17 root alias
-          -rw-rw-rw- 17 root catalina.policy
-          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx 17 root certs
-          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- 17 root jss.conf
-          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- 17 root password.conf
-          -rw-rw-rw- 17 root server.xml
-          -rw-rw-rw- 17 root tomcat.conf
-          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx root Catalina
+          drwxrwxrwx root acme
+          drwxrwxrwx root alias
+          -rw-rw-rw- root catalina.policy
+          lrwxrwxrwx root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx root certs
+          lrwxrwxrwx root context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- root jss.conf
+          lrwxrwxrwx root logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- root password.conf
+          -rw-rw-rw- root server.xml
+          -rw-rw-rw- root tomcat.conf
+          lrwxrwxrwx root web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -128,15 +135,15 @@ jobs:
           ls -l data/conf/acme \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by root group (GID=0)
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- 17 root database.conf
-          -rw-rw-rw- 17 root issuer.conf
-          -rw-rw-rw- 17 root realm.conf
+          -rw-rw-rw- root database.conf
+          -rw-rw-rw- root issuer.conf
+          -rw-rw-rw- root realm.conf
           EOF
 
           diff expected output
@@ -147,21 +154,21 @@ jobs:
           ls -l data/logs \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by root group (GID=0)
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwx--- 17 root backup
-          -rw-rw-rw- 17 root catalina.$DATE.log
-          -rw-rw-rw- 17 root host-manager.$DATE.log
-          -rw-rw-rw- 17 root localhost.$DATE.log
-          -rw-rw-rw- 17 root localhost_access_log.$DATE.txt
-          -rw-rw-rw- 17 root manager.$DATE.log
-          drwxrwxrwx 17 root pki
+          drwxrwx--- root backup
+          -rw-rw-rw- root catalina.$DATE.log
+          -rw-rw-rw- root host-manager.$DATE.log
+          -rw-rw-rw- root localhost.$DATE.log
+          -rw-rw-rw- root localhost_access_log.$DATE.txt
+          -rw-rw-rw- root manager.$DATE.log
+          drwxrwxrwx root pki
           EOF
 
           diff expected output
@@ -244,6 +251,11 @@ jobs:
         run: |
           docker logs acme 2>&1
 
+      - name: Check certbot logs
+        if: always()
+        run: |
+          docker exec client cat /var/log/letsencrypt/letsencrypt.log
+
       - name: Check client container logs
         if: always()
         run: |
@@ -252,13 +264,15 @@ jobs:
       - name: Gather artifacts
         if: always()
         run: |
-          docker exec acme ls -la /etc/pki/pki-tomcat
-          mkdir -p /tmp/artifacts/acme/etc/pki
-          docker cp acme:/etc/pki/pki-tomcat /tmp/artifacts/acme/etc/pki
+          mkdir -p /tmp/artifacts/acme
+          cp -r certs /tmp/artifacts/acme
+          cp -r metadata /tmp/artifacts/acme
+          cp -r database /tmp/artifacts/acme
+          cp -r issuer /tmp/artifacts/acme
+          cp -r realm /tmp/artifacts/acme
+          cp -r data /tmp/artifacts/acme
 
-          docker exec acme ls -la /var/log/pki/pki-tomcat
-          mkdir -p /tmp/artifacts/acme/var/log/pki
-          docker cp acme:/var/log/pki/pki-tomcat /tmp/artifacts/acme/var/log/pki
+          docker logs acme > /tmp/artifacts/acme/container.out 2> /tmp/artifacts/acme/container.err
 
           docker exec client ls -la /etc/letsencrypt/live
           mkdir -p /tmp/artifacts/client/etc/letsencrypt

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -13,6 +13,14 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+
+          # replace docker with podman
+          sudo apt-get -y purge --auto-remove docker-ce-cli
+          sudo apt-get -y install podman-docker
+
       - name: Clone repository
         uses: actions/checkout@v4
 
@@ -35,12 +43,10 @@ jobs:
 
       - name: Set up client container
         run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client.example.com
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              client
 
       - name: Create CA signing cert
         run: |
@@ -227,14 +233,14 @@ jobs:
           ls -l data \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root conf
-          drwxrwxrwx 17 root logs
+          drwxrwxrwx docker conf
+          drwxrwxrwx docker logs
           EOF
 
           diff expected output
@@ -245,26 +251,26 @@ jobs:
           ls -l data/conf \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root Catalina
-          drwxrwxrwx 17 root alias
-          drwxrwxrwx 17 root ca
-          -rw-rw-rw- 17 root catalina.policy
-          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx 17 root certs
-          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- 17 root jss.conf
-          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- 17 root password.conf
-          -rw-rw-rw- 17 root server.xml
-          -rw-rw-rw- 17 root serverCertNick.conf
-          -rw-rw-rw- 17 root tomcat.conf
-          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx docker Catalina
+          drwxrwxrwx docker alias
+          drwxrwxrwx docker ca
+          -rw-rw-rw- docker catalina.policy
+          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx docker certs
+          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- docker jss.conf
+          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- docker password.conf
+          -rw-rw-rw- docker server.xml
+          -rw-rw-rw- docker serverCertNick.conf
+          -rw-rw-rw- docker tomcat.conf
+          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -275,26 +281,26 @@ jobs:
           ls -l data/conf/ca \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
                   -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- 17 root CS.cfg
-          -rw-rw-rw- 17 root adminCert.profile
-          drwxrwxrwx 17 root archives
-          -rw-rw-rw- 17 root caAuditSigningCert.profile
-          -rw-rw-rw- 17 root caCert.profile
-          -rw-rw-rw- 17 root caOCSPCert.profile
-          drwxrwxrwx 17 root emails
-          -rw-rw-rw- 17 root flatfile.txt
-          drwxrwxrwx 17 root profiles
-          -rw-rw-rw- 17 root proxy.conf
-          -rw-rw-rw- 17 root registry.cfg
-          -rw-rw-rw- 17 root serverCert.profile
-          -rw-rw-rw- 17 root subsystemCert.profile
+          -rw-rw-rw- docker CS.cfg
+          -rw-rw-rw- docker adminCert.profile
+          drwxrwxrwx docker archives
+          -rw-rw-rw- docker caAuditSigningCert.profile
+          -rw-rw-rw- docker caCert.profile
+          -rw-rw-rw- docker caOCSPCert.profile
+          drwxrwxrwx docker emails
+          -rw-rw-rw- docker flatfile.txt
+          drwxrwxrwx docker profiles
+          -rw-rw-rw- docker proxy.conf
+          -rw-rw-rw- docker registry.cfg
+          -rw-rw-rw- docker serverCert.profile
+          -rw-rw-rw- docker subsystemCert.profile
           EOF
 
           diff expected output
@@ -305,22 +311,22 @@ jobs:
           ls -l data/logs \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwx--- 17 root backup
-          drwxrwx--- 17 root ca
-          -rw-rw-r-- 17 root catalina.$DATE.log
-          -rw-rw-r-- 17 root host-manager.$DATE.log
-          -rw-rw-r-- 17 root localhost.$DATE.log
-          -rw-rw-rw- 17 root localhost_access_log.$DATE.txt
-          -rw-rw-r-- 17 root manager.$DATE.log
-          drwxrwxrwx 17 root pki
+          drwxrwx--- docker backup
+          drwxrwx--- docker ca
+          -rw-rw-r-- docker catalina.$DATE.log
+          -rw-rw-r-- docker host-manager.$DATE.log
+          -rw-rw-r-- docker localhost.$DATE.log
+          -rw-rw-rw- docker localhost_access_log.$DATE.txt
+          -rw-rw-r-- docker manager.$DATE.log
+          drwxrwxrwx docker pki
           EOF
 
           diff expected output
@@ -339,14 +345,13 @@ jobs:
 
       - name: Set up DS container
         run: |
-          tests/bin/ds-container-create.sh ds
-        env:
-          IMAGE: ${{ env.DB_IMAGE }}
-          HOSTNAME: ds.example.com
-          PASSWORD: Secret.123
-
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
+          tests/bin/ds-container-create.sh \
+              --image=${{ env.DB_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
       - name: Initialize CA database
@@ -565,13 +570,9 @@ jobs:
         run: |
           tests/bin/ds-artifacts-save.sh ds
 
-          docker exec ca ls -la /etc/pki
-          mkdir -p /tmp/artifacts/ca/etc/pki
-          docker cp ca:/etc/pki/pki.conf /tmp/artifacts/ca/etc/pki
-
-          docker exec ca ls -la /var/log/pki
-          mkdir -p /tmp/artifacts/ca/var/log
-          docker cp ca:/var/log/pki /tmp/artifacts/ca/var/log
+          mkdir -p /tmp/artifacts/ca
+          cp -r certs /tmp/artifacts/ca
+          cp -r data /tmp/artifacts/ca
 
           docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
 

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -13,6 +13,14 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+
+          # replace docker with podman
+          sudo apt-get -y purge --auto-remove docker-ce-cli
+          sudo apt-get -y install podman-docker
+
       - name: Clone repository
         uses: actions/checkout@v4
 
@@ -37,12 +45,10 @@ jobs:
 
       - name: Set up client container
         run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client.example.com
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              client
 
       - name: Set up CA container
         run: |
@@ -70,14 +76,13 @@ jobs:
 
       - name: Set up CA DS container
         run: |
-          tests/bin/ds-container-create.sh cads
-        env:
-          IMAGE: ${{ env.DB_IMAGE }}
-          HOSTNAME: cads.example.com
-          PASSWORD: Secret.123
-
-      - name: Connect CA DS container to network
-        run: docker network connect example cads --alias cads.example.com
+          tests/bin/ds-container-create.sh \
+              --image=${{ env.DB_IMAGE }} \
+              --hostname=cads.example.com \
+              --network=example \
+              --network-alias=cads.example.com \
+              --password=Secret.123 \
+              cads
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
       - name: Initialize CA database
@@ -343,14 +348,14 @@ jobs:
           ls -l kra/data \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root conf
-          drwxrwxrwx 17 root logs
+          drwxrwxrwx docker conf
+          drwxrwxrwx docker logs
           EOF
 
           diff expected output
@@ -361,26 +366,26 @@ jobs:
           ls -l kra/data/conf \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root Catalina
-          drwxrwxrwx 17 root alias
-          -rw-rw-rw- 17 root catalina.policy
-          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx 17 root certs
-          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- 17 root jss.conf
-          drwxrwxrwx 17 root kra
-          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- 17 root password.conf
-          -rw-rw-rw- 17 root server.xml
-          -rw-rw-rw- 17 root serverCertNick.conf
-          -rw-rw-rw- 17 root tomcat.conf
-          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx docker Catalina
+          drwxrwxrwx docker alias
+          -rw-rw-rw- docker catalina.policy
+          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx docker certs
+          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- docker jss.conf
+          drwxrwxrwx docker kra
+          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- docker password.conf
+          -rw-rw-rw- docker server.xml
+          -rw-rw-rw- docker serverCertNick.conf
+          -rw-rw-rw- docker tomcat.conf
+          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -391,16 +396,16 @@ jobs:
           ls -l kra/data/conf/kra \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
-                  -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+                  -e '/^\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- 17 root CS.cfg
-          drwxrwxrwx 17 root archives
-          -rw-rw-rw- 17 root registry.cfg
+          -rw-rw-rw- docker CS.cfg
+          drwxrwxrwx docker archives
+          -rw-rw-rw- docker registry.cfg
           EOF
 
           diff expected output
@@ -411,21 +416,22 @@ jobs:
           ls -l kra/data/logs \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
           DATE=$(date +'%Y-%m-%d')
 
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwx--- 17 root backup
-          -rw-rw-r-- 17 root catalina.$DATE.log
-          -rw-rw-r-- 17 root host-manager.$DATE.log
-          drwxrwx--- 17 root kra
-          -rw-rw-r-- 17 root localhost.$DATE.log
-          -rw-rw-rw- 17 root localhost_access_log.$DATE.txt
-          -rw-rw-r-- 17 root manager.$DATE.log
-          drwxrwxrwx 17 root pki
+          drwxrwx--- docker backup
+          -rw-rw-r-- docker catalina.$DATE.log
+          -rw-rw-r-- docker host-manager.$DATE.log
+          drwxrwx--- docker kra
+          -rw-rw-r-- docker localhost.$DATE.log
+          -rw-rw-rw- docker localhost_access_log.$DATE.txt
+          -rw-rw-r-- docker manager.$DATE.log
+          drwxrwxrwx docker pki
           EOF
 
           diff expected output
@@ -444,14 +450,13 @@ jobs:
 
       - name: Set up KRA DS container
         run: |
-          tests/bin/ds-container-create.sh krads
-        env:
-          IMAGE: ${{ env.DB_IMAGE }}
-          HOSTNAME: krads.example.com
-          PASSWORD: Secret.123
-
-      - name: Connect KRA DS container to network
-        run: docker network connect example krads --alias krads.example.com
+          tests/bin/ds-container-create.sh \
+              --image=${{ env.DB_IMAGE }} \
+              --hostname=krads.example.com \
+              --network=example \
+              --network-alias=krads.example.com \
+              --password=Secret.123 \
+              krads
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-KRA-Database
       - name: Set up KRA database
@@ -731,25 +736,17 @@ jobs:
         run: |
           tests/bin/ds-artifacts-save.sh cads
 
-          docker exec ca ls -la /etc/pki
-          mkdir -p /tmp/artifacts/ca/etc/pki
-          docker cp ca:/etc/pki/pki.conf /tmp/artifacts/ca/etc/pki
-
-          docker exec ca ls -la /var/log/pki
-          mkdir -p /tmp/artifacts/ca/var/log
-          docker cp ca:/var/log/pki /tmp/artifacts/ca/var/log
+          mkdir -p /tmp/artifacts/ca
+          cp -r ca/certs /tmp/artifacts/ca
+          cp -r ca/data /tmp/artifacts/ca
 
           docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
 
           tests/bin/ds-artifacts-save.sh krads
 
-          docker exec kra ls -la /etc/pki
-          mkdir -p /tmp/artifacts/kra/etc/pki
-          docker cp kra:/etc/pki/pki.conf /tmp/artifacts/kra/etc/pki
-
-          docker exec kra ls -la /var/log/pki
-          mkdir -p /tmp/artifacts/kra/var/log
-          docker cp kra:/var/log/pki /tmp/artifacts/kra/var/log
+          mkdir -p /tmp/artifacts/kra
+          cp -r kra/certs /tmp/artifacts/kra
+          cp -r kra/data /tmp/artifacts/kra
 
           docker logs kra > /tmp/artifacts/kra/container.out 2> /tmp/artifacts/kra/container.err
 

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -18,6 +18,10 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install libxml2-utils
 
+          # replace docker with podman
+          sudo apt-get -y purge --auto-remove docker-ce-cli
+          sudo apt-get -y install podman-docker
+
       - name: Clone repository
         uses: actions/checkout@v4
 
@@ -42,12 +46,10 @@ jobs:
 
       - name: Set up client container
         run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client.example.com
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              client
 
       - name: Set up CA container
         run: |
@@ -75,14 +77,13 @@ jobs:
 
       - name: Set up CA DS container
         run: |
-          tests/bin/ds-container-create.sh cads
-        env:
-          IMAGE: ${{ env.DB_IMAGE }}
-          HOSTNAME: cads.example.com
-          PASSWORD: Secret.123
-
-      - name: Connect CA DS container to network
-        run: docker network connect example cads --alias cads.example.com
+          tests/bin/ds-container-create.sh \
+              --image=${{ env.DB_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=cads.example.com \
+              --password=Secret.123 \
+              cads
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
       - name: Initialize CA database
@@ -329,14 +330,14 @@ jobs:
           ls -l ocsp/data \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root conf
-          drwxrwxrwx 17 root logs
+          drwxrwxrwx docker conf
+          drwxrwxrwx docker logs
           EOF
 
           diff expected output
@@ -347,26 +348,26 @@ jobs:
           ls -l ocsp/data/conf \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root Catalina
-          drwxrwxrwx 17 root alias
-          -rw-rw-rw- 17 root catalina.policy
-          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx 17 root certs
-          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- 17 root jss.conf
-          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
-          drwxrwxrwx 17 root ocsp
-          -rw-rw-rw- 17 root password.conf
-          -rw-rw-rw- 17 root server.xml
-          -rw-rw-rw- 17 root serverCertNick.conf
-          -rw-rw-rw- 17 root tomcat.conf
-          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx docker Catalina
+          drwxrwxrwx docker alias
+          -rw-rw-rw- docker catalina.policy
+          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx docker certs
+          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- docker jss.conf
+          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
+          drwxrwxrwx docker ocsp
+          -rw-rw-rw- docker password.conf
+          -rw-rw-rw- docker server.xml
+          -rw-rw-rw- docker serverCertNick.conf
+          -rw-rw-rw- docker tomcat.conf
+          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -377,16 +378,16 @@ jobs:
           ls -l ocsp/data/conf/ocsp \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
-                  -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+                  -e '/^\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- 17 root CS.cfg
-          drwxrwxrwx 17 root archives
-          -rw-rw-rw- 17 root registry.cfg
+          -rw-rw-rw- docker CS.cfg
+          drwxrwxrwx docker archives
+          -rw-rw-rw- docker registry.cfg
           EOF
 
           diff expected output
@@ -397,21 +398,22 @@ jobs:
           ls -l ocsp/data/logs \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
           DATE=$(date +'%Y-%m-%d')
 
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwx--- 17 root backup
-          -rw-rw-rw- 17 root catalina.$DATE.log
-          -rw-rw-rw- 17 root host-manager.$DATE.log
-          -rw-rw-rw- 17 root localhost.$DATE.log
-          -rw-rw-rw- 17 root localhost_access_log.$DATE.txt
-          -rw-rw-rw- 17 root manager.$DATE.log
-          drwxrwx--- 17 root ocsp
-          drwxrwxrwx 17 root pki
+          drwxrwx--- docker backup
+          -rw-rw-rw- docker catalina.$DATE.log
+          -rw-rw-rw- docker host-manager.$DATE.log
+          -rw-rw-rw- docker localhost.$DATE.log
+          -rw-rw-rw- docker localhost_access_log.$DATE.txt
+          -rw-rw-rw- docker manager.$DATE.log
+          drwxrwx--- docker ocsp
+          drwxrwxrwx docker pki
           EOF
 
           diff expected output
@@ -430,14 +432,13 @@ jobs:
 
       - name: Set up OCSP DS container
         run: |
-          tests/bin/ds-container-create.sh ocspds
-        env:
-          IMAGE: ${{ env.DB_IMAGE }}
-          HOSTNAME: ocspds.example.com
-          PASSWORD: Secret.123
-
-      - name: Connect OCSP DS container to network
-        run: docker network connect example ocspds --alias ocspds.example.com
+          tests/bin/ds-container-create.sh \
+              --image=${{ env.DB_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ocspds.example.com \
+              --password=Secret.123 \
+              ocspds
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-OCSP-Database
       - name: Set up OCSP database
@@ -753,25 +754,17 @@ jobs:
         run: |
           tests/bin/ds-artifacts-save.sh cads
 
-          docker exec ca ls -la /etc/pki
-          mkdir -p /tmp/artifacts/ca/etc/pki
-          docker cp ca:/etc/pki/pki.conf /tmp/artifacts/ca/etc/pki
-
-          docker exec ca ls -la /var/log/pki
-          mkdir -p /tmp/artifacts/ca/var/log
-          docker cp ca:/var/log/pki /tmp/artifacts/ca/var/log
+          mkdir -p /tmp/artifacts/ca
+          cp -r ca/certs /tmp/artifacts/ca
+          cp -r ca/data /tmp/artifacts/ca
 
           docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
 
           tests/bin/ds-artifacts-save.sh ocspds
 
-          docker exec ocsp ls -la /etc/pki
-          mkdir -p /tmp/artifacts/ocsp/etc/pki
-          docker cp ocsp:/etc/pki/pki.conf /tmp/artifacts/ocsp/etc/pki
-
-          docker exec ocsp ls -la /var/log/pki
-          mkdir -p /tmp/artifacts/ocsp/var/log
-          docker cp ocsp:/var/log/pki /tmp/artifacts/ocsp/var/log
+          mkdir -p /tmp/artifacts/ocsp
+          cp -r ocsp/certs /tmp/artifacts/ocsp
+          cp -r ocsp/data /tmp/artifacts/ocsp
 
           docker logs ocsp > /tmp/artifacts/ocsp/container.out 2> /tmp/artifacts/ocsp/container.err
 

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -13,6 +13,14 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+
+          # replace docker with podman
+          sudo apt-get -y purge --auto-remove docker-ce-cli
+          sudo apt-get -y install podman-docker
+
       - name: Clone repository
         uses: actions/checkout@v4
 
@@ -35,12 +43,10 @@ jobs:
 
       - name: Set up client container
         run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client.example.com
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              client
 
       - name: Set up server container
         run: |
@@ -70,14 +76,14 @@ jobs:
           ls -l data \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root conf
-          drwxrwxrwx 17 root logs
+          drwxrwxrwx docker conf
+          drwxrwxrwx docker logs
           EOF
 
           diff expected output
@@ -88,24 +94,24 @@ jobs:
           ls -l data/conf \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx 17 root Catalina
-          drwxrwxrwx 17 root alias
-          -rw-rw-rw- 17 root catalina.policy
-          lrwxrwxrwx 17 root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx 17 root certs
-          lrwxrwxrwx 17 root context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- 17 root jss.conf
-          lrwxrwxrwx 17 root logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- 17 root password.conf
-          -rw-rw-rw- 17 root server.xml
-          -rw-rw-rw- 17 root tomcat.conf
-          lrwxrwxrwx 17 root web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx docker Catalina
+          drwxrwxrwx docker alias
+          -rw-rw-rw- docker catalina.policy
+          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx docker certs
+          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- docker jss.conf
+          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- docker password.conf
+          -rw-rw-rw- docker server.xml
+          -rw-rw-rw- docker tomcat.conf
+          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -116,21 +122,21 @@ jobs:
           ls -l data/logs \
               | sed \
                   -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by pkiuser:root (UID=17, GID=0)
+          # everything should be owned by docker group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwx--- 17 root backup
-          -rw-rw-rw- 17 root catalina.$DATE.log
-          -rw-rw-rw- 17 root host-manager.$DATE.log
-          -rw-rw-rw- 17 root localhost.$DATE.log
-          -rw-rw-rw- 17 root localhost_access_log.$DATE.txt
-          -rw-rw-rw- 17 root manager.$DATE.log
-          drwxrwxrwx 17 root pki
+          drwxrwx--- docker backup
+          -rw-rw-rw- docker catalina.$DATE.log
+          -rw-rw-rw- docker host-manager.$DATE.log
+          -rw-rw-rw- docker localhost.$DATE.log
+          -rw-rw-rw- docker localhost_access_log.$DATE.txt
+          -rw-rw-rw- docker manager.$DATE.log
+          drwxrwxrwx docker pki
           EOF
 
           diff expected output
@@ -181,13 +187,9 @@ jobs:
       - name: Gather artifacts
         if: always()
         run: |
-          docker exec server ls -la /etc/pki
-          mkdir -p /tmp/artifacts/server/etc
-          docker cp server:/etc/pki /tmp/artifacts/server/etc
-
-          docker exec server ls -la /var/log/pki
-          mkdir -p /tmp/artifacts/server/var/log
-          docker cp server:/var/log/pki /tmp/artifacts/server/var/log
+          mkdir -p /tmp/artifacts/server
+          cp -r certs /tmp/artifacts/server
+          cp -r data /tmp/artifacts/server
 
           docker logs server > /tmp/artifacts/server/container.out 2> /tmp/artifacts/server/container.err
 

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -394,12 +394,12 @@ echo "##########################################################################
 echo "INFO: Starting PKI CA"
 
 if [ "$UID" = "0" ]; then
-    # In Docker/Podman the server runs as pkiuser (UID=17) that
-    # belongs to the root group (GID=0).
+    # In Docker the server runs as root user but it will switch
+    # into pkiuser (UID=17) that belongs to the root group (GID=0).
     pki-server run
 
 else
-    # In OpenShift the server runs as an OpenShift-assigned user
+    # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -170,12 +170,12 @@ echo "##########################################################################
 echo "INFO: Starting PKI KRA"
 
 if [ "$UID" = "0" ]; then
-    # In Docker/Podman the server runs as pkiuser (UID=17) that
-    # belongs to the root group (GID=0).
+    # In Docker the server runs as root user but it will switch
+    # into pkiuser (UID=17) that belongs to the root group (GID=0).
     pki-server run
 
 else
-    # In OpenShift the server runs as an OpenShift-assigned user
+    # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -167,12 +167,12 @@ echo "##########################################################################
 echo "INFO: Starting OCSP Responder"
 
 if [ "$UID" = "0" ]; then
-    # In Docker/Podman the server runs as pkiuser (UID=17) that
-    # belongs to the root group (GID=0).
+    # In Docker the server runs as root user but it will switch
+    # into pkiuser (UID=17) that belongs to the root group (GID=0).
     pki-server run
 
 else
-    # In OpenShift the server runs as an OpenShift-assigned user
+    # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -201,12 +201,12 @@ echo "##########################################################################
 echo "INFO: Starting PKI server"
 
 if [ "$UID" = "0" ]; then
-    # In Docker/Podman the server runs as pkiuser (UID=17) that
-    # belongs to the root group (GID=0).
+    # In Docker the server runs as root user but it will switch
+    # into pkiuser (UID=17) that belongs to the root group (GID=0).
     pki-server run
 
 else
-    # In OpenShift the server runs as an OpenShift-assigned user
+    # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id


### PR DESCRIPTION
The container tests have been updated to use Podman instead of Docker (except for ACME container test due to a compatibility issue with Certbot). The `docker` command is now just an alias to `podman`.

In Podman the containers will run as a non-root user with random UID so the tests now will only verify the group owner of the files.

Also in Podman the containers need to be connected to the network as soon as it's created using `docker run` command instead of using a separate `docker network connect` command.

The tests have also been updated to capture the files generated by the containers in the shared folders.