### PR TITLE
Fix CLI help messages

### DIFF
--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -124,6 +124,19 @@ jobs:
               --cert admin.crt \
               caadmin
 
+      - name: Check pki-server ca CLI help message
+        run: |
+          docker exec pki pki-server ca
+          docker exec pki pki-server ca --help
+
+          # TODO: validate output
+
+      - name: Check pki-server ca-create CLI help message
+        run: |
+          docker exec pki pki-server ca-create --help
+
+          # TODO: validate output
+
       - name: Create CA subsystem
         run: |
           docker exec pki pki-server ca-create -v
@@ -402,17 +415,3 @@ jobs:
         if: always()
         run: |
           docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ca-existing-ds
-          path: /tmp/artifacts

--- a/.github/workflows/pki-basic-test.yml
+++ b/.github/workflows/pki-basic-test.yml
@@ -1,0 +1,70 @@
+name: Basic PKI CLI
+# https://github.com/dogtagpki/pki/wiki/PKI-CLI
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Set up runner container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              pki
+
+      - name: Check pki CLI help message
+        run: |
+          docker exec pki pki
+          docker exec pki pki --help
+
+          # TODO: validate output
+
+      - name: Check pki CLI version
+        run: |
+          docker exec pki pki --version
+
+          # TODO: validate output
+
+      - name: Check pki CLI with wrong option
+        run: |
+          docker exec pki pki --wrong \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # TODO: validate output
+
+      - name: Check pki CLI with wrong sub-command
+        run: |
+          docker exec pki pki wrong \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ERROR: Invalid module "wrong".
+          EOF
+
+          diff expected stderr
+
+      - name: Check pki nss CLI help message
+        run: |
+          docker exec pki pki nss
+          docker exec pki pki nss --help
+
+          # TODO: validate output

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -1,4 +1,5 @@
 name: Basic server
+# https://github.com/dogtagpki/pki/wiki/PKI-Server-CLI
 
 on: workflow_call
 
@@ -36,6 +37,43 @@ jobs:
 
       - name: Connect server container to network
         run: docker network connect example pki --alias pki.example.com
+
+      - name: Check pki-server CLI help message
+        run: |
+          docker exec pki pki-server
+          docker exec pki pki-server --help
+
+          # TODO: validate output
+
+      - name: Check pki-server CLI version
+        run: |
+          docker exec pki pki-server --version
+
+          # TODO: validate output
+
+      - name: Check pki-server CLI with wrong option
+        run: |
+          docker exec pki pki-server --wrong \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # TODO: validate output
+
+      - name: Check pki-server CLI with wrong sub-command
+        run: |
+          docker exec pki pki-server wrong \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ERROR: Invalid module "wrong".
+          EOF
+
+          diff expected stderr
+
+      - name: Check pki-server create CLI help message
+        run: |
+          docker exec pki pki-server create --help
+
+          # TODO: validate output
 
       - name: Create pki-tomcat server
         run: |
@@ -412,24 +450,3 @@ jobs:
           EOF
 
           diff expected output
-
-      - name: Gather artifacts from server container
-        if: always()
-        run: |
-          tests/bin/pki-artifacts-save.sh pki
-
-          docker exec pki ls -la /var/lib/tomcats/pki/conf
-          mkdir -p /tmp/artifacts/pki/var/lib/tomcats/pki/conf
-          docker cp pki:/var/lib/tomcats/pki/conf/* /tmp/artifacts/var/lib/tomcats/pki/conf
-
-          docker exec pki ls -la /var/lib/tomcats/pki/logs
-          mkdir -p /tmp/artifacts/pki/var/lib/tomcats/pki/logs
-          docker cp pki:/var/lib/tomcats/pki/logs/* /tmp/artifacts/var/lib/tomcats/pki/logs
-        continue-on-error: true
-
-      - name: Upload artifacts from server container
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: server-basic-test
-          path: /tmp/artifacts

--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -41,6 +41,19 @@ jobs:
         run: |
           docker exec pki pki-server create -v
 
+      - name: Check pki-server nss CLI help message
+        run: |
+          docker exec pki pki-server nss
+          docker exec pki pki-server nss --help
+
+          # TODO: validate output
+
+      - name: Check pki-server nss-create CLI help message
+        run: |
+          docker exec pki pki-server nss-create --help
+
+          # TODO: validate output
+
       - name: Create NSS database in PKI server
         run: |
           docker exec pki pki-server nss-create --no-password
@@ -371,17 +384,3 @@ jobs:
         if: always()
         run: |
           docker exec pki find /var/lib/pki/pki-tomcat/logs/pki -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts from server container
-        if: always()
-        run: |
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Upload artifacts from server container
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: server-https-nss-test
-          path: |
-            /tmp/artifacts/pki

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -8,6 +8,11 @@ jobs:
     uses: ./.github/workflows/wait-for-build.yml
     secrets: inherit
 
+  pki-basic-test:
+    name: Basic PKI CLI
+    needs: build
+    uses: ./.github/workflows/pki-basic-test.yml
+
   PKICertImport-test:
     name: PKICertImport
     needs: build

--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -174,10 +174,10 @@ class PKICLI(pki.cli.CLI):
               'certificate validity statuses')
         print('      --ignore-banner            Ignore banner')
         print()
-        print('  -v, --verbose                Run in verbose mode.')
-        print('      --debug                  Show debug messages.')
-        print('      --help                   Show help message.')
-        print('      --version                Show version number.')
+        print('  -v, --verbose                  Run in verbose mode.')
+        print('      --debug                    Show debug messages.')
+        print('      --help                     Show help message.')
+        print('      --version                  Show version number.')
         print()
 
         super(PKICLI, self).print_help()
@@ -358,8 +358,14 @@ class PKICLI(pki.cli.CLI):
         self.ignore_cert_status = args.ignore_cert_status
         self.ignore_banner = args.ignore_banner
 
-        command = args.remainder[0]
+        command = None
+        if len(args.remainder) > 0:
+            command = args.remainder[0]
         logger.debug('Command: %s', command)
+
+        if not command:
+            self.print_help()
+            return
 
         if client_type == 'python' or command in PYTHON_COMMANDS:
             module = self.find_module(command)

--- a/base/server/python/pki/server/cli/acme.py
+++ b/base/server/python/pki/server/cli/acme.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
+import argparse
 import logging
 import os
 
@@ -41,7 +42,7 @@ class ACMECreateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -110,7 +111,7 @@ class ACMERemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -194,7 +195,7 @@ class ACMEDeployCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -286,7 +287,7 @@ class ACMEUndeployCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -380,7 +381,7 @@ class ACMEMetadataShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -467,7 +468,7 @@ class ACMEMetadataModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -579,7 +580,7 @@ class ACMEDatabaseShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -699,7 +700,7 @@ class ACMEDatabaseModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -917,7 +918,7 @@ class ACMEIssuerShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1032,7 +1033,7 @@ class ACMEIssuerModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1247,7 +1248,7 @@ class ACMERealmShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1377,7 +1378,7 @@ class ACMERealmModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/audit.py
+++ b/base/server/python/pki/server/cli/audit.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import logging
 import os
 import shutil
@@ -93,7 +94,7 @@ class AuditConfigShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -164,7 +165,7 @@ class AuditConfigModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -322,7 +323,7 @@ class AuditEventFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -425,7 +426,7 @@ class AuditEventShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -500,7 +501,7 @@ class AuditEventEnableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -588,7 +589,7 @@ class AuditEventUpdateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -670,7 +671,7 @@ class AuditEventDisableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -758,7 +759,7 @@ class AuditFileFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -839,7 +840,7 @@ class AuditFileVerifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/banner.py
+++ b/base/server/python/pki/server/cli/banner.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import logging
 import io
 import sys
@@ -43,7 +44,7 @@ class BannerShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -109,7 +110,7 @@ class BannerValidateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import inspect
 import io
 import logging
@@ -96,7 +97,7 @@ class CACertFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -184,7 +185,7 @@ class CACertCreateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -314,7 +315,7 @@ class CACertImportCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -417,7 +418,7 @@ class CACertRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -493,7 +494,7 @@ class CACertChainExportCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -614,7 +615,7 @@ class CACertRequestFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -700,7 +701,7 @@ class CACertRequestShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -778,7 +779,7 @@ class CACertRequestImportCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -895,7 +896,7 @@ class CACRLShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1020,7 +1021,7 @@ class CACRLIPFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1102,7 +1103,7 @@ class CACRLIPShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1181,7 +1182,7 @@ class CACRLIPModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1267,7 +1268,7 @@ class CAClonePrepareCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1414,7 +1415,7 @@ class CAProfileFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1483,7 +1484,7 @@ class CAProfileImportCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1578,7 +1579,7 @@ class CAProfileModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -19,6 +19,7 @@
 # All rights reserved.
 #
 
+import argparse
 from contextlib import contextmanager
 import datetime
 import getpass
@@ -104,7 +105,7 @@ class CertFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -195,7 +196,7 @@ class CertShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -310,7 +311,7 @@ class CertValidateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -380,7 +381,7 @@ class CertUpdateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -522,7 +523,7 @@ class CertRequestCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -630,7 +631,7 @@ class CertCreateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -787,7 +788,7 @@ class CertImportCLI(pki.cli.CLI):
         super().__init__('import', inspect.cleandoc(self.__class__.__doc__))
 
     def create_parser(self, subparsers=None):
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -859,7 +860,7 @@ class CertExportCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1098,7 +1099,7 @@ class CertRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1179,7 +1180,7 @@ class CertFixCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/config.py
+++ b/base/server/python/pki/server/cli/config.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import logging
 import sys
 
@@ -47,7 +48,7 @@ class SubsystemConfigFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -120,7 +121,7 @@ class SubsystemConfigShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -200,7 +201,7 @@ class SubsystemConfigSetCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -276,7 +277,7 @@ class SubsystemConfigUnsetCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/db.py
+++ b/base/server/python/pki/server/cli/db.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import getpass
 import inspect
 import logging
@@ -48,7 +49,7 @@ class DBSchemaUpgradeCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -137,7 +138,7 @@ class DBUpgradeCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -298,7 +299,7 @@ class SubsystemDBConfigShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -371,7 +372,7 @@ class SubsystemDBConfigModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -548,7 +549,7 @@ class SubsystemDBInfoCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -641,7 +642,7 @@ class SubsystemDBCreateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -726,7 +727,7 @@ class SubsystemDBInitCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -813,7 +814,7 @@ class SubsystemDBEmptyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -896,7 +897,7 @@ class SubsystemDBRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -981,7 +982,7 @@ class SubsystemDBUpgradeCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1092,7 +1093,7 @@ class SubsystemDBAccessGrantCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1181,7 +1182,7 @@ class SubsystemDBAccessRevokeCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1285,7 +1286,7 @@ class SubsystemDBIndexAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1367,7 +1368,7 @@ class SubsystemDBIndexRebuildCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1472,7 +1473,7 @@ class SubsystemDBReplicationEnableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1620,7 +1621,7 @@ class SubsystemDBReplicationAgreementAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1746,7 +1747,7 @@ class SubsystemDBReplicationAgreementInitCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1856,7 +1857,7 @@ class SubsystemDBVLVFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1935,7 +1936,7 @@ class SubsystemDBVLVAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -2014,7 +2015,7 @@ class SubsystemDBVLVDeleteCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -2093,7 +2094,7 @@ class SubsystemDBVLVReindexCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/est.py
+++ b/base/server/python/pki/server/cli/est.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 
+import argparse
 import logging
 import os
 
@@ -34,7 +35,7 @@ class ESTCreateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -106,7 +107,7 @@ class ESTRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/group.py
+++ b/base/server/python/pki/server/cli/group.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
+
+import argparse
 import logging
 import sys
 
@@ -33,7 +35,7 @@ class GroupFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -121,7 +123,7 @@ class GroupMemberFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -207,7 +209,7 @@ class GroupMemberAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -286,7 +288,7 @@ class GroupMemberRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import inspect
 import logging
 import sys
@@ -103,7 +104,7 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -221,7 +222,7 @@ class HTTPConnectorDeleteCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -287,7 +288,7 @@ class HTTPConnectorFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -362,7 +363,7 @@ class HTTPConnectorShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -432,7 +433,7 @@ class HTTPConnectorModCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -622,7 +623,7 @@ class SSLHostAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -716,7 +717,7 @@ class SSLHostDeleteCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -790,7 +791,7 @@ class SSLHostFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -887,7 +888,7 @@ class SSLHostModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -984,7 +985,7 @@ class SSLHostShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1085,7 +1086,7 @@ class SSLCertAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1212,7 +1213,7 @@ class SSLCertDeleteCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1303,7 +1304,7 @@ class SSLCertFindLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/id.py
+++ b/base/server/python/pki/server/cli/id.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
+import argparse
 import logging
 import sys
 
@@ -43,7 +44,7 @@ class IdGeneratorShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -116,7 +117,7 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/instance.py
+++ b/base/server/python/pki/server/cli/instance.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import getpass
 import logging
 import os
@@ -69,7 +70,7 @@ class InstanceCertExportCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -187,7 +188,7 @@ class InstanceFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -256,7 +257,7 @@ class InstanceShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -314,7 +315,7 @@ class InstanceStartCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -377,7 +378,7 @@ class InstanceStopCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -440,7 +441,7 @@ class InstanceMigrateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument('--tomcat')
@@ -513,7 +514,7 @@ class InstanceNuxwdogEnableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -576,7 +577,7 @@ class InstanceNuxwdogDisableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -639,7 +640,7 @@ class InstanceExternalCertAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -760,7 +761,7 @@ class InstanceExternalCertDeleteCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/jss.py
+++ b/base/server/python/pki/server/cli/jss.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import logging
 import sys
 
@@ -40,7 +41,7 @@ class JSSEnableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -109,7 +110,7 @@ class JSSDisableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/kra.py
+++ b/base/server/python/pki/server/cli/kra.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import io
 import logging
 import os
@@ -70,7 +71,7 @@ class KRAClonePrepareCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/listener.py
+++ b/base/server/python/pki/server/cli/listener.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import logging
 
 import pki.cli
@@ -46,7 +47,7 @@ class ListenerFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/migrate.py
+++ b/base/server/python/pki/server/cli/migrate.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import logging
 import sys
 
@@ -36,7 +37,7 @@ class MigrateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/nss.py
+++ b/base/server/python/pki/server/cli/nss.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import getpass
 import logging
 
@@ -40,7 +41,7 @@ class NSSCreateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -133,7 +134,7 @@ class NSSRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/nuxwdog.py
+++ b/base/server/python/pki/server/cli/nuxwdog.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import fileinput
 import logging
 from lxml import etree
@@ -52,7 +53,7 @@ class NuxwdogEnableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -229,7 +230,7 @@ class NuxwdogDisableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/ocsp.py
+++ b/base/server/python/pki/server/cli/ocsp.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import io
 import logging
 import os
@@ -69,7 +70,7 @@ class OCSPClonePrepareCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -200,7 +201,7 @@ class OCSPCRLIssuingPointFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -270,7 +271,7 @@ class OCSPCRLIssuingPointAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/password.py
+++ b/base/server/python/pki/server/cli/password.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import getpass
 import logging
 
@@ -49,7 +50,7 @@ class PasswordFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -119,7 +120,7 @@ class PasswordAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -193,7 +194,7 @@ class PasswordRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -261,7 +262,7 @@ class PasswordSetCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -341,7 +342,7 @@ class PasswordUnsetCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/range.py
+++ b/base/server/python/pki/server/cli/range.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
+import argparse
 import logging
 import sys
 
@@ -34,7 +35,7 @@ class RangeShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -115,7 +116,7 @@ class RangeRequestCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -204,7 +205,7 @@ class RangeUpdateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/sd.py
+++ b/base/server/python/pki/server/cli/sd.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
+import argparse
 import logging
 import sys
 
@@ -29,7 +30,7 @@ class SDCreateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -108,7 +109,7 @@ class SDSubsystemFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -174,7 +175,7 @@ class SDSubsystemAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -283,7 +284,7 @@ class SDSubsystemRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/selftest.py
+++ b/base/server/python/pki/server/cli/selftest.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import sys
 import logging
 
@@ -38,7 +39,7 @@ class EnableSelfTestCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -127,7 +128,7 @@ class DisableSelftestCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -20,6 +20,7 @@
 # All rights reserved.
 #
 
+import argparse
 import getpass
 import inspect
 import logging
@@ -61,7 +62,7 @@ class SubsystemFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -132,7 +133,7 @@ class SubsystemShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -219,7 +220,7 @@ class SubsystemCreateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -286,7 +287,7 @@ class SubsystemDeployCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -382,7 +383,7 @@ class SubsystemUndeployCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -490,7 +491,7 @@ class SubsystemRedeployCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -583,7 +584,7 @@ class SubsystemEnableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -691,7 +692,7 @@ class SubsystemDisableCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -818,7 +819,7 @@ class SubsystemCertFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -913,7 +914,7 @@ class SubsystemCertShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -996,7 +997,7 @@ class SubsystemCertExportCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1172,7 +1173,7 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1320,7 +1321,7 @@ class SubsystemCertValidateCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/tks.py
+++ b/base/server/python/pki/server/cli/tks.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import io
 import logging
 import os
@@ -68,7 +69,7 @@ class TKSClonePrepareCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/tps.py
+++ b/base/server/python/pki/server/cli/tps.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import io
 import logging
 import os
@@ -68,7 +69,7 @@ class TPSClonePrepareCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/upgrade.py
+++ b/base/server/python/pki/server/cli/upgrade.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import logging
 
 import pki.cli
@@ -34,7 +35,7 @@ class UpgradeCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
+import argparse
 import inspect
 import logging
 import sys
@@ -66,7 +67,7 @@ class UserAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -183,7 +184,7 @@ class UserFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -287,7 +288,7 @@ class UserModifyCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -392,7 +393,7 @@ class UserRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -460,7 +461,7 @@ class UserShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -566,7 +567,7 @@ class UserCertFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -640,7 +641,7 @@ class UserCertAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -746,7 +747,7 @@ class UserCertRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -843,7 +844,7 @@ class UserRoleFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -928,7 +929,7 @@ class UserRoleAddCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -1014,7 +1015,7 @@ class UserRoleRemoveCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/cli/webapp.py
+++ b/base/server/python/pki/server/cli/webapp.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 #
 
+import argparse
 import inspect
 import logging
 import sys
@@ -59,7 +60,7 @@ class WebappFindCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -139,7 +140,7 @@ class WebappShowCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -201,7 +202,7 @@ class WebappDeployCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(
@@ -290,7 +291,7 @@ class WebappUndeployCLI(pki.cli.CLI):
 
     def create_parser(self, subparsers=None):
 
-        self.parser = subparsers.add_parser(
+        self.parser = argparse.ArgumentParser(
             self.get_full_name(),
             add_help=False)
         self.parser.add_argument(

--- a/base/server/python/pki/server/pkiserver.py
+++ b/base/server/python/pki/server/pkiserver.py
@@ -57,6 +57,9 @@ if __name__ == '__main__':
 
         sys.exit(e.returncode)
 
+    except pki.cli.CLIException as e:
+        logger.error(str(e))
+
     except Exception as e:  # pylint: disable=broad-except
 
         logger.exception(e)


### PR DESCRIPTION
Previously if a user called `pki-server` CLI with a wrong sub-command the `ArgumentParser` would show an auto-generated error message which looks significantly different from help message already defined in `print_help()`.
    
To fix the issue the `PKIServerCLI.create_parser()` and `execute()` have been modified to use `remainder` instead of subparsers, and the `create_parser()` in the sub-commands has been modified to create a regular `ArgumentParser` instead of a subparser.
    
Similar changes were made to the `CLI` base class to fix the help messages for sub-commands (e.g. `pki-server ca`).

The `pki-server` has also been modified to provide a `--version` option to show the version number of the tool.

A new `CLIException` has been added to distinguish a normal CLI error (which will generate a simple error message such as `Invalid module`) from an unexpected exception which will generate a full stack trace.

Some tests have been added to check the help and error messages generated by `pki` and `pki-server` CLIs.

Resolves: https://github.com/dogtagpki/pki/issues/4932
