### PR TITLE
Add tests for next begin/end numbers

### DIFF
--- a/.github/workflows/ca-clone-sequential-test.yml
+++ b/.github/workflows/ca-clone-sequential-test.yml
@@ -140,6 +140,8 @@ jobs:
           cat > expected << EOF
           dbs.beginRequestNumber=1
           dbs.endRequestNumber=10
+          dbs.nextBeginRequestNumber=11
+          dbs.nextEndRequestNumber=20
           dbs.requestCloneTransferNumber=5
           dbs.requestIncrement=10
           dbs.requestLowWaterMark=5
@@ -313,6 +315,8 @@ jobs:
           cat > expected << EOF
           dbs.beginRequestNumber=1
           dbs.endRequestNumber=10
+          dbs.nextBeginRequestNumber=11
+          dbs.nextEndRequestNumber=15
           dbs.requestCloneTransferNumber=5
           dbs.requestIncrement=10
           dbs.requestLowWaterMark=5
@@ -491,6 +495,8 @@ jobs:
           cat > expected << EOF
           dbs.beginRequestNumber=1
           dbs.endRequestNumber=10
+          dbs.nextBeginRequestNumber=11
+          dbs.nextEndRequestNumber=15
           dbs.requestCloneTransferNumber=5
           dbs.requestIncrement=10
           dbs.requestLowWaterMark=5
@@ -659,6 +665,8 @@ jobs:
           cat > expected << EOF
           dbs.beginRequestNumber=1
           dbs.endRequestNumber=10
+          dbs.nextBeginRequestNumber=11
+          dbs.nextEndRequestNumber=15
           dbs.requestCloneTransferNumber=5
           dbs.requestIncrement=10
           dbs.requestLowWaterMark=5

--- a/.github/workflows/ca-sequential-test.yml
+++ b/.github/workflows/ca-sequential-test.yml
@@ -210,6 +210,8 @@ jobs:
           cat > expected << EOF
           dbs.beginRequestNumber=1
           dbs.endRequestNumber=10
+          dbs.nextBeginRequestNumber=11
+          dbs.nextEndRequestNumber=20
           dbs.requestCloneTransferNumber=5
           dbs.requestIncrement=10
           dbs.requestLowWaterMark=5
@@ -554,6 +556,8 @@ jobs:
           cat > expected << EOF
           dbs.beginRequestNumber=11
           dbs.endRequestNumber=20
+          dbs.nextBeginRequestNumber=21
+          dbs.nextEndRequestNumber=30
           dbs.requestCloneTransferNumber=5
           dbs.requestIncrement=10
           dbs.requestLowWaterMark=5
@@ -569,6 +573,8 @@ jobs:
           cat > expected << EOF
           dbs.beginSerialNumber=9
           dbs.endSerialNumber=18
+          dbs.nextBeginSerialNumber=19
+          dbs.nextEndSerialNumber=2a
           dbs.serialCloneTransferNumber=9
           dbs.serialIncrement=12
           dbs.serialLowWaterMark=9
@@ -911,6 +917,8 @@ jobs:
           cat > expected << EOF
           dbs.beginRequestNumber=21
           dbs.endRequestNumber=30
+          dbs.nextBeginRequestNumber=31
+          dbs.nextEndRequestNumber=40
           dbs.requestCloneTransferNumber=5
           dbs.requestIncrement=10
           dbs.requestLowWaterMark=5
@@ -926,6 +934,8 @@ jobs:
           cat > expected << EOF
           dbs.beginSerialNumber=19
           dbs.endSerialNumber=2a
+          dbs.nextBeginSerialNumber=37
+          dbs.nextEndSerialNumber=48
           dbs.serialCloneTransferNumber=9
           dbs.serialIncrement=12
           dbs.serialLowWaterMark=9

--- a/tests/ca/bin/ca-cert-range-config.sh
+++ b/tests/ca/bin/ca-cert-range-config.sh
@@ -6,6 +6,8 @@ docker exec $NAME pki-server ca-config-find \
     | grep \
         -e dbs.beginSerialNumber \
         -e dbs.endSerialNumber \
+        -e dbs.nextBeginSerialNumber \
+        -e dbs.nextEndSerialNumber \
         -e dbs.serialCloneTransferNumber \
         -e dbs.serialIncrement \
         -e dbs.serialLowWaterMark

--- a/tests/ca/bin/ca-request-range-config.sh
+++ b/tests/ca/bin/ca-request-range-config.sh
@@ -6,6 +6,8 @@ docker exec $NAME pki-server ca-config-find \
     | grep \
         -e dbs.beginRequestNumber \
         -e dbs.endRequestNumber \
+        -e dbs.nextBeginRequestNumber \
+        -e dbs.nextEndRequestNumber \
         -e dbs.requestCloneTransferNumber \
         -e dbs.requestIncrement \
         -e dbs.requestLowWaterMark


### PR DESCRIPTION
The tests for CA with sequential serial numbers have been updated to verify the `dbs.nextBegin...` and `dbs.nextEnd...` parameters.