### PR TITLE
[branch v11.5] Include -a when calling certutil to verify a certificate exists

### DIFF
--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -1489,7 +1489,7 @@ class Certutil:
                                   critical_failure=True):
         try:
             # Compose this "certutil" command
-            command = ["certutil", "-L"]
+            command = ["certutil", "-L", "-a"]
             #   Provide a path to the NSS security databases
             if path:
                 command.extend(["-d", path])


### PR DESCRIPTION
Without the -a certutil pauses just prior to displaying the trust flags. This is strange because the flags are stored in the internal token which is what is being queried. Only the internal token password is made available to certutil.

The call looks like this in an IPA installation:

certutil -L -d /etc/pki/pki-tomcat/alias -h internal \ -f/etc/pki/pki-tomcat/pfile -n 'Directory Server CA certificate'

In any case adding -a skips this trust value and displays the cert as a PEM and doesn't require the password.

Fixes: https://github.com/dogtagpki/pki/issues/4782