### PR TITLE
Fix pki-server subsystem-cert-find

### DIFF
--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -56,7 +56,23 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
+      - name: Check PKI system certs
+        run: |
           docker exec pki pki-server cert-find
+          docker exec pki pki-server cert-show ca_signing
+          docker exec pki pki-server cert-show ca_ocsp_signing
+          docker exec pki pki-server cert-show sslserver
+          docker exec pki pki-server cert-show subsystem
+          docker exec pki pki-server cert-show ca_audit_signing
+
+      - name: Check CA system certs
+        run: |
+          docker exec pki pki-server subsystem-cert-find ca
+          docker exec pki pki-server subsystem-cert-show ca signing
+          docker exec pki pki-server subsystem-cert-show ca ocsp_signing
+          docker exec pki pki-server subsystem-cert-show ca sslserver
+          docker exec pki pki-server subsystem-cert-show ca subsystem
+          docker exec pki pki-server subsystem-cert-show ca audit_signing
 
       - name: Check security domain config in CA
         run: |
@@ -106,6 +122,25 @@ jobs:
               -s OCSP \
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
+
+      - name: Check PKI system certs
+        run: |
+          docker exec pki pki-server cert-find
+          docker exec pki pki-server cert-show ca_signing
+          docker exec pki pki-server cert-show ca_ocsp_signing
+          docker exec pki pki-server cert-show sslserver
+          docker exec pki pki-server cert-show subsystem
+          docker exec pki pki-server cert-show ca_audit_signing
+          docker exec pki pki-server cert-show ocsp_signing
+          docker exec pki pki-server cert-show ocsp_audit_signing
+
+      - name: Check OCSP system certs
+        run: |
+          docker exec pki pki-server subsystem-cert-find ocsp
+          docker exec pki pki-server subsystem-cert-show ocsp signing
+          docker exec pki pki-server subsystem-cert-show ocsp sslserver
+          docker exec pki pki-server subsystem-cert-show ocsp subsystem
+          docker exec pki pki-server subsystem-cert-show ocsp audit_signing
 
       - name: Check PKI server base dir after installation
         run: |

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -814,7 +814,7 @@ class SubsystemCertCLI(pki.cli.CLI):
 class SubsystemCertFindCLI(pki.cli.CLI):
 
     def __init__(self):
-        super().__init__('find', 'Find subsystem certificates')
+        super().__init__('find', 'Find subsystem certificates', deprecated=True)
 
     def create_parser(self, subparsers=None):
 
@@ -851,6 +851,10 @@ class SubsystemCertFindCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv, args=None):
+
+        logger.warning(
+            'The pki-server subsystem-cert-find has been deprecated. '
+            'Use pki-server cert-find instead.')
 
         if not args:
             args = self.parser.parse_args(args=argv)
@@ -905,7 +909,7 @@ class SubsystemCertFindCLI(pki.cli.CLI):
 class SubsystemCertShowCLI(pki.cli.CLI):
 
     def __init__(self):
-        super().__init__('show', 'Show subsystem certificate')
+        super().__init__('show', 'Show subsystem certificate', deprecated=True)
 
     def create_parser(self, subparsers=None):
 
@@ -943,6 +947,10 @@ class SubsystemCertShowCLI(pki.cli.CLI):
         print()
 
     def execute(self, argv, args=None):
+
+        logger.warning(
+            'The pki-server subsystem-cert-show has been deprecated. '
+            'Use pki-server cert-show instead.')
 
         if not args:
             args = self.parser.parse_args(args=argv)

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -355,12 +355,16 @@ class PKISubsystem(object):
 
     def get_cert_infos(self):
 
+        cert_infos = []
+
         cert_list = self.config.get('%s.cert.list' % self.name)
         if not cert_list:
-            return []
+            return cert_infos
 
         for cert_tag in cert_list.split(','):
-            yield self.get_cert_info(cert_tag)
+            cert_infos.append(self.get_cert_info(cert_tag))
+
+        return cert_infos
 
     def get_subsystem_certs(self):
         certs = self.config.get('%s.cert.list' % self.name)

--- a/docs/changes/v11.6.0/Tools-Changes.adoc
+++ b/docs/changes/v11.6.0/Tools-Changes.adoc
@@ -66,9 +66,14 @@ The `pkispawn` command has been updated to include ACME and EST subsystem deploy
 
 The `pkidestroy` command has been updated to include ACME and EST subsystem removal.
 
-== Add pki-server pki-server password-set/unset ==
+== Add pki-server password-set/unset ==
 
 The `pki-server password-set/unset` commands have been added
 to replace `pki-server password-add/del`.
 
 The `pki-server password-add/del` commands have been deprecated.
+
+== Deprecate pki-server subsystem-cert-find/show ==
+
+The `pki-server subsystem-cert-find/show` commands have been deprecated.
+Use `pki-server cert-find/show` commands instead.


### PR DESCRIPTION
The `PKISubsystem.get_cert_infos()` has been updated to return a list instead of a generator object such that the number of entries can be counted using `len()`.

The `pki-server subsystem-cert-find/show` commands have been deprecated since some of the certs returned by these commands are shared with other subsystems (e.g. `sslserver`, `subsystem`) which could cause some confusions. It's recommended to use `pki-server cert-find/show` instead.

The test for basic OCSP installation has been updated to check the above commands.

https://github.com/edewata/pki/blob/cli/docs/changes/v11.6.0/Tools-Changes.adoc#deprecate-pki-server-subsystem-cert-findshow
