### PR TITLE
Fix CA cloning test with secure DS connection

### DIFF
--- a/.github/workflows/ca-clone-secure-ds-test.yml
+++ b/.github/workflows/ca-clone-secure-ds-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up primary DS container
         run: |
           tests/bin/ds-create.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               --hostname=primaryds.example.com \
               --password=Secret.123 \
               primaryds
@@ -100,17 +100,17 @@ jobs:
           sudo chmod go+r primaryds_server.p12
 
           tests/bin/ds-certs-import.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               --input=primaryds_server.p12 \
               --password=Secret.123 \
               primaryds
 
           tests/bin/ds-stop.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               primaryds
 
           tests/bin/ds-start.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               primaryds
 
       - name: Install CA in primary PKI container
@@ -159,7 +159,7 @@ jobs:
       - name: Set up secondary DS container
         run: |
           tests/bin/ds-create.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               --hostname=secondaryds.example.com \
               --password=Secret.123 \
               secondaryds
@@ -224,17 +224,17 @@ jobs:
           sudo chmod go+r secondaryds_server.p12
 
           tests/bin/ds-certs-import.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               --input=secondaryds_server.p12 \
               --password=Secret.123 \
               secondaryds
 
           tests/bin/ds-stop.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               secondaryds
 
           tests/bin/ds-start.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               secondaryds
 
       - name: Install CA in secondary PKI container

--- a/.github/workflows/ca-secure-ds-test.yml
+++ b/.github/workflows/ca-secure-ds-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up DS container
         run: |
           tests/bin/ds-create.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
               --password=Secret.123 \
               ds
@@ -99,18 +99,18 @@ jobs:
           sudo chmod go+r ds_server.p12
 
           tests/bin/ds-certs-import.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               --input=ds_server.p12 \
               --password=Secret.123 \
               --debug \
               ds
 
           tests/bin/ds-stop.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               ds
 
           tests/bin/ds-start.sh \
-              --image=pki-runner \
+              --image=${{ env.DS_IMAGE }} \
               ds
 
       - name: Install CA


### PR DESCRIPTION
The tests for CA with secure DS connection (including cloning) have been updated to use DS containers instead of DS RPM packages from Fedora to avoid DS issue #6316.

https://github.com/389ds/389-ds-base/issues/6316