### PR TITLE
Fixing race condition on close connection

### DIFF
--- a/base/server/src/main/java/com/netscape/cmscore/dbs/LDAPPagedSearch.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/LDAPPagedSearch.java
@@ -117,7 +117,6 @@ public class LDAPPagedSearch<E extends IDBObj>  extends DBPagedSearch<E> {
                     }
                 }
                 if (cookie == null) {
-                    conn.close();
                     return entries;
                 }
             }


### PR DESCRIPTION
LDAPConnection is closed before it is re-used. Closing the connection in case it is not needed create a race conditions in some cases preventing the execution. This is present in IPA cloning operations.