### PR TITLE
Fix container restart issue

### DIFF
--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -314,6 +314,8 @@ jobs:
           docker restart ca
           sleep 10
 
+          docker network reload --all
+
           # wait for CA to restart
           docker exec client curl \
               --retry 180 \

--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -312,6 +312,7 @@ jobs:
       - name: Restart CA
         run: |
           docker restart ca
+          sleep 10
 
           # wait for CA to restart
           docker exec client curl \

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -405,6 +405,8 @@ jobs:
           docker restart ca
           sleep 10
 
+          docker network reload --all
+
           # wait for CA to restart
           docker exec client curl \
               --retry 180 \

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -403,7 +403,7 @@ jobs:
       - name: Restart CA
         run: |
           docker restart ca
-          sleep 5
+          sleep 10
 
           # wait for CA to restart
           docker exec client curl \

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -489,6 +489,8 @@ jobs:
           docker restart ca
           sleep 10
 
+          docker network reload --all
+
           # wait for CA to restart
           docker exec client curl \
               --retry 180 \
@@ -624,6 +626,8 @@ jobs:
         run: |
           docker restart kra
           sleep 10
+
+          docker network reload --all
 
           # wait for KRA to restart
           docker exec client curl \

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -487,7 +487,7 @@ jobs:
       - name: Restart CA
         run: |
           docker restart ca
-          sleep 5
+          sleep 10
 
           # wait for CA to restart
           docker exec client curl \
@@ -623,7 +623,7 @@ jobs:
       - name: Restart KRA
         run: |
           docker restart kra
-          sleep 5
+          sleep 10
 
           # wait for KRA to restart
           docker exec client curl \

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -487,7 +487,7 @@ jobs:
       - name: Restart CA
         run: |
           docker restart ca
-          sleep 5
+          sleep 10
 
           # wait for CA to restart
           docker exec client curl \
@@ -645,7 +645,7 @@ jobs:
       - name: Restart OCSP
         run: |
           docker restart ocsp
-          sleep 5
+          sleep 10
 
           # wait for OCSP to restart
           docker exec client curl \

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -489,6 +489,8 @@ jobs:
           docker restart ca
           sleep 10
 
+          docker network reload --all
+
           # wait for CA to restart
           docker exec client curl \
               --retry 180 \
@@ -646,6 +648,8 @@ jobs:
         run: |
           docker restart ocsp
           sleep 10
+
+          docker network reload --all
 
           # wait for OCSP to restart
           docker exec client curl \

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -150,6 +150,8 @@ jobs:
           docker restart server
           sleep 10
 
+          docker network reload --all
+
           # wait for server to restart
           docker exec client curl \
               --retry 60 \

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Restart server
         run: |
           docker restart server
-          sleep 5
+          sleep 10
 
           # wait for server to restart
           docker exec client curl \

--- a/.github/workflows/tks-container-test.yml
+++ b/.github/workflows/tks-container-test.yml
@@ -430,6 +430,8 @@ jobs:
           docker restart tks
           sleep 10
 
+          docker network reload --all
+
           # wait for TKS to restart
           docker exec client curl \
               --retry 180 \

--- a/.github/workflows/tks-container-test.yml
+++ b/.github/workflows/tks-container-test.yml
@@ -428,7 +428,7 @@ jobs:
       - name: Restart TKS
         run: |
           docker restart tks
-          sleep 5
+          sleep 10
 
           # wait for TKS to restart
           docker exec client curl \

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -415,7 +415,7 @@ jobs:
       - name: Restart CA
         run: |
           docker restart ca
-          sleep 5
+          sleep 10
 
           # wait for CA to restart
           docker exec client curl \
@@ -785,7 +785,7 @@ jobs:
       - name: Restart TPS
         run: |
           docker restart tps
-          sleep 5
+          sleep 10
 
           # wait for TPS to restart
           docker exec client curl \

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -417,6 +417,8 @@ jobs:
           docker restart ca
           sleep 10
 
+          docker network reload --all
+
           # wait for CA to restart
           docker exec client curl \
               --retry 180 \
@@ -786,6 +788,8 @@ jobs:
         run: |
           docker restart tps
           sleep 10
+
+          docker network reload --all
 
           # wait for TPS to restart
           docker exec client curl \

--- a/base/ca/bin/pki-ca-run
+++ b/base/ca/bin/pki-ca-run
@@ -361,15 +361,20 @@ rm /tmp/sslserver.crt
 echo "################################################################################"
 echo "INFO: Starting CA server"
 
+trap "kill -- -$(ps -o pgid= $PID | grep -o '[0-9]*')" TERM
+
 if [ "$UID" = "0" ]; then
     # In Docker the server runs as root user but it will switch
     # into pkiuser (UID=17) that belongs to the root group (GID=0).
-    pki-server run
-
+    pki-server run &
+    PID=$!
+    wait $PID
 else
     # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-    pki-server run --as-current-user
+    pki-server run --as-current-user &
+    PID=$!
+    wait $PID
 fi

--- a/base/kra/bin/pki-kra-run
+++ b/base/kra/bin/pki-kra-run
@@ -199,15 +199,20 @@ find /logs -type d -exec chmod +rwx -- {} +
 echo "################################################################################"
 echo "INFO: Starting KRA server"
 
+trap "kill -- -$(ps -o pgid= $PID | grep -o '[0-9]*')" TERM
+
 if [ "$UID" = "0" ]; then
     # In Docker the server runs as root user but it will switch
     # into pkiuser (UID=17) that belongs to the root group (GID=0).
-    pki-server run
-
+    pki-server run &
+    PID=$!
+    wait $PID
 else
     # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-    pki-server run --as-current-user
+    pki-server run --as-current-user &
+    PID=$!
+    wait $PID
 fi

--- a/base/ocsp/bin/pki-ocsp-run
+++ b/base/ocsp/bin/pki-ocsp-run
@@ -180,15 +180,20 @@ find /logs -type d -exec chmod +rwx -- {} +
 echo "################################################################################"
 echo "INFO: Starting OCSP server"
 
+trap "kill -- -$(ps -o pgid= $PID | grep -o '[0-9]*')" TERM
+
 if [ "$UID" = "0" ]; then
     # In Docker the server runs as root user but it will switch
     # into pkiuser (UID=17) that belongs to the root group (GID=0).
-    pki-server run
-
+    pki-server run &
+    PID=$!
+    wait $PID
 else
     # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-    pki-server run --as-current-user
+    pki-server run --as-current-user &
+    PID=$!
+    wait $PID
 fi

--- a/base/server/bin/pki-server-run
+++ b/base/server/bin/pki-server-run
@@ -228,15 +228,21 @@ rm /tmp/sslserver.crt
 echo "################################################################################"
 echo "INFO: Starting PKI server"
 
+trap "kill -- -$(ps -o pgid= $PID | grep -o '[0-9]*')" TERM
+
 if [ "$UID" = "0" ]; then
     # In Docker the server runs as root user but it will switch
     # into pkiuser (UID=17) that belongs to the root group (GID=0).
-    pki-server run
+    pki-server run &
+    PID=$!
+    wait $PID
 
 else
     # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-    pki-server run --as-current-user
+    pki-server run --as-current-user &
+    PID=$!
+    wait $PID
 fi

--- a/base/tks/bin/pki-tks-run
+++ b/base/tks/bin/pki-tks-run
@@ -161,15 +161,21 @@ find /logs -type d -exec chmod +rwx -- {} +
 echo "################################################################################"
 echo "INFO: Starting TKS server"
 
+trap "kill -- -$(ps -o pgid= $PID | grep -o '[0-9]*')" TERM
+
 if [ "$UID" = "0" ]; then
     # In Docker the server runs as root user but it will switch
     # into pkiuser (UID=17) that belongs to the root group (GID=0).
-    pki-server run
+    pki-server run &
+    PID=$!
+    wait $PID
 
 else
     # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-    pki-server run --as-current-user
+    pki-server run --as-current-user &
+    PID=$!
+    wait $PID
 fi

--- a/base/tps/bin/pki-tps-run
+++ b/base/tps/bin/pki-tps-run
@@ -168,15 +168,21 @@ find /logs -type d -exec chmod +rwx -- {} +
 echo "################################################################################"
 echo "INFO: Starting TPS server"
 
+trap "kill -- -$(ps -o pgid= $PID | grep -o '[0-9]*')" TERM
+
 if [ "$UID" = "0" ]; then
     # In Docker the server runs as root user but it will switch
     # into pkiuser (UID=17) that belongs to the root group (GID=0).
-    pki-server run
+    pki-server run &
+    PID=$!
+    wait $PID
 
 else
     # In OpenShift/Podman the server runs as a non-root user
     # (with a random UID) that belongs to the root group (GID=0).
     #
     # https://www.redhat.com/en/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-    pki-server run --as-current-user
+    pki-server run --as-current-user &
+    PID=$!
+    wait $PID
 fi


### PR DESCRIPTION
When container are restarted with podman the reestart will send the TERM signal to the entry process. Since the main entry for these container is a script running other script and waiting the singal are not propagated to the thread group making the restart hanging until a KILL signal is used but these return with an error code making the automation failing.