### PR TITLE
Next Range Calculation error

### DIFF
--- a/base/server/src/main/java/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/Repository.java
@@ -539,10 +539,10 @@ public abstract class Repository {
             }
 
             String nextRange = attr.getStringValues().nextElement();
-            BigInteger nextRangeNo = new BigInteger(nextRange);
+            BigInteger nextRangeNo = new BigInteger(nextRange, mRadix);
             BigInteger newNextRangeNo = nextRangeNo.add(mIncrementNo);
-            String newNextRange = newNextRangeNo.toString();
-            String endRange = newNextRangeNo.subtract(BigInteger.ONE).toString();
+            String newNextRange = newNextRangeNo.toString(mRadix);
+            String endRange = newNextRangeNo.subtract(BigInteger.ONE).toString(mRadix);
 
             logger.info("Repository: Updating " + DBSubsystem.PROP_NEXT_RANGE + " from " + nextRange + " to " + newNextRange);
 


### PR DESCRIPTION
NextRange is stored in ldap database as a Hex string

mIncrementNo is provided by CertificateRepository.java

nextRangeNo Needs to be treated the same as mIncrementNo so that add and subtract work correctly and produce the correct values and match up with what will be put into CS.cfg to prevent large gaps with sequential Serial Managment.


