### PR TITLE
Update Python API to support REST API v2

### DIFF
--- a/.github/workflows/python-ca-rest-api-v1-test.yml
+++ b/.github/workflows/python-ca-rest-api-v1-test.yml
@@ -1,0 +1,646 @@
+name: CA Python API with REST API v1
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # https://github.com/dogtagpki/pki/wiki/Deploying-CA-Container
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              client
+
+      ####################################################################################################
+      # Create system certs
+
+      - name: Create CA signing cert
+        run: |
+          mkdir certs
+
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=CA Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr $SHARED/certs/ca_signing.csr
+
+          docker exec client pki \
+              nss-cert-issue \
+              --csr $SHARED/certs/ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert $SHARED/certs/ca_signing.crt
+
+          docker exec client pki \
+              nss-cert-import \
+              --cert $SHARED/certs/ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec client pki \
+              nss-cert-show \
+              ca_signing
+
+      - name: Create OCSP signing cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=OCSP Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+              --csr $SHARED/certs/ocsp_signing.csr
+
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/certs/ocsp_signing.csr \
+              --ext /usr/share/pki/server/certs/ocsp_signing.conf \
+              --cert $SHARED/certs/ocsp_signing.crt
+
+          docker exec client pki \
+              nss-cert-import \
+              --cert $SHARED/certs/ocsp_signing.crt \
+              ocsp_signing
+
+          docker exec client pki \
+              nss-cert-show \
+              ocsp_signing
+
+      - name: Create audit signing cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --csr $SHARED/certs/audit_signing.csr
+
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/certs/audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert $SHARED/certs/audit_signing.crt
+
+          docker exec client pki \
+              nss-cert-import \
+              --cert $SHARED/certs/audit_signing.crt \
+              --trust ,,P \
+              audit_signing
+
+          docker exec client pki \
+              nss-cert-show \
+              audit_signing
+
+      - name: Create subsystem cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=Subsystem Certificate" \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --csr $SHARED/certs/subsystem.csr
+
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/certs/subsystem.csr \
+              --ext /usr/share/pki/server/certs/subsystem.conf \
+              --cert $SHARED/certs/subsystem.crt
+
+          docker exec client pki \
+              nss-cert-import \
+              --cert $SHARED/certs/subsystem.crt \
+              subsystem
+
+          docker exec client pki \
+              nss-cert-show \
+              subsystem
+
+      - name: Create SSL server cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=ca.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr $SHARED/certs/sslserver.csr
+
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/certs/sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --cert $SHARED/certs/sslserver.crt
+
+          docker exec client pki \
+              nss-cert-import \
+              --cert $SHARED/certs/sslserver.crt \
+              sslserver
+
+          docker exec client pki \
+              nss-cert-show \
+              sslserver
+
+      - name: Create admin cert
+        run: |
+          docker exec client pki \
+              nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr $SHARED/certs/admin.csr
+
+          docker exec client pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/certs/admin.csr \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --cert $SHARED/certs/admin.crt
+
+          docker exec client pki \
+              nss-cert-import \
+              --cert $SHARED/certs/admin.crt \
+              admin
+
+          docker exec client pki \
+              nss-cert-show \
+              admin
+
+      - name: "Export system certs and keys to PKCS #12 file"
+        run: |
+          docker exec client pki pkcs12-export \
+              --pkcs12 $SHARED/certs/server.p12 \
+              --password Secret.123 \
+              ca_signing \
+              ocsp_signing \
+              audit_signing \
+              subsystem \
+              sslserver
+
+      - name: "Export admin cert and key to PKCS #12 file"
+        run: |
+          docker exec client pki pkcs12-export \
+              --pkcs12 $SHARED/certs/admin.p12 \
+              --password Secret.123 \
+              admin
+
+      - name: "Export admin key to PEM file"
+        run: |
+          docker exec client openssl pkcs12 \
+             -in $SHARED/certs/admin.p12 \
+             -passin pass:Secret.123 \
+             -out $SHARED/certs/admin.key \
+             -nodes \
+             -nocerts
+
+      ####################################################################################################
+      # Set up CA database
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
+      - name: Configure DS database
+        run: |
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/base/server/database/ds/config.ldif
+
+      - name: Add PKI schema
+        run: |
+          docker exec ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/base/server/database/ds/schema.ldif
+
+      - name: Add CA base entry
+        run: |
+          docker exec -i ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: dc=ca,dc=pki,dc=example,dc=com
+          objectClass: dcObject
+          dc: ca
+          EOF
+
+      - name: Add CA database entries
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/create.ldif \
+              | tee create.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/create.ldif
+
+      - name: Add CA search indexes
+        run: |
+          sed \
+              -e 's/{database}/userroot/g' \
+              base/ca/database/ds/index.ldif \
+              | tee index.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/index.ldif
+
+      - name: Rebuild CA search indexes
+        run: |
+          # start rebuild task
+          sed \
+              -e 's/{database}/userroot/g' \
+              base/ca/database/ds/indextasks.ldif \
+              | tee indextasks.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/indextasks.ldif
+
+          # wait for task to complete
+          while true; do
+              sleep 1
+
+              docker exec ds ldapsearch \
+                  -H ldap://ds.example.com:3389 \
+                  -D "cn=Directory Manager" \
+                  -w Secret.123 \
+                  -b "cn=index1160589770, cn=index, cn=tasks, cn=config" \
+                  -LLL \
+                  nsTaskExitCode \
+                  | tee output
+
+              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
+              cat nsTaskExitCode
+
+              if [ -s nsTaskExitCode ]; then
+                  break
+              fi
+          done
+
+          echo "0" > expected
+          diff expected nsTaskExitCode
+
+      - name: Add CA ACL resources
+        run: |
+          sed \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/acl.ldif \
+              | tee acl.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/acl.ldif
+
+      - name: Add CA VLV indexes
+        run: |
+          sed \
+              -e 's/{instanceId}/pki-tomcat/g' \
+              -e 's/{database}/userroot/g' \
+              -e 's/{rootSuffix}/dc=ca,dc=pki,dc=example,dc=com/g' \
+              base/ca/database/ds/vlv.ldif \
+              | tee vlv.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/vlv.ldif
+
+      - name: Rebuild CA VLV indexes
+        run: |
+          # start rebuild task
+          sed \
+              -e 's/{database}/userroot/g' \
+              -e 's/{instanceId}/pki-tomcat/g' \
+              base/ca/database/ds/vlvtasks.ldif \
+              | tee vlvtasks.ldif
+          docker exec ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f $SHARED/vlvtasks.ldif
+
+          # wait for task to complete
+          while true; do
+              sleep 1
+
+              docker exec ds ldapsearch \
+                  -H ldap://ds.example.com:3389 \
+                  -D "cn=Directory Manager" \
+                  -w Secret.123 \
+                  -b "cn=index1160589769, cn=index, cn=tasks, cn=config" \
+                  -LLL \
+                  nsTaskExitCode \
+                  | tee output
+
+              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
+              cat nsTaskExitCode
+
+              if [ -s nsTaskExitCode ]; then
+                  break
+              fi
+          done
+
+          echo "0" > expected
+          diff expected nsTaskExitCode
+
+      ####################################################################################################
+      # Set up admin user
+
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Admin-User
+      - name: Add admin user
+        run: |
+          docker exec -i ds ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          objectClass: person
+          objectClass: organizationalPerson
+          objectClass: inetOrgPerson
+          objectClass: cmsuser
+          cn: admin
+          sn: admin
+          uid: admin
+          mail: admin@example.com
+          userPassword: Secret.123
+          userState: 1
+          userType: adminType
+          EOF
+
+      - name: Assign admin cert to admin user
+        run: |
+          # convert cert from PEM to DER
+          openssl x509 -outform der -in certs/admin.crt -out certs/admin.der
+
+          # get serial number
+          openssl x509 -text -noout -in certs/admin.crt | tee output
+          SERIAL=$(sed -En 'N; s/^ *Serial Number:\n *(.*)$/\1/p; D' output)
+          echo "SERIAL: $SERIAL"
+          HEX_SERIAL=$(echo "$SERIAL" | tr -d ':')
+          echo "HEX_SERIAL: $HEX_SERIAL"
+          DEC_SERIAL=$(python -c "print(int('$HEX_SERIAL', 16))")
+          echo "DEC_SERIAL: $DEC_SERIAL"
+
+          docker exec -i ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: description
+          description: 2;$DEC_SERIAL;CN=CA Signing Certificate;CN=Administrator
+          -
+          add: userCertificate
+          userCertificate:< file:$SHARED/certs/admin.der
+          -
+          EOF
+
+      - name: Add admin user into CA groups
+        run: |
+          docker exec -i ds ldapmodify \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 << EOF
+          dn: cn=Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Certificate Manager Agents,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Security Domain Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise CA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise KRA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise RA Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise TKS Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise OCSP Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+
+          dn: cn=Enterprise TPS Administrators,ou=groups,dc=ca,dc=pki,dc=example,dc=com
+          changetype: modify
+          add: uniqueMember
+          uniqueMember: uid=admin,ou=people,dc=ca,dc=pki,dc=example,dc=com
+          -
+          EOF
+
+      ####################################################################################################
+      # Install CA that only supports REST API v1
+
+      - name: Create PKI CA 11.4 Dockerfile
+        run: |
+          # create a new Dockerfile to disable access log buffer
+          cat > Dockerfile-pki-ca-11.4 <<EOF
+          FROM quay.io/dogtagpki/pki-ca:11.4 AS pki-ca-11.4
+
+          RUN dnf install -y xmlstarlet
+
+          RUN cat /etc/tomcat/server.xml
+          RUN xmlstarlet edit --inplace \
+              -u "//Valve[@className='org.apache.catalina.valves.AccessLogValve']/@buffered" \
+              -v "false" \
+              -i "//Valve[@className='org.apache.catalina.valves.AccessLogValve' and not(@buffered)]" \
+              -t attr \
+              -n "buffered" \
+              -v "false" \
+              /etc/tomcat/server.xml
+          EOF
+
+      - name: Build PKI CA 11.4 image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: pki-ca:11.4
+          target: pki-ca-11.4
+          file: Dockerfile-pki-ca-11.4
+
+      - name: Create PKI CA 11.4 container
+        run: |
+          docker run \
+              --name ca \
+              --hostname=ca.example.com \
+              --network=example \
+              --network-alias=ca.example.com \
+              -v $PWD/certs:/certs \
+              --detach \
+              pki-ca:11.4
+
+      - name: Wait for CA container to start
+        run: |
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ca.example.com:8443
+
+      ####################################################################################################
+      # Check Python API against CA that only supports REST API v1
+
+      - name: Check PKI server info
+        run: |
+          docker exec client python /usr/share/pki/tests/bin/pki-info.py \
+              -U https://ca.example.com:8443 \
+              --ca-bundle $SHARED/certs/ca_signing.crt \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec ca find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -2 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should fall back to REST API v1
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 404 -
+          GET /pki/rest/info HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check CA certs
+        run: |
+          docker exec client python /usr/share/pki/tests/ca/bin/pki-ca-cert-find.py \
+              -U https://ca.example.com:8443 \
+              --ca-bundle $SHARED/certs/ca_signing.crt \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec ca find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -3 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should fall back to REST API v1
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 404 -
+          GET /pki/rest/info HTTP/1.1 200 -
+          POST /ca/rest/certs/search HTTP/1.1 200 -
+          EOF
+
+      - name: Check CA users
+        run: |
+          docker exec client python /usr/share/pki/tests/ca/bin/pki-ca-user-find.py \
+              -U https://ca.example.com:8443 \
+              --ca-bundle $SHARED/certs/ca_signing.crt \
+              --client-cert $SHARED/certs/admin.crt \
+              --client-key $SHARED/certs/admin.key \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec ca find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -5 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should fall back to REST API v1
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 404 -
+          GET /pki/rest/info HTTP/1.1 200 -
+          GET /ca/rest/account/login HTTP/1.1 200 admin
+          GET /ca/rest/admin/users HTTP/1.1 200 admin
+          GET /ca/rest/account/logout HTTP/1.1 204 admin
+          EOF
+
+          diff expected output
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server access log
+        if: always()
+        run: |
+          docker exec ca find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check CA container logs
+        if: always()
+        run: |
+          docker logs ca

--- a/.github/workflows/python-ca-test.yml
+++ b/.github/workflows/python-ca-test.yml
@@ -1,0 +1,281 @@
+name: CA Python API
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # docs/installation/ca/Installing_CA.md
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      ####################################################################################################
+      # Install CA that supports both REST API v1 and v2
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Update PKI server configuration
+        run: |
+          docker exec pki dnf install -y xmlstarlet
+
+          # disable access log buffer
+          docker exec pki xmlstarlet edit --inplace \
+              -u "//Valve[@className='org.apache.catalina.valves.AccessLogValve']/@buffered" \
+              -v "false" \
+              -i "//Valve[@className='org.apache.catalina.valves.AccessLogValve' and not(@buffered)]" \
+              -t attr \
+              -n "buffered" \
+              -v "false" \
+              /etc/pki/pki-tomcat/server.xml
+
+          # restart PKI server
+          docker exec pki pki-server restart --wait
+
+      - name: Set up client
+        run: |
+          # export CA signing cert
+          docker exec pki pki-server cert-export \
+              --cert-file $SHARED/ca_signing.crt \
+              ca_signing
+
+          # export admin cert
+          docker exec pki openssl pkcs12 \
+             -in /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+             -passin pass:Secret.123 \
+             -out admin.crt \
+             -clcerts \
+             -nokeys
+
+          # export admin key
+          docker exec pki openssl pkcs12 \
+             -in /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+             -passin pass:Secret.123 \
+             -out admin.key \
+             -nodes \
+             -nocerts
+
+      ####################################################################################################
+      # Check Python API
+
+      - name: Check PKI server info
+        run: |
+          docker exec pki python /usr/share/pki/tests/bin/pki-info.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -1 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server info with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/bin/pki-info.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --api v1 \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -1 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1 as specified
+          cat > expected << EOF
+          GET /pki/v1/info HTTP/1.1 200 -
+          EOF
+
+      - name: Check CA certs
+        run: |
+          docker exec pki python /usr/share/pki/tests/ca/bin/pki-ca-cert-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -2 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          POST /ca/v2/certs/search HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check CA certs with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/ca/bin/pki-ca-cert-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --api v1 \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -1 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1 as specified
+          cat > expected << EOF
+          POST /ca/v1/certs/search HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check CA users
+        run: |
+          docker exec pki python /usr/share/pki/tests/ca/bin/pki-ca-user-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /ca/v2/account/login HTTP/1.1 200 caadmin
+          GET /ca/v2/admin/users HTTP/1.1 200 caadmin
+          GET /ca/v2/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      - name: Check CA users with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/ca/bin/pki-ca-user-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --api v1 \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -3 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1 as specified
+          cat > expected << EOF
+          GET /ca/v1/account/login HTTP/1.1 200 caadmin
+          GET /ca/v1/admin/users HTTP/1.1 200 caadmin
+          GET /ca/v1/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check PKI server access log
+        if: always()
+        run: |
+          docker exec pki find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;

--- a/.github/workflows/python-kra-test.yml
+++ b/.github/workflows/python-kra-test.yml
@@ -1,0 +1,244 @@
+name: KRA Python API
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # docs/installation/ca/Installing_CA.md
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      ####################################################################################################
+      # Install KRA that supports both REST API v1 and v2
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Install KRA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/kra.cfg \
+              -s KRA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Update PKI server configuration
+        run: |
+          docker exec pki dnf install -y xmlstarlet
+
+          # disable access log buffer
+          docker exec pki xmlstarlet edit --inplace \
+              -u "//Valve[@className='org.apache.catalina.valves.AccessLogValve']/@buffered" \
+              -v "false" \
+              -i "//Valve[@className='org.apache.catalina.valves.AccessLogValve' and not(@buffered)]" \
+              -t attr \
+              -n "buffered" \
+              -v "false" \
+              /etc/pki/pki-tomcat/server.xml
+
+          # restart PKI server
+          docker exec pki pki-server restart --wait
+
+      - name: Set up client
+        run: |
+          # export CA signing cert
+          docker exec pki pki-server cert-export \
+              --cert-file $SHARED/ca_signing.crt \
+              ca_signing
+
+          # export admin cert
+          docker exec pki openssl pkcs12 \
+             -in /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+             -passin pass:Secret.123 \
+             -out admin.crt \
+             -clcerts \
+             -nokeys
+
+          # export admin key
+          docker exec pki openssl pkcs12 \
+             -in /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+             -passin pass:Secret.123 \
+             -out admin.key \
+             -nodes \
+             -nocerts
+
+      ####################################################################################################
+      # Check Python API
+
+      - name: Check PKI server info
+        run: |
+          docker exec pki python /usr/share/pki/tests/bin/pki-info.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -1 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server info with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/bin/pki-info.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --api v1 \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -1 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1 as specified
+          cat > expected << EOF
+          GET /pki/v1/info HTTP/1.1 200 -
+          EOF
+
+      - name: Check KRA users
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-user-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /kra/v2/account/login HTTP/1.1 200 kraadmin
+          GET /kra/v2/admin/users HTTP/1.1 200 kraadmin
+          GET /kra/v2/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      - name: Check KRA users with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-user-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --api v1 \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -3 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1 as specified
+          cat > expected << EOF
+          GET /kra/v1/account/login HTTP/1.1 200 kraadmin
+          GET /kra/v1/admin/users HTTP/1.1 200 kraadmin
+          GET /kra/v1/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check PKI server access log
+        if: always()
+        run: |
+          docker exec pki find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check KRA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,3 +12,18 @@ jobs:
     name: Python lint
     needs: build
     uses: ./.github/workflows/python-lint-test.yml
+
+  python-ca-test:
+    name: CA Python API
+    needs: build
+    uses: ./.github/workflows/python-ca-test.yml
+
+  python-ca-rest-api-v1-test:
+    name: CA Python API with REST API v1
+    needs: build
+    uses: ./.github/workflows/python-ca-rest-api-v1-test.yml
+
+  python-kra-test:
+    name: KRA Python API
+    needs: build
+    uses: ./.github/workflows/python-kra-test.yml

--- a/base/common/python/pki/ca.py
+++ b/base/common/python/pki/ca.py
@@ -1,0 +1,17 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CAClient:
+
+    def __init__(self, parent):
+
+        self.name = 'ca'
+        self.parent = parent

--- a/base/common/python/pki/kra.py
+++ b/base/common/python/pki/kra.py
@@ -25,11 +25,15 @@ to interact with the DRM to expose the functionality of the KeyClient and
 KeyRequestResource REST APIs.
 """
 
-from __future__ import absolute_import
-from pki.info import InfoClient
-import pki.key as key
+import inspect
+import logging
 
-from pki.systemcert import SystemCertClient
+import pki.client
+import pki.info
+import pki.key
+import pki.systemcert
+
+logger = logging.getLogger(__name__)
 
 
 class KRAClient(object):
@@ -38,7 +42,7 @@ class KRAClient(object):
     KeyRequest REST APIs.
     """
 
-    def __init__(self, connection, crypto, transport_cert_nick=None):
+    def __init__(self, parent, crypto=None, transport_cert_nick=None):
         """ Constructor
 
         :param connection - PKIConnection object with DRM connection info.
@@ -52,13 +56,36 @@ class KRAClient(object):
                         Note that for NSS databases, the database must have
                         been initialized beforehand.
         """
-        self.connection = connection
-        self.crypto = crypto
-        self.info = InfoClient(connection)
-        self.keys = key.KeyClient(
-            connection,
-            crypto,
-            transport_cert_nick,
-            self.info
-        )
-        self.system_certs = SystemCertClient(connection)
+
+        self.name = 'kra'
+        self.parent = parent
+
+        if isinstance(parent, pki.client.PKIConnection):
+
+            logger.warning(
+                '%s:%s: The PKIConnection parameter in KRAClient.__init__() has been deprecated. '
+                'Provide PKIClient instead.',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)
+
+            self.connection = parent
+
+            self.crypto = crypto
+            self.info = pki.info.InfoClient(self.connection)
+
+            self.keys = pki.key.KeyClient(
+                self.connection,
+                crypto,
+                transport_cert_nick,
+                self.info)
+
+            self.system_certs = pki.systemcert.SystemCertClient(self.connection)
+
+        else:
+            self.connection = parent.connection
+
+            # do not automatically create these objects in KRAClient.
+            # client application should create them as needed.
+            self.crypto = None
+            self.info = None
+            self.keys = None
+            self.system_certs = None

--- a/base/common/python/pki/user.py
+++ b/base/common/python/pki/user.py
@@ -1,0 +1,37 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class UserClient:
+
+    def __init__(self, parent):
+
+        self.subsystem_client = parent
+        self.pki_client = self.subsystem_client.parent
+        self.connection = self.pki_client.connection
+
+    def find_users(self):
+
+        api_path = self.pki_client.get_api_path()
+
+        # the UserClient doesn't support legacy code so the subsystem name
+        # needs to be included in the path
+        path = '/%s/%s/admin/users' % (self.subsystem_client.name, api_path)
+
+        logger.info('Getting %s users from %s', self.subsystem_client.name.upper(), path)
+
+        response = self.connection.get(path)
+
+        json_response = response.json()
+        logger.debug('Response:\n%s', json.dumps(json_response, indent=4))
+
+        # TODO: return UserCollection object instead of JSON/XML
+        return json_response

--- a/tests/bin/pki-info.py
+++ b/tests/bin/pki-info.py
@@ -1,0 +1,58 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+
+import pki.ca
+import pki.cert
+import pki.client
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+info = pki_client.get_info()
+
+print('  Server Version: %s' % pki_client.get_server_version())
+print('  API Version: %s' % pki_client.get_api_version())

--- a/tests/ca/bin/pki-ca-cert-find.py
+++ b/tests/ca/bin/pki-ca-cert-find.py
@@ -1,0 +1,71 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+
+import pki.ca
+import pki.cert
+import pki.client
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+ca_client = pki.ca.CAClient(pki_client)
+cert_client = pki.cert.CertClient(ca_client)
+
+certs = cert_client.list_certs()
+
+first = True
+
+for cert in certs:
+
+    if first:
+        first = False
+    else:
+        print()
+
+    print('  Serial Number: ' + cert.serial_number)
+    print('  Subject DN: ' + cert.subject_dn)
+    print('  Status: ' + cert.status)

--- a/tests/ca/bin/pki-ca-user-find.py
+++ b/tests/ca/bin/pki-ca-user-find.py
@@ -1,0 +1,88 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+
+import pki.ca
+import pki.account
+import pki.client
+import pki.user
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--client-cert',
+    help='Path to client certificate',
+    dest='client_cert')
+parser.add_argument(
+    '--client-key',
+    help='Path to client key',
+    dest='client_key')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+pki_client.set_client_auth(
+    client_cert=args.client_cert,
+    client_key=args.client_key)
+
+ca_client = pki.ca.CAClient(pki_client)
+
+account_client = pki.account.AccountClient(ca_client)
+account_client.login()
+
+user_client = pki.user.UserClient(ca_client)
+users = user_client.find_users()
+
+first = True
+
+for user in users['entries']:
+
+    if first:
+        first = False
+    else:
+        print()
+
+    print('  User ID: %s' % user['UserID'])
+    print('  Full name: %s' % user['FullName'])
+
+account_client.logout()

--- a/tests/kra/bin/pki-kra-user-find.py
+++ b/tests/kra/bin/pki-kra-user-find.py
@@ -1,0 +1,88 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+
+import pki.kra
+import pki.account
+import pki.client
+import pki.user
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--client-cert',
+    help='Path to client certificate',
+    dest='client_cert')
+parser.add_argument(
+    '--client-key',
+    help='Path to client key',
+    dest='client_key')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+pki_client.set_client_auth(
+    client_cert=args.client_cert,
+    client_key=args.client_key)
+
+kra_client = pki.kra.KRAClient(pki_client)
+
+account_client = pki.account.AccountClient(kra_client)
+account_client.login()
+
+user_client = pki.user.UserClient(kra_client)
+users = user_client.find_users()
+
+first = True
+
+for user in users['entries']:
+
+    if first:
+        first = False
+    else:
+        print()
+
+    print('  User ID: %s' % user['UserID'])
+    print('  Full name: %s' % user['FullName'])
+
+account_client.logout()


### PR DESCRIPTION
The `PKIClient` class has been added to replace `PKIConnection` as the main access point to PKI services. By default it will use REST API v2, then fall back to v1 if it's not available. Optionally, `PKIClient` can be configured to use a specific REST API version.

The `InfoClient`, `CertClient`, `AccountClient`, and `UserClient` classes have been added/updated to construct the proper REST URL according to the REST API version in `PKIClient`.

The `pki-healthcheck` has been updated to use `PKIClient`. Some simple Python scripts have also been added to demonstrate how to use `PKIClient`.

New tests have been added to run these scripts against the current CA and KRA which support both REST API v1 and v2 and also against an older CA that only supports REST API v1.