### PR TITLE
New ranges tree for legacy2  migration

### DIFF
--- a/.github/workflows/ca-clone-ssnv1-test.yml
+++ b/.github/workflows/ca-clone-ssnv1-test.yml
@@ -1006,7 +1006,7 @@ jobs:
           docker exec primary pki-server ca-id-generator-update --type legacy2 request
           docker exec primary pki-server ca-id-generator-update --type legacy2 cert
 
-      - name: Check request range objects
+      - name: Check old request range objects
         run: |
           tests/ca/bin/ca-request-range-objects-ssnv1.sh primaryds | tee output
 
@@ -1026,6 +1026,21 @@ jobs:
 
           diff expected output
 
+      - name: Check new request range objects
+        run: |
+          tests/ca/bin/ca-request-range-objects-ssnv1.sh primaryds ou=requests,ou=ranges_v2 | tee output
+
+          # request ranges should remain the same
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 11
+          endRange: 20
+          host: primary.example.com
+
+          EOF
+
+          diff expected output
+
       - name: Check request next range
         run: |
           tests/ca/bin/ca-request-next-range-ssnv1.sh primaryds | tee output
@@ -1037,7 +1052,7 @@ jobs:
 
           diff expected output
 
-      - name: Check cert range objects
+      - name: Check old cert range objects
         run: |
           tests/ca/bin/ca-cert-range-objects-ssnv1.sh primaryds | tee output
 
@@ -1045,10 +1060,26 @@ jobs:
           # the range value for the primary move from 13-30 (hex) to 19-48 (dec) 
           cat > expected << EOF
           SecurePort: 8443
+          beginRange: 13
+          endRange: 30
+          host: primary.example.com
+
+          SecurePort: 8443
           beginRange: 31
           endRange: 48
           host: secondary.example.com
 
+          EOF
+
+          diff expected output
+
+      - name: Check new cert range objects
+        run: |
+          tests/ca/bin/ca-cert-range-objects-ssnv1.sh primaryds ou=certificateRepository,ou=ranges_v2 | tee output
+
+          # cert ranges should remain the same but converted from hex to decimal
+          # the range value for the primary move from 13-30 (hex) to 19-48 (dec) 
+          cat > expected << EOF
           SecurePort: 8443
           beginRange: 19
           endRange: 48
@@ -1127,6 +1158,22 @@ jobs:
 
           diff expected output
           
+      - name: Check the new range object is configured in a different DN in all CAs
+        run: |
+          docker exec primary pki-server ca-config-show dbs.serialRangeDN | tee output
+          docker exec primary pki-server ca-config-show dbs.requestRangeDN | tee -a output
+          docker exec secondary pki-server ca-config-show dbs.serialRangeDN | tee -a output
+          docker exec secondary pki-server ca-config-show dbs.requestRangeDN | tee -a output
+
+          cat > expected <<EOF
+          ou=certificateRepository,ou=ranges_v2
+          ou=requests,ou=ranges_v2
+          ou=certificateRepository,ou=ranges_v2
+          ou=requests,ou=ranges_v2
+          EOF
+
+          diff expected output
+
       - name: Check cert range config in primary CA
         run: |
           tests/ca/bin/ca-cert-range-config.sh primary | tee output
@@ -1155,9 +1202,28 @@ jobs:
 
           diff expected output
 
-      - name: Check request range objects
+      - name: Check old request range objects
         run: |
           tests/ca/bin/ca-request-range-objects-ssnv1.sh primaryds | tee output
+
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 11
+          endRange: 20
+          host: primary.example.com
+
+          SecurePort: 8443
+          beginRange: 21
+          endRange: 30
+          host: secondary.example.com
+
+          EOF
+
+          diff expected output
+
+      - name: Check new request range objects
+        run: |
+          tests/ca/bin/ca-request-range-objects-ssnv1.sh primaryds ou=requests,ou=ranges_v2 | tee output
 
           cat > expected << EOF
           SecurePort: 8443
@@ -1184,9 +1250,29 @@ jobs:
 
           diff expected output
 
-      - name: Check cert range objects
+      - name: Check old cert range objects
         run: |
           tests/ca/bin/ca-cert-range-objects-ssnv1.sh primaryds | tee output
+
+          # cert ranges should remain the same
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 13
+          endRange: 30
+          host: primary.example.com
+
+          SecurePort: 8443
+          beginRange: 31
+          endRange: 48
+          host: secondary.example.com
+
+          EOF
+
+          diff expected output
+
+      - name: Check new cert range objects
+        run: |
+          tests/ca/bin/ca-cert-range-objects-ssnv1.sh primaryds ou=certificateRepository,ou=ranges_v2 | tee output
 
           # cert ranges should remain the same but in dec.
           # the range value for the primary move from 13-30 (hex) to 19-48 (dec)
@@ -1395,9 +1481,28 @@ jobs:
 
           diff expected output
 
-      - name: Check request range objects
+      - name: Check old request range objects
         run: |
           tests/ca/bin/ca-request-range-objects-ssnv1.sh primaryds | tee output
+
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 11
+          endRange: 20
+          host: primary.example.com
+
+          SecurePort: 8443
+          beginRange: 21
+          endRange: 30
+          host: secondary.example.com
+
+          EOF
+
+          diff expected output
+
+      - name: Check new request range objects
+        run: |
+          tests/ca/bin/ca-request-range-objects-ssnv1.sh primaryds ou=requests,ou=ranges_v2 | tee output
 
           cat > expected << EOF
           SecurePort: 8443
@@ -1449,9 +1554,29 @@ jobs:
 
           diff expected output
 
-      - name: Check cert range objects
+      - name: Check old cert range objects
         run: |
           tests/ca/bin/ca-cert-range-objects-ssnv1.sh primaryds | tee output
+
+          # cert ranges should remain the same
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 13
+          endRange: 30
+          host: primary.example.com
+
+          SecurePort: 8443
+          beginRange: 31
+          endRange: 48
+          host: secondary.example.com
+
+          EOF
+
+          diff expected output
+
+      - name: Check new cert range objects
+        run: |
+          tests/ca/bin/ca-cert-range-objects-ssnv1.sh primaryds ou=certificateRepository,ou=ranges_v2 | tee output
 
           cat > expected << EOF
           SecurePort: 8443

--- a/.github/workflows/ca-ssnv1-test.yml
+++ b/.github/workflows/ca-ssnv1-test.yml
@@ -1196,14 +1196,26 @@ jobs:
 
           diff expected output
 
-      - name: Check the radix in for the new generator
+      - name: Check the radix configured for the new generator
         run: |
           docker exec pki pki-server ca-config-show dbs.request.id.radix | tee output
           docker exec pki pki-server ca-config-show dbs.cert.id.radix | tee -a output
 
-          cat > expected <<EOF                                                                                                                                                                                                                                 
+          cat > expected <<EOF
           10
           16
+          EOF
+
+          diff expected output
+
+      - name: Check ranges entry is configured in a new tree
+        run: |
+          docker exec pki pki-server ca-config-show dbs.serialRangeDN | tee output
+          docker exec pki pki-server ca-config-show dbs.requestRangeDN | tee -a output
+
+          cat > expected <<EOF
+          ou=certificateRepository,ou=ranges_v2
+          ou=requests,ou=ranges_v2
           EOF
 
           diff expected output
@@ -1229,9 +1241,34 @@ jobs:
 
           diff expected output
 
-      - name: Check request range objects
+      - name: Check old request range objects
         run: |
           tests/ca/bin/ca-request-range-objects-ssnv1.sh ds | tee output
+
+          # new request range should be 31 - 40 decimal (total: 10)
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 11
+          endRange: 20
+          host: pki.example.com
+
+          SecurePort: 8443
+          beginRange: 21
+          endRange: 30
+          host: pki.example.com
+
+          SecurePort: 8443
+          beginRange: 31
+          endRange: 40
+          host: pki.example.com
+
+          EOF
+
+          diff expected output
+
+      - name: Check new request range objects
+        run: |
+          tests/ca/bin/ca-request-range-objects-ssnv1.sh ds ou=requests,ou=ranges_v2 | tee output
 
           # new request range should be 31 - 40 decimal (total: 10)
           cat > expected << EOF
@@ -1259,9 +1296,31 @@ jobs:
 
           diff expected output
 
-      - name: Check cert range objects
+      - name: Check old cert range objects
         run: |
           tests/ca/bin/ca-cert-range-objects-ssnv1.sh ds | tee output
+
+          # new cert range should be the same but converted to decimal
+          # first range move from 19-36 (hex) to 25-54 (dec)
+          # second range move from 37-54 (hex) to 55-84 (dec)
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 19
+          endRange: 36
+          host: pki.example.com
+
+          SecurePort: 8443
+          beginRange: 37
+          endRange: 54
+          host: pki.example.com
+
+          EOF
+
+          diff expected output
+
+      - name: Check new cert range objects
+        run: |
+          tests/ca/bin/ca-cert-range-objects-ssnv1.sh ds ou=certificateRepository,ou=ranges_v2 | tee output
 
           # new cert range should be the same but converted to decimal
           # first range move from 19-36 (hex) to 25-54 (dec)
@@ -1398,9 +1457,34 @@ jobs:
 
           diff expected output
 
-      - name: Check request range objects
+      - name: Check old request range objects
         run: |
           tests/ca/bin/ca-request-range-objects-ssnv1.sh ds | tee output
+
+          # new request range should be 31 - 40 decimal (total: 10)
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 11
+          endRange: 20
+          host: pki.example.com
+
+          SecurePort: 8443
+          beginRange: 21
+          endRange: 30
+          host: pki.example.com
+
+          SecurePort: 8443
+          beginRange: 31
+          endRange: 40
+          host: pki.example.com
+
+          EOF
+
+          diff expected output
+
+      - name: Check new request range objects
+        run: |
+          tests/ca/bin/ca-request-range-objects-ssnv1.sh ds ou=requests,ou=ranges_v2 | tee output
 
           cat > expected << EOF
           SecurePort: 8443
@@ -1452,9 +1536,31 @@ jobs:
 
           diff expected output
 
-      - name: Check cert range objects
+      - name: Check old cert range objects
         run: |
           tests/ca/bin/ca-cert-range-objects-ssnv1.sh ds | tee output
+
+          # new cert range should be the same but converted to decimal
+          # first range move from 19-36 (hex) to 25-54 (dec)
+          # second range move from 37-54 (hex) to 55-84 (dec)
+          cat > expected << EOF
+          SecurePort: 8443
+          beginRange: 19
+          endRange: 36
+          host: pki.example.com
+
+          SecurePort: 8443
+          beginRange: 37
+          endRange: 54
+          host: pki.example.com
+
+          EOF
+
+          diff expected output
+
+      - name: Check new cert range objects
+        run: |
+          tests/ca/bin/ca-cert-range-objects-ssnv1.sh ds ou=certificateRepository,ou=ranges_v2 | tee output
 
           cat > expected << EOF
           SecurePort: 8443

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CAIdGeneratorUpdateCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CAIdGeneratorUpdateCLI.java
@@ -9,9 +9,7 @@ import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.dbs.CertificateRepository;
 import com.netscape.cmscore.dbs.Repository;
 import com.netscape.cmscore.dbs.Repository.IDGenerator;
-import com.netscape.cmscore.ldapconn.LdapAuthInfo;
-import com.netscape.cmscore.ldapconn.LdapConnInfo;
-import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmscore.ldapconn.LdapBoundConnection;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.server.cli.SubsystemIdGeneratorUpdateCLI;
 import org.slf4j.Logger;
@@ -28,8 +26,9 @@ public class CAIdGeneratorUpdateCLI extends SubsystemIdGeneratorUpdateCLI {
     }
 
     @Override
-    protected void updateSerialNumberRangeGenerator(PKISocketFactory socketFactory, LdapConnInfo connInfo,
-            LdapAuthInfo authInfo, DatabaseConfig dbConfig, String baseDN, IDGenerator newGenerator, String hostName, String securePort) throws Exception {
+    protected void updateSerialNumberRangeGenerator(LdapBoundConnection conn,
+            DatabaseConfig dbConfig, String baseDN, String newRangesName,
+            IDGenerator newGenerator, String hostName, String securePort) throws Exception {
         String value = dbConfig.getString(
                 CertificateRepository.PROP_CERT_ID_GENERATOR,
                 CertificateRepository.DEFAULT_CERT_ID_GENERATOR);
@@ -46,7 +45,7 @@ public class CAIdGeneratorUpdateCLI extends SubsystemIdGeneratorUpdateCLI {
             dbConfig.put(CertificateRepository.PROP_CERT_ID_RADIX, Integer.toString(Repository.HEX));
         }
 
-        super.updateSerialNumberRangeGenerator(socketFactory, connInfo, authInfo, dbConfig, baseDN, newGenerator, hostName, securePort);
+        super.updateSerialNumberRangeGenerator(conn, dbConfig, baseDN, newRangesName, newGenerator, hostName, securePort);
     }
 
     

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/kraIdGeneratorUpdateCLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/kraIdGeneratorUpdateCLI.java
@@ -8,9 +8,7 @@ package org.dogtagpki.server.kra.cli;
 import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.dbs.KeyRepository;
 import com.netscape.cmscore.dbs.Repository;
-import com.netscape.cmscore.ldapconn.LdapAuthInfo;
-import com.netscape.cmscore.ldapconn.LdapConnInfo;
-import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmscore.ldapconn.LdapBoundConnection;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.server.cli.SubsystemIdGeneratorUpdateCLI;
 
@@ -24,8 +22,9 @@ public class kraIdGeneratorUpdateCLI extends SubsystemIdGeneratorUpdateCLI {
     }
 
     @Override
-    protected void updateSerialNumberRangeGenerator(PKISocketFactory socketFactory, LdapConnInfo connInfo,
-            LdapAuthInfo authInfo, DatabaseConfig dbConfig, String baseDN, Repository.IDGenerator newGenerator, String hostName, String securePort) throws Exception {
+    protected void updateSerialNumberRangeGenerator(LdapBoundConnection conn,
+            DatabaseConfig dbConfig, String baseDN, String newRangesName,
+            Repository.IDGenerator newGenerator, String hostName, String securePort) throws Exception {
         String value = dbConfig.getString(
                 KeyRepository.PROP_KEY_ID_GENERATOR,
                 KeyRepository.DEFAULT_KEY_ID_GENERATOR);
@@ -40,6 +39,6 @@ public class kraIdGeneratorUpdateCLI extends SubsystemIdGeneratorUpdateCLI {
             dbConfig.put(KeyRepository.PROP_KEY_ID_RADIX, Integer.toString(Repository.HEX));
         }
 
-        super.updateSerialNumberRangeGenerator(socketFactory, connInfo, authInfo, dbConfig, baseDN, newGenerator, hostName, securePort);
+        super.updateSerialNumberRangeGenerator(conn, dbConfig, baseDN, newRangesName, newGenerator, hostName, securePort);
     }
 }

--- a/base/server/python/pki/server/cli/id.py
+++ b/base/server/python/pki/server/cli/id.py
@@ -115,18 +115,19 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
         print('Usage: pki-server %s-id-generator-update [OPTIONS] <object>' %
               self.parent.parent.parent.name)
         print()
-        print('  <object>                           Element to apply the generator (e.g. cert).')
-        print('  -t, --type <generator type>        Type of generator to use (e.g. random).')
-        print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
-        print('  -v, --verbose                      Run in verbose mode.')
-        print('      --debug                        Run in debug mode.')
-        print('      --help                         Show help message.')
+        print('  <object>                         Element to apply the generator (e.g. cert).')
+        print('  -t, --type <generator type>      Type of generator to use (e.g. random).')
+        print('  -r, --range <rangeTree>          Name for the new range tree if needed.')
+        print('  -i, --instance <instance ID>     Instance ID (default: pki-tomcat).')
+        print('  -v, --verbose                    Run in verbose mode.')
+        print('      --debug                      Run in debug mode.')
+        print('      --help                       Show help message.')
         print()
 
     def execute(self, argv):
         try:
-            opts, args = getopt.gnu_getopt(argv, 'i:t:v', [
-                'instance=', 'type=',
+            opts, args = getopt.gnu_getopt(argv, 'i:t:r:v', [
+                'instance=', 'type=', 'range=',
                 'verbose', 'debug', 'help'])
 
         except getopt.GetoptError as e:
@@ -143,10 +144,14 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
         instance_name = 'pki-tomcat'
         subsystem_name = self.parent.parent.parent.name
         generator = None
+        range_object = None
 
         for o, a in opts:
             if o in ('-t', '--type'):
                 generator = a
+
+            elif o in ('-r', '--range'):
+                range_object = a
 
             elif o in ('-i', '--instance'):
                 instance_name = a
@@ -185,4 +190,4 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
                          subsystem_name.upper(), instance_name)
             sys.exit(1)
 
-        subsystem.update_id_generator(generator, generator_object)
+        subsystem.update_id_generator(generator, generator_object, range_object)

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1563,7 +1563,9 @@ class PKISubsystem(object):
 
         self.run(cmd, as_current_user=as_current_user)
 
-    def update_id_generator(self, generator, generator_object, as_current_user=False):
+    def update_id_generator(
+            self, generator, generator_object,
+            range_object=None, as_current_user=False):
 
         cmd = [self.name + '-id-generator-update']
 
@@ -1572,6 +1574,10 @@ class PKISubsystem(object):
 
         elif logger.isEnabledFor(logging.INFO):
             cmd.append('--verbose')
+
+        if range_object:
+            cmd.append('--range')
+            cmd.append(range_object)
 
         cmd.append('--type')
         cmd.append(generator)

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemIdGeneratorUpdateCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemIdGeneratorUpdateCLI.java
@@ -9,10 +9,8 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.apps.EngineConfig;
-import com.netscape.cmscore.dbs.DBSubsystem;
 import com.netscape.cmscore.dbs.Repository;
 import com.netscape.cmscore.dbs.Repository.IDGenerator;
-import static com.netscape.cmscore.dbs.Repository.logger;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
 import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
 import com.netscape.cmscore.ldapconn.LdapAuthInfo;
@@ -32,7 +30,6 @@ import netscape.ldap.LDAPModification;
 import netscape.ldap.LDAPSearchResults;
 import netscape.ldap.LDAPv3;
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.util.logging.PKILogger;
 import org.slf4j.Logger;
@@ -51,15 +48,20 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
     @Override
     public void createOptions() {
         options.addOption("t", "type", true, "Generator type to update.");
+        options.addOption("r", "range", true, "Name of the ranges entry in DS.");
     }
 
     @Override
     public void execute(CommandLine cmd) throws Exception {
-
         if (!cmd.hasOption("type")) {
             throw new Exception("Missing generator type.");
         }
         IDGenerator generator = IDGenerator.fromString(cmd.getOptionValue("type"));
+        
+        String newRangesName = generator == IDGenerator.LEGACY_2 ? "ranges_v2" : "ranges_new";
+        if (cmd.hasOption("range")) {
+            newRangesName = cmd.getOptionValue("range");
+        }
 
         if (cmd.hasOption("debug")) {
             PKILogger.setLevel(PKILogger.LogLevel.DEBUG);
@@ -101,35 +103,40 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
         socketFactory.init(socketConfig);
 
         DatabaseConfig dbConfig = cs.getDatabaseConfig();
-
-        if (generatorAtttirbute.equals("cert")){
-            updateSerialNumberRangeGenerator(
-                    socketFactory,
-                    connInfo,
-                    authInfo,
-                    dbConfig,
-                    baseDN,
-                    generator,
-                    cs.getHostname(),
-                    getSecurePort(cs));
-            cs.commit(false);
-        } else if (generatorAtttirbute.equals("request")) {
-            updateRequestNumberRangeGenerator(
-                    socketFactory,
-                    connInfo,
-                    authInfo,
-                    dbConfig,
-                    baseDN,
-                    generator);
-            cs.commit(false);
-        } else {
-            throw new EBaseException("Generator for " + generatorAtttirbute + " not supported.");            
+        LdapBoundConnection conn = new LdapBoundConnection(socketFactory, connInfo, authInfo);
+        try {
+            if (generatorAtttirbute.equals("cert")){
+                updateSerialNumberRangeGenerator(
+                        conn,
+                        dbConfig,
+                        baseDN,
+                        newRangesName,
+                        generator,
+                        cs.getHostname(),
+                        getSecurePort(cs));
+                cs.commit(false);
+            } else if (generatorAtttirbute.equals("request")) {
+                updateRequestNumberRangeGenerator(
+                        conn,
+                        dbConfig,
+                        baseDN,
+                        newRangesName,
+                        generator,
+                        cs.getHostname(),
+                        getSecurePort(cs));
+                cs.commit(false);
+            } else {
+                throw new EBaseException("Generator for " + generatorAtttirbute + " not supported.");            
+            }
+        } finally {
+            conn.disconnect();
         }
+
     }
 
-    protected void updateSerialNumberRangeGenerator(PKISocketFactory socketFactory, LdapConnInfo connInfo,
-            LdapAuthInfo authInfo, DatabaseConfig dbConfig, String baseDN, IDGenerator newGenerator,
-            String hostName, String securePort) throws Exception {
+    protected void updateSerialNumberRangeGenerator(LdapBoundConnection conn,
+            DatabaseConfig dbConfig, String baseDN, String newRangesName,
+            IDGenerator newGenerator, String hostName, String securePort) throws Exception {
         
         if (newGenerator == IDGenerator.RANDOM && idGenerator != IDGenerator.RANDOM) {
             logger.debug("Remove serial ranges from configuration");
@@ -141,81 +148,81 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
             dbConfig.remove(DatabaseConfig.SERIAL_RANGE_DN);
             return;
         }
+
         if (newGenerator == IDGenerator.LEGACY_2 && idGenerator == IDGenerator.LEGACY) {
-            logger.debug("Repository: Updating ranges entry to hex format");
+            logger.debug("SubsystemIdGeneratorUpdateCLI: Updating ranges entry to hex format");
 
-            LdapBoundConnection conn = new LdapBoundConnection(socketFactory, connInfo, authInfo);
-            try{
-                String rangeDN = dbConfig.getSerialRangeDN() + "," + baseDN;
+            String rangeDN = dbConfig.getSerialRangeDN() + "," + baseDN;
+            String newRangeDN = createRangesEntry(conn, "certificateRepository", newRangesName, baseDN);
+            dbConfig.setSerialRangeDN(newRangeDN);
+            newRangeDN = newRangeDN + "," + baseDN;
 
-                String serialIncrement = dbConfig.getSerialIncrement();
-                dbConfig.setSerialIncrement("0x" + serialIncrement);
-                BigInteger incremennt = new BigInteger(serialIncrement, 16);
+            String serialIncrement = dbConfig.getSerialIncrement();
+            dbConfig.setSerialIncrement("0x" + serialIncrement);
+            BigInteger incremennt = new BigInteger(serialIncrement, 16);
 
-                String serialLowWaterMark = dbConfig.getSerialLowWaterMark();
-                dbConfig.setSerialLowWaterMark("0x" + serialLowWaterMark);
+            String serialLowWaterMark = dbConfig.getSerialLowWaterMark();
+            dbConfig.setSerialLowWaterMark("0x" + serialLowWaterMark);
 
-                String serialCloneTransfer = dbConfig.getSerialCloneTransferNumber();
-                dbConfig.setSerialCloneTransferNumber("0x" + serialCloneTransfer);
+            String serialCloneTransfer = dbConfig.getSerialCloneTransferNumber();
+            dbConfig.setSerialCloneTransferNumber("0x" + serialCloneTransfer);
 
-                String beginSerialNumber = dbConfig.getBeginSerialNumber();
-                dbConfig.setBeginSerialNumber("0x" + beginSerialNumber);
-                BigInteger beginSerialNo = new BigInteger(beginSerialNumber, 16);
-                String endSerialNumber = dbConfig.getEndSerialNumber();
-                BigInteger endSerialNo = new BigInteger(endSerialNumber, 16);
-                if (endSerialNo.equals(beginSerialNo.add(incremennt).subtract(BigInteger.ONE))){
-                    try {
-                        LDAPEntry entrySerial = conn.read("cn=" + beginSerialNumber+"," + rangeDN);
-                        LDAPAttribute attrEnd = entrySerial.getAttribute("endRange");
-                        if (attrEnd != null) {
-                            endSerialNumber = attrEnd.getStringValues().nextElement();
-                        }
-                    } catch (LDAPException ldae) {
-                        if (ldae.getLDAPResultCode() == 32) {
-                            logger.debug("No range available, using config values");
-                        } else {
-                            logger.error("LDAP error: " + ldae.getMessage(), ldae);
-                            return;
-                        }
-
+            String beginSerialNumber = dbConfig.getBeginSerialNumber();
+            dbConfig.setBeginSerialNumber("0x" + beginSerialNumber);
+            BigInteger beginSerialNo = new BigInteger(beginSerialNumber, 16);
+            String endSerialNumber = dbConfig.getEndSerialNumber();
+            BigInteger endSerialNo = new BigInteger(endSerialNumber, 16);
+            if (endSerialNo.equals(beginSerialNo.add(incremennt).subtract(BigInteger.ONE))){
+                try {
+                    LDAPEntry entrySerial = conn.read("cn=" + beginSerialNumber+"," + rangeDN);
+                    LDAPAttribute attrEnd = entrySerial.getAttribute("endRange");
+                    if (attrEnd != null) {
+                        endSerialNumber = attrEnd.getStringValues().nextElement();
                     }
-                }
-                dbConfig.setEndSerialNumber("0x" + endSerialNumber);
-
-                String nextBeginSerial = dbConfig.getNextBeginSerialNumber();
-                String nextEndSerial = dbConfig.getNextEndSerialNumber();
-                if (nextBeginSerial != null && !nextBeginSerial.equals("-1")) {
-                    dbConfig.setNextBeginSerialNumber("0x" + nextBeginSerial);
-       
-                    try {
-                        LDAPEntry entryNextSerial = conn.read("cn=" + nextBeginSerial + "," + rangeDN);
-                        LDAPAttribute attrNextEnd = entryNextSerial.getAttribute("endRange");
-                        if (attrNextEnd != null) {
-                            nextEndSerial = attrNextEnd.getStringValues().nextElement();
-                        }
-                    } catch (LDAPException ldae) {
-                        if (ldae.getLDAPResultCode() == 32) {
-                            logger.debug("No range available, using config vaules");
-                        } else {
-                            logger.error("LDAP error", ldae);
-                            return;
-                        }
-
+                } catch (LDAPException ldae) {
+                    if (ldae.getLDAPResultCode() == 32) {
+                        logger.debug("No range available, using config values");
+                    } else {
+                        logger.error("LDAP error: " + ldae.getMessage(), ldae);
+                        return;
                     }
-                    dbConfig.setNextEndSerialNumber("0x" + nextEndSerial);
-                    endSerialNumber = nextEndSerial;
+
                 }
-                updateRanges(dbConfig, conn, baseDN, rangeDN, endSerialNumber, hostName, securePort);
-            } finally {
-                conn.disconnect();
             }
+            dbConfig.setEndSerialNumber("0x" + endSerialNumber);
+
+            String nextBeginSerial = dbConfig.getNextBeginSerialNumber();
+            String nextEndSerial = dbConfig.getNextEndSerialNumber();
+            if (nextBeginSerial != null && !nextBeginSerial.equals("-1")) {
+                dbConfig.setNextBeginSerialNumber("0x" + nextBeginSerial);
+
+                try {
+                    LDAPEntry entryNextSerial = conn.read("cn=" + nextBeginSerial + "," + rangeDN);
+                    LDAPAttribute attrNextEnd = entryNextSerial.getAttribute("endRange");
+                    if (attrNextEnd != null) {
+                        nextEndSerial = attrNextEnd.getStringValues().nextElement();
+                    }
+                } catch (LDAPException ldae) {
+                    if (ldae.getLDAPResultCode() == 32) {
+                        logger.debug("No range available, using config vaules");
+                    } else {
+                        logger.error("LDAP error", ldae);
+                        return;
+                    }
+
+                }
+                dbConfig.setNextEndSerialNumber("0x" + nextEndSerial);
+                endSerialNumber = nextEndSerial;
+            }
+            updateCertificateRanges(dbConfig, conn, baseDN, rangeDN, newRangeDN, endSerialNumber, hostName, securePort);
             return;
         }
         throw new EBaseException("Update to " + newGenerator + " not supported");
     }
 
-    protected void updateRequestNumberRangeGenerator(PKISocketFactory socketFactory, LdapConnInfo connInfo,
-            LdapAuthInfo authInfo, DatabaseConfig dbConfig, String baseDN, IDGenerator newGenerator) throws EBaseException {
+    protected void updateRequestNumberRangeGenerator(LdapBoundConnection conn,
+            DatabaseConfig dbConfig, String baseDN, String newRangesName, IDGenerator newGenerator,
+            String hostName, String securePort) throws Exception {
         
         String value = dbConfig.getString(
                 RequestRepository.PROP_REQUEST_ID_GENERATOR,
@@ -237,13 +244,21 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
         if (newGenerator == IDGenerator.LEGACY_2 && idGenerator == IDGenerator.LEGACY) {
             dbConfig.put(RequestRepository.PROP_REQUEST_ID_GENERATOR, newGenerator.toString());
             dbConfig.put(RequestRepository.PROP_REQUEST_ID_RADIX, Integer.toString(Repository.DEC));
+            String rangeDN = dbConfig.getRequestRangeDN() + "," + baseDN;
+
+            String newRangeDN = createRangesEntry(conn, "requests", newRangesName, baseDN);
+            dbConfig.setRequestRangeDN(newRangeDN);
+            newRangeDN = newRangeDN + "," + baseDN;
+
+            updateRequestRanges(conn, rangeDN, newRangeDN, hostName, securePort);
             return;
         }
         throw new EBaseException("Update to " + newGenerator + " not supported");
     }
     
-    private void updateRanges(DatabaseConfig dbConfig, LdapBoundConnection conn, String baseDN, String rangeDN, String configEndSerialNumber,
-        String hostName, String securePort) throws Exception{
+    private void updateCertificateRanges(DatabaseConfig dbConfig, LdapBoundConnection conn,
+            String baseDN, String rangeDN, String newRangeDN, String configEndSerialNumber,
+            String hostName, String securePort) throws Exception{
         LDAPSearchResults instanceRanges = conn.search(rangeDN, LDAPv3.SCOPE_SUB, "(&(objectClass=pkiRange)(host= " +
                     hostName + ")(SecurePort=" + securePort + "))", null, false);
         
@@ -268,15 +283,13 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
             attrs.add(new LDAPAttribute("host", hostName));
             attrs.add(new LDAPAttribute("securePort", securePort));
 
-            String dn = "cn=" + beginRangeNo.toString() + "," + rangeDN;
+            String dn = "cn=" + beginRangeNo.toString() + "," + newRangeDN;
             LDAPEntry rangeEntry = new LDAPEntry(dn, attrs);
-            logger.info("SubsystemRangeGeneratorUpdateCLI.updateRanges: Remove entry " + entry.getDN());
-            conn.delete(entry.getDN());
             logger.info("SubsystemRangeGeneratorUpdateCLI.updateRanges: Adding entry " + dn);
             conn.add(rangeEntry);
         }
 
-        LDAPSearchResults ranges = conn.search(rangeDN, LDAPv3.SCOPE_SUB, "(objectClass=pkiRange)", null, false);
+        LDAPSearchResults ranges = conn.search(newRangeDN, LDAPv3.SCOPE_SUB, "(objectClass=pkiRange)", null, false);
 
         BigInteger lastUsedSerial = BigInteger.ZERO;
         boolean nextRangeToUpdate = true;
@@ -309,5 +322,72 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
 
             conn.modify(serialDN, serialmod);
         }
+    }
+    private void updateRequestRanges(LdapBoundConnection conn, String rangeDN, String newRangeDN,
+            String hostName, String securePort) throws Exception{
+        LDAPSearchResults instanceRanges = conn.search(rangeDN, LDAPv3.SCOPE_SUB, "(&(objectClass=pkiRange)(host= " +
+                    hostName + ")(SecurePort=" + securePort + "))", null, false);
+        
+        // update all ranges associated to the CA to update to decimal
+        while (instanceRanges.hasMoreElements()) {
+            LDAPEntry entry = instanceRanges.next();
+            String beginRange = entry.getAttribute("beginRange").getStringValues().nextElement();
+            String endRange = entry.getAttribute("endRange").getStringValues().nextElement();
+            LDAPAttributeSet attrs = new LDAPAttributeSet();
+            attrs.add(new LDAPAttribute("objectClass", "top"));
+            attrs.add(new LDAPAttribute("objectClass", "pkiRange"));
+
+            // store beginRange as decimal
+            attrs.add(new LDAPAttribute("beginRange", beginRange));
+
+            // store endRange as decimal
+            attrs.add(new LDAPAttribute("endRange", endRange));
+
+            attrs.add(new LDAPAttribute("cn", beginRange));
+            attrs.add(new LDAPAttribute("host", hostName));
+            attrs.add(new LDAPAttribute("securePort", securePort));
+
+            String dn = "cn=" + beginRange + "," + newRangeDN;
+            LDAPEntry rangeEntry = new LDAPEntry(dn, attrs);
+            logger.info("SubsystemRangeGeneratorUpdateCLI.updateRanges: Adding entry " + dn);
+            conn.add(rangeEntry);
+        }
+    }
+    
+    private String createRangesEntry(LdapBoundConnection conn, String newRangeObject, String ranges, String baseDN) throws Exception {
+        String baseRanges =  "ou=" + ranges;
+        String baseRangesDN = baseRanges + "," + baseDN;
+        try {
+            logger.debug("SubsystemRangeGeneratorUpdateCLI: Create ranges entry: {}", baseRangesDN);
+            LDAPAttributeSet attrs = new LDAPAttributeSet();
+            attrs.add(new LDAPAttribute("objectClass", "top"));
+            attrs.add(new LDAPAttribute("objectClass", "organizationalUnit"));
+            attrs.add(new LDAPAttribute("ou", ranges));
+            LDAPEntry rangesEntry = new LDAPEntry(baseRangesDN, attrs);
+            conn.add(rangesEntry);
+        } catch (LDAPException ldae) {
+            if (ldae.getLDAPResultCode() != 68) {
+                throw new EBaseException("Impossible create ranges object: " + ldae.getMessage(), ldae);
+            }
+            logger.debug("SubsystemRangeGeneratorUpdateCLI: entry {} already exist", baseRangesDN);
+        }
+        
+        String newRangeEntry = "ou=" + newRangeObject + "," + baseRanges;
+        String newRangeEntryDN = newRangeEntry + "," + baseDN;
+        logger.debug("SubsystemRangeGeneratorUpdateCLI: Create range entry: {}", newRangeEntryDN);
+        try {
+            LDAPAttributeSet attrs = new LDAPAttributeSet();
+            attrs.add(new LDAPAttribute("objectClass", "top"));
+            attrs.add(new LDAPAttribute("objectClass", "organizationalUnit"));
+            attrs.add(new LDAPAttribute("ou", newRangeObject));
+            LDAPEntry rangeEntry = new LDAPEntry(newRangeEntryDN, attrs);
+            conn.add(rangeEntry);
+        } catch (LDAPException ldae) {
+            if (ldae.getLDAPResultCode() != 68) {
+                throw new EBaseException("Impossible access object in ranges: " + ldae.getMessage(), ldae);
+            }
+            logger.debug("SubsystemRangeGeneratorUpdateCLI: entry {} already exist", baseRangesDN);            
+        }
+        return newRangeEntry;
     }
 }

--- a/tests/ca/bin/ca-cert-range-objects-ssnv1.sh
+++ b/tests/ca/bin/ca-cert-range-objects-ssnv1.sh
@@ -1,12 +1,13 @@
 #!/bin/bash -e
 
 NAME=$1
+RANGE_OBJECT=$2
 
 LIST=$(docker exec $NAME ldapsearch \
     -H ldap://$NAME.example.com:3389 \
     -D "cn=Directory Manager" \
     -w Secret.123 \
-    -b ou=certificateRepository,ou=ranges,dc=ca,dc=pki,dc=example,dc=com \
+    -b ${RANGE_OBJECT:-ou=certificateRepository,ou=ranges},dc=ca,dc=pki,dc=example,dc=com \
     -s one \
     -o ldif_wrap=no \
     -LLL \

--- a/tests/ca/bin/ca-request-range-objects-ssnv1.sh
+++ b/tests/ca/bin/ca-request-range-objects-ssnv1.sh
@@ -1,12 +1,13 @@
 #!/bin/bash -e
 
 NAME=$1
+RANGE_OBJECT=$2
 
 LIST=$(docker exec $NAME ldapsearch \
     -H ldap://$NAME.example.com:3389 \
     -D "cn=Directory Manager" \
     -w Secret.123 \
-    -b ou=requests,ou=ranges,dc=ca,dc=pki,dc=example,dc=com \
+    -b ${RANGE_OBJECT:-ou=requests,ou=ranges},dc=ca,dc=pki,dc=example,dc=com \
     -s one \
     -o ldif_wrap=no \
     -LLL \


### PR DESCRIPTION
During migration from `legacy` to `legacy2` generator the ranges object are not modified but entries are duplicated in a new tree with the correct format and this new tree is used for the following range allocations.

The default ranges object will be `ranges_v2` but the value can be modified wit the option `-r` or `--range` to the command `pki-server <subsystem>-id-generator-update`.