### PR TITLE
Remove server classes from common library

### DIFF
--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -6,7 +6,7 @@ javac(pki-common-classes
         src/main/java/*.java
     CLASSPATH
         ${SLF4J_API_JAR}
-        ${LDAPJDK_JAR} ${SERVLET_JAR}
+        ${LDAPJDK_JAR}
         ${JSS_JAR}
         ${COMMONS_CODEC_JAR} ${COMMONS_IO_JAR}
         ${COMMONS_LANG3_JAR} ${COMMONS_CLI_JAR}

--- a/base/common/src/main/java/com/netscape/certsrv/base/BadRequestException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/BadRequestException.java
@@ -16,18 +16,19 @@
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.base;
-import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpStatus;
 
 public class BadRequestException extends PKIException {
 
     private static final long serialVersionUID = -4784839378360933483L;
 
     public BadRequestException(String message) {
-        super(HttpServletResponse.SC_BAD_REQUEST, message);
+        super(HttpStatus.SC_BAD_REQUEST, message);
     }
 
     public BadRequestException(String message, Throwable cause) {
-        super(HttpServletResponse.SC_BAD_REQUEST, message, cause);
+        super(HttpStatus.SC_BAD_REQUEST, message, cause);
     }
 
     public BadRequestException(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/ConflictingOperationException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/ConflictingOperationException.java
@@ -1,17 +1,17 @@
 package com.netscape.certsrv.base;
 
-import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
 
 public class ConflictingOperationException extends PKIException {
 
     private static final long serialVersionUID = -5780172673428115193L;
 
     public ConflictingOperationException(String message) {
-        super(HttpServletResponse.SC_CONFLICT, message);
+        super(HttpStatus.SC_CONFLICT, message);
     }
 
     public ConflictingOperationException(String message, Throwable cause) {
-        super(HttpServletResponse.SC_CONFLICT, message, cause);
+        super(HttpStatus.SC_CONFLICT, message, cause);
     }
 
     public ConflictingOperationException(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/ForbiddenException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/ForbiddenException.java
@@ -1,16 +1,16 @@
 package com.netscape.certsrv.base;
 
-import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
 
 public class ForbiddenException extends PKIException {
     private static final long serialVersionUID = 3199015969025638546L;
 
     public ForbiddenException(String message) {
-        super(HttpServletResponse.SC_FORBIDDEN, message);
+        super(HttpStatus.SC_FORBIDDEN, message);
     }
 
     public ForbiddenException(String message, Throwable cause) {
-        super(HttpServletResponse.SC_FORBIDDEN, message, cause);
+        super(HttpStatus.SC_FORBIDDEN, message, cause);
     }
 
     public ForbiddenException(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/HTTPGoneException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/HTTPGoneException.java
@@ -1,17 +1,17 @@
 package com.netscape.certsrv.base;
 
-import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
 
 public class HTTPGoneException extends PKIException {
 
     private static final long serialVersionUID = 1256191208802745690L;
 
     public HTTPGoneException(String message) {
-        super(HttpServletResponse.SC_GONE, message);
+        super(HttpStatus.SC_GONE, message);
     }
 
     public HTTPGoneException(String message, Throwable cause) {
-        super(HttpServletResponse.SC_GONE, message, cause);
+        super(HttpStatus.SC_GONE, message, cause);
     }
 
     public HTTPGoneException(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/PKIException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/PKIException.java
@@ -20,7 +20,6 @@ package com.netscape.certsrv.base;
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import javax.servlet.http.HttpServletResponse;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -30,6 +29,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.apache.http.HttpStatus;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -45,7 +45,7 @@ public class PKIException extends RuntimeException {
 
     private static final long serialVersionUID = 6000910362260369923L;
 
-    public int code;
+    private int code;
 
     public PKIException(int code, String message, Throwable cause) {
         super(message, cause);
@@ -53,7 +53,7 @@ public class PKIException extends RuntimeException {
     }
 
     public PKIException(String message) {
-        this(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message, null);
+        this(HttpStatus.SC_INTERNAL_SERVER_ERROR, message, null);
     }
 
     public PKIException(int code, String message) {
@@ -61,11 +61,11 @@ public class PKIException extends RuntimeException {
     }
 
     public PKIException(Throwable cause) {
-        this(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, cause.getMessage(), cause);
+        this(HttpStatus.SC_INTERNAL_SERVER_ERROR, cause.getMessage(), cause);
     }
 
     public PKIException(String message, Throwable cause) {
-        this(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message, cause);
+        this(HttpStatus.SC_INTERNAL_SERVER_ERROR, message, cause);
     }
 
     public PKIException(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/RequestNotAcceptable.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/RequestNotAcceptable.java
@@ -5,7 +5,7 @@
 //
 package com.netscape.certsrv.base;
 
-import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
 
 /**
  * @author Marco Fargetta {@literal <mfargett@redhat.com>}
@@ -15,11 +15,11 @@ public class RequestNotAcceptable extends PKIException {
     private static final long serialVersionUID = 1L;
 
     public RequestNotAcceptable(String message) {
-        super(HttpServletResponse.SC_NOT_ACCEPTABLE, message);
+        super(HttpStatus.SC_NOT_ACCEPTABLE, message);
     }
 
     public RequestNotAcceptable(String message, Throwable cause) {
-        super(HttpServletResponse.SC_NOT_ACCEPTABLE, message, cause);
+        super(HttpStatus.SC_NOT_ACCEPTABLE, message, cause);
     }
 
     public RequestNotAcceptable(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/ResourceNotFoundException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/ResourceNotFoundException.java
@@ -1,17 +1,17 @@
 package com.netscape.certsrv.base;
 
-import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
 
 public class ResourceNotFoundException extends PKIException {
 
     private static final long serialVersionUID = 2283994502912462263L;
 
     public ResourceNotFoundException(String message) {
-        super(HttpServletResponse.SC_NOT_FOUND, message);
+        super(HttpStatus.SC_NOT_FOUND, message);
     }
 
     public ResourceNotFoundException(String message, Throwable cause) {
-        super(HttpServletResponse.SC_NOT_FOUND, message, cause);
+        super(HttpStatus.SC_NOT_FOUND, message, cause);
     }
 
     public ResourceNotFoundException(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/ServiceUnavailableException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/ServiceUnavailableException.java
@@ -1,17 +1,17 @@
 package com.netscape.certsrv.base;
 
-import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
 
 public class ServiceUnavailableException extends PKIException {
 
     private static final long serialVersionUID = -9160776882517621347L;
 
     public ServiceUnavailableException(String message) {
-        super(HttpServletResponse.SC_SERVICE_UNAVAILABLE, message);
+        super(HttpStatus.SC_SERVICE_UNAVAILABLE, message);
     }
 
     public ServiceUnavailableException(String message, Throwable cause) {
-        super(HttpServletResponse.SC_SERVICE_UNAVAILABLE, message, cause);
+        super(HttpStatus.SC_SERVICE_UNAVAILABLE, message, cause);
     }
 
     public ServiceUnavailableException(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/UnauthorizedException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/UnauthorizedException.java
@@ -18,8 +18,7 @@
 
 package com.netscape.certsrv.base;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.http.HttpStatus;
 
 /**
  * @author Endi S. Dewata
@@ -29,11 +28,11 @@ public class UnauthorizedException extends PKIException {
     private static final long serialVersionUID = -2025082875126996556L;
 
     public UnauthorizedException(String message) {
-        super(HttpServletResponse.SC_UNAUTHORIZED, message);
+        super(HttpStatus.SC_UNAUTHORIZED, message);
     }
 
     public UnauthorizedException(String message, Throwable cause) {
-        super(HttpServletResponse.SC_UNAUTHORIZED, message, cause);
+        super(HttpStatus.SC_UNAUTHORIZED, message, cause);
     }
 
     public UnauthorizedException(Data data) {

--- a/base/common/src/main/java/com/netscape/certsrv/base/UnsupportedMediaType.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/UnsupportedMediaType.java
@@ -5,7 +5,7 @@
 //
 package com.netscape.certsrv.base;
 
-import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
 
 /**
  * @author Marco Fargetta {@literal <mfargett@redhat.com>}
@@ -15,11 +15,11 @@ public class UnsupportedMediaType extends PKIException {
     private static final long serialVersionUID = 1L;
 
     public UnsupportedMediaType(String message) {
-        super(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE, message);
+        super(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, message);
     }
 
     public UnsupportedMediaType(String message, Throwable cause) {
-        super(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE, message, cause);
+        super(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, message, cause);
     }
 
     public UnsupportedMediaType(Data data) {


### PR DESCRIPTION
Status codes were retrieved from tomcat servlet.jar package but since the common package should be used in the server as well as the client this dependency has been removed. The codes are now handled in the the common package.