### PR TITLE
Fix profiles for EST certificate and re-enrollment

### DIFF
--- a/.github/workflows/est-ds-realm-separate-test.yml
+++ b/.github/workflows/est-ds-realm-separate-test.yml
@@ -250,7 +250,7 @@ jobs:
           docker exec est curl -o cacert.p7 -k https://est.example.com:8443/.well-known/est/cacerts
 
           docker exec est openssl base64 -d --in cacert.p7 --out cacert.p7.der
-          docker exec est openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -out cacert.pem
+          docker exec est openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -quiet -out cacert.pem
           docker exec est openssl x509 -in cacert.pem -text -noout | tee actual
           docker exec est openssl x509 -in $SHARED/ca_signing.crt -text -noout | tee expected
           diff expected actual
@@ -266,7 +266,7 @@ jobs:
               --common-name test.example.com -o . -u est-test-user -h Secret.123
 
           docker exec est openssl base64 -d --in cert-0-0.pkcs7 --out cert-0-0.pkcs7.der
-          docker exec est openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -out cert.pem
+          docker exec est openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -quiet -out cert.pem
           docker exec est openssl x509 -in cert.pem -subject -noout | tee actual
           echo "subject=CN=test.example.com" > expected
           diff expected actual

--- a/.github/workflows/est-ds-realm-test.yml
+++ b/.github/workflows/est-ds-realm-test.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           docker exec pki curl -o cacert.p7 -k https://pki.example.com:8443/.well-known/est/cacerts
           docker exec pki openssl base64 -d --in cacert.p7 --out cacert.p7.der
-          docker exec pki openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -out cacert.pem
+          docker exec pki openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -quiet -out cacert.pem
           docker exec pki openssl x509 -in cacert.pem -text -noout | tee actual
           docker exec pki openssl x509 -in ca_signing.crt -text -noout | tee expected
           diff expected actual
@@ -276,14 +276,61 @@ jobs:
           docker exec pki dnf copr enable -y @pki/libest 
           docker exec pki dnf install -y libest
 
-      - name: Enroll certificate
+      - name: Enroll certificate with user/password
         run: |
           docker exec -e EST_OPENSSL_CACERT=cacert.pem pki estclient -e -s pki.example.com -p 8443 \
               --common-name test.example.com -o . -u est-test-user -h Secret.123
 
           docker exec pki openssl base64 -d --in cert-0-0.pkcs7 --out cert-0-0.pkcs7.der
-          docker exec pki openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -out cert.pem
+          docker exec pki openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -quiet -out cert.pem
           docker exec pki openssl x509 -in cert.pem -subject -noout | tee actual
+          echo "subject=CN=test.example.com" > expected
+          diff expected actual
+
+      - name: Add certificate to the user
+        run: |
+          VERSION=$(docker exec pki PrettyPrintCert cert.pem | sed -n 's/\s*Version:\s*v3/2/p')
+          SERIAL_HEX=$(docker exec pki PrettyPrintCert cert.pem | sed -n 's/\s*Serial Number:\s*0x\(.*\)/\1/p')
+          SERIAL=$(python3 -c 'print(int("'$SERIAL_HEX'", 16))')
+          ISSUER=$(docker exec pki PrettyPrintCert cert.pem | sed -n 's/\s*Issuer:\s*\(.*\)/\1/p' | sed 's/, /,/g')
+          SUBJECT=$(docker exec pki PrettyPrintCert cert.pem | sed -n 's/\s*Subject:\s*\(.*\)/\1/p' | sed 's/, /,/g')
+
+          docker exec pki openssl x509 -in cert.pem -outform DER -out cert.der
+          CERTIFICATE=$(docker exec pki openssl base64 -in cert.der | sed 's/^/ /')
+          
+          docker exec -i pki ldapmodify -H ldap://ds.example.com:3389 -D "cn=Directory Manager" -w Secret.123 <<EOF
+          dn: uid=est-test-user,ou=people,dc=est,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: description
+          description: $VERSION;$SERIAL;$ISSUER;$SUBJECT
+          -
+          add: userCertificate
+          userCertificate::$CERTIFICATE
+          EOF
+
+          docker exec -i pki ldapsearch -H ldap://ds.example.com:3389 -D "cn=Directory Manager" -w Secret.123 -b ou=people,dc=est,dc=pki,dc=example,dc=com
+
+      - name: Enroll new certificate with certificate
+        run: |
+          docker exec pki mkdir new_certs
+          docker exec -e EST_OPENSSL_CACERT=cacert.pem pki estclient -e -s pki.example.com -p 8443 \
+              --common-name test-new.example.com -o ./new_certs -c cert.pem -k key-x-x.pem
+
+          docker exec pki openssl base64 -d --in new_certs/cert-0-0.pkcs7 --out new_certs/cert-0-0.pkcs7.der
+          docker exec pki openssl pkcs7 -in new_certs/cert-0-0.pkcs7.der -inform DER -print_certs -quiet -out new_certs/cert.pem
+          docker exec pki openssl x509 -in new_certs/cert.pem -subject -noout | tee actual
+          echo "subject=CN=test-new.example.com" > expected
+          diff expected actual
+          
+      - name: Re-Enroll new certificate with certificate
+        run: |
+          docker exec pki mkdir re_certs
+          docker exec -e EST_OPENSSL_CACERT=cacert.pem pki estclient -r -s pki.example.com -p 8443 \
+              -o ./re_certs -c cert.pem -k key-x-x.pem
+
+          docker exec pki openssl base64 -d --in re_certs/cert-0-0.pkcs7 --out re_certs/cert-0-0.pkcs7.der
+          docker exec pki openssl pkcs7 -in re_certs/cert-0-0.pkcs7.der -inform DER -print_certs -quiet -out re_certs/cert.pem
+          docker exec pki openssl x509 -in re_certs/cert.pem -subject -noout | tee actual
           echo "subject=CN=test.example.com" > expected
           diff expected actual
 

--- a/.github/workflows/est-postgresql-realm-test.yml
+++ b/.github/workflows/est-postgresql-realm-test.yml
@@ -311,7 +311,7 @@ jobs:
         run: |
           docker exec pki curl -o cacert.p7 -k https://pki.example.com:8443/.well-known/est/cacerts
           docker exec pki openssl base64 -d --in cacert.p7 --out cacert.p7.der
-          docker exec pki openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -out cacert.pem
+          docker exec pki openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -quiet -out cacert.pem
           docker exec pki openssl x509 -in cacert.pem -text -noout | tee actual
           docker exec pki openssl x509 -in ca_signing.crt -text -noout | tee expected
           diff expected actual
@@ -327,11 +327,54 @@ jobs:
               --common-name test.example.com -o . -u est-test-user -h Secret.123
 
           docker exec pki openssl base64 -d --in cert-0-0.pkcs7 --out cert-0-0.pkcs7.der
-          docker exec pki openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -out cert.pem
+          docker exec pki openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -quiet -out cert.pem
           docker exec pki openssl x509 -in cert.pem -subject -noout | tee actual
           echo "subject=CN=test.example.com" > expected
           diff expected actual
 
+      - name: Add certificate to the user
+        run: |
+          VERSION=$(docker exec pki PrettyPrintCert cert.pem | sed -n 's/\s*Version:\s*v3/2/p')
+          SERIAL_HEX=$(docker exec pki PrettyPrintCert cert.pem | sed -n 's/\s*Serial Number:\s*0x\(.*\)/\1/p')
+          SERIAL=$(python3 -c 'print(int("'$SERIAL_HEX'", 16))')
+          ISSUER=$(docker exec pki PrettyPrintCert cert.pem | sed -n 's/\s*Issuer:\s*\(.*\)/\1/p' | sed 's/, /,/g')
+          SUBJECT=$(docker exec pki PrettyPrintCert cert.pem | sed -n 's/\s*Subject:\s*\(.*\)/\1/p' | sed 's/, /,/g')
+
+          docker exec pki openssl x509 -in cert.pem -outform DER -out cert.der
+          docker cp pki:cert.der .
+          docker cp cert.der postgresql:/cert.der
+
+          docker exec postgresql psql -U est -t -A -c \
+              "INSERT INTO user_certs VALUES ('est-test-user', '$VERSION;$SERIAL;$ISSUER;$SUBJECT', pg_read_binary_file('/cert.der'));" \
+              est
+
+          docker exec postgresql psql -U est -t -A -c "SELECT * FROM user_certs;"  est
+
+      - name: Enroll new certificate with certificate
+        run: |
+          docker exec pki mkdir new_certs
+          docker exec -e EST_OPENSSL_CACERT=cacert.pem pki estclient -e -s pki.example.com -p 8443 \
+              --common-name test-new.example.com -o ./new_certs -c cert.pem -k key-x-x.pem
+
+          docker exec pki openssl base64 -d --in new_certs/cert-0-0.pkcs7 --out new_certs/cert-0-0.pkcs7.der
+          docker exec pki openssl pkcs7 -in new_certs/cert-0-0.pkcs7.der -inform DER \
+              -print_certs -quiet -out new_certs/cert.pem
+          docker exec pki openssl x509 -in new_certs/cert.pem -subject -noout | tee actual
+          echo "subject=CN=test-new.example.com" > expected
+          diff expected actual
+          
+      - name: Re-Enroll new certificate with certificate
+        run: |
+          docker exec pki mkdir re_certs
+          docker exec -e EST_OPENSSL_CACERT=cacert.pem pki estclient -r -s pki.example.com -p 8443 \
+              -o ./re_certs -c cert.pem -k key-x-x.pem
+
+          docker exec pki openssl base64 -d --in re_certs/cert-0-0.pkcs7 --out re_certs/cert-0-0.pkcs7.der
+          docker exec pki openssl pkcs7 -in re_certs/cert-0-0.pkcs7.der -inform DER -print_certs -quiet -out re_certs/cert.pem
+          docker exec pki openssl x509 -in re_certs/cert.pem -subject -noout | tee actual
+          echo "subject=CN=test.example.com" > expected
+          diff expected actual
+          
       - name: Remove EST
         run: |
           docker exec pki pkidestroy -i pki-tomcat -s EST -v

--- a/.github/workflows/est-separate-provided-certs-test.yml
+++ b/.github/workflows/est-separate-provided-certs-test.yml
@@ -92,23 +92,23 @@ jobs:
               est-ra-1 --fullName "EST RA 1" --password Secret.est
           docker exec ca pki -n caadmin ca-group-member-add "EST RA Agents" est-ra-1
 
-      - name: Create CA EST user certificate end store top p12
+      - name: Create EST subsystem cert for the user end store into the same p12
         run: |
           docker exec ca pki nss-cert-request --csr estUser.csr \
-              --ext /usr/share/pki/server/certs/admin.conf --subject 'UID=estUser'
+              --ext /usr/share/pki/server/certs/admin.conf --subject 'CN=EST Subsystem Certificate,OU=pki-tomcat,O=EXAMPLE'
 
           docker exec ca pki \
               -n caadmin \
               ca-cert-issue \
               --csr-file estUser.csr \
-              --profile caUserCert \
+              --profile caSubsystemCert \
               --output-file estUser.crt
 
-          docker exec ca pki nss-cert-import --cert estUser.crt estUser
+          docker exec ca pki nss-cert-import --cert estUser.crt "EST subsystem cert"
           
           docker exec ca pki -n caadmin ca-user-cert-add est-ra-1 --input estUser.crt
 
-          docker exec ca pki pkcs12-cert-import estUser --pkcs12-file $SHARED/est_server.p12 --pkcs12-password Secret.123 --append
+          docker exec ca pki pkcs12-cert-import "EST subsystem cert" --pkcs12-file $SHARED/est_server.p12 --pkcs12-password Secret.123 --append
           
       - name: Configure CA est profile
         run: |
@@ -178,7 +178,7 @@ jobs:
               -D est_realm_url=ldap://estds.example.com:3389 \
               -D pki_ca_uri=https://ca.example.com:8443 \
               -D est_ca_user_password= \
-              -D est_ca_user_certificate=estUser \
+              -D est_ca_user_certificate="EST subsystem cert" \
               -D pki_server_pkcs12_path=$SHARED/est_server.p12 \
               -D pki_server_pkcs12_password=Secret.123 \
               -v
@@ -286,7 +286,7 @@ jobs:
           docker exec est curl -o cacert.p7 -k https://est.example.com:8443/.well-known/est/cacerts
 
           docker exec est openssl base64 -d --in cacert.p7 --out cacert.p7.der
-          docker exec est openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -out cacert.pem
+          docker exec est openssl pkcs7 --in cacert.p7.der -inform DER -print_certs -quiet -out cacert.pem
           docker exec est openssl x509 -in cacert.pem -text -noout | tee actual
           docker exec est openssl x509 -in $SHARED/ca_signing.crt -text -noout | tee expected
           diff expected actual
@@ -302,7 +302,7 @@ jobs:
               --common-name test.example.com -o . -u est-test-user -h Secret.123
 
           docker exec est openssl base64 -d --in cert-0-0.pkcs7 --out cert-0-0.pkcs7.der
-          docker exec est openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -out cert.pem
+          docker exec est openssl pkcs7 -in cert-0-0.pkcs7.der -inform DER -print_certs -quiet -out cert.pem
           docker exec est openssl x509 -in cert.pem -subject -noout | tee actual
           echo "subject=CN=test.example.com" > expected
           diff expected actual

--- a/.github/workflows/est-tests.yml
+++ b/.github/workflows/est-tests.yml
@@ -58,6 +58,6 @@ jobs:
     uses: ./.github/workflows/est-ds-realm-separate-test.yml
 
   est-separate-provided-certs-test:
-    name: EST with ds realm on a separate instance
+    name: EST on separate instance with provided certificates
     needs: build
     uses: ./.github/workflows/est-separate-provided-certs-test.yml


### PR DESCRIPTION
Generate EST certificates with same profile of other subsystems.

Additionally, add EST generate certificate to the user and test both enrollment with certificate and re-enrollment.