### PR TITLE
EST generate SSL certificate

### DIFF
--- a/.github/workflows/est-ds-realm-separate-test.yml
+++ b/.github/workflows/est-ds-realm-separate-test.yml
@@ -106,7 +106,7 @@ jobs:
 
           docker exec ca pki nss-cert-import --cert estUser.crt estUser
           
-          docker exec ca pki -n caadmin ca-user-cert-add est-ra-1 --input estUser.crt $CERT_ID
+          docker exec ca pki -n caadmin ca-user-cert-add est-ra-1 --input estUser.crt
 
           docker exec ca pki pkcs12-cert-import estUser --pkcs12-file $SHARED/est_server.p12 --pkcs12-password Secret.123 --append
           
@@ -229,6 +229,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
           -rw-rw---- pkiuser pkiuser password.conf
           -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
           -rw-rw---- pkiuser pkiuser tomcat.conf
           lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
           EOF
@@ -275,7 +276,7 @@ jobs:
           -rw-rw---- pkiuser pkiuser authorizer.conf
           -rw-rw---- pkiuser pkiuser backend.conf
           -rw-rw-r-- pkiuser pkiuser realm.conf
-          -rw-r--r-- pkiuser pkiuser registry.cfg
+          -rw-rw-r-- pkiuser pkiuser registry.cfg
           EOF
 
           diff expected output
@@ -352,6 +353,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser logging.properties -> /usr/share/pki/server/conf/logging.properties
           -rw-rw---- pkiuser pkiuser password.conf
           -rw-rw---- pkiuser pkiuser server.xml
+          -rw-rw---- pkiuser pkiuser serverCertNick.conf
           -rw-rw---- pkiuser pkiuser tomcat.conf
           lrwxrwxrwx pkiuser pkiuser web.xml -> /etc/tomcat/web.xml
           EOF

--- a/.github/workflows/est-ds-realm-test.yml
+++ b/.github/workflows/est-ds-realm-test.yml
@@ -219,6 +219,7 @@ jobs:
           -rw-rw---- pkiuser pkiuser authorizer.conf
           -rw-rw---- pkiuser pkiuser backend.conf
           -rw-rw-r-- pkiuser pkiuser realm.conf
+          -rw-rw-r-- pkiuser pkiuser registry.cfg
           EOF
 
           diff expected output

--- a/.github/workflows/est-postgresql-realm-test.yml
+++ b/.github/workflows/est-postgresql-realm-test.yml
@@ -301,6 +301,7 @@ jobs:
           -rw-rw---- pkiuser pkiuser authorizer.conf
           -rw-rw---- pkiuser pkiuser backend.conf
           -rw-rw-r-- pkiuser pkiuser realm.conf
+          -rw-rw-r-- pkiuser pkiuser registry.cfg
           EOF
 
           diff expected output

--- a/.github/workflows/est-separate-provided-certs-test.yml
+++ b/.github/workflows/est-separate-provided-certs-test.yml
@@ -1,4 +1,4 @@
-name: EST with ds realm on separate instance
+name: EST on separate instance with provided certificates
 
 on: workflow_call
 
@@ -69,12 +69,46 @@ jobs:
 
           docker exec ca pki info
 
+      - name: Create EST server certificates in p12
+        run: |
+          docker exec ca pki nss-cert-request --csr estSSLServer.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf --subject 'CN=est.example.com'
+
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --csr-file estSSLServer.csr \
+              --profile caServerCert \
+              --output-file estSSLServer.crt
+
+          docker exec ca pki nss-cert-import --cert estSSLServer.crt sslserver
+
+          docker exec ca pki pkcs12-cert-import sslserver --pkcs12-file $SHARED/est_server.p12 --pkcs12-password Secret.123
+
       - name: Add CA EST user
         run: |
           docker exec ca pki -n caadmin ca-group-add "EST RA Agents"
           docker exec ca pki -n caadmin ca-user-add \
               est-ra-1 --fullName "EST RA 1" --password Secret.est
           docker exec ca pki -n caadmin ca-group-member-add "EST RA Agents" est-ra-1
+
+      - name: Create CA EST user certificate end store top p12
+        run: |
+          docker exec ca pki nss-cert-request --csr estUser.csr \
+              --ext /usr/share/pki/server/certs/admin.conf --subject 'UID=estUser'
+
+          docker exec ca pki \
+              -n caadmin \
+              ca-cert-issue \
+              --csr-file estUser.csr \
+              --profile caUserCert \
+              --output-file estUser.crt
+
+          docker exec ca pki nss-cert-import --cert estUser.crt estUser
+          
+          docker exec ca pki -n caadmin ca-user-cert-add est-ra-1 --input estUser.crt
+
+          docker exec ca pki pkcs12-cert-import estUser --pkcs12-file $SHARED/est_server.p12 --pkcs12-password Secret.123 --append
           
       - name: Configure CA est profile
         run: |
@@ -143,8 +177,10 @@ jobs:
               -s EST \
               -D est_realm_url=ldap://estds.example.com:3389 \
               -D pki_ca_uri=https://ca.example.com:8443 \
-              -D pki_cert_chain_path=$SHARED/ca_signing.crt \
-              -D pki_cert_chain_nickname=caSigning \
+              -D est_ca_user_password= \
+              -D est_ca_user_certificate=estUser \
+              -D pki_server_pkcs12_path=$SHARED/est_server.p12 \
+              -D pki_server_pkcs12_password=Secret.123 \
               -v
 
       - name: Check EST server base dir after installation
@@ -392,5 +428,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: est-ds-separate
+          name: est-separate-provided-certs
           path: /tmp/artifacts

--- a/.github/workflows/est-tests.yml
+++ b/.github/workflows/est-tests.yml
@@ -56,3 +56,8 @@ jobs:
     name: EST with ds realm on a separate instance
     needs: build
     uses: ./.github/workflows/est-ds-realm-separate-test.yml
+
+  est-separate-provided-certs-test:
+    name: EST with ds realm on a separate instance
+    needs: build
+    uses: ./.github/workflows/est-separate-provided-certs-test.yml

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -668,9 +668,11 @@ pki_registry_enable=True
 # See /usr/share/pki/acme/realm/<type>/realm.conf
 [EST]
 pki_ds_setup=False
+pki_share_db=False
 pki_security_domain_setup=False
 pki_registry_enable=True
 pki_ca_uri=https://%(pki_hostname)s:%(pki_https_port)s
+pki_audit_signing_nickname=
 est_ca_profile=estServiceCert
 est_ca_user_name=
 est_ca_user_password=

--- a/base/server/examples/installation/est.cfg
+++ b/base/server/examples/installation/est.cfg
@@ -1,5 +1,6 @@
 [DEFAULT]
 pki_server_database_password=Secret.123
+pki_admin_setup=False
 
 [EST]
 est_realm_type=ds
@@ -7,3 +8,4 @@ est_realm_url=ldap://localhost.localdomain:3389
 est_realm_bind_password=Secret.123
 est_ca_user_name=est-ra-1
 est_ca_user_password=Secret.est
+pki_sslserver_nickname=sslserver

--- a/base/server/python/pki/server/deployment/scriptlets/configuration.py
+++ b/base/server/python/pki/server/deployment/scriptlets/configuration.py
@@ -182,15 +182,14 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 deployer.remove_temp_sslserver_cert()
 
             # Store perm SSL server cert nickname and token
-            nickname = system_certs['sslserver']['nickname']
-            token = pki.nssdb.normalize_token(system_certs['sslserver']['token'])
-
-            if not token:
-                token = deployer.mdict.get('pki_sslserver_token')
+            if 'sslserver' in system_certs:
+                nickname = system_certs['sslserver']['nickname']
+                token = pki.nssdb.normalize_token(system_certs['sslserver']['token'])
                 if not token:
-                    token = deployer.mdict['pki_token_name']
-
-            instance.set_sslserver_cert_nickname(nickname, token)
+                    token = deployer.mdict.get('pki_sslserver_token')
+                    if not token:
+                        token = deployer.mdict['pki_token_name']
+                instance.set_sslserver_cert_nickname(nickname, token)
 
         else:
             if config.str2bool(deployer.mdict['pki_hsm_enable']):

--- a/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/subsystem_layout.py
@@ -74,7 +74,8 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         if config.str2bool(deployer.mdict['pki_registry_enable']):
             subsystem.create_registry(exist_ok=True)
 
-        deployer.create_cs_cfg(subsystem)
+        if deployer.subsystem_type != "EST":
+            deployer.create_cs_cfg(subsystem)
 
         if deployer.subsystem_type == "CA":
 
@@ -287,6 +288,12 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                 pki_target_phone_home_xml,
                 params=deployer.mdict,
                 exist_ok=True)
+
+        elif deployer.subsystem_type == "EST":
+            subsystem.add_est_config(exist_ok=True, force=True)
+            deployer.configure_est_backend(subsystem)
+            deployer.configure_est_authorizer(subsystem)
+            deployer.configure_est_realm(subsystem)
 
         instance.load()
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -362,6 +362,12 @@ class PKISubsystem(object):
         for cert_tag in cert_list.split(','):
             yield self.get_cert_info(cert_tag)
 
+    def get_subsystem_certs(self):
+        certs = self.config.get('%s.cert.list' % self.name)
+        if certs:
+            return certs.split(',')
+        return []
+
     def get_subsystem_cert(self, tag):
 
         logger.debug('PKISubsystem.get_subsystem_cert(%s)', tag)
@@ -3002,6 +3008,17 @@ class ESTSubsystem(PKISubsystem):
             self.realm_conf,
             exist_ok=False,
             force=True)
+
+    def get_subsystem_cert(self, tag):
+
+        logger.debug('ESTSubsystem.get_subsystem_cert(%s)', tag)
+        return None
+
+    def validate_system_cert(self, tag):
+        """
+        EST subsystem does not keep certificate information in its configuration file so
+        the validation cannot be performed like for other subsystems
+        """
 
     def is_ready(self, secure_connection=True, timeout=None):
         """


### PR DESCRIPTION
EST integration in pkispawn has been modified to perform its operations during the corresponding steps of other subsystem. Additionally, if the SSL certificate is not provided then it will be created. To create the certificate the EST user credentials and relative profile is used.
The CI test for EST in a separate instance, which use ssl certificate from a pkcs12 bundle, has been moved to a new test while the original has been modified to generate the SSL certificate.