### PR TITLE
Add test for installing CA with obsolete admin cert

### DIFF
--- a/.github/workflows/ca-existing-config-test.yml
+++ b/.github/workflows/ca-existing-config-test.yml
@@ -100,9 +100,9 @@ jobs:
 
           docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/localhost/ca_admin_cert.p12 \
-              --pkcs12-password Secret.123
+              --password Secret.123
 
-          docker exec pki pki nss-cert-find | tee admin-cert.orig
+          docker exec pki pki nss-cert-show caadmin | tee admin-cert.orig
 
           docker exec pki pki -n caadmin ca-user-show caadmin
 
@@ -211,7 +211,18 @@ jobs:
 
           diff expected output
 
-      - name: Install CA again
+      - name: Check admin cert after first removal
+        run: |
+          docker exec pki ls -l /root/.dogtag/localhost
+
+          docker exec pki pki nss-cert-show \
+              --cert-file /root/.dogtag/localhost/ca_admin.cert
+
+          docker exec pki pki pkcs12-cert-find \
+              --pkcs12 /root/.dogtag/localhost/ca_admin_cert.p12 \
+              --password Secret.123
+
+      - name: Install CA with the same config
         run: |
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
@@ -283,7 +294,7 @@ jobs:
 
       - name: Check CA admin again
         run: |
-          docker exec pki pki nss-cert-find | tee admin-cert.new
+          docker exec pki pki nss-cert-show caadmin | tee admin-cert.new
 
           # admin cert should not change
           diff admin-cert.orig admin-cert.new
@@ -361,6 +372,102 @@ jobs:
           EOF
 
           diff expected stderr
+
+      - name: Check admin cert after second removal
+        run: |
+          docker exec pki ls -l /root/.dogtag/localhost
+
+          docker exec pki pki nss-cert-show \
+              --cert-file /root/.dogtag/localhost/ca_admin.cert
+
+          docker exec pki pki pkcs12-cert-find \
+              --pkcs12 /root/.dogtag/localhost/ca_admin_cert.p12 \
+              --password Secret.123
+
+      - name: Install CA with new config and old admin cert
+        run: |
+          rc=0
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_instance_name=localhost \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v \
+              || rc=$?
+
+          # pkispawn should fail
+          [ $rc -ne 0 ]
+
+      - name: Remove old admin cert
+        run: |
+          docker exec pki rm -f /root/.dogtag/localhost/ca_admin.cert
+          docker exec pki rm -f /root/.dogtag/localhost/ca_admin_cert.p12
+
+      - name: Install CA with new config and no admin cert
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_instance_name=localhost \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+          # pkispawn should succeed
+
+      - name: Check system certs again
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/localhost/conf/alias \
+              nss-cert-find | tee system-certs.new
+
+          # system certs should be different
+          rc=0
+          diff system-certs.orig system-certs.new || rc=$?
+
+          [ $rc -ne 0 ]
+
+      - name: Check CA admin
+        run: |
+          # remove old certs
+          docker exec pki pki nss-cert-del caadmin
+          docker exec pki pki nss-cert-del ca_signing
+
+          # export new CA signing cert
+          docker exec pki pki-server \
+              cert-export \
+              -i localhost \
+              --cert-file ca_signing.crt \
+              ca_signing
+
+          # import new CA signing cert
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          # import new admin cert
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/localhost/ca_admin_cert.p12 \
+              --password Secret.123
+
+          docker exec pki pki nss-cert-show caadmin | tee admin-cert.new
+
+          # admin cert should be different
+          rc=0
+          diff admin-cert.orig admin-cert.new || rc=$?
+
+          [ $rc -ne 0 ]
+
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Remove CA again
+        run: |
+          docker exec pki pkidestroy \
+              -i localhost \
+              -s CA \
+              --remove-conf \
+              --remove-logs \
+              -v
 
       - name: Check DS server systemd journal
         if: always()

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2583,7 +2583,8 @@ class PKIDeployer:
                     logger.info('Verifying admin cert in %s', cert_file)
                     self.instance.verify_cert(admin_cert)
                 except Exception:
-                    raise pki.cli.CLIException('Invalid admin certificate in %s' % cert_file)
+                    raise pki.cli.CLIException(
+                        'Invalid/obsolete admin certificate in %s' % cert_file)
 
                 self.import_admin_cert(admin_cert)
 
@@ -4013,7 +4014,7 @@ class PKIDeployer:
                     self.instance.verify_cert(pem_cert)
                 except Exception:
                     raise pki.cli.CLIException(
-                        'Invalid admin certificate in %s' % client_nssdb.directory)
+                        'Invalid/obsolete admin certificate in %s' % client_nssdb.directory)
 
                 if external and subsystem.type != 'CA' or standalone:
                     # no need to re-import admin cert into NSS database
@@ -4048,7 +4049,8 @@ class PKIDeployer:
                     logger.info('Verifying admin cert in %s', pkcs12_file)
                     self.instance.verify_cert(pem_cert)
                 except Exception:
-                    raise pki.cli.CLIException('Invalid admin certificate in %s' % pkcs12_file)
+                    raise pki.cli.CLIException(
+                        'Invalid/obsolete admin certificate in %s' % pkcs12_file)
 
                 logger.info('Importing admin cert into %s', client_nssdb.directory)
 
@@ -4080,7 +4082,8 @@ class PKIDeployer:
                 logger.info('Verifying admin cert in %s', cert_path)
                 self.instance.verify_cert(pem_cert)
             except Exception:
-                raise pki.cli.CLIException('Invalid admin certificate in %s' % cert_path)
+                raise pki.cli.CLIException(
+                    'Invalid/obsolete admin certificate in %s' % cert_path)
 
             if external and subsystem.type != 'CA' or standalone:
                 self.import_admin_cert(pem_cert)
@@ -4104,7 +4107,8 @@ class PKIDeployer:
                 logger.info('Verifying admin cert in %s', cert_file)
                 self.instance.verify_cert(pem_cert)
             except Exception:
-                raise pki.cli.CLIException('Invalid admin certificate in %s' % cert_file)
+                raise pki.cli.CLIException(
+                    'Invalid/obsolete admin certificate in %s' % cert_file)
 
             if external and subsystem.type != 'CA' or standalone:
                 self.import_admin_cert(pem_cert)

--- a/base/server/python/pki/server/pkidestroy.py
+++ b/base/server/python/pki/server/pkidestroy.py
@@ -246,6 +246,12 @@ def main(argv):
         print()
         sys.exit(1)
 
+    except pki.cli.CLIException as e:
+        print()
+        print('Uninstallation failed: %s' % str(e))
+        print()
+        sys.exit(1)
+
     except Exception as e:  # pylint: disable=broad-except
         log_error_details()
         print()

--- a/base/server/python/pki/server/pkispawn.py
+++ b/base/server/python/pki/server/pkispawn.py
@@ -628,6 +628,12 @@ def main(argv):
 
         sys.exit(1)
 
+    except pki.cli.CLIException as e:
+        print()
+        print('Installation failed: %s' % str(e))
+        print()
+        sys.exit(1)
+
     except Exception as e:  # pylint: disable=broad-except
         log_error_details()
         print()


### PR DESCRIPTION
The test for installing CA with existing config has been updated to reinstall the CA with new system certs but with an old admin cert from the previous installation (which should fail). Then the test will remove the admin cert and reinstall the CA again (which should succeed) and a new admin cert should be created.

`pkispawn` was updated to indicate that the installation failure might be caused by an obsolete admin cert.

```
...
INFO: Checking admin cert in /root/.dogtag/localhost/ca_admin_cert.p12
INFO: Exporting admin cert from /root/.dogtag/localhost/ca_admin_cert.p12
INFO: Verifying admin cert in /root/.dogtag/localhost/ca_admin_cert.p12
ERROR: Invalid certificate: Unable to validate certificate signature: CN=PKI Administrator,E=caadmin@example.com,OU=localhost,O=EXAMPLE

Installation failed: Invalid/obsolete admin certificate in /root/.dogtag/localhost/ca_admin_cert.p12
```
