### PR TITLE
Relocate SSNv2 nextRange attribute

### DIFF
--- a/.github/workflows/ca-clone-ssnv1-test.yml
+++ b/.github/workflows/ca-clone-ssnv1-test.yml
@@ -1063,7 +1063,7 @@ jobs:
           docker exec primary pki-server ca-id-generator-update -v --type legacy2 request
           docker exec primary pki-server ca-id-generator-update -v --type legacy2 cert
 
-      - name: Check old request range objects
+      - name: Check request range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh primaryds | tee output
@@ -1084,7 +1084,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new request range objects
+      - name: Check request range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
@@ -1100,7 +1100,7 @@ jobs:
 
           diff expected output
 
-      - name: Check request next range
+      - name: Check request next range for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-request-next-range.sh primaryds | tee output
@@ -1112,7 +1112,19 @@ jobs:
 
           diff expected output
 
-      - name: Check old cert range objects
+      - name: Check request next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 primaryds | tee output
+
+          # request nextRange should remain the same
+          cat > expected << EOF
+          nextRange: 21
+          EOF
+
+          diff expected output
+
+      - name: Check cert range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh primaryds | tee output
@@ -1134,7 +1146,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new cert range objects
+      - name: Check cert range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
@@ -1151,12 +1163,24 @@ jobs:
 
           diff expected output
 
-      - name: Check cert next range
+      - name: Check cert next range for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-cert-next-range.sh primaryds | tee output
 
-          # cert nextRange should remain the same
+          # next range should remain the same
+          cat > expected << EOF
+          nextRange: 49
+          EOF
+
+          diff expected output
+
+      - name: Check cert next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 primaryds | tee output
+
+          # next range should be endRange + 1
           cat > expected << EOF
           nextRange: 49
           EOF
@@ -1273,7 +1297,7 @@ jobs:
 
           diff expected output
 
-      - name: Check old request range objects
+      - name: Check request range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh primaryds | tee output
@@ -1293,7 +1317,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new request range objects
+      - name: Check request range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
@@ -1323,7 +1347,29 @@ jobs:
 
           diff expected output
 
-      - name: Check old cert range objects
+      - name: Check request next range for SSNv1
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh primaryds | tee output
+
+          cat > expected << EOF
+          nextRange: 31
+          EOF
+
+          diff expected output
+
+      - name: Check request next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 primaryds | tee output
+
+          cat > expected << EOF
+          nextRange: 51
+          EOF
+
+          diff expected output
+
+      - name: Check cert range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh primaryds | tee output
@@ -1344,7 +1390,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new cert range objects
+      - name: Check cert range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
@@ -1367,22 +1413,24 @@ jobs:
 
           diff expected output
 
-      - name: Check request repository
-        if: always()
-        run: |
-          tests/ca/bin/ca-request-next-range.sh primaryds | tee output
-
-          cat > expected << EOF
-          nextRange: 51
-          EOF
-
-          diff expected output
-
-      - name: Check cert repository
+      - name: Check cert next range for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-cert-next-range.sh primaryds | tee output
 
+          # next range should remain the same
+          cat > expected << EOF
+          nextRange: 49
+          EOF
+
+          diff expected output
+
+      - name: Check cert next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 primaryds | tee output
+
+          # next range should be endRange + 1
           cat > expected << EOF
           nextRange: 73
           EOF
@@ -1568,7 +1616,7 @@ jobs:
 
           diff expected output
 
-      - name: Check old request range objects
+      - name: Check request range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh primaryds | tee output
@@ -1588,7 +1636,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new request range objects
+      - name: Check request range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh -t legacy2 primaryds | tee output
@@ -1643,7 +1691,29 @@ jobs:
 
           diff expected output
 
-      - name: Check old cert range objects
+      - name: Check request next range for SSNv1
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh primaryds | tee output
+
+          cat > expected << EOF
+          nextRange: 31
+          EOF
+
+          diff expected output
+
+      - name: Check request next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 primaryds | tee output
+
+          cat > expected << EOF
+          nextRange: 101
+          EOF
+
+          diff expected output
+
+      - name: Check cert range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh primaryds | tee output
@@ -1664,7 +1734,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new cert range objects
+      - name: Check cert range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh -t legacy2 primaryds | tee output
@@ -1699,22 +1769,24 @@ jobs:
 
           diff expected output
 
-      - name: Check request repository
-        if: always()
-        run: |
-          tests/ca/bin/ca-request-next-range.sh primaryds | tee output
-
-          cat > expected << EOF
-          nextRange: 101
-          EOF
-
-          diff expected output
-
-      - name: Check cert repository
+      - name: Check cert next range for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-cert-next-range.sh primaryds | tee output
 
+          # next range should remain the same
+          cat > expected << EOF
+          nextRange: 49
+          EOF
+
+          diff expected output
+
+      - name: Check cert next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 primaryds | tee output
+
+          # next range should be endRange + 1
           cat > expected << EOF
           nextRange: 127
           EOF

--- a/.github/workflows/ca-clone-ssnv2-test.yml
+++ b/.github/workflows/ca-clone-ssnv2-test.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh primaryds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 primaryds | tee output
 
           # nextRange should be endRange + 1 = 11
           cat > expected << EOF
@@ -208,7 +208,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh primaryds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 primaryds | tee output
 
           # nextRange should be dbs.endSerialNumber + 1 = 0x19 or 25
           cat > expected << EOF
@@ -412,7 +412,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh secondaryds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 secondaryds | tee output
 
           # nextRange should be the same
           cat > expected << EOF
@@ -424,7 +424,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh secondaryds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 secondaryds | tee output
 
           # nextRange should be the same
           cat > expected << EOF
@@ -579,7 +579,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh primaryds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 primaryds | tee output
 
           # nextRange should be the same
           cat > expected << EOF
@@ -591,7 +591,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh primaryds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 primaryds | tee output
 
           # nextRange should be the same
           cat > expected << EOF
@@ -885,7 +885,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh primaryds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 primaryds | tee output
 
           # nextRange should be endRange + 1 = 31
           cat > expected << EOF
@@ -897,7 +897,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh primaryds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 primaryds | tee output
 
           # nextRange should be endRange + 1 = 61 or 0x3d
           cat > expected << EOF
@@ -1081,7 +1081,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh primaryds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 primaryds | tee output
 
           # nextRange should be the same
           cat > expected << EOF
@@ -1093,7 +1093,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh primaryds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 primaryds | tee output
 
           # nextRange should be the same
           cat > expected << EOF

--- a/.github/workflows/ca-ssnv1-test.yml
+++ b/.github/workflows/ca-ssnv1-test.yml
@@ -1298,30 +1298,7 @@ jobs:
 
           diff expected output
 
-      - name: Check request repository
-        if: always()
-        run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
-
-          # request nextRange should be incremented by 10 decimal to 41 decimal
-          cat > expected << EOF
-          nextRange: 51
-          EOF
-
-          diff expected output
-
-      - name: Check cert repository
-        if: always()
-        run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
-
-          cat > expected << EOF
-          nextRange: 85
-          EOF
-
-          diff expected output
-
-      - name: Check old request range objects
+      - name: Check request range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh ds | tee output
@@ -1347,7 +1324,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new request range objects
+      - name: Check request range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
@@ -1378,7 +1355,31 @@ jobs:
 
           diff expected output
 
-      - name: Check old cert range objects
+      - name: Check request next range for SSNv1
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh ds | tee output
+
+          # request nextRange should be incremented by 10 decimal to 41 decimal
+          cat > expected << EOF
+          nextRange: 41
+          EOF
+
+          diff expected output
+
+      - name: Check request next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
+
+          # request nextRange should be incremented by 10 decimal to 41 decimal
+          cat > expected << EOF
+          nextRange: 51
+          EOF
+
+          diff expected output
+
+      - name: Check cert range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh ds | tee output
@@ -1401,7 +1402,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new cert range objects
+      - name: Check cert range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
@@ -1420,6 +1421,30 @@ jobs:
           endRange: 84
           host: pki.example.com
 
+          EOF
+
+          diff expected output
+
+      - name: Check cert next range for SSNv1
+        if: always()
+        run: |
+          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+
+          # next range should remain the same
+          cat > expected << EOF
+          nextRange: 55
+          EOF
+
+          diff expected output
+
+      - name: Check cert next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
+
+          # next range should be endRange + 1
+          cat > expected << EOF
+          nextRange: 85
           EOF
 
           diff expected output
@@ -1524,29 +1549,7 @@ jobs:
 
           diff expected output
 
-      - name: Check request repository
-        if: always()
-        run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
-
-          cat > expected << EOF
-          nextRange: 101
-          EOF
-
-          diff expected output
-
-      - name: Check cert repository
-        if: always()
-        run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
-
-          cat > expected << EOF
-          nextRange: 121
-          EOF
-
-          diff expected output
-
-      - name: Check old request range objects
+      - name: Check request range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh ds | tee output
@@ -1572,7 +1575,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new request range objects
+      - name: Check request range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-request-range-objects.sh -t legacy2 ds | tee output
@@ -1627,7 +1630,29 @@ jobs:
 
           diff expected output
 
-      - name: Check old cert range objects
+      - name: Check request next range for SSNv1
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh ds | tee output
+
+          cat > expected << EOF
+          nextRange: 41
+          EOF
+
+          diff expected output
+
+      - name: Check request next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
+
+          cat > expected << EOF
+          nextRange: 101
+          EOF
+
+          diff expected output
+
+      - name: Check cert range objects for SSNv1
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh ds | tee output
@@ -1650,7 +1675,7 @@ jobs:
 
           diff expected output
 
-      - name: Check new cert range objects
+      - name: Check cert range objects for SSNv2
         if: always()
         run: |
           tests/ca/bin/ca-cert-range-objects.sh -t legacy2 ds | tee output
@@ -1676,6 +1701,30 @@ jobs:
           endRange: 120
           host: pki.example.com
 
+          EOF
+
+          diff expected output
+
+      - name: Check cert next range for SSNv1
+        if: always()
+        run: |
+          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+
+          # next range should remain the same
+          cat > expected << EOF
+          nextRange: 55
+          EOF
+
+          diff expected output
+
+      - name: Check cert next range for SSNv2
+        if: always()
+        run: |
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
+
+          # next range should be endRange + 1
+          cat > expected << EOF
+          nextRange: 121
           EOF
 
           diff expected output

--- a/.github/workflows/ca-ssnv2-test.yml
+++ b/.github/workflows/ca-ssnv2-test.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # request nextRange should be dbs.endRequestNumber + 1 = 11
           cat > expected << EOF
@@ -184,7 +184,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # cert nextRange should be dbs.endSerialNumber + 1 = 0x19 or 25
           cat > expected << EOF
@@ -280,7 +280,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # nextRange should be endRange + 1 = 21
           cat > expected << EOF
@@ -292,7 +292,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # nextRange should be the same
           cat > expected << EOF
@@ -415,7 +415,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # nextRange should be the same
           cat > expected << EOF
@@ -427,7 +427,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # nextRange should be the same
           cat > expected << EOF
@@ -543,7 +543,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # request nextRange should be the same
           cat > expected << EOF
@@ -555,7 +555,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # cert nextRange should be the same
           cat > expected << EOF
@@ -653,7 +653,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # request nextRange should be incremented by 10 to 31
           cat > expected << EOF
@@ -665,7 +665,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # cert nextRequest should incremented by 0x12 to 0x2b or 43
           cat > expected << EOF
@@ -790,7 +790,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # request nextRange should be the same
           cat > expected << EOF
@@ -802,7 +802,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # cert nextRange should be the same
           cat > expected << EOF
@@ -929,7 +929,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # request nextRange should be the same
           cat > expected << EOF
@@ -941,7 +941,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # cert nextRange should be the same
           cat > expected << EOF
@@ -1049,7 +1049,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # request nextRange should be incremented by 10 to 41
           cat > expected << EOF
@@ -1061,7 +1061,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # cert nextRange should be incremented by 0x12 to 0x47 or 61
           cat > expected << EOF
@@ -1196,7 +1196,7 @@ jobs:
       - name: Check request next range
         if: always()
         run: |
-          tests/ca/bin/ca-request-next-range.sh ds | tee output
+          tests/ca/bin/ca-request-next-range.sh -t legacy2 ds | tee output
 
           # request nextRange should be the same
           cat > expected << EOF
@@ -1208,7 +1208,7 @@ jobs:
       - name: Check cert next range
         if: always()
         run: |
-          tests/ca/bin/ca-cert-next-range.sh ds | tee output
+          tests/ca/bin/ca-cert-next-range.sh -t legacy2 ds | tee output
 
           # cert nextRange should be the same
           cat > expected << EOF

--- a/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
@@ -109,7 +109,7 @@ public class CertificateRepository extends Repository {
         try {
             this.mRadix = dbc.getInteger(PROP_CERT_ID_RADIX, HEX);
             logger.debug("CertificateRepository: number radix {}", this.mRadix);
-            
+
         } catch (EBaseException ex) {
             logger.debug("CertificateRepository: error reading number radix config, using default {} for ", HEX);
         }
@@ -217,6 +217,17 @@ public class CertificateRepository extends Repository {
         if (incrementNo != null) {
             mIncrementNo = new BigInteger(incrementNo, mRadix);
         }
+    }
+
+    public String getNextRangeDN() {
+
+        if (idGenerator == IDGenerator.LEGACY_2) {
+            // store nextRange in range subtree for SSNv2
+            return rangeDN;
+        }
+
+        // store nextRange in repository subtree for SSNv1
+        return super.getNextRangeDN();
     }
 
     public void setMinSerialConfig() throws EBaseException {

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CARangeUpdateCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CARangeUpdateCLI.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.dbs.CertificateRepository;
 import com.netscape.cmscore.dbs.Repository.IDGenerator;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
 import com.netscape.cmscore.ldapconn.LdapAuthInfo;
 import com.netscape.cmscore.ldapconn.LdapConnInfo;
 import com.netscape.cmscore.ldapconn.PKISocketFactory;
@@ -44,6 +45,7 @@ public class CARangeUpdateCLI extends SubsystemRangeUpdateCLI {
             PKISocketFactory socketFactory,
             LdapConnInfo connInfo,
             LdapAuthInfo authInfo,
+            LDAPConfig ldapConfig,
             DatabaseConfig dbConfig,
             String baseDN) throws Exception {
 
@@ -58,6 +60,7 @@ public class CARangeUpdateCLI extends SubsystemRangeUpdateCLI {
                 socketFactory,
                 connInfo,
                 authInfo,
+                ldapConfig,
                 dbConfig,
                 baseDN);
     }

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRARangeUpdateCLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRARangeUpdateCLI.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.dbs.KeyRepository;
 import com.netscape.cmscore.dbs.Repository.IDGenerator;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
 import com.netscape.cmscore.ldapconn.LdapAuthInfo;
 import com.netscape.cmscore.ldapconn.LdapConnInfo;
 import com.netscape.cmscore.ldapconn.PKISocketFactory;
@@ -44,6 +45,7 @@ public class KRARangeUpdateCLI extends SubsystemRangeUpdateCLI {
             PKISocketFactory socketFactory,
             LdapConnInfo connInfo,
             LdapAuthInfo authInfo,
+            LDAPConfig ldapConfig,
             DatabaseConfig dbConfig,
             String baseDN) throws Exception {
 
@@ -58,6 +60,7 @@ public class KRARangeUpdateCLI extends SubsystemRangeUpdateCLI {
                 socketFactory,
                 connInfo,
                 authInfo,
+                ldapConfig,
                 dbConfig,
                 baseDN);
     }

--- a/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
+++ b/base/server/src/main/java/com/netscape/cmscore/request/RequestRepository.java
@@ -83,7 +83,7 @@ public class RequestRepository extends Repository {
         try {
             this.mRadix = dbc.getInteger(PROP_REQUEST_ID_RADIX, DEC);
             logger.debug("CertificateRepository: number radix {}", this.mRadix);
-            
+
         } catch (EBaseException ex) {
             logger.debug("CertificateRepository: error reading number radix config, using default {} for ", HEX);
         }
@@ -200,6 +200,17 @@ public class RequestRepository extends Repository {
         if (incrementNo != null) {
             mIncrementNo = new BigInteger(incrementNo, mRadix);
         }
+    }
+
+    public String getNextRangeDN() {
+
+        if (idGenerator == IDGenerator.LEGACY_2) {
+            // store nextRange in range subtree for SSNv2
+            return rangeDN;
+        }
+
+        // store nextRange in repository subtree for SSNv1
+        return super.getNextRangeDN();
     }
 
     public void setMinSerialConfig() throws EBaseException {

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
@@ -109,6 +109,15 @@ public class SubsystemDBInitCLI extends SubsystemCLI {
             return;
         }
 
+        if (serialIDGenerator == IDGenerator.LEGACY_2) {
+            // create serial ranges subtree for SSNv2
+            // use repository object class to support nextRange
+            ldapConfigurator.createEntry(
+                    requestRangeRDN + "," + ldapConfig.getBaseDN(),
+                    new String[] { "repository" });
+            return;
+        }
+
         // create ou=requests,ou=ranges for SSNv1 or
         // ou=requests,ou=ranges_v2 for SSNv2
         ldapConfigurator.createEntry(
@@ -125,15 +134,25 @@ public class SubsystemDBInitCLI extends SubsystemCLI {
 
         if (StringUtils.isEmpty(serialRangeRDN)) {
             // dbs.serialRangeDN only exists in CA and KRA
+            // serial ranges subtree is not needed for other subsystems
             return;
         }
 
         if (serialIDGenerator == IDGenerator.RANDOM) {
+            // serial ranges subtree is not needed for RSNv3
             return;
         }
 
-        // create ou=certificateRepository,ou=ranges for SSNv1 or
-        // ou=certificateRepository,ou=ranges_v2 for SSNv2
+        if (serialIDGenerator == IDGenerator.LEGACY_2) {
+            // create serial ranges subtree for SSNv2
+            // use repository object class to support nextRange
+            ldapConfigurator.createEntry(
+                    serialRangeRDN + "," + ldapConfig.getBaseDN(),
+                    new String[] { "repository" });
+            return;
+        }
+
+        // create serial ranges subtree for SSNv1
         ldapConfigurator.createEntry(
                 serialRangeRDN + "," + ldapConfig.getBaseDN(),
                 new String[] { "organizationalUnit" });

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemIdGeneratorUpdateCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemIdGeneratorUpdateCLI.java
@@ -5,10 +5,19 @@
 //
 package org.dogtagpki.server.cli;
 
+import java.math.BigInteger;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.util.logging.PKILogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.DatabaseConfig;
 import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.dbs.DBSubsystem;
 import com.netscape.cmscore.dbs.Repository;
 import com.netscape.cmscore.dbs.Repository.IDGenerator;
 import com.netscape.cmscore.ldapconn.LDAPConfig;
@@ -21,7 +30,7 @@ import com.netscape.cmscore.ldapconn.PKISocketFactory;
 import com.netscape.cmscore.request.RequestRepository;
 import com.netscape.cmsutil.password.PasswordStore;
 import com.netscape.cmsutil.password.PasswordStoreConfig;
-import java.math.BigInteger;
+
 import netscape.ldap.LDAPAttribute;
 import netscape.ldap.LDAPAttributeSet;
 import netscape.ldap.LDAPEntry;
@@ -29,11 +38,6 @@ import netscape.ldap.LDAPException;
 import netscape.ldap.LDAPModification;
 import netscape.ldap.LDAPSearchResults;
 import netscape.ldap.LDAPv3;
-import org.apache.commons.cli.CommandLine;
-import org.dogtagpki.cli.CLI;
-import org.dogtagpki.util.logging.PKILogger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Marco Fargetta {@literal <mfargett@redhat.com>}
@@ -57,7 +61,7 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
             throw new Exception("Missing generator type.");
         }
         IDGenerator generator = IDGenerator.fromString(cmd.getOptionValue("type"));
-        
+
         String newRangesName = generator == IDGenerator.LEGACY_2 ? "ranges_v2" : "ranges_new";
         if (cmd.hasOption("range")) {
             newRangesName = cmd.getOptionValue("range");
@@ -126,7 +130,7 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
                         getSecurePort(cs));
                 cs.commit(false);
             } else {
-                throw new EBaseException("Generator for " + generatorAtttirbute + " not supported.");            
+                throw new EBaseException("Generator for " + generatorAtttirbute + " not supported.");
             }
         } finally {
             conn.disconnect();
@@ -137,7 +141,7 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
     protected void updateSerialNumberRangeGenerator(LdapBoundConnection conn,
             DatabaseConfig dbConfig, String baseDN, String newRangesName,
             IDGenerator newGenerator, String hostName, String securePort) throws Exception {
-        
+
         if (newGenerator == IDGenerator.RANDOM && idGenerator != IDGenerator.RANDOM) {
             logger.debug("Remove serial ranges from configuration");
             dbConfig.remove(DatabaseConfig.MIN_SERIAL_NUMBER);
@@ -214,7 +218,8 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
                 dbConfig.setNextEndSerialNumber("0x" + nextEndSerial);
                 endSerialNumber = nextEndSerial;
             }
-            updateCertificateRanges(dbConfig, conn, baseDN, rangeDN, newRangeDN, endSerialNumber, hostName, securePort);
+
+            updateSerialRanges(conn, rangeDN, newRangeDN, endSerialNumber, hostName, securePort);
             return;
         }
         throw new EBaseException("Update to " + newGenerator + " not supported");
@@ -223,7 +228,7 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
     protected void updateRequestNumberRangeGenerator(LdapBoundConnection conn,
             DatabaseConfig dbConfig, String baseDN, String newRangesName, IDGenerator newGenerator,
             String hostName, String securePort) throws Exception {
-        
+
         String value = dbConfig.getString(
                 RequestRepository.PROP_REQUEST_ID_GENERATOR,
                 RequestRepository.DEFAULT_REQUEST_ID_GENERATOR);
@@ -241,27 +246,88 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
             dbConfig.put(RequestRepository.PROP_REQUEST_ID_LENGTH, "128");
             return;
         }
+
         if (newGenerator == IDGenerator.LEGACY_2 && idGenerator == IDGenerator.LEGACY) {
+
+            logger.info("Updating request range configuration");
+
             dbConfig.put(RequestRepository.PROP_REQUEST_ID_GENERATOR, newGenerator.toString());
             dbConfig.put(RequestRepository.PROP_REQUEST_ID_RADIX, Integer.toString(Repository.DEC));
-            String rangeDN = dbConfig.getRequestRangeDN() + "," + baseDN;
 
+            String rangeDN = dbConfig.getRequestRangeDN() + "," + baseDN;
             String newRangeDN = createRangesEntry(conn, "requests", newRangesName, baseDN);
             dbConfig.setRequestRangeDN(newRangeDN);
             newRangeDN = newRangeDN + "," + baseDN;
 
-            updateRequestRanges(conn, rangeDN, newRangeDN, hostName, securePort);
+            String requestIncrement = dbConfig.getRequestIncrement();
+            BigInteger increment = new BigInteger(requestIncrement);
+
+            String beginRequestNumber = dbConfig.getBeginRequestNumber();
+            BigInteger beginRequestNo = new BigInteger(beginRequestNumber);
+
+            String endRequestNumber = dbConfig.getEndRequestNumber();
+            BigInteger endRequestNo = new BigInteger(endRequestNumber);
+
+            if (endRequestNo.equals(beginRequestNo.add(increment).subtract(BigInteger.ONE))) {
+                try {
+                    LDAPEntry entryRequest = conn.read("cn=" + beginRequestNumber+"," + rangeDN);
+                    LDAPAttribute attrEnd = entryRequest.getAttribute("endRange");
+                    if (attrEnd != null) {
+                        endRequestNumber = attrEnd.getStringValues().nextElement();
+                    }
+                } catch (LDAPException ldae) {
+                    if (ldae.getLDAPResultCode() == 32) {
+                        logger.info("No range available, using config values");
+                    } else {
+                        logger.error("LDAP error: " + ldae.getMessage(), ldae);
+                        return;
+                    }
+
+                }
+            }
+
+            dbConfig.setEndRequestNumber(endRequestNumber);
+
+            String nextBeginRequest = dbConfig.getNextBeginRequestNumber();
+            String nextEndRequest = dbConfig.getNextEndRequestNumber();
+
+            if (nextBeginRequest != null && !nextBeginRequest.equals("-1")) {
+                try {
+                    LDAPEntry entryNextRequest = conn.read("cn=" + nextBeginRequest + "," + rangeDN);
+                    LDAPAttribute attrNextEnd = entryNextRequest.getAttribute("endRange");
+                    if (attrNextEnd != null) {
+                        nextEndRequest = attrNextEnd.getStringValues().nextElement();
+                    }
+                } catch (LDAPException ldae) {
+                    if (ldae.getLDAPResultCode() == 32) {
+                        logger.info("No range available, using config values");
+                    } else {
+                        logger.error("LDAP error: " + ldae.getMessage(), ldae);
+                        return;
+                    }
+
+                }
+                dbConfig.setNextEndRequestNumber(nextEndRequest);
+                endRequestNumber = nextEndRequest;
+            }
+
+            updateRequestRanges(conn, rangeDN, newRangeDN, endRequestNumber, hostName, securePort);
             return;
         }
         throw new EBaseException("Update to " + newGenerator + " not supported");
     }
-    
-    private void updateCertificateRanges(DatabaseConfig dbConfig, LdapBoundConnection conn,
-            String baseDN, String rangeDN, String newRangeDN, String configEndSerialNumber,
-            String hostName, String securePort) throws Exception{
+
+    private void updateSerialRanges(
+            LdapBoundConnection conn,
+            String rangeDN,
+            String newRangeDN,
+            String configEndSerialNumber,
+            String hostName,
+            String securePort) throws Exception{
+
         LDAPSearchResults instanceRanges = conn.search(rangeDN, LDAPv3.SCOPE_SUB, "(&(objectClass=pkiRange)(host= " +
                     hostName + ")(SecurePort=" + securePort + "))", null, false);
-        
+
         // update all ranges associated to the CA to update to decimal
         while (instanceRanges.hasMoreElements()) {
             LDAPEntry entry = instanceRanges.next();
@@ -269,23 +335,27 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
             BigInteger beginRangeNo = new BigInteger(beginRange, 16);
             String endRange = entry.getAttribute("endRange").getStringValues().nextElement();
             BigInteger endRangeNo = new BigInteger(endRange, 16);
+
+            String dn = "cn=" + beginRangeNo.toString() + "," + newRangeDN;
+            logger.info("Creating serial range " + dn);
+
             LDAPAttributeSet attrs = new LDAPAttributeSet();
             attrs.add(new LDAPAttribute("objectClass", "top"));
             attrs.add(new LDAPAttribute("objectClass", "pkiRange"));
 
             // store beginRange as decimal
+            logger.info("- begin range: " + beginRangeNo.toString() + " (0x" + beginRangeNo.toString(16) + ")");
             attrs.add(new LDAPAttribute("beginRange", beginRangeNo.toString()));
 
             // store endRange as decimal
+            logger.info("- end range: " + endRangeNo.toString() + " (0x" + endRangeNo.toString(16) + ")");
             attrs.add(new LDAPAttribute("endRange", endRangeNo.toString()));
 
             attrs.add(new LDAPAttribute("cn", beginRangeNo.toString()));
             attrs.add(new LDAPAttribute("host", hostName));
             attrs.add(new LDAPAttribute("securePort", securePort));
 
-            String dn = "cn=" + beginRangeNo.toString() + "," + newRangeDN;
             LDAPEntry rangeEntry = new LDAPEntry(dn, attrs);
-            logger.info("SubsystemRangeGeneratorUpdateCLI.updateRanges: Adding entry " + dn);
             conn.add(rangeEntry);
         }
 
@@ -294,7 +364,7 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
         BigInteger lastUsedSerial = BigInteger.ZERO;
         boolean nextRangeToUpdate = true;
         // Search for the last range entry. If it is associated to the CA to update or ranges are not defined
-        // then the nextRange is         
+        // then the nextRange is
         while (ranges.hasMoreElements()) {
             LDAPEntry entry = ranges.next();
             String endRange = entry.getAttribute("endRange").getStringValues().nextElement();
@@ -304,57 +374,112 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
             if (lastUsedSerial.compareTo(next) < 0) {
                 lastUsedSerial = next;
                 nextRangeToUpdate = host.equals(hostName) && port.equals(securePort);
-                
             }
         }
 
         if (nextRangeToUpdate) {
+
+            logger.info("Updating serial next range in " + newRangeDN);
+
             // nextRange is updated using last range entry or, if no ranges, the configured endSerialNumber
             if (lastUsedSerial == BigInteger.ZERO) {
                 lastUsedSerial = new BigInteger(configEndSerialNumber, 16);
             }
             BigInteger nextSerialNumber = lastUsedSerial.add(BigInteger.ONE);
-            String serialDN = dbConfig.getSerialDN() + "," + baseDN;
+
             // store nextRange as decimal
-            LDAPAttribute attrSerialNextRange = new LDAPAttribute("nextRange", nextSerialNumber.toString());
+            logger.info("- next range: " + nextSerialNumber.toString() + " (0x" + nextSerialNumber.toString(16) + ")");
+            LDAPAttribute attrSerialNextRange = new LDAPAttribute(DBSubsystem.PROP_NEXT_RANGE, nextSerialNumber.toString());
 
             LDAPModification serialmod = new LDAPModification(LDAPModification.REPLACE, attrSerialNextRange);
 
-            conn.modify(serialDN, serialmod);
+            conn.modify(newRangeDN, serialmod);
         }
     }
-    private void updateRequestRanges(LdapBoundConnection conn, String rangeDN, String newRangeDN,
-            String hostName, String securePort) throws Exception{
+
+    private void updateRequestRanges(
+            LdapBoundConnection conn,
+            String rangeDN,
+            String newRangeDN,
+            String configEndRequestNumber,
+            String hostName,
+            String securePort) throws Exception{
+
         LDAPSearchResults instanceRanges = conn.search(rangeDN, LDAPv3.SCOPE_SUB, "(&(objectClass=pkiRange)(host= " +
                     hostName + ")(SecurePort=" + securePort + "))", null, false);
-        
+
         // update all ranges associated to the CA to update to decimal
         while (instanceRanges.hasMoreElements()) {
             LDAPEntry entry = instanceRanges.next();
             String beginRange = entry.getAttribute("beginRange").getStringValues().nextElement();
             String endRange = entry.getAttribute("endRange").getStringValues().nextElement();
+
+            String dn = "cn=" + beginRange + "," + newRangeDN;
+            logger.info("Creating request range " + dn);
+
             LDAPAttributeSet attrs = new LDAPAttributeSet();
             attrs.add(new LDAPAttribute("objectClass", "top"));
             attrs.add(new LDAPAttribute("objectClass", "pkiRange"));
 
             // store beginRange as decimal
+            logger.info("- begin range: " + beginRange);
             attrs.add(new LDAPAttribute("beginRange", beginRange));
 
             // store endRange as decimal
+            logger.info("- end range: " + endRange);
             attrs.add(new LDAPAttribute("endRange", endRange));
 
             attrs.add(new LDAPAttribute("cn", beginRange));
             attrs.add(new LDAPAttribute("host", hostName));
             attrs.add(new LDAPAttribute("securePort", securePort));
 
-            String dn = "cn=" + beginRange + "," + newRangeDN;
             LDAPEntry rangeEntry = new LDAPEntry(dn, attrs);
-            logger.info("SubsystemRangeGeneratorUpdateCLI.updateRanges: Adding entry " + dn);
             conn.add(rangeEntry);
         }
+
+        LDAPSearchResults ranges = conn.search(newRangeDN, LDAPv3.SCOPE_SUB, "(objectClass=pkiRange)", null, false);
+
+        BigInteger lastUsedNumber = BigInteger.ZERO;
+        boolean nextRangeToUpdate = true;
+
+        // Search for the last range entry. If it is associated to the CA to update or ranges are not defined
+        // then the nextRange is
+        while (ranges.hasMoreElements()) {
+            LDAPEntry entry = ranges.next();
+
+            String endRange = entry.getAttribute("endRange").getStringValues().nextElement();
+            String host = entry.getAttribute("host").getStringValues().nextElement();
+            String port = entry.getAttribute("securePort").getStringValues().nextElement();
+            BigInteger next = new BigInteger(endRange);
+
+            if (lastUsedNumber.compareTo(next) < 0) {
+                lastUsedNumber = next;
+                nextRangeToUpdate = host.equals(hostName) && port.equals(securePort);
+            }
+        }
+
+        if (nextRangeToUpdate) {
+
+            logger.info("Updating request next range in " + newRangeDN);
+
+            // nextRange is updated using last range entry or, if no ranges, the configured endRequestNumber
+            if (lastUsedNumber == BigInteger.ZERO) {
+                lastUsedNumber = new BigInteger(configEndRequestNumber);
+            }
+            BigInteger nextRequestNumber = lastUsedNumber.add(BigInteger.ONE);
+
+            // store nextRange as decimal
+            logger.info("- next range: " + nextRequestNumber.toString());
+            LDAPAttribute attrRequestNextRange = new LDAPAttribute(DBSubsystem.PROP_NEXT_RANGE, nextRequestNumber.toString());
+
+            LDAPModification mods = new LDAPModification(LDAPModification.REPLACE, attrRequestNextRange);
+
+            conn.modify(newRangeDN, mods);
+        }
     }
-    
+
     private String createRangesEntry(LdapBoundConnection conn, String newRangeObject, String ranges, String baseDN) throws Exception {
+
         String baseRanges =  "ou=" + ranges;
         String baseRangesDN = baseRanges + "," + baseDN;
         try {
@@ -371,14 +496,14 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
             }
             logger.debug("SubsystemRangeGeneratorUpdateCLI: entry {} already exist", baseRangesDN);
         }
-        
+
         String newRangeEntry = "ou=" + newRangeObject + "," + baseRanges;
         String newRangeEntryDN = newRangeEntry + "," + baseDN;
         logger.debug("SubsystemRangeGeneratorUpdateCLI: Create range entry: {}", newRangeEntryDN);
         try {
             LDAPAttributeSet attrs = new LDAPAttributeSet();
             attrs.add(new LDAPAttribute("objectClass", "top"));
-            attrs.add(new LDAPAttribute("objectClass", "organizationalUnit"));
+            attrs.add(new LDAPAttribute("objectClass", "repository"));
             attrs.add(new LDAPAttribute("ou", newRangeObject));
             LDAPEntry rangeEntry = new LDAPEntry(newRangeEntryDN, attrs);
             conn.add(rangeEntry);
@@ -386,7 +511,7 @@ public abstract class SubsystemIdGeneratorUpdateCLI extends SubsystemCLI {
             if (ldae.getLDAPResultCode() != 68) {
                 throw new EBaseException("Impossible access object in ranges: " + ldae.getMessage(), ldae);
             }
-            logger.debug("SubsystemRangeGeneratorUpdateCLI: entry {} already exist", baseRangesDN);            
+            logger.debug("SubsystemRangeGeneratorUpdateCLI: entry {} already exist", baseRangesDN);
         }
         return newRangeEntry;
     }

--- a/tests/ca/bin/ca-cert-next-range.sh
+++ b/tests/ca/bin/ca-cert-next-range.sh
@@ -1,12 +1,32 @@
 #!/bin/bash -e
 
+GENERATOR_TYPE=legacy
+
+while getopts "t:" arg ; do
+    case $arg in
+    t)
+        GENERATOR_TYPE=$OPTARG
+        ;;
+    esac
+done
+
+# remove parsed options and args from $@ list
+shift $((OPTIND-1))
+
 NAME=$1
+
+if [ "$GENERATOR_TYPE" == "legacy2" ]
+then
+    RANGE_DN=ou=certificateRepository,ou=ranges_v2,dc=ca,dc=pki,dc=example,dc=com
+else
+    RANGE_DN=ou=certificateRepository,ou=ca,dc=ca,dc=pki,dc=example,dc=com
+fi
 
 docker exec $NAME ldapsearch \
     -H ldap://$NAME.example.com:3389 \
     -D "cn=Directory Manager" \
     -w Secret.123 \
-    -b ou=certificateRepository,ou=ca,dc=ca,dc=pki,dc=example,dc=com \
+    -b $RANGE_DN \
     -s base \
     -o ldif_wrap=no \
     -LLL \

--- a/tests/ca/bin/ca-request-next-range.sh
+++ b/tests/ca/bin/ca-request-next-range.sh
@@ -1,12 +1,32 @@
 #!/bin/bash -e
 
+GENERATOR_TYPE=legacy
+
+while getopts "t:" arg ; do
+    case $arg in
+    t)
+        GENERATOR_TYPE=$OPTARG
+        ;;
+    esac
+done
+
+# remove parsed options and args from $@ list
+shift $((OPTIND-1))
+
 NAME=$1
+
+if [ "$GENERATOR_TYPE" == "legacy2" ]
+then
+    RANGE_DN=ou=requests,ou=ranges_v2,dc=ca,dc=pki,dc=example,dc=com
+else
+    RANGE_DN=ou=ca,ou=requests,dc=ca,dc=pki,dc=example,dc=com
+fi
 
 docker exec $NAME ldapsearch \
     -H ldap://$NAME.example.com:3389 \
     -D "cn=Directory Manager" \
     -w Secret.123 \
-    -b ou=ca,ou=requests,dc=ca,dc=pki,dc=example,dc=com \
+    -b $RANGE_DN \
     -s base \
     -o ldif_wrap=no \
     -LLL \


### PR DESCRIPTION
The `nextRange` attribute for SSNv2 has been moved to `ou=requests,ou=ranges_v2` for requests and `ou=certificateRepository,ou=ranges_v2` for certs such that the `nextRange` for SSNv1 is unchanged during migration. This will simplify the recovery process in case there's an issue during migration.

The `SubsystemIdGeneratorUpdateCLI` has been updated to compute the request `nextRange` for SSNv2 with the same process used to compute the cert `nextRange` for SSNv2.

The SSNv1 and SSNv2 tests have been updated to use the new SSNv2 `nextRange` location.
