### PR TITLE
Add pki-server ca-cert-import --csr option

### DIFF
--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -200,15 +200,10 @@ jobs:
               --cert-file /conf/certs/ca_signing.crt \
               ca_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/ca_signing.csr \
-              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/ca_signing.crt \
-              --profile /usr/share/pki/ca/conf/caCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile
 
       - name: Import CA OCSP signing cert into CA database
         run: |
@@ -216,15 +211,10 @@ jobs:
               --cert-file /conf/certs/ocsp_signing.crt \
               ca_ocsp_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/ocsp_signing.csr \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/ocsp_signing.crt \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
       - name: Import CA audit signing cert into CA database
         run: |
@@ -232,15 +222,10 @@ jobs:
               --cert-file /conf/certs/audit_signing.crt \
               ca_audit_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/audit_signing.crt \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
 
       - name: Import subsystem cert into CA database
         run: |
@@ -248,15 +233,10 @@ jobs:
               --cert-file /conf/certs/subsystem.crt \
               subsystem
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/subsystem.csr \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/subsystem.crt \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile
 
       - name: Import SSL server cert into CA database
         run: |
@@ -264,15 +244,10 @@ jobs:
               --cert-file /conf/certs/sslserver.crt \
               sslserver
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/sslserver.csr \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/sslserver.crt \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
       - name: Import admin cert into CA database
         run: |
@@ -280,15 +255,10 @@ jobs:
               --output-file /conf/certs/admin.crt \
               admin
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/admin.crt \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
 
       - name: Check CA certs
         run: |

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -360,75 +360,45 @@ jobs:
 
       - name: Import CA signing cert into CA database
         run: |
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/ca_signing.csr \
-              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /certs/ca_signing.crt \
-              --profile /usr/share/pki/ca/conf/caCert.profile \
-              --request $REQUEST_ID
+              --csr /certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile
 
       - name: Import CA OCSP signing cert into CA database
         run: |
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/ocsp_signing.csr \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /certs/ocsp_signing.crt \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
-              --request $REQUEST_ID
+              --csr /certs/ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
       - name: Import CA audit signing cert into CA database
         run: |
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /certs/audit_signing.crt \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
-              --request $REQUEST_ID
+              --csr /certs/audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
 
       - name: Import subsystem cert into CA database
         run: |
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/subsystem.csr \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /certs/subsystem.crt \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
-              --request $REQUEST_ID
+              --csr /certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile
 
       - name: Import SSL server cert into CA database
         run: |
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/sslserver.csr \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /certs/sslserver.crt \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
-              --request $REQUEST_ID
+              --csr /certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
       - name: Import admin cert into CA database
         run: |
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /certs/admin.crt \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --request $REQUEST_ID
+              --csr /certs/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -198,75 +198,45 @@ jobs:
 
       - name: Import CA signing cert into CA database
         run: |
-          docker exec pki pki-server ca-cert-request-import \
-              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_signing.csr \
-              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec pki pki-server ca-cert-import \
               --cert /var/lib/pki/pki-tomcat/conf/certs/ca_signing.crt \
-              --profile /usr/share/pki/ca/conf/caCert.profile \
-              --request $REQUEST_ID
+              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile
 
       - name: Import CA OCSP signing cert into CA database
         run: |
-          docker exec pki pki-server ca-cert-request-import \
-              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec pki pki-server ca-cert-import \
               --cert /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.crt \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
-              --request $REQUEST_ID
+              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
       - name: Import CA audit signing cert into CA database
         run: |
-          docker exec pki pki-server ca-cert-request-import \
-              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec pki pki-server ca-cert-import \
               --cert /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.crt \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
-              --request $REQUEST_ID
+              --csr /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
 
       - name: Import subsystem cert into CA database
         run: |
-          docker exec pki pki-server ca-cert-request-import \
-              --csr /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec pki pki-server ca-cert-import \
               --cert /var/lib/pki/pki-tomcat/conf/certs/subsystem.crt \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
-              --request $REQUEST_ID
+              --csr /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile
 
       - name: Import SSL server cert into CA database
         run: |
-          docker exec pki pki-server ca-cert-request-import \
-              --csr /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec pki pki-server ca-cert-import \
               --cert /var/lib/pki/pki-tomcat/conf/certs/sslserver.crt \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
-              --request $REQUEST_ID
+              --csr /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
       - name: Import admin cert into CA database
         run: |
-          docker exec pki pki-server ca-cert-request-import \
-              --csr admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec pki pki-server ca-cert-import \
               --cert admin.crt \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --request $REQUEST_ID
+              --csr admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database-User
       - name: Add database user

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -102,15 +102,10 @@ jobs:
               --cert-file /conf/certs/ca_signing.crt \
               ca_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/ca_signing.csr \
-              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/ca_signing.crt \
-              --profile /usr/share/pki/ca/conf/caCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile
 
       - name: Import CA OCSP signing cert into CA database
         run: |
@@ -118,15 +113,10 @@ jobs:
               --cert-file /conf/certs/ocsp_signing.crt \
               ca_ocsp_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/ocsp_signing.csr \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/ocsp_signing.crt \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
       - name: Import CA audit signing cert into CA database
         run: |
@@ -134,15 +124,10 @@ jobs:
               --cert-file /conf/certs/audit_signing.crt \
               ca_audit_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/audit_signing.crt \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
 
       - name: Import CA subsystem cert into CA database
         run: |
@@ -150,15 +135,10 @@ jobs:
               --cert-file /conf/certs/subsystem.crt \
               subsystem
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/subsystem.csr \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/subsystem.crt \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile
 
       - name: Import SSL server cert into CA database
         run: |
@@ -166,15 +146,10 @@ jobs:
               --cert-file /conf/certs/sslserver.crt \
               sslserver
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/sslserver.csr \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/sslserver.crt \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
       - name: Import admin cert into CA database
         run: |
@@ -182,15 +157,10 @@ jobs:
               --output-file /conf/certs/admin.crt \
               admin
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/admin.crt \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -103,15 +103,10 @@ jobs:
               --cert-file /conf/certs/ca_signing.crt \
               ca_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/ca_signing.csr \
-              --profile /usr/share/pki/ca/conf/caCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/ca_signing.crt \
-              --profile /usr/share/pki/ca/conf/caCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/ca_signing.csr \
+              --profile /usr/share/pki/ca/conf/caCert.profile
 
       - name: Import CA OCSP signing cert into CA database
         run: |
@@ -119,15 +114,10 @@ jobs:
               --cert-file /conf/certs/ocsp_signing.crt \
               ca_ocsp_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/ocsp_signing.csr \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/ocsp_signing.crt \
-              --profile /usr/share/pki/ca/conf/caOCSPCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/ocsp_signing.csr \
+              --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
       - name: Import CA audit signing cert into CA database
         run: |
@@ -135,15 +125,10 @@ jobs:
               --cert-file /conf/certs/audit_signing.crt \
               ca_audit_signing
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/audit_signing.crt \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/audit_signing.csr \
+              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
 
       - name: Import CA subsystem cert into CA database
         run: |
@@ -151,15 +136,10 @@ jobs:
               --cert-file /conf/certs/subsystem.crt \
               subsystem
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/subsystem.csr \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/subsystem.crt \
-              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/subsystem.csr \
+              --profile /usr/share/pki/ca/conf/rsaSubsystemCert.profile
 
       - name: Import SSL server cert into CA database
         run: |
@@ -167,15 +147,10 @@ jobs:
               --cert-file /conf/certs/sslserver.crt \
               sslserver
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/sslserver.csr \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/sslserver.crt \
-              --profile /usr/share/pki/ca/conf/rsaServerCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/sslserver.csr \
+              --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
       - name: Import admin cert into CA database
         run: |
@@ -183,15 +158,10 @@ jobs:
               --output-file /conf/certs/admin.crt \
               admin
 
-          docker exec ca pki-server ca-cert-request-import \
-              --csr /conf/certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           docker exec ca pki-server ca-cert-import \
               --cert /conf/certs/admin.crt \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --request $REQUEST_ID
+              --csr /conf/certs/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user

--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -301,6 +301,8 @@ class CACertImportCLI(pki.cli.CLI):
         print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat)')
         print('      --cert <path>                  Certificate path')
         print('      --format <format>              Certificate format: PEM (default), DER')
+        print('      --csr <path>                   CSR path')
+        print('      --csr-format <format>          CSR format: PEM (default), DER')
         print('      --profile <path>               Bootstrap profile path')
         print('      --request <ID>                 Request ID')
         print('  -v, --verbose                      Run in verbose mode.')
@@ -313,7 +315,9 @@ class CACertImportCLI(pki.cli.CLI):
         try:
             opts, _ = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=',
-                'cert=', 'format=', 'profile=', 'request=',
+                'cert=', 'format=',
+                'csr=', 'csr-format=',
+                'profile=', 'request=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -324,6 +328,8 @@ class CACertImportCLI(pki.cli.CLI):
         instance_name = 'pki-tomcat'
         cert_path = None
         cert_format = None
+        csr_path = None
+        csr_format = None
         profile_path = None
         request_id = None
 
@@ -336,6 +342,12 @@ class CACertImportCLI(pki.cli.CLI):
 
             elif o == '--format':
                 cert_format = a
+
+            elif o == '--csr':
+                csr_path = a
+
+            elif o == '--csr-format':
+                csr_format = a
 
             elif o == '--profile':
                 profile_path = a
@@ -370,6 +382,17 @@ class CACertImportCLI(pki.cli.CLI):
             logger.error('No CA subsystem in instance %s', instance_name)
             sys.exit(1)
 
+        if csr_path:
+            # import CSR if provided
+            result = subsystem.import_cert_request(
+                request_path=csr_path,
+                request_format=csr_format,
+                profile_path=profile_path,
+                request_id=request_id)
+
+            request_id = result['requestID']
+
+        # import cert
         subsystem.import_cert(
             cert_path=cert_path,
             cert_format=cert_format,

--- a/docs/changes/v11.6.0/Tools-Changes.adoc
+++ b/docs/changes/v11.6.0/Tools-Changes.adoc
@@ -16,15 +16,20 @@ the subsystem `Type` field since it's redundant.
 Instead, it will show an `SD Manager` field which will indicate whether
 the subsystem is a security domain manager.
 
-== Update certifcate enrollment commands ==
+== Update certificate enrollment commands ==
 
 The `pki ca-cert-request-submit` command has been updated to provide options
 to specify the enrollment password and PIN.
 
-== Update certifcate revocation commands ==
+== Update certificate revocation commands ==
 
 The `pki ca-cert-revoke`, `pki ca-cert-hold`, and `pki ca-cert-release-hold` commands
 have been updated to accept multiple serial numbers.
+
+== Update certificate import command ==
+
+The `pki-server ca-cert-import` command has been updated to provide an option
+to specify the CSR of the certificate to be imported.
 
 == Deprecate revoker tool ==
 

--- a/tests/bin/runner-init.sh
+++ b/tests/bin/runner-init.sh
@@ -109,6 +109,10 @@ OPTIONS+=(--hostname $HOSTNAME)
 OPTIONS+=(--tmpfs /tmp)
 OPTIONS+=(--tmpfs /run)
 OPTIONS+=(-v $GITHUB_WORKSPACE:$SHARED)
+
+# required to run Podman in container
+OPTIONS+=(-v /var/lib/containers:/var/lib/containers)
+
 OPTIONS+=(-e BUILDUSER_UID=$(id -u))
 OPTIONS+=(-e BUILDUSER_GID=$(id -g))
 OPTIONS+=(-e SHARED=$SHARED)


### PR DESCRIPTION
The `pki-server ca-cert-import` has been updated to provide an option to specify the CSR of the cert to be imported. This way the cert and the CSR can be imported using a single command.

The tests have been updated to use the new option.

https://github.com/edewata/pki/blob/cli/docs/changes/v11.6.0/Tools-Changes.adoc
