### PR TITLE
Fix logrotate error

### DIFF
--- a/base/server/share/conf/pki.policy
+++ b/base/server/share/conf/pki.policy
@@ -26,6 +26,13 @@ grant codeBase "file:${catalina.home}/bin/tomcat-juli.jar" {
         permission java.io.FilePermission "${catalina.base}/logs/-", "read,write";
 };
 
+// If log rotate is initiated by a log call using slf4j-impl
+// the library need to have read/write access to log folder or
+// the policy will denied access and the rotation fails
+grant codeBase "file:/usr/share/java/slf4j/-" {
+        permission java.io.FilePermission "${catalina.base}/logs/-", "read,write";
+};
+
 // According to /etc/tomcat/catalina.policy:
 // If using a per instance lib directory, i.e. ${catalina.base}/lib,
 // then the following permission will need to be uncommented
@@ -49,3 +56,4 @@ grant codeBase "file:/usr/share/java/pki/-" {
 grant codeBase "file:${catalina.base}/webapps/-" {
         permission java.security.AllPermission;
 };
+


### PR DESCRIPTION
If the log rotate is invoked following a log using slf4j-impl the current policy denied the accees to the log folder and the rotate fails.

This is always the case with the change to the SessionTimer class.

To solve the problem the policy is updated to grant slf4j-impl read/write access to log folders.

For reference the deamon error  for the logrotate is:
```
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]: java.util.logging.ErrorManager: 1: FileHandler is closed or not yet initialized, unable to log [2025-01-20 00:01:26 [Timer-0] WARNING: SessionTimer: access denied ("java.io.FilePermission" "/var/lib/pki/pki-tomcat/logs/ca" "read")
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]: java.security.AccessControlException: access denied ("java.io.FilePermission" "/var/lib/pki/pki-tomcat/logs/ca" "read")
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:488)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.base/java.security.AccessController.checkPermission(AccessController.java:1071)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:411)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.base/java.lang.SecurityManager.checkRead(SecurityManager.java:742)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.base/java.io.File.exists(File.java:831)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.base/java.io.File.mkdirs(File.java:1405)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at org.apache.juli.FileHandler.openWriter(FileHandler.java:428)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at org.apache.juli.FileHandler.publish(FileHandler.java:220)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.logging/java.util.logging.Logger.log(Logger.java:983)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at org.slf4j.impl.JDK14LoggerAdapter.log(JDK14LoggerAdapter.java:582)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at org.slf4j.impl.JDK14LoggerAdapter.info(JDK14LoggerAdapter.java:277)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at com.netscape.cmscore.session.SessionTimer.runImpl(SessionTimer.java:63)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at com.netscape.cmscore.session.SessionTimer.run(SessionTimer.java:55)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]:         at java.base/java.util.TimerThread.run(Timer.java:516)
Jan 20 00:01:26 vm-10-0-187-130.hosted.upshift.rdu2.redhat.com server[8609]: ]
```

The policy checker will verify the permission for all method in stack trace and `slf4j-impl` is the missing one generating the deny.

Additionally,, if only the read grant is provided there is another error when the file is created so both read and write are needed. 
