### PR TITLE
Update test for pki ca-user-show

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -431,12 +431,51 @@ jobs:
 
           diff expected output
 
-      - name: Test CA admin
+      - name: Check pki ca-user-show with default API
         run: |
           docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
+
           docker exec pki pki -n caadmin ca-user-show caadmin
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v1/info HTTP/1.1 200 -
+          GET /ca/v1/account/login HTTP/1.1 200 caadmin
+          GET /ca/v1/admin/users/caadmin HTTP/1.1 200 caadmin
+          GET /ca/v1/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      - name: Check pki ca-user-show with API v2
+        run: |
+          docker exec pki pki -n caadmin --api v2 ca-user-show caadmin
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /ca/v2/account/login HTTP/1.1 200 caadmin
+          GET /ca/v2/admin/users/caadmin HTTP/1.1 200 caadmin
+          GET /ca/v2/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
 
       - name: Check cert requests in CA
         run: |

--- a/base/common/src/main/java/com/netscape/certsrv/account/AccountClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/account/AccountClient.java
@@ -30,7 +30,7 @@ public class AccountClient extends Client {
     public boolean loggedIn;
 
     public AccountClient(PKIClient client, String subsystem) throws Exception {
-        super(client, subsystem, null, "account");
+        super(client, subsystem, "account");
     }
 
     public AccountClient(PKIClient client, String subsystem, String prefix) throws Exception {

--- a/base/common/src/main/java/com/netscape/certsrv/client/SubsystemClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/SubsystemClient.java
@@ -60,7 +60,7 @@ public class SubsystemClient extends Client {
         // subsystem name should match the client name
         super(client, name, name);
 
-        accountClient = new AccountClient(client, name, "rest");
+        accountClient = new AccountClient(client, name);
         addClient(accountClient);
     }
 

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v2/AccountServlet.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v2/AccountServlet.java
@@ -42,5 +42,6 @@ public class AccountServlet extends PKIServlet {
             logger.info("AccountServlet: Destroying session {}", session.getId());
             session.invalidate();
         }
+        response.sendError(HttpServletResponse.SC_NO_CONTENT);
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/ProxyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/ProxyCLI.java
@@ -133,7 +133,7 @@ public class ProxyCLI extends CLI {
                 if (subsystem == null) subsystem = defaultSubsystem;
 
                 PKIClient client = module.getClient();
-                accountClient = new AccountClient(client, subsystem, "rest");
+                accountClient = new AccountClient(client, subsystem);
                 accountClient.login();
             }
 


### PR DESCRIPTION
The basic CA test has been updated to run `pki ca-user-show` with default API and API v2 then verify the access logs generated by these commands.

The `AccountClient` has been updated to use the API version from `PKIClient`.

The `AccountServlet.logout()` has been updated to return `NO_CONTENT` status for consistency with API v1.