### PR TITLE
fix createUserNotice parameter order

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/profile/def/CertificatePoliciesExtDefault.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/def/CertificatePoliciesExtDefault.java
@@ -343,7 +343,7 @@ public class CertificatePoliciesExtDefault extends EnrollExtDefault {
                                         + i + SEPARATOR + CONFIG_PREFIX1 + j + SEPARATOR
                                         + CONFIG_USERNOTICE_TEXT);
                                 org.mozilla.jss.netscape.security.x509.PolicyQualifierInfo qualifierInfo = createUserNotice(orgName,
-                                        explicitText, noticenumbers);
+                                        noticenumbers, explicitText);
                                 if (qualifierInfo != null)
                                     policyQualifiers.add(qualifierInfo);
                             }
@@ -703,7 +703,7 @@ public class CertificatePoliciesExtDefault extends EnrollExtDefault {
                             String explicitText = substore1.getString(CONFIG_USERNOTICE_TEXT);
 
                             PolicyQualifierInfo qualifierInfo = createUserNotice(orgName,
-                                    explicitText, noticenumbers);
+                                    noticenumbers, explicitText);
 
                             if (qualifierInfo != null) {
                                 policyQualifiers.add(qualifierInfo);


### PR DESCRIPTION
### PR Description

The usernotice certificate policy qualifier can contain an organizationname, noticenumbers and explicittext field. The explicittext and noticenumbers fields are not handled correctly, causing the error "wrong notice numbers" when submitting a CSR on a certificate profile that contains a value in explicittext.

The createUserNotice() function is defined in:
https://github.com/dogtagpki/pki/blob/master/base/ca/src/main/java/com/netscape/cms/profile/def/CertificatePoliciesExtDefault.java#L770
with parameters orgName, noticeNums, noticeText
and called in:
https://github.com/dogtagpki/pki/blob/master/base/ca/src/main/java/com/netscape/cms/profile/def/CertificatePoliciesExtDefault.java#L345
and
https://github.com/dogtagpki/pki/blob/master/base/ca/src/main/java/com/netscape/cms/profile/def/CertificatePoliciesExtDefault.java#L705
with parameters orgName, noticeText, noticeNums.

This PR fixes the order of parameters so that noticeText and noticeNums no longer get inverted.


### Test procedure

Create a certificate profile containing the following certificate policy:
```
policyset.userCertSet.<i>.constraint.class_id=noConstraintImpl
policyset.userCertSet.<i>.constraint.name=No Constraint
policyset.userCertSet.<i>.default.class_id=certificatePoliciesExtDefaultImpl
policyset.userCertSet.<i>.default.name=Certificate Policies Extension Default
policyset.userCertSet.<i>.default.params.Critical=false
policyset.userCertSet.<i>.default.params.PoliciesExt.num=1
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.enable=true
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.policyId=2.16.528.1.1003.1.2.44.14.11.5
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.PolicyQualifiers.num=2
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.PolicyQualifiers0.CPSURI.enable=true
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.PolicyQualifiers0.CPSURI.value=https://example.com/cps.pdf
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.PolicyQualifiers1.usernotice.enable=true
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.PolicyQualifiers1.usernotice.explicitText.value=This is the usernotice explicittext field.
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.PolicyQualifiers1.usernotice.noticeReference.noticeNumbers=
policyset.userCertSet.<i>.default.params.PoliciesExt.certPolicy0.PolicyQualifiers1.usernotice.noticeReference.organization=
```
Submit a certificate request via the EE portal, and accept the certificate request via the agent portal.
The certificate should contain:
```
                Identifier: Certificate Policies: - 2.5.29.32
                    Critical: no 
                    Certificate Policies: 
                        Policy Identifier: 2.16.528.1.1003.1.2.44.14.11.5
                            Policy Qualifier Identifier: CPS Pointer Qualifier - 1.3.6.1.5.5.7.2.1
                            Policy Qualifier Data: https://example.com/cps.pdf
                            Policy Qualifier Identifier: CPS User Notice Qualifier - 1.3.6.1.5.5.7.2.2
                            Policy Qualifier Data: 
                                Explicit Text: VisibleString: This is the usernotice explicittext field.
```
