### PR TITLE
Update ACME tests to create DS indexes

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -34,20 +34,18 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up PKI container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
-
-      - name: Connect PKI container to network
-        run: docker network connect example pki --alias pki.example.com
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
 
       - name: Install CA in PKI container
         run: |
@@ -59,7 +57,9 @@ jobs:
 
       - name: Install CA admin cert
         run: |
-          docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt
+          docker exec pki pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
 
           docker exec pki pki nss-cert-import \
               --cert ca_signing.crt \
@@ -69,6 +69,7 @@ jobs:
           docker exec pki pki pkcs12-import \
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
+
           docker exec pki pki -n caadmin ca-user-show caadmin
 
       - name: Check initial CA certs
@@ -80,23 +81,31 @@ jobs:
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
 
-      - name: Set up ACME database in DS container
+      - name: Set up ACME database
         run: |
-          docker exec ds ldapmodify \
+          docker exec pki ldapmodify \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -f $SHARED/base/acme/database/ds/schema.ldif
-          docker exec ds ldapadd \
+              -f /usr/share/pki/acme/database/ds/schema.ldif
+          docker exec pki ldapadd \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -f $SHARED/base/acme/database/ds/create.ldif
-          docker exec ds ldapadd \
+              -f /usr/share/pki/acme/database/ds/index.ldif
+          docker exec pki ldapadd \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -f $SHARED/base/acme/realm/ds/create.ldif
+              -f /usr/share/pki/acme/database/ds/create.ldif
+
+      - name: Set up ACME realm
+        run: |
+          docker exec pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/realm/ds/create.ldif
 
       - name: Install ACME in PKI container
         run: |
@@ -341,12 +350,11 @@ jobs:
 
       - name: Set up client container
         run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client.example.com
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              --network-alias=client.example.com \
+              client
 
       - name: Install certbot in client container
         run: docker exec client dnf install -y certbot
@@ -793,28 +801,3 @@ jobs:
         if: always()
         run: |
           docker exec client cat /var/log/letsencrypt/letsencrypt.log
-
-      - name: Gather artifacts from server containers
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Gather artifacts from client container
-        if: always()
-        run: |
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
-          mkdir -p /tmp/artifacts/client/etc/letsencrypt
-          docker cp client:/etc/letsencrypt/live /tmp/artifacts/client/etc/letsencrypt
-          mkdir -p /tmp/artifacts/client/var/log/letsencrypt
-          docker cp client:/var/log/letsencrypt/letsencrypt.log /tmp/artifacts/client/var/log/letsencrypt
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acme-basic
-          path: /tmp/artifacts

--- a/.github/workflows/acme-container-test.yml
+++ b/.github/workflows/acme-container-test.yml
@@ -42,6 +42,7 @@ jobs:
           tests/bin/runner-init.sh \
               --hostname=client.example.com \
               --network=example \
+              --network-alias=client.example.com \
               client
 
       - name: Install dependencies in client container
@@ -269,33 +270,3 @@ jobs:
         if: always()
         run: |
           docker logs client 2>&1
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          mkdir -p /tmp/artifacts/acme
-          cp -r certs /tmp/artifacts/acme
-          cp -r metadata /tmp/artifacts/acme
-          cp -r database /tmp/artifacts/acme
-          cp -r issuer /tmp/artifacts/acme
-          cp -r realm /tmp/artifacts/acme
-          cp -r conf /tmp/artifacts/acme
-          cp -r logs /tmp/artifacts/acme
-
-          docker logs acme > /tmp/artifacts/acme/container.out 2> /tmp/artifacts/acme/container.err
-
-          docker exec client ls -la /etc/letsencrypt/live
-          mkdir -p /tmp/artifacts/client/etc/letsencrypt
-          docker cp client:/etc/letsencrypt/live /tmp/artifacts/client/etc/letsencrypt
-
-          docker exec client ls -la /var/log/letsencrypt
-          mkdir -p /tmp/artifacts/client/var/log/letsencrypt
-          docker cp client:/var/log/letsencrypt/letsencrypt.log /tmp/artifacts/client/var/log/letsencrypt
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acme-container
-          path: /tmp/artifacts

--- a/.github/workflows/acme-existing-nssdb-test.yml
+++ b/.github/workflows/acme-existing-nssdb-test.yml
@@ -154,7 +154,15 @@ jobs:
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
+              -f /usr/share/pki/acme/database/ds/index.ldif
+          docker exec acme ldapadd \
+              -H ldap://acmeds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/create.ldif
+
+      - name: Set up ACME realm
+        run: |
           docker exec acme ldapadd \
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \

--- a/.github/workflows/acme-postgresql-test.yml
+++ b/.github/workflows/acme-postgresql-test.yml
@@ -33,20 +33,18 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up PKI container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
-
-      - name: Connect PKI container to network
-        run: docker network connect example pki --alias pki.example.com
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
 
       - name: Install CA in PKI container
         run: |
@@ -127,16 +125,18 @@ jobs:
 
       - name: Deploy postgresql
         run: |
-          docker run -d --name postgresql \
+          docker run \
+              --name postgresql \
               --hostname postgresql.example.com \
+              --network example \
+              --network-alias postgresql.example.com \
               -e POSTGRES_PASSWORD=mysecretpassword \
               -e POSTGRES_USER=acme \
-              postgres-ssl -c ssl=on \
+              --detach \
+              postgres-ssl \
+              -c ssl=on \
               -c ssl_cert_file=/var/lib/postgresql/server.crt \
               -c ssl_key_file=/var/lib/postgresql/server.key
-
-      - name: Connect DB container to network
-        run: docker network connect example postgresql --alias postgresql.example.com
 
       - name: Set up database drivers
         run: |
@@ -249,12 +249,11 @@ jobs:
 
       - name: Set up client container
         run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client.example.com
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              --network-alias=client.example.com \
+              client
 
       - name: Install certbot in client container
         run: docker exec client dnf install -y certbot
@@ -574,36 +573,3 @@ jobs:
         if: always()
         run: |
           docker exec client cat /var/log/letsencrypt/letsencrypt.log
-
-      - name: Gather artifacts from server containers
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Gather artifacts from client container
-        if: always()
-        run: |
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
-          mkdir -p /tmp/artifacts/client/etc/letsencrypt
-          docker cp client:/etc/letsencrypt/live /tmp/artifacts/client/etc/letsencrypt
-          mkdir -p /tmp/artifacts/client/var/log/letsencrypt
-          docker cp client:/var/log/letsencrypt/letsencrypt.log /tmp/artifacts/client/var/log/letsencrypt
-        continue-on-error: true
-
-      - name: Upload artifacts from server containers
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acme-postgresql-server
-          path: |
-            /tmp/artifacts/pki
-
-      - name: Upload artifacts from client container
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acme-postgresql-client
-          path: /tmp/artifacts/client

--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -110,7 +110,15 @@ jobs:
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
+              -f /usr/share/pki/acme/database/ds/index.ldif
+          docker exec acme ldapadd \
+              -H ldap://acmeds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/create.ldif
+
+      - name: Set up ACME realm
+        run: |
           docker exec acme ldapadd \
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \
@@ -843,30 +851,3 @@ jobs:
         if: always()
         run: |
           docker exec client cat /var/log/letsencrypt/letsencrypt.log
-
-      - name: Gather artifacts from server containers
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh cads
-          tests/bin/pki-artifacts-save.sh ca
-          tests/bin/ds-artifacts-save.sh acmeds
-          tests/bin/pki-artifacts-save.sh acme
-        continue-on-error: true
-
-      - name: Gather artifacts from client container
-        if: always()
-        run: |
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
-          mkdir -p /tmp/artifacts/client/etc/letsencrypt
-          docker cp client:/etc/letsencrypt/live /tmp/artifacts/client/etc/letsencrypt
-          mkdir -p /tmp/artifacts/client/var/log/letsencrypt
-          docker cp client:/var/log/letsencrypt/letsencrypt.log /tmp/artifacts/client/var/log/letsencrypt
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acme-separate
-          path: /tmp/artifacts

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -34,20 +34,19 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up PKI container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
-
-      - name: Connect PKI container to network
-        run: docker network connect example pki --alias pki.example.com --alias server1.example.com
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              --network-alias=server1.example.com \
+              pki
 
       - name: Install CA in PKI container
         run: |
@@ -57,23 +56,31 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
-      - name: Set up ACME database in DS container
+      - name: Set up ACME database
         run: |
-          docker exec ds ldapmodify \
+          docker exec pki ldapmodify \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -f $SHARED/base/acme/database/ds/schema.ldif
-          docker exec ds ldapadd \
+              -f /usr/share/pki/acme/database/ds/schema.ldif
+          docker exec pki ldapadd \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -f $SHARED/base/acme/database/ds/create.ldif
-          docker exec ds ldapadd \
+              -f /usr/share/pki/acme/database/ds/index.ldif
+          docker exec pki ldapadd \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
-              -f $SHARED/base/acme/realm/ds/create.ldif
+              -f /usr/share/pki/acme/database/ds/create.ldif
+
+      - name: Set up ACME realm
+        run: |
+          docker exec pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/realm/ds/create.ldif
 
       - name: Install ACME in PKI container
         run: |
@@ -95,12 +102,12 @@ jobs:
 
       - name: Set up client container
         run: |
-          tests/bin/runner-init.sh client
-        env:
-          HOSTNAME: client.example.com
-
-      - name: Connect client container to network
-        run: docker network connect example client --alias client1.example.com --alias client2.example.com
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              --network-alias=client1.example.com \
+              --network-alias=client2.example.com \
+              client
 
       - name: Install dependencies in client container
         run: docker exec client dnf install -y certbot jq
@@ -205,36 +212,3 @@ jobs:
         if: always()
         run: |
           docker exec client cat /var/log/letsencrypt/letsencrypt.log
-
-      - name: Gather artifacts from server containers
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh --output=/tmp/artifacts/pki ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Gather artifacts from client container
-        if: always()
-        run: |
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
-          mkdir -p /tmp/artifacts/client/etc/letsencrypt
-          docker cp client:/etc/letsencrypt/live /tmp/artifacts/client/etc/letsencrypt
-          mkdir -p /tmp/artifacts/client/var/log/letsencrypt
-          docker cp client:/var/log/letsencrypt/letsencrypt.log /tmp/artifacts/client/var/log/letsencrypt
-        continue-on-error: true
-
-      - name: Upload artifacts from server containers
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acme-switchover-server
-          path: |
-            /tmp/artifacts/pki
-
-      - name: Upload artifacts from client container
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: acme-switchover-client
-          path: /tmp/artifacts/client

--- a/tests/bin/runner-init.sh
+++ b/tests/bin/runner-init.sh
@@ -47,7 +47,7 @@ while getopts v-: arg ; do
             NETWORK="$LONG_OPTARG"
             ;;
         network-alias=?*)
-            ALIAS="$LONG_OPTARG"
+            ALIASES+=("$LONG_OPTARG")
             ;;
         verbose)
             VERBOSE=true
@@ -100,7 +100,7 @@ if [ "$DEBUG" = true ] ; then
     echo "IMAGE: $IMAGE"
     echo "HOSTNAME: $HOSTNAME"
     echo "NETWORK: $NETWORK"
-    echo "ALIAS: $ALIAS"
+    echo "ALIASES: ${$ALIASES[@]}"
 fi
 
 OPTIONS=()
@@ -132,10 +132,10 @@ then
     OPTIONS+=(--network $NETWORK)
 fi
 
-if [ "$ALIAS" != "" ]
-then
+for ALIAS in "${ALIASES[@]}"
+do
     OPTIONS+=(--network-alias $ALIAS)
-fi
+done
 
 docker run "${OPTIONS[@]}" $IMAGE "/usr/sbin/init"
 


### PR DESCRIPTION
The ACME tests have been updated to create DS indexes as described in the docs.

The tests have also been updated to no longer upload test artifacts to save space and reduce execution time.

The `runner-init.sh` has been updated to support multiple network aliases.

https://github.com/dogtagpki/pki/wiki/Installing-ACME-Responder-using-pkispawn
https://github.com/dogtagpki/pki/wiki/Installing-ACME-Responder-using-PKI-Server-ACME-CLI