### PR TITLE
Make ACL filter configurable for method and path

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/CAServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/CAServlet.java
@@ -28,6 +28,20 @@ public class CAServlet extends PKIServlet {
         response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
+    @Override
+    public void put(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    @Override
+    public void patch(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    @Override
+    public void delete(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
 
     public CAEngine getCAEngine() {
         ServletContext servletContext = getServletContext();

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/CAServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/CAServlet.java
@@ -47,4 +47,9 @@ public class CAServlet extends PKIServlet {
         ServletContext servletContext = getServletContext();
         return (CAEngine) servletContext.getAttribute("engine");
     }
+
+    @Override
+    protected String getSubsystemName() {
+        return getCAEngine().getID();
+    }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/logging/ActivityCollection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/logging/ActivityCollection.java
@@ -31,7 +31,7 @@ import com.netscape.certsrv.util.JSONSerializer;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class ActivityCollection extends DataCollection<ActivityData> implements JSONSerializer{
+public class ActivityCollection extends DataCollection<ActivityData> implements JSONSerializer {
 
     @Override
     public Collection<ActivityData> getEntries() {

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/ActivityServlet.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/ActivityServlet.java
@@ -6,7 +6,6 @@
 package org.dogtagpki.server.tps.rest.v2;
 
 import java.io.PrintWriter;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -27,12 +26,10 @@ import org.slf4j.LoggerFactory;
 import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.base.ResourceNotFoundException;
-import com.netscape.certsrv.base.SessionContext;
 import com.netscape.certsrv.base.UnauthorizedException;
 import com.netscape.certsrv.logging.ActivityCollection;
 import com.netscape.certsrv.logging.ActivityData;
 import com.netscape.certsrv.user.UserResource;
-import com.netscape.cmscore.usrgrp.User;
 
 /**
  * @author Marco Fargetta {@literal <mfargett@redhat.com>}
@@ -42,7 +39,7 @@ import com.netscape.cmscore.usrgrp.User;
         urlPatterns = "/v2/activities/*")
 public class ActivityServlet extends TPSServlet {
     private static final long serialVersionUID = 1L;
-    private static Logger logger = LoggerFactory.getLogger(ActivityServlet.class);
+    private static final Logger logger = LoggerFactory.getLogger(ActivityServlet.class);
 
     @Override
     public void get(HttpServletRequest request, HttpServletResponse response) throws Exception {
@@ -97,18 +94,6 @@ public class ActivityServlet extends TPSServlet {
         ActivityCollection activities = retrieveActivities(database, authorizedProfiles, filter, start, size);
         out.println(activities.toJSON());
     }
-    /*
-     * returns a list of TPS profiles allowed for the current user
-     */
-    private List<String> getAuthorizedProfiles(HttpServletRequest req) {
-        SessionContext context = SessionContext.getContext();
-        User user = (User) context.get(SessionContext.USER);
-        if (user == null) {
-            logger.debug("ActivityServlet.getAuthorizedProfiles: no user in session context");
-            return Collections.emptyList();
-        }
-        return user.getTpsProfiles();
-    }
 
     private ActivityData createActivityData(ActivityRecord activityRecord) {
         ActivityData activityData = new ActivityData();
@@ -158,7 +143,6 @@ public class ActivityServlet extends TPSServlet {
 
         List<ActivityRecord> activityList = (List<ActivityRecord>) database.findRecords(
                 filter, null, new String[] { "-date" }, start, size);
-
 
         if (authorizedProfiles.contains(UserResource.ALL_PROFILES)) {
             for (ActivityRecord aRec: activityList) {

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/TPSServlet.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/TPSServlet.java
@@ -5,6 +5,9 @@
 //
 package org.dogtagpki.server.tps.rest.v2;
 
+import java.util.Collections;
+import java.util.List;
+
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -12,6 +15,9 @@ import javax.servlet.http.HttpServletResponse;
 import org.dogtagpki.server.rest.v2.PKIServlet;
 import org.dogtagpki.server.tps.TPSEngine;
 import org.dogtagpki.server.tps.TPSSubsystem;
+
+import com.netscape.certsrv.base.SessionContext;
+import com.netscape.cmscore.usrgrp.User;
 
 /**
  * @author Marco Fargetta {@literal <mfargett@redhat.com>}
@@ -54,5 +60,21 @@ public class TPSServlet extends PKIServlet {
         TPSEngine engine = (TPSEngine) servletContext.getAttribute("engine");
 
         return (TPSSubsystem) engine.getSubsystem(TPSSubsystem.ID);
+    }
+
+    /*
+     * returns a list of TPS profiles allowed for the current user
+     */
+    protected List<String> getAuthorizedProfiles(HttpServletRequest req) {
+        SessionContext context = SessionContext.getContext();
+        User user = (User) context.get(SessionContext.USER);
+        if (user == null) {
+            return Collections.emptyList();
+        }
+        return user.getTpsProfiles();
+    }
+    @Override
+    protected String getSubsystemName() {
+        return getTPSEngine().getID();
     }
 }

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/TPSServlet.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/TPSServlet.java
@@ -29,6 +29,20 @@ public class TPSServlet extends PKIServlet {
         response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
+    @Override
+    public void put(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    @Override
+    public void patch(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    @Override
+    public void delete(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
 
     protected TPSEngine getTPSEngine() {
         ServletContext servletContext = getServletContext();


### PR DESCRIPTION
If the servlet has different ACLs for different HTTP methods or paths the new implementation allows to define a map to identify the correct ACL.

The MAP will associate a key with the ACL and the key is made as `<method>:<path>`. The method is one of the HTTP defined method (e.g. GET, POST, ...) and the special value of "*" indicate all methods. The path is internal of the servlet path and in case of path parameter these can be identified with "{}". 
An example of entry could be:
```
         key= PUT:/token/{} value= token.read
```