### PR TITLE
Add tests for CA admin cert

### DIFF
--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -166,6 +166,7 @@ jobs:
       - name: Check CA admin cert
         run: |
           docker exec ipa ls -la /root/.dogtag/pki-tomcat
+          docker exec ipa cat /root/.dogtag/pki-tomcat/ca_admin.cert
           docker exec ipa openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
           # import CA admin cert and key into the client's NSS database

--- a/.github/workflows/ipa-kra-test.yml
+++ b/.github/workflows/ipa-kra-test.yml
@@ -50,6 +50,10 @@ jobs:
 
       - name: Install CA admin cert
         run: |
+          docker exec ipa ls -la /root/.dogtag/pki-tomcat
+          docker exec ipa cat /root/.dogtag/pki-tomcat/ca_admin.cert
+          docker exec ipa openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
+
           # import CA admin cert and key into the client's NSS database
           docker exec ipa pki nss-cert-import \
               --cert ca_signing.crt \
@@ -94,6 +98,17 @@ jobs:
           echo "0" > expected
           grep "(orphan)" output | wc -l > actual
           diff expected actual
+
+      - name: Check CA admin cert after installing KRA
+        run: |
+          docker exec ipa ls -la /root/.dogtag/pki-tomcat
+          docker exec ipa cat /root/.dogtag/pki-tomcat/ca_admin.cert
+
+          # Currently IPA creates ca_admin.cert in Base64 format
+          # so it cannot be parsed by OpenSSL.
+          # https://pagure.io/freeipa/issue/9735
+          # TODO: Enable the test after the issue is fixed.
+          # docker exec ipa openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
       - name: Check KRA users
         run: |

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -99,6 +99,12 @@ jobs:
           docker exec pki pki securitydomain-show | tee output
           diff expected output
 
+      - name: Check CA admin cert
+        run: |
+          docker exec pki ls -la /root/.dogtag/pki-tomcat
+          docker exec pki cat /root/.dogtag/pki-tomcat/ca_admin.cert
+          docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
+
       - name: Install KRA
         run: |
           docker exec pki pkispawn \
@@ -293,14 +299,16 @@ jobs:
               -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
-      - name: Check KRA admin cert
+      - name: Check CA admin cert after installing KRA
         run: |
+          docker exec pki ls -la /root/.dogtag/pki-tomcat
+          docker exec pki cat /root/.dogtag/pki-tomcat/ca_admin.cert
           docker exec pki openssl x509 -text -noout -in /root/.dogtag/pki-tomcat/ca_admin.cert
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only
 
-      - name: Verify KRA admin
+      - name: Check accesing KRA using CA admin cert
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
 


### PR DESCRIPTION
Some tests have been updated to check the `ca_admin.cert`. Apparently IPA is creating the file with an invalid format.

https://pagure.io/freeipa/issue/9735