### PR TITLE
Use gcc option -mbranch-protection=standard

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -1300,6 +1300,12 @@ CXX_FLAGS="$CXX_FLAGS -D_FORTIFY_SOURCE=3"
 C_FLAGS="$C_FLAGS -fstack-clash-protection"
 CXX_FLAGS="$CXX_FLAGS -fstack-clash-protection"
 
+%ifarch aarch64
+# https://sourceware.org/annobin/annobin.html/Test-dynamic-tags.html
+C_FLAGS="$C_FLAGS -mbranch-protection=standard"
+CXX_FLAGS="$CXX_FLAGS -mbranch-protection=standard"
+%endif
+
 %endif
 
 pkgs=base\


### PR DESCRIPTION
The RPM spec has been updated to use `gcc` option `-mbranch-protection=standard` on AArch64 since it's now required by `rpminspect`.

https://sourceware.org/annobin/annobin.html/Test-dynamic-tags.html