### PR TITLE
Update pkiconsole script

### DIFF
--- a/base/console/bin/pkiconsole
+++ b/base/console/bin/pkiconsole
@@ -23,104 +23,13 @@
 # set NSS_DEFAULT_DB_TYPE.
 . /usr/share/pki/scripts/config
 
-# Check to insure that this script's original invocation directory
-# has not been deleted!
-
-# shellcheck disable=SC2034
-CWD=`/bin/pwd > /dev/null 2>&1`
-if [ $? -ne 0 ] ; then
-    echo "Cannot invoke '$0' from non-existent directory!"
-    exit 255
-fi
-
-
-###############################################################################
-##  (1) Specify variables used by this script.                               ##
-###############################################################################
-
-PRODUCT="pki"
-
-
-###############################################################################
-##  (3) Define helper functions.                                             ##
-###############################################################################
-
-invalid_operating_system() {
-    echo
-    echo "ERROR:  '$0' does not execute on the '$1' operating system!"
-    echo
-}
-
-invalid_architecture() {
-    echo
-    echo "ERROR:  '$0' does not execute on the '$1' architecture!"
-    echo
-}
-
-###############################################################################
-##  (4) Set the LD_LIBRARY_PATH environment variable to determine the        ##
-##      search order this command wrapper uses to find shared libraries.     ##
-###############################################################################
-
-OS=`uname -s`
-ARCHITECTURE=""
-
-if [ "${OS}" = "Linux" ] ; then
-    ARCHITECTURE=`arch`
-    JAVA="java"
-    JAVA_OPTIONS=""
-elif [ "${OS}" = "SunOS" ] ; then
-    ARCHITECTURE=`uname -p`
-    if [ "${ARCHITECTURE}" = "sparc" ] &&
-       [ -d "/usr/lib/sparcv9/" ] ; then
-        ARCHITECTURE="sparcv9"
-    fi
-    if [ "${ARCHITECTURE}" = "sparc" ] ; then
-        JAVA="/usr/jdk/instances/jdk1.5.0/jre/bin/java"
-        JAVA_OPTIONS=""
-
-        LD_LIBRARY_PATH=/usr/lib:/lib
-        LD_LIBRARY_PATH=/usr/lib/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/${PRODUCT}:${LD_LIBRARY_PATH}
-        export LD_LIBRARY_PATH
-    elif [ "${ARCHITECTURE}" = "sparcv9" ] ; then
-        JAVA="/usr/jdk/instances/jdk1.5.0/jre/bin/java"
-        JAVA_OPTIONS="-d64"
-
-        LD_LIBRARY_PATH=/usr/lib:/lib
-        LD_LIBRARY_PATH=/usr/lib/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/${PRODUCT}:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9:/lib/sparcv9:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9/dirsec:${LD_LIBRARY_PATH}
-        LD_LIBRARY_PATH=/usr/lib/sparcv9/${PRODUCT}:${LD_LIBRARY_PATH}
-        export LD_LIBRARY_PATH
-    else
-        invalid_architecture "${ARCHITECTURE}"
-        exit 255
-    fi
-else
-    invalid_operating_system "${OS}"
-    exit 255
-fi
-
-
-###############################################################################
-##  (5) Set the CP environment variable to determine the search              ##
-##      order this command wrapper uses to find jar files.                   ##
-###############################################################################
-
 CP=${PKI_LIB}/*
-CP=/usr/share/java/${PRODUCT}/pki-console-theme.jar:${CP}
-CP=/usr/share/java/${PRODUCT}/pki-console.jar:${CP}
+CP=/usr/share/java/pki/pki-console-theme.jar:${CP}
+CP=/usr/share/java/pki/pki-console.jar:${CP}
 export CP
 
-
-###############################################################################
-##  (6) Execute the java command specified by this java command wrapper      ##
-##      based upon the preset LD_LIBRARY_PATH and CP environment variables.  ##
-###############################################################################
-
-${JAVA} ${JAVA_OPTIONS} \
+${JAVA_HOME}/bin/java \
+  ${JAVA_OPTIONS} \
   -cp ${CP} \
   -Djava.util.prefs.systemRoot=/tmp/.java \
   -Djava.util.prefs.userRoot=/tmp/java \


### PR DESCRIPTION
The `pkiconsole` script has been updated to use the JVM specified in `JAVA_HOME` so it will be more consistent with other PKI tools (e.g.  `pki`, `pki-server`, `pkispawn`).