### PR TITLE
Add pki ca-cert-issue

### DIFF
--- a/.github/workflows/acme-postgresql-test.yml
+++ b/.github/workflows/acme-postgresql-test.yml
@@ -85,13 +85,14 @@ jobs:
               --subject "CN=postgresql.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --csr sslserver.csr
-          REC_ID=$(docker exec pki pki ca-cert-request-submit \
+
+          docker exec pki pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caServerCert \
               --csr-file sslserver.csr \
-              --subject "CN=postgresql.example.com" | grep "Request ID")
-          CERT_ID=$(docker exec pki pki -n caadmin ca-cert-request-approve ${REC_ID:14} --force | \
-              grep "Certificate ID")
-          docker exec pki pki ca-cert-export ${CERT_ID:18} --output-file sslserver.crt
+              --subject "CN=postgresql.example.com" \
+              --output-file sslserver.crt
 
           docker exec pki pki nss-cert-import \
               --cert sslserver.crt \

--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -120,18 +120,13 @@ jobs:
           docker exec acme cp /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/sslserver.csr
 
-          # submit cert request
-          docker exec ca pki ca-cert-request-submit \
+          # issue cert
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caServerCert \
-              --csr-file $SHARED/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          # approve cert request
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          # export cert
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/sslserver.crt
+              --csr-file $SHARED/sslserver.csr \
+              --output-file $SHARED/sslserver.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/sslserver.crt
 
           # install cert

--- a/.github/workflows/est-ds-realm-separate-test.yml
+++ b/.github/workflows/est-ds-realm-separate-test.yml
@@ -74,13 +74,13 @@ jobs:
           docker exec ca pki nss-cert-request --csr estSSLServer.csr \
               --ext /usr/share/pki/server/certs/sslserver.conf --subject 'CN=est.example.com'
 
-          docker exec ca pki ca-cert-request-submit --csr-file estSSLServer.csr --profile caServerCert | tee output
-          REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" output)
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --csr-file estSSLServer.csr \
+              --profile caServerCert \
+              --output-file estSSLServer.crt
 
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" output)
-
-          docker exec ca pki -n caadmin ca-cert-export --output-file estSSLServer.crt $CERT_ID
           docker exec ca pki nss-cert-import --cert estSSLServer.crt sslserver
 
           docker exec ca pk12util -d /root/.dogtag/nssdb -o $SHARED/est_server.p12 -n sslserver -W Secret.123

--- a/.github/workflows/kra-existing-certs-test.yml
+++ b/.github/workflows/kra-existing-certs-test.yml
@@ -94,15 +94,12 @@ jobs:
               --csr $SHARED/kra_storage.csr
           docker exec ca openssl req -text -noout -in $SHARED/kra_storage.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caStorageCert \
-              --csr-file $SHARED/kra_storage.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_storage.crt
+              --csr-file $SHARED/kra_storage.csr \
+              --output-file $SHARED/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_storage.crt
 
           docker exec kra pki nss-cert-import \
@@ -125,15 +122,12 @@ jobs:
               --csr $SHARED/kra_transport.csr
           docker exec ca openssl req -text -noout -in $SHARED/kra_transport.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caTransportCert \
-              --csr-file $SHARED/kra_transport.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_transport.crt
+              --csr-file $SHARED/kra_transport.csr \
+              --output-file $SHARED/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_transport.crt
 
           docker exec kra pki nss-cert-import \
@@ -156,15 +150,12 @@ jobs:
               --csr $SHARED/kra_audit_signing.csr
           docker exec ca openssl req -text -noout -in $SHARED/kra_audit_signing.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caAuditSigningCert \
-              --csr-file $SHARED/kra_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_audit_signing.crt
+              --csr-file $SHARED/kra_audit_signing.csr \
+              --output-file $SHARED/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_audit_signing.crt
 
           docker exec kra pki nss-cert-import \
@@ -188,15 +179,12 @@ jobs:
               --csr $SHARED/subsystem.csr
           docker exec ca openssl req -text -noout -in $SHARED/subsystem.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caSubsystemCert \
-              --csr-file $SHARED/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/subsystem.crt
+              --csr-file $SHARED/subsystem.csr \
+              --output-file $SHARED/subsystem.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/subsystem.crt
 
           docker exec kra pki nss-cert-import \
@@ -219,15 +207,12 @@ jobs:
               --csr $SHARED/sslserver.csr
           docker exec ca openssl req -text -noout -in $SHARED/sslserver.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caServerCert \
-              --csr-file $SHARED/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/sslserver.crt
+              --csr-file $SHARED/sslserver.csr \
+              --output-file $SHARED/sslserver.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/sslserver.crt
 
           docker exec kra pki nss-cert-import \
@@ -250,15 +235,12 @@ jobs:
               --csr $SHARED/kra_admin.csr
           docker exec ca openssl req -text -noout -in $SHARED/kra_admin.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile AdminCert \
-              --csr-file $SHARED/kra_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_admin.crt
+              --csr-file $SHARED/kra_admin.csr \
+              --output-file $SHARED/kra_admin.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_admin.crt
 
           docker exec kra pki nss-cert-import \

--- a/.github/workflows/kra-existing-ds-test.yml
+++ b/.github/workflows/kra-existing-ds-test.yml
@@ -95,18 +95,13 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_storage.csr $SHARED
           docker exec kra openssl req -text -noout -in $SHARED/kra_storage.csr
 
-          # submit cert request
-          docker exec ca pki ca-cert-request-submit \
-              --profile caStorageCert \
-              --csr-file $SHARED/kra_storage.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           # issue cert
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          # retrieve cert
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_storage.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caStorageCert \
+              --csr-file $SHARED/kra_storage.csr \
+              --output-file $SHARED/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_storage.crt
           docker exec kra cp $SHARED/kra_storage.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -137,18 +132,13 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_transport.csr
 
-          # submit cert request
-          docker exec ca pki ca-cert-request-submit \
-              --profile caTransportCert \
-              --csr-file $SHARED/kra_transport.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           # issue cert
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          # retrieve cert
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_transport.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caTransportCert \
+              --csr-file $SHARED/kra_transport.csr \
+              --output-file $SHARED/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_transport.crt
           docker exec kra cp $SHARED/kra_transport.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -179,18 +169,13 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_audit_signing.csr
 
-          # submit cert request
-          docker exec ca pki ca-cert-request-submit \
-              --profile caAuditSigningCert \
-              --csr-file $SHARED/kra_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           # issue cert
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          # retrieve cert
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file $SHARED/kra_audit_signing.csr \
+              --output-file $SHARED/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_audit_signing.crt
           docker exec kra cp $SHARED/kra_audit_signing.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -221,18 +206,13 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/subsystem.csr
 
-          # submit cert request
-          docker exec ca pki ca-cert-request-submit \
-              --profile caSubsystemCert \
-              --csr-file $SHARED/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           # issue cert
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          # retrieve cert
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file $SHARED/subsystem.csr \
+              --output-file $SHARED/subsystem.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/subsystem.crt
           docker exec kra cp $SHARED/subsystem.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -263,18 +243,13 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/sslserver.csr
 
-          # submit cert request
-          docker exec ca pki ca-cert-request-submit \
-              --profile caServerCert \
-              --csr-file $SHARED/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           # issue cert
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          # retrieve cert
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file $SHARED/sslserver.csr \
+              --output-file $SHARED/sslserver.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/sslserver.crt
           docker exec kra cp $SHARED/sslserver.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -304,18 +279,13 @@ jobs:
               --csr $SHARED/kra_admin.csr
           docker exec ca openssl req -text -noout -in $SHARED/kra_admin.csr
 
-          # submit cert request
-          docker exec ca pki ca-cert-request-submit \
-              --profile AdminCert \
-              --csr-file $SHARED/kra_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
           # issue cert
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          # retrieve cert
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file $SHARED/kra_admin.csr \
+              --output-file $SHARED/kra_admin.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_admin.crt
 
           # import cert

--- a/.github/workflows/kra-existing-hsm-test.yml
+++ b/.github/workflows/kra-existing-hsm-test.yml
@@ -124,15 +124,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_storage.csr $SHARED
           docker exec kra openssl req -text -noout -in $SHARED/kra_storage.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caStorageCert \
-              --csr-file $SHARED/kra_storage.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_storage.crt
+              --csr-file $SHARED/kra_storage.csr \
+              --output-file $SHARED/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_storage.crt
           docker exec kra cp $SHARED/kra_storage.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -166,15 +163,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_transport.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caTransportCert \
-              --csr-file $SHARED/kra_transport.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_transport.crt
+              --csr-file $SHARED/kra_transport.csr \
+              --output-file $SHARED/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_transport.crt
           docker exec kra cp $SHARED/kra_transport.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -208,15 +202,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_audit_signing.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caAuditSigningCert \
-              --csr-file $SHARED/kra_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_audit_signing.crt
+              --csr-file $SHARED/kra_audit_signing.csr \
+              --output-file $SHARED/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_audit_signing.crt
           docker exec kra cp $SHARED/kra_audit_signing.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -250,15 +241,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/subsystem.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caSubsystemCert \
-              --csr-file $SHARED/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/subsystem.crt
+              --csr-file $SHARED/subsystem.csr \
+              --output-file $SHARED/subsystem.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/subsystem.crt
           docker exec kra cp $SHARED/subsystem.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -291,15 +279,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/sslserver.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caServerCert \
-              --csr-file $SHARED/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/sslserver.crt
+              --csr-file $SHARED/sslserver.csr \
+              --output-file $SHARED/sslserver.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/sslserver.crt
           docker exec kra cp $SHARED/sslserver.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -328,15 +313,12 @@ jobs:
               --csr $SHARED/kra_admin.csr
           docker exec ca openssl req -text -noout -in $SHARED/kra_admin.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile AdminCert \
-              --csr-file $SHARED/kra_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_admin.crt
+              --csr-file $SHARED/kra_admin.csr \
+              --output-file $SHARED/kra_admin.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_admin.crt
 
           docker exec kra pki nss-cert-import \

--- a/.github/workflows/kra-existing-nssdb-test.yml
+++ b/.github/workflows/kra-existing-nssdb-test.yml
@@ -100,15 +100,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_storage.csr $SHARED
           docker exec kra openssl req -text -noout -in $SHARED/kra_storage.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caStorageCert \
-              --csr-file $SHARED/kra_storage.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_storage.crt
+              --csr-file $SHARED/kra_storage.csr \
+              --output-file $SHARED/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_storage.crt
           docker exec kra cp $SHARED/kra_storage.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -138,15 +135,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_transport.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caTransportCert \
-              --csr-file $SHARED/kra_transport.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_transport.crt
+              --csr-file $SHARED/kra_transport.csr \
+              --output-file $SHARED/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_transport.crt
           docker exec kra cp $SHARED/kra_transport.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -176,15 +170,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/kra_audit_signing.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caAuditSigningCert \
-              --csr-file $SHARED/kra_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_audit_signing.crt
+              --csr-file $SHARED/kra_audit_signing.csr \
+              --output-file $SHARED/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_audit_signing.crt
           docker exec kra cp $SHARED/kra_audit_signing.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -214,15 +205,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/subsystem.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caSubsystemCert \
-              --csr-file $SHARED/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/subsystem.crt
+              --csr-file $SHARED/subsystem.csr \
+              --output-file $SHARED/subsystem.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/subsystem.crt
           docker exec kra cp $SHARED/subsystem.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -252,15 +240,12 @@ jobs:
           docker exec kra cp /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr $SHARED
           docker exec ca openssl req -text -noout -in $SHARED/sslserver.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile caServerCert \
-              --csr-file $SHARED/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/sslserver.crt
+              --csr-file $SHARED/sslserver.csr \
+              --output-file $SHARED/sslserver.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/sslserver.crt
           docker exec kra cp $SHARED/sslserver.crt /var/lib/pki/pki-tomcat/conf/certs
 
@@ -289,15 +274,12 @@ jobs:
               --csr $SHARED/kra_admin.csr
           docker exec ca openssl req -text -noout -in $SHARED/kra_admin.csr
 
-          docker exec ca pki ca-cert-request-submit \
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
               --profile AdminCert \
-              --csr-file $SHARED/kra_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-
-          docker exec ca pki ca-cert-export $CERT_ID --output-file $SHARED/kra_admin.crt
+              --csr-file $SHARED/kra_admin.csr \
+              --output-file $SHARED/kra_admin.crt
           docker exec ca openssl x509 -text -noout -in $SHARED/kra_admin.crt
 
           docker exec kra pki nss-cert-import \

--- a/.github/workflows/kra-external-certs-test.yml
+++ b/.github/workflows/kra-external-certs-test.yml
@@ -109,61 +109,67 @@ jobs:
       - name: Issue KRA storage cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_storage.csr
-          docker exec ca pki ca-cert-request-submit --profile caStorageCert --csr-file ${SHARED}/kra_storage.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/kra_storage.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caStorageCert \
+              --csr-file ${SHARED}/kra_storage.csr \
+              --output-file ${SHARED}/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_storage.crt
 
       - name: Issue KRA transport cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_transport.csr
-          docker exec ca pki ca-cert-request-submit --profile caTransportCert --csr-file ${SHARED}/kra_transport.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/kra_transport.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caTransportCert \
+              --csr-file ${SHARED}/kra_transport.csr \
+              --output-file ${SHARED}/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_transport.crt
 
       - name: Issue subsystem cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file ${SHARED}/subsystem.csr \
+              --output-file ${SHARED}/subsystem.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file ${SHARED}/sslserver.csr \
+              --output-file ${SHARED}/sslserver.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue KRA audit signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_audit_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/kra_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/kra_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file ${SHARED}/kra_audit_signing.csr \
+              --output-file ${SHARED}/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_audit_signing.crt
 
       - name: Issue KRA admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/kra_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/kra_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file ${SHARED}/kra_admin.csr \
+              --output-file ${SHARED}/kra_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_admin.crt
 
       - name: Install KRA in KRA container (step 2)

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -112,61 +112,67 @@ jobs:
       - name: Issue KRA storage cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_storage.csr
-          docker exec ca pki ca-cert-request-submit --profile caStorageCert --csr-file ${SHARED}/kra_storage.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/kra_storage.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caStorageCert \
+              --csr-file ${SHARED}/kra_storage.csr \
+              --output-file ${SHARED}/kra_storage.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_storage.crt
 
       - name: Issue KRA transport cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_transport.csr
-          docker exec ca pki ca-cert-request-submit --profile caTransportCert --csr-file ${SHARED}/kra_transport.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/kra_transport.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caTransportCert \
+              --csr-file ${SHARED}/kra_transport.csr \
+              --output-file ${SHARED}/kra_transport.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_transport.crt
 
       - name: Issue subsystem cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file ${SHARED}/subsystem.csr \
+              --output-file ${SHARED}/subsystem.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file ${SHARED}/sslserver.csr \
+              --output-file ${SHARED}/sslserver.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue KRA audit signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_audit_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/kra_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/kra_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file ${SHARED}/kra_audit_signing.csr \
+              --output-file ${SHARED}/kra_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_audit_signing.crt
 
       - name: Issue KRA admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/kra_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/kra_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/kra_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file ${SHARED}/kra_admin.csr \
+              --output-file ${SHARED}/kra_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_admin.crt
 
       - name: Install standalone KRA (step 2)

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -112,51 +112,56 @@ jobs:
       - name: Issue OCSP signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caOCSPCert --csr-file ${SHARED}/ocsp_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caOCSPCert \
+              --csr-file ${SHARED}/ocsp_signing.csr \
+              --output-file ${SHARED}/ocsp_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_signing.crt
 
       - name: Issue subsystem cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file ${SHARED}/subsystem.csr \
+              --output-file ${SHARED}/subsystem.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file ${SHARED}/sslserver.csr \
+              --output-file ${SHARED}/sslserver.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue OCSP audit signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_audit_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/ocsp_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file ${SHARED}/ocsp_audit_signing.csr \
+              --output-file ${SHARED}/ocsp_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_audit_signing.crt
 
       - name: Issue OCSP admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/ocsp_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file ${SHARED}/ocsp_admin.csr \
+              --output-file ${SHARED}/ocsp_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_admin.crt
 
       - name: Install OCSP in OCSP container (step 2)

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -113,51 +113,56 @@ jobs:
       - name: Issue OCSP signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caOCSPCert --csr-file ${SHARED}/ocsp_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caOCSPCert \
+              --csr-file ${SHARED}/ocsp_signing.csr \
+              --output-file ${SHARED}/ocsp_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_signing.crt
 
       - name: Issue subsystem cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file ${SHARED}/subsystem.csr \
+              --output-file ${SHARED}/subsystem.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file ${SHARED}/sslserver.csr \
+              --output-file ${SHARED}/sslserver.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue OCSP audit signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_audit_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/ocsp_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file ${SHARED}/ocsp_audit_signing.csr \
+              --output-file ${SHARED}/ocsp_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_audit_signing.crt
 
       - name: Issue OCSP admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/ocsp_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file ${SHARED}/ocsp_admin.csr \
+              --output-file ${SHARED}/ocsp_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_admin.crt
 
       - name: Install OCSP in OCSP container (step 2)

--- a/.github/workflows/ocsp-external-certs-test.yml
+++ b/.github/workflows/ocsp-external-certs-test.yml
@@ -108,51 +108,56 @@ jobs:
       - name: Issue OCSP signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caOCSPCert --csr-file ${SHARED}/ocsp_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caOCSPCert \
+              --csr-file ${SHARED}/ocsp_signing.csr \
+              --output-file ${SHARED}/ocsp_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_signing.crt
 
       - name: Issue subsystem cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file ${SHARED}/subsystem.csr \
+              --output-file ${SHARED}/subsystem.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file ${SHARED}/sslserver.csr \
+              --output-file ${SHARED}/sslserver.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue OCSP audit signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_audit_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/ocsp_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file ${SHARED}/ocsp_audit_signing.csr \
+              --output-file ${SHARED}/ocsp_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_audit_signing.crt
 
       - name: Issue OCSP admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/ocsp_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file ${SHARED}/ocsp_admin.csr \
+              --output-file ${SHARED}/ocsp_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_admin.crt
 
       - name: Install OCSP in OCSP container (step 2)

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -112,51 +112,56 @@ jobs:
       - name: Issue OCSP signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caOCSPCert --csr-file ${SHARED}/ocsp_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caOCSPCert \
+              --csr-file ${SHARED}/ocsp_signing.csr \
+              --output-file ${SHARED}/ocsp_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_signing.crt
 
       - name: Issue subsystem cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file ${SHARED}/subsystem.csr \
+              --output-file ${SHARED}/subsystem.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file ${SHARED}/sslserver.csr \
+              --output-file ${SHARED}/sslserver.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue OCSP audit signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_audit_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/ocsp_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file ${SHARED}/ocsp_audit_signing.csr \
+              --output-file ${SHARED}/ocsp_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_audit_signing.crt
 
       - name: Issue OCSP admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/ocsp_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/ocsp_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/ocsp_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file ${SHARED}/ocsp_admin.csr \
+              --output-file ${SHARED}/ocsp_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/ocsp_admin.crt
 
       - name: Install standalone OCSP (step 2)

--- a/.github/workflows/tks-external-certs-test.yml
+++ b/.github/workflows/tks-external-certs-test.yml
@@ -110,41 +110,45 @@ jobs:
       - name: Issue subsystem cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file ${SHARED}/subsystem.csr \
+              --output-file ${SHARED}/subsystem.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file ${SHARED}/sslserver.csr \
+              --output-file ${SHARED}/sslserver.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue TKS audit signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/tks_audit_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/tks_audit_signing.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/tks_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file ${SHARED}/tks_audit_signing.csr \
+              --output-file ${SHARED}/tks_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/tks_audit_signing.crt
 
       - name: Issue TKS admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/tks_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/tks_admin.csr | tee output
-          REQUEST_ID=$(sed -n 's/Request ID: *\(.*\)/\1/p' output)
-          docker exec ca pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee output
-          CERT_ID=$(sed -n 's/Certificate ID: *\(.*\)/\1/p' output)
-          docker exec ca pki ca-cert-export $CERT_ID --output-file ${SHARED}/tks_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file ${SHARED}/tks_admin.csr \
+              --output-file ${SHARED}/tks_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/tks_admin.crt
 
       - name: Install TKS in TKS container (step 2)

--- a/.github/workflows/tps-external-certs-test.yml
+++ b/.github/workflows/tps-external-certs-test.yml
@@ -184,33 +184,45 @@ jobs:
       - name: Issue subsystem cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki ca-cert-request-submit --profile caSubsystemCert --csr-file ${SHARED}/subsystem.csr | sed -n 's/Request ID: *\(.*\)/\1/p' > subsystem.reqid
-          docker exec ca pki -n caadmin ca-cert-request-approve `cat subsystem.reqid` --force | sed -n 's/Certificate ID: *\(.*\)/\1/p' > subsystem.certid
-          docker exec ca pki ca-cert-export `cat subsystem.certid` --output-file ${SHARED}/subsystem.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caSubsystemCert \
+              --csr-file ${SHARED}/subsystem.csr \
+              --output-file ${SHARED}/subsystem.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki ca-cert-request-submit --profile caServerCert --csr-file ${SHARED}/sslserver.csr | sed -n 's/Request ID: *\(.*\)/\1/p' > sslserver.reqid
-          docker exec ca pki -n caadmin ca-cert-request-approve `cat sslserver.reqid` --force | sed -n 's/Certificate ID: *\(.*\)/\1/p' > sslserver.certid
-          docker exec ca pki ca-cert-export `cat sslserver.certid` --output-file ${SHARED}/sslserver.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caServerCert \
+              --csr-file ${SHARED}/sslserver.csr \
+              --output-file ${SHARED}/sslserver.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue TPS audit signing cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/tps_audit_signing.csr
-          docker exec ca pki ca-cert-request-submit --profile caAuditSigningCert --csr-file ${SHARED}/tps_audit_signing.csr | sed -n 's/Request ID: *\(.*\)/\1/p' > tps_audit_signing.reqid
-          docker exec ca pki -n caadmin ca-cert-request-approve `cat tps_audit_signing.reqid` --force | sed -n 's/Certificate ID: *\(.*\)/\1/p' > tps_audit_signing.certid
-          docker exec ca pki ca-cert-export `cat tps_audit_signing.certid` --output-file ${SHARED}/tps_audit_signing.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file ${SHARED}/tps_audit_signing.csr \
+              --output-file ${SHARED}/tps_audit_signing.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/tps_audit_signing.crt
 
       - name: Issue TPS admin cert
         run: |
           docker exec ca openssl req -text -noout -in ${SHARED}/tps_admin.csr
-          docker exec ca pki ca-cert-request-submit --profile AdminCert --csr-file ${SHARED}/tps_admin.csr | sed -n 's/Request ID: *\(.*\)/\1/p' > tps_admin.reqid
-          docker exec ca pki -n caadmin ca-cert-request-approve `cat tps_admin.reqid` --force | sed -n 's/Certificate ID: *\(.*\)/\1/p' > tps_admin.certid
-          docker exec ca pki ca-cert-export `cat tps_admin.certid` --output-file ${SHARED}/tps_admin.crt
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile AdminCert \
+              --csr-file ${SHARED}/tps_admin.csr \
+              --output-file ${SHARED}/tps_admin.crt
           docker exec ca openssl x509 -text -noout -in ${SHARED}/tps_admin.crt
 
       - name: Install TPS in TPS container (step 2)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3681,7 +3681,7 @@ class PKIDeployer:
                 '-f', self.instance.password_conf,
                 '-U', url,
                 '--ignore-banner',
-                'ca-cert-request-submit',
+                'ca-cert-issue',
                 '--request-type', request_type,
                 '--csr-file', request_file,
                 '--profile', profile,

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACertCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACertCLI.java
@@ -45,6 +45,7 @@ public class CACertCLI extends CLI {
         super("cert", "Certificate management commands", parent);
 
         addModule(new CACertFindCLI(this));
+        addModule(new CACertIssueCLI(this));
         addModule(new CACertShowCLI(this));
         addModule(new CACertExportCLI(this));
         addModule(new CACertRevokeCLI(this));

--- a/tests/ansible/ocsp/tasks/certificate_self_validation_with_crl.yml
+++ b/tests/ansible/ocsp/tasks/certificate_self_validation_with_crl.yml
@@ -211,108 +211,68 @@
       -D pki_admin_csr_path={{ shared_workspace }}/ocsp_admin.csr
       -v
 
-- name: Issue OCSP signing cert - submit
+- name: Issue OCSP signing cert
   community.docker.docker_container_exec:
     container: "{{ ca_container }}"
-    command: pki ca-cert-request-submit --profile caOCSPCert --csr-file {{ shared_workspace }}/ocsp_signing.csr
+    command: >
+      pki
+      -n caadmin
+      ca-cert-issue
+      --profile caOCSPCert
+      --csr-file {{ shared_workspace }}/ocsp_signing.csr
+      --output-file {{ shared_workspace }}/ocsp_signing.crt
   register:
     ca_command
 
-- name: Issue OCSP signing cert - approve
+- name: Issue subsystem cert
   community.docker.docker_container_exec:
     container: "{{ ca_container }}"
-    command: "pki -n caadmin ca-cert-request-approve {{ ca_command.stdout | regex_search('Request ID: *(.*)', '\\1') | first }} --force"
+    command: >
+      pki
+      -n caadmin
+      ca-cert-issue
+      --profile caSubsystemCert
+      --csr-file {{ shared_workspace }}/subsystem.csr
+      --output-file {{ shared_workspace }}/subsystem.crt
   register:
     ca_command
 
-- name: Issue OCSP signing cert - export
+- name: Issue SSL server cert
   community.docker.docker_container_exec:
     container: "{{ ca_container }}"
-    command: "pki ca-cert-export {{ ca_command.stdout | regex_search('Certificate ID: *(.*)', '\\1') | first }} --output-file {{ shared_workspace }}/ocsp_signing.crt"
+    command: >
+      pki
+      -n caadmin
+      ca-cert-issue
+      --profile caServerCert
+      --csr-file {{ shared_workspace }}/sslserver.csr
+      --output-file {{ shared_workspace }}/sslserver.crt
   register:
     ca_command
 
-- name: Issue subsystem cert - submit
+- name: Issue OCSP audit signing cert
   community.docker.docker_container_exec:
     container: "{{ ca_container }}"
-    command: pki ca-cert-request-submit --profile caSubsystemCert --csr-file {{ shared_workspace }}/subsystem.csr
+    command: >
+      pki
+      -n caadmin
+      ca-cert-issue
+      --profile caAuditSigningCert
+      --csr-file {{ shared_workspace }}/ocsp_audit_signing.csr
+      --output-file {{ shared_workspace }}/ocsp_audit_signing.crt
   register:
     ca_command
 
-- name: Issue subsystem cert - approve
+- name: Issue OCSP admin cert
   community.docker.docker_container_exec:
     container: "{{ ca_container }}"
-    command: "pki -n caadmin ca-cert-request-approve {{ ca_command.stdout | regex_search('Request ID: *(.*)', '\\1') | first }} --force"
-  register:
-    ca_command
-
-- name: Issue subsystem cert - export
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "pki ca-cert-export {{ ca_command.stdout | regex_search('Certificate ID: *(.*)', '\\1') | first }} --output-file {{ shared_workspace }}/subsystem.crt"
-  register:
-    ca_command
-
-- name: Issue SSL server cert - submit
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: pki ca-cert-request-submit --profile caServerCert --csr-file {{ shared_workspace }}/sslserver.csr
-  register:
-    ca_command
-
-- name: Issue SSL server cert - approve
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "pki -n caadmin ca-cert-request-approve {{ ca_command.stdout | regex_search('Request ID: *(.*)', '\\1') | first }} --force"
-  register:
-    ca_command
-
-- name: Issue SSL server cert - export
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "pki ca-cert-export {{ ca_command.stdout | regex_search('Certificate ID: *(.*)', '\\1') | first }} --output-file {{ shared_workspace }}/sslserver.crt"
-  register:
-    ca_command
-
-- name: Issue OCSP audit signing cert - submit
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: pki ca-cert-request-submit --profile caAuditSigningCert --csr-file {{ shared_workspace }}/ocsp_audit_signing.csr
-  register:
-    ca_command
-
-- name: Issue OCSP audit signing cert - approve
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "pki -n caadmin ca-cert-request-approve {{ ca_command.stdout | regex_search('Request ID: *(.*)', '\\1') | first }} --force"
-  register:
-    ca_command
-
-- name: Issue OCSP audit signing cert - export
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "pki ca-cert-export {{ ca_command.stdout | regex_search('Certificate ID: *(.*)', '\\1') | first }} --output-file {{ shared_workspace }}/ocsp_audit_signing.crt"
-  register:
-    ca_command
-
-- name: Issue OCSP admin cert - submit
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: pki ca-cert-request-submit --profile AdminCert --csr-file {{ shared_workspace }}/ocsp_admin.csr
-  register:
-    ca_command
-
-- name: Issue OCSP admin cert - approve
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "pki -n caadmin ca-cert-request-approve {{ ca_command.stdout | regex_search('Request ID: *(.*)', '\\1') | first }} --force"
-  register:
-    ca_command
-
-- name: Issue OCSP admin cert - export
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "pki ca-cert-export {{ ca_command.stdout | regex_search('Certificate ID: *(.*)', '\\1') | first }} --output-file {{ shared_workspace }}/ocsp_admin.crt"
+    command: >
+      pki
+      -n caadmin
+      ca-cert-issue
+      --profile AdminCert
+      --csr-file {{ shared_workspace }}/ocsp_admin.csr
+      --output-file {{ shared_workspace }}/ocsp_admin.crt
   register:
     ca_command
 
@@ -454,29 +414,18 @@
   register: good_certificate_check
   failed_when: "'CertStatus=Good' not in good_certificate_check.stdout_lines[-1]"
 
-- name: Create CSR for DS and submit
+- name: Issue DS cert
   community.docker.docker_container_exec:
     container: "{{ ca_container }}"
     command: "{{ item }}"
   loop:
     - pki nss-cert-request --subject "CN={{ ocspds_hostname }}" --ext /usr/share/pki/server/certs/sslserver.conf --subjectAltName "critical, DNS:{{ ocspds_hostname }}" --csr {{ shared_workspace }}/ocspds.csr
-    - pki ca-cert-request-submit --profile caServerCert --csr-file {{ shared_workspace }}/ocspds.csr
-  register:
-    ca_command
-
-- name: Approve CSR request
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "pki -n caadmin ca-cert-request-approve {{ ca_command.results[-1].stdout | regex_search('Request ID: *(.*)', '\\1') | first }} --force"
-  register:
-    ca_command
-
-- name: Issue OCSP admin cert - export
-  community.docker.docker_container_exec:
-    container: "{{ ca_container }}"
-    command: "{{ item }}"
-  loop:
-    - "pki ca-cert-export {{ ca_command.stdout | regex_search('Certificate ID: *(.*)', '\\1') | first }} --output-file {{ shared_workspace }}/ocspds.crt"
+    - pki
+          -n caadmin
+          ca-cert-issue
+          --profile caServerCert
+          --csr-file {{ shared_workspace }}/ocspds.csr
+          --output-file {{ shared_workspace }}/ocspds.crt
     - "certutil -d /root/.dogtag/nssdb -A -n ocspds -t ',,' -i {{ shared_workspace }}/ocspds.crt"
     - pk12util -d /root/.dogtag/nssdb -o {{ shared_workspace }}/ocspds.p12 -n ocspds -W {{ ocspds_password }}
   register:

--- a/tests/ca/bin/sslserver-create.sh
+++ b/tests/ca/bin/sslserver-create.sh
@@ -9,17 +9,11 @@ pki nss-cert-request \
     --ext /usr/share/pki/server/certs/sslserver.conf \
     --csr sslserver.csr
 
-pki ca-cert-request-submit --profile caServerCert --csr-file sslserver.csr | tee /tmp/output
-
-sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" /tmp/output > /tmp/request_id
-REQUEST_ID=$(cat /tmp/request_id)
-
-# approve the cert request and capture the cert ID
-pki -n caadmin ca-cert-request-approve $REQUEST_ID --force | tee /tmp/output
-
-sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" /tmp/output > /tmp/cert_id
-CERT_ID=$(cat /tmp/cert_id)
-
-pki ca-cert-export $CERT_ID --output-file sslserver.crt
+pki \
+    -n caadmin \
+    ca-cert-issue \
+    --profile caServerCert \
+    --csr-file sslserver.csr \
+    --output-file sslserver.crt
 
 pki nss-cert-import sslserver --cert sslserver.crt


### PR DESCRIPTION
The `pki ca-cert-request-submit` command can be used in two ways. If it's invoked with an install token, the cert will be issued immediately. If it's invoked without an install token, it will submit the request to the CA, but then the request will need to be approved, and the cert will need to be retrieved separately.

To make it easier to issue a cert, a new `pki ca-cert-issue` has been added which is similar to `pki ca-cert-request-submit` but it can approve the request and retrieve the cert immediately if invoked with the proper credentials.

`pkispawn` and most CI tests have been updated to use the new command. The `pki ca-cert-request-submit` options that take an install token have been deprecated.
