### PR TITLE
Update pki-server to use ArgumentParser

### DIFF
--- a/base/common/python/pki/cli/__init__.py
+++ b/base/common/python/pki/cli/__init__.py
@@ -102,10 +102,10 @@ class CLI(object):
             if not module or not command:
                 return module
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
         for module in self.modules.values():
-            module.create_parser()
+            module.create_parser(subparsers=subparsers)
 
     def parse_command(self, command):
 

--- a/base/common/python/pki/cli/password.py
+++ b/base/common/python/pki/cli/password.py
@@ -41,7 +41,7 @@ class PasswordGenerateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('generate', 'Generate secure random password')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
         self.parser = argparse.ArgumentParser(
             self.get_full_name(),

--- a/base/common/python/pki/cli/pkcs12.py
+++ b/base/common/python/pki/cli/pkcs12.py
@@ -48,7 +48,7 @@ class PKCS12ImportCLI(pki.cli.CLI):
         super(PKCS12ImportCLI, self).__init__(
             'import', 'Import PKCS #12 file into NSS database')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
         self.parser = argparse.ArgumentParser(
             self.get_full_name(),

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -19,7 +19,6 @@
 #
 
 import argparse
-import getopt
 import logging
 import socket
 import sys
@@ -99,6 +98,31 @@ class PKIServerCLI(pki.cli.CLI):
 
         self.add_module(pki.server.cli.upgrade.UpgradeCLI())
 
+    def create_parser(self, subparsers=None):
+
+        # create main parser
+        self.parser = argparse.ArgumentParser(
+            prog=self.name,
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
+        # create subparsers
+        subparsers = self.parser.add_subparsers(dest='command')
+        super().create_parser(subparsers=subparsers)
+
     def get_full_module_name(self, module_name):
         return module_name
 
@@ -113,34 +137,26 @@ class PKIServerCLI(pki.cli.CLI):
         super().print_help()
 
     def execute(self, argv, args=None):
-        try:
-            opts, args = getopt.getopt(argv, 'v', [
-                'verbose', 'debug', 'help'])
+        if not args:
+            args = self.parser.parse_args(args=argv)
 
-        except getopt.GetoptError as e:
-            logger.error(e)
+        if args.help:
             self.print_help()
-            sys.exit(1)
+            return
 
-        for o, _ in opts:
-            if o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
 
-            elif o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
 
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
+        command = args.command
+        logger.debug('Command: %s', command)
 
-            else:
-                logger.error('Unknown option %s', o)
-                self.print_help()
-                sys.exit(1)
+        module = self.find_module(command)
+        logger.debug('Module: %s', module.get_full_name())
 
-        logger.debug('Command: %s', ' '.join(args))
-
-        super().execute(args)
+        module.execute(argv, args=args)
 
     @staticmethod
     def print_status(instance):
@@ -294,9 +310,9 @@ class CreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', 'Create PKI server')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument('--user')
@@ -391,9 +407,9 @@ class RemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('remove', 'Remove PKI server')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -470,9 +486,9 @@ class StatusCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('status', 'Display PKI service status')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -531,9 +547,9 @@ class StartCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('start', 'Start PKI service')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -610,9 +626,9 @@ class StopCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('stop', 'Stop PKI service')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -689,9 +705,9 @@ class RestartCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('restart', 'Restart PKI service')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -764,9 +780,9 @@ class RunCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('run', 'Run PKI server in foreground')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-import argparse
 import logging
 import os
 
@@ -40,9 +39,9 @@ class ACMECreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', 'Create ACME subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -109,9 +108,9 @@ class ACMERemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('remove', 'Remove ACME subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -193,9 +192,9 @@ class ACMEDeployCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('deploy', 'Deploy ACME subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -285,9 +284,9 @@ class ACMEUndeployCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('undeploy', 'Undeploy ACME subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -379,9 +378,9 @@ class ACMEMetadataShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show ACME metadata configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -466,9 +465,9 @@ class ACMEMetadataModifyCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', 'Modify ACME metadata configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -578,9 +577,9 @@ class ACMEDatabaseShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show ACME database configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -698,9 +697,9 @@ class ACMEDatabaseModifyCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', 'Modify ACME database configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -916,9 +915,9 @@ class ACMEIssuerShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show ACME issuer configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1031,9 +1030,9 @@ class ACMEIssuerModifyCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', 'Modify ACME issuer configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1244,9 +1243,9 @@ class ACMERealmShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show ACME realm configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1374,9 +1373,9 @@ class ACMERealmModifyCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', 'Modify ACME realm configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/audit.py
+++ b/base/server/python/pki/server/cli/audit.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import logging
 import os
 import shutil
@@ -92,9 +91,9 @@ class AuditConfigShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -163,9 +162,9 @@ class AuditConfigModifyCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -321,9 +320,9 @@ class AuditEventFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -424,9 +423,9 @@ class AuditEventShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -499,9 +498,9 @@ class AuditEventEnableCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -587,9 +586,9 @@ class AuditEventUpdateCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -669,9 +668,9 @@ class AuditEventDisableCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -757,9 +756,9 @@ class AuditFileFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -838,9 +837,9 @@ class AuditFileVerifyCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/banner.py
+++ b/base/server/python/pki/server/cli/banner.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import logging
 import io
 import sys
@@ -42,9 +41,9 @@ class BannerShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show banner')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -108,9 +107,9 @@ class BannerValidateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('validate', 'Validate banner')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import inspect
 import io
 import logging
@@ -95,9 +94,9 @@ class CACertFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -183,9 +182,9 @@ class CACertCreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -313,9 +312,9 @@ class CACertImportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('import', 'Import certificate into CA')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -416,9 +415,9 @@ class CACertRemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Remove certificate in CA')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -492,9 +491,9 @@ class CACertChainExportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('export', 'Export certificate chain')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -613,9 +612,9 @@ class CACertRequestFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find CA certificate requests')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -699,9 +698,9 @@ class CACertRequestShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show CA certificate request')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -777,9 +776,9 @@ class CACertRequestImportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('import', 'Import certificate request into CA')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -894,9 +893,9 @@ class CACRLShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1019,9 +1018,9 @@ class CACRLIPFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1101,9 +1100,9 @@ class CACRLIPShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1180,9 +1179,9 @@ class CACRLIPModifyCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1266,9 +1265,9 @@ class CAClonePrepareCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('prepare', 'Prepare CA clone')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1413,9 +1412,9 @@ class CAProfileFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1482,9 +1481,9 @@ class CAProfileImportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('import', 'Import CA profiles')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1577,9 +1576,9 @@ class CAProfileModifyCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -19,7 +19,6 @@
 # All rights reserved.
 #
 
-import argparse
 from contextlib import contextmanager
 import datetime
 import getpass
@@ -44,6 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 class CertCLI(pki.cli.CLI):
+
     def __init__(self):
         super().__init__('cert', 'System certificate management commands')
         self.add_module(CertFindCLI())
@@ -103,9 +103,9 @@ class CertFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find system certificates.')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -194,9 +194,9 @@ class CertShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Display system certificate details.')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -309,9 +309,9 @@ class CertValidateCLI(pki.cli.CLI):
             'validate',
             inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -379,9 +379,9 @@ class CertUpdateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('update', 'Update system certificate.')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -521,9 +521,9 @@ class CertRequestCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('request', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -629,9 +629,9 @@ class CertCreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -787,9 +787,8 @@ class CertImportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('import', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
-
-        self.parser = argparse.ArgumentParser(
+    def create_parser(self, subparsers=None):
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -859,9 +858,9 @@ class CertExportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('export', 'Export system certificate.')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1098,9 +1097,9 @@ class CertRemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Remove system certificate.')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1179,9 +1178,9 @@ class CertFixCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('fix', 'Fix expired system certificate(s).')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/config.py
+++ b/base/server/python/pki/server/cli/config.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import logging
 import sys
 
@@ -46,9 +45,9 @@ class SubsystemConfigFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -119,9 +118,9 @@ class SubsystemConfigShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -199,9 +198,9 @@ class SubsystemConfigSetCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -275,9 +274,9 @@ class SubsystemConfigUnsetCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/db.py
+++ b/base/server/python/pki/server/cli/db.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import getpass
 import inspect
 import logging
@@ -47,9 +46,9 @@ class DBSchemaUpgradeCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('schema-upgrade', 'Upgrade PKI database schema')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -136,9 +135,9 @@ class DBUpgradeCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('upgrade', 'Upgrade PKI server database')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -297,9 +296,9 @@ class SubsystemDBConfigShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -370,9 +369,9 @@ class SubsystemDBConfigModifyCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -547,9 +546,9 @@ class SubsystemDBInfoCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -640,9 +639,9 @@ class SubsystemDBCreateCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -725,9 +724,9 @@ class SubsystemDBInitCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -812,9 +811,9 @@ class SubsystemDBEmptyCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -895,9 +894,9 @@ class SubsystemDBRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -980,9 +979,9 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1091,9 +1090,9 @@ class SubsystemDBAccessGrantCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1180,9 +1179,9 @@ class SubsystemDBAccessRevokeCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1284,9 +1283,9 @@ class SubsystemDBIndexAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1366,9 +1365,9 @@ class SubsystemDBIndexRebuildCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1471,9 +1470,9 @@ class SubsystemDBReplicationEnableCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1619,9 +1618,9 @@ class SubsystemDBReplicationAgreementAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1745,9 +1744,9 @@ class SubsystemDBReplicationAgreementInitCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1855,9 +1854,9 @@ class SubsystemDBVLVFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1934,9 +1933,9 @@ class SubsystemDBVLVAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -2013,9 +2012,9 @@ class SubsystemDBVLVDeleteCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -2092,9 +2091,9 @@ class SubsystemDBVLVReindexCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/est.py
+++ b/base/server/python/pki/server/cli/est.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 
-import argparse
 import logging
 import os
 
@@ -33,9 +32,9 @@ class ESTCreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', 'Create EST subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -105,9 +104,9 @@ class ESTRemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('remove', 'Remove EST subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/group.py
+++ b/base/server/python/pki/server/cli/group.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-import argparse
 import logging
 import sys
 
@@ -32,9 +31,9 @@ class GroupFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -120,9 +119,9 @@ class GroupMemberFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -206,9 +205,9 @@ class GroupMemberAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -285,9 +284,9 @@ class GroupMemberRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import inspect
 import logging
 import sys
@@ -102,9 +101,9 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add connector')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -220,9 +219,9 @@ class HTTPConnectorDeleteCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Delete connector')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -286,9 +285,9 @@ class HTTPConnectorFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find connectors')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -361,9 +360,9 @@ class HTTPConnectorShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show connector')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -431,9 +430,9 @@ class HTTPConnectorModCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', 'Modify connector')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -621,9 +620,9 @@ class SSLHostAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add SSL host configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -715,9 +714,9 @@ class SSLHostDeleteCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Delete SSL host configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -789,9 +788,9 @@ class SSLHostFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find SSL host configurations')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -886,9 +885,9 @@ class SSLHostModifyCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('mod', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -983,9 +982,9 @@ class SSLHostShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1084,9 +1083,9 @@ class SSLCertAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add SSL certificate configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1211,9 +1210,9 @@ class SSLCertDeleteCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Delete SSL certificate configuration')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1302,9 +1301,9 @@ class SSLCertFindLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find SSL certificate configurations')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/id.py
+++ b/base/server/python/pki/server/cli/id.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-import argparse
 import logging
 import sys
 
@@ -42,9 +41,9 @@ class IdGeneratorShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -115,9 +114,9 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/instance.py
+++ b/base/server/python/pki/server/cli/instance.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import getpass
 import logging
 import os
@@ -68,9 +67,9 @@ class InstanceCertExportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('export', 'Export system certificates')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -186,9 +185,9 @@ class InstanceFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find instances')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -254,9 +253,9 @@ class InstanceShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show instance')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -312,9 +311,9 @@ class InstanceStartCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('start', 'Start instance')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -375,9 +374,9 @@ class InstanceStopCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('stop', 'Stop instance')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -438,9 +437,9 @@ class InstanceMigrateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('migrate', 'Migrate instance')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument('--tomcat')
@@ -511,9 +510,9 @@ class InstanceNuxwdogEnableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('nuxwdog-enable', 'Instance enable nuxwdog')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -574,9 +573,9 @@ class InstanceNuxwdogDisableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('nuxwdog-disable', 'Instance disable nuxwdog')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -637,9 +636,9 @@ class InstanceExternalCertAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('externalcert-add', 'Add external certificate or chain to the instance')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -751,9 +750,9 @@ class InstanceExternalCertDeleteCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('externalcert-del', 'Delete external certificate from the instance')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/jss.py
+++ b/base/server/python/pki/server/cli/jss.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import logging
 import sys
 
@@ -39,9 +38,9 @@ class JSSEnableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('enable', 'Enable JSS in PKI server')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -108,9 +107,9 @@ class JSSDisableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('disable', 'Disable JSS in PKI server')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/kra.py
+++ b/base/server/python/pki/server/cli/kra.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import io
 import logging
 import os
@@ -69,9 +68,9 @@ class KRAClonePrepareCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('prepare', 'Prepare KRA clone')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/listener.py
+++ b/base/server/python/pki/server/cli/listener.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import logging
 
 import pki.cli
@@ -45,9 +44,9 @@ class ListenerFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find listeners')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import logging
 import sys
 
@@ -35,9 +34,9 @@ class MigrateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('migrate', 'Migrate system')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/nss.py
+++ b/base/server/python/pki/server/cli/nss.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import getpass
 import logging
 
@@ -39,9 +38,9 @@ class NSSCreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', 'Create NSS database in PKI server')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -132,9 +131,9 @@ class NSSRemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('remove', 'Remove NSS database in PKI server')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/nuxwdog.py
+++ b/base/server/python/pki/server/cli/nuxwdog.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import fileinput
 import logging
 from lxml import etree
@@ -51,9 +50,9 @@ class NuxwdogEnableCLI(pki.cli.CLI):
         )
         super().__init__('enable', 'Enable nuxwdog')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -228,9 +227,9 @@ class NuxwdogDisableCLI(pki.cli.CLI):
         )
         super().__init__('disable', 'Disable nuxwdog')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/ocsp.py
+++ b/base/server/python/pki/server/cli/ocsp.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import io
 import logging
 import os
@@ -68,9 +67,9 @@ class OCSPClonePrepareCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('prepare', 'Prepare OCSP clone')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -199,9 +198,9 @@ class OCSPCRLIssuingPointFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find OCSP CRL issuing points')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -269,9 +268,9 @@ class OCSPCRLIssuingPointAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add OCSP CRL issuing point')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/password.py
+++ b/base/server/python/pki/server/cli/password.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import logging
 
 import pki.cli
@@ -43,9 +42,9 @@ class PasswordFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find passwords')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -113,9 +112,9 @@ class PasswordAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add password')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -183,9 +182,9 @@ class PasswordRemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Remove password')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/range.py
+++ b/base/server/python/pki/server/cli/range.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-import argparse
 import logging
 import sys
 
@@ -33,9 +32,9 @@ class RangeShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -114,9 +113,9 @@ class RangeRequestCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -203,9 +202,9 @@ class RangeUpdateCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/sd.py
+++ b/base/server/python/pki/server/cli/sd.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-import argparse
 import logging
 import sys
 
@@ -28,9 +27,9 @@ class SDCreateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('create', 'Create security domain')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -107,9 +106,9 @@ class SDSubsystemFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find security domain subsystems')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -173,9 +172,9 @@ class SDSubsystemAddCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('add', 'Add security domain subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -282,9 +281,9 @@ class SDSubsystemRemoveCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('del', 'Remove security domain subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/selftest.py
+++ b/base/server/python/pki/server/cli/selftest.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import sys
 import logging
 
@@ -37,9 +36,9 @@ class EnableSelfTestCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('enable', 'Enable selftests.')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -126,9 +125,9 @@ class DisableSelftestCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('disable', 'Disable selftests.')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -20,7 +20,6 @@
 # All rights reserved.
 #
 
-import argparse
 import getpass
 import inspect
 import logging
@@ -60,9 +59,9 @@ class SubsystemFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find subsystems')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -131,9 +130,9 @@ class SubsystemShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -218,9 +217,9 @@ class SubsystemCreateCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -285,9 +284,9 @@ class SubsystemDeployCLI(pki.cli.CLI):
         super().__init__('deploy', 'Deploy %s subsystem' % parent.name.upper())
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -381,9 +380,9 @@ class SubsystemUndeployCLI(pki.cli.CLI):
         super().__init__('undeploy', 'Undeploy %s subsystem' % parent.name.upper())
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -489,9 +488,9 @@ class SubsystemRedeployCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -582,9 +581,9 @@ class SubsystemEnableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('enable', 'Enable subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -690,9 +689,9 @@ class SubsystemDisableCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('disable', 'Disable subsystem')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -817,9 +816,9 @@ class SubsystemCertFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find subsystem certificates')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -908,9 +907,9 @@ class SubsystemCertShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', 'Show subsystem certificate')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -987,9 +986,9 @@ class SubsystemCertExportCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('export', 'Export subsystem certificate')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1163,9 +1162,9 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('update', 'Update subsystem certificate')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1311,9 +1310,9 @@ class SubsystemCertValidateCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('validate', 'Validate subsystem certificates', deprecated=True)
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/tks.py
+++ b/base/server/python/pki/server/cli/tks.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import io
 import logging
 import os
@@ -67,9 +66,9 @@ class TKSClonePrepareCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('prepare', 'Prepare TKS clone')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/tps.py
+++ b/base/server/python/pki/server/cli/tps.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import io
 import logging
 import os
@@ -67,9 +66,9 @@ class TPSClonePrepareCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('prepare', 'Prepare TPS clone')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/upgrade.py
+++ b/base/server/python/pki/server/cli/upgrade.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import logging
 
 import pki.cli
@@ -33,9 +32,9 @@ class UpgradeCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('upgrade', 'Upgrade PKI server')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-import argparse
 import inspect
 import logging
 import sys
@@ -65,9 +64,9 @@ class UserAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -182,9 +181,9 @@ class UserFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -286,9 +285,9 @@ class UserModifyCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -391,9 +390,9 @@ class UserRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -459,9 +458,9 @@ class UserShowCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -565,9 +564,9 @@ class UserCertFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -639,9 +638,9 @@ class UserCertAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -745,9 +744,9 @@ class UserCertRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -842,9 +841,9 @@ class UserRoleFindCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -927,9 +926,9 @@ class UserRoleAddCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1013,9 +1012,9 @@ class UserRoleRemoveCLI(pki.cli.CLI):
 
         self.parent = parent
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/webapp.py
+++ b/base/server/python/pki/server/cli/webapp.py
@@ -18,7 +18,6 @@
 # All rights reserved.
 #
 
-import argparse
 import inspect
 import logging
 import sys
@@ -58,9 +57,9 @@ class WebappFindCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('find', 'Find webapps')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -138,9 +137,9 @@ class WebappShowCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('show', inspect.cleandoc(self.__class__.__doc__))
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -200,9 +199,9 @@ class WebappDeployCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('deploy', 'Deploy webapp')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -289,9 +288,9 @@ class WebappUndeployCLI(pki.cli.CLI):
     def __init__(self):
         super().__init__('undeploy', 'Undeploy webapp')
 
-    def create_parser(self):
+    def create_parser(self, subparsers=None):
 
-        self.parser = argparse.ArgumentParser(
+        self.parser = subparsers.add_parser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(


### PR DESCRIPTION
The `PKIServerCLI` has been modified to create a main parser using `ArgumentParser` then create a subparser for each sub-command.

The `CLI.create_parser()` has been modified to take an optional `subparsers` object and pass it down to the modules.

The `PKICLI`, `PasswordGenerateCLI`, and `PKCS12ImportCLI` will be updated separately later.