### PR TITLE
Update pki CLI to use ArgumentParser

### DIFF
--- a/base/common/python/pki/cli/__init__.py
+++ b/base/common/python/pki/cli/__init__.py
@@ -20,9 +20,7 @@
 #
 
 import collections
-import getopt
 import logging
-import sys
 from six import itervalues
 
 logger = logging.getLogger(__name__)
@@ -184,40 +182,11 @@ class CLI(object):
 
         return (module, module_args)
 
-    def execute(self, argv, args=None):
+    def execute(self, argv, args=None):  # pylint: disable=W0613
         '''
         :param argv: Argument values
         :param args: Parsed arguments
         '''
-        try:
-            opts, args = getopt.getopt(argv, 'v', [
-                'verbose', 'help'])
-
-        except getopt.GetoptError as e:
-            logger.error(e)
-            self.print_help()
-            sys.exit(1)
-
-        if len(args) == 0:
-            self.print_help()
-            sys.exit()
-
-        for o, _ in opts:
-            if o == '--debug':
-                logging.getLogger().setLevel(logging.DEBUG)
-
-            elif o in ('-v', '--verbose'):
-                logging.getLogger().setLevel(logging.INFO)
-
-            elif o == '--help':
-                self.print_help()
-                sys.exit()
-
-            else:
-                logger.error('Unknown option: %s', o)
-                self.print_help()
-                sys.exit(1)
-
         (module, module_argv) = self.parse_args(argv)
 
         module.execute(module_argv)

--- a/base/common/python/pki/cli/pkcs12.py
+++ b/base/common/python/pki/cli/pkcs12.py
@@ -230,11 +230,11 @@ class PKCS12ImportCLI(pki.cli.CLI):
                 cert_file = os.path.join(tmpdir, 'ca-cert.pem')
 
                 nssdb = pki.nssdb.NSSDatabase(
-                    main_cli.database,
+                    main_cli.nss_database,
                     token=main_cli.token,
-                    password=main_cli.password,
-                    password_file=main_cli.password_file,
-                    password_conf=main_cli.password_conf)
+                    password=main_cli.nss_password,
+                    password_file=main_cli.nss_password_file,
+                    password_conf=main_cli.nss_password_conf)
 
                 for cert_info in certs:
 

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -237,7 +237,7 @@ public class MainCLI extends CLI {
         option = new Option(null, "ignore-banner", false, "Ignore access banner");
         options.addOption(option);
 
-        option = new Option(null, "message-format", true, "Message format: xml (default), json");
+        option = new Option(null, "message-format", true, "Message format: json (default), xml");
         option.setArgName("format");
         options.addOption(option);
 


### PR DESCRIPTION
The `pki` CLI has been updated to parse the main arguments (which are also defined in `MainCLI.java`) using `ArgumentParser`, determine the subcommand, then pass the remaining arguments to the Python or Java module corresponding to the subcommand.

It does not use subparsers like in `pki-server` since the `pki` CLI does not have the list of Java subcommands.

The `pki` CLI have options that might conflict with other options in some subcommands. That will be addressed separately later.

The help message for default message format in `MainCLI.java` has also been updated.

**Note:** All pylint issues have been fixed now, but apparently there are existing Flake8 issues that were hidden by pylint issues. They will be fixed separately later.