### PR TITLE
Fix getopt deprecation warnings (part 4)

### DIFF
--- a/base/server/python/pki/server/cli/instance.py
+++ b/base/server/python/pki/server/cli/instance.py
@@ -18,10 +18,7 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-
-import getopt
+import argparse
 import getpass
 import logging
 import os
@@ -71,6 +68,42 @@ class InstanceCertExportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('export', 'Export system certificates')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--pkcs12-file')
+        self.parser.add_argument('--pkcs12-password')
+        self.parser.add_argument('--pkcs12-password-file')
+        self.parser.add_argument(
+            '--append',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-trust-flags',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-key',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-chain',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'nicknames',
+            nargs='*')
+
     def print_help(self):
         print('Usage: pki-server instance-cert-export [OPTIONS] [nicknames...]')
         print()
@@ -91,68 +124,28 @@ class InstanceCertExportCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'pkcs12-file=', 'pkcs12-password=', 'pkcs12-password-file=',
-                'append', 'no-trust-flags', 'no-key', 'no-chain',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        nicknames = args
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        instance_name = 'pki-tomcat'
-        pkcs12_file = None
-        pkcs12_password = None
-        pkcs12_password_file = None
-        append = False
-        include_trust_flags = True
-        include_key = True
-        include_chain = True
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        instance_name = args.instance
+        pkcs12_file = args.pkcs12_file
+        pkcs12_password = args.pkcs12_password
+        pkcs12_password_file = args.pkcs12_password_file
+        append = args.append
+        include_trust_flags = not args.no_trust_flags
+        include_key = not args.no_key
+        include_chain = not args.no_chain
 
-            elif o == '--pkcs12-file':
-                pkcs12_file = a
-
-            elif o == '--pkcs12-password':
-                pkcs12_password = a
-
-            elif o == '--pkcs12-password-file':
-                pkcs12_password_file = a
-
-            elif o == '--append':
-                append = True
-
-            elif o == '--no-trust-flags':
-                include_trust_flags = False
-
-            elif o == '--no-key':
-                include_key = False
-
-            elif o == '--no-chain':
-                include_chain = False
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        nicknames = args.nicknames
 
         if not pkcs12_file:
             logger.error('missing output file')
@@ -190,6 +183,20 @@ class InstanceFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find instances')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server instance-find [OPTIONS]')
         print()
@@ -200,30 +207,17 @@ class InstanceFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
         results = []
         if os.path.exists(pki.server.PKIServer.BASE_DIR):
@@ -254,6 +248,21 @@ class InstanceShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show instance')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('instance_id')
+
     def print_help(self):
         print('Usage: pki-server instance-show [OPTIONS] <instance ID>')
         print()
@@ -264,37 +273,19 @@ class InstanceShowCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            logger.error('Missing instance ID')
-            self.print_help()
-            sys.exit(1)
-
-        instance_name = args[0]
+        instance_name = args.instance_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -312,6 +303,21 @@ class InstanceStartCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('start', 'Start instance')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('instance_id')
+
     def print_help(self):
         print('Usage: pki-server instance-start [OPTIONS] <instance ID>')
         print()
@@ -322,37 +328,19 @@ class InstanceStartCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            logger.error('Missing instance ID')
-            self.print_help()
-            sys.exit(1)
-
-        instance_name = args[0]
+        instance_name = args.instance_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -375,6 +363,21 @@ class InstanceStopCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('stop', 'Stop instance')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('instance_id')
+
     def print_help(self):
         print('Usage: pki-server instance-stop [OPTIONS] <instance ID>')
         print()
@@ -385,37 +388,19 @@ class InstanceStopCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            logger.error('Missing instance ID')
-            self.print_help()
-            sys.exit(1)
-
-        instance_name = args[0]
+        instance_name = args.instance_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -438,6 +423,22 @@ class InstanceMigrateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('migrate', 'Migrate instance')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument('--tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('instance_id')
+
     def print_help(self):
         print('Usage: pki-server instance-migrate [OPTIONS] <instance ID>')
         print()
@@ -449,46 +450,24 @@ class InstanceMigrateCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'tomcat=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        tomcat_version = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o == '--tomcat':
-                tomcat_version = pki.util.Version(a)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            logger.error('Missing instance ID')
-            self.print_help()
-            sys.exit(1)
-
-        instance_name = args[0]
-
-        if not tomcat_version:
+        if args.tomcat:
+            tomcat_version = pki.util.Version(args.tomcat)
+        else:
             tomcat_version = pki.server.Tomcat.get_version()
+
+        instance_name = args.instance_id
 
         logger.info('Migrating to Tomcat %s', tomcat_version)
 
@@ -514,6 +493,21 @@ class InstanceNuxwdogEnableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('nuxwdog-enable', 'Instance enable nuxwdog')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('instance_id')
+
     def print_help(self):
         print('Usage: pki-server instance-nuxwdog-enable [OPTIONS] <instance ID>')
         print()
@@ -523,37 +517,20 @@ class InstanceNuxwdogEnableCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            logger.error('Missing instance ID')
-            self.print_help()
-            sys.exit(1)
-
-        instance_name = args[0]
+        instance_name = args.instance_id
 
         module = self.get_top_module().find_module('nuxwdog-enable')
         module = pki.server.cli.nuxwdog.NuxwdogEnableCLI()
@@ -576,6 +553,21 @@ class InstanceNuxwdogDisableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('nuxwdog-disable', 'Instance disable nuxwdog')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('instance_id')
+
     def print_help(self):
         print('Usage: pki-server instance-nuxwdog-disable [OPTIONS] <instance ID>')
         print()
@@ -585,37 +577,20 @@ class InstanceNuxwdogDisableCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            logger.error('Missing instance ID')
-            self.print_help()
-            sys.exit(1)
-
-        instance_name = args[0]
+        instance_name = args.instance_id
 
         module = self.get_top_module().find_module('nuxwdog-disable')
 
@@ -638,6 +613,32 @@ class InstanceExternalCertAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('externalcert-add', 'Add external certificate or chain to the instance')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--cert-file')
+        self.parser.add_argument(
+            '--trust-args',
+            default='\",,\"')
+        self.parser.add_argument('--nickname')
+        self.parser.add_argument(
+            '--token',
+            default=pki.nssdb.INTERNAL_TOKEN_NAME)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server instance-externalcert-add [OPTIONS]')
         print()
@@ -653,53 +654,24 @@ class InstanceExternalCertAddCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'cert-file=', 'trust-args=', 'nickname=', 'token=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        cert_file = None
-        trust_args = '\",,\"'
-        nickname = None
-        token = pki.nssdb.INTERNAL_TOKEN_NAME
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--cert-file':
-                cert_file = a
-
-            elif o == '--trust-args':
-                trust_args = a
-
-            elif o == '--nickname':
-                nickname = a
-
-            elif o == '--token':
-                token = a
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        cert_file = args.cert_file
+        trust_args = args.trust_args
+        nickname = args.nickname
+        token = args.token
 
         if not cert_file:
             logger.error('Missing input file containing certificate')
@@ -752,6 +724,28 @@ class InstanceExternalCertDeleteCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('externalcert-del', 'Delete external certificate from the instance')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--nickname')
+        self.parser.add_argument(
+            '--token',
+            default=pki.nssdb.INTERNAL_TOKEN_NAME)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server instance-externalcert-del [OPTIONS]')
         print()
@@ -764,44 +758,22 @@ class InstanceExternalCertDeleteCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'nickname=', 'token=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        nickname = None
-        token = pki.nssdb.INTERNAL_TOKEN_NAME
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--nickname':
-                nickname = a
-
-            elif o == '--token':
-                token = a
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        instance_name = args.instance
+        nickname = args.nickname
+        token = args.token
 
         if not nickname:
             logger.error('Missing nickname')

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -20,10 +20,7 @@
 # All rights reserved.
 #
 
-from __future__ import absolute_import
-from __future__ import print_function
-
-import getopt
+import argparse
 import getpass
 import inspect
 import logging
@@ -63,6 +60,24 @@ class SubsystemFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find subsystems')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def usage(self):
         print('Usage: pki-server subsystem-find [OPTIONS]')
         print()
@@ -74,36 +89,19 @@ class SubsystemFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
-            self.usage()
-            sys.exit(1)
+        if args.help:
+            self.print_help()
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.usage()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.usage()
-                sys.exit(1)
+        instance_name = args.instance
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -130,6 +128,25 @@ class SubsystemShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show subsystem')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('subsystem_id')
+
     def usage(self):
         print('Usage: pki-server subsystem-show [OPTIONS] <subsystem ID>')
         print()
@@ -141,43 +158,20 @@ class SubsystemShowCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
-            self.usage()
-            sys.exit(1)
+        if args.help:
+            self.print_help()
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.usage()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.usage()
-                sys.exit(1)
-
-        if len(args) != 1:
-            logger.error('Missing subsystem ID')
-            self.usage()
-            sys.exit(1)
-
-        subsystem_name = args[0]
+        instance_name = args.instance
+        subsystem_name = args.subsystem_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -202,7 +196,7 @@ class SubsystemCreateCLI(pki.cli.CLI):
     '''
 
     help = '''\
-        Usage: pki-server {subsystem}-create [OPTIONS] <subsystem ID>
+        Usage: pki-server {subsystem}-create [OPTIONS]
 
           -i, --instance <instance ID>       Instance ID (default: pki-tomcat)
           -v, --verbose                      Run in verbose mode.
@@ -218,43 +212,44 @@ class SubsystemCreateCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.name))
 
     def execute(self, argv):
 
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -281,6 +276,37 @@ class SubsystemDeployCLI(pki.cli.CLI):
         super().__init__('deploy', 'Deploy %s subsystem' % parent.name.upper())
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--wait',
+            action='store_true')
+        self.parser.add_argument(
+            '--max-wait',
+            type=int,
+            default=60)
+        self.parser.add_argument(
+            '--timeout',
+            type=int)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
+
     def print_help(self):
         print('Usage: pki-server %s-deploy [OPTIONS] [name]' % self.parent.name)
         print()
@@ -295,53 +321,26 @@ class SubsystemDeployCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'wait', 'max-wait=', 'timeout=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         name = self.parent.name
-        instance_name = 'pki-tomcat'
-        wait = False
-        max_wait = 60
-        timeout = None
+        wait = args.wait
+        max_wait = args.max_wait
+        timeout = args.timeout
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--wait':
-                wait = True
-
-            elif o == '--max-wait':
-                max_wait = int(a)
-
-            elif o == '--timeout':
-                timeout = int(a)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) > 0:
-            name = args[0]
+        if args.name:
+            name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -368,7 +367,38 @@ class SubsystemUndeployCLI(pki.cli.CLI):
 
     def __init__(self, parent):
         super().__init__('undeploy', 'Undeploy %s subsystem' % parent.name.upper())
-        self.parenet = parent
+        self.parent = parent
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--wait',
+            action='store_true')
+        self.parser.add_argument(
+            '--max-wait',
+            type=int,
+            default=60)
+        self.parser.add_argument(
+            '--timeout',
+            type=int)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-undeploy [OPTIONS] [name]' % self.parent.name)
@@ -384,53 +414,26 @@ class SubsystemUndeployCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'wait', 'max-wait=', 'timeout=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         name = self.parent.name
-        instance_name = 'pki-tomcat'
-        wait = False
-        max_wait = 60
-        timeout = None
+        wait = args.wait
+        max_wait = args.max_wait
+        timeout = args.timeout
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--wait':
-                wait = True
-
-            elif o == '--max-wait':
-                max_wait = int(a)
-
-            elif o == '--timeout':
-                timeout = int(a)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) > 0:
-            name = args[0]
+        if args.name:
+            name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -471,59 +474,63 @@ class SubsystemRedeployCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--wait',
+            action='store_true')
+        self.parser.add_argument(
+            '--max-wait',
+            type=int,
+            default=60)
+        self.parser.add_argument(
+            '--timeout',
+            type=int)
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.name))
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'wait', 'max-wait=', 'timeout=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         name = self.parent.name
-        instance_name = 'pki-tomcat'
-        wait = False
-        max_wait = 60
-        timeout = None
+        wait = args.wait
+        max_wait = args.max_wait
+        timeout = args.timeout
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--wait':
-                wait = True
-
-            elif o == '--max-wait':
-                max_wait = int(a)
-
-            elif o == '--timeout':
-                timeout = int(a)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) > 0:
-            name = args[0]
+        if args.name:
+            name = args.name
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -557,8 +564,35 @@ class SubsystemEnableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('enable', 'Enable subsystem')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--all',
+            action='store_true')
+        self.parser.add_argument(
+            '--silent',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
+
     def usage(self):
-        print('Usage: pki-server subsystem-enable [OPTIONS] <subsystem ID>')
+        print('Usage: pki-server subsystem-enable [OPTIONS] [<subsystem ID>]')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('      --all                       Enable all subsystems.')
@@ -570,44 +604,21 @@ class SubsystemEnableCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'all', 'silent',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
-            self.usage()
-            sys.exit(1)
+        if args.help:
+            self.print_help()
+            return
 
-        instance_name = 'pki-tomcat'
-        all_subsystems = False
-        silent = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--all':
-                all_subsystems = True
-
-            elif o == '--silent':
-                silent = True
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.usage()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.usage()
-                sys.exit(1)
+        instance_name = args.instance
+        all_subsystems = args.all
+        silent = args.silent
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -627,12 +638,12 @@ class SubsystemEnableCLI(pki.cli.CLI):
 
             return
 
-        if len(args) != 1:
+        if not args.subsystem_id:
             logger.error('Missing subsystem ID')
             self.usage()
             sys.exit(1)
 
-        subsystem_name = args[0]
+        subsystem_name = args.subsystem_id
 
         subsystem = instance.get_subsystem(subsystem_name)
         if not subsystem:
@@ -658,8 +669,32 @@ class SubsystemDisableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('disable', 'Disable subsystem')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--all',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
+
     def usage(self):
-        print('Usage: pki-server subsystem-disable [OPTIONS] <subsystem ID>')
+        print('Usage: pki-server subsystem-disable [OPTIONS] [<subsystem ID>]')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
         print('      --all                       Disable all subsystems.')
@@ -670,40 +705,20 @@ class SubsystemDisableCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'all',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
-            self.usage()
-            sys.exit(1)
+        if args.help:
+            self.print_help()
+            return
 
-        instance_name = 'pki-tomcat'
-        all_subsystems = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--all':
-                all_subsystems = True
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.usage()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.usage()
-                sys.exit(1)
+        instance_name = args.instance
+        all_subsystems = args.all
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -722,12 +737,12 @@ class SubsystemDisableCLI(pki.cli.CLI):
 
             return
 
-        if len(args) != 1:
+        if not args.subsystem_id:
             logger.error('Missing subsystem ID')
             self.usage()
             sys.exit(1)
 
-        subsystem_name = args[0]
+        subsystem_name = args.subsystem_id
 
         subsystem = instance.get_subsystem(subsystem_name)
         if not subsystem:
@@ -778,6 +793,28 @@ class SubsystemCertFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find subsystem certificates')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--show-all',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('subsystem_id')
+
     def print_help(self):
         print('Usage: pki-server subsystem-cert-find [OPTIONS] <subsystem ID>')
         print()
@@ -790,47 +827,21 @@ class SubsystemCertFindCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'show-all',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        show_all = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--show-all':
-                show_all = True
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) != 1:
-            logger.error('Missing subsystem ID')
-            self.print_help()
-            sys.exit(1)
-
-        subsystem_name = args[0]
+        instance_name = args.instance
+        show_all = args.show_all
+        subsystem_name = args.subsystem_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -870,6 +881,29 @@ class SubsystemCertShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show subsystem certificate')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--show-all',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument('cert_id')
+
     def usage(self):
         print('Usage: pki-server subsystem-cert-show [OPTIONS] <subsystem ID> <cert ID>')
         print()
@@ -882,53 +916,23 @@ class SubsystemCertShowCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'show-all',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
-            self.usage()
-            sys.exit(1)
+        if args.help:
+            self.print_help()
+            return
 
-        instance_name = 'pki-tomcat'
-        show_all = False
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--show-all':
-                show_all = True
+        instance_name = args.instance
+        show_all = args.show_all
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.usage()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.usage()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing subsystem ID')
-            self.usage()
-            sys.exit(1)
-
-        if len(args) < 2:
-            logger.error('Missing cert ID')
-            self.usage()
-            sys.exit(1)
-
-        subsystem_name = args[0]
-        cert_tag = args[1]
+        subsystem_name = args.subsystem_id
+        cert_tag = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -952,6 +956,45 @@ class SubsystemCertExportCLI(pki.cli.CLI):
 
     def __init__(self):
         super().__init__('export', 'Export subsystem certificate')
+
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--cert-file')
+        self.parser.add_argument('--csr-file')
+        self.parser.add_argument('--pkcs12-file')
+        self.parser.add_argument('--pkcs12-password')
+        self.parser.add_argument('--pkcs12-password-file')
+        self.parser.add_argument(
+            '--append',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-trust-flags',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-key',
+            action='store_true')
+        self.parser.add_argument(
+            '--no-chain',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server subsystem-cert-export [OPTIONS] <subsystem ID> [cert ID]')
@@ -977,81 +1020,31 @@ class SubsystemCertExportCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'cert-file=', 'csr-file=',
-                'pkcs12-file=', 'pkcs12-password=', 'pkcs12-password-file=',
-                'append', 'no-trust-flags', 'no-key', 'no-chain',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
-        cert_file = None
-        csr_file = None
-        pkcs12_file = None
-        pkcs12_password = None
-        pkcs12_password_file = None
-        append = False
-        include_trust_flags = True
-        include_key = True
-        include_chain = True
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--cert-file':
-                cert_file = a
+        instance_name = args.instance
+        cert_file = args.cert_file
+        csr_file = args.csr_file
+        pkcs12_file = args.pkcs12_file
+        pkcs12_password = args.pkcs12_password
+        pkcs12_password_file = args.pkcs12_password_file
+        append = args.append
+        include_trust_flags = not args.no_trust_flags
+        include_key = not args.no_key
+        include_chain = not args.no_chain
 
-            elif o == '--csr-file':
-                csr_file = a
-
-            elif o == '--pkcs12-file':
-                pkcs12_file = a
-
-            elif o == '--pkcs12-password':
-                pkcs12_password = a
-
-            elif o == '--pkcs12-password-file':
-                pkcs12_password_file = a
-
-            elif o == '--append':
-                append = True
-
-            elif o == '--no-trust-flags':
-                include_trust_flags = False
-
-            elif o == '--no-key':
-                include_key = False
-
-            elif o == '--no-chain':
-                include_chain = False
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing subsystem ID')
-            self.print_help()
-            sys.exit(1)
-
-        subsystem_name = args[0]
+        subsystem_name = args.subsystem_id
+        cert_tag = args.cert_id
 
         if not (cert_file or csr_file or pkcs12_file):
             logger.error('Missing output file')
@@ -1073,8 +1066,7 @@ class SubsystemCertExportCLI(pki.cli.CLI):
             sys.exit(1)
         subsystem_cert = None
 
-        if len(args) >= 2:
-            cert_tag = args[1]
+        if cert_tag:
             subsystem_cert = subsystem.get_subsystem_cert(cert_tag)
 
         if (cert_file or csr_file) and not subsystem_cert:
@@ -1138,6 +1130,27 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('update', 'Update subsystem certificate')
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--cert')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument('cert_id')
+
     def usage(self):
         print('Usage: pki-server subsystem-cert-update [OPTIONS] <subsystem ID> <cert ID>')
         print()
@@ -1150,54 +1163,23 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'cert=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
-            self.usage()
-            sys.exit(1)
+        if args.help:
+            self.print_help()
+            return
 
-        instance_name = 'pki-tomcat'
-        cert_file = None
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        instance_name = args.instance
+        cert_file = args.cert
 
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.usage()
-                sys.exit()
-
-            elif o == '--cert':
-                cert_file = a
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.usage()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing subsystem ID')
-            self.usage()
-            sys.exit(1)
-
-        if len(args) < 2:
-            logger.error('Missing cert ID')
-            self.usage()
-            sys.exit(1)
-
-        subsystem_name = args[0]
-        cert_tag = args[1]
+        subsystem_name = args.subsystem_id
+        cert_tag = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -1293,6 +1275,28 @@ class SubsystemCertValidateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('validate', 'Validate subsystem certificates', deprecated=True)
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
+
     def usage(self):
         print('Usage: pki-server subsystem-cert-validate [OPTIONS] <subsystem ID> [cert ID]')
         print()
@@ -1308,48 +1312,21 @@ class SubsystemCertValidateCLI(pki.cli.CLI):
             'The pki-server subsystem-cert-validate has been deprecated. '
             'Use pki-server cert-validate instead.')
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
-            self.usage()
-            sys.exit(1)
+        if args.help:
+            self.print_help()
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.usage()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.usage()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing subsystem ID')
-            self.usage()
-            sys.exit(1)
-
-        subsystem_name = args[0]
-
-        if len(args) >= 2:
-            cert_tag = args[1]
-        else:
-            cert_tag = None
+        instance_name = args.instance
+        subsystem_name = args.subsystem_id
+        cert_tag = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -3,9 +3,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-from __future__ import absolute_import
-from __future__ import print_function
-import getopt
+
+import argparse
 import inspect
 import logging
 import sys
@@ -66,96 +65,74 @@ class UserAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--full-name')
+        self.parser.add_argument('--email')
+        self.parser.add_argument('--password')
+        self.parser.add_argument('--password-file')
+        self.parser.add_argument('--cert')
+        self.parser.add_argument('--cert-format')
+        self.parser.add_argument('--phone')
+        self.parser.add_argument('--type')
+        self.parser.add_argument('--state')
+        self.parser.add_argument('--tps-profiles')
+        self.parser.add_argument(
+            '--ignore-duplicate',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'full-name=', 'email=',
-                'password=', 'password-file=',
-                'cert=', 'cert-format=',
-                'phone=', 'type=', 'state=', 'tps-profiles=', 'ignore-duplicate'
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-        full_name = None
-        email = None
-        password = None
-        password_file = None
-        cert_path = None
-        cert_format = None
-        phone = None
-        user_type = None
-        state = None
+        full_name = args.full_name
+        email = args.email
+        password = args.password
+        password_file = args.password_file
+        cert_path = args.cert
+        cert_format = args.cert_format
+        phone = args.phone
+        user_type = args.type
+        state = args.state
+
         tps_profiles = None
-        ignore_duplicate = False
+        if args.tps_profiles:
+            tps_profiles = [x.strip() for x in args.tps_profiles.split(',')]
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--full-name':
-                full_name = a
-
-            elif o == '--email':
-                email = a
-
-            elif o == '--password':
-                password = a
-
-            elif o == '--password-file':
-                password_file = a
-
-            elif o == '--cert':
-                cert_path = a
-
-            elif o == '--cert-format':
-                cert_format = a
-
-            elif o == '--phone':
-                phone = a
-
-            elif o == '--type':
-                user_type = a
-
-            elif o == '--state':
-                state = a
-
-            elif o == '--tps-profiles':
-                tps_profiles = [x.strip() for x in a.split(',')]
-
-            elif o == '--ignore-duplicate':
-                ignore_duplicate = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
+        ignore_duplicate = args.ignore_duplicate
+        user_id = args.user_id
 
         if not full_name:
             logger.error('Missing full name')
@@ -202,6 +179,25 @@ class UserFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--see-also')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
     def print_help(self):
         print('Usage: pki-server %s-user-find [OPTIONS]' % self.parent.parent.name)
         print()
@@ -213,41 +209,22 @@ class UserFindCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, _ = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'see-also=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-        see_also = None
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--see-also':
-                see_also = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
+        see_also = args.see_also
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -303,6 +280,29 @@ class UserModifyCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--password')
+        self.parser.add_argument('--password-file')
+        self.parser.add_argument('--add-see-also')
+        self.parser.add_argument('--del-see-also')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+
     def print_help(self):
         print('Usage: pki-server %s-user-mod [OPTIONS] <user ID>' % self.parent.parent.name)
         print()
@@ -317,61 +317,26 @@ class UserModifyCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'password=', 'password-file=',
-                'add-see-also=', 'del-see-also=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-        password = None
-        password_file = None
-        add_see_also = None
-        del_see_also = None
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--password':
-                password = a
-
-            elif o == '--password-file':
-                password_file = a
-
-            elif o == '--add-see-also':
-                add_see_also = a
-
-            elif o == '--del-see-also':
-                del_see_also = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
+        password = args.password
+        password_file = args.password_file
+        add_see_also = args.add_see_also
+        del_see_also = args.del_see_also
+        user_id = args.user_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -417,50 +382,46 @@ class UserRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.name))
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
+        user_id = args.user_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -486,6 +447,25 @@ class UserShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+
     def print_help(self):
         print('Usage: pki-server %s-user-show [OPTIONS] <user ID>' % self.parent.parent.name)
         print()
@@ -496,44 +476,22 @@ class UserShowCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
+        user_id = args.user_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -592,6 +550,25 @@ class UserCertFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+
     def print_help(self):
         print('Usage: pki-server %s-user-cert-find [OPTIONS] <user ID>'
               % self.parent.parent.parent.name)
@@ -603,44 +580,22 @@ class UserCertFindCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
+        user_id = args.user_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -666,6 +621,32 @@ class UserCertAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--cert')
+        self.parser.add_argument(
+            '--format',
+            default='PEM')
+        self.parser.add_argument(
+            '--ignore-duplicate',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+
     def print_help(self):
         print('Usage: pki-server %s-user-cert-add [OPTIONS] <user ID>'
               % self.parent.parent.parent.name)
@@ -680,56 +661,25 @@ class UserCertAddCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'cert=', 'format=', 'ignore-duplicate'
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        cert_path = None
-        cert_format = 'PEM'
-        ignore_duplicate = False
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--cert':
-                cert_path = a
-
-            elif o == '--format':
-                cert_format = a
-
-            elif o == '--ignore-duplicate':
-                ignore_duplicate = True
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
+        cert_path = args.cert
+        cert_format = args.format
+        ignore_duplicate = args.ignore_duplicate
+        user_id = args.user_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -774,56 +724,48 @@ class UserCertRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+        self.parser.add_argument('cert_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
 
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
+        args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        if len(args) < 2:
-            logger.error('Missing certificate ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
-        cert_id = args[1]
+        user_id = args.user_id
+        cert_id = args.cert_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -876,53 +818,48 @@ class UserRoleFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument('--output-format')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=', 'output-format=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
-        output_format = None
-
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o == '--output-format':
-                output_format = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
+        output_format = args.output_format
+        user_id = args.user_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -963,56 +900,49 @@ class UserRoleAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+        self.parser.add_argument('role_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
-
-        if len(args) < 2:
-            logger.error('Missing role ID')
-            self.print_help()
-            sys.exit(1)
-
-        role_id = args[1]
+        user_id = args.user_id
+        role_id = args.role_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -1053,56 +983,49 @@ class UserRoleRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument('user_id')
+        self.parser.add_argument('role_id')
+
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
     def execute(self, argv):
-        try:
-            opts, args = getopt.gnu_getopt(argv, 'i:v', [
-                'instance=',
-                'verbose', 'debug', 'help'])
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        args = self.parser.parse_args(args=argv)
+
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        instance_name = 'pki-tomcat'
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
 
-        for o, a in opts:
-            if o in ('-i', '--instance'):
-                instance_name = a
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Invalid option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
-        if len(args) < 1:
-            logger.error('Missing user ID')
-            self.print_help()
-            sys.exit(1)
-
-        user_id = args[0]
-
-        if len(args) < 2:
-            logger.error('Missing role ID')
-            self.print_help()
-            sys.exit(1)
-
-        role_id = args[1]
+        user_id = args.user_id
+        role_id = args.role_id
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():


### PR DESCRIPTION
The following Python modules have been updated to use `argparse`:

* pki.server.cli.instance
* pki.server.cli.subsystem
* pki.server.cli.user