### PR TITLE
Fix getopt deprecation warnings (part 3)

### DIFF
--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -19,12 +19,9 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-
+import argparse
 from contextlib import contextmanager
 import datetime
-import getopt
 import getpass
 import inspect
 import logging
@@ -106,6 +103,27 @@ class CertFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find system certificates.')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--show-all',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server cert-find [OPTIONS]')
         print()
@@ -118,40 +136,20 @@ class CertFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'show-all',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        show_all = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--show-all':
-                show_all = True
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('option %s not recognized', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        show_all = args.show_all
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -193,6 +191,31 @@ class CertShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Display system certificate details.')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--show-all',
+            action='store_true')
+        self.parser.add_argument(
+            '--pretty-print',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('cert_id')
+
     def print_help(self):
         print('Usage: pki-server cert-show [OPTIONS] <cert ID>')
         print()
@@ -206,51 +229,22 @@ class CertShowCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'show-all', 'pretty-print',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        show_all = False
-        pretty_print = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--show-all':
-                show_all = True
-
-            elif o == '--pretty-print':
-                pretty_print = True
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('option %s not recognized', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing cert ID.')
-            self.print_help()
-            sys.exit(1)
-
-        cert_id = args[0]
+        instance_name = args.instance
+        show_all = args.show_all
+        pretty_print = args.pretty_print
+        cert_id = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -309,47 +303,44 @@ class CertValidateCLI(pki.cli.CLI):
             'validate',
             inspect.cleandoc(self.__class__.__doc__))
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('cert_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing cert ID')
-            self.print_help()
-            sys.exit(1)
-
-        cert_id = args[0]
+        instance_name = args.instance
+        cert_id = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -379,6 +370,25 @@ class CertUpdateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('update', 'Update system certificate.')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('cert_id')
+
     def print_help(self):
         print('Usage: pki-server cert-update [OPTIONS] <cert ID>')
         print()
@@ -390,43 +400,20 @@ class CertUpdateCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('option %s not recognized', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing cert ID.')
-            self.print_help()
-            sys.exit(1)
-
-        cert_id = args[0]
+        instance_name = args.instance
+        cert_id = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -522,61 +509,53 @@ class CertRequestCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('request', inspect.cleandoc(self.__class__.__doc__))
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--token')
+        self.parser.add_argument('--subject')
+        self.parser.add_argument('--ext')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('cert_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'token=', 'subject=', 'ext=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        token = None
-        subject_dn = None
-        ext_conf = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--token':
-                token = a
-
-            elif o == '--subject':
-                subject_dn = a
-
-            elif o == '--ext':
-                ext_conf = a
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            raise Exception('Missing certificate ID')
+        instance_name = args.instance
+        token = args.token
+        subject_dn = args.subject
+        ext_conf = args.ext
+        cert_id = args.cert_id
 
         if subject_dn is None:
             raise Exception('Missing subject DN')
-
-        cert_id = args[0]
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -635,135 +614,107 @@ class CertCreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', inspect.cleandoc(self.__class__.__doc__))
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--token')
+        self.parser.add_argument('--issuer')
+        self.parser.add_argument('--ext')
+        self.parser.add_argument(
+            '-p',
+            '--port',
+            type=int,
+            default=8443)
+        self.parser.add_argument('-d')
+        self.parser.add_argument('-c')
+        self.parser.add_argument('-C')
+        self.parser.add_argument('-n')
+        self.parser.add_argument(
+            '--temp',
+            action='store_true')
+        self.parser.add_argument('--serial')
+        self.parser.add_argument('--output')
+        self.parser.add_argument(
+            '--renew',
+            action='store_true')
+        self.parser.add_argument('-u')
+        self.parser.add_argument('-w')
+        self.parser.add_argument('-W')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('cert_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:d:c:C:n:u:w:W:p:v', [
-                'instance=', 'token=', 'issuer=', 'ext=',
-                'temp', 'serial=',
-                'output=', 'renew', 'port=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        token = None
-        issuer = None
-        ext_conf = None
-        temp_cert = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
+        token = args.token
+        issuer = args.issuer
+        ext_conf = args.ext
+        temp_cert = args.temp
+
         serial = None
+        if args.serial:
+            # string containing the dec or hex value for the identifier
+            serial = str(int(args.serial, 0))
+
         client_nssdb = os.getenv('HOME') + '/.dogtag/nssdb'
-        client_nssdb_password = None
-        client_nssdb_pass_file = None
-        client_cert = None
-        output = None
-        renew = False
-        agent_username = None
-        agent_password = None
-        agent_password_file = None
-        port = '8443'
+        if args.d:
+            client_nssdb = args
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        client_nssdb_password = args.c
+        client_nssdb_pass_file = args.C
+        client_cert = args.n
+        output = args.output
+        renew = args.renew
+        agent_username = args.u
+        agent_password = args.w
+        agent_password_file = args.W
+        cert_id = args.cert_id
 
-            elif o == '--token':
-                token = a
-
-            elif o == '--issuer':
-                issuer = a
-
-            elif o == '--ext':
-                ext_conf = a
-
-            elif o == '-d':
-                client_nssdb = a
-
-            elif o == '-c':
-                client_nssdb_password = a
-
-            elif o == '-C':
-                client_nssdb_pass_file = a
-
-            elif o == '-n':
-                if agent_username:
-                    logger.error('-n cannot be used with -u')
-                    sys.exit(1)
-                client_cert = a
-
-            elif o == '--temp':
-                temp_cert = True
-
-            elif o == '--serial':
-                # string containing the dec or hex value for the identifier
-                serial = str(int(a, 0))
-
-            elif o == '--output':
-                output = a
-
-            elif o == '--renew':
-                renew = True
-
-            elif o == '-u':
-                if client_cert:
-                    logger.error('-u cannot be used with -n')
-                    sys.exit(1)
-                agent_username = a
-
-            elif o == '-w':
-                if agent_password_file:
-                    logger.error('-w cannot be used with -W')
-                    sys.exit(1)
-                agent_password = a
-
-            elif o == '-W':
-                if agent_password:
-                    logger.error('-W cannot be used with -w')
-                    sys.exit(1)
-                agent_password_file = a
-
-            elif o in ('-p', '--port'):
-                port = a
-                try:
-                    n = int(port)
-                    if n < 1 or n > 65535:
-                        raise ValueError
-                except ValueError:
-                    logger.error('-p, --port requires a valid port number as integer')
-                    sys.exit(1)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('option %s not recognized', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing cert ID.')
-            self.print_help()
+        if client_cert and agent_username:
+            logger.error('-n cannot be used with -u')
             sys.exit(1)
+
+        if agent_password and agent_password_file:
+            logger.error('-w cannot be used with -W')
+            sys.exit(1)
+
+        if args.port < 1 or args.port > 65535:
+            raise ValueError('Invalid port number: %d' % args.port)
+
+        port = str(args.port)
 
         # Read the password file for password value
         if agent_password_file:
             with open(agent_password_file, encoding='utf-8') as f:
                 agent_password = f.read().strip()
-
-        cert_id = args[0]
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -818,60 +769,50 @@ class CertImportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('import', inspect.cleandoc(self.__class__.__doc__))
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--token')
+        self.parser.add_argument('--nickname')
+        self.parser.add_argument('--input')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('cert_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'token=', 'nickname=', 'input=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        token = None
-        nickname = None
-        cert_file = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--token':
-                token = a
-
-            elif o == '--nickname':
-                nickname = a
-
-            elif o == '--input':
-                cert_file = a
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('option %s not recognized', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing cert ID.')
-            self.print_help()
-            sys.exit(1)
-
-        cert_id = args[0]
+        instance_name = args.instance
+        token = args.token
+        nickname = args.nickname
+        cert_file = args.input
+        cert_id = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -896,6 +837,45 @@ class CertImportCLI(pki.cli.CLI):
 class CertExportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('export', 'Export system certificate.')
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--cert-file')
+        self.parser.add_argument('--csr-file')
+        self.parser.add_argument('--pkcs12-file')
+        self.parser.add_argument('--pkcs12-password')
+        self.parser.add_argument('--pkcs12-password-file')
+        self.parser.add_argument('--friendly-name')
+        self.parser.add_argument('--cert-encryption')
+        self.parser.add_argument('--key-encryption')
+        self.parser.add_argument(
+            '--append',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-trust-flags',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-key',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-chain',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('cert_id')
 
     def print_help(self):
         print('Usage: pki-server cert-export [OPTIONS] <Cert ID>')
@@ -936,95 +916,32 @@ class CertExportCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'cert-file=', 'csr-file=',
-                'pkcs12-file=', 'pkcs12-password=', 'pkcs12-password-file=',
-                'friendly-name=',
-                'cert-encryption=', 'key-encryption=',
-                'append', 'no-trust-flags', 'no-key', 'no-chain',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        cert_file = None
-        csr_file = None
-        pkcs12_file = None
-        pkcs12_password = None
-        pkcs12_password_file = None
-        friendly_name = None
-        cert_encryption = None
-        key_encryption = None
-        append = False
-        include_trust_flags = True
-        include_key = True
-        include_chain = True
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--cert-file':
-                cert_file = a
-
-            elif o == '--csr-file':
-                csr_file = a
-
-            elif o == '--pkcs12-file':
-                pkcs12_file = a
-
-            elif o == '--pkcs12-password':
-                pkcs12_password = a
-
-            elif o == '--pkcs12-password-file':
-                pkcs12_password_file = a
-
-            elif o == '--friendly-name':
-                friendly_name = a
-
-            elif o == '--cert-encryption':
-                cert_encryption = a
-
-            elif o == '--key-encryption':
-                key_encryption = a
-
-            elif o == '--append':
-                append = True
-
-            elif o == '--no-trust-flags':
-                include_trust_flags = False
-
-            elif o == '--no-key':
-                include_key = False
-
-            elif o == '--no-chain':
-                include_chain = False
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('option %s not recognized', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing cert ID.')
-            self.print_help()
-            sys.exit(1)
-
-        cert_id = args[0]
+        instance_name = args.instance
+        cert_file = args.cert_file
+        csr_file = args.csr_file
+        pkcs12_file = args.pkcs12_file
+        pkcs12_password = args.pkcs12_password
+        pkcs12_password_file = args.pkcs12_password_file
+        friendly_name = args.friendly_name
+        cert_encryption = args.cert_encryption
+        key_encryption = args.key_encryption
+        append = args.append
+        include_trust_flags = not args.no_trust_flags
+        include_key = not args.no_key
+        include_chain = not args.no_chain
+        cert_id = args.cert_id
 
         if not (cert_file or csr_file or pkcs12_file):
             logger.error('missing output file')
@@ -1157,6 +1074,28 @@ class CertRemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Remove system certificate.')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--remove-key',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('cert_id')
+
     def print_help(self):
         print('Usage: pki-server cert-del [OPTIONS] <Cert ID>')
         # CertID:  subsystem, sslserver, kra_storage, kra_transport, ca_ocsp_signing,
@@ -1172,47 +1111,21 @@ class CertRemoveCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'remove-key',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        remove_key = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--remove-key':
-                remove_key = True
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('option %s not recognized', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing cert ID.')
-            self.print_help()
-            sys.exit(1)
-
-        cert_id = args[0]
+        instance_name = args.instance
+        remove_key = args.remove_key
+        cert_id = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -1228,8 +1141,6 @@ class CertRemoveCLI(pki.cli.CLI):
 
 
 class CertFixCLI(pki.cli.CLI):
-    def __init__(self):
-        super().__init__('fix', 'Fix expired system certificate(s).')
 
     PKIDBUSER_LDIF_TEMPLATE = (
         "dn: {dn}\n"
@@ -1237,6 +1148,37 @@ class CertFixCLI(pki.cli.CLI):
         "add: userCertificate\n"
         "userCertificate:< file://{der_file}\n"
     )
+
+    def __init__(self):
+        super().__init__('fix', 'Fix expired system certificate(s).')
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--cert')
+        self.parser.add_argument('--extra-cert')
+        self.parser.add_argument('--agent-uid')
+        self.parser.add_argument('--ldapi-socket')
+        self.parser.add_argument('--ldap-url')
+        self.parser.add_argument(
+            '-p',
+            '--port',
+            type=int,
+            default=8443)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
 
     def print_help(self):
         print('Usage: pki-server cert-fix [OPTIONS]')
@@ -1257,85 +1199,58 @@ class CertFixCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        logging.getLogger().setLevel(logging.INFO)
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:p:v', [
-                'instance=', 'cert=', 'extra-cert=', 'agent-uid=',
-                'ldapi-socket=', 'ldap-url=', 'port=', 'verbose', 'debug', 'help',
-            ])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
+
         all_certs = True
         fix_certs = []
         extra_certs = []
-        agent_uid = None
+
+        if args.cert:
+            all_certs = False
+            fix_certs.append(args.cert)
+            
+        if args.extra_cert:
+            # TODO: add support for hex serial number
+            try:
+                int(args.extra_cert)
+            except ValueError:
+                logger.error('--extra-cert requires serial number as integer')
+                sys.exit(1)
+            all_certs = False
+            extra_certs.append(args.extra_cert)
+
+        agent_uid = args.agent_uid
         ldap_url = None
         use_ldapi = False
-        port = '8443'
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        if args.ldap_socket and args.ldap_url:
+            logger.error('--ldapi-socket cannot be used with --ldap-url')
+            sys.exit(1)
 
-            elif o == '--cert':
-                all_certs = False
-                fix_certs.append(a)
+        if args.ldap_socket:
+            use_ldapi = True
+            ldap_url = 'ldapi://{}'.format(quote(args.ldap_socket, safe=''))
 
-            elif o == '--extra-cert':
-                try:
-                    int(a)
-                except ValueError:
-                    logger.error('--extra-cert requires serial number as integer')
-                    sys.exit(1)
-                all_certs = False
-                extra_certs.append(a)
+        if args.ldap_url:
+            ldap_url = args.ldap_url
 
-            elif o == '--agent-uid':
-                agent_uid = a
+        if args.port < 1 or args.port > 65535:
+            raise ValueError('Invalid port number: %d' % args.port)
 
-            elif o == '--ldapi-socket':
-                if ldap_url is not None:
-                    logger.error('--ldapi-socket cannot be used with --ldap-url')
-                    sys.exit(1)
-                use_ldapi = True
-                ldap_url = 'ldapi://{}'.format(quote(a, safe=''))
-
-            elif o == '--ldap-url':
-                if use_ldapi:
-                    logger.error('--ldap-url cannot be used with --ldapi-socket')
-                    sys.exit(1)
-                ldap_url = a
-
-            elif o in ('-p', '--port'):
-                port = a
-                try:
-                    n = int(port)
-                    if n < 1 or n > 65535:
-                        raise ValueError
-                except ValueError:
-                    logger.error('-p, --port requires a valid port number as integer')
-                    sys.exit(1)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('option %s not recognized', o)
-                self.print_help()
-                sys.exit(1)
+        port = str(args.port)
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 

--- a/base/server/python/pki/server/cli/db.py
+++ b/base/server/python/pki/server/cli/db.py
@@ -18,9 +18,7 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-import getopt
+import argparse
 import getpass
 import inspect
 import logging
@@ -49,6 +47,29 @@ class DBSchemaUpgradeCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('schema-upgrade', 'Upgrade PKI database schema')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-D',
+            '--bind-dn',
+            default='cn=Directory Manager')
+        self.parser.add_argument('-w', '--bind-password')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server db-schema-upgrade [OPTIONS]')
         print()
@@ -61,44 +82,22 @@ class DBSchemaUpgradeCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:D:w:v', [
-                'instance=', 'bind-dn=', 'bind-password=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        bind_dn = 'cn=Directory Manager'
-        bind_password = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-D', '--bind-dn'):
-                bind_dn = a
-
-            elif o in ('-w', '--bind-password'):
-                bind_password = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        bind_dn = args.bind_dn
+        bind_password = args.bind_password
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -134,6 +133,27 @@ class DBUpgradeCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('upgrade', 'Upgrade PKI server database')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server db-upgrade [OPTIONS]')
         print()
@@ -145,45 +165,26 @@ class DBUpgradeCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        as_current_user = False
-        verbose = False
         debug = False
+        verbose = False
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        if args.debug:
+            debug = True
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o == '--as-current-user':
-                as_current_user = True
+        elif args.verbose:
+            verbose = True
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-                verbose = True
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-                debug = True
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        as_current_user = args.as_current_user
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -290,6 +291,24 @@ class SubsystemDBConfigShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-config-show [OPTIONS]' % self.parent.parent.parent.name)
         print()
@@ -300,36 +319,20 @@ class SubsystemDBConfigShowCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -358,6 +361,42 @@ class SubsystemDBConfigModifyCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--hostname')
+        self.parser.add_argument(
+            '--port',
+            type=int)
+        self.parser.add_argument('--secure')
+        self.parser.add_argument('--auth')
+        self.parser.add_argument('--bindDN')
+        self.parser.add_argument('--bindPWPrompt')
+        self.parser.add_argument('--nickname')
+        self.parser.add_argument('--database')
+        self.parser.add_argument('--baseDN')
+        self.parser.add_argument('--multiSuffix')
+        self.parser.add_argument(
+            '--maxConns',
+            type=int)
+        self.parser.add_argument(
+            '--minConns',
+            type=int)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-config-mod [OPTIONS]' % self.parent.parent.parent.name)
         print()
@@ -381,101 +420,49 @@ class SubsystemDBConfigModifyCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'hostname=', 'port=', 'secure=',
-                'auth=',
-                'bindDN=', 'bindPWPrompt=',
-                'nickname=',
-                'database=', 'baseDN=', 'multiSuffix=',
-                'maxConns=', 'minConns=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        hostname = None
-        port = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
+        hostname = args.hostname
+        port = str(args.port)
+
         secure = None
+        if args.secure:
+            if args.secure.lower() not in ['true', 'false']:
+                raise ValueError('Invalid input: --secure accepts True or False')
+            secure = args.secure.lower() == 'true'
+
         auth = None
-        bindDN = None
-        bindPWPrompt = None
-        nickname = None
-        database = None
-        baseDN = None
+        if args.auth:
+            if args.auth not in ['BasicAuth', 'SslClientAuth']:
+                raise ValueError('Invalid input: %s' % args.auth)
+            auth = args.auth
+
+        bindDN = args.bindDN
+        bindPWPrompt = args.bindPWPrompt
+        nickname = args.nickname
+        database = args.database
+        baseDN = args.baseDN
+
         multiSuffix = None
-        maxConns = None
-        minConns = None
+        if args.multiSuffix:
+            if args.multiSuffix.lower() not in ['true', 'false']:
+                raise ValueError('Invalid input: --multiSuffix accepts True or False')
+            multiSuffix = args.multiSuffix.lower() == 'true'
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--hostname':
-                hostname = a
-
-            elif o == '--port':
-                if not a.isdigit():
-                    raise ValueError('Invalid input: %s accepts a number' % o)
-                port = a
-
-            elif o == '--secure':
-                if a.lower() not in ['true', 'false']:
-                    raise ValueError('Invalid input: %s accepts True or False' % o)
-                secure = a.lower() == 'true'
-
-            elif o == '--auth':
-                if a not in ['BasicAuth', 'SslClientAuth']:
-                    raise ValueError('Invalid input: %s' % a)
-                auth = a
-
-            elif o == '--bindDN':
-                bindDN = a
-
-            elif o == '--bindPWPrompt':
-                bindPWPrompt = a
-
-            elif o == '--nickname':
-                nickname = a
-
-            elif o == '--database':
-                database = a
-
-            elif o == '--baseDN':
-                baseDN = a
-
-            elif o == '--multiSuffix':
-                if a.lower() not in ['true', 'false']:
-                    raise ValueError('Invalid input: %s accepts True or False' % o)
-                multiSuffix = a.lower() == 'true'
-
-            elif o == '--maxConns':
-                if not a.isdigit():
-                    raise ValueError('Invalid input: %s accepts a number' % o)
-                maxConns = a
-
-            elif o == '--minConns':
-                if not a.isdigit():
-                    raise ValueError('Invalid input: %s accepts a number' % o)
-                minConns = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        maxConns = args.maxConns
+        minConns = args.minConns
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -548,6 +535,27 @@ class SubsystemDBInfoCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-info [OPTIONS]' % self.parent.parent.name)
         print()
@@ -559,46 +567,24 @@ class SubsystemDBInfoCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-        as_current_user = False
+        as_current_user = args.as_current_user
 
         cmd = [subsystem_name + '-db-info']
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-                cmd.append('--verbose')
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-                cmd.append('--debug')
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -639,42 +625,44 @@ class SubsystemDBCreateCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -719,60 +707,61 @@ class SubsystemDBInitCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--skip-config',
+            action='store_true')
+        self.parser.add_argument(
+            '--skip-schema',
+            action='store_true')
+        self.parser.add_argument(
+            '--skip-base',
+            action='store_true')
+        self.parser.add_argument(
+            '--skip-containers',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'skip-config', 'skip-schema',
-                'skip-base', 'skip-containers',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
 
-        skip_config = False
-        skip_schema = False
-        skip_base = False
-        skip_containers = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--skip-config':
-                skip_config = True
-
-            elif o == '--skip-schema':
-                skip_schema = True
-
-            elif o == '--skip-base':
-                skip_base = True
-
-            elif o == '--skip-containers':
-                skip_containers = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        skip_config = args.skip_config
+        skip_schema = args.skip_schema
+        skip_base = args.skip_base
+        skip_containers = args.skip_containers
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -802,6 +791,30 @@ class SubsystemDBEmptyCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--force',
+            action='store_true')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-empty [OPTIONS]' % self.parent.parent.name)
         print()
@@ -814,46 +827,23 @@ class SubsystemDBEmptyCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'force', 'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-        force = False
-        as_current_user = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--force':
-                force = True
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        force = args.force
+        as_current_user = args.as_current_user
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -881,6 +871,30 @@ class SubsystemDBRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--force',
+            action='store_true')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-remove [OPTIONS]' % self.parent.parent.name)
         print()
@@ -893,46 +907,23 @@ class SubsystemDBRemoveCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'force', 'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-        force = False
-        as_current_user = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--force':
-                force = True
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        force = args.force
+        as_current_user = args.as_current_user
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -962,6 +953,27 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-upgrade [OPTIONS]' % self.parent.parent.name)
         print()
@@ -973,46 +985,24 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-        as_current_user = False
+        as_current_user = args.as_current_user
 
         cmd = [subsystem_name + '-db-upgrade']
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-                cmd.append('--verbose')
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-                cmd.append('--debug')
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -1071,54 +1061,50 @@ class SubsystemDBAccessGrantCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('dn')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        as_current_user = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing DN')
-            self.print_help()
-            sys.exit(1)
-
-        dn = args[0]
+        as_current_user = args.as_current_user
+        dn = args.dn
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1161,54 +1147,50 @@ class SubsystemDBAccessRevokeCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('dn')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        as_current_user = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing DN')
-            self.print_help()
-            sys.exit(1)
-
-        dn = args[0]
+        as_current_user = args.as_current_user
+        dn = args.dn
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1266,42 +1248,44 @@ class SubsystemDBIndexAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1343,42 +1327,44 @@ class SubsystemDBIndexRebuildCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1443,73 +1429,58 @@ class SubsystemDBReplicationEnableCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--url')
+        self.parser.add_argument('--bind-dn')
+        self.parser.add_argument('--bind-password')
+        self.parser.add_argument('--replica-bind-dn')
+        self.parser.add_argument('--replica-bind-password')
+        self.parser.add_argument('--replica-id')
+        self.parser.add_argument('--suffix')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'url=', 'bind-dn=', 'bind-password=',
-                'replica-bind-dn=', 'replica-bind-password=',
-                'replica-id=', 'suffix=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        url = None
-        bind_dn = None
-        bind_password = None
-        replica_bind_dn = None
-        replica_bind_password = None
-        replica_id = None
-        suffix = None
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--url':
-                url = urllib.parse.urlparse(a)
-
-            elif o == '--bind-dn':
-                bind_dn = a
-
-            elif o == '--bind-password':
-                bind_password = a
-
-            elif o == '--replica-bind-dn':
-                replica_bind_dn = a
-
-            elif o == '--replica-bind-password':
-                replica_bind_password = a
-
-            elif o == '--replica-id':
-                replica_id = a
-
-            elif o == '--suffix':
-                suffix = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        url = urllib.parse.urlparse(args.url)
+        bind_dn = args.bind_dn
+        bind_password = args.bind_password
+        replica_bind_dn = args.replica_bind_dn
+        replica_bind_password = args.replica_bind_password
+        replica_id = args.replica_id
+        suffix = args.suffix
 
         # user must provide the replica ID is required since
         # in the future the auto-generated replica ID will no
@@ -1603,84 +1574,62 @@ class SubsystemDBReplicationAgreementAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--url')
+        self.parser.add_argument('--bind-dn')
+        self.parser.add_argument('--bind-password')
+        self.parser.add_argument('--replica-url')
+        self.parser.add_argument('--replica-bind-dn')
+        self.parser.add_argument('--replica-bind-password')
+        self.parser.add_argument('--replication-security')
+        self.parser.add_argument('--suffix')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'url=', 'bind-dn=', 'bind-password=',
-                'replica-url=', 'replica-bind-dn=', 'replica-bind-password=',
-                'replication-security=', 'suffix=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.parent.name
-        url = None
-        bind_dn = None
-        bind_password = None
-        replica_url = None
-        replica_bind_dn = None
-        replica_bind_password = None
-        replication_security = None
-        suffix = None
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--url':
-                url = urllib.parse.urlparse(a)
-
-            elif o == '--bind-dn':
-                bind_dn = a
-
-            elif o == '--bind-password':
-                bind_password = a
-
-            elif o == '--replica-url':
-                replica_url = a
-
-            elif o == '--replica-bind-dn':
-                replica_bind_dn = a
-
-            elif o == '--replica-bind-password':
-                replica_bind_password = a
-
-            elif o == '--replication-security':
-                replication_security = a
-
-            elif o == '--suffix':
-                suffix = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing replication agreement name')
-            self.print_help()
-            sys.exit(1)
-
-        name = args[0]
+        url = urllib.parse.urlparse(args.url)
+        bind_dn = args.bind_dn
+        bind_password = args.bind_password
+        replica_url = args.replica_url
+        replica_bind_dn = args.replica_bind_dn
+        replica_bind_password = args.replica_bind_password
+        replication_security = args.replication_security
+        suffix = args.suffix
+        name = args.name
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1748,66 +1697,54 @@ class SubsystemDBReplicationAgreementInitCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--url')
+        self.parser.add_argument('--bind-dn')
+        self.parser.add_argument('--bind-password')
+        self.parser.add_argument('--suffix')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'url=', 'bind-dn=', 'bind-password=', 'suffix=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.parent.name
-        url = None
-        bind_dn = None
-        bind_password = None
-        suffix = None
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--url':
-                url = urllib.parse.urlparse(a)
-
-            elif o == '--bind-dn':
-                bind_dn = a
-
-            elif o == '--bind-password':
-                bind_password = a
-
-            elif o == '--suffix':
-                suffix = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing replication agreement name')
-            self.print_help()
-            sys.exit(1)
-
-        name = args[0]
+        url = urllib.parse.urlparse(args.url)
+        bind_dn = args.bind_dn
+        bind_password = args.bind_password
+        suffix = args.suffix
+        name = args.name
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1867,6 +1804,27 @@ class SubsystemDBVLVFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-vlv-find [OPTIONS]' % self.parent.parent.parent.name)
         print()
@@ -1878,42 +1836,22 @@ class SubsystemDBVLVFindCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        as_current_user = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        as_current_user = args.as_current_user
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1942,6 +1880,27 @@ class SubsystemDBVLVAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-vlv-add [OPTIONS]' % self.parent.parent.parent.name)
         print()
@@ -1953,42 +1912,22 @@ class SubsystemDBVLVAddCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        as_current_user = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        as_current_user = args.as_current_user
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -2017,6 +1956,27 @@ class SubsystemDBVLVDeleteCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-vlv-del [OPTIONS]' % self.parent.parent.parent.name)
         print()
@@ -2028,42 +1988,22 @@ class SubsystemDBVLVDeleteCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        as_current_user = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        as_current_user = args.as_current_user
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -2092,6 +2032,27 @@ class SubsystemDBVLVReindexCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-db-vlv-reindex [OPTIONS]' % self.parent.parent.parent.name)
         print()
@@ -2103,42 +2064,22 @@ class SubsystemDBVLVReindexCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'as-current-user',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        as_current_user = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--as-current-user':
-                as_current_user = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        as_current_user = args.as_current_user
 
         instance = pki.server.instance.PKIInstance(instance_name)
 

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -18,9 +18,7 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-import getopt
+import argparse
 import inspect
 import logging
 import sys
@@ -104,6 +102,34 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add connector')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--port')
+        self.parser.add_argument('--protocol')
+        self.parser.add_argument('--scheme')
+        self.parser.add_argument('--secure')
+        self.parser.add_argument('--sslEnabled')
+        self.parser.add_argument('--sslImpl')
+        self.parser.add_argument('--sslProtocol')
+        self.parser.add_argument('--certVerification')
+        self.parser.add_argument('--trustManager')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
+
     def print_help(self):
         print('Usage: pki-server http-connector-add [OPTIONS] <connector ID>')
         print()
@@ -124,83 +150,32 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'port=', 'protocol=', 'scheme=',
-                'secure=', 'sslEnabled=', 'sslImpl=',
-                'sslProtocol=', 'certVerification=', 'trustManager=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        port = None
-        protocol = None
-        scheme = None
-        secure = None
-        sslEnabled = None
-        sslImpl = None
-        sslProtocol = None
-        certVerification = None
-        trustManager = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--port':
-                port = a
-
-            elif o == '--protocol':
-                protocol = a
-
-            elif o == '--scheme':
-                scheme = a
-
-            elif o == '--secure':
-                secure = a
-
-            elif o == '--sslEnabled':
-                sslEnabled = a
-
-            elif o == '--sslImpl':
-                sslImpl = a
-
-            elif o == '--sslProtocol':
-                sslProtocol = a
-
-            elif o == '--certVerification':
-                certVerification = a
-
-            elif o == '--trustManager':
-                trustManager = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            raise Exception('Missing connector ID')
+        instance_name = args.instance
+        port = args.port
+        protocol = args.protocol
+        scheme = args.scheme
+        secure = args.secure
+        sslEnabled = args.sslEnabled
+        sslImpl = args.sslImpl
+        sslProtocol = args.sslProtocol
+        certVerification = args.certVerification
+        trustManager = args.trustManager
+        name = args.name
 
         if port is None:
             raise Exception('Missing port number')
-
-        name = args[0]
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -242,6 +217,25 @@ class HTTPConnectorDeleteCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Delete connector')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
+
     def print_help(self):
         print('Usage: pki-server http-connector-del [OPTIONS] <connector ID>')
         print()
@@ -253,43 +247,20 @@ class HTTPConnectorDeleteCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            print('ERROR: Missing connector ID')
-            self.print_help()
-            sys.exit(1)
-
-        name = args[0]
+        instance_name = args.instance
+        name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -309,6 +280,24 @@ class HTTPConnectorFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find connectors')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server http-connector-find [OPTIONS]')
         print()
@@ -320,36 +309,19 @@ class HTTPConnectorFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -380,6 +352,25 @@ class HTTPConnectorShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show connector')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
+
     def print_help(self):
         print('Usage: pki-server http-connector-show [OPTIONS] <connector ID>')
         print()
@@ -391,43 +382,20 @@ class HTTPConnectorShowCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            print('ERROR: Missing connector ID')
-            self.print_help()
-            sys.exit(1)
-
-        name = args[0]
+        instance_name = args.instance
+        name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -450,6 +418,40 @@ class HTTPConnectorModCLI(pki.cli.CLI):
 
     def __init__(self):
         super().__init__('mod', 'Modify connector')
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--type')
+        self.parser.add_argument('--nss-database-dir')
+        self.parser.add_argument('--nss-password-file')
+        self.parser.add_argument('--keystore-file')
+        self.parser.add_argument('--keystore-password-file')
+        self.parser.add_argument('--server-cert-nickname-file')
+        self.parser.add_argument('--port')
+        self.parser.add_argument('--protocol')
+        self.parser.add_argument('--scheme')
+        self.parser.add_argument('--secure')
+        self.parser.add_argument('--sslEnabled')
+        self.parser.add_argument('--sslImp')
+        self.parser.add_argument('--sslProtocol')
+        self.parser.add_argument('--cartVerification')
+        self.parser.add_argument('--trustManager')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('name')
 
     def print_help(self):
         print('Usage: pki-server http-connector-mod [OPTIONS] <connector ID>')
@@ -474,96 +476,32 @@ class HTTPConnectorModCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'type=',
-                'nss-database-dir=', 'nss-password-file=',
-                'keystore-file=', 'keystore-password-file=',
-                'server-cert-nickname-file=',
-                'port=', 'protocol=', 'scheme=',
-                'secure=', 'sslEnabled=', 'sslImpl=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        connector_type = None
-        nss_database_dir = None
-        nss_password_file = None
-        keystore_file = None
-        keystore_password_file = None
-        server_cert_nickname_file = None
-        port = None
-        protocol = None
-        scheme = None
-        secure = None
-        sslEnabled = None
-        sslImpl = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--type':
-                connector_type = a
-
-            elif o == '--nss-database-dir':
-                nss_database_dir = a
-
-            elif o == '--nss-password-file':
-                nss_password_file = a
-
-            elif o == '--keystore-file':
-                keystore_file = a
-
-            elif o == '--keystore-password-file':
-                keystore_password_file = a
-
-            elif o == '--server-cert-nickname-file':
-                server_cert_nickname_file = a
-
-            elif o == '--port':
-                port = a
-
-            elif o == '--protocol':
-                protocol = a
-
-            elif o == '--scheme':
-                scheme = a
-
-            elif o == '--secure':
-                secure = a
-
-            elif o == '--sslEnabled':
-                sslEnabled = a
-
-            elif o == '--sslImpl':
-                sslImpl = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            print('ERROR: Missing connector ID')
-            self.print_help()
-            sys.exit(1)
-
-        name = args[0]
+        instance_name = args.instance
+        connector_type = args.type
+        nss_database_dir = args.nss_database_dir
+        nss_password_file = args.nss_password_file
+        keystore_file = args.keystore_file
+        keystore_password_file = args.keystore_password_file
+        server_cert_nickname_file = args.server_cert_nickname_file
+        port = args.port
+        protocol = args.protocol
+        scheme = args.scheme
+        secure = args.secure
+        sslEnabled = args.sslEnabled
+        sslImpl = args.sslImpl
+        name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -668,6 +606,29 @@ class SSLHostAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add SSL host configuration')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--sslProtocol')
+        self.parser.add_argument('--certVerification')
+        self.parser.add_argument('--trustManager')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('connector_name')
+        self.parser.add_argument('hostname')
+
     def print_help(self):
         print('Usage: pki-server http-connector-host-add [OPTIONS] <connector ID> <hostname>')
         print()
@@ -682,59 +643,24 @@ class SSLHostAddCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'sslProtocol=', 'certVerification=', 'trustManager=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        sslProtocol = None
-        certVerification = None
-        trustManager = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--sslProtocol':
-                sslProtocol = a
-
-            elif o == '--certVerification':
-                certVerification = a
-
-            elif o == '--trustManager':
-                trustManager = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            raise Exception('Missing connector ID')
-
-        connector_name = args[0]
-
-        if len(args) < 2:
-            raise Exception('Missing hostname')
-
-        hostname = args[1]
+        instance_name = args.instance
+        sslProtocol = args.sslProtocol
+        certVerification = args.certVerification
+        trustManager = args.trustManager
+        connector_name = args.connector_name
+        hostname = args.hostname
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -771,6 +697,26 @@ class SSLHostDeleteCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Delete SSL host configuration')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('connector_name')
+        self.parser.add_argument('hostname')
+
     def print_help(self):
         print('Usage: pki-server http-connector-host-del [OPTIONS] <connector ID> <hostname>')
         print()
@@ -782,46 +728,21 @@ class SSLHostDeleteCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            raise Exception('Missing connector ID')
-
-        connector_name = args[0]
-
-        if len(args) < 2:
-            raise Exception('Missing hostname')
-
-        hostname = args[1]
+        instance_name = args.instance
+        connector_name = args.connector_name
+        hostname = args.hostname
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -847,6 +768,25 @@ class SSLHostFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find SSL host configurations')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('connector_name')
+
     def print_help(self):
         print('Usage: pki-server http-connector-sslhost-find [OPTIONS] <connector ID>')
         print()
@@ -858,41 +798,20 @@ class SSLHostFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            raise Exception('Missing connector ID')
-
-        connector_name = args[0]
+        instance_name = args.instance
+        connector_name = args.connector_name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -943,67 +862,52 @@ class SSLHostModifyCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', inspect.cleandoc(self.__class__.__doc__))
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--sslProtocol')
+        self.parser.add_argument('--certVerification')
+        self.parser.add_argument('--trustManager')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('connector_name')
+        self.parser.add_argument('hostname')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'sslProtocol=', 'certVerification=', 'trustManager=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        sslProtocol = None
-        certVerification = None
-        trustManager = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--sslProtocol':
-                sslProtocol = a
-
-            elif o == '--certVerification':
-                certVerification = a
-
-            elif o == '--trustManager':
-                trustManager = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing connector ID')
-            self.print_help()
-            sys.exit(1)
-
-        connector_name = args[0]
-
-        if len(args) < 2:
-            logger.error('Missing hostname')
-            self.print_help()
-            sys.exit(1)
-
-        hostname = args[1]
+        instance_name = args.instance
+        sslProtocol = args.sslProtocol
+        certVerification = args.certVerification
+        trustManager = args.trustManager
+        connector_name = args.connector_name
+        hostname = args.hostname
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -1052,54 +956,46 @@ class SSLHostShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', inspect.cleandoc(self.__class__.__doc__))
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('connector_name')
+        self.parser.add_argument('hostname')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing connector ID')
-            self.print_help()
-            sys.exit(1)
-
-        connector_name = args[0]
-
-        if len(args) < 2:
-            logger.error('Missing hostname')
-            self.print_help()
-            sys.exit(1)
-
-        hostname = args[1]
+        instance_name = args.instance
+        connector_name = args.connector_name
+        hostname = args.hostname
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -1158,6 +1054,41 @@ class SSLCertAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add SSL certificate configuration')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--connector',
+            default='Secure')
+        self.parser.add_argument(
+            '--sslHost',
+            default='_default_')
+        self.parser.add_argument('--certFile')
+        self.parser.add_argument('--keyAlias')
+        self.parser.add_argument('--keyFile')
+        self.parser.add_argument('--keystoreType')
+        self.parser.add_argument('--keystoreProvider')
+        self.parser.add_argument('--keystoreFile')
+        self.parser.add_argument('--keystorePassword')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'type',
+            nargs='?',
+            default='UNDEFINED')
+
     def print_help(self):
         print('Usage: pki-server http-connector-cert-add '
               '[OPTIONS] [<type>]')
@@ -1179,80 +1110,29 @@ class SSLCertAddCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'connector=', 'sslHost=',
-                'certFile=', 'keyAlias=', 'keyFile=',
-                'keystoreType=', 'keystoreProvider=', 'keystoreFile=', 'keystorePassword=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        connector_name = 'Secure'
-        hostname = '_default_'
-        certFile = None
-        keyAlias = None
-        keyFile = None
-        keystoreType = None
-        keystoreProvider = None
-        keystoreFile = None
-        keystorePassword = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--connector':
-                connector_name = a
-
-            elif o == '--sslHost':
-                hostname = a
-
-            elif o == '--certFile':
-                certFile = a
-
-            elif o == '--keyAlias':
-                keyAlias = a
-
-            elif o == '--keyFile':
-                keyFile = a
-
-            elif o == '--keystoreType':
-                keystoreType = a
-
-            elif o == '--keystoreProvider':
-                keystoreProvider = a
-
-            elif o == '--keystoreFile':
-                keystoreFile = a
-
-            elif o == '--keystorePassword':
-                keystorePassword = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            certType = 'UNDEFINED'
-        else:
-            certType = args[0]
+        instance_name = args.instance
+        connector_name = args.connector
+        hostname = args.sslHost
+        certFile = args.certFile
+        keyAlias = args.keyAlias
+        keyFile = args.keyFile
+        keystoreType = args.keystoreType
+        keystoreProvider = args.keystoreProvider
+        keystoreFile = args.keystoreFile
+        keystorePassword = args.keystorePassword
+        certType = args.type
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -1298,6 +1178,34 @@ class SSLCertDeleteCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Delete SSL certificate configuration')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--connector',
+            default='Secure')
+        self.parser.add_argument(
+            '--sslHost',
+            default='_default_')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'type',
+            nargs='?',
+            default='UNDEFINED')
+
     def print_help(self):
         print('Usage: pki-server http-connector-cert-del '
               '[OPTIONS] [<type>]')
@@ -1312,50 +1220,22 @@ class SSLCertDeleteCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'connector=', 'sslHost=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        connector_name = 'Secure'
-        hostname = '_default_'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--connector':
-                connector_name = a
-
-            elif o == '--sslHost':
-                hostname = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            certType = 'UNDEFINED'
-        else:
-            certType = args[0]
+        instance_name = args.instance
+        connector_name = args.connector
+        hostname = args.sslHost
+        certType = args.type
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -1386,6 +1266,30 @@ class SSLCertFindLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find SSL certificate configurations')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--connector',
+            default='Secure')
+        self.parser.add_argument(
+            '--sslHost',
+            default='_default_')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server http-connector-cert-find '
               '[OPTIONS]')
@@ -1400,45 +1304,21 @@ class SSLCertFindLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'connector=', 'sslHost=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            print('ERROR: %s' % e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        connector_name = 'Secure'
-        hostname = '_default_'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--connector':
-                connector_name = a
-
-            elif o == '--sslHost':
-                hostname = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                print('ERROR: Unknown option: %s' % o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        connector_name = args.connector
+        hostname = args.sslHost
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 

--- a/base/server/python/pki/server/cli/sd.py
+++ b/base/server/python/pki/server/cli/sd.py
@@ -3,9 +3,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-from __future__ import absolute_import
-from __future__ import print_function
-import getopt
+
+import argparse
 import logging
 import sys
 
@@ -29,6 +28,25 @@ class SDCreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', 'Create security domain')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--name')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server sd-create [OPTIONS]')
         print()
@@ -41,41 +59,20 @@ class SDCreateCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'name=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        name = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--name':
-                name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -107,6 +104,24 @@ class SDSubsystemFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find security domain subsystems')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server sd-subsystem-find [OPTIONS]')
         print()
@@ -118,36 +133,19 @@ class SDSubsystemFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -169,6 +167,37 @@ class SDSubsystemAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add security domain subsystem')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--subsystem')
+        self.parser.add_argument('--hostname')
+        self.parser.add_argument('--unsecure-port')
+        self.parser.add_argument(
+            '--secure-port',
+            default='8443')
+        self.parser.add_argument(
+            '--domain-manager',
+            action='store_true')
+        self.parser.add_argument(
+            '--clone',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('subsystem_id')
+
     def print_help(self):
         print('Usage: pki-server sd-subsystem-add [OPTIONS] <subsystem ID>')
         print()
@@ -186,68 +215,26 @@ class SDSubsystemAddCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'subsystem=', 'hostname=', 'unsecure-port=', 'secure-port=',
-                'domain-manager', 'clone',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        subsystem_type = None
-        hostname = None
-        unsecure_port = None
-        secure_port = '8443'
-        domain_manager = False
-        clone = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--subsystem':
-                subsystem_type = a
-
-            elif o == '--hostname':
-                hostname = a
-
-            elif o == '--unsecure-port':
-                unsecure_port = a
-
-            elif o == '--secure-port':
-                secure_port = a
-
-            elif o == '--domain-manager':
-                domain_manager = True
-
-            elif o == '--clone':
-                clone = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing subsystem ID')
-            self.print_help()
-            sys.exit(1)
-
-        subsystem_id = args[0]
+        instance_name = args.instance
+        subsystem_type = args.subsystem
+        hostname = args.hostname
+        unsecure_port = args.unsecure_port
+        secure_port = args.secure_port
+        domain_manager = args.domain_manager
+        clone = args.clone
+        subsystem_id = args.subsystem_id
 
         if not subsystem_type:
             logger.error('Missing subsystem type')
@@ -286,6 +273,25 @@ class SDSubsystemRemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Remove security domain subsystem')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('subsystem_id')
+
     def print_help(self):
         print('Usage: pki-server sd-subsystem-del [OPTIONS] <subsystem ID>')
         print()
@@ -297,43 +303,20 @@ class SDSubsystemRemoveCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing subsystem ID')
-            self.print_help()
-            sys.exit(1)
-
-        subsystem_id = args[0]
+        instance_name = args.instance
+        subsystem_id = args.subsystem_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():


### PR DESCRIPTION
The following Python modules have been updated to use `argparse`:

* pki.server.cli.audit
* pki.server.cli.cert
* pki.server.cli.db
* pki.server.cli.http
* pki.server.cli.sd