### PR TITLE
Add pki-server <subsystem>-user-add --cert option

### DIFF
--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -273,10 +273,6 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              admin
-
-          # assign admin cert to CA admin user
-          docker exec ca pki-server ca-user-cert-add \
               --cert /conf/certs/admin.crt \
               admin
 

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -406,11 +406,6 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              admin
-
-      - name: Assign admin cert to CA admin user
-        run: |
-          docker exec ca pki-server ca-user-cert-add \
               --cert /certs/admin.crt \
               admin
 

--- a/.github/workflows/ca-container-system-service-test.yml
+++ b/.github/workflows/ca-container-system-service-test.yml
@@ -246,21 +246,16 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user
         run: |
-          # create CA admin user
-          docker exec pki podman exec systemd-pki-ca \
-              pki-server ca-user-add \
-              --full-name Administrator \
-              --type adminType \
-              admin
-
           docker exec pki podman exec systemd-pki-ca \
               pki nss-cert-export \
               --output-file /conf/certs/admin.crt \
               admin
 
-          # assign admin cert to CA admin user
+          # create CA admin user
           docker exec pki podman exec systemd-pki-ca \
-              pki-server ca-user-cert-add \
+              pki-server ca-user-add \
+              --full-name Administrator \
+              --type adminType \
               --cert /conf/certs/admin.crt \
               admin
 

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -244,11 +244,6 @@ jobs:
           docker exec pki pki-server ca-user-add \
               --full-name pkidbuser \
               --type agentType \
-              pkidbuser
-
-      - name: Assign subsystem cert to database user
-        run: |
-          docker exec pki pki-server ca-user-cert-add \
               --cert /var/lib/pki/pki-tomcat/conf/certs/subsystem.crt \
               pkidbuser
 
@@ -296,11 +291,6 @@ jobs:
           docker exec pki pki-server ca-user-add \
               --full-name CA-pki.example.com-8443 \
               --type agentType \
-              CA-pki.example.com-8443
-
-      - name: Assign subsystem cert to subsystem user
-        run: |
-          docker exec pki pki-server ca-user-cert-add \
               --cert /var/lib/pki/pki-tomcat/conf/certs/subsystem.crt \
               CA-pki.example.com-8443
 
@@ -314,11 +304,6 @@ jobs:
           docker exec pki pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              caadmin
-
-      - name: Assign CA admin cert to CA admin user
-        run: |
-          docker exec pki pki-server ca-user-cert-add \
               --cert admin.crt \
               caadmin
 

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -168,11 +168,6 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              admin
-
-      - name: Assign admin cert to CA admin user
-        run: |
-          docker exec ca pki-server ca-user-cert-add \
               --cert /conf/certs/admin.crt \
               admin
 
@@ -455,15 +450,10 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-KRA-Admin-User
       - name: Add KRA admin user
         run: |
+          cp ca/conf/certs/admin.crt kra/conf/certs/admin.crt
           docker exec kra pki-server kra-user-add \
               --full-name Administrator \
               --type adminType \
-              admin
-
-      - name: Assign admin cert to KRA admin user
-        run: |
-          cp ca/conf/certs/admin.crt kra/conf/certs/admin.crt
-          docker exec kra pki-server kra-user-cert-add \
               --cert /conf/certs/admin.crt \
               admin
 
@@ -483,15 +473,10 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-Subsystem-User
       - name: Add CA subsystem user in KRA
         run: |
+          cp ca/conf/certs/subsystem.crt kra/conf/certs/ca_subsystem.crt
           docker exec kra pki-server kra-user-add \
               --full-name CA-ca.example.com-8443 \
               --type agentType \
-              CA-ca.example.com-8443
-
-      - name: Assign CA subsystem cert to CA subsystem user
-        run: |
-          cp ca/conf/certs/subsystem.crt kra/conf/certs/ca_subsystem.crt
-          docker exec kra pki-server kra-user-cert-add \
               --cert /conf/certs/ca_subsystem.crt \
               CA-ca.example.com-8443
 

--- a/.github/workflows/kra-existing-ds-test.yml
+++ b/.github/workflows/kra-existing-ds-test.yml
@@ -396,11 +396,6 @@ jobs:
           docker exec kra pki-server kra-user-add \
               --full-name Administrator \
               --type adminType \
-              kraadmin
-
-      - name: Assign KRA admin cert to KRA admin user
-        run: |
-          docker exec kra pki-server kra-user-cert-add \
               --cert $SHARED/kra_admin.crt \
               kraadmin
 

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -169,11 +169,6 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              admin
-
-      - name: Assign admin cert to CA admin user
-        run: |
-          docker exec ca pki-server ca-user-cert-add \
               --cert /conf/certs/admin.crt \
               admin
 
@@ -437,15 +432,10 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-OCSP-Admin-User
       - name: Add OCSP admin user
         run: |
+          cp ca/conf/certs/admin.crt ocsp/conf/certs/admin.crt
           docker exec ocsp pki-server ocsp-user-add \
               --full-name Administrator \
               --type adminType \
-              admin
-
-      - name: Assign admin cert to OCSP admin user
-        run: |
-          cp ca/conf/certs/admin.crt ocsp/conf/certs/admin.crt
-          docker exec ocsp pki-server ocsp-user-cert-add \
               --cert /conf/certs/admin.crt \
               admin
 
@@ -464,15 +454,10 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-Subsystem-User
       - name: Add CA subsystem user in OCSP
         run: |
+          cp ca/conf/certs/subsystem.crt ocsp/conf/certs/ca_subsystem.crt
           docker exec ocsp pki-server ocsp-user-add \
               --full-name CA-ca.example.com-8443 \
               --type agentType \
-              CA-ca.example.com-8443
-
-      - name: Assign CA subsystem cert to CA subsystem user
-        run: |
-          cp ca/conf/certs/subsystem.crt ocsp/conf/certs/ca_subsystem.crt
-          docker exec ocsp pki-server ocsp-user-cert-add \
               --cert /conf/certs/ca_subsystem.crt \
               CA-ca.example.com-8443
 

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -193,8 +193,12 @@ jobs:
           docker exec ca pki-server cert-export subsystem --cert-file ${SHARED}/subsystem.crt
 
           # create CA user with CA subsystem cert
-          docker exec ocsp pki-server ocsp-user-add CA --full-name "CA" --type agentType
-          docker exec ocsp pki-server ocsp-user-cert-add CA --cert ${SHARED}/subsystem.crt
+          docker exec ocsp pki-server ocsp-user-add \
+              --full-name "CA" \
+              --type agentType \
+              --cert ${SHARED}/subsystem.crt \
+              CA
+
           docker exec ocsp pki-server ocsp-group-member-add "Trusted Managers" CA
 
       - name: Create CRL issuing point in OCSP

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -46,6 +46,8 @@ class UserAddCLI(pki.cli.CLI):
               --email <email>                Email
               --password <password>          Password
               --password-file <path>         Password file
+              --cert <path>                  Certificate file
+              --cert-format <format>         Certificate format (default: PEM)
               --phone <phone>                Phone
               --type <type>                  Type: userType, agentType, adminType, subsystemType
               --state <state>                State
@@ -73,6 +75,7 @@ class UserAddCLI(pki.cli.CLI):
             opts, args = getopt.gnu_getopt(argv, 'i:v', [
                 'instance=', 'full-name=', 'email=',
                 'password=', 'password-file=',
+                'cert=', 'cert-format=',
                 'phone=', 'type=', 'state=', 'tps-profiles=', 'ignore-duplicate'
                 'verbose', 'debug', 'help'])
 
@@ -87,6 +90,8 @@ class UserAddCLI(pki.cli.CLI):
         email = None
         password = None
         password_file = None
+        cert_path = None
+        cert_format = None
         phone = None
         user_type = None
         state = None
@@ -108,6 +113,12 @@ class UserAddCLI(pki.cli.CLI):
 
             elif o == '--password-file':
                 password_file = a
+
+            elif o == '--cert':
+                cert_path = a
+
+            elif o == '--cert-format':
+                cert_format = a
 
             elif o == '--phone':
                 phone = a
@@ -176,6 +187,12 @@ class UserAddCLI(pki.cli.CLI):
             state=state,
             tps_profiles=tps_profiles,
             ignore_duplicate=ignore_duplicate)
+
+        if cert_path:
+            subsystem.add_user_cert(
+                user_id,
+                cert_path=cert_path,
+                cert_format=cert_format)
 
 
 class UserFindCLI(pki.cli.CLI):

--- a/docs/changes/v11.6.0/Tools-Changes.adoc
+++ b/docs/changes/v11.6.0/Tools-Changes.adoc
@@ -43,3 +43,8 @@ The `revoker` tool has been deprecated. Use the following commands instead:
 
 The `pki-server-upgrade` was deprecated in PKI 10.7.1 so now it has been removed.
 Use `pki-server upgrade` instead.
+
+== Update pki-server <subsystem>-user-add ==
+
+The `pki-server <subsystem>-user-add` command has been updated to provide an option
+to specify the user certificate.


### PR DESCRIPTION
The `pki-server <subsystem>-user-add` has been updated to provide an option to specify the user certificate so it's not necessary to use a separate `pki-server <subsystem>-user-cert-add` command.

https://github.com/edewata/pki/blob/cli/docs/changes/v11.6.0/Tools-Changes.adoc
