### PR TITLE
[skip ci] Adjust DS-Installation link in pki/docs/acme

### DIFF
--- a/docs/installation/acme/Configuring-ACME-with-DS-Database.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-DS-Database.adoc
@@ -4,7 +4,7 @@
 
 This document describes the process to configure ACME responder to use a DS database.
 It assumes that the DS database has been installed as described in
-link:https://github.com/dogtagpki/pki/wiki/DS-Installation[DS Installation].
+link:../others/Creating_DS_instance.adoc[Creating a directory server instance and adding base entries]
 
 ## Initializing DS Database
 

--- a/docs/installation/acme/Configuring-ACME-with-DS-Realm.adoc
+++ b/docs/installation/acme/Configuring-ACME-with-DS-Realm.adoc
@@ -4,7 +4,7 @@
 
 This document describes the process to configure ACME responder to use a DS database for authentication realm.
 It assumes that the DS database has been installed as described in
-link:https://github.com/dogtagpki/pki/wiki/DS-Installation[DS Installation].
+link:../others/Creating_DS_instance.adoc[Creating a directory server instance and adding base entries]
 
 ## Initializing DS Realm
 

--- a/docs/installation/others/Creating_DS_instance.adoc
+++ b/docs/installation/others/Creating_DS_instance.adoc
@@ -10,8 +10,6 @@ Normally the DS installation will automatically generate a self-signed signing c
 In this procedure the certificate generation and the SSL connection will be disabled by default,
 but it can be enabled after installation if necessary.
 
-For DS 1.3 or older, see link:https://github.com/dogtagpki/pki/wiki/DS-1.3-Installation[DS 1.3 Installation].
-
 == Creating a DS Instance ==
 
 === Generate a DS configuration file (e.g. `ds.inf`): ===


### PR DESCRIPTION
- updated pki/docs/acme/ to rely on Installing_DS_Packages.adoc and Creating_DS_instance.adoc in pki/docs/others instead of pki.wiki's DS-Installation.asciidoc.
- Deploying-DS-Container is not included in Creating_DS_instance.adoc. Will add later
- removed version-specific link reference to DS-1.3-Installation in Creating_DS_instance.adoc