### PR TITLE
Enable registry for ACME

### DIFF
--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -99,11 +99,6 @@ jobs:
               --network-alias=acme.example.com \
               acme
 
-      - name: Create PKI server for ACME
-        run: |
-          docker exec acme pki-server create
-          docker exec acme pki-server nss-create --password Secret.123
-
       - name: Set up ACME database
         run: |
           docker exec acme ldapmodify \
@@ -147,13 +142,13 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           lrwxrwxrwx pkiuser pkiuser alias -> /var/lib/pki/pki-tomcat/conf/alias
           lrwxrwxrwx pkiuser pkiuser bin -> /usr/share/tomcat/bin
-          drwxr-x--- pkiuser pkiuser common
+          drwxrwx--- pkiuser pkiuser common
           lrwxrwxrwx pkiuser pkiuser conf -> /etc/pki/pki-tomcat
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
-          drwxr-x--- pkiuser pkiuser temp
-          drwxr-x--- pkiuser pkiuser webapps
-          drwxr-x--- pkiuser pkiuser work
+          drwxrwx--- pkiuser pkiuser temp
+          drwxr-xr-x pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser work
           EOF
 
           diff expected output
@@ -170,12 +165,12 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
-          drwxr-x--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser Catalina
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser alias
-          -rw-rw---- pkiuser pkiuser catalina.policy
+          -rw-r--r-- pkiuser pkiuser catalina.policy
           lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxr-x--- pkiuser pkiuser certs
+          drwxrwx--- pkiuser pkiuser certs
           lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
           lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
           -rw-rw---- pkiuser pkiuser password.conf
@@ -733,6 +728,7 @@ jobs:
         run: docker exec ca pkidestroy -s CA -v
 
       - name: Check ACME server base dir after removal
+        if: always()
         run: |
           # check file types, owners, and permissions
           docker exec acme ls -l /var/lib/pki/pki-tomcat \
@@ -750,6 +746,7 @@ jobs:
           diff expected output
 
       - name: Check ACME server conf dir after removal
+        if: always()
         run: |
           # check file types, owners, and permissions
           docker exec acme ls -l /etc/pki/pki-tomcat \
@@ -760,12 +757,12 @@ jobs:
 
           # TODO: review permissions
           cat > expected << EOF
-          drwxr-x--- pkiuser pkiuser Catalina
+          drwxrwx--- pkiuser pkiuser Catalina
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser alias
-          -rw-rw---- pkiuser pkiuser catalina.policy
+          -rw-r--r-- pkiuser pkiuser catalina.policy
           lrwxrwxrwx pkiuser pkiuser catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxr-x--- pkiuser pkiuser certs
+          drwxrwx--- pkiuser pkiuser certs
           lrwxrwxrwx pkiuser pkiuser context.xml -> /etc/tomcat/context.xml
           lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
           -rw-rw---- pkiuser pkiuser password.conf
@@ -777,6 +774,7 @@ jobs:
           diff expected output
 
       - name: Check ACME server logs dir after removal
+        if: always()
         run: |
           # check file types, owners, and permissions
           docker exec acme ls -l /var/log/pki/pki-tomcat \

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -625,7 +625,7 @@ pki_registry_enable=True
 [ACME]
 pki_ds_setup=False
 pki_security_domain_setup=False
-pki_registry_enable=False
+pki_registry_enable=True
 
 # Database params:
 # - acme_database_type

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -5184,9 +5184,10 @@ class PKIDeployer:
         logger.info('Creating ACME subsystem')
 
         subsystem = pki.server.subsystem.ACMESubsystem(self.instance)
-        subsystem.create()
-        subsystem.create_conf()
-        subsystem.create_logs()
+        subsystem.create(exist_ok=True)
+        subsystem.create_conf(exist_ok=True)
+        subsystem.create_logs(exist_ok=True)
+        subsystem.create_registry(exist_ok=True)
 
         return subsystem
 
@@ -5488,6 +5489,8 @@ class PKIDeployer:
         '''
 
         logger.info('Removing ACME subsystem')
+
+        subsystem.remove_registry(force=self.force)
 
         if self.remove_logs:
             subsystem.remove_logs(force=self.force)

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -287,17 +287,20 @@ class PKISubsystem(object):
 
     def remove_registry(self, force=False):
 
-        # Remove /etc/sysconfig/pki/tomcat/<instance>/<subsystem>/default.cfg
+        if os.path.exists(self.default_cfg):
 
-        default_cfg = os.path.join(self.registry_dir, 'default.cfg')
-        logger.info('Removing %s', default_cfg)
-        pki.util.remove(default_cfg, force=force)
+            # Remove /etc/sysconfig/pki/tomcat/<instance>/<subsystem>/default.cfg
 
-        # Remove subsystem registry folder at
-        # /etc/sysconfig/pki/tomcat/<instance>/<subsystem>
+            logger.info('Removing %s', self.default_cfg)
+            pki.util.remove(self.default_cfg, force=force)
 
-        logger.info('Removing %s', self.registry_dir)
-        pki.util.rmtree(self.registry_dir, force=force)
+        if os.path.exists(self.registry_dir):
+
+            # Remove subsystem registry folder at
+            # /etc/sysconfig/pki/tomcat/<instance>/<subsystem>
+
+            logger.info('Removing %s', self.registry_dir)
+            pki.util.rmtree(self.registry_dir, force=force)
 
     def remove_logs(self, force=False):
 


### PR DESCRIPTION
The default `pki_registry_enable` for ACME has been changed to `True`. This allows `pkispawn` and `pkidestroy` to create and remove ACME properly.

The `PKIDeployer.create_acme_subsystem()` has been modified to create the registry. The `remove_acme_subsystem()` has been modified to remove the registry.

The `PKISubsystem.remove_registry()` has been modified to check whether the files/folders exist before removing them in case the subsystem was created without registry.

The test for ACME on separate instance has been modified to no longer create the server and NSS database before calling `pkispawn`. Some file/folder permissions have also changed due to these changes.