### PR TITLE
Add test for CA container with existing config

### DIFF
--- a/.github/workflows/ca-container-existing-config-test.yml
+++ b/.github/workflows/ca-container-existing-config-test.yml
@@ -1,0 +1,357 @@
+name: CA container with existing config
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+
+          # Currently client fails to connect to CA with Podman.
+          # TODO: Replace Docker with Podman when the issue is resolved.
+          # sudo apt-get -y purge --auto-remove docker-ce-cli
+          # sudo apt-get -y install podman-docker
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-container-create.sh \
+              --image=${{ env.DB_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=ca.example.com \
+              --network=example \
+              --network-alias=ca.example.com \
+              pki
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_ds_password=Secret.123 \
+              -v
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              --network-alias=client.example.com \
+              client
+
+      - name: Check admin user
+        run: |
+          mkdir certs
+
+          # install CA signing cert
+          docker exec pki pki-server cert-export \
+              --cert-file $SHARED/certs/ca_signing.crt \
+              ca_signing
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/certs/ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          # install admin cert
+          docker exec pki cp \
+              /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              $SHARED/certs/admin.p12
+          docker exec client pki pkcs12-import \
+              --pkcs12 $SHARED/certs/admin.p12 \
+              --password Secret.123
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-user-show \
+              caadmin
+
+      - name: Stop CA
+        run: |
+          docker exec pki pki-server stop --wait
+          docker network disconnect example pki
+
+      - name: Export certs
+        run: |
+          # export system certs and keys
+          docker exec pki pki \
+              -v \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              pkcs12-export \
+              --pkcs12 $SHARED/certs/server.p12 \
+              --password Secret.123 \
+              ca_signing \
+              ca_ocsp_signing \
+              ca_audit_signing \
+              subsystem \
+              sslserver
+
+          docker exec pki pki pkcs12-cert-find \
+              --pkcs12 $SHARED/certs/server.p12 \
+              --password Secret.123
+
+          # export system cert requests
+          docker exec pki cp \
+              /var/lib/pki/pki-tomcat/conf/certs/ca_signing.csr \
+              $SHARED/certs/ca_signing.csr
+          docker exec pki cp \
+              /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr \
+              $SHARED/certs/ocsp_signing.csr
+          docker exec pki cp \
+              /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr \
+              $SHARED/certs/audit_signing.csr
+          docker exec pki cp \
+              /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr \
+              $SHARED/certs/subsystem.csr
+          docker exec pki cp \
+              /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr \
+              $SHARED/certs/sslserver.csr
+          docker exec pki cp \
+              /var/lib/pki/pki-tomcat/conf/certs/ca_admin.csr \
+              $SHARED/certs/admin.csr
+
+          docker exec pki pki pkcs12-cert-find \
+              --pkcs12 $SHARED/certs/admin.p12 \
+              --password Secret.123
+
+          ls -la certs
+
+      - name: Export config files
+        run: |
+          docker cp pki:/etc/pki/pki-tomcat conf
+
+          ls -la conf
+
+      - name: Export log files
+        run: |
+          docker cp pki:/var/log/pki/pki-tomcat logs
+
+          ls -la logs
+
+      - name: Set up CA container
+        run: |
+          docker run \
+              --name ca \
+              --hostname ca.example.com \
+              --network example \
+              --network-alias ca.example.com \
+              -v $PWD/certs:/certs \
+              -v $PWD/conf:/conf \
+              -v $PWD/logs:/logs \
+              -e PKI_DS_URL=ldap://ds.example.com:3389 \
+              -e PKI_DS_PASSWORD=Secret.123 \
+              -e PKI_CA_SIGNING_NICKNAME=ca_signing \
+              -e PKI_OCSP_SIGNING_NICKNAME=ca_ocsp_signing \
+              -e PKI_AUDIT_SIGNING_NICKNAME=ca_audit_signing \
+              -e PKI_SUBSYSTEM_NICKNAME=subsystem \
+              -e PKI_SSLSERVER_NICKNAME=sslserver \
+              -e PKI_ADMIN_NICKNAME=caadmin \
+              --detach \
+              pki-ca
+
+          # wait for CA to start
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ca.example.com:8443
+
+      - name: Check conf dir
+        if: always()
+        run: |
+          ls -l conf \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          # everything should be owned by root group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx root Catalina
+          drwxrwxrwx root alias
+          drwxrwxrwx root ca
+          -rw-rw-rw- root catalina.policy
+          lrwxrwxrwx root catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx root certs
+          lrwxrwxrwx root context.xml -> /etc/tomcat/context.xml
+          lrwxrwxrwx root logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- root password.conf
+          -rw-rw-rw- root server.xml
+          -rw-rw-rw- root serverCertNick.conf
+          -rw-rw-rw- root tomcat.conf
+          lrwxrwxrwx root web.xml -> /etc/tomcat/web.xml
+          EOF
+
+          diff expected output
+
+      - name: Check conf/ca dir
+        if: always()
+        run: |
+          ls -l conf/ca \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+                  -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
+              | tee output
+
+          # everything should be owned by root group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          -rw-rw-rw- root CS.cfg
+          -rw-rw-rw- root adminCert.profile
+          drwxrwxrwx root archives
+          -rw-rw-rw- root caAuditSigningCert.profile
+          -rw-rw-rw- root caCert.profile
+          -rw-rw-rw- root caOCSPCert.profile
+          drwxrwxrwx root emails
+          -rw-rw-rw- root flatfile.txt
+          drwxrwxrwx root profiles
+          -rw-rw-rw- root proxy.conf
+          -rw-rw-rw- root registry.cfg
+          -rw-rw-rw- root serverCert.profile
+          -rw-rw-rw- root subsystemCert.profile
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: always()
+        run: |
+          ls -l logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by docker group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx root backup
+          drwxrwxrwx root ca
+          -rw-rw-rw- root catalina.$DATE.log
+          -rw-rw-rw- root host-manager.$DATE.log
+          -rw-rw-rw- root localhost.$DATE.log
+          -rw-rw-rw- root localhost_access_log.$DATE.txt
+          -rw-rw-rw- root manager.$DATE.log
+          drwxrwxrwx root pki
+          EOF
+
+          diff expected output
+
+      - name: Check admin user again
+        run: |
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-user-show \
+              caadmin
+
+      - name: Check cert enrollment
+        run: |
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              client-cert-request \
+              uid=testuser | tee output
+
+          REQUEST_ID=$(sed -n -e 's/^ *Request ID: *\(.*\)$/\1/p' output)
+          echo "REQUEST_ID: $REQUEST_ID"
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-cert-request-approve \
+              $REQUEST_ID \
+              --force
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check CA container logs
+        if: always()
+        run: |
+          docker logs ca 2>&1
+
+      - name: Check CA container debug logs
+        if: always()
+        run: |
+          docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh ds
+          tests/bin/pki-artifacts-save.sh pki
+
+          mkdir -p /tmp/artifacts/ca
+          # TODO: fix permission issue
+          # cp -r certs /tmp/artifacts/ca
+          # cp -r conf /tmp/artifacts/ca
+          # cp -r logs /tmp/artifacts/ca
+
+          docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
+
+          mkdir -p /tmp/artifacts/client
+          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ca-container-existing-config
+          path: /tmp/artifacts

--- a/.github/workflows/ca-container-tests.yml
+++ b/.github/workflows/ca-container-tests.yml
@@ -18,6 +18,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/ca-container-existing-certs-test.yml
 
+  ca-container-existing-config-test:
+    name: CA container with existing config
+    needs: build
+    uses: ./.github/workflows/ca-container-existing-config-test.yml
+
   ca-container-system-service-test:
     name: CA container system service
     needs: build

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -1,8 +1,16 @@
 #!/bin/sh -e
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 
-# TODO:
-# - parameterize hard-coded values
-# - support existing subsystem user
+PKI_CA_SIGNING_NICKNAME="${PKI_CA_SIGNING_NICKNAME:-ca_signing}"
+PKI_OCSP_SIGNING_NICKNAME="${PKI_OCSP_SIGNING_NICKNAME:-ocsp_signing}"
+PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-audit_signing}"
+PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
+PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
+PKI_ADMIN_NICKNAME="${PKI_ADMIN_NICKNAME:-admin}"
 
 # Allow the owner of the container (who might not be in the root group)
 # to manage the config and log files.
@@ -35,6 +43,7 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         pkcs12-import \
         --pkcs12 /certs/server.p12 \
         --password Secret.123
@@ -46,9 +55,10 @@ echo "##########################################################################
 rc=0
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-export \
     --output-file /certs/ca_signing.crt \
-    ca_signing \
+    "$PKI_CA_SIGNING_NICKNAME" \
     2> /dev/null || rc=$?
 
 if [ $rc -ne 0 ]
@@ -57,6 +67,7 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-request \
         --subject "CN=CA Signing Certificate" \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
@@ -64,6 +75,7 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-issue \
         --csr /certs/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
@@ -73,17 +85,19 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-import \
         --cert /certs/ca_signing.crt \
         --trust CT,C,C \
-        ca_signing
+        "$PKI_CA_SIGNING_NICKNAME"
 fi
 
 echo "INFO: CA signing cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    ca_signing
+    "$PKI_CA_SIGNING_NICKNAME"
 
 if [ ! -f /certs/ca_signing.crt ]
 then
@@ -91,9 +105,10 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-export \
         --output-file /certs/ca_signing.crt \
-        ca_signing
+        "$PKI_CA_SIGNING_NICKNAME"
 fi
 
 echo "################################################################################"
@@ -102,9 +117,10 @@ echo "##########################################################################
 rc=0
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-export \
     --output-file /certs/ocsp_signing.crt \
-    ocsp_signing \
+    "$PKI_OCSP_SIGNING_NICKNAME" \
     2> /dev/null || rc=$?
 
 if [ $rc -ne 0 ]
@@ -113,6 +129,7 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-request \
         --subject "CN=OCSP Signing Certificate" \
         --ext /usr/share/pki/server/certs/ocsp_signing.conf \
@@ -120,24 +137,27 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-issue \
-        --issuer ca_signing \
+        --issuer "$PKI_CA_SIGNING_NICKNAME" \
         --csr /certs/ocsp_signing.csr \
         --ext /usr/share/pki/server/certs/ocsp_signing.conf \
         --cert /certs/ocsp_signing.crt
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-import \
         --cert /certs/ocsp_signing.crt \
-        ocsp_signing
+        "$PKI_OCSP_SIGNING_NICKNAME"
 fi
 
 echo "INFO: OCSP signing cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    ocsp_signing
+    "$PKI_OCSP_SIGNING_NICKNAME"
 
 echo "################################################################################"
 
@@ -145,9 +165,10 @@ echo "##########################################################################
 rc=0
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-export \
     --output-file /certs/audit_signing.crt \
-    audit_signing \
+    "$PKI_AUDIT_SIGNING_NICKNAME" \
     2> /dev/null || rc=$?
 
 if [ $rc -ne 0 ]
@@ -156,6 +177,7 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-request \
         --subject "CN=Audit Signing Certificate" \
         --ext /usr/share/pki/server/certs/audit_signing.conf \
@@ -163,25 +185,28 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-issue \
-        --issuer ca_signing \
+        --issuer "$PKI_CA_SIGNING_NICKNAME" \
         --csr /certs/audit_signing.csr \
         --ext /usr/share/pki/server/certs/audit_signing.conf \
         --cert /certs/audit_signing.crt
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-import \
         --cert /certs/audit_signing.crt \
         --trust ,,P \
-        audit_signing
+        "$PKI_AUDIT_SIGNING_NICKNAME"
 fi
 
 echo "INFO: Audit signing cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    audit_signing
+    "$PKI_AUDIT_SIGNING_NICKNAME"
 
 echo "################################################################################"
 
@@ -189,9 +214,10 @@ echo "##########################################################################
 rc=0
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-export \
     --output-file /certs/subsystem.crt \
-    subsystem \
+    "$PKI_SUBSYSTEM_NICKNAME" \
     2> /dev/null || rc=$?
 
 if [ $rc -ne 0 ]
@@ -200,30 +226,34 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-request \
         --subject "CN=Subsystem Certificate" \
         --csr /certs/subsystem.csr
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-issue \
-        --issuer ca_signing \
+        --issuer "$PKI_CA_SIGNING_NICKNAME" \
         --csr /certs/subsystem.csr \
         --ext /usr/share/pki/server/certs/subsystem.conf \
         --cert /certs/subsystem.crt
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-import \
         --cert /certs/subsystem.crt \
-        subsystem
+        "$PKI_SUBSYSTEM_NICKNAME"
 fi
 
 echo "INFO: Subsystem cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    subsystem
+    "$PKI_SUBSYSTEM_NICKNAME"
 
 echo "################################################################################"
 
@@ -231,9 +261,10 @@ echo "##########################################################################
 rc=0
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-export \
     --output-file /certs/sslserver.crt \
-    sslserver \
+    "$PKI_SSLSERVER_NICKNAME" \
     2> /dev/null || rc=$?
 
 if [ $rc -ne 0 ]
@@ -242,6 +273,7 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-request \
         --subject "CN=$HOSTNAME" \
         --ext /usr/share/pki/server/certs/sslserver.conf \
@@ -249,24 +281,27 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-issue \
-        --issuer ca_signing \
+        --issuer "$PKI_CA_SIGNING_NICKNAME" \
         --csr /certs/sslserver.csr \
         --ext /usr/share/pki/server/certs/sslserver.conf \
         --cert /certs/sslserver.crt
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-import \
         --cert /certs/sslserver.crt \
-        sslserver
+        "$PKI_SSLSERVER_NICKNAME"
 fi
 
 echo "INFO: SSL server cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    sslserver
+    "$PKI_SSLSERVER_NICKNAME"
 
 echo "################################################################################"
 
@@ -281,7 +316,7 @@ fi
 
 # check whether CA signing cert exists
 rc=0
-pki nss-cert-export ca_signing \
+pki nss-cert-export "$PKI_CA_SIGNING_NICKNAME" \
     > /dev/null \
     2> /dev/null || rc=$?
 
@@ -291,7 +326,7 @@ then
     pki nss-cert-import \
         --cert /certs/ca_signing.crt \
         --trust CT,C,C \
-        ca_signing
+        "$PKI_CA_SIGNING_NICKNAME"
 fi
 
 echo "################################################################################"
@@ -300,7 +335,7 @@ echo "##########################################################################
 rc=0
 pki nss-cert-export \
     --output-file /certs/admin.crt \
-    admin \
+    "$PKI_ADMIN_NICKNAME" \
     2> /dev/null || rc=$?
 
 if [ $rc -ne 0 ]
@@ -314,19 +349,20 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-issue \
-        --issuer ca_signing \
+        --issuer "$PKI_CA_SIGNING_NICKNAME" \
         --csr /certs/admin.csr \
         --ext /usr/share/pki/server/certs/admin.conf \
         --cert /certs/admin.crt
 
     pki nss-cert-import \
         --cert /certs/admin.crt \
-        admin
+        "$PKI_ADMIN_NICKNAME"
 fi
 
 echo "INFO: Admin cert:"
-pki nss-cert-show admin
+pki nss-cert-show "$PKI_ADMIN_NICKNAME"
 
 if [ ! -f /certs/admin.p12 ]
 then
@@ -335,7 +371,7 @@ then
     pki pkcs12-export \
         --pkcs12 /certs/admin.p12 \
         --password Secret.123 \
-        admin
+        "$PKI_ADMIN_NICKNAME"
 fi
 
 if [ ! -f /certs/admin.crt ]
@@ -344,7 +380,7 @@ then
 
     pki nss-cert-export \
         --output-file /certs/admin.crt \
-        admin
+        "$PKI_ADMIN_NICKNAME"
 fi
 
 echo "################################################################################"
@@ -366,15 +402,15 @@ pkispawn \
     -D pki_skip_ds_verify=True \
     -D pki_share_db=True \
     -D pki_import_system_certs=False \
-    -D pki_ca_signing_nickname=ca_signing \
+    -D pki_ca_signing_nickname="$PKI_CA_SIGNING_NICKNAME" \
     -D pki_ca_signing_csr_path=/certs/ca_signing.csr \
-    -D pki_ocsp_signing_nickname=ocsp_signing \
+    -D pki_ocsp_signing_nickname="$PKI_OCSP_SIGNING_NICKNAME" \
     -D pki_ocsp_signing_csr_path=/certs/ocsp_signing.csr \
-    -D pki_audit_signing_nickname=audit_signing \
+    -D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME" \
     -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
-    -D pki_subsystem_nickname=subsystem \
+    -D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME" \
     -D pki_subsystem_csr_path=/certs/subsystem.csr \
-    -D pki_sslserver_nickname=sslserver \
+    -D pki_sslserver_nickname="$PKI_SSLSERVER_NICKNAME" \
     -D pki_sslserver_csr_path=/certs/sslserver.csr \
     -D pki_admin_setup=False \
     -D pki_security_domain_setup=False \

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -1,8 +1,16 @@
 #!/bin/sh -e
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 
-# TODO:
-# - parameterize hard-coded values
-# - support existing subsystem user
+PKI_STORAGE_NICKNAME="${PKI_OCSP_SIGNING_NICKNAME:-kra_storage}"
+PKI_TRANSPORT_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-kra_transport}"
+PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-audit_signing}"
+PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
+PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
+PKI_ADMIN_NICKNAME="${PKI_ADMIN_NICKNAME:-admin}"
 
 # Allow the owner of the container (who might not be in the root group)
 # to manage the config and log files.
@@ -35,6 +43,7 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         pkcs12-import \
         --pkcs12 /certs/server.p12 \
         --password Secret.123
@@ -45,32 +54,36 @@ echo "##########################################################################
 echo "INFO: KRA storage cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    kra_storage
+    "$PKI_STORAGE_NICKNAME"
 
 echo "################################################################################"
 
 echo "INFO: KRA transport cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    kra_transport
+    "$PKI_TRANSPORT_NICKNAME"
 
 echo "################################################################################"
 
 echo "INFO: Audit signing cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    audit_signing
+    "$PKI_AUDIT_SIGNING_NICKNAME"
 
 echo "################################################################################"
 
 echo "INFO: Subsystem cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    subsystem
+    "$PKI_SUBSYSTEM_NICKNAME"
 
 if [ ! -f /certs/subsystem.crt ]
 then
@@ -78,9 +91,10 @@ then
 
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
+        -f /var/lib/pki/pki-tomcat/conf/password.conf \
         nss-cert-export \
         --output-file /certs/subsystem.crt \
-        subsystem
+        "$PKI_SUBSYSTEM_NICKNAME"
 fi
 
 echo "################################################################################"
@@ -88,8 +102,9 @@ echo "##########################################################################
 echo "INFO: SSL server cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/password.conf \
     nss-cert-show \
-    sslserver
+    "$PKI_SSLSERVER_NICKNAME"
 
 echo "################################################################################"
 
@@ -103,7 +118,7 @@ then
 fi
 
 echo "INFO: Admin cert:"
-pki nss-cert-show admin
+pki nss-cert-show "$PKI_ADMIN_NICKNAME"
 
 if [ ! -f /certs/admin.crt ]
 then
@@ -111,7 +126,7 @@ then
 
     pki nss-cert-export \
         --output-file /certs/admin.crt \
-        admin
+        "$PKI_ADMIN_NICKNAME"
 fi
 
 echo "################################################################################"
@@ -135,15 +150,15 @@ pkispawn \
     -D pki_share_db=True \
     -D pki_issuing_ca= \
     -D pki_import_system_certs=False \
-    -D pki_storage_nickname=kra_storage \
+    -D pki_storage_nickname="$PKI_STORAGE_NICKNAME" \
     -D pki_storage_csr_path=/certs/kra_storage.csr \
-    -D pki_transport_nickname=kra_transport \
+    -D pki_transport_nickname="$PKI_TRANSPORT_NICKNAME" \
     -D pki_transport_csr_path=/certs/kra_transport.csr \
-    -D pki_audit_signing_nickname=audit_signing \
+    -D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME" \
     -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
-    -D pki_subsystem_nickname=subsystem \
+    -D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME" \
     -D pki_subsystem_csr_path=/certs/subsystem.csr \
-    -D pki_sslserver_nickname=sslserver \
+    -D pki_sslserver_nickname="$PKI_SSLSERVER_NICKNAME" \
     -D pki_sslserver_csr_path=/certs/sslserver.csr \
     -D pki_admin_setup=False \
     -D pki_security_domain_setup=False \

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -1,8 +1,15 @@
 #!/bin/sh -e
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 
-# TODO:
-# - parameterize hard-coded values
-# - support existing subsystem user
+PKI_OCSP_SIGNING_NICKNAME="${PKI_OCSP_SIGNING_NICKNAME:-ocsp_signing}"
+PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-audit_signing}"
+PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
+PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
+PKI_ADMIN_NICKNAME="${PKI_ADMIN_NICKNAME:-admin}"
 
 # Allow the owner of the container (who might not be in the root group)
 # to manage the config and log files.
@@ -46,7 +53,7 @@ echo "INFO: OCSP signing cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
-    ocsp_signing
+    "$PKI_OCSP_SIGNING_NICKNAME"
 
 echo "################################################################################"
 
@@ -54,7 +61,7 @@ echo "INFO: Audit signing cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
-    audit_signing
+    "$PKI_AUDIT_SIGNING_NICKNAME"
 
 echo "################################################################################"
 
@@ -62,7 +69,7 @@ echo "INFO: Subsystem cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
-    subsystem
+    "$PKI_SUBSYSTEM_NICKNAME"
 
 if [ ! -f /certs/subsystem.crt ]
 then
@@ -72,7 +79,7 @@ then
         -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-export \
         --output-file /certs/subsystem.crt \
-        subsystem
+        "$PKI_SUBSYSTEM_NICKNAME"
 fi
 
 echo "################################################################################"
@@ -81,7 +88,7 @@ echo "INFO: SSL server cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
-    sslserver
+    "$PKI_SSLSERVER_NICKNAME"
 
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
@@ -99,7 +106,7 @@ then
 fi
 
 echo "INFO: Admin cert:"
-pki nss-cert-show admin
+pki nss-cert-show "$PKI_ADMIN_NICKNAME"
 
 if [ ! -f /certs/admin.crt ]
 then
@@ -107,7 +114,7 @@ then
 
     pki nss-cert-export \
         --output-file /certs/admin.crt \
-        admin
+        "$PKI_ADMIN_NICKNAME"
 fi
 
 pki nss-cert-find
@@ -134,13 +141,13 @@ pkispawn \
     -D pki_share_db=True \
     -D pki_issuing_ca= \
     -D pki_import_system_certs=False \
-    -D pki_ocsp_signing_nickname=ocsp_signing \
+    -D pki_ocsp_signing_nickname="$PKI_OCSP_SIGNING_NICKNAME" \
     -D pki_ocsp_signing_csr_path=/certs/ocsp_signing.csr \
-    -D pki_audit_signing_nickname=audit_signing \
+    -D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME" \
     -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
-    -D pki_subsystem_nickname=subsystem \
+    -D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME" \
     -D pki_subsystem_csr_path=/certs/subsystem.csr \
-    -D pki_sslserver_nickname=sslserver \
+    -D pki_sslserver_nickname="$PKI_SSLSERVER_NICKNAME" \
     -D pki_sslserver_csr_path=/certs/sslserver.csr \
     -D pki_admin_setup=False \
     -D pki_security_domain_setup=False \

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -7,6 +7,9 @@
 
 . /usr/share/pki/scripts/config
 
+PKI_CA_SIGNING_NICKNAME="${PKI_CA_SIGNING_NICKNAME:-ca_signing}"
+PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
+
 # Allow the owner of the container (who might not be in the root group)
 # to manage the config and log files.
 umask 000
@@ -45,7 +48,7 @@ then
         -in /certs/ca_signing.crt \
         -inkey /certs/ca_signing.key \
         -out /tmp/certs.p12 \
-        -name ca_signing \
+        -name "$PKI_CA_SIGNING_NICKNAME" \
         -passout file:/tmp/password
 
     # trust CA signing cert in PKCS #12 file
@@ -55,7 +58,7 @@ then
         --pkcs12 /tmp/certs.p12 \
         --password-file /tmp/password \
         --trust-flags CT,C,C \
-        ca_signing
+        "$PKI_CA_SIGNING_NICKNAME"
 
     # import PKCS #12 file into NSS database
     pki \
@@ -87,7 +90,7 @@ pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-export \
     --output-file /certs/ca_signing.crt \
-    ca_signing \
+    "$PKI_CA_SIGNING_NICKNAME" \
     2> /dev/null || rc=$?
 
 # generate a CA signing certificate if not available
@@ -119,14 +122,14 @@ then
         nss-cert-import \
         --cert /certs/ca_signing.crt \
         --trust CT,C,C \
-        ca_signing
+        "$PKI_CA_SIGNING_NICKNAME"
 fi
 
 echo "INFO: CA signing cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
-    ca_signing
+    "$PKI_CA_SIGNING_NICKNAME"
 
 echo "################################################################################"
 
@@ -136,7 +139,7 @@ pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-export \
     --output-file /certs/sslserver.crt \
-    sslserver \
+    "$PKI_SSLSERVER_NICKNAME" \
     2> /dev/null || rc=$?
 
 # generate a SSL server certificate if not available
@@ -156,7 +159,7 @@ then
     pki \
         -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-issue \
-        --issuer ca_signing \
+        --issuer "$PKI_CA_SIGNING_NICKNAME" \
         --csr /certs/sslserver.csr \
         --ext /usr/share/pki/server/certs/sslserver.conf \
         --cert /certs/sslserver.crt
@@ -166,20 +169,20 @@ then
         -d /var/lib/pki/pki-tomcat/conf/alias \
         nss-cert-import \
         --cert /certs/sslserver.crt \
-        sslserver
+        "$PKI_SSLSERVER_NICKNAME"
 fi
 
 echo "INFO: SSL server cert:"
 pki \
     -d /var/lib/pki/pki-tomcat/conf/alias \
     nss-cert-show \
-    sslserver
+    "$PKI_SSLSERVER_NICKNAME"
 
 echo "################################################################################"
 
 # check whether CA signing cert exists in default NSS database
 rc=0
-pki nss-cert-export ca_signing \
+pki nss-cert-export "$PKI_CA_SIGNING_NICKNAME" \
     > /dev/null \
     2> /dev/null || rc=$?
 
@@ -189,7 +192,7 @@ then
     pki nss-cert-import \
         --cert /certs/ca_signing.crt \
         --trust CT,C,C \
-        ca_signing
+        "$PKI_CA_SIGNING_NICKNAME"
 fi
 
 echo "################################################################################"


### PR DESCRIPTION
A new test has been added to install a regular CA, then reuse the certs, database, and config files to run the same CA as a container.

The container startup scripts have been updated to provide params to specify the nicknames of the existing certs and to use `password.conf` to access the server's NSS database.