### PR TITLE
Fix pki-server instance-find

### DIFF
--- a/.github/workflows/ca-existing-config-test.yml
+++ b/.github/workflows/ca-existing-config-test.yml
@@ -56,6 +56,29 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
+      - name: Check instance
+        run: |
+          docker exec pki pki-server instance-find | tee output
+
+          cat > expected << EOF
+          -----------------
+          1 entries matched
+          -----------------
+            Instance ID: localhost
+            Active: True
+          EOF
+
+          diff expected output
+
+          docker exec pki pki-server instance-show localhost | tee output
+
+          cat > expected << EOF
+            Instance ID: localhost
+            Active: True
+          EOF
+
+          diff expected output
+
       - name: Check system certs
         run: |
           docker exec pki pki \
@@ -89,6 +112,28 @@ jobs:
               -i localhost \
               -s CA \
               -v
+
+      - name: Check instance
+        run: |
+          docker exec pki pki-server instance-find \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          -----------------
+          0 entries matched
+          -----------------
+          EOF
+
+          diff expected stdout
+
+          docker exec pki pki-server instance-show localhost \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ERROR: Invalid instance localhost.
+          EOF
+
+          diff expected stderr
 
       - name: Check PKI server base dir after first removal
         run: |
@@ -175,6 +220,29 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
+      - name: Check instance
+        run: |
+          docker exec pki pki-server instance-find | tee output
+
+          cat > expected << EOF
+          -----------------
+          1 entries matched
+          -----------------
+            Instance ID: localhost
+            Active: True
+          EOF
+
+          diff expected output
+
+          docker exec pki pki-server instance-show localhost | tee output
+
+          cat > expected << EOF
+            Instance ID: localhost
+            Active: True
+          EOF
+
+          diff expected output
+
       - name: Check PKI server config after second installation
         run: |
           # server config should not change
@@ -235,6 +303,28 @@ jobs:
               --remove-conf \
               --remove-logs \
               -v
+
+      - name: Check instance
+        run: |
+          docker exec pki pki-server instance-find \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          -----------------
+          0 entries matched
+          -----------------
+          EOF
+
+          diff expected stdout
+
+          docker exec pki pki-server instance-show localhost \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ERROR: Invalid instance localhost.
+          EOF
+
+          diff expected stderr
 
       - name: Check PKI server base dir after second removal
         run: |

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -278,7 +278,17 @@ class PKIServer(object):
         return self.exists()
 
     def exists(self):
-        return os.path.exists(self.base_dir)
+        '''
+        Check whether the PKI server instance exists.
+
+        This method checks the bin folder under the instance's base folder.
+        If the folder exists the method will return True, otherwise False.
+
+        The instance's base folder itself is not a reliable indicator since
+        there might be files (e.g. config files, logs) left in the folder
+        after removing an instance.
+        '''
+        return os.path.isdir(self.bin_dir)
 
     def validate(self):
         if not self.exists():

--- a/base/server/python/pki/server/cli/instance.py
+++ b/base/server/python/pki/server/cli/instance.py
@@ -224,25 +224,26 @@ class InstanceFindCLI(pki.cli.CLI):
         elif args.verbose:
             logging.getLogger().setLevel(logging.INFO)
 
-        results = []
+        instances = []
         if os.path.exists(pki.server.PKIServer.BASE_DIR):
-            for f in os.listdir(pki.server.PKIServer.BASE_DIR):
+            for instance_name in os.listdir(pki.server.PKIServer.BASE_DIR):
 
-                if not os.path.isdir:
+                instance = pki.server.PKIServerFactory.create(instance_name)
+
+                if not instance.exists():
                     continue
 
-                results.append(f)
+                instances.append(instance)
 
-        self.print_message('%s entries matched' % len(results))
+        self.print_message('%s entries matched' % len(instances))
 
         first = True
-        for instance_name in results:
+        for instance in instances:
             if first:
                 first = False
             else:
                 print()
 
-            instance = pki.server.PKIServerFactory.create(instance_name)
             instance.load()
 
             InstanceCLI.print_instance(instance)


### PR DESCRIPTION
The `pki-server instance-find` has been updated to find instances existing on the system based on `PKIServer.exists()`.

The `PKIServer.exists()` has also been updated to check whether the instance actually exists based on the `<instance>/bin` folder. It does not use the `<instance>` folder itself since there might be files (e.g. config files, logs) left in the folder after removing the instance.

The test for installing CA with existing config has been updated to validate `pki-server instance-*` commands.