### PR TITLE
Update pkidestroy to support ACME

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -119,6 +119,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
           lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/conf/alias
           lrwxrwxrwx pkiuser pkiuser bin -> /usr/share/tomcat/bin
           drwxrwx--- pkiuser pkiuser ca
@@ -175,7 +176,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
-          drwxr-xr-x pkiuser pkiuser acme
+          drwxrwx--- pkiuser pkiuser acme
           drwxr-x--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log
@@ -184,6 +185,23 @@ jobs:
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           -rw-rw-r-- pkiuser pkiuser manager.$DATE.log
           drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check ACME base dir
+        if: always()
+        run: |
+          docker exec pki ls -l /var/lib/pki/pki-tomcat/acme \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # TODO: review permissions
+          cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /var/lib/pki/pki-tomcat/conf/acme
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/lib/pki/pki-tomcat/logs/acme
           EOF
 
           diff expected output
@@ -220,6 +238,11 @@ jobs:
         if: always()
         run: |
           docker exec pki cat /etc/pki/pki-tomcat/acme/realm.conf
+
+      - name: Check ACME logs dir
+        if: always()
+        run: |
+          docker exec pki ls -l /var/log/pki/pki-tomcat/acme
 
       - name: Check initial ACME accounts
         run: |
@@ -664,9 +687,7 @@ jobs:
           diff expected actual
 
       - name: Remove ACME from PKI container
-        run: |
-          docker exec pki pki-server acme-undeploy --wait
-          docker exec pki pki-server acme-remove
+        run: docker exec pki pkidestroy -s ACME -v
 
       - name: Remove CA from PKI container
         run: docker exec pki pkidestroy -s CA -v
@@ -700,6 +721,7 @@ jobs:
           # TODO: review permissions
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser alias
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser catalina.policy
@@ -729,7 +751,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
-          drwxr-xr-x pkiuser pkiuser acme
+          drwxrwx--- pkiuser pkiuser acme
           drwxr-x--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-rw-r-- pkiuser pkiuser catalina.$DATE.log

--- a/.github/workflows/acme-postgresql-test.yml
+++ b/.github/workflows/acme-postgresql-test.yml
@@ -539,9 +539,7 @@ jobs:
           diff expected actual
 
       - name: Remove ACME from PKI container
-        run: |
-          docker exec pki pki-server acme-undeploy --wait
-          docker exec pki pki-server acme-remove
+        run: docker exec pki pkidestroy -s ACME -v
 
       - name: Remove CA from PKI container
         run: docker exec pki pkidestroy -s CA -v

--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -178,6 +178,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
           lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/conf/alias
           lrwxrwxrwx pkiuser pkiuser bin -> /usr/share/tomcat/bin
           drwxr-x--- pkiuser pkiuser common
@@ -231,11 +232,29 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
           drwxr-x--- pkiuser pkiuser backup
           -rw-r--r-- pkiuser pkiuser catalina.$DATE.log
           -rw-r--r-- pkiuser pkiuser host-manager.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser manager.$DATE.log
+          EOF
+
+          diff expected output
+
+      - name: Check ACME base dir
+        if: always()
+        run: |
+          docker exec acme ls -l /var/lib/pki/pki-tomcat/acme \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          # TODO: review permissions
+          cat > expected << EOF
+          lrwxrwxrwx pkiuser pkiuser conf -> /var/lib/pki/pki-tomcat/conf/acme
+          lrwxrwxrwx pkiuser pkiuser logs -> /var/lib/pki/pki-tomcat/logs/acme
           EOF
 
           diff expected output
@@ -272,6 +291,11 @@ jobs:
         if: always()
         run: |
           docker exec acme cat /etc/pki/pki-tomcat/acme/realm.conf
+
+      - name: Check ACME logs dir
+        if: always()
+        run: |
+          docker exec acme ls -l /var/log/pki/pki-tomcat/acme
 
       - name: Check initial ACME accounts
         run: |
@@ -724,14 +748,10 @@ jobs:
           diff expected actual
 
       - name: Remove ACME
-        run: |
-          docker exec acme pki-server acme-undeploy --wait -v
-          docker exec acme pki-server acme-remove -v
-          docker exec acme pki-server stop --wait -v
-          docker exec acme pki-server remove -v
+        run: docker exec acme pkidestroy -s ACME -v
 
       - name: Remove CA
-        run: docker exec ca pkidestroy -i pki-tomcat -s CA -v
+        run: docker exec ca pkidestroy -s CA -v
 
       - name: Check ACME server base dir after removal
         run: |
@@ -762,6 +782,7 @@ jobs:
           # TODO: review permissions
           cat > expected << EOF
           drwxr-x--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser alias
           -rw-rw---- pkiuser pkiuser catalina.policy
           lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
@@ -789,7 +810,7 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
-          drwxr-xr-x pkiuser pkiuser acme
+          drwxrwx--- pkiuser pkiuser acme
           drwxr-x--- pkiuser pkiuser backup
           -rw-r--r-- pkiuser pkiuser catalina.$DATE.log
           -rw-r--r-- pkiuser pkiuser host-manager.$DATE.log

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -55,7 +55,7 @@ SYSCONFIG_DIR = '/etc/sysconfig'
 ETC_SYSTEMD_DIR = '/etc/systemd'
 LIB_SYSTEMD_DIR = '/lib/systemd'
 
-SUBSYSTEM_TYPES = ['ca', 'kra', 'ocsp', 'tks', 'tps']
+SUBSYSTEM_TYPES = ['ca', 'kra', 'ocsp', 'tks', 'tps', 'acme']
 
 DEFAULT_DIR_MODE = 0o0770
 DEFAULT_FILE_MODE = 0o0660

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -5187,6 +5187,8 @@ class PKIDeployer:
 
         subsystem = pki.server.subsystem.ACMESubsystem(self.instance)
         subsystem.create()
+        subsystem.create_conf()
+        subsystem.create_logs()
 
         return subsystem
 
@@ -5370,6 +5372,49 @@ class PKIDeployer:
         self.configure_acme_realm(subsystem)
 
         self.deploy_acme_webapp(subsystem)
+
+    def undeploy_acme_webapp(self, subsystem):
+        '''
+        See also pki-server acme-undeploy.
+        '''
+
+        logger.info('Undeploying ACME webapp')
+
+        subsystem.disable(wait=True)
+
+    def remove_acme_subsystem(self, subsystem):
+        '''
+        See also pki-server acme-remove.
+        '''
+
+        logger.info('Removing ACME subsystem')
+
+        if self.remove_logs:
+            subsystem.remove_logs(force=self.force)
+
+        if self.remove_conf:
+            subsystem.remove_conf(force=self.force)
+
+        subsystem.remove(force=self.force)
+
+    def destroy_acme(self):
+
+        subsystem = self.instance.remove_subsystem('acme')
+
+        self.undeploy_acme_webapp(subsystem)
+        self.remove_acme_subsystem(subsystem)
+
+        if len(self.instance.get_subsystems()) == 0:
+            # if this is the last subsystem, stop the server
+            self.instance.stop(
+                wait=True,
+                max_wait=self.startup_timeout,
+                timeout=self.request_timeout)
+
+            # then remove the server
+            self.instance.remove(
+                remove_conf=self.remove_conf,
+                remove_logs=self.remove_logs)
 
     def create_est_subsystem(self):
         '''
@@ -5563,6 +5608,10 @@ class PKIDeployer:
     def destroy(self):
 
         print('Uninstalling ' + self.subsystem_type + ' from ' + self.instance.base_dir + '.')
+
+        if self.subsystem_type == 'ACME':
+            self.destroy_acme()
+            return
 
         scriptlet = pki.server.deployment.scriptlets.initialization.PkiScriptlet()
         scriptlet.deployer = self


### PR DESCRIPTION
`pkidestroy` has been updated to support removing ACME from PKI server. If it is the last subsystem on the server, the server will be removed as well.

The `ACMESubsystem.create()` has been modified to create a base dir (i.e. `/var/lib/pki/<instance>/<subsystem>`) which is used by `PKIServer.load_subsystems()` to determine if the subsystem exists. The code that creates the conf and logs folders has been moved into create_conf() and create_logs(), respectively.

The `pki-server acme-remove` has been updated to provide options to remove the conf and logs folders.

The tests that use `pkispawn` to install ACME have been updated to use `pkidestroy` to remove ACME.