### PR TITLE
Fix Bug 2265180 - Add Support for Symmetric Key Rollover [RHCS 9.7.z].

### DIFF
--- a/base/server/cms/src/com/netscape/cms/servlet/tks/SecureChannelProtocol.java
+++ b/base/server/cms/src/com/netscape/cms/servlet/tks/SecureChannelProtocol.java
@@ -1189,8 +1189,8 @@ public class SecureChannelProtocol {
             throw new EBaseException(method + "No raw array to use to create key!");
         }
 
-        SymmetricKey transport = getSharedSecretKey(token);
-        unwrapped = this.unwrapSymKeyOnToken(token, transport, inputKeyArray, isPerm, SymmetricKey.DES3);
+        //RedHat For DES3 don's use the AES shared secret as wrapping key
+        unwrapped = this.unwrapSymKeyOnToken(token, null, inputKeyArray, isPerm, SymmetricKey.DES3);
 
         CMS.debug(method + "Returning symkey: length = " + unwrapped.getLength());
         //CMS.debug(method + "Returning symkey: " + unwrapped);
@@ -1630,8 +1630,16 @@ public class SecureChannelProtocol {
         byte[] output = null;
         byte[] finalOutput = new byte[3];
 
+        // RedHat :Do the same behavior as computeKeyCheck, use the token where the aes key resides.
+        String keysToken = null;
         try {
-            output = computeAES_CBCEncryption(symKey, selectedToken, key_check_message, key_check_iv);
+            keysToken = symKey.getOwningToken().getName();
+        } catch (TokenException e1) {
+            throw new EBaseException(e1 + " Can't get owning token for key/");
+        }
+
+        try {
+            output = computeAES_CBCEncryption(symKey, keysToken, key_check_message, key_check_iv);
         } catch (EBaseException e) {
             CMS.debug(method + e);
             throw e;

--- a/base/tps/src/org/dogtagpki/server/tps/processor/TPSProcessor.java
+++ b/base/tps/src/org/dogtagpki/server/tps/processor/TPSProcessor.java
@@ -2570,7 +2570,8 @@ public class TPSProcessor {
                 symKeyUpgradeStatus = TPSStatus.STATUS_ERROR_SYMKEY_256_UPGRADE;
             }
             // Check whether exception is caused by attempting to change 256 OMK to 128 FMK
-            else if (getSelectedKeySet().equals(getKeyDowngradeKeySet()) && getSymmetricKeysRequiredVersion() == getKeyDowngradeVersion())
+            // RedHat : avoid null ptr. For non external reg case.
+            else if (getSelectedKeySet() != null && getSelectedKeySet().equals(getKeyDowngradeKeySet()) && getSymmetricKeysRequiredVersion() == getKeyDowngradeVersion())
             {
                 // proceed with downgrade if configured to do so
                 CMS.debug("TPSProcessor.checkAndUpgradeSymKeys: try downgrade key size.");
@@ -3660,7 +3661,8 @@ public class TPSProcessor {
             
             // ** G&D 256 Key Rollover Support **
             // set the flag to indicate if card needs to roll over to 256 OMK
-            boolean keyRollNeeded = (getSelectedKeySet().equals(getKeyRolloverKeySet()) && requiredVersion == getKeyRolloverVersion());
+            // RedHat : avoid null ptr. For non external reg case.
+            boolean keyRollNeeded = (getSelectedKeySet() != null && getSelectedKeySet().equals(getKeyRolloverKeySet()) && requiredVersion == getKeyRolloverVersion());
             CMS.debug(" keyRollNeeded: " + keyRollNeeded);
             // try to make a secure channel with the 'requiredVersion' keys
             // If this fails, we know we will have to attempt an upgrade


### PR DESCRIPTION
We found in QE a situation in fips mode with the hsm that the calculation of the scp03 keycheck value could fail. Simply making that method behave like the scp01 version of the method fixes the issue.

Also added some trivial code to apease tpsclient. We do so by creating a new secret config value used only by those testing the product with tpsclient:

channel.scp01.no.le.byte=true

This will skip the le zero byte on only the generatekey and readobject apdu's only if scp01 is detected and this value is true. Otherwise everything will default to current behavior and the le byte of zero will be added as per current behavior.

Fix case when rollover feature checks config in non external reg mode and caused NPE. Adding one file that didn't make it into the last commit.