### PR TITLE
Publish Maven artifacts to dogtagpki/repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,11 @@ jobs:
     name: Publishing Maven artifacts
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install xmlstarlet
+
       - name: Clone repository
         uses: actions/checkout@v4
 
@@ -23,15 +28,22 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Check settings.xml
+      - name: Configure settings.xml
         run: |
-          cat ~/.m2/settings.xml
+          xmlstarlet edit --inplace \
+              -u "/_:settings/_:servers/_:server[_:id='github']/_:password" \
+              -v "$REPO_TOKEN" \
+              ~/.m2/settings.xml
+        env:
+          REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
 
-      - name: Update pom.xml
+      - name: Configure pom.xml
         run: |
-          sed -i \
-              -e "s/OWNER/$NAMESPACE/g" \
-              -e "s/REPOSITORY/pki/g" \
+          xmlstarlet edit --inplace \
+              -u "/_:project/_:build/_:plugins/_:plugin[_:artifactId='site-maven-plugin']/_:configuration/_:repositoryOwner" \
+              -v "$NAMESPACE" \
+              -u "/_:project/_:repositories/_:repository[_:id='dogtagpki']/_:url" \
+              -v "https://raw.githubusercontent.com/$NAMESPACE/repo/maven" \
               pom.xml
           cat pom.xml
 
@@ -43,8 +55,6 @@ jobs:
               --update-snapshots \
               -DskipTests \
               deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   wait-for-images:
     if: vars.REGISTRY != ''

--- a/pki.spec
+++ b/pki.spec
@@ -1012,8 +1012,10 @@ fi
 %pom_disable_module console base
 %endif
 
-# flatten-maven-plugin is not available in RPM
+# remove plugins not needed to build RPM
 %pom_remove_plugin org.codehaus.mojo:flatten-maven-plugin
+%pom_remove_plugin org.apache.maven.plugins:maven-deploy-plugin
+%pom_remove_plugin com.github.github:site-maven-plugin
 
 # specify Maven artifact locations
 %mvn_file org.dogtagpki.pki:pki-common            pki/pki-common

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <github.global.server>github</github.global.server>
     </properties>
 
     <modules>
@@ -69,25 +70,50 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <altDeploymentRepository>local::default::file://${project.build.directory}/repo</altDeploymentRepository>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.12</version>
+                <configuration>
+                    <message>Deploy ${project.groupId}:${project.artifactId}:${project.version}</message>
+                    <outputDirectory>${project.build.directory}/repo</outputDirectory>
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                    <repositoryOwner>dogtagpki</repositoryOwner>
+                    <repositoryName>repo</repositoryName>
+                    <branch>refs/heads/maven</branch>
+                    <merge>true</merge>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
     <repositories>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/OWNER/*</url>
+            <id>dogtagpki</id>
+            <url>https://raw.githubusercontent.com/dogtagpki/repo/maven</url>
             <snapshots>
                 <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/OWNER/REPOSITORY</url>
-        </repository>
-    </distributionManagement>
 
 </project>


### PR DESCRIPTION
Previously PKI's Maven artifacts were published to [GitHub Packages](https://github.com/orgs/dogtagpki/packages?repo_name=pki) which is a private repository so it's difficult to use.

To resolve the problem, the `pom.xml` has been modified to publish the artifacts to a publicly accessible [dogtagpki/repo](https://github.com/dogtagpki/repo) instead.

The build job in the publish action will use JSS and LDAP SDK artifacts already in that repo: [/dogtagpki/repo/tree/maven](https://github.com/dogtagpki/repo/tree/maven). In the future all build jobs in the CI should be updated to use that repo as well.