### PR TITLE
Relocate SSNv2 range objects for new CA instances

### DIFF
--- a/.github/workflows/ca-clone-ssnv1-test.yml
+++ b/.github/workflows/ca-clone-ssnv1-test.yml
@@ -1003,8 +1003,8 @@ jobs:
 
       - name: Switch primary to legacy2
         run: |
-          docker exec primary pki-server ca-id-generator-update --type legacy2 request
-          docker exec primary pki-server ca-id-generator-update --type legacy2 cert
+          docker exec primary pki-server ca-id-generator-update -v --type legacy2 request
+          docker exec primary pki-server ca-id-generator-update -v --type legacy2 cert
 
       - name: Check old request range objects
         run: |
@@ -1028,7 +1028,7 @@ jobs:
 
       - name: Check new request range objects
         run: |
-          tests/ca/bin/ca-request-range-objects.sh primaryds ou=requests,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
 
           # request ranges should remain the same
           cat > expected << EOF
@@ -1075,7 +1075,7 @@ jobs:
 
       - name: Check new cert range objects
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh primaryds ou=certificateRepository,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
 
           # cert ranges should remain the same but converted from hex to decimal
           # the range value for the primary move from 13-30 (hex) to 19-48 (dec) 
@@ -1102,8 +1102,8 @@ jobs:
 
       - name: Switch secondary to legacy2
         run: |
-          docker exec secondary pki-server ca-id-generator-update --type legacy2 request
-          docker exec secondary pki-server ca-id-generator-update --type legacy2 cert
+          docker exec secondary pki-server ca-id-generator-update -v --type legacy2 request
+          docker exec secondary pki-server ca-id-generator-update -v --type legacy2 cert
 
       - name: Start the CAs
         run: |
@@ -1223,7 +1223,7 @@ jobs:
 
       - name: Check new request range objects
         run: |
-          tests/ca/bin/ca-request-range-objects.sh primaryds ou=requests,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
 
           cat > expected << EOF
           SecurePort: 8443
@@ -1272,7 +1272,7 @@ jobs:
 
       - name: Check new cert range objects
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh primaryds ou=certificateRepository,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
 
           # cert ranges should remain the same but in dec.
           # the range value for the primary move from 13-30 (hex) to 19-48 (dec)
@@ -1502,7 +1502,7 @@ jobs:
 
       - name: Check new request range objects
         run: |
-          tests/ca/bin/ca-request-range-objects.sh primaryds ou=requests,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
 
           cat > expected << EOF
           SecurePort: 8443
@@ -1576,7 +1576,7 @@ jobs:
 
       - name: Check new cert range objects
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh primaryds ou=certificateRepository,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
 
           cat > expected << EOF
           SecurePort: 8443

--- a/.github/workflows/ca-clone-ssnv2-test.yml
+++ b/.github/workflows/ca-clone-ssnv2-test.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh primaryds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
 
           # new range should be 11 - 20 (size: 10)
           cat > expected << EOF
@@ -188,7 +188,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh primaryds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
 
           # there should be no new range
           diff /dev/null output
@@ -386,7 +386,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh secondaryds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 secondaryds | tee output
 
           # there should be no new range
           # NOTE: there's no indication that part of is has
@@ -404,7 +404,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh secondaryds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 secondaryds | tee output
 
           # there should be no new range
           diff /dev/null output
@@ -555,7 +555,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh primaryds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
 
           # there should be no new range
           cat > expected << EOF
@@ -571,7 +571,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh primaryds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
 
           # there should be no new range
           diff /dev/null output
@@ -843,7 +843,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh primaryds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
 
           # new range should be 21 - 30 (size: 10)
           cat > expected << EOF
@@ -864,7 +864,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh primaryds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
 
           # new range should be 0x2b - 0x3c or 43 - 60 (size: 0x12)
           cat > expected << EOF
@@ -1039,7 +1039,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh primaryds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
 
           # there should be no new range
           cat > expected << EOF
@@ -1060,7 +1060,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh primaryds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
 
           # there should be no new range
           cat > expected << EOF

--- a/.github/workflows/ca-ssnv1-test.yml
+++ b/.github/workflows/ca-ssnv1-test.yml
@@ -1161,8 +1161,8 @@ jobs:
       - name: Switch to legacy2
         run: |
           docker exec pki pki-server stop
-          docker exec pki pki-server ca-id-generator-update --type legacy2 request
-          docker exec pki pki-server ca-id-generator-update --type legacy2 cert
+          docker exec pki pki-server ca-id-generator-update -v --type legacy2 request
+          docker exec pki pki-server ca-id-generator-update -v --type legacy2 cert
           docker exec pki pki-server start --wait
           
 
@@ -1268,7 +1268,7 @@ jobs:
 
       - name: Check new request range objects
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds ou=requests,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # new request range should be 31 - 40 decimal (total: 10)
           cat > expected << EOF
@@ -1320,7 +1320,7 @@ jobs:
 
       - name: Check new cert range objects
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds ou=certificateRepository,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # new cert range should be the same but converted to decimal
           # first range move from 19-36 (hex) to 25-54 (dec)
@@ -1484,7 +1484,7 @@ jobs:
 
       - name: Check new request range objects
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds ou=requests,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           cat > expected << EOF
           SecurePort: 8443
@@ -1560,7 +1560,7 @@ jobs:
 
       - name: Check new cert range objects
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds ou=certificateRepository,ou=ranges_v2 | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           cat > expected << EOF
           SecurePort: 8443

--- a/.github/workflows/ca-ssnv2-test.yml
+++ b/.github/workflows/ca-ssnv2-test.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # there should be no new range
           diff /dev/null output
@@ -164,7 +164,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # there should be no new range
           diff /dev/null output
@@ -256,7 +256,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # new range should be 11 - 20 (size: 10)
           cat > expected << EOF
@@ -272,7 +272,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # there should be no new range
           diff /dev/null output
@@ -391,7 +391,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # there should be no new range
           cat > expected << EOF
@@ -407,7 +407,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # there should be no new range
           diff /dev/null output
@@ -519,7 +519,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # there should be no new range
           cat > expected << EOF
@@ -535,7 +535,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # there should be no new range
           diff /dev/null output
@@ -616,7 +616,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # new request range should be 21 - 30 (size: 10)
           cat > expected << EOF
@@ -637,7 +637,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # new cert range should be 0x19 - 0x2a or 25 - 42 (size: 0x12)
           cat > expected << EOF
@@ -753,7 +753,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # request range objects should be the same
           cat > expected << EOF
@@ -774,7 +774,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # cert range objects should be the same
           cat > expected << EOF
@@ -892,7 +892,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # request range objects should be the same
           cat > expected << EOF
@@ -913,7 +913,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # cert range objects should be the same
           cat > expected << EOF
@@ -1002,7 +1002,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # new range should be 31 - 40 (size: 10)
           cat > expected << EOF
@@ -1028,7 +1028,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # new range should be 0x2b - 0x3c or 43 - 60 (size: 0x12)
           cat > expected << EOF
@@ -1149,7 +1149,7 @@ jobs:
       - name: Check request range objects
         if: always()
         run: |
-          tests/ca/bin/ca-request-range-objects.sh ds | tee output
+          tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
 
           # request range objects should be the same
           cat > expected << EOF
@@ -1175,7 +1175,7 @@ jobs:
       - name: Check cert range objects
         if: always()
         run: |
-          tests/ca/bin/ca-cert-range-objects.sh ds | tee output
+          tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
 
           # cert range objects should be the same
           cat > expected << EOF

--- a/base/ca/database/ds/create.ldif
+++ b/base/ca/database/ds/create.ldif
@@ -150,16 +150,6 @@ objectClass: top
 objectClass: organizationalUnit
 ou: replica
 
-dn: ou=requests, ou=ranges,{rootSuffix}
-objectClass: top
-objectClass: organizationalUnit
-ou: requests
-
-dn: ou=certificateRepository, ou=ranges,{rootSuffix}
-objectClass: top
-objectClass: organizationalUnit
-ou: certificateRepository
-
 dn: ou=certificateProfiles,ou=ca,{rootSuffix}
 objectClass: top
 objectClass: organizationalUnit

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBCLI.java
@@ -24,7 +24,6 @@ import org.dogtagpki.server.cli.SubsystemDBCreateCLI;
 import org.dogtagpki.server.cli.SubsystemDBEmptyCLI;
 import org.dogtagpki.server.cli.SubsystemDBIndexCLI;
 import org.dogtagpki.server.cli.SubsystemDBInfoCLI;
-import org.dogtagpki.server.cli.SubsystemDBInitCLI;
 import org.dogtagpki.server.cli.SubsystemDBRemoveCLI;
 import org.dogtagpki.server.cli.SubsystemDBReplicationCLI;
 import org.dogtagpki.server.cli.SubsystemDBVLVCLI;
@@ -39,7 +38,7 @@ public class CADBCLI extends CLI {
 
         addModule(new SubsystemDBInfoCLI(this));
         addModule(new SubsystemDBCreateCLI(this));
-        addModule(new SubsystemDBInitCLI(this));
+        addModule(new CADBInitCLI(this));
         addModule(new SubsystemDBEmptyCLI(this));
         addModule(new SubsystemDBRemoveCLI(this));
         addModule(new CADBUpgradeCLI(this));

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBInitCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CADBInitCLI.java
@@ -1,0 +1,38 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.ca.cli;
+
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemDBInitCLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmscore.apps.DatabaseConfig;
+import com.netscape.cmscore.dbs.CertificateRepository;
+import com.netscape.cmscore.dbs.Repository.IDGenerator;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class CADBInitCLI extends SubsystemDBInitCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(CADBInitCLI.class);
+
+    public CADBInitCLI(CLI parent) {
+        super("init", "Initialize CA database", parent);
+    }
+
+    @Override
+    public void init(DatabaseConfig dbConfig) throws Exception {
+
+        super.init(dbConfig);
+
+        String value = dbConfig.getString(
+                CertificateRepository.PROP_CERT_ID_GENERATOR,
+                CertificateRepository.DEFAULT_CERT_ID_GENERATOR);
+        serialIDGenerator = IDGenerator.fromString(value);
+    }
+}

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CARangeUpdateCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CARangeUpdateCLI.java
@@ -29,6 +29,17 @@ public class CARangeUpdateCLI extends SubsystemRangeUpdateCLI {
     }
 
     @Override
+    public void init(DatabaseConfig dbConfig) throws Exception {
+
+        super.init(dbConfig);
+
+        String value = dbConfig.getString(
+                CertificateRepository.PROP_CERT_ID_GENERATOR,
+                CertificateRepository.DEFAULT_CERT_ID_GENERATOR);
+        serialIDGenerator = IDGenerator.fromString(value);
+    }
+
+    @Override
     public void updateSerialNumberRange(
             PKISocketFactory socketFactory,
             LdapConnInfo connInfo,
@@ -36,12 +47,7 @@ public class CARangeUpdateCLI extends SubsystemRangeUpdateCLI {
             DatabaseConfig dbConfig,
             String baseDN) throws Exception {
 
-        String value = dbConfig.getString(
-                CertificateRepository.PROP_CERT_ID_GENERATOR,
-                CertificateRepository.DEFAULT_CERT_ID_GENERATOR);
-        idGenerator = IDGenerator.fromString(value);
-
-        if (idGenerator == IDGenerator.RANDOM) {
+        if (serialIDGenerator == IDGenerator.RANDOM) {
             logger.info("No need to update certificate ID range");
             return;
         }

--- a/base/kra/database/ds/create.ldif
+++ b/base/kra/database/ds/create.ldif
@@ -107,13 +107,3 @@ objectClass: top
 objectClass: organizationalUnit
 ou: replica
 
-dn: ou=requests, ou=ranges,{rootSuffix}
-objectClass: top
-objectClass: organizationalUnit
-ou: requests
-
-dn: ou=keyRepository, ou=ranges,{rootSuffix}
-objectClass: top
-objectClass: organizationalUnit
-ou: certificateRepository
-

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRACLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRACLI.java
@@ -20,7 +20,6 @@ package org.dogtagpki.server.kra.cli;
 
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.server.cli.SDCLI;
-import org.dogtagpki.server.cli.SubsystemDBCLI;
 import org.dogtagpki.server.cli.SubsystemGroupCLI;
 import org.dogtagpki.server.cli.SubsystemUserCLI;
 
@@ -32,7 +31,7 @@ public class KRACLI extends CLI {
     public KRACLI(CLI parent) {
         super("kra", "KRA subsystem management commands", parent);
 
-        addModule(new SubsystemDBCLI(this));
+        addModule(new KRADBCLI(this));
         addModule(new SubsystemGroupCLI(this));
         addModule(new KRARangeCLI(this));
         addModule(new KRAIdCLI(this));

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRADBCLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRADBCLI.java
@@ -1,0 +1,39 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.kra.cli;
+
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemDBAccessCLI;
+import org.dogtagpki.server.cli.SubsystemDBCreateCLI;
+import org.dogtagpki.server.cli.SubsystemDBEmptyCLI;
+import org.dogtagpki.server.cli.SubsystemDBIndexCLI;
+import org.dogtagpki.server.cli.SubsystemDBInfoCLI;
+import org.dogtagpki.server.cli.SubsystemDBRemoveCLI;
+import org.dogtagpki.server.cli.SubsystemDBReplicationCLI;
+import org.dogtagpki.server.cli.SubsystemDBUpgradeCLI;
+import org.dogtagpki.server.cli.SubsystemDBVLVCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class KRADBCLI extends CLI {
+
+    public KRADBCLI(CLI parent) {
+        super("db", "KRA database management commands", parent);
+
+        addModule(new SubsystemDBInfoCLI(this));
+        addModule(new SubsystemDBCreateCLI(this));
+        addModule(new KRADBInitCLI(this));
+        addModule(new SubsystemDBEmptyCLI(this));
+        addModule(new SubsystemDBRemoveCLI(this));
+        addModule(new SubsystemDBUpgradeCLI(this));
+
+        addModule(new SubsystemDBAccessCLI(this));
+        addModule(new SubsystemDBIndexCLI(this));
+        addModule(new SubsystemDBReplicationCLI(this));
+        addModule(new SubsystemDBVLVCLI(this));
+    }
+}

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRADBInitCLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRADBInitCLI.java
@@ -1,0 +1,38 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.kra.cli;
+
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemDBInitCLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmscore.apps.DatabaseConfig;
+import com.netscape.cmscore.dbs.KeyRepository;
+import com.netscape.cmscore.dbs.Repository.IDGenerator;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class KRADBInitCLI extends SubsystemDBInitCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(KRADBInitCLI.class);
+
+    public KRADBInitCLI(CLI parent) {
+        super("init", "Initialize KRA database", parent);
+    }
+
+    @Override
+    public void init(DatabaseConfig dbConfig) throws Exception {
+
+        super.init(dbConfig);
+
+        String value = dbConfig.getString(
+                KeyRepository.PROP_KEY_ID_GENERATOR,
+                KeyRepository.DEFAULT_KEY_ID_GENERATOR);
+        serialIDGenerator = IDGenerator.fromString(value);
+    }
+}

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRARangeUpdateCLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRARangeUpdateCLI.java
@@ -29,6 +29,17 @@ public class KRARangeUpdateCLI extends SubsystemRangeUpdateCLI {
     }
 
     @Override
+    public void init(DatabaseConfig dbConfig) throws Exception {
+
+        super.init(dbConfig);
+
+       String value = dbConfig.getString(
+                KeyRepository.PROP_KEY_ID_GENERATOR,
+                KeyRepository.DEFAULT_KEY_ID_GENERATOR);
+        serialIDGenerator = IDGenerator.fromString(value);
+    }
+
+    @Override
     public void updateSerialNumberRange(
             PKISocketFactory socketFactory,
             LdapConnInfo connInfo,
@@ -36,12 +47,7 @@ public class KRARangeUpdateCLI extends SubsystemRangeUpdateCLI {
             DatabaseConfig dbConfig,
             String baseDN) throws Exception {
 
-        String value = dbConfig.getString(
-                KeyRepository.PROP_KEY_ID_GENERATOR,
-                KeyRepository.DEFAULT_KEY_ID_GENERATOR);
-        IDGenerator idGenerator = IDGenerator.fromString(value);
-
-        if (idGenerator == IDGenerator.RANDOM) {
+        if (serialIDGenerator == IDGenerator.RANDOM) {
             logger.info("No need to update key ID range");
             return;
         }

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1186,7 +1186,6 @@ class PKIDeployer:
             subsystem.set_config('dbs.requestIncrement', '10000000')  # decimal
             subsystem.set_config('dbs.requestLowWaterMark', '2000000')  # decimal
             subsystem.set_config('dbs.requestCloneTransferNumber', '10000')  # decimal
-            subsystem.set_config('dbs.requestRangeDN', 'ou=requests,ou=ranges')
 
             request_number_range_start = self.mdict.get('pki_request_number_range_start')
             if request_number_range_start:
@@ -1208,6 +1207,12 @@ class PKIDeployer:
             if request_transfer:
                 subsystem.set_config('dbs.requestCloneTransferNumber', request_transfer)
 
+            if request_id_generator == 'legacy2':
+                request_dn = 'ou=requests,ou=ranges_v2'
+            else:
+                request_dn = 'ou=requests,ou=ranges'
+            subsystem.set_config('dbs.requestRangeDN', request_dn)
+
         cert_id_generator = self.mdict['pki_cert_id_generator']
 
         subsystem.set_config('dbs.cert.id.generator', cert_id_generator)
@@ -1221,7 +1226,6 @@ class PKIDeployer:
             subsystem.set_config('dbs.serialIncrement', '10000000')  # hex
             subsystem.set_config('dbs.serialLowWaterMark', '2000000')  # hex
             subsystem.set_config('dbs.serialCloneTransferNumber', '10000')  # hex
-            subsystem.set_config('dbs.serialRangeDN', 'ou=certificateRepository,ou=ranges')
 
             if config.str2bool(self.mdict['pki_random_serial_numbers_enable']):
                 subsystem.set_config('dbs.enableRandomSerialNumbers', 'true')
@@ -1246,6 +1250,12 @@ class PKIDeployer:
             serial_transfer = self.mdict.get('pki_serial_number_range_transfer')
             if serial_transfer:
                 subsystem.set_config('dbs.serialCloneTransferNumber', serial_transfer)
+
+            if cert_id_generator == 'legacy2':
+                serial_dn = 'ou=certificateRepository,ou=ranges_v2'
+            else:
+                serial_dn = 'ou=certificateRepository,ou=ranges'
+            subsystem.set_config('dbs.serialRangeDN', serial_dn)
 
         replica_number_range_start = self.mdict.get('pki_replica_number_range_start')
         if replica_number_range_start:
@@ -1277,7 +1287,12 @@ class PKIDeployer:
             subsystem.set_config('dbs.requestIncrement', '10000000')  # decimal
             subsystem.set_config('dbs.requestLowWaterMark', '2000000')  # decimal
             subsystem.set_config('dbs.requestCloneTransferNumber', '10000')  # decimal
-            subsystem.set_config('dbs.requestRangeDN', 'ou=requests,ou=ranges')
+
+            if request_id_generator == 'legacy2':
+                request_dn = 'ou=requests,ou=ranges_v2'
+            else:
+                request_dn = 'ou=requests,ou=ranges'
+            subsystem.set_config('dbs.requestRangeDN', request_dn)
 
         key_id_generator = self.mdict['pki_key_id_generator']
 
@@ -1292,7 +1307,12 @@ class PKIDeployer:
             subsystem.set_config('dbs.serialIncrement', '10000000')  # hex
             subsystem.set_config('dbs.serialLowWaterMark', '2000000')  # hex
             subsystem.set_config('dbs.serialCloneTransferNumber', '10000')  # hex
-            subsystem.set_config('dbs.serialRangeDN', 'ou=keyRepository,ou=ranges')
+
+            if key_id_generator == 'legacy2':
+                serial_dn = 'ou=keyRepository,ou=ranges_v2'
+            else:
+                serial_dn = 'ou=keyRepository,ou=ranges'
+            subsystem.set_config('dbs.serialRangeDN', serial_dn)
 
         if config.str2bool(self.mdict['pki_kra_ephemeral_requests']):
             logger.debug('Setting ephemeral requests to true')

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
@@ -238,6 +238,18 @@ public class LDAPConfigurator {
         }
     }
 
+    public void createEntry(String dn, String[] objectClasses) throws Exception {
+
+        logger.info("Adding " + dn);
+
+        LDAPAttributeSet attrs = new LDAPAttributeSet();
+        attrs.add(new LDAPAttribute("objectClass", objectClasses));
+
+        LDAPEntry entry = new LDAPEntry(dn, attrs);
+
+        connection.add(entry);
+    }
+
     public void validateDatabaseOwnership(String database, String baseDN) throws Exception {
 
         logger.info("Validating database " + database + " is owned by " + baseDN);

--- a/tests/ca/bin/ca-cert-range-objects.sh
+++ b/tests/ca/bin/ca-cert-range-objects.sh
@@ -1,13 +1,32 @@
 #!/bin/bash -e
 
+GENERATOR_TYPE=legacy
+
+while getopts "t:" arg ; do
+    case $arg in
+    t)
+        GENERATOR_TYPE=$OPTARG
+        ;;
+    esac
+done
+
+# remove parsed options and args from $@ list
+shift $((OPTIND-1))
+
 NAME=$1
-RANGE_OBJECT=$2
+
+if [ "$GENERATOR_TYPE" == "legacy2" ]
+then
+    RANGE_DN=ou=certificateRepository,ou=ranges_v2,dc=ca,dc=pki,dc=example,dc=com
+else
+    RANGE_DN=ou=certificateRepository,ou=ranges,dc=ca,dc=pki,dc=example,dc=com
+fi
 
 LIST=$(docker exec $NAME ldapsearch \
     -H ldap://$NAME.example.com:3389 \
     -D "cn=Directory Manager" \
     -w Secret.123 \
-    -b ${RANGE_OBJECT:-ou=certificateRepository,ou=ranges},dc=ca,dc=pki,dc=example,dc=com \
+    -b $RANGE_DN \
     -s one \
     -o ldif_wrap=no \
     -LLL \

--- a/tests/ca/bin/ca-request-range-objects.sh
+++ b/tests/ca/bin/ca-request-range-objects.sh
@@ -1,13 +1,32 @@
 #!/bin/bash -e
 
+GENERATOR_TYPE=legacy
+
+while getopts "t:" arg ; do
+    case $arg in
+    t)
+        GENERATOR_TYPE=$OPTARG
+        ;;
+    esac
+done
+
+# remove parsed options and args from $@ list
+shift $((OPTIND-1))
+
 NAME=$1
-RANGE_OBJECT=$2
+
+if [ "$GENERATOR_TYPE" == "legacy2" ]
+then
+    RANGE_DN=ou=requests,ou=ranges_v2,dc=ca,dc=pki,dc=example,dc=com
+else
+    RANGE_DN=ou=requests,ou=ranges,dc=ca,dc=pki,dc=example,dc=com
+fi
 
 LIST=$(docker exec $NAME ldapsearch \
     -H ldap://$NAME.example.com:3389 \
     -D "cn=Directory Manager" \
     -w Secret.123 \
-    -b ${RANGE_OBJECT:-ou=requests,ou=ranges},dc=ca,dc=pki,dc=example,dc=com \
+    -b $RANGE_DN \
     -s one \
     -o ldif_wrap=no \
     -LLL \


### PR DESCRIPTION
`pkispawn` has been modified to create `ou=ranges` subtree for SSNv1 and optionally `ou=ranges_v2` subtree for SSNv2 if it's enabled for new CA instances. The `pki-server <subsystem>-db-init` and `<subsystem>-range-update` commands have been updated to use the proper subtree to store the range objects. Hard-coded subtrees in the `create.ldif` have been removed.

Similar changes are made to KRA as well, but since there are no tests for KRA with SSNv2 it's not officially supported yet.

The test scripts have been updated to use `ou=ranges_v2` subtree for SSNv2 range objects.
