### PR TITLE
Fix IPA Clone checks

### DIFF
--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -495,6 +495,8 @@ jobs:
           sed -e 's/^\(ca.crl.MasterCRL.enable\)=.*$/\1=false/' \
               -e 's/^\(ca.crl.MasterCRL.enableCRLCache\)=.*$/\1=false/' \
               -e 's/^\(ca.crl.MasterCRL.enableCRLUpdates\)=.*$/\1=false/' \
+              -e 's/^\(ca.listenToCloneModifications\)=.*$/\1=false/' \
+              -e '$ a ca.certStatusUpdateInterval=0' \
               CS.cfg.primary.after-renewal-update \
               | sort > expected
 
@@ -520,11 +522,13 @@ jobs:
           sed -e 's/^\(ca.crl.MasterCRL.enable\)=.*$/\1=true/' \
               -e 's/^\(ca.crl.MasterCRL.enableCRLCache\)=.*$/\1=true/' \
               -e 's/^\(ca.crl.MasterCRL.enableCRLUpdates\)=.*$/\1=true/' \
+              -e 's/^\(ca.listenToCloneModifications\)=.*$/\1=true/' \
               CS.cfg.secondary.after-renewal-update \
               | sort > expected
 
           # normalize actual result
-          sort CS.cfg.secondary.after-crl-update > actual
+          sed -e '$ a ca.certStatusUpdateInterval=0' \
+              CS.cfg.secondary.after-crl-update | sort > actual
 
           diff expected actual
 


### PR DESCRIPTION
Some parameber are modified after the CRL move from the primary to the secondary. These are:
  - ca.listenToCloneModifications
  - ca.certStatusUpdateInterval