### PR TITLE
Fix problem reinstalling CA with custom ports

### DIFF
--- a/.github/workflows/ca-custom-ports-test.yml
+++ b/.github/workflows/ca-custom-ports-test.yml
@@ -1,0 +1,129 @@
+name: CA with custom ports
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      - name: Connect DS container to network
+        run: docker network connect example ds --alias ds.example.com
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh pki
+        env:
+          HOSTNAME: pki.example.com
+
+      - name: Connect PKI container to network
+        run: docker network connect example pki --alias pki.example.com
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_http_port=9080 \
+              -D pki_https_port=9443 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check server.xml
+        run: docker exec pki cat /etc/pki/pki-tomcat/server.xml
+
+      - name: Run PKI healthcheck
+        run: docker exec pki pki-healthcheck --failures-only
+
+      - name: Initialize PKI client
+        run: |
+          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec pki pki -U https://pki.example.com:9443 info
+
+      - name: Check CA admin
+        run: |
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki \
+              -U https://pki.example.com:9443 \
+              -n caadmin \
+              ca-user-show caadmin
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -s CA -v
+
+      - name: Install CA again
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_http_port=9080 \
+              -D pki_https_port=9443 \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Check CA admin again
+        run: |
+          docker exec pki pki \
+              -U https://pki.example.com:9443 \
+              -n caadmin \
+              ca-user-show caadmin
+
+      - name: Remove CA again
+        run: docker exec pki pkidestroy -s CA -v
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -97,3 +97,8 @@ jobs:
     name: CA with custom user
     needs: build
     uses: ./.github/workflows/ca-custom-user-test.yml
+
+  ca-custom-ports-test:
+    name: CA with custom ports
+    needs: build
+    uses: ./.github/workflows/ca-custom-ports-test.yml

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -293,7 +293,7 @@ class PKIServer(object):
     def export_ca_cert(self):
 
         server_config = self.get_server_config()
-        connector = server_config.get_connector(name='Secure')
+        connector = server_config.get_https_connector()
 
         if connector is None:
             # HTTPS connector not configured, skip
@@ -1549,7 +1549,7 @@ grant codeBase "file:%s" {
         # Load SSL server cert nickname from server.xml
 
         server_config = self.get_server_config()
-        connector = server_config.get_connector(name='Secure')
+        connector = server_config.get_https_connector()
 
         if connector is None:
             return None
@@ -1576,7 +1576,7 @@ grant codeBase "file:%s" {
             fullname = token + ':' + nickname
 
         server_config = self.get_server_config()
-        connector = server_config.get_connector(name='Secure')
+        connector = server_config.get_https_connector()
 
         if connector is None:
             raise KeyError('Connector not found: Secure')

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -343,8 +343,8 @@ class PKIDeployer:
 
         server_config = self.instance.get_server_config()
 
-        # find default HTTP connector
-        connector = server_config.get_connector(port='8080')
+        # find current HTTP connector
+        connector = server_config.get_http_connector()
         service = connector.getparent()
 
         # get HTTP connector position
@@ -371,7 +371,7 @@ class PKIDeployer:
             logger.info('Removing HTTP connector')
             service.remove(connector)
 
-        connector = server_config.get_connector(port=self.mdict['pki_https_port'])
+        connector = server_config.get_https_connector()
 
         if connector is None:
             logger.info('Adding HTTPS connector')


### PR DESCRIPTION
The code that calls `ServerConfig.get_connector()` to find a connector with a specific name or port number has been modified to call `get_<protocol>_connector()` instead such that it can always find the connector for the protocol regardless of the name or the port number.

A new test has been added to install CA with custom port numbers, remove it, install it again, and remove it again.