### PR TITLE
Create home directory for default PKI user

### DIFF
--- a/base/server/python/pki/server/pkidestroy.py
+++ b/base/server/python/pki/server/pkidestroy.py
@@ -114,10 +114,6 @@ def main(argv):
 
     interactive = False
 
-    # Only run this program as "root".
-    if not os.geteuid() == 0:
-        sys.exit("'%s' must be run as root!" % argv[0])
-
     while True:
 
         # -s <subsystem>

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -183,10 +183,6 @@ def main(argv):
     else:
         validate_user_deployment_cfg(config.user_deployment_cfg)
 
-    # Only run this program as "root".
-    if not os.geteuid() == 0:
-        sys.exit("'%s' must be run as root!" % argv[0])
-
     while True:
         # -s <subsystem>
         if args.pki_subsystem is None:

--- a/pki.spec
+++ b/pki.spec
@@ -135,7 +135,7 @@ ExcludeArch: i686
 %define pki_uid 17
 %define pki_groupname pkiuser
 %define pki_gid 17
-%define pki_homedir /usr/share/pki
+%define pki_homedir /home/%{pki_username}
 
 %global saveFileContext() \
 if [ -s /etc/selinux/config ]; then \
@@ -1115,10 +1115,23 @@ pkgs=base\
 %if %{with server}
 
 %pre -n %{product_id}-server
+
+# create PKI group if it doesn't exist
 getent group %{pki_groupname} >/dev/null || groupadd -f -g %{pki_gid} -r %{pki_groupname}
+
+# create PKI user if it doesn't exist
 if ! getent passwd %{pki_username} >/dev/null ; then
     useradd -r -u %{pki_uid} -g %{pki_groupname} -d %{pki_homedir} -s /sbin/nologin -c "Certificate System" %{pki_username}
 fi
+
+# create PKI home directory if it doesn't exist
+if [ ! -d %{pki_homedir} ] ; then
+    cp -ar /etc/skel %{pki_homedir}
+    chown -R %{pki_username}:%{pki_groupname} %{pki_homedir}
+    chmod 700 %{pki_homedir}
+    usermod -d %{pki_homedir} %{pki_username}
+fi
+
 exit 0
 
 # with server

--- a/tests/dogtag/acceptance/install-tests/ca-installer.sh
+++ b/tests/dogtag/acceptance/install-tests/ca-installer.sh
@@ -342,16 +342,6 @@ run_rhcs_ca_installer_tests()
                   rlAssertGrep "$exp_messg1" "$TmpDir/wrong_ds_passwd.out"
 	rlPhaseEnd
 
-	rlPhaseStartTest "pki_run_rhcs_ca_installer_tests-018: instance creation as non root user"
-                 local username=rhcs
-                  rlRun "useradd $username"
-                  rlRun "cp $INSTANCECFG /home/$username/tmpconfigfile15.in"
-                  rlRun "su -c \"pkispawn -s CA -f /home/$username/tmpconfigfile15.in > /home/$username/nonroot.out 2>&1\" $username" 1 "pkispawn as non-root user should fail"
-                  exp_messg1="'/usr/sbin/pkispawn' must be run as root!"
-                  rlAssertGrep "$exp_messg1" "/home/$username/nonroot.out"
-                  rlRun "userdel -r $username"
-          rlPhaseEnd
-
 
 	  rlPhaseStartTest "pki_run_rhcs_ca_installer_tests-019: special characters in certificate nickname"
                  local nickname=rh@cs/-$%%!!red^hat


### PR DESCRIPTION
The RPM spec has been modified to create a home directory for the default PKI user if it does not exist. The home directory can be used to store files that should be owned/accessible by PKI user (e.g. SoftHSM tokens, systemd user services) so they cannot be stored in root user's home directory.

`pkispawn` and `pkidestroy` have been modified to no longer require the user to be running as root. Currently non-root users still cannot complete the installation due to other permission issues, but eventually a user should be able to create a PKI server for a rootless systemd service.

Resolves: https://github.com/dogtagpki/pki/issues/4501