### PR TITLE
Split container data folder

### DIFF
--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -54,7 +54,8 @@ jobs:
           mkdir database
           mkdir issuer
           mkdir realm
-          mkdir data
+          mkdir conf
+          mkdir logs
 
       - name: Set up ACME container
         run: |
@@ -68,7 +69,8 @@ jobs:
               -v $PWD/database:/database \
               -v $PWD/issuer:/issuer \
               -v $PWD/realm:/realm \
-              -v $PWD/data:/data \
+              -v $PWD/conf:/conf \
+              -v $PWD/logs:/logs \
               --detach \
               pki-acme
 
@@ -82,28 +84,10 @@ jobs:
               -o /dev/null \
               http://acme.example.com:8080/acme/directory
 
-      - name: Check data dir
+      - name: Check conf dir
         if: always()
         run: |
-          ls -l data \
-              | sed \
-                  -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
-              | tee output
-
-          # everything should be owned by root group (GID=0)
-          # TODO: review owners/permissions
-          cat > expected << EOF
-          drwxrwxrwx root conf
-          drwxrwxrwx root logs
-          EOF
-
-          diff expected output
-
-      - name: Check data/conf dir
-        if: always()
-        run: |
-          ls -l data/conf \
+          ls -l conf \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -129,10 +113,10 @@ jobs:
 
           diff expected output
 
-      - name: Check data/conf/acme dir
+      - name: Check conf/acme dir
         if: always()
         run: |
-          ls -l data/conf/acme \
+          ls -l conf/acme \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -148,10 +132,10 @@ jobs:
 
           diff expected output
 
-      - name: Check data/logs dir
+      - name: Check logs dir
         if: always()
         run: |
-          ls -l data/logs \
+          ls -l logs \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -270,7 +254,8 @@ jobs:
           cp -r database /tmp/artifacts/acme
           cp -r issuer /tmp/artifacts/acme
           cp -r realm /tmp/artifacts/acme
-          cp -r data /tmp/artifacts/acme
+          cp -r conf /tmp/artifacts/acme
+          cp -r logs /tmp/artifacts/acme
 
           docker logs acme > /tmp/artifacts/acme/container.out 2> /tmp/artifacts/acme/container.err
 

--- a/.github/workflows/ca-container-test.yml
+++ b/.github/workflows/ca-container-test.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Create shared folders
         run: |
           mkdir certs
-          mkdir data
+          mkdir conf
+          mkdir logs
 
       - name: Set up client container
         run: |
@@ -211,7 +212,8 @@ jobs:
               --network example \
               --network-alias ca.example.com \
               -v $PWD/certs:/certs \
-              -v $PWD/data:/data \
+              -v $PWD/conf:/conf \
+              -v $PWD/logs:/logs \
               -e PKI_DS_URL=ldap://ds.example.com:3389 \
               -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
@@ -227,28 +229,10 @@ jobs:
               -o /dev/null \
               https://ca.example.com:8443
 
-      - name: Check data dir
+      - name: Check conf dir
         if: always()
         run: |
-          ls -l data \
-              | sed \
-                  -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
-              | tee output
-
-          # everything should be owned by docker group
-          # TODO: review owners/permissions
-          cat > expected << EOF
-          drwxrwxrwx docker conf
-          drwxrwxrwx docker logs
-          EOF
-
-          diff expected output
-
-      - name: Check data/conf dir
-        if: always()
-        run: |
-          ls -l data/conf \
+          ls -l conf \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -275,10 +259,10 @@ jobs:
 
           diff expected output
 
-      - name: Check data/conf/ca dir
+      - name: Check conf/ca dir
         if: always()
         run: |
-          ls -l data/conf/ca \
+          ls -l conf/ca \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -305,10 +289,10 @@ jobs:
 
           diff expected output
 
-      - name: Check data/logs dir
+      - name: Check logs dir
         if: always()
         run: |
-          ls -l data/logs \
+          ls -l logs \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -320,12 +304,12 @@ jobs:
           # TODO: review owners/permissions
           cat > expected << EOF
           drwxrwx--- docker backup
-          drwxrwx--- docker ca
-          -rw-rw-r-- docker catalina.$DATE.log
-          -rw-rw-r-- docker host-manager.$DATE.log
-          -rw-rw-r-- docker localhost.$DATE.log
+          drwxrwxrwx docker ca
+          -rw-rw-rw- docker catalina.$DATE.log
+          -rw-rw-rw- docker host-manager.$DATE.log
+          -rw-rw-rw- docker localhost.$DATE.log
           -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-r-- docker manager.$DATE.log
+          -rw-rw-rw- docker manager.$DATE.log
           drwxrwxrwx docker pki
           EOF
 
@@ -572,7 +556,8 @@ jobs:
 
           mkdir -p /tmp/artifacts/ca
           cp -r certs /tmp/artifacts/ca
-          cp -r data /tmp/artifacts/ca
+          cp -r conf /tmp/artifacts/ca
+          cp -r logs /tmp/artifacts/ca
 
           docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
 

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -39,9 +39,11 @@ jobs:
       - name: Create shared folders
         run: |
           mkdir -p ca/certs
-          mkdir -p ca/data
+          mkdir -p ca/conf
+          mkdir -p ca/logs
           mkdir -p kra/certs
-          mkdir -p kra/data
+          mkdir -p kra/conf
+          mkdir -p kra/logs
 
       - name: Set up client container
         run: |
@@ -58,7 +60,8 @@ jobs:
               --network example \
               --network-alias ca.example.com \
               -v $PWD/ca/certs:/certs \
-              -v $PWD/ca/data:/data \
+              -v $PWD/ca/conf:/conf \
+              -v $PWD/ca/logs:/logs \
               -e PKI_DS_URL=ldap://cads.example.com:3389 \
               -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
@@ -203,7 +206,7 @@ jobs:
               --ext /usr/share/pki/server/certs/kra_storage.conf \
               --csr $SHARED/kra/certs/kra_storage.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/kra/certs/kra_storage.csr \
@@ -221,7 +224,7 @@ jobs:
               --ext /usr/share/pki/server/certs/kra_transport.conf \
               --csr $SHARED/kra/certs/kra_transport.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/kra/certs/kra_transport.csr \
@@ -239,7 +242,7 @@ jobs:
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               --csr $SHARED/kra/certs/audit_signing.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/kra/certs/audit_signing.csr \
@@ -258,7 +261,7 @@ jobs:
               --ext /usr/share/pki/server/certs/subsystem.conf \
               --csr $SHARED/kra/certs/subsystem.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/kra/certs/subsystem.csr \
@@ -276,7 +279,7 @@ jobs:
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --csr $SHARED/kra/certs/sslserver.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/kra/certs/sslserver.csr \
@@ -325,7 +328,8 @@ jobs:
               --network example \
               --network-alias kra.example.com \
               -v $PWD/kra/certs:/certs \
-              -v $PWD/kra/data:/data \
+              -v $PWD/kra/conf:/conf \
+              -v $PWD/kra/logs:/logs \
               -e PKI_DS_URL=ldap://krads.example.com:3389 \
               -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
@@ -342,28 +346,10 @@ jobs:
               -o /dev/null \
               https://kra.example.com:8443
 
-      - name: Check KRA data dir
+      - name: Check KRA conf dir
         if: always()
         run: |
-          ls -l kra/data \
-              | sed \
-                  -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
-              | tee output
-
-          # everything should be owned by docker group
-          # TODO: review owners/permissions
-          cat > expected << EOF
-          drwxrwxrwx docker conf
-          drwxrwxrwx docker logs
-          EOF
-
-          diff expected output
-
-      - name: Check KRA data/conf dir
-        if: always()
-        run: |
-          ls -l kra/data/conf \
+          ls -l kra/conf \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -390,10 +376,10 @@ jobs:
 
           diff expected output
 
-      - name: Check KRA data/conf/kra dir
+      - name: Check KRA conf/kra dir
         if: always()
         run: |
-          ls -l kra/data/conf/kra \
+          ls -l kra/conf/kra \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -410,10 +396,10 @@ jobs:
 
           diff expected output
 
-      - name: Check KRA data/logs dir
+      - name: Check KRA logs dir
         if: always()
         run: |
-          ls -l kra/data/logs \
+          ls -l kra/logs \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -425,12 +411,12 @@ jobs:
           # TODO: review owners/permissions
           cat > expected << EOF
           drwxrwx--- docker backup
-          -rw-rw-r-- docker catalina.$DATE.log
-          -rw-rw-r-- docker host-manager.$DATE.log
-          drwxrwx--- docker kra
-          -rw-rw-r-- docker localhost.$DATE.log
+          -rw-rw-rw- docker catalina.$DATE.log
+          -rw-rw-rw- docker host-manager.$DATE.log
+          drwxrwxrwx docker kra
+          -rw-rw-rw- docker localhost.$DATE.log
           -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-r-- docker manager.$DATE.log
+          -rw-rw-rw- docker manager.$DATE.log
           drwxrwxrwx docker pki
           EOF
 
@@ -738,7 +724,8 @@ jobs:
 
           mkdir -p /tmp/artifacts/ca
           cp -r ca/certs /tmp/artifacts/ca
-          cp -r ca/data /tmp/artifacts/ca
+          cp -r ca/conf /tmp/artifacts/ca
+          cp -r ca/logs /tmp/artifacts/ca
 
           docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
 
@@ -746,7 +733,8 @@ jobs:
 
           mkdir -p /tmp/artifacts/kra
           cp -r kra/certs /tmp/artifacts/kra
-          cp -r kra/data /tmp/artifacts/kra
+          cp -r kra/conf /tmp/artifacts/kra
+          cp -r kra/logs /tmp/artifacts/kra
 
           docker logs kra > /tmp/artifacts/kra/container.out 2> /tmp/artifacts/kra/container.err
 

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -40,9 +40,11 @@ jobs:
       - name: Create shared folders
         run: |
           mkdir -p ca/certs
-          mkdir -p ca/data
+          mkdir -p ca/conf
+          mkdir -p ca/logs
           mkdir -p ocsp/certs
-          mkdir -p ocsp/data
+          mkdir -p ocsp/conf
+          mkdir -p ocsp/logs
 
       - name: Set up client container
         run: |
@@ -59,7 +61,8 @@ jobs:
               --network example \
               --network-alias ca.example.com \
               -v $PWD/ca/certs:/certs \
-              -v $PWD/ca/data:/data \
+              -v $PWD/ca/conf:/conf \
+              -v $PWD/ca/logs:/logs \
               -e PKI_DS_URL=ldap://cads.example.com:3389 \
               -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
@@ -204,7 +207,7 @@ jobs:
               --ext /usr/share/pki/server/certs/ocsp_signing.conf \
               --csr $SHARED/ocsp/certs/ocsp_signing.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/ocsp/certs/ocsp_signing.csr \
@@ -222,7 +225,7 @@ jobs:
               --ext /usr/share/pki/server/certs/audit_signing.conf \
               --csr $SHARED/ocsp/certs/audit_signing.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/ocsp/certs/audit_signing.csr \
@@ -241,7 +244,7 @@ jobs:
               --ext /usr/share/pki/server/certs/subsystem.conf \
               --csr $SHARED/ocsp/certs/subsystem.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/ocsp/certs/subsystem.csr \
@@ -259,7 +262,7 @@ jobs:
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --csr $SHARED/ocsp/certs/sslserver.csr
           docker exec client pki \
-              -d $SHARED/ca/data/conf/alias \
+              -d $SHARED/ca/conf/alias \
               nss-cert-issue \
               --issuer ca_signing \
               --csr $SHARED/ocsp/certs/sslserver.csr \
@@ -307,7 +310,8 @@ jobs:
               --network example \
               --network-alias ocsp.example.com \
               -v $PWD/ocsp/certs:/certs \
-              -v $PWD/ocsp/data:/data \
+              -v $PWD/ocsp/conf:/conf \
+              -v $PWD/ocsp/logs:/logs \
               -e PKI_DS_URL=ldap://ocspds.example.com:3389 \
               -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
@@ -324,28 +328,10 @@ jobs:
               -o /dev/null \
               https://ocsp.example.com:8443
 
-      - name: Check OCSP data dir
+      - name: Check OCSP conf dir
         if: always()
         run: |
-          ls -l ocsp/data \
-              | sed \
-                  -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
-              | tee output
-
-          # everything should be owned by docker group
-          # TODO: review owners/permissions
-          cat > expected << EOF
-          drwxrwxrwx docker conf
-          drwxrwxrwx docker logs
-          EOF
-
-          diff expected output
-
-      - name: Check OCSP data/conf dir
-        if: always()
-        run: |
-          ls -l ocsp/data/conf \
+          ls -l ocsp/conf \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -372,10 +358,10 @@ jobs:
 
           diff expected output
 
-      - name: Check OCSP data/conf/ocsp dir
+      - name: Check OCSP conf/ocsp dir
         if: always()
         run: |
-          ls -l ocsp/data/conf/ocsp \
+          ls -l ocsp/conf/ocsp \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -392,10 +378,10 @@ jobs:
 
           diff expected output
 
-      - name: Check OCSP data/logs dir
+      - name: Check OCSP logs dir
         if: always()
         run: |
-          ls -l ocsp/data/logs \
+          ls -l ocsp/logs \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -412,7 +398,7 @@ jobs:
           -rw-rw-rw- docker localhost.$DATE.log
           -rw-rw-rw- docker localhost_access_log.$DATE.txt
           -rw-rw-rw- docker manager.$DATE.log
-          drwxrwx--- docker ocsp
+          drwxrwxrwx docker ocsp
           drwxrwxrwx docker pki
           EOF
 
@@ -756,7 +742,8 @@ jobs:
 
           mkdir -p /tmp/artifacts/ca
           cp -r ca/certs /tmp/artifacts/ca
-          cp -r ca/data /tmp/artifacts/ca
+          cp -r ca/conf /tmp/artifacts/ca
+          cp -r ca/logs /tmp/artifacts/ca
 
           docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
 
@@ -764,7 +751,8 @@ jobs:
 
           mkdir -p /tmp/artifacts/ocsp
           cp -r ocsp/certs /tmp/artifacts/ocsp
-          cp -r ocsp/data /tmp/artifacts/ocsp
+          cp -r ocsp/conf /tmp/artifacts/ocsp
+          cp -r ocsp/logs /tmp/artifacts/ocsp
 
           docker logs ocsp > /tmp/artifacts/ocsp/container.out 2> /tmp/artifacts/ocsp/container.err
 

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Create shared folders
         run: |
           mkdir certs
-          mkdir data
+          mkdir conf
+          mkdir logs
 
       - name: Set up client container
         run: |
@@ -56,7 +57,8 @@ jobs:
               --network example \
               --network-alias pki.example.com \
               -v $PWD/certs:/certs \
-              -v $PWD/data:/data \
+              -v $PWD/conf:/conf \
+              -v $PWD/logs:/logs \
               --detach \
               pki-server
 
@@ -70,28 +72,10 @@ jobs:
               -o /dev/null \
               https://pki.example.com:8443
 
-      - name: Check data dir
+      - name: Check conf dir
         if: always()
         run: |
-          ls -l data \
-              | sed \
-                  -e '/^total/d' \
-                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
-              | tee output
-
-          # everything should be owned by docker group
-          # TODO: review owners/permissions
-          cat > expected << EOF
-          drwxrwxrwx docker conf
-          drwxrwxrwx docker logs
-          EOF
-
-          diff expected output
-
-      - name: Check data/conf dir
-        if: always()
-        run: |
-          ls -l data/conf \
+          ls -l conf \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -116,10 +100,10 @@ jobs:
 
           diff expected output
 
-      - name: Check data/logs dir
+      - name: Check logs dir
         if: always()
         run: |
-          ls -l data/logs \
+          ls -l logs \
               | sed \
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
@@ -189,7 +173,8 @@ jobs:
         run: |
           mkdir -p /tmp/artifacts/server
           cp -r certs /tmp/artifacts/server
-          cp -r data /tmp/artifacts/server
+          cp -r conf /tmp/artifacts/server
+          cp -r logs /tmp/artifacts/server
 
           docker logs server > /tmp/artifacts/server/container.out 2> /tmp/artifacts/server/container.err
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,8 +125,8 @@ EXPOSE 8080 8443
 # Create PKI server
 RUN pki-server create \
     --group root \
-    --conf /data/conf \
-    --logs /data/logs
+    --conf /conf \
+    --logs /logs
 
 # In Docker/Podman the server runs as pkiuser (UID=17). To
 # ensure it generates files with the proper ownership the
@@ -169,14 +169,14 @@ RUN pki-server webapp-deploy \
   pki
 
 # Store default config files
-RUN cp -r /data/conf /var/lib/pki/pki-tomcat/conf.default
+RUN cp -r /conf /var/lib/pki/pki-tomcat/conf.default
 
 # Grant the root group the full access to PKI server files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
 RUN chgrp -Rf root /var/lib/pki/pki-tomcat
 RUN chmod -Rf g+rw /var/lib/pki/pki-tomcat
 
-VOLUME [ "/certs", "/data" ]
+VOLUME [ "/certs", "/conf", "/logs" ]
 
 CMD [ "/usr/share/pki/server/bin/pki-server-run" ]
 
@@ -202,7 +202,7 @@ RUN pki-server ca-create
 RUN pki-server ca-deploy
 
 # Store additional default config files
-RUN cp -r /data/conf/* /var/lib/pki/pki-tomcat/conf.default
+RUN cp -r /conf/* /var/lib/pki/pki-tomcat/conf.default
 
 # Grant the root group the full access to PKI server files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
@@ -233,7 +233,7 @@ RUN pki-server kra-create
 RUN pki-server kra-deploy
 
 # Store additional default config files
-RUN cp -r /data/conf/* /var/lib/pki/pki-tomcat/conf.default
+RUN cp -r /conf/* /var/lib/pki/pki-tomcat/conf.default
 
 # Grant the root group the full access to PKI server files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
@@ -264,7 +264,7 @@ RUN pki-server ocsp-create
 RUN pki-server ocsp-deploy
 
 # Store additional default config files
-RUN cp -r /data/conf/* /var/lib/pki/pki-tomcat/conf.default
+RUN cp -r /conf/* /var/lib/pki/pki-tomcat/conf.default
 
 # Grant the root group the full access to PKI server files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
@@ -313,7 +313,7 @@ RUN rm -f /usr/share/pki/acme/webapps/acme/WEB-INF/classes/logging.properties
 RUN pki-server acme-deploy
 
 # Store additional default config files
-RUN cp -r /data/conf/* /var/lib/pki/pki-tomcat/conf.default
+RUN cp -r /conf/* /var/lib/pki/pki-tomcat/conf.default
 
 # Grant the root group the full access to PKI ACME files
 # https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
@@ -326,7 +326,8 @@ VOLUME [ \
     "/database", \
     "/issuer", \
     "/realm", \
-    "/data" ]
+    "/conf", \
+    "/logs" ]
 
 CMD [ "/usr/share/pki/acme/bin/pki-acme-run" ]
 

--- a/base/acme/bin/pki-acme-run
+++ b/base/acme/bin/pki-acme-run
@@ -13,24 +13,22 @@ umask 000
 
 echo "################################################################################"
 
-if [ -d /data/conf ]
+if [ -z "$(ls -A /conf 2>/dev/null)" ]
 then
-    echo "INFO: Reusing /data/conf"
-else
-    echo "INFO: Creating /data/conf"
-    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    echo "INFO: Installing default config files"
+    cp -r /var/lib/pki/pki-tomcat/conf.default/* /conf
 fi
 
-echo "################################################################################"
-
-if [ -d /data/logs ]
+if [ "$UID" = "0" ]
 then
-    echo "INFO: Reusing /data/logs"
-else
-    echo "INFO: Creating /data/logs"
-    mkdir /data/logs
-    chown -Rf pkiuser:root /data/logs
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
 fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -10,24 +10,22 @@ umask 000
 
 echo "################################################################################"
 
-if [ -d /data/conf ]
+if [ -z "$(ls -A /conf 2>/dev/null)" ]
 then
-    echo "INFO: Reusing /data/conf"
-else
-    echo "INFO: Creating /data/conf"
-    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    echo "INFO: Installing default config files"
+    cp -r /var/lib/pki/pki-tomcat/conf.default/* /conf
 fi
 
-echo "################################################################################"
-
-if [ -d /data/logs ]
+if [ "$UID" = "0" ]
 then
-    echo "INFO: Reusing /data/logs"
-else
-    echo "INFO: Creating /data/logs"
-    mkdir /data/logs
-    chown -Rf pkiuser:root /data/logs
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
 fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 
@@ -348,8 +346,8 @@ echo "INFO: Creating PKI CA"
 # with existing database user, with RSNv3, without security manager,
 # and without systemd service.
 pkispawn \
-    --conf /data/conf \
-    --logs /data/logs \
+    --conf /conf \
+    --logs /logs \
     -f /usr/share/pki/server/examples/installation/ca.cfg \
     -s CA \
     -D pki_group=root \
@@ -386,9 +384,16 @@ pki-server ca-config-set ca.authorityMonitor.enable false
 echo "################################################################################"
 echo "INFO: Updating owners and permissions"
 
-chown -Rf pkiuser:root /data/conf
-find /data/conf -type f -exec chmod +rw -- {} +
-find /data/conf -type d -exec chmod +rwx -- {} +
+if [ "$UID" = "0" ]
+then
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
+fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 echo "INFO: Starting PKI CA"

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -10,24 +10,22 @@ umask 000
 
 echo "################################################################################"
 
-if [ -d /data/conf ]
+if [ -z "$(ls -A /conf 2>/dev/null)" ]
 then
-    echo "INFO: Reusing /data/conf"
-else
-    echo "INFO: Creating /data/conf"
-    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    echo "INFO: Installing default config files"
+    cp -r /var/lib/pki/pki-tomcat/conf.default/* /conf
 fi
 
-echo "################################################################################"
-
-if [ -d /data/logs ]
+if [ "$UID" = "0" ]
 then
-    echo "INFO: Reusing /data/logs"
-else
-    echo "INFO: Creating /data/logs"
-    mkdir /data/logs
-    chown -Rf pkiuser:root /data/logs
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
 fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 
@@ -123,8 +121,8 @@ echo "INFO: Creating PKI KRA"
 # with existing database user, with RSNv3, without security manager,
 # and without systemd service.
 pkispawn \
-    --conf /data/conf \
-    --logs /data/logs \
+    --conf /conf \
+    --logs /logs \
     -f /usr/share/pki/server/examples/installation/kra.cfg \
     -s KRA \
     -D pki_group=root \
@@ -162,9 +160,16 @@ pki-server kra-config-set internaldb.minConns 0
 echo "################################################################################"
 echo "INFO: Updating owners and permissions"
 
-chown -Rf pkiuser:root /data/conf
-find /data/conf -type f -exec chmod +rw -- {} +
-find /data/conf -type d -exec chmod +rwx -- {} +
+if [ "$UID" = "0" ]
+then
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
+fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 echo "INFO: Starting PKI KRA"

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -10,24 +10,22 @@ umask 000
 
 echo "################################################################################"
 
-if [ -d /data/conf ]
+if [ -z "$(ls -A /conf 2>/dev/null)" ]
 then
-    echo "INFO: Reusing /data/conf"
-else
-    echo "INFO: Creating /data/conf"
-    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    echo "INFO: Installing default config files"
+    cp -r /var/lib/pki/pki-tomcat/conf.default/* /conf
 fi
 
-echo "################################################################################"
-
-if [ -d /data/logs ]
+if [ "$UID" = "0" ]
 then
-    echo "INFO: Reusing /data/logs"
-else
-    echo "INFO: Creating /data/logs"
-    mkdir /data/logs
-    chown -Rf pkiuser:root /data/logs
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
 fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 
@@ -159,9 +157,16 @@ pki-server ocsp-config-set internaldb.minConns 0
 echo "################################################################################"
 echo "INFO: Updating owners and permissions"
 
-chown -Rf pkiuser:root /data/conf
-find /data/conf -type f -exec chmod +rw -- {} +
-find /data/conf -type d -exec chmod +rwx -- {} +
+if [ "$UID" = "0" ]
+then
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
+fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 echo "INFO: Starting OCSP Responder"

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -13,24 +13,22 @@ umask 000
 
 echo "################################################################################"
 
-if [ -d /data/conf ]
+if [ -z "$(ls -A /conf 2>/dev/null)" ]
 then
-    echo "info: Reusing /data/conf"
-else
-    echo "INFO: Creating /data/conf"
-    cp -r /var/lib/pki/pki-tomcat/conf.default /data/conf
+    echo "INFO: Installing default config files"
+    cp -r /var/lib/pki/pki-tomcat/conf.default/* /conf
 fi
 
-echo "################################################################################"
-
-if [ -d /data/logs ]
+if [ "$UID" = "0" ]
 then
-    echo "INFO: Reusing /data/logs"
-else
-    echo "INFO: Creating /data/logs"
-    mkdir /data/logs
-    chown -Rf pkiuser:root /data/logs
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
 fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 
@@ -193,9 +191,16 @@ fi
 echo "################################################################################"
 echo "INFO: Updating owners and permissions"
 
-chown -Rf pkiuser:root /data/conf
-find /data/conf -type f -exec chmod +rw -- {} +
-find /data/conf -type d -exec chmod +rwx -- {} +
+if [ "$UID" = "0" ]
+then
+    chown -Rf pkiuser:root /conf
+    chown -Rf pkiuser:root /logs
+fi
+
+find /conf -type f -exec chmod +rw -- {} +
+find /conf -type d -exec chmod +rwx -- {} +
+find /logs -type f -exec chmod +rw -- {} +
+find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 echo "INFO: Starting PKI server"


### PR DESCRIPTION
The `/data` folder in all containers has been split into `/conf` and `/logs` which will allow them to be stored in different volumes and will also make it easier to migrate from a regular installation.

The container startup scripts have been modified to update the owner and permissions twice: first, to make sure the startup script can create/update the server config and log files, and second, to make sure the server can access the files at runtime.