### PR TITLE
Reverting the test-ca-certs.sh

### DIFF
--- a/tests/ca/bin/test-ca-certs.sh
+++ b/tests/ca/bin/test-ca-certs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+# list certs in CA
+pki ca-cert-find | tee /tmp/certs.txt
+
+# get the number of certs returned
+sed -n "s/^\(\S*\) entries found$/\1/p" /tmp/certs.txt > /tmp/certs.count
+
+# by default there should be 6 certs initially
+echo 6 > /tmp/expected
+diff /tmp/certs.count /tmp/expected


### PR DESCRIPTION
The file is currently used for JSS tests

https://github.com/dogtagpki/jss/blob/master/.github/workflows/pki-ca-test.yml#L128