### PR TITLE
Update spec for compiler flags and systemd user

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,6 +117,11 @@ jobs:
           -e '/^\/usr\/share\/pki\/lib\/resteasy-jackson2-provider-.*\.jar/d' \
           -e '/^\/usr\/share\/pki\/server\/common\/lib\/resteasy-servlet-initializer-.*\.jar/d' \
           file_list
+
+      # exclude user managemant files only available in RPM
+      sed -i \
+          -e '/^\/usr\/lib\/sysusers\.d\/dogtag-pki\.conf/d' \
+          file_list
     displayName: Get list of files from RPM packages
 
   - script: |

--- a/pki.spec
+++ b/pki.spec
@@ -1266,45 +1266,8 @@ popd
 %endif
 
 # Remove all symbol table and relocation information from the executable.
-C_FLAGS="-s"
-CXX_FLAGS="$CXX_FLAGS -g -fPIE -pie"
-
-%if 0%{?fedora} || 0%{?rhel} && 0%{?rhel} >= 10
-# https://sourceware.org/annobin/annobin.html/Test-gaps.html
-C_FLAGS="$C_FLAGS -fplugin=annobin"
-
-%ifarch x86_64
-# https://sourceware.org/annobin/annobin.html/Test-cf-protection.html
-C_FLAGS="$C_FLAGS -fcf-protection=full"
-CXX_FLAGS="$CXX_FLAGS -fcf-protection=full"
-%endif
-
-# https://sourceware.org/annobin/annobin.html/Test-optimization.html
-C_FLAGS="$C_FLAGS -O2"
-CXX_FLAGS="$CXX_FLAGS -O2"
-
-# https://sourceware.org/annobin/annobin.html/Test-glibcxx-assertions.html
-C_FLAGS="$C_FLAGS -D_GLIBCXX_ASSERTIONS"
-CXX_FLAGS="$CXX_FLAGS -D_GLIBCXX_ASSERTIONS"
-
-# https://sourceware.org/annobin/annobin.html/Test-lto.html
-C_FLAGS="$C_FLAGS -flto"
-
-# https://sourceware.org/annobin/annobin.html/Test-fortify.html
-C_FLAGS="$C_FLAGS -D_FORTIFY_SOURCE=3"
-CXX_FLAGS="$CXX_FLAGS -D_FORTIFY_SOURCE=3"
-
-# https://sourceware.org/annobin/annobin.html/Test-stack-clash.html
-C_FLAGS="$C_FLAGS -fstack-clash-protection"
-CXX_FLAGS="$CXX_FLAGS -fstack-clash-protection"
-
-%ifarch aarch64
-# https://sourceware.org/annobin/annobin.html/Test-dynamic-tags.html
-C_FLAGS="$C_FLAGS -mbranch-protection=standard"
-CXX_FLAGS="$CXX_FLAGS -mbranch-protection=standard"
-%endif
-
-%endif
+C_FLAGS="%{optflags}"
+CXX_FLAGS="%{optflags}"
 
 pkgs=base\
 %{?with_server:,server}\


### PR DESCRIPTION
C and C++ flags are now retrieved from 'optflags' macro. In Fedora this is:

CFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer '

Additionally, user creation is moved to systemd.