### PR TITLE
Fix mail notification CI

### DIFF
--- a/.github/workflows/ca-notification-request-test.yml
+++ b/.github/workflows/ca-notification-request-test.yml
@@ -58,6 +58,11 @@ jobs:
               -e 's/^inet_protocols = .*$/inet_protocols = ipv4/' \
               /etc/postfix/main.cf
 
+          # This is needed because of the smuggling fix in postfix
+          # https://bugzilla.redhat.com/show_bug.cgi?id=2255563
+          #
+          # The mail sender code has to be updated
+          docker exec pki postconf smtpd_forbid_unauth_pipelining=no
           docker exec pki systemctl start postfix
 
       - name: Install CA


### PR DESCRIPTION
The notification was not working because of a CVE in postfix required to modify the default policy becoming more restrictive.

The fix is documented here: https://bugzilla.redhat.com/show_bug.cgi?id=2255563

This is a workaround which put back the original policy. The proper fix would be to update the code communicating with smtp server.