### PR TITLE
Fix getopt deprecation warnings (part 2)

### DIFF
--- a/base/server/python/pki/server/cli/config.py
+++ b/base/server/python/pki/server/cli/config.py
@@ -18,9 +18,7 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import, print_function
-
-import getopt
+import argparse
 import logging
 import sys
 
@@ -45,7 +43,26 @@ class SubsystemConfigFindCLI(pki.cli.CLI):
 
     def __init__(self, parent):
         super().__init__('find', 'Find %s configuration parameters' % parent.parent.name.upper())
+
         self.parent = parent
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
 
     def print_help(self):
         print('Usage: pki-server %s-config-find [OPTIONS]' % self.parent.parent.name)
@@ -58,36 +75,19 @@ class SubsystemConfigFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -113,7 +113,27 @@ class SubsystemConfigShowCLI(pki.cli.CLI):
         super().__init__(
             'show',
             'Show %s configuration parameter value' % parent.parent.name.upper())
+
         self.parent = parent
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
 
     def print_help(self):
         print('Usage: pki-server %s-config-show [OPTIONS] <name>' % self.parent.parent.name)
@@ -126,44 +146,20 @@ class SubsystemConfigShowCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing %s configuration parameter name',
-                         self.parent.parent.name.upper())
-            self.print_help()
-            sys.exit(1)
-
-        name = args[0]
+        instance_name = args.instance
+        name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -194,7 +190,28 @@ class SubsystemConfigSetCLI(pki.cli.CLI):
         super().__init__(
             'set',
             'Set %s configuration parameter value' % parent.parent.name.upper())
+
         self.parent = parent
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
+        self.parser.add_argument('value')
 
     def print_help(self):
         print('Usage: pki-server %s-config-set [OPTIONS] <name> <value>'
@@ -208,51 +225,21 @@ class SubsystemConfigSetCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing %s configuration parameter name',
-                         self.parent.parent.name.upper())
-            self.print_help()
-            sys.exit(1)
-
-        if len(args) < 2:
-            logger.error('Missing %s configuration parameter value',
-                         self.parent.parent.name.upper())
-            self.print_help()
-            sys.exit(1)
-
-        name = args[0]
-        value = args[1]
+        instance_name = args.instance
+        name = args.name
+        value = args.value
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -276,7 +263,27 @@ class SubsystemConfigUnsetCLI(pki.cli.CLI):
 
     def __init__(self, parent):
         super().__init__('unset', 'Unset %s configuration parameter' % parent.parent.name.upper())
+
         self.parent = parent
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
 
     def print_help(self):
         print('Usage: pki-server %s-config-unset [OPTIONS] <name>'
@@ -290,44 +297,20 @@ class SubsystemConfigUnsetCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing %s configuration parameter name',
-                         self.parent.parent.name.upper())
-            self.print_help()
-            sys.exit(1)
-
-        name = args[0]
+        instance_name = args.instance
+        name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/id.py
+++ b/base/server/python/pki/server/cli/id.py
@@ -3,9 +3,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-from __future__ import absolute_import
-from __future__ import print_function
-import getopt
+
+import argparse
 import logging
 import sys
 
@@ -43,6 +42,24 @@ class IdGeneratorShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-id-generator-show [OPTIONS]' %
               self.parent.parent.parent.name)
@@ -54,37 +71,21 @@ class IdGeneratorShowCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -111,6 +112,27 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('-t', '--type')
+        self.parser.add_argument('-r', '--range')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('object_name')
+
     def print_help(self):
         print('Usage: pki-server %s-id-generator-update [OPTIONS] <object>' %
               self.parent.parent.parent.name)
@@ -125,51 +147,24 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:t:r:v', [
-                'instance=', 'type=', 'range=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        if len(args) != 1:
-            logger.error('Missing object for generator')
-            self.print_help()
-            sys.exit(1)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        generator_object = args[0]
-        instance_name = 'pki-tomcat'
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        generator = None
-        range_object = None
-
-        for o, a in opts:
-            if o in ('-t', '--type'):
-                generator = a
-
-            elif o in ('-r', '--range'):
-                range_object = a
-
-            elif o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        generator_object = args.object_name
+        generator = args.type
+        range_object = args.range
 
         if not generator:
             logger.error('No <generator type> specified')

--- a/base/server/python/pki/server/cli/nuxwdog.py
+++ b/base/server/python/pki/server/cli/nuxwdog.py
@@ -18,22 +18,16 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-
+import argparse
 import fileinput
-import getopt
 import logging
+from lxml import etree
 import os
 import re
 import subprocess
-import sys
-
-import pki.server
-from lxml import etree
 
 import pki.cli
-import pki.server.instance
+import pki.server
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +43,6 @@ class NuxwdogCLI(pki.cli.CLI):
 class NuxwdogEnableCLI(pki.cli.CLI):
 
     def __init__(self):
-        self.parser = etree.XMLParser(remove_blank_text=True)
         self.nuxwdog_listener_class = (
             'com.netscape.cms.tomcat.PKIListener'
         )
@@ -57,6 +50,20 @@ class NuxwdogEnableCLI(pki.cli.CLI):
             'com.netscape.cms.tomcat.NuxwdogPasswordStore'
         )
         super().__init__('enable', 'Enable nuxwdog')
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
 
     def print_help(self):
         print('Usage: pki-server nuxwdog-enable [OPTIONS]')
@@ -67,30 +74,18 @@ class NuxwdogEnableCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
         instances = pki.server.instance.PKIInstance.instances()
 
@@ -144,7 +139,8 @@ class NuxwdogEnableCLI(pki.cli.CLI):
 
         conf_file = self.get_conf_file(instance)
 
-        document = etree.parse(filename, self.parser)
+        parser = etree.XMLParser(remove_blank_text=True)
+        document = etree.parse(filename, parser)
 
         server = document.getroot()
 
@@ -221,7 +217,6 @@ class NuxwdogEnableCLI(pki.cli.CLI):
 class NuxwdogDisableCLI(pki.cli.CLI):
 
     def __init__(self):
-        self.parser = etree.XMLParser(remove_blank_text=True)
         self.nuxwdog_listener_class = (
             'com.netscape.cms.tomcat.PKIListener'
         )
@@ -229,6 +224,20 @@ class NuxwdogDisableCLI(pki.cli.CLI):
             'org.dogtagpki.jss.tomcat.PlainPasswordFile'
         )
         super().__init__('disable', 'Disable nuxwdog')
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
 
     def print_help(self):
         print('Usage: pki-server nuxwdog-disable [OPTIONS]')
@@ -239,30 +248,18 @@ class NuxwdogDisableCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
         instances = pki.server.instance.PKIInstance.instances()
 
@@ -299,7 +296,8 @@ class NuxwdogDisableCLI(pki.cli.CLI):
 
         pw_conf = os.path.join(instance.conf_dir, 'password.conf')
 
-        document = etree.parse(filename, self.parser)
+        parser = etree.XMLParser(remove_blank_text=True)
+        document = etree.parse(filename, parser)
 
         server = document.getroot()
 

--- a/base/server/python/pki/server/cli/range.py
+++ b/base/server/python/pki/server/cli/range.py
@@ -3,9 +3,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-from __future__ import absolute_import
-from __future__ import print_function
-import getopt
+
+import argparse
 import logging
 import sys
 
@@ -34,6 +33,24 @@ class RangeShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-range-show [OPTIONS]' % self.parent.parent.name)
         print()
@@ -44,37 +61,21 @@ class RangeShowCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -110,6 +111,27 @@ class RangeRequestCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--master')
+        self.parser.add_argument('--session')
+        self.parser.add_argument('--install-token')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-range-request [OPTIONS]' % self.parent.parent.name)
         print()
@@ -123,50 +145,24 @@ class RangeRequestCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'master=', 'session=', 'install-token=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-        master_url = None
-        session_id = None
-        install_token = None
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--master':
-                master_url = a
-
-            elif o == '--session':
-                session_id = a
-
-            elif o == '--install-token':
-                install_token = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        master_url = args.master
+        session_id = args.session
+        install_token = args.install_token
 
         if not master_url:
             raise Exception('Missing master URL')
@@ -201,6 +197,24 @@ class RangeUpdateCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-range-update [OPTIONS]' % self.parent.parent.name)
         print()
@@ -211,37 +225,21 @@ class RangeUpdateCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/selftest.py
+++ b/base/server/python/pki/server/cli/selftest.py
@@ -18,10 +18,7 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-
-import getopt
+import argparse
 import sys
 import logging
 
@@ -40,6 +37,28 @@ class EnableSelfTestCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('enable', 'Enable selftests.')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--subsystem',
+            action='append')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('selftest_id')
+
     def print_help(self):
         print('Usage: pki-server selftest-enable [OPTIONS] [<Selftest ID>]')
         print()
@@ -50,38 +69,21 @@ class EnableSelfTestCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:', [
-                'subsystem=', 'instance=', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: ' + str(e))
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        # To hold the subsystem names
-        subsystems = []
-        test = None
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        if len(args) == 1:
-            test = args[0]
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--subsystem':
-                subsystems.append(a)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: unknown option ' + o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        subsystem_names = args.subsystem
+        test = args.selftest_id
 
         # Load instance
         instance = pki.server.PKIServerFactory.create(instance_name)
@@ -96,11 +98,11 @@ class EnableSelfTestCLI(pki.cli.CLI):
         target_subsystems = []
 
         # Load subsystem or subsystems
-        if not subsystems:
+        if not subsystem_names:
             for subsys in instance.get_subsystems():
                 target_subsystems.append(subsys)
         else:
-            for subsys in subsystems:
+            for subsys in subsystem_names:
                 target_subsystems.append(instance.get_subsystem(subsys))
 
         try:
@@ -119,6 +121,28 @@ class DisableSelftestCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('disable', 'Disable selftests.')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--subsystem',
+            action='append')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('selftest_id')
+
     def print_help(self):
         print('Usage: pki-server selftest-disable [OPTIONS] [<Selftest ID>]')
         print()
@@ -129,38 +153,21 @@ class DisableSelftestCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:', [
-                'subsystem=', 'instance=', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: ' + str(e))
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        # To hold the subsystem names
-        subsystems = []
-        test = None
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        if len(args) == 1:
-            test = args[0]
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--subsystem':
-                subsystems.append(a)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: unknown option ' + o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        subsystem_names = args.subsystem
+        test = args.selftest_id
 
         # Load instance
         instance = pki.server.PKIServerFactory.create(instance_name)
@@ -175,11 +182,11 @@ class DisableSelftestCLI(pki.cli.CLI):
         target_subsystems = []
 
         # Load subsystem or subsystems
-        if not subsystems:
+        if not subsystem_names:
             for subsys in instance.get_subsystems():
                 target_subsystems.append(subsys)
         else:
-            for subsys in subsystems:
+            for subsys in subsystem_names:
                 target_subsystems.append(instance.get_subsystem(subsys))
 
         try:

--- a/base/server/python/pki/server/cli/webapp.py
+++ b/base/server/python/pki/server/cli/webapp.py
@@ -18,9 +18,7 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-import getopt
+import argparse
 import inspect
 import logging
 import sys
@@ -60,6 +58,24 @@ class WebappFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find webapps')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server webapp-find [OPTIONS]')
         print()
@@ -71,39 +87,19 @@ class WebappFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) > 0:
-            instance_name = args[0]
+        instance_name = args.instance
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -139,48 +135,44 @@ class WebappShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', inspect.cleandoc(self.__class__.__doc__))
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('webapp_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing webapp ID')
-            self.print_help()
-            sys.exit(1)
-
-        webapp_id = args[0]
+        instance_name = args.instance
+        webapp_id = args.webapp_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -202,6 +194,37 @@ class WebappDeployCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('deploy', 'Deploy webapp')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--descriptor')
+        self.parser.add_argument('--doc-base')
+        self.parser.add_argument(
+            '--wait',
+            action='store_true')
+        self.parser.add_argument(
+            '--max-wait',
+            type=int,
+            default=60)
+        self.parser.add_argument(
+            '--timeout',
+            type=int)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('webapp_id')
+
     def print_help(self):
         print('Usage: pki-server webapp-deploy [OPTIONS] <webapp ID>')
         print()
@@ -218,65 +241,27 @@ class WebappDeployCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'wait', 'max-wait=', 'timeout=',
-                'descriptor=', 'doc-base=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        descriptor = None
-        doc_base = None
-        wait = False
-        max_wait = 60
-        timeout = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--descriptor':
-                descriptor = a
-
-            elif o == '--doc-base':
-                doc_base = a
-
-            elif o == '--wait':
-                wait = True
-
-            elif o == '--max-wait':
-                max_wait = int(a)
-
-            elif o == '--timeout':
-                timeout = int(a)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            raise Exception('Missing Webapp ID')
+        instance_name = args.instance
+        descriptor = args.descriptor
+        doc_base = args.doc_base
+        wait = args.wait
+        max_wait = args.max_wait
+        timeout = args.timeout
+        webapp_id = args.webapp_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
-
-        webapp_id = args[0]
 
         if not instance.exists():
             raise Exception('Invalid instance: %s' % instance_name)
@@ -295,6 +280,35 @@ class WebappUndeployCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('undeploy', 'Undeploy webapp')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--wait',
+            action='store_true')
+        self.parser.add_argument(
+            '--max-wait',
+            type=int,
+            default=60)
+        self.parser.add_argument(
+            '--timeout',
+            type=int)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('webapp_id')
+
     def print_help(self):
         print('Usage: pki-server webapp-undeploy [OPTIONS] [<webapp ID>]')
         print()
@@ -309,54 +323,23 @@ class WebappUndeployCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'wait', 'max-wait=', 'timeout=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        wait = False
-        max_wait = 60
-        timeout = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--wait':
-                wait = True
-
-            elif o == '--max-wait':
-                max_wait = int(a)
-
-            elif o == '--timeout':
-                timeout = int(a)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            raise Exception('Missing Webapp ID')
-
-        webapp_id = args[0]
+        instance_name = args.instance
+        wait = args.wait
+        max_wait = args.max_wait
+        timeout = args.timeout
+        webapp_id = args.webapp_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 


### PR DESCRIPTION
The following Python modules have been updated to use `argparse`:

* pki.server.cli.config
* pki.server.cli.id
* pki.server.cli.nuxwdog
* pki.server.cli.range
* pki.server.cli.selftest
* pki.server.cli.upgrade
* pki.server.cli.webapp