### PR TITLE
Cert validation changes in the latest NSS

### DIFF
--- a/.github/workflows/ipa-subca-test.yml
+++ b/.github/workflows/ipa-subca-test.yml
@@ -96,11 +96,16 @@ jobs:
           docker exec ipa pki nss-cert-import \
               --cert root-ca_signing.crt \
               --trust CT,C,C \
+              root-ca_signing
+
+          docker exec ipa pki nss-cert-import \
+              --cert ipa.crt \
               ca_signing
 
           docker exec ipa pki pkcs12-import \
               --pkcs12 /root/ca-agent.p12 \
               --pkcs12-password Secret.123
+
           docker exec ipa pki -n ipa-ca-agent ca-user-show admin
 
       - name: Check lightweight CAs

--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -163,7 +163,7 @@ jobs:
               -o /dev/null \
               https://pki.example.com:8443
 
-      - name: Check PKI CLI with untrusted server cert
+      - name: Check PKI CLI with unknown issuer
         run: |
           # run PKI CLI but don't trust the cert
           echo n | docker exec -i client pki -U https://pki.example.com:8443 info \
@@ -178,7 +178,7 @@ jobs:
 
           # check stderr
           cat > expected << EOF
-          WARNING: UNTRUSTED ISSUER encountered on 'CN=pki.example.com' indicates a non-trusted CA cert 'CN=CA Signing Certificate'
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
           Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: BAD_CERTIFICATE
           IOException: Unable to write to socket: Failed to write to socket: (-5987) Invalid function argument.
           EOF
@@ -190,7 +190,7 @@ jobs:
 
           diff /dev/null output
 
-      - name: Check PKI CLI with untrusted server cert with wrong hostname
+      - name: Check PKI CLI with unknown issuer with wrong hostname
         run: |
           # run PKI CLI with wrong hostname
           echo n | docker exec -i client pki -U https://server.example.com:8443 info \
@@ -205,8 +205,8 @@ jobs:
 
           # check stderr
           cat > expected << EOF
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
           WARNING: BAD_CERT_DOMAIN encountered on 'CN=pki.example.com' indicates a common-name mismatch
-          WARNING: UNTRUSTED ISSUER encountered on 'CN=pki.example.com' indicates a non-trusted CA cert 'CN=CA Signing Certificate'
           Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: BAD_CERTIFICATE
           IOException: Unable to write to socket: Failed to write to socket: (-12276) Unable to communicate securely with peer: requested domain name does not match the server's certificate.
           EOF
@@ -229,7 +229,7 @@ jobs:
 
           # check stderr
           cat > expected << EOF
-          WARNING: UNTRUSTED ISSUER encountered on 'CN=pki.example.com' indicates a non-trusted CA cert 'CN=CA Signing Certificate'
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
           Trust this certificate (y/N)?
           EOF
 

--- a/.github/workflows/server-https-pkcs12-test.yml
+++ b/.github/workflows/server-https-pkcs12-test.yml
@@ -197,7 +197,7 @@ jobs:
               -o /dev/null \
               https://pki.example.com:8443
 
-      - name: Check PKI CLI with untrusted server cert
+      - name: Check PKI CLI with unknown issuer
         run: |
           # run PKI CLI but don't trust the cert
           echo n | docker exec -i client pki \
@@ -214,7 +214,7 @@ jobs:
 
           # check stderr
           cat > expected << EOF
-          WARNING: UNTRUSTED ISSUER encountered on 'CN=pki.example.com' indicates a non-trusted CA cert 'CN=CA Signing Certificate'
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
           Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: BAD_CERTIFICATE
           IOException: Unable to write to socket: Failed to write to socket: (-5987) Invalid function argument.
           EOF
@@ -226,7 +226,7 @@ jobs:
 
           diff /dev/null output
 
-      - name: Check PKI CLI with untrusted server cert and wrong hostname
+      - name: Check PKI CLI with unknown issuer and wrong hostname
         run: |
           # run PKI CLI with wrong hostname
           echo n | docker exec -i client pki \
@@ -243,8 +243,8 @@ jobs:
 
           # check stderr
           cat > expected << EOF
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
           WARNING: BAD_CERT_DOMAIN encountered on 'CN=pki.example.com' indicates a common-name mismatch
-          WARNING: UNTRUSTED ISSUER encountered on 'CN=pki.example.com' indicates a non-trusted CA cert 'CN=CA Signing Certificate'
           Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: BAD_CERTIFICATE
           IOException: Unable to write to socket: Failed to write to socket: (-12276) Unable to communicate securely with peer: requested domain name does not match the server's certificate.
           EOF
@@ -269,7 +269,7 @@ jobs:
 
           # check stderr
           cat > expected << EOF
-          WARNING: UNTRUSTED ISSUER encountered on 'CN=pki.example.com' indicates a non-trusted CA cert 'CN=CA Signing Certificate'
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
           Trust this certificate (y/N)?
           EOF
 

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -172,11 +172,16 @@ jobs:
           docker exec subordinate pki nss-cert-import \
               --cert $SHARED/root-ca_signing.crt \
               --trust CT,C,C \
+              root-ca_signing
+
+          docker exec subordinate pki nss-cert-import \
+              --cert ca_signing.crt \
               ca_signing
 
           docker exec subordinate pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
+
           docker exec subordinate pki -n caadmin --ignore-banner ca-user-show caadmin
 
       - name: Check cert requests in subordinate CA

--- a/.github/workflows/subca-clone-hsm-test.yml
+++ b/.github/workflows/subca-clone-hsm-test.yml
@@ -283,6 +283,7 @@ jobs:
           docker exec primary-subca pki pkcs12-import \
               --pkcs12 $SHARED/caadmin.p12 \
               --pkcs12-password Secret.123
+
           docker exec primary-subca pki -n caadmin ca-user-show caadmin
 
       - name: Set up secondary DS container

--- a/.github/workflows/subca-clone-test.yml
+++ b/.github/workflows/subca-clone-test.yml
@@ -116,9 +116,14 @@ jobs:
               --trust CT,C,C \
               root-ca_signing
 
+          docker exec primary-subca pki nss-cert-import \
+              --cert $SHARED/subca_signing.crt \
+              ca_signing
+
           docker exec primary-subca pki pkcs12-import \
               --pkcs12 $SHARED/caadmin.p12 \
               --pkcs12-password Secret.123
+
           docker exec primary-subca pki -n caadmin ca-user-show caadmin
 
       - name: Export primary sub-CA certs
@@ -246,9 +251,14 @@ jobs:
               --trust CT,C,C \
               root-ca_signing
 
+          docker exec secondary-subca pki nss-cert-import \
+              --cert $SHARED/subca_signing.crt \
+              ca_signing
+
           docker exec secondary-subca pki pkcs12-import \
               --pkcs12 $SHARED/caadmin.p12 \
               --pkcs12-password Secret.123
+
           docker exec secondary-subca pki -n caadmin ca-user-show caadmin
 
       - name: Check users in primary sub-CA and secondary sub-CA

--- a/.github/workflows/subca-cmc-test.yml
+++ b/.github/workflows/subca-cmc-test.yml
@@ -187,10 +187,19 @@ jobs:
 
       - name: Verify subordinate CA admin cert
         run: |
-          docker exec subordinate pki client-cert-import ca_signing --ca-cert $SHARED/ca_signing.p7b
+          docker exec subordinate pki nss-cert-import \
+              --cert $SHARED/root-ca_signing.crt \
+              --trust CT,C,C \
+              root-ca_signing
+
+          docker exec subordinate pki nss-cert-import \
+              --cert ca_signing.crt \
+              ca_signing
+
           docker exec subordinate pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
+
           docker exec subordinate pki -n caadmin ca-user-show caadmin
 
       - name: Check cert requests in subordinate CA

--- a/.github/workflows/subca-external-test.yml
+++ b/.github/workflows/subca-external-test.yml
@@ -117,11 +117,16 @@ jobs:
           docker exec pki pki nss-cert-import \
               --cert root-ca_signing.crt \
               --trust CT,C,C \
+              root-ca_signing
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
               ca_signing
 
           docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
+
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Check cert requests in CA

--- a/.github/workflows/subca-hsm-test.yml
+++ b/.github/workflows/subca-hsm-test.yml
@@ -272,6 +272,7 @@ jobs:
           docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
+
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Check CA certs and requests


### PR DESCRIPTION
Previously if a client tries to connect to a server but it does not have the CA signing cert installed and trusted it will get an `UNTRUSTED_ISSUER` error from NSS and the cert approval callback will ask the user whether to trust the cert. In the latest NSS the error has changed to `UNKNOWN_ISSUER`, so the callback has been updated to handle the error in the same way. The tests have also been updated accordingly.

The latest NSS also requires the client to have the full cert chain in order to validate a cert, so most of the sub CA tests have been updated to install the sub CA signing cert in addition to the root CA signing cert. For some reason the sub CA tests with HSM still work without these changes. That will be investigated separately later.

