### PR TITLE
Command file required for PrettyPrintCert

### DIFF
--- a/pki.spec
+++ b/pki.spec
@@ -593,6 +593,7 @@ Requires:         openldap-clients
 Requires:         nss-tools >= 3.36.1
 Requires:         %{product_id}-java = %{version}-%{release}
 Requires:         p11-kit-trust
+Requires:         file
 
 # PKICertImport depends on certutil and openssl
 Requires:         nss-tools


### PR DESCRIPTION
F41 does not include the `file` command in the default installation and need to be installed because it is used by PrettyPrintCert to distinguish between pem and der certificates.

Solve EST CI error: https://github.com/dogtagpki/pki/actions/runs/11614781119/job/32344308552#step:25:27