### PR TITLE
Update pkispawn to support ACME

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -100,17 +100,28 @@ jobs:
 
       - name: Install ACME in PKI container
         run: |
-          docker exec pki pki-server acme-create
-          docker exec pki pki-server acme-database-mod \
-              --type ds \
-              -D url=ldap://ds.example.com:3389
-          docker exec pki pki-server acme-issuer-mod \
-              --type pki \
-              -D url=https://pki.example.com:8443
-          docker exec pki pki-server acme-realm-mod \
-              --type ds \
-              -D url=ldap://ds.example.com:3389
-          docker exec pki pki-server acme-deploy --wait
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/acme.cfg \
+              -s ACME \
+              -D acme_database_url=ldap://ds.example.com:3389 \
+              -D acme_issuer_url=https://pki.example.com:8443 \
+              -D acme_realm_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check ACME database config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/acme/database.conf
+
+      - name: Check ACME issuer config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/acme/issuer.conf
+
+      - name: Check ACME realm config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/acme/realm.conf
 
       - name: Check initial ACME accounts
         run: |

--- a/.github/workflows/acme-postgresql-test.yml
+++ b/.github/workflows/acme-postgresql-test.yml
@@ -149,19 +149,32 @@ jobs:
 
       - name: Install ACME in PKI container
         run: |
-          docker exec pki pki-server acme-create
-          docker exec pki pki-server acme-database-mod \
-              --type postgresql \
-              -Dpassword=mysecretpassword \
-              -Durl='jdbc:postgresql://postgresql.example.com:5432/acme?ssl=true&sslmode=require'
-          docker exec pki pki-server acme-issuer-mod \
-              --type pki \
-              -D url=https://pki.example.com:8443
-          docker exec pki pki-server acme-realm-mod \
-              --type postgresql \
-              -Dpassword=mysecretpassword \
-              -Durl='jdbc:postgresql://postgresql.example.com:5432/acme?ssl=true&sslmode=require'
-          docker exec pki pki-server acme-deploy --wait
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/acme.cfg \
+              -s ACME \
+              -D acme_database_type=postgresql \
+              -D acme_database_url="jdbc:postgresql://postgresql.example.com:5432/acme?ssl=true&sslmode=require" \
+              -D acme_database_password=mysecretpassword \
+              -D acme_issuer_url=https://pki.example.com:8443 \
+              -D acme_realm_type=postgresql \
+              -D acme_realm_url="jdbc:postgresql://postgresql.example.com:5432/acme?ssl=true&sslmode=require" \
+              -D acme_realm_password=mysecretpassword \
+              -v
+
+      - name: Check ACME database config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/acme/database.conf
+
+      - name: Check ACME issuer config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/acme/issuer.conf
+
+      - name: Check ACME realm config
+        if: always()
+        run: |
+          docker exec pki cat /etc/pki/pki-tomcat/acme/realm.conf
 
       - name: Run PKI healthcheck in PKI container
         run: docker exec pki pki-healthcheck --failures-only

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -80,13 +80,16 @@ jobs:
           docker exec pki pki-server acme-create
           docker exec pki pki-server acme-database-mod \
               --type ds \
-              -D url=ldap://ds.example.com:3389
+              -D url=ldap://ds.example.com:3389 \
+              -D bindPassword=Secret.123
           docker exec pki pki-server acme-issuer-mod \
               --type pki \
-              -D url=https://pki.example.com:8443
+              -D url=https://pki.example.com:8443 \
+              -D password=Secret.123
           docker exec pki pki-server acme-realm-mod \
               --type ds \
-              -D url=ldap://ds.example.com:3389
+              -D url=ldap://ds.example.com:3389 \
+              -D bindPassword=Secret.123
           docker exec pki bash -c "echo baseURL=http://server1.example.com:8080/acme >> /var/lib/pki/pki-tomcat/conf/acme/engine.conf"
           docker exec pki pki-server acme-deploy --wait
 

--- a/base/acme/database/ds/database.conf
+++ b/base/acme/database/ds/database.conf
@@ -2,5 +2,5 @@ class=org.dogtagpki.acme.database.DSDatabase
 url=ldap://localhost.localdomain:389
 authType=BasicAuth
 bindDN=cn=Directory Manager
-bindPassword=Secret.123
+bindPassword=
 baseDN=dc=acme,dc=pki,dc=example,dc=com

--- a/base/acme/database/ldap/database.conf
+++ b/base/acme/database/ldap/database.conf
@@ -2,5 +2,5 @@ class=org.dogtagpki.acme.database.LDAPDatabase
 url=ldap://localhost.localdomain:389
 authType=BasicAuth
 bindDN=cn=Directory Manager
-bindPassword=Secret.123
+bindPassword=
 baseDN=dc=acme,dc=pki,dc=example,dc=com

--- a/base/acme/database/openldap/database.conf
+++ b/base/acme/database/openldap/database.conf
@@ -2,5 +2,5 @@ class=org.dogtagpki.acme.database.OpenLDAPDatabase
 url=ldap://localhost.localdomain:389
 authType=BasicAuth
 bindDN=cn=Manager,dc=example,dc=com
-bindPassword=Secret.123
+bindPassword=
 baseDN=dc=acme,dc=pki,dc=example,dc=com

--- a/base/acme/database/postgresql/database.conf
+++ b/base/acme/database/postgresql/database.conf
@@ -1,4 +1,4 @@
 class=org.dogtagpki.acme.database.PostgreSQLDatabase
 url=jdbc:postgresql://localhost.localdomain:5432/acme
 user=acme
-password=Secret.123
+password=

--- a/base/acme/issuer/pki/issuer.conf
+++ b/base/acme/issuer/pki/issuer.conf
@@ -2,4 +2,4 @@ class=org.dogtagpki.acme.issuer.PKIIssuer
 url=https://localhost.localdomain:8443
 profile=acmeServerCert
 username=caadmin
-password=Secret.123
+password=

--- a/base/acme/openshift/pki-acme-database.yaml
+++ b/base/acme/openshift/pki-acme-database.yaml
@@ -14,7 +14,7 @@ stringData:
   # url: ldap://ds:389
   # authType: BasicAuth
   # bindDN: cn=Directory Manager
-  # bindPassword: Secret.123
+  # bindPassword: ...
   # baseDN: dc=acme,dc=pki,dc=example,dc=com
   #
   # OpenLDAP Database
@@ -23,12 +23,12 @@ stringData:
   # url: ldap://openldap:389
   # authType: BasicAuth
   # bindDN: cn=Manager,dc=example,dc=com
-  # bindPassword: Secret.123
+  # bindPassword: ...
   # baseDN: dc=acme,dc=pki,dc=example,dc=com
   #
   # PostgreSQL Database
   # -------------------
   # class: org.dogtagpki.acme.database.PostgreSQLDatabase
-  # password: Secret.123
+  # password: ...
   # url: jdbc:postgresql://postgresql:5432/acme
   # user: acme

--- a/base/acme/openshift/pki-acme-issuer.yaml
+++ b/base/acme/openshift/pki-acme-issuer.yaml
@@ -14,4 +14,4 @@ stringData:
   # url: https://pki-ca:8443
   # profile: acmeServerCert
   # username: caadmin
-  # password: Secret.123
+  # password: ...

--- a/base/acme/openshift/pki-acme-realm.yaml
+++ b/base/acme/openshift/pki-acme-realm.yaml
@@ -14,13 +14,13 @@ stringData:
   # url: ldap://ds:389
   # authType: BasicAuth
   # bindDN: cn=Directory Manager
-  # bindPassword: Secret.123
+  # bindPassword: ...
   # usersDN: ou=people,dc=acme,dc=pki,dc=example,dc=com
   # groupsDN: ou=groups,dc=acme,dc=pki,dc=example,dc=com
   #
   # PostgreSQL Realm
   # ----------------
   # class: org.dogtagpki.acme.realm.PostgreSQLRealm
-  # password: Secret.123
+  # password: ...
   # url: jdbc:postgresql://postgresql:5432/acme
   # user: acme

--- a/base/acme/realm/ds/realm.conf
+++ b/base/acme/realm/ds/realm.conf
@@ -2,6 +2,6 @@ class=org.dogtagpki.acme.realm.DSRealm
 url=ldap://localhost.localdomain:389
 authType=BasicAuth
 bindDN=cn=Directory Manager
-bindPassword=Secret.123
+bindPassword=
 usersDN=ou=people,dc=acme,dc=pki,dc=example,dc=com
 groupsDN=ou=groups,dc=acme,dc=pki,dc=example,dc=com

--- a/base/acme/realm/in-memory/realm.conf
+++ b/base/acme/realm/in-memory/realm.conf
@@ -1,3 +1,3 @@
 class=org.dogtagpki.acme.realm.InMemoryRealm
 username=admin
-password=Secret.123
+password=

--- a/base/acme/realm/postgresql/realm.conf
+++ b/base/acme/realm/postgresql/realm.conf
@@ -1,4 +1,4 @@
 class=org.dogtagpki.acme.realm.PostgreSQLRealm
 url=jdbc:postgresql://localhost.localdomain:5432/acme
 user=acme
-password=Secret.123
+password=

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -33,6 +33,11 @@ sensitive_parameters=
     pki_server_database_password
     pki_server_pkcs12_password
     pki_token_password
+    acme_database_bind_password
+    acme_database_password
+    acme_issuer_password
+    acme_realm_bind_password
+    acme_realm_password
 
 pki_instance_name=pki-tomcat
 pki_http_port=8080
@@ -80,7 +85,6 @@ pki_ds_ldap_port=389
 pki_ds_ldaps_port=636
 pki_ds_password=
 pki_ds_remove_data=True
-pki_ds_setup=True
 pki_ds_secure_connection=False
 pki_ds_secure_connection_ca_nickname=Directory Server CA certificate
 pki_ds_secure_connection_ca_pem_file=
@@ -94,13 +98,14 @@ pki_issuing_ca_uri=https://%(pki_issuing_ca_hostname)s:%(pki_issuing_ca_https_po
 pki_issuing_ca=%(pki_issuing_ca_uri)s
 pki_replication_password=
 pki_status_request_timeout=
-pki_security_domain_setup=True
+
 pki_security_domain_hostname=%(pki_hostname)s
 pki_security_domain_https_port=8443
 pki_security_domain_uri=https://%(pki_security_domain_hostname)s:%(pki_security_domain_https_port)s
 pki_security_domain_name=%(pki_dns_domainname)s Security Domain
 pki_security_domain_password=
 pki_security_domain_user=caadmin
+
 #for supporting server cert SAN injection
 pki_san_inject=False
 pki_san_for_server_cert=
@@ -247,8 +252,6 @@ CATALINA_HOME=/usr/share/tomcat
 pki_tomcat_bin_path=%(CATALINA_HOME)s/bin
 pki_tomcat_lib_path=%(CATALINA_HOME)s/lib
 
-pki_registry_enable=True
-
 ###############################################################################
 ##  CA Configuration:                                                        ##
 ##                                                                           ##
@@ -329,9 +332,11 @@ pki_admin_uid=caadmin
 pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s CA
 pki_audit_signing_subject_dn=cn=CA Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 
+pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-CA
 pki_ds_database=%(pki_instance_name)s-CA
 pki_ds_hostname=%(pki_hostname)s
+
 pki_subsystem_name=CA %(pki_hostname)s %(pki_https_port)s
 pki_share_db=False
 pki_master_crl_enable=True
@@ -359,6 +364,9 @@ pki_request_id_generator=random
 
 # Cert request ID length in bits
 pki_request_id_length=128
+
+pki_security_domain_setup=True
+pki_registry_enable=True
 
 ###############################################################################
 ##  KRA Configuration:                                                       ##
@@ -441,9 +449,11 @@ pki_admin_uid=kraadmin
 pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s KRA
 pki_audit_signing_subject_dn=cn=KRA Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 
+pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-KRA
 pki_ds_database=%(pki_instance_name)s-KRA
 pki_ds_hostname=%(pki_hostname)s
+
 pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
@@ -459,6 +469,9 @@ pki_request_id_generator=random
 
 # Key request ID length in bits
 pki_request_id_length=128
+
+pki_security_domain_setup=True
+pki_registry_enable=True
 
 ###############################################################################
 ##  OCSP Configuration:                                                      ##
@@ -528,13 +541,17 @@ pki_admin_uid=ocspadmin
 pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s OCSP
 pki_audit_signing_subject_dn=cn=OCSP Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 
+pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-OCSP
 pki_ds_database=%(pki_instance_name)s-OCSP
 pki_ds_hostname=%(pki_hostname)s
+
 pki_subsystem_name=OCSP %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
+pki_security_domain_setup=True
+pki_registry_enable=True
 
 ###############################################################################
 ##  TKS Configuration:                                                       ##
@@ -552,12 +569,18 @@ pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instanc
 pki_admin_uid=tksadmin
 pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s TKS
 pki_audit_signing_subject_dn=cn=TKS Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+
+pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-TKS
 pki_ds_database=%(pki_instance_name)s-TKS
 pki_ds_hostname=%(pki_hostname)s
+
 pki_subsystem_name=TKS %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
+
+pki_security_domain_setup=True
+pki_registry_enable=True
 
 ###############################################################################
 ##  TPS Configuration:                                                       ##
@@ -574,9 +597,12 @@ pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instanc
 pki_admin_uid=tpsadmin
 pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s TPS
 pki_audit_signing_subject_dn=cn=TPS Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
+
+pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-TPS
 pki_ds_database=%(pki_instance_name)s-TPS
 pki_ds_hostname=%(pki_hostname)s
+
 pki_subsystem_name=TPS %(pki_hostname)s %(pki_https_port)s
 pki_authdb_hostname=%(pki_hostname)s
 pki_authdb_port=389
@@ -589,3 +615,51 @@ pki_import_shared_secret=False
 pki_share_db=True
 pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 pki_source_phone_home_xml=/usr/share/pki/%(pki_subsystem_type)s/conf/phoneHome.xml
+
+pki_security_domain_setup=True
+pki_registry_enable=True
+
+[ACME]
+pki_ds_setup=False
+pki_security_domain_setup=False
+pki_registry_enable=False
+
+# Database params:
+# - acme_database_type
+# - acme_database_url
+# - acme_database_auth_type
+# - acme_database_bind_dn
+# - acme_database_bind_password
+# - acme_database_bind_nickname
+# - acme_database_user
+# - acme_database_password
+# - acme_database_base_dn
+#
+# See /usr/share/pki/acme/database/<type>/database.conf
+
+# Issuer params:
+# - acme_issuer_type
+# - acme_issuer_url
+# - acme_issuer_nickname
+# - acme_issuer_extensions
+# - acme_issuer_username
+# - acme_issuer_password
+# - acme_issuer_password_file
+# - acme_issuer_profile
+#
+# See /usr/share/pki/acme/issuer/<type>/issuer.conf
+
+# Realm params:
+# - acme_realm_type
+# - acme_realm_url
+# - acme_realm_auth_type
+# - acme_realm_bind_dn
+# - acme_realm_bind_password
+# - acme_realm_nickname
+# - acme_realm_user
+# - acme_realm_username
+# - acme_realm_password
+# - acme_realm_users_dn
+# - acme_realm_groups_dn
+#
+# See /usr/share/pki/acme/realm/<type>/realm.conf

--- a/base/server/examples/installation/acme.cfg
+++ b/base/server/examples/installation/acme.cfg
@@ -1,0 +1,15 @@
+[DEFAULT]
+pki_server_database_password=Secret.123
+
+[ACME]
+acme_database_type=ds
+acme_database_url=ldap://localhost.localdomain:3389
+acme_database_bind_password=Secret.123
+
+acme_issuer_type=pki
+acme_issuer_url=https://localhost.localdomain:8443
+acme_issuer_password=Secret.123
+
+acme_realm_type=ds
+acme_realm_url=ldap://localhost.localdomain:3389
+acme_realm_bind_password=Secret.123

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -5183,9 +5183,197 @@ class PKIDeployer:
 
         trans.finish()
 
+    def create_acme_subsystem(self):
+        '''
+        See also pki-server acme-create.
+        '''
+
+        logger.info('Creating ACME subsystem')
+
+        subsystem = pki.server.subsystem.ACMESubsystem(self.instance)
+        subsystem.create()
+
+        return subsystem
+
+    def configure_acme_database(self, subsystem):
+        '''
+        See also pki-server acme-database-mod.
+        '''
+
+        logger.info('Configuring ACME database')
+
+        database_type = self.mdict['acme_database_type']
+        props = subsystem.get_database_config(database_type=database_type)
+
+        database_class = pki.server.subsystem.ACME_DATABASE_CLASSES.get(database_type)
+        pki.util.set_property(props, 'class', database_class)
+
+        if database_type in ['ds', 'ldap', 'openldap']:
+
+            url = self.mdict.get('acme_database_url')
+            pki.util.set_property(props, 'url', url)
+
+            auth_type = props.get('authType')
+            auth_type = self.mdict.get('acme_database_auth_type', auth_type)
+            pki.util.set_property(props, 'authType', auth_type)
+
+            if auth_type == 'BasicAuth':
+                bind_dn = self.mdict.get('acme_database_bind_dn')
+                pki.util.set_property(props, 'bindDN', bind_dn)
+
+                bind_password = self.mdict.get('acme_database_bind_password')
+                pki.util.set_property(props, 'bindPassword', bind_password)
+
+            elif auth_type == 'SslClientAuth':
+                nickname = self.mdict.get('acme_database_nickname')
+                pki.util.set_property(props, 'nickname', nickname)
+
+            base_dn = self.mdict.get('acme_database_base_dn')
+            pki.util.set_property(props, 'baseDN', base_dn)
+
+        elif database_type == 'postgresql':
+
+            url = self.mdict.get('acme_database_url')
+            pki.util.set_property(props, 'url', url)
+
+            user = self.mdict.get('acme_database_user')
+            pki.util.set_property(props, 'user', user)
+
+            password = self.mdict.get('acme_database_password')
+            pki.util.set_property(props, 'password', password)
+
+        subsystem.update_database_config(props)
+
+    def configure_acme_issuer(self, subsystem):
+        '''
+        See also pki-server acme-issuer-mod.
+        '''
+
+        logger.info('Configuring ACME issuer')
+
+        issuer_type = self.mdict['acme_issuer_type']
+        props = subsystem.get_issuer_config(issuer_type=issuer_type)
+
+        issuer_class = pki.server.subsystem.ACME_ISSUER_CLASSES.get(issuer_type)
+        pki.util.set_property(props, 'class', issuer_class)
+
+        if issuer_type == 'nss':
+
+            nickname = self.mdict.get('acme_issuer_nickname')
+            pki.util.set_property(props, 'nickname', nickname)
+
+            extensions = self.mdict.get('acme_issuer_extensions')
+            pki.util.set_property(props, 'extensions', extensions)
+
+        elif issuer_type == 'pki':
+
+            url = self.mdict.get('acme_issuer_url')
+            pki.util.set_property(props, 'url', url)
+
+            nickname = self.mdict.get('acme_issuer_nickname')
+            pki.util.set_property(props, 'nickname', nickname)
+
+            username = self.mdict.get('acme_issuer_username')
+            pki.util.set_property(props, 'username', username)
+
+            password = self.mdict.get('acme_issuer_password')
+            pki.util.set_property(props, 'password', password)
+
+            password_file = self.mdict.get('acme_issuer_password_file')
+            pki.util.set_property(props, 'passwordFile', password_file)
+
+            profile = self.mdict.get('acme_issuer_profile')
+            pki.util.set_property(props, 'profile', profile)
+
+        subsystem.update_issuer_config(props)
+
+    def configure_acme_realm(self, subsystem):
+        '''
+        See also pki-server acme-realm-mod.
+        '''
+
+        logger.info('Configuring ACME realm')
+
+        realm_type = self.mdict['acme_realm_type']
+        props = subsystem.get_realm_config(realm_type=realm_type)
+
+        realm_class = pki.server.subsystem.ACME_REALM_CLASSES.get(realm_type)
+        pki.util.set_property(props, 'class', realm_class)
+
+        if realm_type == 'in-memory':
+
+            username = self.mdict.get('acme_realm_username')
+            pki.util.set_property(props, 'username', username)
+
+            password = self.mdict.get('acme_realm_password')
+            pki.util.set_property(props, 'password', password)
+
+        elif realm_type == 'ds':
+
+            url = self.mdict.get('acme_realm_url')
+            pki.util.set_property(props, 'url', url)
+
+            auth_type = props.get('authType')
+            auth_type = self.mdict.get('acme_realm_auth_type', auth_type)
+            pki.util.set_property(props, 'authType', auth_type)
+
+            if auth_type == 'BasicAuth':
+                bind_dn = self.mdict.get('acme_realm_bind_dn')
+                pki.util.set_property(props, 'bindDN', bind_dn)
+
+                bind_password = self.mdict.get('acme_realm_bind_password')
+                pki.util.set_property(props, 'bindPassword', bind_password)
+
+            elif auth_type == 'SslClientAuth':
+                nickname = self.mdict.get('acme_realm_nickname')
+                pki.util.set_property(props, 'nickname', nickname)
+
+            users_dn = self.mdict.get('acme_realm_users_dn')
+            pki.util.set_property(props, 'usersDN', users_dn)
+
+            groups_dn = self.mdict.get('acme_realm_groups_dn')
+            pki.util.set_property(props, 'groupsDN', groups_dn)
+
+        elif realm_type == 'postgresql':
+
+            url = self.mdict.get('acme_realm_url')
+            pki.util.set_property(props, 'url', url)
+
+            user = self.mdict.get('acme_realm_user')
+            pki.util.set_property(props, 'user', user)
+
+            password = self.mdict.get('acme_realm_password')
+            pki.util.set_property(props, 'password', password)
+
+        subsystem.update_realm_config(props)
+
+    def deploy_acme_webapp(self, subsystem):
+        '''
+        See also pki-server acme-deploy.
+        '''
+
+        logger.info('Deploying ACME webapp')
+
+        subsystem.enable(wait=True)
+
+    def spawn_acme(self):
+
+        subsystem = self.create_acme_subsystem()
+        self.instance.add_subsystem(subsystem)
+
+        self.configure_acme_database(subsystem)
+        self.configure_acme_issuer(subsystem)
+        self.configure_acme_realm(subsystem)
+
+        self.deploy_acme_webapp(subsystem)
+
     def spawn(self):
 
         print('Installing ' + self.subsystem_type + ' into ' + self.instance.base_dir + '.')
+
+        if self.subsystem_type == 'ACME':
+            self.spawn_acme()
+            return
 
         scriptlet = pki.server.deployment.scriptlets.initialization.PkiScriptlet()
         scriptlet.deployer = self

--- a/base/server/python/pki/server/deployment/pkiconfig.py
+++ b/base/server/python/pki/server/deployment/pkiconfig.py
@@ -36,7 +36,7 @@ PKI_DEPLOYMENT_DEFAULT_SHELL = "/sbin/nologin"
 PKI_DEPLOYMENT_DEFAULT_UID = 17
 PKI_DEPLOYMENT_DEFAULT_USER = "pkiuser"
 
-PKI_SUBSYSTEMS = ["CA", "KRA", "OCSP", "TKS", "TPS"]
+PKI_SUBSYSTEMS = ['CA', 'KRA', 'OCSP', 'TKS', 'TPS', 'ACME']
 PKI_BASE_RESERVED_NAMES = ["alias", "bin", "ca", "common", "conf", "kra",
                            "lib", "logs", "ocsp", "temp", "tks", "tps",
                            "webapps", "work"]

--- a/base/server/python/pki/server/deployment/pkimessages.py
+++ b/base/server/python/pki/server/deployment/pkimessages.py
@@ -349,7 +349,7 @@ PKI_CONFIG_NOT_YET_IMPLEMENTED_1 = " %s NOT YET IMPLEMENTED"
 PKI_CHECK_STATUS_MESSAGE = '''
       To check the status of the subsystem:
             systemctl status pki-tomcatd@%s.service'''
-PKI_ACCESS_URL = '''
+PKI_ACCESS_URL = '''\
       The URL for the subsystem is:
             https://%s:%s/%s'''
 PKI_INSTANCE_RESTART_MESSAGE = '''

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -190,8 +190,8 @@ def main(argv):
             parser.indent = 0
 
             deployer.subsystem_type = parser.read_text(
-                'Subsystem (CA/KRA/OCSP/TKS/TPS)',
-                options=['CA', 'KRA', 'OCSP', 'TKS', 'TPS'],
+                'Subsystem (CA/KRA/OCSP/TKS/TPS/ACME)',
+                options=['CA', 'KRA', 'OCSP', 'TKS', 'TPS', 'ACME'],
                 default='CA', case_sensitive=False).upper()
             print()
         else:
@@ -669,6 +669,9 @@ def main(argv):
         elif deployer.subsystem_type == 'TPS':
             print_tps_step_one_information(parser.mdict, deployer.instance)
 
+    elif deployer.subsystem_type == 'ACME':
+        print_acme_install_information()
+
     else:
         print_final_install_information(parser.mdict, deployer.instance)
 
@@ -682,7 +685,15 @@ def validate_user_deployment_cfg(user_deployment_cfg):
         line = line.strip()
         if not line.startswith('['):
             continue
-        if line not in ['[DEFAULT]', '[Tomcat]', '[CA]', '[KRA]', '[OCSP]', '[TKS]', '[TPS]']:
+        if line not in [
+                '[DEFAULT]',
+                '[Tomcat]',
+                '[CA]',
+                '[KRA]',
+                '[OCSP]',
+                '[TKS]',
+                '[TPS]',
+                '[ACME]']:
             raise Exception('Invalid deployment configuration section: %s' % line)
 
 
@@ -919,6 +930,7 @@ def print_skip_configuration_information(mdict, instance):
         print(log.PKI_CHECK_STATUS_MESSAGE % instance.name)
         print(log.PKI_INSTANCE_RESTART_MESSAGE % instance.name)
 
+    print()
     print(log.PKI_ACCESS_URL % (mdict['pki_hostname'],
                                 mdict['pki_https_port'],
                                 deployer.subsystem_type.lower()))
@@ -926,6 +938,17 @@ def print_skip_configuration_information(mdict, instance):
         print(log.PKI_SYSTEM_BOOT_STATUS_MESSAGE % "disabled")
     else:
         print(log.PKI_SYSTEM_BOOT_STATUS_MESSAGE % "enabled")
+    print(log.PKI_SPAWN_INFORMATION_FOOTER)
+
+
+def print_acme_install_information():
+
+    print(log.PKI_SPAWN_INFORMATION_HEADER)
+
+    print(log.PKI_ACCESS_URL % (deployer.mdict['pki_hostname'],
+                                deployer.mdict['pki_https_port'],
+                                deployer.subsystem_type.lower()))
+
     print(log.PKI_SPAWN_INFORMATION_FOOTER)
 
 
@@ -970,6 +993,7 @@ def print_final_install_information(mdict, instance):
         print(log.PKI_CHECK_STATUS_MESSAGE % instance.name)
         print(log.PKI_INSTANCE_RESTART_MESSAGE % instance.name)
 
+    print()
     print(log.PKI_ACCESS_URL % (mdict['pki_hostname'],
                                 mdict['pki_https_port'],
                                 deployer.subsystem_type.lower()))


### PR DESCRIPTION
`pkispawn` has been modified to support installing ACME in a shared PKI server (e.g. with existing CA).

New `pkispawn` params have been added to specify the ACME database, issuer, and realm. A sample configuration has been provided in `acme.cfg`.

The `pki_ds_setup`, `pki_security_domain_setup`, and `pki_registry_enable` params in the `default.cfg` have been moved from `[DEFAULT]` into each subsystem's section so that ACME can skip DS setup, security domain setup, and registry setup by default.

The config templates for ACME database, issuer, and realm have been modified to no longer contain passwords. The passwords will need to be specified during installation.

Some code in `acme.py` has been moved into `subsystem.py` so that it can be reused.

The basic ACME test and the test with PostgreSQL have been modified to install ACME using `pkispawn`.