### PR TITLE
Add fallback for Certificate.not_valid_before/after_utc

### DIFF
--- a/docs/changes/v11.6.0/API-Changes.adoc
+++ b/docs/changes/v11.6.0/API-Changes.adoc
@@ -1,0 +1,5 @@
+= API Changes =
+
+== NSSDatabase.get_cert_info() changes ==
+
+The `NSSDatabase.get_cert_info()` has been modified to return `not_before` and `not_after` attributes in UTC timezone.


### PR DESCRIPTION
The `NSSDatabase.get_cert_info()` has been modified so that it will use `Certificate.not_valid_before/after_utc` attributes which are available since Python Cryptography 42, otherwise it will use the deprecated `not_valid_before/after` then convert them into UTC.

https://github.com/edewata/pki/blob/python/docs/changes/v11.6.0/API-Changes.adoc