### PR TITLE
Remove redundant files in containers

### DIFF
--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -159,9 +159,16 @@ jobs:
 
       - name: Install CA signing cert
         run: |
+          docker exec acme pki \
+              -d /conf/alias \
+              -f /conf/password.conf \
+              nss-cert-export \
+              --output-file /conf/certs/ca_signing.crt \
+              ca_signing
+
           docker exec client pki \
               nss-cert-import \
-              --cert $SHARED/certs/ca_signing.crt \
+              --cert $SHARED/conf/certs/ca_signing.crt \
               --trust CT,C,C \
               ca_signing
 

--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -162,8 +162,12 @@ jobs:
 
       - name: Check CA info
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/ca_signing.crt \
+              ca_signing
+
           docker exec client pki nss-cert-import \
-              --cert $SHARED/certs/ca_signing.crt \
+              --cert $SHARED/conf/certs/ca_signing.crt \
               --trust CT,C,C \
               ca_signing
 
@@ -192,73 +196,97 @@ jobs:
 
       - name: Import CA signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/ca_signing.crt \
+              ca_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/ca_signing.csr \
+              --csr /conf/certs/ca_signing.csr \
               --profile /usr/share/pki/ca/conf/caCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/ca_signing.crt \
+              --cert /conf/certs/ca_signing.crt \
               --profile /usr/share/pki/ca/conf/caCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA OCSP signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/ocsp_signing.crt \
+              ca_ocsp_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/ocsp_signing.csr \
+              --csr /conf/certs/ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/ocsp_signing.crt \
+              --cert /conf/certs/ocsp_signing.crt \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA audit signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/audit_signing.crt \
+              ca_audit_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/audit_signing.csr \
+              --csr /conf/certs/audit_signing.csr \
               --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/audit_signing.crt \
+              --cert /conf/certs/audit_signing.crt \
               --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
               --request $REQUEST_ID
 
       - name: Import subsystem cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/subsystem.crt \
+              subsystem
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/subsystem.csr \
+              --csr /conf/certs/subsystem.csr \
               --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/subsystem.crt \
+              --cert /conf/certs/subsystem.crt \
               --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
               --request $REQUEST_ID
 
       - name: Import SSL server cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/sslserver.crt \
+              sslserver
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/sslserver.csr \
+              --csr /conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/sslserver.crt \
+              --cert /conf/certs/sslserver.crt \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
               --request $REQUEST_ID
 
       - name: Import admin cert into CA database
         run: |
+          docker exec ca pki nss-cert-export \
+              --output-file /conf/certs/admin.crt \
+              admin
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/admin.csr \
+              --csr /conf/certs/admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
               --request $REQUEST_ID
 
@@ -279,7 +307,7 @@ jobs:
 
           # assign admin cert to CA admin user
           docker exec ca pki-server ca-user-cert-add \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               admin
 
           # add CA admin user into CA groups
@@ -288,8 +316,13 @@ jobs:
 
       - name: Check CA admin user
         run: |
+          docker exec ca pki pkcs12-export \
+              --pkcs12 /conf/certs/admin.p12 \
+              --password Secret.123 \
+              admin
+
           docker exec client pki pkcs12-import \
-              --pkcs12 $SHARED/certs/admin.p12 \
+              --pkcs12 $SHARED/conf/certs/admin.p12 \
               --pkcs12-password Secret.123
 
           docker exec client pki \

--- a/.github/workflows/ca-container-system-service-test.yml
+++ b/.github/workflows/ca-container-system-service-test.yml
@@ -217,8 +217,13 @@ jobs:
 
       - name: Check CA info
         run: |
+          docker exec pki podman exec systemd-pki-ca \
+              pki-server cert-export \
+              --cert-file /conf/certs/ca_signing.crt \
+              ca_signing
+
           docker exec pki pki nss-cert-import \
-              --cert /home/pkiuser/certs/ca_signing.crt \
+              --cert /home/pkiuser/conf/certs/ca_signing.crt \
               --trust CT,C,C \
               ca_signing
 
@@ -248,10 +253,15 @@ jobs:
               --type adminType \
               admin
 
+          docker exec pki podman exec systemd-pki-ca \
+              pki nss-cert-export \
+              --output-file /conf/certs/admin.crt \
+              admin
+
           # assign admin cert to CA admin user
           docker exec pki podman exec systemd-pki-ca \
               pki-server ca-user-cert-add \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               admin
 
           # add CA admin user into CA groups
@@ -262,8 +272,14 @@ jobs:
 
       - name: Check CA admin user
         run: |
+          docker exec pki podman exec systemd-pki-ca \
+              pki pkcs12-export \
+              --pkcs12 /conf/certs/admin.p12 \
+              --password Secret.123 \
+              admin
+
           docker exec pki pki pkcs12-import \
-              --pkcs12 /home/pkiuser/certs/admin.p12 \
+              --pkcs12 /home/pkiuser/conf/certs/admin.p12 \
               --password Secret.123
 
           docker exec pki pki \

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -98,73 +98,97 @@ jobs:
 
       - name: Import CA signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/ca_signing.crt \
+              ca_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/ca_signing.csr \
+              --csr /conf/certs/ca_signing.csr \
               --profile /usr/share/pki/ca/conf/caCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/ca_signing.crt \
+              --cert /conf/certs/ca_signing.crt \
               --profile /usr/share/pki/ca/conf/caCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA OCSP signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/ocsp_signing.crt \
+              ca_ocsp_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/ocsp_signing.csr \
+              --csr /conf/certs/ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/ocsp_signing.crt \
+              --cert /conf/certs/ocsp_signing.crt \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA audit signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/audit_signing.crt \
+              ca_audit_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/audit_signing.csr \
+              --csr /conf/certs/audit_signing.csr \
               --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/audit_signing.crt \
+              --cert /conf/certs/audit_signing.crt \
               --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA subsystem cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/subsystem.crt \
+              subsystem
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/subsystem.csr \
+              --csr /conf/certs/subsystem.csr \
               --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/subsystem.crt \
+              --cert /conf/certs/subsystem.crt \
               --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
               --request $REQUEST_ID
 
       - name: Import SSL server cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/sslserver.crt \
+              sslserver
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/sslserver.csr \
+              --csr /conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/sslserver.crt \
+              --cert /conf/certs/sslserver.crt \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
               --request $REQUEST_ID
 
       - name: Import admin cert into CA database
         run: |
+          docker exec ca pki nss-cert-export \
+              --output-file /conf/certs/admin.crt \
+              admin
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/admin.csr \
+              --csr /conf/certs/admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
               --request $REQUEST_ID
 
@@ -179,7 +203,7 @@ jobs:
       - name: Assign admin cert to CA admin user
         run: |
           docker exec ca pki-server ca-user-cert-add \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               admin
 
       - name: Add admin user into CA groups
@@ -189,8 +213,13 @@ jobs:
 
       - name: Install admin cert
         run: |
+          docker exec ca pki pkcs12-export \
+              --pkcs12 /conf/certs/admin.p12 \
+              --password Secret.123 \
+              admin
+
           docker exec client pki pkcs12-import \
-              --pkcs12 $SHARED/ca/certs/admin.p12 \
+              --pkcs12 $SHARED/ca/conf/certs/admin.p12 \
               --password Secret.123
 
           docker exec client pki \
@@ -293,7 +322,7 @@ jobs:
       - name: Prepare KRA certs and keys
         run: |
           # export CA signing cert
-          docker exec client cp $SHARED/ca/certs/ca_signing.crt $SHARED/kra/certs
+          docker exec client cp $SHARED/ca/conf/certs/ca_signing.crt $SHARED/kra/certs
 
           docker exec client pki nss-cert-find
 
@@ -312,7 +341,7 @@ jobs:
               --password Secret.123 \
 
           # export admin cert and key
-          docker exec client cp $SHARED/ca/certs/admin.p12 $SHARED/kra/certs
+          docker exec client cp $SHARED/ca/conf/certs/admin.p12 $SHARED/kra/certs
 
           docker exec client pki pkcs12-cert-find \
               --pkcs12 $SHARED/kra/certs/admin.p12 \
@@ -463,8 +492,9 @@ jobs:
 
       - name: Assign admin cert to KRA admin user
         run: |
+          cp ca/conf/certs/admin.crt kra/conf/certs/admin.crt
           docker exec kra pki-server kra-user-cert-add \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               admin
 
       - name: Add KRA admin user into KRA groups
@@ -490,10 +520,9 @@ jobs:
 
       - name: Assign CA subsystem cert to CA subsystem user
         run: |
-          docker cp ca/certs/subsystem.crt kra:ca_subsystem.crt
-          docker exec kra ls -la
+          cp ca/conf/certs/subsystem.crt kra/conf/certs/ca_subsystem.crt
           docker exec kra pki-server kra-user-cert-add \
-              --cert ca_subsystem.crt \
+              --cert /conf/certs/ca_subsystem.crt \
               CA-ca.example.com-8443
 
       - name: Assign roles to CA subsystem user

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -99,73 +99,97 @@ jobs:
 
       - name: Import CA signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/ca_signing.crt \
+              ca_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/ca_signing.csr \
+              --csr /conf/certs/ca_signing.csr \
               --profile /usr/share/pki/ca/conf/caCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/ca_signing.crt \
+              --cert /conf/certs/ca_signing.crt \
               --profile /usr/share/pki/ca/conf/caCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA OCSP signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/ocsp_signing.crt \
+              ca_ocsp_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/ocsp_signing.csr \
+              --csr /conf/certs/ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/ocsp_signing.crt \
+              --cert /conf/certs/ocsp_signing.crt \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA audit signing cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/audit_signing.crt \
+              ca_audit_signing
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/audit_signing.csr \
+              --csr /conf/certs/audit_signing.csr \
               --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/audit_signing.crt \
+              --cert /conf/certs/audit_signing.crt \
               --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
               --request $REQUEST_ID
 
       - name: Import CA subsystem cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/subsystem.crt \
+              subsystem
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/subsystem.csr \
+              --csr /conf/certs/subsystem.csr \
               --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/subsystem.crt \
+              --cert /conf/certs/subsystem.crt \
               --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
               --request $REQUEST_ID
 
       - name: Import SSL server cert into CA database
         run: |
+          docker exec ca pki-server cert-export \
+              --cert-file /conf/certs/sslserver.crt \
+              sslserver
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/sslserver.csr \
+              --csr /conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/sslserver.crt \
+              --cert /conf/certs/sslserver.crt \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
               --request $REQUEST_ID
 
       - name: Import admin cert into CA database
         run: |
+          docker exec ca pki nss-cert-export \
+              --output-file /conf/certs/admin.crt \
+              admin
+
           docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/admin.csr \
+              --csr /conf/certs/admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
           REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
 
           docker exec ca pki-server ca-cert-import \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
               --request $REQUEST_ID
 
@@ -180,7 +204,7 @@ jobs:
       - name: Assign admin cert to CA admin user
         run: |
           docker exec ca pki-server ca-user-cert-add \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               admin
 
       - name: Add admin user into CA groups
@@ -190,8 +214,13 @@ jobs:
 
       - name: Install admin cert
         run: |
+          docker exec ca pki pkcs12-export \
+              --pkcs12 /conf/certs/admin.p12 \
+              --password Secret.123 \
+              admin
+
           docker exec client pki pkcs12-import \
-              --pkcs12 $SHARED/ca/certs/admin.p12 \
+              --pkcs12 $SHARED/ca/conf/certs/admin.p12 \
               --password Secret.123
 
           docker exec client pki \
@@ -276,7 +305,7 @@ jobs:
       - name: Prepare OCSP certs and keys
         run: |
           # export CA signing cert
-          docker exec client cp $SHARED/ca/certs/ca_signing.crt $SHARED/ocsp/certs
+          docker exec client cp $SHARED/ca/conf/certs/ca_signing.crt $SHARED/ocsp/certs
 
           docker exec client pki nss-cert-find
 
@@ -294,7 +323,7 @@ jobs:
               --password Secret.123 \
 
           # export admin cert and key
-          docker exec client cp $SHARED/ca/certs/admin.p12 $SHARED/ocsp/certs
+          docker exec client cp $SHARED/ca/conf/certs/admin.p12 $SHARED/ocsp/certs
 
           docker exec client pki pkcs12-cert-find \
               --pkcs12 $SHARED/ocsp/certs/admin.p12 \
@@ -445,8 +474,9 @@ jobs:
 
       - name: Assign admin cert to OCSP admin user
         run: |
+          cp ca/conf/certs/admin.crt ocsp/conf/certs/admin.crt
           docker exec ocsp pki-server ocsp-user-cert-add \
-              --cert /certs/admin.crt \
+              --cert /conf/certs/admin.crt \
               admin
 
       - name: Add OCSP admin user into OCSP groups
@@ -471,9 +501,9 @@ jobs:
 
       - name: Assign CA subsystem cert to CA subsystem user
         run: |
-          docker cp ca/certs/subsystem.crt ocsp:ca_subsystem.crt
+          cp ca/conf/certs/subsystem.crt ocsp/conf/certs/ca_subsystem.crt
           docker exec ocsp pki-server ocsp-user-cert-add \
-              --cert ca_subsystem.crt \
+              --cert /conf/certs/ca_subsystem.crt \
               CA-ca.example.com-8443
 
       - name: Assign roles to CA subsystem user
@@ -558,7 +588,7 @@ jobs:
           # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
           docker exec client curl \
               --cert-type P12 \
-              --cert $SHARED/ca/certs/admin.p12:Secret.123 \
+              --cert $SHARED/ca/conf/certs/admin.p12:Secret.123 \
               -sk \
               -d "xml=true" \
               https://ca.example.com:8443/ca/agent/ca/updateCRL \
@@ -601,7 +631,7 @@ jobs:
           # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
           docker exec client curl \
               --cert-type P12 \
-              --cert $SHARED/ca/certs/admin.p12:Secret.123 \
+              --cert $SHARED/ca/conf/certs/admin.p12:Secret.123 \
               -sk \
               -d "xml=true" \
               https://ca.example.com:8443/ca/agent/ca/updateCRL \
@@ -644,7 +674,7 @@ jobs:
           # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
           docker exec client curl \
               --cert-type P12 \
-              --cert $SHARED/ca/certs/admin.p12:Secret.123 \
+              --cert $SHARED/ca/conf/certs/admin.p12:Secret.123 \
               -sk \
               -d "xml=true" \
               https://ca.example.com:8443/ca/agent/ca/updateCRL \

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -131,8 +131,15 @@ jobs:
 
       - name: Install CA signing cert
         run: |
+          docker exec server pki \
+              -d /conf/alias \
+              -f /conf/password.conf \
+              nss-cert-export \
+              --output-file /conf/certs/ca_signing.crt \
+              ca_signing
+
           docker exec client pki nss-cert-import \
-              --cert $SHARED/certs/ca_signing.crt \
+              --cert $SHARED/conf/certs/ca_signing.crt \
               --trust CT,C,C \
               ca_signing
 

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -37,6 +37,44 @@ find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 
+if [ -f /certs/ca_signing.csr ]
+then
+    echo "INFO: Importing CA signing CSR"
+    cp /certs/ca_signing.csr /conf/certs/ca_signing.csr
+fi
+
+if [ -f /certs/ocsp_signing.csr ]
+then
+    echo "INFO: Importing OCSP signing CSR"
+    cp /certs/ocsp_signing.csr /conf/certs/ocsp_signing.csr
+fi
+
+if [ -f /certs/audit_signing.csr ]
+then
+    echo "INFO: Importing audit signing CSR"
+    cp /certs/audit_signing.csr /conf/certs/audit_signing.csr
+fi
+
+if [ -f /certs/subsystem.csr ]
+then
+    echo "INFO: Importing subsystem CSR"
+    cp /certs/subsystem.csr /conf/certs/subsystem.csr
+fi
+
+if [ -f /certs/sslserver.csr ]
+then
+    echo "INFO: Importing SSL server CSR"
+    cp /certs/sslserver.csr /conf/certs/sslserver.csr
+fi
+
+if [ -f /certs/admin.csr ]
+then
+    echo "INFO: Importing admin CSR"
+    cp /certs/admin.csr /conf/certs/admin.csr
+fi
+
+echo "################################################################################"
+
 if [ -f /certs/server.p12 ]
 then
     echo "INFO: Importing server certs and keys"
@@ -57,7 +95,7 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-export \
-    --output-file /certs/ca_signing.crt \
+    --output-file /tmp/ca_signing.crt \
     "$PKI_CA_SIGNING_NICKNAME" \
     2> /dev/null || rc=$?
 
@@ -71,23 +109,23 @@ then
         nss-cert-request \
         --subject "CN=CA Signing Certificate" \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
-        --csr /certs/ca_signing.csr
+        --csr /conf/certs/ca_signing.csr
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-issue \
-        --csr /certs/ca_signing.csr \
+        --csr /conf/certs/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
         --validity-length 1 \
         --validity-unit year \
-        --cert /certs/ca_signing.crt
+        --cert /tmp/ca_signing.crt
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-import \
-        --cert /certs/ca_signing.crt \
+        --cert /tmp/ca_signing.crt \
         --trust CT,C,C \
         "$PKI_CA_SIGNING_NICKNAME"
 fi
@@ -99,18 +137,6 @@ pki \
     nss-cert-show \
     "$PKI_CA_SIGNING_NICKNAME"
 
-if [ ! -f /certs/ca_signing.crt ]
-then
-    echo "INFO: Exporting CA signing cert"
-
-    pki \
-        -d /conf/alias \
-        -f /conf/password.conf \
-        nss-cert-export \
-        --output-file /certs/ca_signing.crt \
-        "$PKI_CA_SIGNING_NICKNAME"
-fi
-
 echo "################################################################################"
 
 # check whether OCSP signing cert exists
@@ -119,7 +145,7 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-export \
-    --output-file /certs/ocsp_signing.crt \
+    --output-file /tmp/ocsp_signing.crt \
     "$PKI_OCSP_SIGNING_NICKNAME" \
     2> /dev/null || rc=$?
 
@@ -133,22 +159,22 @@ then
         nss-cert-request \
         --subject "CN=OCSP Signing Certificate" \
         --ext /usr/share/pki/server/certs/ocsp_signing.conf \
-        --csr /certs/ocsp_signing.csr
+        --csr /conf/certs/ocsp_signing.csr
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-issue \
         --issuer "$PKI_CA_SIGNING_NICKNAME" \
-        --csr /certs/ocsp_signing.csr \
+        --csr /conf/certs/ocsp_signing.csr \
         --ext /usr/share/pki/server/certs/ocsp_signing.conf \
-        --cert /certs/ocsp_signing.crt
+        --cert /tmp/ocsp_signing.crt
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-import \
-        --cert /certs/ocsp_signing.crt \
+        --cert /tmp/ocsp_signing.crt \
         "$PKI_OCSP_SIGNING_NICKNAME"
 fi
 
@@ -167,7 +193,7 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-export \
-    --output-file /certs/audit_signing.crt \
+    --output-file /tmp/audit_signing.crt \
     "$PKI_AUDIT_SIGNING_NICKNAME" \
     2> /dev/null || rc=$?
 
@@ -181,22 +207,22 @@ then
         nss-cert-request \
         --subject "CN=Audit Signing Certificate" \
         --ext /usr/share/pki/server/certs/audit_signing.conf \
-        --csr /certs/audit_signing.csr
+        --csr /conf/certs/audit_signing.csr
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-issue \
         --issuer "$PKI_CA_SIGNING_NICKNAME" \
-        --csr /certs/audit_signing.csr \
+        --csr /conf/certs/audit_signing.csr \
         --ext /usr/share/pki/server/certs/audit_signing.conf \
-        --cert /certs/audit_signing.crt
+        --cert /tmp/audit_signing.crt
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-import \
-        --cert /certs/audit_signing.crt \
+        --cert /tmp/audit_signing.crt \
         --trust ,,P \
         "$PKI_AUDIT_SIGNING_NICKNAME"
 fi
@@ -216,7 +242,7 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-export \
-    --output-file /certs/subsystem.crt \
+    --output-file /tmp/subsystem.crt \
     "$PKI_SUBSYSTEM_NICKNAME" \
     2> /dev/null || rc=$?
 
@@ -229,22 +255,22 @@ then
         -f /conf/password.conf \
         nss-cert-request \
         --subject "CN=Subsystem Certificate" \
-        --csr /certs/subsystem.csr
+        --csr /conf/certs/subsystem.csr
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-issue \
         --issuer "$PKI_CA_SIGNING_NICKNAME" \
-        --csr /certs/subsystem.csr \
+        --csr /conf/certs/subsystem.csr \
         --ext /usr/share/pki/server/certs/subsystem.conf \
-        --cert /certs/subsystem.crt
+        --cert /tmp/subsystem.crt
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-import \
-        --cert /certs/subsystem.crt \
+        --cert /tmp/subsystem.crt \
         "$PKI_SUBSYSTEM_NICKNAME"
 fi
 
@@ -263,7 +289,7 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-export \
-    --output-file /certs/sslserver.crt \
+    --output-file /tmp/sslserver.crt \
     "$PKI_SSLSERVER_NICKNAME" \
     2> /dev/null || rc=$?
 
@@ -277,22 +303,22 @@ then
         nss-cert-request \
         --subject "CN=$HOSTNAME" \
         --ext /usr/share/pki/server/certs/sslserver.conf \
-        --csr /certs/sslserver.csr
+        --csr /conf/certs/sslserver.csr
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-issue \
         --issuer "$PKI_CA_SIGNING_NICKNAME" \
-        --csr /certs/sslserver.csr \
+        --csr /conf/certs/sslserver.csr \
         --ext /usr/share/pki/server/certs/sslserver.conf \
-        --cert /certs/sslserver.crt
+        --cert /tmp/sslserver.crt
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-import \
-        --cert /certs/sslserver.crt \
+        --cert /tmp/sslserver.crt \
         "$PKI_SSLSERVER_NICKNAME"
 fi
 
@@ -324,7 +350,7 @@ if [ $rc -ne 0 ]
 then
     echo "INFO: Importing CA signing cert"
     pki nss-cert-import \
-        --cert /certs/ca_signing.crt \
+        --cert /tmp/ca_signing.crt \
         --trust CT,C,C \
         "$PKI_CA_SIGNING_NICKNAME"
 fi
@@ -334,7 +360,7 @@ echo "##########################################################################
 # check whether admin cert exists
 rc=0
 pki nss-cert-export \
-    --output-file /certs/admin.crt \
+    --output-file /tmp/admin.crt \
     "$PKI_ADMIN_NICKNAME" \
     2> /dev/null || rc=$?
 
@@ -345,43 +371,24 @@ then
     pki nss-cert-request \
         --subject "CN=Administrator" \
         --ext /usr/share/pki/server/certs/admin.conf \
-        --csr /certs/admin.csr
+        --csr /conf/certs/admin.csr
 
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-issue \
         --issuer "$PKI_CA_SIGNING_NICKNAME" \
-        --csr /certs/admin.csr \
+        --csr /conf/certs/admin.csr \
         --ext /usr/share/pki/server/certs/admin.conf \
-        --cert /certs/admin.crt
+        --cert /tmp/admin.crt
 
     pki nss-cert-import \
-        --cert /certs/admin.crt \
+        --cert /tmp/admin.crt \
         "$PKI_ADMIN_NICKNAME"
 fi
 
 echo "INFO: Admin cert:"
 pki nss-cert-show "$PKI_ADMIN_NICKNAME"
-
-if [ ! -f /certs/admin.p12 ]
-then
-    echo "INFO: Exporting admin cert and key"
-
-    pki pkcs12-export \
-        --pkcs12 /certs/admin.p12 \
-        --password Secret.123 \
-        "$PKI_ADMIN_NICKNAME"
-fi
-
-if [ ! -f /certs/admin.crt ]
-then
-    echo "INFO: Exporting admin cert"
-
-    pki nss-cert-export \
-        --output-file /certs/admin.crt \
-        "$PKI_ADMIN_NICKNAME"
-fi
 
 echo "################################################################################"
 echo "INFO: Creating PKI CA"
@@ -403,15 +410,15 @@ pkispawn \
     -D pki_share_db=True \
     -D pki_import_system_certs=False \
     -D pki_ca_signing_nickname="$PKI_CA_SIGNING_NICKNAME" \
-    -D pki_ca_signing_csr_path=/certs/ca_signing.csr \
+    -D pki_ca_signing_csr_path=/conf/certs/ca_signing.csr \
     -D pki_ocsp_signing_nickname="$PKI_OCSP_SIGNING_NICKNAME" \
-    -D pki_ocsp_signing_csr_path=/certs/ocsp_signing.csr \
+    -D pki_ocsp_signing_csr_path=/conf/certs/ocsp_signing.csr \
     -D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME" \
-    -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
+    -D pki_audit_signing_csr_path=/conf/certs/audit_signing.csr \
     -D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME" \
-    -D pki_subsystem_csr_path=/certs/subsystem.csr \
+    -D pki_subsystem_csr_path=/conf/certs/subsystem.csr \
     -D pki_sslserver_nickname="$PKI_SSLSERVER_NICKNAME" \
-    -D pki_sslserver_csr_path=/certs/sslserver.csr \
+    -D pki_sslserver_csr_path=/conf/certs/sslserver.csr \
     -D pki_admin_setup=False \
     -D pki_security_domain_setup=False \
     -D pki_security_manager=False \
@@ -438,6 +445,16 @@ find /conf -type f -exec chmod +rw -- {} +
 find /conf -type d -exec chmod +rwx -- {} +
 find /logs -type f -exec chmod +rw -- {} +
 find /logs -type d -exec chmod +rwx -- {} +
+
+echo "################################################################################"
+echo "INFO: Removing temporary files"
+
+rm /tmp/ca_signing.crt
+rm /tmp/ocsp_signing.crt
+rm /tmp/audit_signing.crt
+rm /tmp/subsystem.crt
+rm /tmp/sslserver.crt
+rm /tmp/admin.crt
 
 echo "################################################################################"
 echo "INFO: Starting PKI CA"

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -37,6 +37,44 @@ find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 
+if [ -f /certs/kra_storage.csr ]
+then
+    echo "INFO: Importing KRA storage CSR"
+    cp /certs/kra_storage.csr /conf/certs/kra_storage.csr
+fi
+
+if [ -f /certs/kra_transport.csr ]
+then
+    echo "INFO: Importing KRA transport CSR"
+    cp /certs/kra_transport.csr /conf/certs/kra_transport.csr
+fi
+
+if [ -f /certs/audit_signing.csr ]
+then
+    echo "INFO: Importing audit signing CSR"
+    cp /certs/audit_signing.csr /conf/certs/audit_signing.csr
+fi
+
+if [ -f /certs/subsystem.csr ]
+then
+    echo "INFO: Importing subsystem CSR"
+    cp /certs/subsystem.csr /conf/certs/subsystem.csr
+fi
+
+if [ -f /certs/sslserver.csr ]
+then
+    echo "INFO: Importing SSL server CSR"
+    cp /certs/sslserver.csr /conf/certs/sslserver.csr
+fi
+
+if [ -f /certs/admin.csr ]
+then
+    echo "INFO: Importing admin CSR"
+    cp /certs/admin.csr /conf/certs/admin.csr
+fi
+
+echo "################################################################################"
+
 if [ -f /certs/server.p12 ]
 then
     echo "INFO: Importing system certs and keys"
@@ -85,18 +123,6 @@ pki \
     nss-cert-show \
     "$PKI_SUBSYSTEM_NICKNAME"
 
-if [ ! -f /certs/subsystem.crt ]
-then
-    echo "INFO: Exporting subsystem cert"
-
-    pki \
-        -d /conf/alias \
-        -f /conf/password.conf \
-        nss-cert-export \
-        --output-file /certs/subsystem.crt \
-        "$PKI_SUBSYSTEM_NICKNAME"
-fi
-
 echo "################################################################################"
 
 echo "INFO: SSL server cert:"
@@ -120,14 +146,8 @@ fi
 echo "INFO: Admin cert:"
 pki nss-cert-show "$PKI_ADMIN_NICKNAME"
 
-if [ ! -f /certs/admin.crt ]
-then
-    echo "INFO: Exporting admin cert"
-
-    pki nss-cert-export \
-        --output-file /certs/admin.crt \
-        "$PKI_ADMIN_NICKNAME"
-fi
+echo "################################################################################"
+echo "INFO: Removing temporary files"
 
 echo "################################################################################"
 echo "INFO: Creating PKI KRA"
@@ -151,15 +171,15 @@ pkispawn \
     -D pki_issuing_ca= \
     -D pki_import_system_certs=False \
     -D pki_storage_nickname="$PKI_STORAGE_NICKNAME" \
-    -D pki_storage_csr_path=/certs/kra_storage.csr \
+    -D pki_storage_csr_path=/conf/certs/kra_storage.csr \
     -D pki_transport_nickname="$PKI_TRANSPORT_NICKNAME" \
-    -D pki_transport_csr_path=/certs/kra_transport.csr \
+    -D pki_transport_csr_path=/conf/certs/kra_transport.csr \
     -D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME" \
-    -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
+    -D pki_audit_signing_csr_path=/conf/certs/audit_signing.csr \
     -D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME" \
-    -D pki_subsystem_csr_path=/certs/subsystem.csr \
+    -D pki_subsystem_csr_path=/conf/certs/subsystem.csr \
     -D pki_sslserver_nickname="$PKI_SSLSERVER_NICKNAME" \
-    -D pki_sslserver_csr_path=/certs/sslserver.csr \
+    -D pki_sslserver_csr_path=/conf/certs/sslserver.csr \
     -D pki_admin_setup=False \
     -D pki_security_domain_setup=False \
     -D pki_security_manager=False \

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -36,6 +36,38 @@ find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 
+if [ -f /certs/ocsp_signing.csr ]
+then
+    echo "INFO: Importing OCSP signing CSR"
+    cp /certs/ocsp_signing.csr /conf/certs/ocsp_signing.csr
+fi
+
+if [ -f /certs/audit_signing.csr ]
+then
+    echo "INFO: Importing audit signing CSR"
+    cp /certs/audit_signing.csr /conf/certs/audit_signing.csr
+fi
+
+if [ -f /certs/subsystem.csr ]
+then
+    echo "INFO: Importing subsystem CSR"
+    cp /certs/subsystem.csr /conf/certs/subsystem.csr
+fi
+
+if [ -f /certs/sslserver.csr ]
+then
+    echo "INFO: Importing SSL server CSR"
+    cp /certs/sslserver.csr /conf/certs/sslserver.csr
+fi
+
+if [ -f /certs/admin.csr ]
+then
+    echo "INFO: Importing admin CSR"
+    cp /certs/admin.csr /conf/certs/admin.csr
+fi
+
+echo "################################################################################"
+
 if [ -f /certs/server.p12 ]
 then
     echo "INFO: Importing system certs and keys"
@@ -75,18 +107,6 @@ pki \
     nss-cert-show \
     "$PKI_SUBSYSTEM_NICKNAME"
 
-if [ ! -f /certs/subsystem.crt ]
-then
-    echo "INFO: Exporting subsystem cert"
-
-    pki \
-        -d /conf/alias \
-        -f /conf/password.conf \
-        nss-cert-export \
-        --output-file /certs/subsystem.crt \
-        "$PKI_SUBSYSTEM_NICKNAME"
-fi
-
 echo "################################################################################"
 
 echo "INFO: SSL server cert:"
@@ -115,17 +135,6 @@ fi
 echo "INFO: Admin cert:"
 pki nss-cert-show "$PKI_ADMIN_NICKNAME"
 
-if [ ! -f /certs/admin.crt ]
-then
-    echo "INFO: Exporting admin cert"
-
-    pki nss-cert-export \
-        --output-file /certs/admin.crt \
-        "$PKI_ADMIN_NICKNAME"
-fi
-
-pki nss-cert-find
-
 echo "################################################################################"
 echo "INFO: Creating OCSP Responder"
 
@@ -149,13 +158,13 @@ pkispawn \
     -D pki_issuing_ca= \
     -D pki_import_system_certs=False \
     -D pki_ocsp_signing_nickname="$PKI_OCSP_SIGNING_NICKNAME" \
-    -D pki_ocsp_signing_csr_path=/certs/ocsp_signing.csr \
+    -D pki_ocsp_signing__path=/conf/certs/ocsp_signing.csr \
     -D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME" \
-    -D pki_audit_signing_csr_path=/certs/audit_signing.csr \
+    -D pki_audit_signing_csr_path=/conf/certs/audit_signing.csr \
     -D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME" \
-    -D pki_subsystem_csr_path=/certs/subsystem.csr \
+    -D pki_subsystem_csr_path=/conf/certs/subsystem.csr \
     -D pki_sslserver_nickname="$PKI_SSLSERVER_NICKNAME" \
-    -D pki_sslserver_csr_path=/certs/sslserver.csr \
+    -D pki_sslserver_csr_path=/conf/certs/sslserver.csr \
     -D pki_admin_setup=False \
     -D pki_security_domain_setup=False \
     -D pki_security_manager=False \

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -35,6 +35,20 @@ find /logs -type d -exec chmod +rwx -- {} +
 
 echo "################################################################################"
 
+if [ -f /certs/ca_signing.csr ]
+then
+    echo "INFO: Importing CA signing CSR"
+    cp /certs/ca_signing.csr /conf/certs/ca_signing.csr
+fi
+
+if [ -f /certs/sslserver.csr ]
+then
+    echo "INFO: Importing SSL server CSR"
+    cp /certs/ca_signing.csr /conf/certs/sslserver.csr
+fi
+
+echo "################################################################################"
+
 # import ca_signing.cert and ca_signing.key if available
 if [ -f /certs/ca_signing.crt ] && [ -f /certs/ca_signing.key ]
 then
@@ -93,7 +107,7 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-export \
-    --output-file /certs/ca_signing.crt \
+    --output-file /tmp/ca_signing.crt \
     "$PKI_CA_SIGNING_NICKNAME" \
     2> /dev/null || rc=$?
 
@@ -109,25 +123,25 @@ then
         nss-cert-request \
         --subject "CN=CA Signing Certificate" \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
-        --csr /certs/ca_signing.csr
+        --csr /conf/certs/ca_signing.csr
 
     # issue self-signed CA signing cert
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-issue \
-        --csr /certs/ca_signing.csr \
+        --csr /conf/certs/ca_signing.csr \
         --ext /usr/share/pki/server/certs/ca_signing.conf \
         --validity-length 1 \
         --validity-unit year \
-        --cert /certs/ca_signing.crt
+        --cert /tmp/ca_signing.crt
 
     # import and trust CA signing cert into NSS database
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-import \
-        --cert /certs/ca_signing.crt \
+        --cert /tmp/ca_signing.crt \
         --trust CT,C,C \
         "$PKI_CA_SIGNING_NICKNAME"
 fi
@@ -147,7 +161,7 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-export \
-    --output-file /certs/sslserver.crt \
+    --output-file /tmp/sslserver.crt \
     "$PKI_SSLSERVER_NICKNAME" \
     2> /dev/null || rc=$?
 
@@ -163,7 +177,7 @@ then
         nss-cert-request \
         --subject "CN=$HOSTNAME" \
         --ext /usr/share/pki/server/certs/sslserver.conf \
-        --csr /certs/sslserver.csr
+        --csr /conf/certs/sslserver.csr
 
     # issue SSL server cert
     pki \
@@ -171,16 +185,16 @@ then
         -f /conf/password.conf \
         nss-cert-issue \
         --issuer "$PKI_CA_SIGNING_NICKNAME" \
-        --csr /certs/sslserver.csr \
+        --csr /conf/certs/sslserver.csr \
         --ext /usr/share/pki/server/certs/sslserver.conf \
-        --cert /certs/sslserver.crt
+        --cert /tmp/sslserver.crt
 
     # import SSL server cert into NSS database
     pki \
         -d /conf/alias \
         -f /conf/password.conf \
         nss-cert-import \
-        --cert /certs/sslserver.crt \
+        --cert /tmp/sslserver.crt \
         "$PKI_SSLSERVER_NICKNAME"
 fi
 
@@ -203,7 +217,7 @@ if [ $rc -ne 0 ]
 then
     echo "INFO: Importing CA signing cert"
     pki nss-cert-import \
-        --cert /certs/ca_signing.crt \
+        --cert /tmp/ca_signing.crt \
         --trust CT,C,C \
         "$PKI_CA_SIGNING_NICKNAME"
 fi
@@ -221,6 +235,12 @@ find /conf -type f -exec chmod +rw -- {} +
 find /conf -type d -exec chmod +rwx -- {} +
 find /logs -type f -exec chmod +rw -- {} +
 find /logs -type d -exec chmod +rwx -- {} +
+
+echo "################################################################################"
+echo "INFO: Removing temporary files"
+
+rm /tmp/ca_signing.crt
+rm /tmp/sslserver.crt
 
 echo "################################################################################"
 echo "INFO: Starting PKI server"


### PR DESCRIPTION
The containers have been updated to remove redundant files to avoid conflicting or obsolete certs.

When the container is started the certs provided in `/certs` will be the authoritative data and will be imported into the server and admin NSS databases. If the certs are not provided, the container will generate new certs directly in the NSS databases. Once the container is running, the certs in the NSS databases will be the authoritative data until the container is restarted.

So now the container will only store certs and keys in NSS databases and CSR files, but it will no longer store cert files or PKCS #12 files since they are redundant. The tests have been updated to export these files from the container when they are needed.