### PR TITLE
Update pkispawn to verify admin cert

### DIFF
--- a/.github/workflows/ca-existing-certs-test.yml
+++ b/.github/workflows/ca-existing-certs-test.yml
@@ -189,28 +189,6 @@ jobs:
               nss-key-find \
               --nickname sslserver | tee sslserver.key.before
 
-      - name: Create admin cert
-        run: |
-          docker exec pki pki \
-              nss-cert-request \
-              --subject "CN=Administrator" \
-              --ext /usr/share/pki/server/certs/admin.conf \
-              --csr admin.csr
-          docker exec pki pki \
-              nss-cert-issue \
-              --issuer ca_signing \
-              --csr admin.csr \
-              --ext /usr/share/pki/server/certs/admin.conf \
-              --cert admin.crt
-
-          docker exec pki pki nss-cert-import \
-              --cert admin.crt \
-              caadmin
-
-          docker exec pki pki \
-              nss-cert-show \
-              caadmin
-
       - name: Export system certs
         run: |
           docker exec pki pki \
@@ -227,8 +205,44 @@ jobs:
               --pkcs12 ca-certs.p12 \
               --password Secret.123
 
-      - name: Install CA with existing certs
+      - name: Create self-signed admin cert
         run: |
+          # create cert request
+          docker exec pki pki \
+              nss-cert-request \
+              --subject "CN=Administrator" \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --csr admin.csr
+
+          # create self-signed cert
+          docker exec pki pki \
+              nss-cert-issue \
+              --csr admin.csr \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --cert admin.crt
+
+          # import cert
+          docker exec pki pki \
+              nss-cert-import \
+              --cert admin.crt \
+              caadmin
+
+          # check cert
+          docker exec pki pki nss-cert-show caadmin
+
+          # cert should be invalid
+          docker exec pki pki nss-cert-verify caadmin \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ERROR: Invalid certificate: Unable to validate certificate signature: CN=Administrator
+          EOF
+
+          diff expected stderr
+
+      - name: Install CA with existing system certs and self-signed admin cert
+        run: |
+          # run step 1
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
@@ -236,7 +250,67 @@ jobs:
               -D pki_external=True \
               -D pki_external_step_two=False \
               -v
-          sleep 1  # avoid pkispawn log conflict due to identical timestamps
+
+          # run step 2
+          rc=0
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_external=True \
+              -D pki_external_step_two=True \
+              -D pki_pkcs12_path=ca-certs.p12 \
+              -D pki_pkcs12_password=Secret.123 \
+              -D pki_ca_signing_csr_path=ca_signing.csr \
+              -D pki_ocsp_signing_csr_path=ca_ocsp_signing.csr \
+              -D pki_audit_signing_csr_path=ca_audit_signing.csr \
+              -D pki_subsystem_csr_path=subsystem.csr \
+              -D pki_sslserver_csr_path=sslserver.csr \
+              -D pki_admin_cert_path=admin.crt \
+              -D pki_admin_csr_path=admin.csr \
+              -v \
+              || rc=$?
+
+          # pkispawn should fail
+          [ $rc -ne 0 ]
+
+      - name: Create CA-signed admin cert
+        run: |
+          # remove old cert
+          docker exec pki pki nss-cert-del caadmin
+
+          # create CA-signed cert
+          docker exec pki pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr admin.csr \
+              --ext /usr/share/pki/server/certs/admin.conf \
+              --cert admin.crt
+
+          # import new cert
+          docker exec pki pki \
+              nss-cert-import \
+              --cert admin.crt \
+              caadmin
+
+          # check new cert
+          docker exec pki pki nss-cert-show caadmin
+
+          # cert should be valid
+          docker exec pki pki nss-cert-verify caadmin
+
+      - name: Install CA with existing system certs and CA-signed admin cert
+        run: |
+          # run step 1
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_external=True \
+              -D pki_external_step_two=False \
+              -v
+
+          # run step 2
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
@@ -253,6 +327,8 @@ jobs:
               -D pki_admin_cert_path=admin.crt \
               -D pki_admin_csr_path=admin.csr \
               -v
+
+          # pkispawn should succeed
 
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -569,7 +569,7 @@ class HTTPConnectorModCLI(pki.cli.CLI):
             HTTPConnectorCLI.set_param(connector, 'keyAlias', 'sslserver')
 
             HTTPConnectorCLI.set_param(connector, 'trustManagerClassName',
-                                       'org.dogtagpki.tomcat.PKITrustManager')
+                                       'org.dogtagpki.cert.PKITrustManager')
 
             HTTPConnectorCLI.set_param(connector, 'certdbDir', nss_database_dir)
             HTTPConnectorCLI.set_param(connector, 'passwordClass',

--- a/base/server/python/pki/server/instance.py
+++ b/base/server/python/pki/server/instance.py
@@ -970,6 +970,16 @@ class PKIInstance(pki.server.PKIServer):
             nssdb.close()
             shutil.rmtree(tmpdir)
 
+    def verify_cert(self, cert_data):
+
+        nssdb = self.open_nssdb()
+
+        try:
+            nssdb.verify_cert(cert_data=cert_data)
+
+        finally:
+            nssdb.close()
+
     def configure_ajp_connectors_secret(self):
 
         logger.info('Configuring AJP connectors secret')

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertCLI.java
@@ -23,6 +23,7 @@ public class NSSCertCLI extends CLI {
         addModule(new NSSCertRequestCLI(this));
         addModule(new NSSCertShowCLI(this));
         addModule(new NSSCertRemoveCLI(this));
+        addModule(new NSSCertVerifyCLI(this));
     }
 
     public static NSSCertInfo createCertInfo(X509Certificate cert) throws Exception {

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertVerifyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertVerifyCLI.java
@@ -1,0 +1,104 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.cert.X509Certificate;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.io.IOUtils;
+import org.dogtagpki.cert.PKITrustManager;
+import org.dogtagpki.cli.CLIException;
+import org.dogtagpki.cli.CommandCLI;
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.netscape.security.util.Cert;
+import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+
+import com.netscape.cmstools.cli.MainCLI;
+
+public class NSSCertVerifyCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSCertVerifyCLI.class);
+
+    public NSSCertVerifyCLI(NSSCertCLI nssCertCLI) {
+        super("verify", "Verify certificate", nssCertCLI);
+    }
+
+    @Override
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] [nickname]", options);
+    }
+
+    @Override
+    public void createOptions() {
+        Option option = new Option(null, "cert", true, "Certificate to verify");
+        option.setArgName("path");
+        options.addOption(option);
+
+        option = new Option(null, "format", true, "Certificate format: PEM (default), DER");
+        option.setArgName("format");
+        options.addOption(option);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String certFile = cmd.getOptionValue("cert");
+        String certFormat = cmd.getOptionValue("format", "PEM");
+
+        String[] cmdArgs = cmd.getArgs();
+        String nickname = null;
+
+        if (cmdArgs.length >= 1) {
+            nickname = cmdArgs[0];
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        X509Certificate cert;
+
+        if (nickname != null) {
+            // get cert from NSS database
+            CryptoManager cm = CryptoManager.getInstance();
+            cert = cm.findCertByNickname(nickname);
+
+        } else {
+            byte[] bytes;
+            if (certFile != null) {
+                // get cert from file
+                bytes = Files.readAllBytes(Paths.get(certFile));
+
+            } else {
+                // get cert from standard input
+                bytes = IOUtils.toByteArray(System.in);
+            }
+
+            if ("PEM".equalsIgnoreCase(certFormat)) {
+                bytes = Cert.parseCertificate(new String(bytes));
+
+            } else if ("DER".equalsIgnoreCase(certFormat)) {
+                // nothing to do
+
+            } else {
+                throw new CLIException("Unsupported certificate format: " + certFormat);
+            }
+
+            cert = new X509CertImpl(bytes);
+        }
+
+        PKITrustManager tm = new PKITrustManager();
+
+        try {
+            tm.checkCert(cert);
+
+        } catch (Exception e) {
+            throw new CLIException("Invalid certificate: " + e.getMessage());
+        }
+    }
+}

--- a/docs/changes/v11.6.0/API-Changes.adoc
+++ b/docs/changes/v11.6.0/API-Changes.adoc
@@ -3,3 +3,7 @@
 == NSSDatabase.get_cert_info() changes ==
 
 The `NSSDatabase.get_cert_info()` has been modified to return `not_before` and `not_after` attributes in UTC timezone.
+
+== Relocate PKITrustManager ==
+
+The `org.dogtagpki.tomcat.PKITrustManager` has been moved into `org.dogtagpki.cert.PKITrustManager`.

--- a/docs/changes/v11.6.0/Packaging-Changes.adoc
+++ b/docs/changes/v11.6.0/Packaging-Changes.adoc
@@ -4,3 +4,8 @@
 
 The IDM Console Framework has been merged into PKI Console.
 Dependencies on IDM Console Framework have been removed.
+
+== Relocate PKITrustManager ==
+
+The `org.dogtagpki.tomcat.PKITrustManager` in `pki-tomcat.jar` has been moved into
+`org.dogtagpki.cert.PKITrustManager` in `pki-common.jar`.


### PR DESCRIPTION
The `pki nss-cert-verify` has been added to verify that a cert is issued by a trusted CA. The cert can be provided in an NSS database, in a file, or via standard input.

The `PKITrustManager` class has been moved into `pki-common.jar` such that it can be used by the CLI. This class is not yet officially supported so it's not necessary to provide an upgrade script.

The `NSSDatabase.verify_cert()` has been added to verify a cert using `pki nss-cert-verify`.

The `PKIDeployer.import_system_certs()` and `setup_admin_cert()` have been modified to verify the admin cert provided during installation.

The test for installing CA with existing certs has been updated to install the CA with a self-signed admin cert (which should fail), then install it again with a CA-signed cert (which should work).

https://github.com/edewata/pki/blob/install/docs/changes/v11.6.0/API-Changes.adoc
https://github.com/edewata/pki/blob/install/docs/changes/v11.6.0/Packaging-Changes.adoc
