### PR TITLE
Add pki-server password-set/unset

### DIFF
--- a/.github/workflows/ca-clone-replicated-ds-test.yml
+++ b/.github/workflows/ca-clone-replicated-ds-test.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Configure connection to CA database
         run: |
           # store DS password
-          docker exec secondary pki-server password-add \
+          docker exec secondary pki-server password-set \
               --password Secret.123 \
               internaldb
 

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Configure connection to CA database
         run: |
           # store DS password
-          docker exec pki pki-server password-add \
+          docker exec pki pki-server password-set \
               --password Secret.123 \
               internaldb
 

--- a/.github/workflows/ca-existing-hsm-test.yml
+++ b/.github/workflows/ca-existing-hsm-test.yml
@@ -70,7 +70,7 @@ jobs:
           docker exec pki pki-server create
           docker exec pki pki-server nss-create --no-password
 
-          docker exec pki pki-server password-add "hardware-HSM" --password "Secret.HSM"
+          docker exec pki pki-server password-set "hardware-HSM" --password "Secret.HSM"
           docker exec pki cat /var/lib/pki/pki-tomcat/conf/password.conf
 
       - name: Create CA signing cert

--- a/.github/workflows/kra-clone-replicated-ds-test.yml
+++ b/.github/workflows/kra-clone-replicated-ds-test.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Configure connection to CA database
         run: |
           # store DS password
-          docker exec secondary pki-server password-add \
+          docker exec secondary pki-server password-set \
               --password Secret.123 \
               internaldb
 

--- a/.github/workflows/kra-existing-ds-test.yml
+++ b/.github/workflows/kra-existing-ds-test.yml
@@ -319,7 +319,7 @@ jobs:
       - name: Configure connection to KRA database
         run: |
           # store DS password
-          docker exec kra pki-server password-add \
+          docker exec kra pki-server password-set \
               --password Secret.123 \
               internaldb
 

--- a/.github/workflows/kra-existing-hsm-test.yml
+++ b/.github/workflows/kra-existing-hsm-test.yml
@@ -111,7 +111,7 @@ jobs:
           docker exec kra pki-server create
           docker exec kra pki-server nss-create --password Secret.123
 
-          docker exec kra pki-server password-add "hardware-HSM" --password "Secret.HSM"
+          docker exec kra pki-server password-set "hardware-HSM" --password "Secret.HSM"
           docker exec kra cat /var/lib/pki/pki-tomcat/conf/password.conf
 
       - name: Issue KRA storage cert

--- a/docs/changes/v11.6.0/Tools-Changes.adoc
+++ b/docs/changes/v11.6.0/Tools-Changes.adoc
@@ -65,3 +65,10 @@ The `pkispawn` command has been updated to include ACME and EST subsystem deploy
 == Update pkidestroy
 
 The `pkidestroy` command has been updated to include ACME and EST subsystem removal.
+
+== Add pki-server pki-server password-set/unset ==
+
+The `pki-server password-set/unset` commands have been added
+to replace `pki-server password-add/del`.
+
+The `pki-server password-add/del` commands have been deprecated.


### PR DESCRIPTION
The `pki-server password-set/unset` have been added to replace `pki-server password-add/del` for managing the passwords in `password.conf`.

The `pki-server password-add` will only work if the password does not exist already, whereas the `pki-server password-set` will overwrite the existing password.

The `pki-server password-set` will also support reading the password from file and from console.

https://github.com/edewata/pki/blob/refs/heads/cli/docs/changes/v11.6.0/Tools-Changes.adoc#add-pki-server-pki-server-password-setunset
