### PR TITLE
Remove default audit signing cert in containers

### DIFF
--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -216,17 +216,6 @@ jobs:
               --csr /conf/certs/ca_ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
-      - name: Import CA audit signing cert into CA database
-        run: |
-          docker exec ca pki-server cert-export \
-              --cert-file /conf/certs/ca_audit_signing.crt \
-              ca_audit_signing
-
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/ca_audit_signing.crt \
-              --csr /conf/certs/ca_audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
-
       - name: Import subsystem cert into CA database
         run: |
           docker exec ca pki-server cert-export \

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -95,29 +95,6 @@ jobs:
               nss-cert-show \
               ca_ocsp_signing
 
-      - name: Create audit signing cert
-        run: |
-          docker exec client pki \
-              nss-cert-request \
-              --subject "CN=Audit Signing Certificate" \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr $SHARED/certs/ca_audit_signing.csr
-          docker exec client pki \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr $SHARED/certs/ca_audit_signing.csr \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert $SHARED/certs/ca_audit_signing.crt
-
-          docker exec client pki nss-cert-import \
-              --cert $SHARED/certs/ca_audit_signing.crt \
-              --trust ,,P \
-              ca_audit_signing
-
-          docker exec client pki \
-              nss-cert-show \
-              ca_audit_signing
-
       - name: Create subsystem cert
         run: |
           docker exec client pki \
@@ -169,7 +146,6 @@ jobs:
               --password Secret.123 \
               ca_signing \
               ca_ocsp_signing \
-              ca_audit_signing \
               subsystem \
               sslserver
 
@@ -340,13 +316,6 @@ jobs:
               --cert /certs/ca_ocsp_signing.crt \
               --csr /certs/ca_ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile
-
-      - name: Import CA audit signing cert into CA database
-        run: |
-          docker exec ca pki-server ca-cert-import \
-              --cert /certs/ca_audit_signing.crt \
-              --csr /certs/ca_audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
 
       - name: Import subsystem cert into CA database
         run: |

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -135,17 +135,6 @@ jobs:
               --csr /conf/certs/ca_ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
-      - name: Import CA audit signing cert into CA database
-        run: |
-          docker exec ca pki-server cert-export \
-              --cert-file /conf/certs/ca_audit_signing.crt \
-              ca_audit_signing
-
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/ca_audit_signing.crt \
-              --csr /conf/certs/ca_audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
-
       - name: Import CA subsystem cert into CA database
         run: |
           docker exec ca pki-server cert-export \
@@ -254,27 +243,6 @@ jobs:
 
           docker exec client pki nss-cert-show kra_transport
 
-      - name: Create KRA audit signing cert
-        run: |
-          docker exec client pki nss-cert-request \
-              --subject "CN=Audit Signing Certificate" \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr $SHARED/kra/certs/kra_audit_signing.csr
-          docker exec client pki \
-              -d $SHARED/ca/conf/alias \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr $SHARED/kra/certs/kra_audit_signing.csr \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert $SHARED/kra/certs/kra_audit_signing.crt
-
-          docker exec client pki nss-cert-import \
-              --cert $SHARED/kra/certs/kra_audit_signing.crt \
-              --trust ,,P \
-              kra_audit_signing
-
-          docker exec client pki nss-cert-show kra_audit_signing
-
       - name: Create KRA subsystem cert
         run: |
           docker exec client pki nss-cert-request \
@@ -328,7 +296,6 @@ jobs:
               --password Secret.123 \
               kra_storage \
               kra_transport \
-              kra_audit_signing \
               subsystem \
               sslserver
 

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -136,17 +136,6 @@ jobs:
               --csr /conf/certs/ca_ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
-      - name: Import CA audit signing cert into CA database
-        run: |
-          docker exec ca pki-server cert-export \
-              --cert-file /conf/certs/ca_audit_signing.crt \
-              ca_audit_signing
-
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/ca_audit_signing.crt \
-              --csr /conf/certs/ca_audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
-
       - name: Import CA subsystem cert into CA database
         run: |
           docker exec ca pki-server cert-export \
@@ -235,27 +224,6 @@ jobs:
 
           docker exec client pki nss-cert-show ocsp_signing
 
-      - name: Create OCSP audit signing cert
-        run: |
-          docker exec client pki nss-cert-request \
-              --subject "CN=Audit Signing Certificate" \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr $SHARED/ocsp/certs/ocsp_audit_signing.csr
-          docker exec client pki \
-              -d $SHARED/ca/conf/alias \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr $SHARED/ocsp/certs/ocsp_audit_signing.csr \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert $SHARED/ocsp/certs/ocsp_audit_signing.crt
-
-          docker exec client pki nss-cert-import \
-              --cert $SHARED/ocsp/certs/ocsp_audit_signing.crt \
-              --trust ,,P \
-              ocsp_audit_signing
-
-          docker exec client pki nss-cert-show ocsp_audit_signing
-
       - name: Create OCSP subsystem cert
         run: |
           docker exec client pki nss-cert-request \
@@ -308,7 +276,6 @@ jobs:
               --pkcs12 $SHARED/ocsp/certs/server.p12 \
               --password Secret.123 \
               ocsp_signing \
-              ocsp_audit_signing \
               subsystem \
               sslserver
 

--- a/.github/workflows/tks-container-test.yml
+++ b/.github/workflows/tks-container-test.yml
@@ -136,17 +136,6 @@ jobs:
               --csr /conf/certs/ca_ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
-      - name: Import CA audit signing cert into CA database
-        run: |
-          docker exec ca pki-server cert-export \
-              --cert-file /conf/certs/ca_audit_signing.crt \
-              ca_audit_signing
-
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/ca_audit_signing.crt \
-              --csr /conf/certs/ca_audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
-
       - name: Import CA subsystem cert into CA database
         run: |
           docker exec ca pki-server cert-export \
@@ -215,27 +204,6 @@ jobs:
               ca-user-show \
               admin
 
-      - name: Create TKS audit signing cert
-        run: |
-          docker exec client pki nss-cert-request \
-              --subject "CN=Audit Signing Certificate" \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr $SHARED/tks/certs/tks_audit_signing.csr
-          docker exec client pki \
-              -d $SHARED/ca/conf/alias \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr $SHARED/tks/certs/tks_audit_signing.csr \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert $SHARED/tks/certs/tks_audit_signing.crt
-
-          docker exec client pki nss-cert-import \
-              --cert $SHARED/tks/certs/tks_audit_signing.crt \
-              --trust ,,P \
-              tks_audit_signing
-
-          docker exec client pki nss-cert-show tks_audit_signing
-
       - name: Create TKS subsystem cert
         run: |
           docker exec client pki nss-cert-request \
@@ -285,7 +253,6 @@ jobs:
           docker exec client pki pkcs12-export \
               --pkcs12 $SHARED/tks/certs/server.p12 \
               --password Secret.123 \
-              tks_audit_signing \
               tks_subsystem \
               tks_sslserver
 

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -141,17 +141,6 @@ jobs:
               --csr /conf/certs/ca_ocsp_signing.csr \
               --profile /usr/share/pki/ca/conf/caOCSPCert.profile
 
-      - name: Import CA audit signing cert into CA database
-        run: |
-          docker exec ca pki-server cert-export \
-              --cert-file /conf/certs/ca_audit_signing.crt \
-              ca_audit_signing
-
-          docker exec ca pki-server ca-cert-import \
-              --cert /conf/certs/ca_audit_signing.crt \
-              --csr /conf/certs/ca_audit_signing.csr \
-              --profile /usr/share/pki/ca/conf/caAuditSigningCert.profile
-
       - name: Import CA subsystem cert into CA database
         run: |
           docker exec ca pki-server cert-export \
@@ -256,25 +245,6 @@ jobs:
               kra_transport
           docker exec client pki nss-cert-show kra_transport
 
-      - name: Create KRA audit signing cert
-        run: |
-          docker exec client pki nss-cert-request \
-              --subject "CN=Audit Signing Certificate" \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr $SHARED/kra/certs/kra_audit_signing.csr
-          docker exec client pki \
-              -d $SHARED/ca/conf/alias \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr $SHARED/kra/certs/kra_audit_signing.csr \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert $SHARED/kra/certs/kra_audit_signing.crt
-          docker exec client pki nss-cert-import \
-              --cert $SHARED/kra/certs/kra_audit_signing.crt \
-              --trust ,,P \
-              kra_audit_signing
-          docker exec client pki nss-cert-show kra_audit_signing
-
       - name: Create KRA subsystem cert
         run: |
           docker exec client pki nss-cert-request \
@@ -324,7 +294,6 @@ jobs:
               --password Secret.123 \
               kra_storage \
               kra_transport \
-              kra_audit_signing \
               kra_subsystem \
               kra_sslserver
 
@@ -458,25 +427,6 @@ jobs:
               -o /dev/null \
               https://ca.example.com:8443
 
-      - name: Create TKS audit signing cert
-        run: |
-          docker exec client pki nss-cert-request \
-              --subject "CN=Audit Signing Certificate" \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr $SHARED/tks/certs/tks_audit_signing.csr
-          docker exec client pki \
-              -d $SHARED/ca/conf/alias \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr $SHARED/tks/certs/tks_audit_signing.csr \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert $SHARED/tks/certs/tks_audit_signing.crt
-          docker exec client pki nss-cert-import \
-              --cert $SHARED/tks/certs/tks_audit_signing.crt \
-              --trust ,,P \
-              tks_audit_signing
-          docker exec client pki nss-cert-show tks_audit_signing
-
       - name: Create TKS subsystem cert
         run: |
           docker exec client pki nss-cert-request \
@@ -522,7 +472,6 @@ jobs:
           docker exec client pki pkcs12-export \
               --pkcs12 $SHARED/tks/certs/server.p12 \
               --password Secret.123 \
-              tks_audit_signing \
               tks_subsystem \
               tks_sslserver
 
@@ -613,25 +562,6 @@ jobs:
               tks-user-show \
               admin
 
-      - name: Create TPS audit signing cert
-        run: |
-          docker exec client pki nss-cert-request \
-              --subject "CN=Audit Signing Certificate" \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --csr $SHARED/tps/certs/tps_audit_signing.csr
-          docker exec client pki \
-              -d $SHARED/ca/conf/alias \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr $SHARED/tps/certs/tps_audit_signing.csr \
-              --ext /usr/share/pki/server/certs/audit_signing.conf \
-              --cert $SHARED/tps/certs/tps_audit_signing.crt
-          docker exec client pki nss-cert-import \
-              --cert $SHARED/tps/certs/tps_audit_signing.crt \
-              --trust ,,P \
-              tps_audit_signing
-          docker exec client pki nss-cert-show tps_audit_signing
-
       - name: Create TPS subsystem cert
         run: |
           docker exec client pki nss-cert-request \
@@ -677,7 +607,6 @@ jobs:
           docker exec client pki pkcs12-export \
               --pkcs12 $SHARED/tps/certs/server.p12 \
               --password Secret.123 \
-              tps_audit_signing \
               tps_subsystem \
               tps_sslserver
 

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -7,7 +7,6 @@
 
 PKI_CA_SIGNING_NICKNAME="${PKI_CA_SIGNING_NICKNAME:-ca_signing}"
 PKI_OCSP_SIGNING_NICKNAME="${PKI_OCSP_SIGNING_NICKNAME:-ca_ocsp_signing}"
-PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-ca_audit_signing}"
 PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
 PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
 
@@ -166,52 +165,13 @@ then
     cp /certs/ca_audit_signing.csr /conf/certs/ca_audit_signing.csr
 fi
 
-# check whether audit signing cert exists
-rc=0
-pki \
-    -d /conf/alias \
-    -f /conf/password.conf \
-    nss-cert-export \
-    --output-file /tmp/ca_audit_signing.crt \
-    "$PKI_AUDIT_SIGNING_NICKNAME" \
-    2> /dev/null || rc=$?
-
-if [ $rc -ne 0 ]
-then
-    echo "INFO: Creating audit signing cert"
-
-    pki \
-        -d /conf/alias \
-        -f /conf/password.conf \
-        nss-cert-request \
-        --subject "CN=Audit Signing Certificate" \
-        --ext /usr/share/pki/server/certs/audit_signing.conf \
-        --csr /conf/certs/ca_audit_signing.csr
-
-    pki \
-        -d /conf/alias \
-        -f /conf/password.conf \
-        nss-cert-issue \
-        --issuer "$PKI_CA_SIGNING_NICKNAME" \
-        --csr /conf/certs/ca_audit_signing.csr \
-        --ext /usr/share/pki/server/certs/audit_signing.conf \
-        --cert /tmp/ca_audit_signing.crt
-
-    pki \
-        -d /conf/alias \
-        -f /conf/password.conf \
-        nss-cert-import \
-        --cert /tmp/ca_audit_signing.crt \
-        --trust ,,P \
-        "$PKI_AUDIT_SIGNING_NICKNAME"
-fi
-
 echo "INFO: Audit signing cert:"
 pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-show \
-    "$PKI_AUDIT_SIGNING_NICKNAME"
+    "$PKI_AUDIT_SIGNING_NICKNAME" \
+    2> /dev/null || true
 
 echo "################################################################################"
 
@@ -349,7 +309,10 @@ OPTIONS+=(-D pki_ocsp_signing_nickname="$PKI_OCSP_SIGNING_NICKNAME")
 OPTIONS+=(-D pki_ocsp_signing_csr_path=/conf/certs/ca_ocsp_signing.csr)
 
 OPTIONS+=(-D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME")
-OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/ca_audit_signing.csr)
+if [ -f /conf/certs/ca_audit_signing.csr ]
+then
+    OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/ca_audit_signing.csr)
+fi
 
 OPTIONS+=(-D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME")
 OPTIONS+=(-D pki_subsystem_csr_path=/conf/certs/subsystem.csr)
@@ -392,7 +355,6 @@ echo "INFO: Removing temporary files"
 
 rm /tmp/ca_signing.crt
 rm /tmp/ca_ocsp_signing.crt
-rm /tmp/ca_audit_signing.crt
 rm /tmp/subsystem.crt
 rm /tmp/sslserver.crt
 

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -7,7 +7,6 @@
 
 PKI_STORAGE_NICKNAME="${PKI_STORAGE_NICKNAME:-kra_storage}"
 PKI_TRANSPORT_NICKNAME="${PKI_TRANSPORT_NICKNAME:-kra_transport}"
-PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-kra_audit_signing}"
 PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
 PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
 
@@ -91,7 +90,8 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-show \
-    "$PKI_AUDIT_SIGNING_NICKNAME"
+    "$PKI_AUDIT_SIGNING_NICKNAME" \
+    2> /dev/null || true
 
 echo "################################################################################"
 
@@ -156,7 +156,10 @@ OPTIONS+=(-D pki_transport_nickname="$PKI_TRANSPORT_NICKNAME")
 OPTIONS+=(-D pki_transport_csr_path=/conf/certs/kra_transport.csr)
 
 OPTIONS+=(-D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME")
-OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/kra_audit_signing.csr)
+if [ -f /conf/certs/kra_audit_signing.csr ]
+then
+    OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/kra_audit_signing.csr)
+fi
 
 OPTIONS+=(-D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME")
 OPTIONS+=(-D pki_subsystem_csr_path=/conf/certs/subsystem.csr)

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -6,7 +6,6 @@
 #
 
 PKI_OCSP_SIGNING_NICKNAME="${PKI_OCSP_SIGNING_NICKNAME:-ocsp_signing}"
-PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-ocsp_audit_signing}"
 PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
 PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
 
@@ -75,7 +74,8 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-show \
-    "$PKI_AUDIT_SIGNING_NICKNAME"
+    "$PKI_AUDIT_SIGNING_NICKNAME" \
+    2> /dev/null || true
 
 echo "################################################################################"
 
@@ -137,7 +137,10 @@ OPTIONS+=(-D pki_ocsp_signing_nickname="$PKI_OCSP_SIGNING_NICKNAME")
 OPTIONS+=(-D pki_ocsp_signing__path=/conf/certs/ocsp_signing.csr)
 
 OPTIONS+=(-D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME")
-OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/ocsp_audit_signing.csr)
+if [ -f /conf/certs/ocsp_audit_signing.csr ]
+then
+    OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/ocsp_audit_signing.csr)
+fi
 
 OPTIONS+=(-D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME")
 OPTIONS+=(-D pki_subsystem_csr_path=/conf/certs/subsystem.csr)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2529,9 +2529,11 @@ class PKIDeployer:
         if subsystem.name == 'ocsp':
             subsystem.validate_system_cert('signing')
 
+        if self.mdict['pki_audit_signing_nickname']:
+            subsystem.validate_system_cert('audit_signing')
+
         subsystem.validate_system_cert('sslserver')
         subsystem.validate_system_cert('subsystem')
-        subsystem.validate_system_cert('audit_signing')
 
     def record(self, name, record_type, uid, gid, perms, acls=None):
         record = manifest.Record()
@@ -3374,6 +3376,10 @@ class PKIDeployer:
 
         logger.debug('PKIDeployer.setup_system_cert()')
 
+        if not request.systemCert.nickname:
+            # skip cert setup
+            return
+
         # Check whether the cert already exists in NSS database
 
         cert_info = nssdb.get_cert_info(
@@ -3616,9 +3622,10 @@ class PKIDeployer:
                 nickname=token + self.mdict['pki_ca_signing_nickname'],
                 trust_attributes='CTu,Cu,Cu')
 
-        nssdb.modify_cert(
-            nickname=token + self.mdict['pki_audit_signing_nickname'],
-            trust_attributes='u,u,Pu')
+        if self.mdict['pki_audit_signing_nickname']:
+            nssdb.modify_cert(
+                nickname=token + self.mdict['pki_audit_signing_nickname'],
+                trust_attributes='u,u,Pu')
 
         # update NSS database owner
         self.instance.chown(self.instance.nssdb_dir)

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -1059,6 +1059,12 @@ public class CMSEngine {
          */
         LoggersConfig loggersConfig = config.getLoggingConfig().getLoggersConfig();
         LoggerConfig loggerConfig = loggersConfig.getLoggerConfig("SignedAudit");
+
+        if (!loggerConfig.getLogSigning()) {
+            // skip log signing setup
+            return;
+        }
+
         String mSAuditCertNickName = loggerConfig.getString("signedAuditCertNickname");
         logger.debug("CMSEngine: audit signing cert: " + mSAuditCertNickName);
 
@@ -1955,8 +1961,8 @@ public class CMSEngine {
         try {
             String nickname = config.getString(id + ".cert." + tag + ".nickname", "");
             if (nickname.equals("")) {
-                logger.error("CMSEngine: verifySystemCertByTag() nickname for cert tag " + tag + " undefined in CS.cfg");
-                throw new Exception("Missing nickname for " + tag + " certificate");
+                logger.info("CMSEngine: Skipping " + tag + " cert verification");
+                return;
             }
 
             String certusage = config.getString(id + ".cert." + tag + ".certusage", "");

--- a/base/tks/bin/pki-tks-run
+++ b/base/tks/bin/pki-tks-run
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-tks_audit_signing}"
 PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
 PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
 
@@ -59,7 +58,8 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-show \
-    "$PKI_AUDIT_SIGNING_NICKNAME"
+    "$PKI_AUDIT_SIGNING_NICKNAME" \
+    2> /dev/null || true
 
 echo "################################################################################"
 
@@ -118,7 +118,10 @@ OPTIONS+=(-D pki_issuing_ca=)
 OPTIONS+=(-D pki_import_system_certs=False)
 
 OPTIONS+=(-D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME")
-OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/tks_audit_signing.csr)
+if [ -f /conf/certs/tks_audit_signing.csr ]
+then
+    OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/tks_audit_signing.csr)
+fi
 
 OPTIONS+=(-D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME")
 OPTIONS+=(-D pki_subsystem_csr_path=/conf/certs/subsystem.csr)

--- a/base/tps/bin/pki-tps-run
+++ b/base/tps/bin/pki-tps-run
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-PKI_AUDIT_SIGNING_NICKNAME="${PKI_AUDIT_SIGNING_NICKNAME:-tps_audit_signing}"
 PKI_SUBSYSTEM_NICKNAME="${PKI_SUBSYSTEM_NICKNAME:-subsystem}"
 PKI_SSLSERVER_NICKNAME="${PKI_SSLSERVER_NICKNAME:-sslserver}"
 
@@ -59,7 +58,8 @@ pki \
     -d /conf/alias \
     -f /conf/password.conf \
     nss-cert-show \
-    "$PKI_AUDIT_SIGNING_NICKNAME"
+    "$PKI_AUDIT_SIGNING_NICKNAME" \
+    2> /dev/null || true
 
 echo "################################################################################"
 
@@ -118,7 +118,10 @@ OPTIONS+=(-D pki_issuing_ca=)
 OPTIONS+=(-D pki_import_system_certs=False)
 
 OPTIONS+=(-D pki_audit_signing_nickname="$PKI_AUDIT_SIGNING_NICKNAME")
-OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/tps_audit_signing.csr)
+if [ -f /conf/certs/tps_audit_signing.csr ]
+then
+    OPTIONS+=(-D pki_audit_signing_csr_path=/conf/certs/tps_audit_signing.csr)
+fi
 
 OPTIONS+=(-D pki_subsystem_nickname="$PKI_SUBSYSTEM_NICKNAME")
 OPTIONS+=(-D pki_subsystem_csr_path=/conf/certs/subsystem.csr)


### PR DESCRIPTION
Audit signing is disabled by default so it's not necessary to create an audit signing cert for containers by default. The containers have been modified such that the audit signing cert nickname and CSR are optional.

The `PKIDeployer` and `CMSEngine` classes have been modified to skip processing the cert if the nickname or the CSR is blank.

The container tests have been updated to no longer create or process audit signing certs.

In the future the default audit signing cert for regular PKI server installation might be removed as well.