### PR TITLE
Clean up Repository classes

### DIFF
--- a/base/ca/src/main/java/com/netscape/cmscore/dbs/CRLRepository.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/dbs/CRLRepository.java
@@ -67,21 +67,18 @@ public class CRLRepository extends Repository {
         rangeDN = dbConfig.getRequestRangeDN() + "," + dbSubsystem.getBaseDN();
         logger.info("CRLRepository: - range DN: " + rangeDN);
 
-        minSerialName = DatabaseConfig.MIN_REQUEST_NUMBER;
         String minSerial = dbConfig.getBeginRequestNumber();
         if (minSerial != null) {
             mMinSerialNo = new BigInteger(minSerial, mRadix);
         }
         logger.info("CRLRepository: - min serial: " + mMinSerialNo);
 
-        maxSerialName = DatabaseConfig.MAX_REQUEST_NUMBER;
         String maxSerial = dbConfig.getEndRequestNumber();
         if (maxSerial != null) {
             mMaxSerialNo = new BigInteger(maxSerial, mRadix);
         }
         logger.info("CRLRepository: - max serial: " + mMaxSerialNo);
 
-        nextMinSerialName = DatabaseConfig.NEXT_MIN_REQUEST_NUMBER;
         String nextMinSerial = dbConfig.getNextBeginRequestNumber();
         if (nextMinSerial == null || nextMinSerial.equals("-1")) {
             mNextMinSerialNo = null;
@@ -90,7 +87,6 @@ public class CRLRepository extends Repository {
         }
         logger.info("CRLRepository: - next min serial: " + mNextMinSerialNo);
 
-        nextMaxSerialName = DatabaseConfig.NEXT_MAX_REQUEST_NUMBER;
         String nextMaxSerial = dbConfig.getNextEndRequestNumber();
         if (nextMaxSerial == null || nextMaxSerial.equals("-1")) {
             mNextMaxSerialNo = null;
@@ -127,6 +123,52 @@ public class CRLRepository extends Repository {
         reg.registerAttribute(CRLIssuingPointRecord.ATTR_CRL,
                 new ByteArrayMapper(Schema.LDAP_ATTR_CRL));
         */
+    }
+
+    public void setMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMinSerialNo.toString(mRadix);
+        logger.debug("CRLRepository: Setting min serial number: " + serial);
+        dbConfig.setBeginRequestNumber(serial);
+    }
+
+    public void setMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMaxSerialNo.toString(mRadix);
+        logger.debug("CRLRepository: Setting max serial number: " + serial);
+        dbConfig.setEndRequestNumber(serial);
+    }
+
+    public void setNextMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMinSerialNo == null) {
+            logger.debug("CRLRepository: Removing next min number");
+            dbConfig.removeNextBeginRequestNumber();
+
+        } else {
+            String serial = mNextMinSerialNo.toString(mRadix);
+            logger.debug("CRLRepository: Setting next min number: " + serial);
+            dbConfig.setNextBeginRequestNumber(serial);
+        }
+    }
+
+    public void setNextMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMaxSerialNo == null) {
+            logger.debug("CRLRepository: Removing next max number");
+            dbConfig.removeNextEndRequestNumber();
+
+        } else {
+            String serial = mNextMaxSerialNo.toString(mRadix);
+            logger.debug("CRLRepository: Setting next max number: " + serial);
+            dbConfig.setNextEndRequestNumber(serial);
+        }
     }
 
     /**

--- a/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
@@ -137,21 +137,18 @@ public class CertificateRepository extends Repository {
         rangeDN = mDBConfig.getSerialRangeDN() + "," + dbSubsystem.getBaseDN();
         logger.debug("CertificateRepository: - range DN: " + rangeDN);
 
-        minSerialName = DatabaseConfig.MIN_SERIAL_NUMBER;
         String minSerial = mDBConfig.getBeginSerialNumber();
         if (minSerial != null) {
             mMinSerialNo = new BigInteger(minSerial, mRadix);
         }
         logger.debug("CertificateRepository: - min serial: " + mMinSerialNo);
 
-        maxSerialName = DatabaseConfig.MAX_SERIAL_NUMBER;
         String maxSerial = mDBConfig.getEndSerialNumber();
         if (maxSerial != null) {
             mMaxSerialNo = new BigInteger(maxSerial, mRadix);
         }
         logger.debug("CertificateRepository: - max serial: " + mMaxSerialNo);
 
-        nextMinSerialName = DatabaseConfig.NEXT_MIN_SERIAL_NUMBER;
         String nextMinSerial = mDBConfig.getNextBeginSerialNumber();
         if (nextMinSerial == null || nextMinSerial.equals("-1")) {
             mNextMinSerialNo = null;
@@ -160,7 +157,6 @@ public class CertificateRepository extends Repository {
         }
         logger.debug("CertificateRepository: - next min serial: " + mNextMinSerialNo);
 
-        nextMaxSerialName = DatabaseConfig.NEXT_MAX_SERIAL_NUMBER;
         String nextMaxSerial = mDBConfig.getNextEndSerialNumber();
         if (nextMaxSerial == null || nextMaxSerial.equals("-1")) {
             mNextMaxSerialNo = null;
@@ -177,6 +173,52 @@ public class CertificateRepository extends Repository {
         String incrementNo = mDBConfig.getSerialIncrement();
         if (incrementNo != null) {
             mIncrementNo = new BigInteger(incrementNo, mRadix);
+        }
+    }
+
+    public void setMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMinSerialNo.toString(mRadix);
+        logger.debug("CertificateRepository: Setting min serial number: " + serial);
+        dbConfig.setBeginSerialNumber(serial);
+    }
+
+    public void setMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMaxSerialNo.toString(mRadix);
+        logger.debug("CertificateRepository: Setting max serial number: " + serial);
+        dbConfig.setEndSerialNumber(serial);
+    }
+
+    public void setNextMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMinSerialNo == null) {
+            logger.debug("CertificateRepository: Removing next min number");
+            dbConfig.removeNextBeginSerialNumber();
+
+        } else {
+            String serial = mNextMinSerialNo.toString(mRadix);
+            logger.debug("CertificateRepository: Setting next min number: " + serial);
+            dbConfig.setNextBeginSerialNumber(serial);
+        }
+    }
+
+    public void setNextMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMaxSerialNo == null) {
+            logger.debug("CertificateRepository: Removing next max number");
+            dbConfig.removeNextEndSerialNumber();
+
+        } else {
+            String serial = mNextMaxSerialNo.toString(mRadix);
+            logger.debug("CertificateRepository: Setting next max number: " + serial);
+            dbConfig.setNextEndSerialNumber(serial);
         }
     }
 

--- a/base/kra/src/main/java/com/netscape/cmscore/dbs/KeyRepository.java
+++ b/base/kra/src/main/java/com/netscape/cmscore/dbs/KeyRepository.java
@@ -175,21 +175,18 @@ public class KeyRepository extends Repository {
         rangeDN = dbConfig.getSerialRangeDN() + "," + dbSubsystem.getBaseDN();
         logger.info("KeyRepository: - range DN: {}", rangeDN);
 
-        minSerialName = DatabaseConfig.MIN_SERIAL_NUMBER;
         String minSerial = dbConfig.getBeginSerialNumber();
         if (minSerial != null) {
             mMinSerialNo = new BigInteger(minSerial, mRadix);
         }
         logger.info("KeyRepository: - min serial: {}", mMinSerialNo);
 
-        maxSerialName = DatabaseConfig.MAX_SERIAL_NUMBER;
         String maxSerial = dbConfig.getEndSerialNumber();
         if (maxSerial != null) {
             mMaxSerialNo = new BigInteger(maxSerial, mRadix);
         }
         logger.info("KeyRepository: - max serial: {}", mMaxSerialNo);
 
-        nextMinSerialName = DatabaseConfig.NEXT_MIN_SERIAL_NUMBER;
         String nextMinSerial = dbConfig.getNextBeginSerialNumber();
         if (nextMinSerial == null || nextMinSerial.equals("-1")) {
             mNextMinSerialNo = null;
@@ -198,7 +195,6 @@ public class KeyRepository extends Repository {
         }
         logger.info("KeyRepository: - next min serial: {}", mNextMinSerialNo);
 
-        nextMaxSerialName = DatabaseConfig.NEXT_MAX_SERIAL_NUMBER;
         String nextMaxSerial = dbConfig.getNextEndSerialNumber();
         if (nextMaxSerial == null || nextMaxSerial.equals("-1")) {
             mNextMaxSerialNo = null;
@@ -215,6 +211,52 @@ public class KeyRepository extends Repository {
         String incrementNo = dbConfig.getSerialIncrement();
         if (incrementNo != null) {
             mIncrementNo = new BigInteger(incrementNo, mRadix);
+        }
+    }
+
+    public void setMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMinSerialNo.toString(mRadix);
+        logger.debug("KeyRepository: Setting min serial number: " + serial);
+        dbConfig.setBeginSerialNumber(serial);
+    }
+
+    public void setMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMaxSerialNo.toString(mRadix);
+        logger.debug("KeyRepository: Setting max serial number: " + serial);
+        dbConfig.setEndSerialNumber(serial);
+    }
+
+    public void setNextMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMinSerialNo == null) {
+            logger.debug("KeyRepository: Removing next min number");
+            dbConfig.removeNextBeginSerialNumber();
+
+        } else {
+            String serial = mNextMinSerialNo.toString(mRadix);
+            logger.debug("KeyRepository: Setting next min number: " + serial);
+            dbConfig.setNextBeginSerialNumber(serial);
+        }
+    }
+
+    public void setNextMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMaxSerialNo == null) {
+            logger.debug("KeyRepository: Removing next max number");
+            dbConfig.removeNextEndSerialNumber();
+
+        } else {
+            String serial = mNextMaxSerialNo.toString(mRadix);
+            logger.debug("KeyRepository: Setting next max number: " + serial);
+            dbConfig.setNextEndSerialNumber(serial);
         }
     }
 

--- a/base/server/src/main/java/com/netscape/cmscore/apps/DatabaseConfig.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/DatabaseConfig.java
@@ -148,12 +148,20 @@ public class DatabaseConfig extends ConfigStore {
         putString(NEXT_MIN_SERIAL_NUMBER, nextBeginSerialNumber);
     }
 
+    public void removeNextBeginSerialNumber() throws EBaseException {
+        remove(NEXT_MIN_SERIAL_NUMBER);
+    }
+
     public String getNextEndSerialNumber() throws EBaseException {
         return getString(NEXT_MAX_SERIAL_NUMBER, "-1");
     }
 
     public void setNextEndSerialNumber(String nextEndSerialNumber) {
         putString(NEXT_MAX_SERIAL_NUMBER, nextEndSerialNumber);
+    }
+
+    public void removeNextEndSerialNumber() throws EBaseException {
+        remove(NEXT_MAX_SERIAL_NUMBER);
     }
 
     public String getSerialLowWaterMark() throws EBaseException {
@@ -212,12 +220,20 @@ public class DatabaseConfig extends ConfigStore {
         putString(NEXT_MIN_REQUEST_NUMBER, nextBeginRequestNumber);
     }
 
+    public void removeNextBeginRequestNumber() throws EBaseException {
+        remove(NEXT_MIN_REQUEST_NUMBER);
+    }
+
     public String getNextEndRequestNumber() throws EBaseException {
         return getString(NEXT_MAX_REQUEST_NUMBER, "-1");
     }
 
     public void setNextEndRequestNumber(String nextEndRequestNumber) {
         putString(NEXT_MAX_REQUEST_NUMBER, nextEndRequestNumber);
+    }
+
+    public void removeNextEndRequestNumber() throws EBaseException {
+        remove(NEXT_MAX_REQUEST_NUMBER);
     }
 
     public String getRequestLowWaterMark() throws EBaseException {
@@ -276,12 +292,20 @@ public class DatabaseConfig extends ConfigStore {
         putString(NEXT_MIN_REPLICA_NUMBER, nextBeginReplicaNumber);
     }
 
+    public void removeNextBeginReplicaNumber() throws EBaseException {
+        remove(NEXT_MIN_REPLICA_NUMBER);
+    }
+
     public String getNextEndReplicaNumber() throws EBaseException {
         return getString(NEXT_MAX_REPLICA_NUMBER, "-1");
     }
 
     public void setNextEndReplicaNumber(String nextEndReplicaNumber) {
         putString(NEXT_MAX_REPLICA_NUMBER, nextEndReplicaNumber);
+    }
+
+    public void removeNextEndReplicaNumber() throws EBaseException {
+        remove(NEXT_MAX_REPLICA_NUMBER);
     }
 
     public String getReplicaLowWaterMark() throws EBaseException {

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/ReplicaIDRepository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/ReplicaIDRepository.java
@@ -54,21 +54,18 @@ public class ReplicaIDRepository extends Repository {
         rangeDN = dbConfig.getReplicaRangeDN() + "," + dbSubsystem.getBaseDN();
         logger.info("ReplicaIDRepository: - range DN: " + rangeDN);
 
-        minSerialName = DatabaseConfig.MIN_REPLICA_NUMBER;
         String minSerial = dbConfig.getBeginReplicaNumber();
         if (minSerial != null) {
             mMinSerialNo = new BigInteger(minSerial, mRadix);
         }
         logger.info("ReplicaIDRepository: - min serial: " + mMinSerialNo);
 
-        maxSerialName = DatabaseConfig.MAX_REPLICA_NUMBER;
         String maxSerial = dbConfig.getEndReplicaNumber();
         if (maxSerial != null) {
             mMaxSerialNo = new BigInteger(maxSerial, mRadix);
         }
         logger.info("ReplicaIDRepository: - max serial: " + mMaxSerialNo);
 
-        nextMinSerialName = DatabaseConfig.NEXT_MIN_REPLICA_NUMBER;
         String nextMinSerial = dbConfig.getNextBeginReplicaNumber();
         if (nextMinSerial == null || nextMinSerial.equals("-1")) {
             mNextMinSerialNo = null;
@@ -77,7 +74,6 @@ public class ReplicaIDRepository extends Repository {
         }
         logger.info("ReplicaIDRepository: - next min serial: " + mNextMinSerialNo);
 
-        nextMaxSerialName = DatabaseConfig.NEXT_MAX_REPLICA_NUMBER;
         String nextMaxSerial = dbConfig.getNextEndReplicaNumber();
         if (nextMaxSerial == null || nextMaxSerial.equals("-1")) {
             mNextMaxSerialNo = null;
@@ -94,6 +90,52 @@ public class ReplicaIDRepository extends Repository {
         String incrementNo = dbConfig.getReplicaIncrement();
         if (incrementNo != null) {
             mIncrementNo = new BigInteger(incrementNo, mRadix);
+        }
+    }
+
+    public void setMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMinSerialNo.toString(mRadix);
+        logger.debug("ReplicaIDRepository: Setting min serial number: " + serial);
+        dbConfig.setBeginReplicaNumber(serial);
+    }
+
+    public void setMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMaxSerialNo.toString(mRadix);
+        logger.debug("ReplicaIDRepository: Setting max serial number: " + serial);
+        dbConfig.setEndReplicaNumber(serial);
+    }
+
+    public void setNextMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMinSerialNo == null) {
+            logger.debug("ReplicaIDRepository: Removing next min number");
+            dbConfig.removeNextBeginReplicaNumber();
+
+        } else {
+            String serial = mNextMinSerialNo.toString(mRadix);
+            logger.debug("ReplicaIDRepository: Setting next min number: " + serial);
+            dbConfig.setNextBeginReplicaNumber(serial);
+        }
+    }
+
+    public void setNextMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMaxSerialNo == null) {
+            logger.debug("ReplicaIDRepository: Removing next max number");
+            dbConfig.removeNextEndReplicaNumber();
+
+        } else {
+            String serial = mNextMaxSerialNo.toString(mRadix);
+            logger.debug("ReplicaIDRepository: Setting next max number: " + serial);
+            dbConfig.setNextEndReplicaNumber(serial);
         }
     }
 

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/Repository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/Repository.java
@@ -25,7 +25,6 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.dbs.DBException;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
-import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.apps.EngineConfig;
 
 import netscape.ldap.LDAPAttribute;
@@ -78,16 +77,10 @@ public abstract class Repository {
     // (the next serialNo to be issued) - 1
     private BigInteger mSerialNo = null;
 
-    protected String minSerialName;
     protected BigInteger mMinSerialNo;
-
-    protected String maxSerialName;
     protected BigInteger mMaxSerialNo;
 
-    protected String nextMinSerialName;
     protected BigInteger mNextMinSerialNo;
-
-    protected String nextMaxSerialName;
     protected BigInteger mNextMaxSerialNo;
 
     protected BigInteger mCounter = null;
@@ -422,78 +415,28 @@ public abstract class Repository {
      *
      * @exception EBaseException failed to set
      */
-    public void setMinSerialConfig() throws EBaseException {
-
-        EngineConfig cs = engine.getConfig();
-        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
-
-        String serial = mMinSerialNo.toString(mRadix);
-        logger.debug("Repository: Setting min serial number: " + serial);
-
-        dbConfig.putString(minSerialName, serial);
-        cs.commit(false);
-    }
+    public abstract void setMinSerialConfig() throws EBaseException;
 
     /**
      * Sets maximum serial number limit in config file
      *
      * @exception EBaseException failed to set
      */
-    public void setMaxSerialConfig() throws EBaseException {
-
-        EngineConfig cs = engine.getConfig();
-        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
-
-        String serial = mMaxSerialNo.toString(mRadix);
-        logger.debug("Repository: Setting max serial number: " + serial);
-
-        dbConfig.putString(maxSerialName, serial);
-        cs.commit(false);
-    }
+    public abstract void setMaxSerialConfig() throws EBaseException;
 
     /**
      * Sets minimum serial number limit for next range in config file
      *
      * @exception EBaseException failed to set
      */
-    public void setNextMinSerialConfig() throws EBaseException {
-
-        EngineConfig cs = engine.getConfig();
-        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
-
-        if (mNextMinSerialNo == null) {
-            logger.debug("Repository: Removing next min number");
-            dbConfig.remove(nextMinSerialName);
-        } else {
-            String serial = mNextMinSerialNo.toString(mRadix);
-            logger.debug("Repository: Setting next min number: " + serial);
-            dbConfig.putString(nextMinSerialName, serial);
-        }
-
-        cs.commit(false);
-    }
+    public abstract void setNextMinSerialConfig() throws EBaseException;
 
     /**
      * Sets maximum serial number limit for next range in config file
      *
      * @exception EBaseException failed to set
      */
-    public void setNextMaxSerialConfig() throws EBaseException {
-
-        EngineConfig cs = engine.getConfig();
-        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
-
-        if (mNextMaxSerialNo == null) {
-            logger.debug("Repository: Removing next max number");
-            dbConfig.remove(nextMaxSerialName);
-        } else {
-            String serial = mNextMaxSerialNo.toString(mRadix);
-            logger.debug("Repository: Setting next max number: " + serial);
-            dbConfig.putString(nextMaxSerialName, serial);
-        }
-
-        cs.commit(false);
-    }
+    public abstract void setNextMaxSerialConfig() throws EBaseException;
 
     /**
      * Switch to the next range and persist the changes.
@@ -512,6 +455,9 @@ public abstract class Repository {
         setMaxSerialConfig();
         setNextMinSerialConfig();
         setNextMaxSerialConfig();
+
+        EngineConfig cs = engine.getConfig();
+        cs.commit(false);
     }
 
     /**
@@ -708,6 +654,9 @@ public abstract class Repository {
 
                 setNextMinSerialConfig();
                 setNextMaxSerialConfig();
+
+                EngineConfig cs = engine.getConfig();
+                cs.commit(false);
             }
         }
 
@@ -721,6 +670,9 @@ public abstract class Repository {
 
                 setNextMinSerialConfig();
                 setNextMaxSerialConfig();
+
+                EngineConfig cs = engine.getConfig();
+                cs.commit(false);
             }
         }
     }

--- a/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
@@ -119,21 +119,18 @@ public class RequestRepository extends Repository {
         rangeDN = dbConfig.getRequestRangeDN() + "," + dbSubsystem.getBaseDN();
         logger.debug("RequestRepository: - range DN: " + rangeDN);
 
-        minSerialName = DatabaseConfig.MIN_REQUEST_NUMBER;
         String minSerial = dbConfig.getBeginRequestNumber();
         if (minSerial != null) {
             mMinSerialNo = new BigInteger(minSerial, mRadix);
         }
         logger.debug("RequestRepository: - min serial: " + mMinSerialNo);
 
-        maxSerialName = DatabaseConfig.MAX_REQUEST_NUMBER;
         String maxSerial = dbConfig.getEndRequestNumber();
         if (maxSerial != null) {
             mMaxSerialNo = new BigInteger(maxSerial, mRadix);
         }
         logger.debug("RequestRepository: - max serial: " + mMaxSerialNo);
 
-        nextMinSerialName = DatabaseConfig.NEXT_MIN_REQUEST_NUMBER;
         String nextMinSerial = dbConfig.getNextBeginRequestNumber();
         if (nextMinSerial == null || nextMinSerial.equals("-1")) {
             mNextMinSerialNo = null;
@@ -142,7 +139,6 @@ public class RequestRepository extends Repository {
         }
         logger.debug("RequestRepository: - next min serial: " + mNextMinSerialNo);
 
-        nextMaxSerialName = DatabaseConfig.NEXT_MAX_REQUEST_NUMBER;
         String nextMaxSerial = dbConfig.getNextEndRequestNumber();
         if (nextMaxSerial == null || nextMaxSerial.equals("-1")) {
             mNextMaxSerialNo = null;
@@ -159,6 +155,52 @@ public class RequestRepository extends Repository {
         String incrementNo = dbConfig.getRequestIncrement();
         if (incrementNo != null) {
             mIncrementNo = new BigInteger(incrementNo, mRadix);
+        }
+    }
+
+    public void setMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMinSerialNo.toString(mRadix);
+        logger.debug("RequestRepository: Setting min serial number: " + serial);
+        dbConfig.setBeginRequestNumber(serial);
+    }
+
+    public void setMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+        String serial = mMaxSerialNo.toString(mRadix);
+        logger.debug("RequestRepository: Setting max serial number: " + serial);
+        dbConfig.setEndRequestNumber(serial);
+    }
+
+    public void setNextMinSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMinSerialNo == null) {
+            logger.debug("RequestRepository: Removing next min number");
+            dbConfig.removeNextBeginRequestNumber();
+
+        } else {
+            String serial = mNextMinSerialNo.toString(mRadix);
+            logger.debug("RequestRepository: Setting next min number: " + serial);
+            dbConfig.setNextBeginRequestNumber(serial);
+        }
+    }
+
+    public void setNextMaxSerialConfig() throws EBaseException {
+
+        DatabaseConfig dbConfig = dbSubsystem.getDBConfigStore();
+
+        if (mNextMaxSerialNo == null) {
+            logger.debug("RequestRepository: Removing next max number");
+            dbConfig.removeNextEndRequestNumber();
+
+        } else {
+            String serial = mNextMaxSerialNo.toString(mRadix);
+            logger.debug("RequestRepository: Setting next max number: " + serial);
+            dbConfig.setNextEndRequestNumber(serial);
         }
     }
 


### PR DESCRIPTION
The `Repository` classes have been updated to no longer use class fields to store the names of the parameters that define the boundaries of the ranges. Instead, the classes will use the setter & remover methods of the parameters directly. This will make it easier to find the code that modifies the parameters.