### PR TITLE
Replace deprecated params in examples

### DIFF
--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -84,11 +84,14 @@ pki_client_dir=%(home_dir)s/.dogtag/%(pki_instance_name)s
 pki_client_pkcs12_password=
 pki_ds_bind_dn=cn=Directory Manager
 pki_ds_create_new_db=True
+
+# DEPRECATED: Use 'pki_ds_url' instead.
 pki_ds_ldap_port=389
 pki_ds_ldaps_port=636
+pki_ds_secure_connection=False
+
 pki_ds_password=
 pki_ds_remove_data=True
-pki_ds_secure_connection=False
 pki_ds_secure_connection_ca_nickname=Directory Server CA certificate
 pki_ds_secure_connection_ca_pem_file=
 pki_group=pkiuser
@@ -338,6 +341,8 @@ pki_audit_signing_subject_dn=cn=CA Audit Signing Certificate,ou=%(pki_instance_n
 pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-CA
 pki_ds_database=%(pki_instance_name)s-CA
+
+# DEPRECATED: Use 'pki_ds_url' instead.
 pki_ds_hostname=%(pki_hostname)s
 
 pki_subsystem_name=CA %(pki_hostname)s %(pki_https_port)s
@@ -463,6 +468,8 @@ pki_audit_signing_subject_dn=cn=KRA Audit Signing Certificate,ou=%(pki_instance_
 pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-KRA
 pki_ds_database=%(pki_instance_name)s-KRA
+
+# DEPRECATED: Use 'pki_ds_url' instead.
 pki_ds_hostname=%(pki_hostname)s
 
 pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
@@ -555,6 +562,8 @@ pki_audit_signing_subject_dn=cn=OCSP Audit Signing Certificate,ou=%(pki_instance
 pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-OCSP
 pki_ds_database=%(pki_instance_name)s-OCSP
+
+# DEPRECATED: Use 'pki_ds_url' instead.
 pki_ds_hostname=%(pki_hostname)s
 
 pki_subsystem_name=OCSP %(pki_hostname)s %(pki_https_port)s
@@ -584,6 +593,8 @@ pki_audit_signing_subject_dn=cn=TKS Audit Signing Certificate,ou=%(pki_instance_
 pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-TKS
 pki_ds_database=%(pki_instance_name)s-TKS
+
+# DEPRECATED: Use 'pki_ds_url' instead.
 pki_ds_hostname=%(pki_hostname)s
 
 pki_subsystem_name=TKS %(pki_hostname)s %(pki_https_port)s
@@ -612,6 +623,8 @@ pki_audit_signing_subject_dn=cn=TPS Audit Signing Certificate,ou=%(pki_instance_
 pki_ds_setup=True
 pki_ds_base_dn=o=%(pki_instance_name)s-TPS
 pki_ds_database=%(pki_instance_name)s-TPS
+
+# DEPRECATED: Use 'pki_ds_url' instead.
 pki_ds_hostname=%(pki_hostname)s
 
 pki_subsystem_name=TPS %(pki_hostname)s %(pki_https_port)s

--- a/base/server/examples/installation/ca-ecc.cfg
+++ b/base/server/examples/installation/ca-ecc.cfg
@@ -20,11 +20,10 @@ pki_admin_key_algorithm=SHA384withEC
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/base/server/examples/installation/ca-existing-certs-step1.cfg
+++ b/base/server/examples/installation/ca-existing-certs-step1.cfg
@@ -17,11 +17,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/base/server/examples/installation/ca-existing-certs-step2.cfg
+++ b/base/server/examples/installation/ca-existing-certs-step2.cfg
@@ -17,11 +17,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/base/server/examples/installation/ca-external-cert-step1.cfg
+++ b/base/server/examples/installation/ca-external-cert-step1.cfg
@@ -17,11 +17,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/base/server/examples/installation/ca-external-cert-step2.cfg
+++ b/base/server/examples/installation/ca-external-cert-step2.cfg
@@ -19,11 +19,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/base/server/examples/installation/ca-secure-ds-secondary.cfg
+++ b/base/server/examples/installation/ca-secure-ds-secondary.cfg
@@ -26,8 +26,6 @@ pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_hostname=primary.example.com
 pki_security_domain_https_port=8443

--- a/base/server/examples/installation/ca-secure-ds.cfg
+++ b/base/server/examples/installation/ca-secure-ds.cfg
@@ -24,8 +24,6 @@ pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/base/server/examples/installation/ca.cfg
+++ b/base/server/examples/installation/ca.cfg
@@ -18,11 +18,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/base/server/examples/installation/ocsp-clone.cfg
+++ b/base/server/examples/installation/ocsp-clone.cfg
@@ -18,11 +18,10 @@ pki_admin_uid=ocspadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_hostname=primary.example.com
 pki_security_domain_name=EXAMPLE

--- a/base/server/examples/installation/ocsp-external-certs-step1.cfg
+++ b/base/server/examples/installation/ocsp-external-certs-step1.cfg
@@ -21,11 +21,10 @@ pki_admin_uid=ocspadmin
 pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_hostname=ca.example.com
 pki_security_domain_name=EXAMPLE

--- a/base/server/examples/installation/ocsp-external-certs-step2.cfg
+++ b/base/server/examples/installation/ocsp-external-certs-step2.cfg
@@ -20,11 +20,10 @@ pki_admin_uid=ocspadmin
 pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_hostname=ca.example.com
 pki_security_domain_name=EXAMPLE

--- a/base/server/examples/installation/ocsp-standalone-step1.cfg
+++ b/base/server/examples/installation/ocsp-standalone-step1.cfg
@@ -18,11 +18,10 @@ pki_admin_uid=ocspadmin
 pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_ocsp_signing_nickname=ocsp_signing
 pki_subsystem_nickname=subsystem

--- a/base/server/examples/installation/ocsp-standalone-step2.cfg
+++ b/base/server/examples/installation/ocsp-standalone-step2.cfg
@@ -21,11 +21,10 @@ pki_admin_uid=ocspadmin
 pki_client_database_password=Secret.123
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_ocsp_signing_nickname=ocsp_signing
 pki_subsystem_nickname=subsystem

--- a/base/server/examples/installation/ocsp.cfg
+++ b/base/server/examples/installation/ocsp.cfg
@@ -17,11 +17,10 @@ pki_admin_uid=ocspadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/base/server/examples/installation/subca.cfg
+++ b/base/server/examples/installation/subca.cfg
@@ -18,11 +18,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_hostname=root.example.com
 pki_security_domain_user=caadmin

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.adoc
@@ -60,11 +60,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_hostname=pki.example.com
 pki_security_domain_https_port=8443

--- a/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.adoc
+++ b/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.adoc
@@ -28,11 +28,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.adoc
@@ -38,11 +38,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/docs/installation/ca/Installing_CA_with_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_with_HSM.adoc
@@ -35,11 +35,10 @@ pki_admin_uid=caadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ca,dc=pki,dc=example,dc=com
 pki_ds_database=ca
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.adoc
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.adoc
@@ -40,11 +40,10 @@ pki_admin_uid=kraadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com
 pki_ds_database=kra
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_hostname=pki.example.com
 pki_security_domain_https_port=8443

--- a/docs/installation/kra/Installing_KRA_with_Custom_Keys.adoc
+++ b/docs/installation/kra/Installing_KRA_with_Custom_Keys.adoc
@@ -30,11 +30,10 @@ pki_admin_uid=kraadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com
 pki_ds_database=kra
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/kra/Installing_KRA_with_ECC.adoc
+++ b/docs/installation/kra/Installing_KRA_with_ECC.adoc
@@ -42,11 +42,10 @@ pki_admin_uid=kraadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com
 pki_ds_database=kra
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/kra/Installing_KRA_with_HSM.adoc
+++ b/docs/installation/kra/Installing_KRA_with_HSM.adoc
@@ -38,11 +38,10 @@ pki_admin_uid=kraadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=kra,dc=pki,dc=example,dc=com
 pki_ds_database=kra
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.adoc
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.adoc
@@ -26,7 +26,7 @@ pki_admin_uid=kraadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_url=ldaps://localhost:636
+pki_ds_url=ldaps://localhost.localdomain:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.adoc
@@ -41,11 +41,10 @@ pki_admin_uid=ocspadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.adoc
@@ -31,11 +31,10 @@ pki_admin_uid=ocspadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/ocsp/Installing_OCSP_with_ECC.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_ECC.adoc
@@ -43,11 +43,10 @@ pki_admin_uid=ocspadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.adoc
@@ -37,11 +37,10 @@ pki_admin_uid=ocspadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.adoc
@@ -35,15 +35,13 @@ pki_admin_uid=ocspadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_url=ldaps://localhost:636
+pki_ds_url=ldaps://localhost.localdomain:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 
 pki_ds_base_dn=dc=ocsp,dc=pki,dc=example,dc=com
 pki_ds_database=ocsp
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/tks/Installing_TKS_with_HSM.adoc
+++ b/docs/installation/tks/Installing_TKS_with_HSM.adoc
@@ -38,11 +38,10 @@ pki_admin_uid=tksadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com
 pki_ds_database=tks
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.adoc
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.adoc
@@ -33,15 +33,13 @@ pki_admin_uid=tksadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_url=ldaps://localhost:636
+pki_ds_url=ldaps://localhost.localdomain:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 
 pki_ds_base_dn=dc=tks,dc=pki,dc=example,dc=com
 pki_ds_database=tks
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/tps/Installing_TPS_with_HSM.adoc
+++ b/docs/installation/tps/Installing_TPS_with_HSM.adoc
@@ -38,11 +38,10 @@ pki_admin_uid=tpsadmin
 
 pki_client_pkcs12_password=Secret.123
 
+pki_ds_url=ldap://localhost.localdomain:389
 pki_ds_base_dn=dc=tps,dc=pki,dc=example,dc=com
 pki_ds_database=tps
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.adoc
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.adoc
@@ -33,15 +33,13 @@ pki_admin_uid=tpsadmin
 
 pki_client_pkcs12_password=Secret.123
 
-pki_ds_url=ldaps://localhost:636
+pki_ds_url=ldaps://localhost.localdomain:636
 pki_ds_secure_connection_ca_nickname=ds_signing
 pki_ds_secure_connection_ca_pem_file=ds_signing.crt
 
 pki_ds_base_dn=dc=tps,dc=pki,dc=example,dc=com
 pki_ds_database=tps
 pki_ds_password=Secret.123
-pki_ds_ldap_port=389
-pki_ds_ldaps_port=636
 
 pki_security_domain_name=EXAMPLE
 pki_security_domain_user=caadmin


### PR DESCRIPTION
The sample config files have been updated to use `pki_ds_url` instead of `pki_ds_ldap_port` and `pki_ds_ldaps_port` since those params have been deprecated since PKI 11.5 and will generate deprecation warnings if used.

https://github.com/edewata/pki/blob/ci/base/server/etc/default.cfg#L88-L92
https://github.com/dogtagpki/pki/blob/master/docs/changes/v11.5.0/Server-Changes.adoc#add-pki_ds_url-parameter
https://github.com/dogtagpki/pki/blob/master/docs/manuals/man5/pki_default.cfg.5.md#internal-database-parameters
