### PR TITLE
Workaround for Podman issue

### DIFF
--- a/.github/workflows/ca-container-migration-test.yml
+++ b/.github/workflows/ca-container-migration-test.yml
@@ -12,6 +12,12 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
+      - name: Install dependencies
+        run: |
+          # workaround for https://github.com/containers/podman/issues/21683
+          sudo ls -lR /var/lib/containers
+          sudo rm -rf /var/lib/containers/*
+
       - name: Clone repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/ca-container-system-service-test.yml
+++ b/.github/workflows/ca-container-system-service-test.yml
@@ -12,6 +12,12 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
+      - name: Install dependencies
+        run: |
+          # workaround for https://github.com/containers/podman/issues/21683
+          sudo ls -lR /var/lib/containers
+          sudo rm -rf /var/lib/containers/*
+
       - name: Clone repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/ca-container-user-service-test.yml
+++ b/.github/workflows/ca-container-user-service-test.yml
@@ -17,6 +17,10 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install jq
 
+          # workaround for https://github.com/containers/podman/issues/21683
+          sudo ls -lR /var/lib/containers
+          sudo rm -rf /var/lib/containers/*
+
       - name: Clone repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
The tests that use Podman inside Docker have been modified to remove the content of `/var/lib/containers` as a workaround for a known issue in Podman.

https://github.com/containers/podman/issues/21683