### PR TITLE
Add est to pkispawn

### DIFF
--- a/.github/workflows/est-ds-realm-test.yml
+++ b/.github/workflows/est-ds-realm-test.yml
@@ -1,0 +1,233 @@
+name: EST with ds realm
+
+on: workflow_call
+
+env:
+  DB_IMAGE: ${{ vars.DB_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # docs/installation/ca/Installing_CA.md
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DB_IMAGE }} \
+              --hostname=ds.example.com \
+              --password=Secret.123 \
+              --network=example \
+              --network-alias=ds.example.com \
+              ds
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+          --hostname=pki.example.com \
+          --network=example \
+          --network-alias=ca.example.com \
+          pki
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Initialize PKI client
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki info
+
+      - name: Add CA EST user
+        run: |
+          docker exec pki pki -n caadmin ca-group-add "EST RA Agents"
+          docker exec pki pki -n caadmin ca-user-add \
+              est-ra-1 --fullName "EST RA 1" --password Secret.est
+          docker exec pki pki -n caadmin ca-group-member-add "EST RA Agents" est-ra-1
+          
+      - name: Configure CA est profile
+        run: |
+          docker exec pki pki -n caadmin ca-profile-add \
+              --raw /usr/share/pki/ca/profiles/ca/estServiceCert.cfg
+          docker exec pki pki -n caadmin ca-profile-enable estServiceCert
+          docker exec pki pki-server restart --wait
+
+      - name: Install EST
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/est.cfg \
+              -s EST \
+              -D est_realm_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check EST backend config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/est/backend.conf
+
+      - name: Check EST authorizer config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/est/authorizer.conf
+
+      - name: Check EST realm config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/est/realm.conf
+
+      - name: Check webapps
+        run: |
+          docker exec pki pki-server webapp-find | tee output
+
+          # CA instance should have ROOT, ca, and pki webapps
+          echo "ROOT" > expected
+          echo "ca" >> expected
+          echo "est" >> expected
+          echo "pki" >> expected
+          sed -n 's/^ *Webapp ID: *\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          docker exec pki pki-server webapp-show ROOT
+          docker exec pki pki-server webapp-show ca
+          docker exec pki pki-server webapp-show est
+          docker exec pki pki-server webapp-show pki
+
+      - name: Create EST users
+        run: |
+          docker exec -i pki ldapadd -x -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager"  -w Secret.123 << EOF
+          dn: dc=est,dc=pki,dc=example,dc=com
+          objectClass: domain
+          dc: est 
+          
+          dn: ou=people,dc=est,dc=pki,dc=example,dc=com
+          ou: people
+          objectClass: top
+          objectClass: organizationalUnit
+          
+          dn: ou=groups,dc=est,dc=pki,dc=example,dc=com
+          ou: groups
+          objectClass: top
+          objectClass: organizationalUnit
+          
+          dn: uid=est-test-user,ou=people,dc=est,dc=pki,dc=example,dc=com
+          objectClass: top
+          objectClass: person
+          objectClass: organizationalPerson
+          objectClass: inetOrgPerson
+          objectClass: cmsuser
+          uid: est-test-user
+          sn: EST TEST USER
+          cn: EST TEST USER
+          usertype: undefined
+          userPassword: Secret.123
+          
+          dn: cn=estclient,ou=groups,dc=est,dc=pki,dc=example,dc=com
+          objectClass: top
+          objectClass: groupOfUniqueNames
+          cn: estclient
+          uniqueMember: uid=est-test-user,ou=People,dc=est,dc=pki,dc=example,dc=com
+          EOF
+
+      - name: Test CA certs
+        run: |
+          docker exec pki curl -o cacert.p7 -k https://pki.example.com:8443/.well-known/est/cacerts
+          docker exec pki openssl base64 -d --in cacert.p7 --out cacert.p7.der
+          docker exec pki openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -out cacert.pem
+          docker exec pki openssl x509 -in cacert.pem -text -noout | tee actual
+          docker exec pki openssl x509 -in ca_signing.crt -text -noout | tee expected
+          diff expected actual
+
+      - name: Install est client
+        run: |
+          docker exec pki dnf copr enable -y @pki/libest 
+          docker exec pki dnf install -y libest
+
+      - name: Enroll certificate
+        run: |
+          docker exec -e EST_OPENSSL_CACERT=cacert.pem pki estclient -e -s pki.example.com -p 8443 \
+              --common-name test.example.com -o . -u est-test-user -h Secret.123
+
+          docker exec pki openssl base64 -d --in cert-0-0.pkcs7 --out cert-0-0.pkcs7.der
+          docker exec pki openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -out cert.pem
+          docker exec pki openssl x509 -in cert.pem -subject -noout | tee actual
+          echo "subject=CN=test.example.com" > expected
+          diff expected actual
+
+      - name: Remove EST
+        run: |
+          docker exec pki pki-server est-undeploy --wait
+          docker exec pki pki-server est-remove
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -i pki-tomcat -s CA -v
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check EST debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/est -name "debug.*" -exec cat {} \;
+
+      - name: Gather artifacts
+        if: always()
+        run: |
+          tests/bin/ds-artifacts-save.sh ds
+          tests/bin/pki-artifacts-save.sh pki
+        continue-on-error: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: est-ds-basic
+          path: /tmp/artifacts

--- a/.github/workflows/est-tests.yml
+++ b/.github/workflows/est-tests.yml
@@ -40,3 +40,9 @@ jobs:
           ansible-playbook  -e 'pki_subsystem="est"' tests/ansible/pki-playbook.yml 
         env:
           ANSIBLE_CONFIG: ${{ github.workspace }}/tests/ansible/ansible.cfg
+
+          
+  est-ds-realm-test:
+    name: EST with ds realm
+    needs: build
+    uses: ./.github/workflows/est-ds-realm-test.yml

--- a/base/est/CMakeLists.txt
+++ b/base/est/CMakeLists.txt
@@ -96,3 +96,23 @@ install(
     DESTINATION
         ${DATA_INSTALL_DIR}/est/webapps/est/WEB-INF/lib
 )
+
+install(
+    DIRECTORY
+        shared/
+    DESTINATION
+        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}/conf/
+    PATTERN
+        "CMakeLists.txt" EXCLUDE
+)
+
+install(
+    FILES
+        bin/estauthz
+    DESTINATION
+        ${SHARE_INSTALL_PREFIX}/${APPLICATION_NAME}/${PROJECT_NAME}/bin/
+    PERMISSIONS
+	OWNER_EXECUTE OWNER_WRITE OWNER_READ
+	GROUP_EXECUTE GROUP_READ
+	WORLD_EXECUTE WORLD_READ
+)

--- a/base/est/bin/estauthz
+++ b/base/est/bin/estauthz
@@ -1,0 +1,7 @@
+#!/usr/bin/python3
+import json, sys
+ALLOWED_ROLE = 'estclient'
+obj = json.loads(sys.stdin.read())
+if not ALLOWED_ROLE in obj['authzData']['principal']['roles']:
+    print(f'Principal does not have required role {ALLOWED_ROLE!r}')
+    sys.exit(1)

--- a/base/est/conf/realm.conf
+++ b/base/est/conf/realm.conf
@@ -1,1 +1,0 @@
-class=org.apache.catalina.realm.MemoryRealm

--- a/base/est/shared/authorizer.conf
+++ b/base/est/shared/authorizer.conf
@@ -1,0 +1,2 @@
+class=org.dogtagpki.est.ExternalProcessRequestAuthorizer
+executable=/usr/share/pki/est/bin/estauthz

--- a/base/est/shared/backend.conf
+++ b/base/est/shared/backend.conf
@@ -1,0 +1,5 @@
+class=org.dogtagpki.est.DogtagRABackend
+url=https://fedora:8443
+profile=estServiceCert
+username=est-ra-1
+password=est4ever

--- a/base/est/shared/realm/ds.conf
+++ b/base/est/shared/realm/ds.conf
@@ -1,0 +1,7 @@
+class=com.netscape.cms.realm.PKILDAPRealm
+url=ldap://localhost.localdomain:389
+authType=BasicAuth
+bindDN=cn=Directory Manager
+bindPassword=Secret.123
+usersDN=ou=people,dc=est,dc=pki,dc=example,dc=com
+groupsDN=ou=groups,dc=est,dc=pki,dc=example,dc=com

--- a/base/est/shared/realm/in-memory.conf
+++ b/base/est/shared/realm/in-memory.conf
@@ -1,0 +1,4 @@
+class=com.netscape.cms.realm.PKIInMemoryRealm
+username=admin
+password=Secret.123
+roles=estclient

--- a/base/est/shared/realm/postgresql.conf
+++ b/base/est/shared/realm/postgresql.conf
@@ -1,0 +1,5 @@
+class=com.netscape.cms.realm.PKIPostgreSQLRealm
+url=jdbc:postgresql://localhost.localdomain:5432/est
+user=est
+password=Secret.123
+statements=/usr/share/pki/est/conf/realm/statements.conf

--- a/base/est/shared/realm/statements.conf
+++ b/base/est/shared/realm/statements.conf
@@ -1,0 +1,31 @@
+getUserByID=\
+SELECT \
+    "id", "full_name", "password" \
+FROM \
+    "users" \
+WHERE \
+    "id" = ?
+
+getUserByCertID=\
+SELECT \
+    u."id", u."full_name", u."password" \
+FROM \
+    "users" u, "user_certs" uc \
+WHERE \
+    u."id" = uc."user_id" AND uc."cert_id" = ?
+
+getUserCerts=\
+SELECT \
+    "data" \
+FROM \
+    "user_certs" \
+WHERE \
+    "user_id" = ?
+
+getUserRoles=\
+SELECT \
+    "group_id" \
+FROM \
+    "group_members" \
+WHERE \
+    "user_id" = ?

--- a/base/est/webapps/est/index.jsp
+++ b/base/est/webapps/est/index.jsp
@@ -1,0 +1,25 @@
+<!-- --- BEGIN COPYRIGHT BLOCK ---
+     This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation; version 2 of the License.
+
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along
+     with this program; if not, write to the Free Software Foundation, Inc.,
+     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+     Copyright (C) 2013 Red Hat, Inc.
+     All rights reserved.
+     --- END COPYRIGHT BLOCK --- -->
+<html>
+<head>
+    <title>Enrollment over Secure Transport</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+</body>
+</html>

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -38,6 +38,9 @@ sensitive_parameters=
     acme_issuer_password
     acme_realm_bind_password
     acme_realm_password
+    est_realm_bind_password
+    est_realm_password
+    est_ca_password
 
 pki_instance_name=pki-tomcat
 pki_http_port=8080
@@ -663,3 +666,27 @@ pki_registry_enable=False
 # - acme_realm_groups_dn
 #
 # See /usr/share/pki/acme/realm/<type>/realm.conf
+[EST]
+pki_ds_setup=False
+pki_security_domain_setup=False
+pki_registry_enable=False
+pki_ca_uri=https://%(pki_hostname)s:%(pki_https_port)s
+est_ca_profile=estServiceCert
+est_ca_user_name=
+est_ca_user_password=
+est_ca_user_password_file=
+est_ca_user_certificate=
+est_realm_type=
+est_realm_custom=
+est_realm_url=
+est_realm_auth_type=BasicAuth
+est_realm_bind_dn=cn=Directory Manager
+est_realm_bind_password=
+est_realm_nickname=
+est_realm_user=
+est_realm_username=
+est_realm_password=
+est_realm_users_dn=ou=people,dc=est,dc=pki,dc=example,dc=com
+est_realm_groups_dn=ou=groups,dc=est,dc=pki,dc=example,dc=com
+est_realm_statements=/usr/share/pki/est/conf/realm/statements.conf
+est_authorizer_exec_path=/usr/share/pki/est/bin/estauthz

--- a/base/server/examples/installation/est.cfg
+++ b/base/server/examples/installation/est.cfg
@@ -1,0 +1,9 @@
+[DEFAULT]
+pki_server_database_password=Secret.123
+
+[EST]
+est_realm_type=ds
+est_realm_url=ldap://localhost.localdomain:3389
+est_realm_bind_password=Secret.123
+est_ca_user_name=est-ra-1
+est_ca_user_password=Secret.est

--- a/base/server/python/pki/server/deployment/pkiconfig.py
+++ b/base/server/python/pki/server/deployment/pkiconfig.py
@@ -36,7 +36,7 @@ PKI_DEPLOYMENT_DEFAULT_SHELL = "/sbin/nologin"
 PKI_DEPLOYMENT_DEFAULT_UID = 17
 PKI_DEPLOYMENT_DEFAULT_USER = "pkiuser"
 
-PKI_SUBSYSTEMS = ['CA', 'KRA', 'OCSP', 'TKS', 'TPS', 'ACME']
+PKI_SUBSYSTEMS = ['CA', 'KRA', 'OCSP', 'TKS', 'TPS', 'ACME', 'EST']
 PKI_BASE_RESERVED_NAMES = ["alias", "bin", "ca", "common", "conf", "kra",
                            "lib", "logs", "ocsp", "temp", "tks", "tps",
                            "webapps", "work"]

--- a/base/server/python/pki/server/deployment/scriptlets/initialization.py
+++ b/base/server/python/pki/server/deployment/scriptlets/initialization.py
@@ -41,8 +41,9 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         configuration_file = deployer.configuration_file
 
         # Verify existence of Admin Password (except for Clones)
-        if configuration_file.subsystem != 'ACME' and \
-                not configuration_file.clone:
+        if (configuration_file.subsystem != 'ACME' and
+                configuration_file.subsystem != 'EST' and not
+                configuration_file.clone):
             configuration_file.confirm_data_exists('pki_admin_password')
 
         # If HSM, verify absence of all PKCS #12 backup parameters
@@ -64,7 +65,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
             configuration_file.confirm_data_exists('pki_client_database_password')
 
         # Verify existence of Client PKCS #12 Password for Admin Cert
-        if configuration_file.subsystem != 'ACME':
+        if (configuration_file.subsystem != 'ACME' and
+                configuration_file.subsystem != 'EST'):
             configuration_file.confirm_data_exists('pki_client_pkcs12_password')
 
         if configuration_file.clone:

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -190,8 +190,8 @@ def main(argv):
             parser.indent = 0
 
             deployer.subsystem_type = parser.read_text(
-                'Subsystem (CA/KRA/OCSP/TKS/TPS/ACME)',
-                options=['CA', 'KRA', 'OCSP', 'TKS', 'TPS', 'ACME'],
+                'Subsystem (CA/KRA/OCSP/TKS/TPS/ACME/EST)',
+                options=['CA', 'KRA', 'OCSP', 'TKS', 'TPS', 'ACME', 'EST'],
                 default='CA', case_sensitive=False).upper()
             print()
         else:
@@ -672,6 +672,9 @@ def main(argv):
     elif deployer.subsystem_type == 'ACME':
         print_acme_install_information()
 
+    elif deployer.subsystem_type == 'EST':
+        print_est_install_information()
+
     else:
         print_final_install_information(parser.mdict, deployer.instance)
 
@@ -693,7 +696,8 @@ def validate_user_deployment_cfg(user_deployment_cfg):
                 '[OCSP]',
                 '[TKS]',
                 '[TPS]',
-                '[ACME]']:
+                '[ACME]',
+                '[EST]']:
             raise Exception('Invalid deployment configuration section: %s' % line)
 
 
@@ -949,6 +953,16 @@ def print_acme_install_information():
                                 deployer.mdict['pki_https_port'],
                                 deployer.subsystem_type.lower()))
 
+    print(log.PKI_SPAWN_INFORMATION_FOOTER)
+
+
+def print_est_install_information():
+
+    print(log.PKI_SPAWN_INFORMATION_HEADER)
+
+    print(log.PKI_ACCESS_URL % (deployer.mdict['pki_hostname'],
+                                deployer.mdict['pki_https_port'],
+                                '.well-known/%s' % deployer.subsystem_type.lower()))
     print(log.PKI_SPAWN_INFORMATION_FOOTER)
 
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -2857,6 +2857,116 @@ class ACMESubsystem(PKISubsystem):
         self.instance.store_properties(self.realm_conf, config)
 
 
+class ESTSubsystem(PKISubsystem):
+
+    def __init__(self, instance):
+        super().__init__(instance, 'est')
+
+    @property
+    def backend_conf(self):
+        return os.path.join(self.conf_dir, 'backend.conf')
+
+    @property
+    def authorizer_conf(self):
+        return os.path.join(self.conf_dir, 'authorizer.conf')
+
+    @property
+    def realm_conf(self):
+        return os.path.join(self.conf_dir, 'realm.conf')
+
+    def create(self, exist_ok=False, force=False):
+
+        self.instance.makedirs(self.conf_dir, exist_ok=exist_ok)
+
+        default_conf_dir = os.path.join(pki.server.PKIServer.SHARE_DIR, 'est', 'conf')
+
+        self.instance.copy(
+            os.path.join(default_conf_dir, 'backend.conf'),
+            self.backend_conf,
+            exist_ok=exist_ok,
+            force=force)
+
+        self.instance.copy(
+            os.path.join(default_conf_dir, 'authorizer.conf'),
+            self.authorizer_conf,
+            exist_ok=exist_ok,
+            force=force)
+
+    def get_backend_config(self, default=False):
+
+        if default:
+            backend_conf = os.path.join(
+                pki.server.PKIServer.SHARE_DIR,
+                'est',
+                'conf',
+                'backend.conf')
+        else:
+            backend_conf = self.backend_conf
+
+        logger.info('Loading %s', backend_conf)
+        config = {}
+        pki.util.load_properties(backend_conf, config)
+        return config
+
+    def update_backend_config(self, config):
+
+        logger.info('Updating %s', self.backend_conf)
+        self.instance.store_properties(self.backend_conf, config)
+
+    def get_authorizer_config(self, default=False):
+
+        if default:
+            authorizer_conf = os.path.join(
+                pki.server.PKIServer.SHARE_DIR,
+                'est',
+                'conf',
+                'authorizer.conf')
+        else:
+            authorizer_conf = self.authorizer_conf
+
+        logger.info('Loading %s', authorizer_conf)
+        config = {}
+        pki.util.load_properties(authorizer_conf, config)
+
+        return config
+
+    def update_authorizer_config(self, config):
+
+        logger.info('Updating %s', self.authorizer_conf)
+        self.instance.store_properties(self.authorizer_conf, config)
+
+    def get_realm_config(self, realm_type=None):
+
+        template_dir = os.path.join(pki.server.PKIServer.SHARE_DIR, 'est', 'conf', 'realm')
+
+        if realm_type:
+            # if realm type is specified, load the realm.conf template
+            realm_conf = os.path.join(template_dir, '%s.conf' % realm_type)
+        else:
+            # otherwise, load the current realm.conf in the instance
+            realm_conf = self.realm_conf
+
+        logger.info('Loading %s', realm_conf)
+        config = {}
+        pki.util.load_properties(realm_conf, config)
+
+        return config
+
+    def update_realm_config(self, config):
+
+        logger.info('Updating %s', self.realm_conf)
+        self.instance.store_properties(self.realm_conf, config)
+
+    def replace_realm_config(self, realm_path):
+
+        logger.info('Replace %s', self.realm_conf)
+        self.instance.copy(
+            realm_path,
+            self.realm_conf,
+            exist_ok=False,
+            force=True)
+
+
 class PKISubsystemFactory(object):
 
     @classmethod


### PR DESCRIPTION
This initial commit add est configuration for deployment in instance with existing CA.

Actually, several step are just skipped which could be required like creating initial users, reporting the status, etc....

The final installation is compliant with the page: https://github.com/dogtagpki/pki/blob/master/docs/installation/est/Installing_EST.md