### PR TITLE
Remove default admin cert in containers

### DIFF
--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -249,18 +249,31 @@ jobs:
               --csr /conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
-      - name: Import admin cert into CA database
+      - name: Create admin cert
         run: |
-          docker exec ca pki nss-cert-export \
-              --output-file /conf/certs/admin.crt \
+          # create cert request
+          docker exec client pki nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr $SHARED/admin.csr
+
+          docker cp admin.csr ca:.
+
+          # issue cert
+          docker exec ca pki-server ca-cert-create \
+              --csr admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --cert admin.crt \
+              --import-cert
+
+          docker cp ca:admin.crt .
+
+          # import cert
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/admin.crt \
               admin
 
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/admin.crt \
-              --csr /conf/certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
-
-      - name: Check CA certs
+      - name: Check certs in CA
         run: |
           docker exec client pki \
               -U https://ca.example.com:8443 \
@@ -273,7 +286,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
           # add CA admin user into CA groups
@@ -282,15 +295,6 @@ jobs:
 
       - name: Check CA admin user
         run: |
-          docker exec ca pki pkcs12-export \
-              --pkcs12 /conf/certs/admin.p12 \
-              --password Secret.123 \
-              admin
-
-          docker exec client pki pkcs12-import \
-              --pkcs12 $SHARED/conf/certs/admin.p12 \
-              --pkcs12-password Secret.123
-
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n admin \

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -162,29 +162,7 @@ jobs:
               nss-cert-show \
               sslserver
 
-      - name: Create admin cert
-        run: |
-          docker exec client pki \
-              nss-cert-request \
-              --subject "CN=Administrator" \
-              --ext /usr/share/pki/server/certs/admin.conf \
-              --csr $SHARED/certs/admin.csr
-          docker exec client pki \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr $SHARED/certs/admin.csr \
-              --ext /usr/share/pki/server/certs/admin.conf \
-              --cert $SHARED/certs/admin.crt
-
-          docker exec client pki nss-cert-import \
-              --cert $SHARED/certs/admin.crt \
-              admin
-
-          docker exec client pki \
-              nss-cert-show \
-              admin
-
-      - name: Export system certs and keys
+      - name: Prepare CA certs and keys
         run: |
           docker exec client pki pkcs12-export \
               --pkcs12 $SHARED/certs/server.p12 \
@@ -199,16 +177,7 @@ jobs:
               --pkcs12 $SHARED/certs/server.p12 \
               --password Secret.123
 
-      - name: Export admin cert and key
-        run: |
-          docker exec client pki pkcs12-export \
-              --pkcs12 $SHARED/certs/admin.p12 \
-              --password Secret.123 \
-              admin
-
-          docker exec client pki pkcs12-cert-find \
-              --pkcs12 $SHARED/certs/admin.p12 \
-              --password Secret.123
+          ls -la certs
 
       - name: Set up CA container
         run: |
@@ -393,12 +362,35 @@ jobs:
               --csr /certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
-      - name: Import admin cert into CA database
+      - name: Create admin cert
         run: |
-          docker exec ca pki-server ca-cert-import \
-              --cert /certs/admin.crt \
-              --csr /certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
+          # create cert request
+          docker exec client pki nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr $SHARED/admin.csr
+
+          docker cp admin.csr ca:.
+
+          # issue cert
+          docker exec ca pki-server ca-cert-create \
+              --csr admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --cert admin.crt \
+              --import-cert
+
+          docker cp ca:admin.crt .
+
+          # import cert
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/admin.crt \
+              admin
+
+      - name: Check certs in CA
+        run: |
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              ca-cert-find
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user
@@ -406,7 +398,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /certs/admin.crt \
+              --cert admin.crt \
               admin
 
       - name: Add CA admin user into CA groups
@@ -414,48 +406,16 @@ jobs:
           docker exec ca pki-server ca-user-role-add admin "Administrators"
           docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
 
-      - name: Check public operations from CA container
+      - name: Check CA admin user
         run: |
-          # check certs in CA
-          docker exec ca pki ca-cert-find
-
-      - name: Check admin operations from CA container
-        run: |
-          # check CA admin user
-          docker exec ca pki \
-              -n admin \
-              ca-user-show \
-              admin
-
-          docker exec ca pki \
-              client-cert-request \
-              uid=testuser | tee output
-
-          REQUEST_ID=$(sed -n -e 's/^ *Request ID: *\(.*\)$/\1/p' output)
-          echo "REQUEST_ID: $REQUEST_ID"
-
-          docker exec ca pki \
-              -n admin \
-              ca-cert-request-approve \
-              $REQUEST_ID \
-              --force
-
-      - name: Check public operations from client container
-        run: |
-          # check certs in CA
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              ca-cert-find
-
-      - name: Check admin operations from client container
-        run: |
-          # check CA admin user
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n admin \
               ca-user-show \
               admin
 
+      - name: Check cert enrollment
+        run: |
           docker exec client pki \
               -U https://ca.example.com:8443 \
               client-cert-request \

--- a/.github/workflows/ca-container-existing-config-test.yml
+++ b/.github/workflows/ca-container-existing-config-test.yml
@@ -145,16 +145,6 @@ jobs:
           docker exec pki cp \
               /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr \
               $SHARED/certs/sslserver.csr
-          docker exec pki cp \
-              /var/lib/pki/pki-tomcat/conf/certs/ca_admin.csr \
-              $SHARED/certs/admin.csr
-
-          # export admin cert and key
-          docker cp pki:/root/.dogtag/pki-tomcat/ca_admin_cert.p12 certs/admin.p12
-
-          docker exec pki pki pkcs12-cert-find \
-              --pkcs12 $SHARED/certs/admin.p12 \
-              --password Secret.123
 
           ls -la certs
 
@@ -187,7 +177,6 @@ jobs:
               -e PKI_AUDIT_SIGNING_NICKNAME=ca_audit_signing \
               -e PKI_SUBSYSTEM_NICKNAME=subsystem \
               -e PKI_SSLSERVER_NICKNAME=sslserver \
-              -e PKI_ADMIN_NICKNAME=caadmin \
               --detach \
               pki-ca
 

--- a/.github/workflows/ca-container-migration-test.yml
+++ b/.github/workflows/ca-container-migration-test.yml
@@ -131,7 +131,6 @@ jobs:
           Environment=PKI_AUDIT_SIGNING_NICKNAME=ca_audit_signing
           Environment=PKI_SUBSYSTEM_NICKNAME=subsystem
           Environment=PKI_SSLSERVER_NICKNAME=sslserver
-          Environment=PKI_ADMIN_NICKNAME=caadmin
 
           [Install]
           WantedBy=multi-user.target

--- a/.github/workflows/ca-container-system-service-test.yml
+++ b/.github/workflows/ca-container-system-service-test.yml
@@ -243,20 +243,39 @@ jobs:
           docker exec pki podman exec systemd-pki-ca \
               pki-server ca-db-vlv-reindex -v
 
+      - name: Create admin cert
+        run: |
+          # create cert request
+          docker exec pki pki nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr admin.csr
+
+          docker exec pki podman cp admin.csr systemd-pki-ca:/home/pkiuser
+
+          # issue cert
+          docker exec pki podman exec systemd-pki-ca pki-server ca-cert-create \
+              --csr /home/pkiuser/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --cert /home/pkiuser/admin.crt \
+              --import-cert
+
+          docker exec pki podman cp systemd-pki-ca:/home/pkiuser/admin.crt .
+
+          # import cert
+          docker exec pki pki nss-cert-import \
+              --cert admin.crt \
+              admin
+
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user
         run: |
-          docker exec pki podman exec systemd-pki-ca \
-              pki nss-cert-export \
-              --output-file /conf/certs/admin.crt \
-              admin
-
           # create CA admin user
           docker exec pki podman exec systemd-pki-ca \
               pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert /home/pkiuser/admin.crt \
               admin
 
           # add CA admin user into CA groups
@@ -267,16 +286,6 @@ jobs:
 
       - name: Check CA admin user
         run: |
-          docker exec pki podman exec systemd-pki-ca \
-              pki pkcs12-export \
-              --pkcs12 /conf/certs/admin.p12 \
-              --password Secret.123 \
-              admin
-
-          docker exec pki pki pkcs12-import \
-              --pkcs12 /home/pkiuser/conf/certs/admin.p12 \
-              --password Secret.123
-
           docker exec pki pki \
               -n admin \
               ca-user-show \

--- a/.github/workflows/ca-container-user-service-test.yml
+++ b/.github/workflows/ca-container-user-service-test.yml
@@ -297,23 +297,26 @@ jobs:
 
       - name: Create admin cert
         run: |
-          docker exec -u pkiuser pki pki \
-              nss-cert-request \
+          # create cert request
+          docker exec -u pkiuser pki pki nss-cert-request \
               --subject "CN=Administrator" \
               --ext /usr/share/pki/server/certs/admin.conf \
-              --csr /home/pkiuser/.dogtag/pki-ca/conf/certs/admin.csr
+              --csr /home/pkiuser/admin.csr
 
-          docker exec -u pkiuser pki podman exec systemd-pki-ca pki \
-              -d /conf/alias \
-              -f /conf/password.conf \
-              nss-cert-issue \
-              --issuer "ca_signing" \
-              --csr /conf/certs/admin.csr \
-              --ext /usr/share/pki/server/certs/admin.conf \
-              --cert /conf/certs/admin.crt
+          docker exec -u pkiuser pki podman cp /home/pkiuser/admin.csr systemd-pki-ca:/home/pkiuser
 
+          # issue cert
+          docker exec -u pkiuser pki podman exec systemd-pki-ca pki-server ca-cert-create \
+              --csr /home/pkiuser/admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --cert /home/pkiuser/admin.crt \
+              --import-cert
+
+          docker exec -u pkiuser pki podman cp systemd-pki-ca:/home/pkiuser/admin.crt /home/pkiuser
+
+          # import cert
           docker exec -u pkiuser pki pki nss-cert-import \
-              --cert /home/pkiuser/.dogtag/pki-ca/conf/certs/admin.crt \
+              --cert /home/pkiuser/admin.crt \
               admin
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
@@ -324,7 +327,7 @@ jobs:
               pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert /home/pkiuser/admin.crt \
               admin
 
           # add CA admin user into CA groups

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -168,16 +168,29 @@ jobs:
               --csr /conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
-      - name: Import admin cert into CA database
+      - name: Create admin cert
         run: |
-          docker exec ca pki nss-cert-export \
-              --output-file /conf/certs/admin.crt \
-              admin
+          # create cert request
+          docker exec client pki nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr $SHARED/admin.csr
 
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/admin.crt \
-              --csr /conf/certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
+          docker cp admin.csr ca:.
+
+          # issue cert
+          docker exec ca pki-server ca-cert-create \
+              --csr admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --cert admin.crt \
+              --import-cert
+
+          docker cp ca:admin.crt .
+
+          # import cert
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/admin.crt \
+              admin
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user
@@ -185,25 +198,16 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
-      - name: Add admin user into CA groups
+      - name: Add CA admin user into CA groups
         run: |
           docker exec ca pki-server ca-user-role-add admin "Administrators"
           docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
 
-      - name: Install admin cert
+      - name: Check CA admin user
         run: |
-          docker exec ca pki pkcs12-export \
-              --pkcs12 /conf/certs/admin.p12 \
-              --password Secret.123 \
-              admin
-
-          docker exec client pki pkcs12-import \
-              --pkcs12 $SHARED/ca/conf/certs/admin.p12 \
-              --password Secret.123
-
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n admin \
@@ -330,13 +334,6 @@ jobs:
 
           docker exec client pki pkcs12-cert-find \
               --pkcs12 $SHARED/kra/certs/server.p12 \
-              --password Secret.123
-
-          # export admin cert and key
-          docker exec client cp $SHARED/ca/conf/certs/admin.p12 $SHARED/kra/certs
-
-          docker exec client pki pkcs12-cert-find \
-              --pkcs12 $SHARED/kra/certs/admin.p12 \
               --password Secret.123
 
           ls -la kra/certs
@@ -471,11 +468,12 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-KRA-Admin-User
       - name: Add KRA admin user
         run: |
-          cp ca/conf/certs/admin.crt kra/conf/certs/admin.crt
+          docker cp admin.crt kra:.
+
           docker exec kra pki-server kra-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
       - name: Add KRA admin user into KRA groups

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -169,16 +169,29 @@ jobs:
               --csr /conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
-      - name: Import admin cert into CA database
+      - name: Create admin cert
         run: |
-          docker exec ca pki nss-cert-export \
-              --output-file /conf/certs/admin.crt \
-              admin
+          # create cert request
+          docker exec client pki nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr $SHARED/admin.csr
 
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/admin.crt \
-              --csr /conf/certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
+          docker cp admin.csr ca:.
+
+          # issue cert
+          docker exec ca pki-server ca-cert-create \
+              --csr admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --cert admin.crt \
+              --import-cert
+
+          docker cp ca:admin.crt .
+
+          # import cert
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/admin.crt \
+              admin
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user
@@ -186,25 +199,16 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
-      - name: Add admin user into CA groups
+      - name: Add CA admin user into CA groups
         run: |
           docker exec ca pki-server ca-user-role-add admin "Administrators"
           docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
 
-      - name: Install admin cert
+      - name: Check CA admin user
         run: |
-          docker exec ca pki pkcs12-export \
-              --pkcs12 /conf/certs/admin.p12 \
-              --password Secret.123 \
-              admin
-
-          docker exec client pki pkcs12-import \
-              --pkcs12 $SHARED/ca/conf/certs/admin.p12 \
-              --password Secret.123
-
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n admin \
@@ -310,13 +314,6 @@ jobs:
 
           docker exec client pki pkcs12-cert-find \
               --pkcs12 $SHARED/ocsp/certs/server.p12 \
-              --password Secret.123
-
-          # export admin cert and key
-          docker exec client cp $SHARED/ca/conf/certs/admin.p12 $SHARED/ocsp/certs
-
-          docker exec client pki pkcs12-cert-find \
-              --pkcs12 $SHARED/ocsp/certs/admin.p12 \
               --password Secret.123
 
           ls -la ocsp/certs
@@ -451,11 +448,12 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-OCSP-Admin-User
       - name: Add OCSP admin user
         run: |
-          cp ca/conf/certs/admin.crt ocsp/conf/certs/admin.crt
+          docker cp admin.crt ocsp:.
+
           docker exec ocsp pki-server ocsp-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
       - name: Add OCSP admin user into OCSP groups
@@ -559,10 +557,16 @@ jobs:
         run: |
           CERT_ID=$(cat cert.id)
 
+          # export admin cert and key
+          docker exec client pki pkcs12-export \
+              --pkcs12 admin.p12 \
+              --password Secret.123 \
+              admin
+
           # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
           docker exec client curl \
               --cert-type P12 \
-              --cert $SHARED/ca/conf/certs/admin.p12:Secret.123 \
+              --cert admin.p12:Secret.123 \
               -sk \
               -d "xml=true" \
               https://ca.example.com:8443/ca/agent/ca/updateCRL \
@@ -605,7 +609,7 @@ jobs:
           # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
           docker exec client curl \
               --cert-type P12 \
-              --cert $SHARED/ca/conf/certs/admin.p12:Secret.123 \
+              --cert admin.p12:Secret.123 \
               -sk \
               -d "xml=true" \
               https://ca.example.com:8443/ca/agent/ca/updateCRL \
@@ -648,7 +652,7 @@ jobs:
           # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
           docker exec client curl \
               --cert-type P12 \
-              --cert $SHARED/ca/conf/certs/admin.p12:Secret.123 \
+              --cert admin.p12:Secret.123 \
               -sk \
               -d "xml=true" \
               https://ca.example.com:8443/ca/agent/ca/updateCRL \

--- a/.github/workflows/tks-container-test.yml
+++ b/.github/workflows/tks-container-test.yml
@@ -169,16 +169,29 @@ jobs:
               --csr /conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
-      - name: Import admin cert into CA database
+      - name: Create admin cert
         run: |
-          docker exec ca pki nss-cert-export \
-              --output-file /conf/certs/admin.crt \
-              admin
+          # create cert request
+          docker exec client pki nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr $SHARED/admin.csr
 
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/admin.crt \
-              --csr /conf/certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
+          docker cp admin.csr ca:.
+
+          # issue cert
+          docker exec ca pki-server ca-cert-create \
+              --csr admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --cert admin.crt \
+              --import-cert
+
+          docker cp ca:admin.crt .
+
+          # import cert
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/admin.crt \
+              admin
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user
@@ -186,25 +199,16 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
-      - name: Add admin user into CA groups
+      - name: Add CA admin user into CA groups
         run: |
           docker exec ca pki-server ca-user-role-add admin "Administrators"
           docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
 
-      - name: Check admin cert
+      - name: Check CA admin user
         run: |
-          docker exec ca pki pkcs12-export \
-              --pkcs12 /conf/certs/admin.p12 \
-              --password Secret.123 \
-              admin
-
-          docker exec client pki pkcs12-import \
-              --pkcs12 $SHARED/ca/conf/certs/admin.p12 \
-              --pkcs12-password Secret.123
-
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n admin \
@@ -433,11 +437,12 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-TKS-Admin-User
       - name: Add TKS admin user
         run: |
-          cp ca/conf/certs/admin.crt tks/conf/certs/admin.crt
+          docker cp admin.crt tks:.
+
           docker exec tks pki-server tks-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
       - name: Add TKS admin user into TKS groups

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -174,16 +174,29 @@ jobs:
               --csr /conf/certs/sslserver.csr \
               --profile /usr/share/pki/ca/conf/rsaServerCert.profile
 
-      - name: Import admin cert into CA database
+      - name: Create admin cert
         run: |
-          docker exec ca pki nss-cert-export \
-              --output-file /conf/certs/admin.crt \
-              admin
+          # create cert request
+          docker exec client pki nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr $SHARED/admin.csr
 
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/admin.crt \
-              --csr /conf/certs/admin.csr \
-              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
+          docker cp admin.csr ca:.
+
+          # issue cert
+          docker exec ca pki-server ca-cert-create \
+              --csr admin.csr \
+              --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
+              --cert admin.crt \
+              --import-cert
+
+          docker cp ca:admin.crt .
+
+          # import cert
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/admin.crt \
+              admin
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
       - name: Add CA admin user
@@ -191,7 +204,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
       - name: Add admin user into CA groups
@@ -199,17 +212,8 @@ jobs:
           docker exec ca pki-server ca-user-role-add admin "Administrators"
           docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
 
-      - name: Check admin cert
+      - name: Check CA admin user
         run: |
-          docker exec ca pki pkcs12-export \
-              --pkcs12 /conf/certs/admin.p12 \
-              --password Secret.123 \
-              admin
-
-          docker exec client pki pkcs12-import \
-              --pkcs12 $SHARED/ca/conf/certs/admin.p12 \
-              --pkcs12-password Secret.123
-
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n admin \
@@ -340,13 +344,6 @@ jobs:
               --pkcs12 $SHARED/kra/certs/server.p12 \
               --password Secret.123
 
-          # export admin cert and key
-          docker exec client cp $SHARED/ca/conf/certs/admin.p12 $SHARED/kra/certs
-
-          docker exec client pki pkcs12-cert-find \
-              --pkcs12 $SHARED/kra/certs/admin.p12 \
-              --password Secret.123
-
           ls -la kra/certs
 
       - name: Set up KRA container
@@ -397,11 +394,12 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-KRA-Admin-User
       - name: Add KRA admin user
         run: |
-          cp ca/conf/certs/admin.crt kra/conf/certs/admin.crt
+          docker cp admin.crt kra:.
+
           docker exec kra pki-server kra-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
       - name: Add KRA admin user into KRA groups
@@ -594,11 +592,12 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-TKS-Admin-User
       - name: Add TKS admin user
         run: |
-          cp ca/conf/certs/admin.crt tks/conf/certs/admin.crt
+          docker cp admin.crt tks:.
+
           docker exec tks pki-server tks-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
       - name: Add TKS admin user into TKS groups
@@ -832,11 +831,12 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-TPS-Admin-User
       - name: Add TPS admin user
         run: |
-          cp ca/conf/certs/admin.crt tps/conf/certs/admin.crt
+          docker cp admin.crt tps:.
+
           docker exec tps pki-server tps-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert /conf/certs/admin.crt \
+              --cert admin.crt \
               admin
 
       - name: Add TPS admin user into TPS groups

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -10,7 +10,6 @@ PKI_OCSP_SIGNING_NICKNAME="${PKI_OCSP_SIGNING_NICKNAME:-ca_ocsp_signing}"
 PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-ca_audit_signing}"
 PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
 PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
-PKI_ADMIN_NICKNAME="${PKI_ADMIN_NICKNAME:-admin}"
 
 # Allow the owner of the container (who might not be in the root group)
 # to manage the config and log files.
@@ -65,12 +64,6 @@ if [ -f /certs/sslserver.csr ]
 then
     echo "INFO: Importing SSL server CSR"
     cp /certs/sslserver.csr /conf/certs/sslserver.csr
-fi
-
-if [ -f /certs/admin.csr ]
-then
-    echo "INFO: Importing admin CSR"
-    cp /certs/admin.csr /conf/certs/admin.csr
 fi
 
 echo "################################################################################"
@@ -330,67 +323,6 @@ pki \
     "$PKI_SSLSERVER_NICKNAME"
 
 echo "################################################################################"
-
-if [ -f /certs/admin.p12 ]
-then
-    echo "INFO: Importing admin cert and key"
-
-    pki pkcs12-import \
-        --pkcs12 /certs/admin.p12 \
-        --password Secret.123
-fi
-
-# check whether CA signing cert exists
-rc=0
-pki nss-cert-export "$PKI_CA_SIGNING_NICKNAME" \
-    > /dev/null \
-    2> /dev/null || rc=$?
-
-if [ $rc -ne 0 ]
-then
-    echo "INFO: Importing CA signing cert"
-    pki nss-cert-import \
-        --cert /tmp/ca_signing.crt \
-        --trust CT,C,C \
-        "$PKI_CA_SIGNING_NICKNAME"
-fi
-
-echo "################################################################################"
-
-# check whether admin cert exists
-rc=0
-pki nss-cert-export \
-    --output-file /tmp/admin.crt \
-    "$PKI_ADMIN_NICKNAME" \
-    2> /dev/null || rc=$?
-
-if [ $rc -ne 0 ]
-then
-    echo "INFO: Creating admin cert"
-
-    pki nss-cert-request \
-        --subject "CN=Administrator" \
-        --ext /usr/share/pki/server/certs/admin.conf \
-        --csr /conf/certs/admin.csr
-
-    pki \
-        -d /conf/alias \
-        -f /conf/password.conf \
-        nss-cert-issue \
-        --issuer "$PKI_CA_SIGNING_NICKNAME" \
-        --csr /conf/certs/admin.csr \
-        --ext /usr/share/pki/server/certs/admin.conf \
-        --cert /tmp/admin.crt
-
-    pki nss-cert-import \
-        --cert /tmp/admin.crt \
-        "$PKI_ADMIN_NICKNAME"
-fi
-
-echo "INFO: Admin cert:"
-pki nss-cert-show "$PKI_ADMIN_NICKNAME"
-
-echo "################################################################################"
 echo "INFO: Creating PKI CA"
 
 # Create CA with existing certs and keys, with existing database,
@@ -454,7 +386,6 @@ rm /tmp/ca_ocsp_signing.crt
 rm /tmp/ca_audit_signing.crt
 rm /tmp/subsystem.crt
 rm /tmp/sslserver.crt
-rm /tmp/admin.crt
 
 echo "################################################################################"
 echo "INFO: Starting PKI CA"

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -10,7 +10,6 @@ PKI_TRANSPORT_NICKNAME="${PKI_TRANSPORT_NICKNAME:-kra_transport}"
 PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-kra_audit_signing}"
 PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
 PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
-PKI_ADMIN_NICKNAME="${PKI_ADMIN_NICKNAME:-admin}"
 
 # Allow the owner of the container (who might not be in the root group)
 # to manage the config and log files.
@@ -65,12 +64,6 @@ if [ -f /certs/sslserver.csr ]
 then
     echo "INFO: Importing SSL server CSR"
     cp /certs/sslserver.csr /conf/certs/sslserver.csr
-fi
-
-if [ -f /certs/admin.csr ]
-then
-    echo "INFO: Importing admin CSR"
-    cp /certs/admin.csr /conf/certs/admin.csr
 fi
 
 echo "################################################################################"
@@ -131,23 +124,6 @@ pki \
     -f /conf/password.conf \
     nss-cert-show \
     "$PKI_SSLSERVER_NICKNAME"
-
-echo "################################################################################"
-
-if [ -f /certs/admin.p12 ]
-then
-    echo "INFO: Importing admin cert and key"
-
-    pki pkcs12-import \
-        --pkcs12 /certs/admin.p12 \
-        --password Secret.123
-fi
-
-echo "INFO: Admin cert:"
-pki nss-cert-show "$PKI_ADMIN_NICKNAME"
-
-echo "################################################################################"
-echo "INFO: Removing temporary files"
 
 echo "################################################################################"
 echo "INFO: Creating PKI KRA"

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -9,7 +9,6 @@ PKI_OCSP_SIGNING_NICKNAME="${PKI_OCSP_SIGNING_NICKNAME:-ocsp_signing}"
 PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-ocsp_audit_signing}"
 PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
 PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
-PKI_ADMIN_NICKNAME="${PKI_ADMIN_NICKNAME:-admin}"
 
 # Allow the owner of the container (who might not be in the root group)
 # to manage the config and log files.
@@ -58,12 +57,6 @@ if [ -f /certs/sslserver.csr ]
 then
     echo "INFO: Importing SSL server CSR"
     cp /certs/sslserver.csr /conf/certs/sslserver.csr
-fi
-
-if [ -f /certs/admin.csr ]
-then
-    echo "INFO: Importing admin CSR"
-    cp /certs/admin.csr /conf/certs/admin.csr
 fi
 
 echo "################################################################################"
@@ -120,20 +113,6 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-find
-
-echo "################################################################################"
-
-if [ -f /certs/admin.p12 ]
-then
-    echo "INFO: Importing admin cert and key"
-
-    pki pkcs12-import \
-        --pkcs12 /certs/admin.p12 \
-        --password Secret.123
-fi
-
-echo "INFO: Admin cert:"
-pki nss-cert-show "$PKI_ADMIN_NICKNAME"
 
 echo "################################################################################"
 echo "INFO: Creating OCSP Responder"

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -206,23 +206,6 @@ pki \
     "$PKI_SSLSERVER_NICKNAME"
 
 echo "################################################################################"
-
-# check whether CA signing cert exists in default NSS database
-rc=0
-pki nss-cert-export "$PKI_CA_SIGNING_NICKNAME" \
-    > /dev/null \
-    2> /dev/null || rc=$?
-
-if [ $rc -ne 0 ]
-then
-    echo "INFO: Importing CA signing cert"
-    pki nss-cert-import \
-        --cert /tmp/ca_signing.crt \
-        --trust CT,C,C \
-        "$PKI_CA_SIGNING_NICKNAME"
-fi
-
-echo "################################################################################"
 echo "INFO: Updating owners and permissions"
 
 if [ "$UID" = "0" ]

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3346,7 +3346,7 @@ class PKIDeployer:
 
         cert_data = subsystem.create_cert(
             request_id=request.systemCert.requestID,
-            profile_id=request.systemCert.profile,
+            profile_path=request.systemCert.profile,
             cert_type=request.systemCert.type,
             key_id=request.systemCert.keyID,
             key_token=request.systemCert.token,

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -2331,7 +2331,7 @@ class CASubsystem(PKISubsystem):
     def create_cert(
             self,
             request_id=None,
-            profile_id=None,
+            profile_path=None,
             cert_type=None,
             key_id=None,
             key_token=None,
@@ -2354,8 +2354,8 @@ class CASubsystem(PKISubsystem):
             if request_id:
                 cmd.extend(['--request', request_id])
 
-            if profile_id:
-                cmd.extend(['--profile', profile_id])
+            if profile_path:
+                cmd.extend(['--profile', profile_path])
 
             if cert_type:
                 cmd.extend(['--type', cert_type])

--- a/docs/changes/v11.6.0/Tools-Changes.adoc
+++ b/docs/changes/v11.6.0/Tools-Changes.adoc
@@ -48,3 +48,8 @@ Use `pki-server upgrade` instead.
 
 The `pki-server <subsystem>-user-add` command has been updated to provide an option
 to specify the user certificate.
+
+== Update pki-server ca-cert-create ==
+
+The `pki-server ca-cert-create` command has been updated to provide an option
+to import the new certificate into CA database.


### PR DESCRIPTION
Currently if the CA container is started without any certs, it will create an admin cert in the container's default NSS database but it's not permanent, so every time the container is restarted it will create a new admin cert.

To avoid problems all containers have been modified to no longer generate or store anything in the container's default NSS database. Instead, the admin cert will need to be created after the CA container is started, and it will only be stored in the client's NSS database outside of the container.

The `pki-server ca-cert-create` command has been updated to provide an option to import the new cert into CA database.

The `profile_id` param in `CASubsystem.create_cert()` has been renamed into `profile_path` which accepts both the profile full path and the filename (for backward compatibility).

https://github.com/edewata/pki/blob/container/docs/changes/v11.6.0/Tools-Changes.adoc
