### PR TITLE
Add support for subsystem logging.properties

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -348,6 +348,18 @@ jobs:
       - name: Verify ACME in PKI container
         run: docker exec pki pki acme-info
 
+      - name: Update ACME configuration
+        run: |
+          # configure RESTEasy logging
+          docker exec -i pki tee /var/lib/pki/pki-tomcat/conf/acme/logging.properties << EOF
+          org.jboss.resteasy.level = INFO
+          EOF
+
+          docker exec pki chown pkiuser:pkiuser /var/lib/pki/pki-tomcat/conf/acme/logging.properties
+
+          # restart PKI server
+          docker exec pki pki-server restart --wait
+
       - name: Set up client container
         run: |
           tests/bin/runner-init.sh \

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -315,6 +315,13 @@ jobs:
           # enable CA signed audit log
           docker exec pki pki-server ca-config-set log.instance.SignedAudit.logSigning true
 
+          # configure RESTEasy logging
+          docker exec -i pki tee /var/lib/pki/pki-tomcat/conf/ca/logging.properties << EOF
+          org.jboss.resteasy.level = INFO
+          EOF
+
+          docker exec pki chown pkiuser:pkiuser /var/lib/pki/pki-tomcat/conf/ca/logging.properties
+
           # restart PKI server
           docker exec pki pki-server restart --wait
 

--- a/base/est/src/main/java/org/dogtagpki/est/ESTEngine.java
+++ b/base/est/src/main/java/org/dogtagpki/est/ESTEngine.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.util.Map;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 import org.apache.catalina.Realm;
 import org.apache.catalina.realm.RealmBase;
@@ -60,6 +61,7 @@ public class ESTEngine {
 
         logger.info("EST configuration directory: " + estConfDir);
 
+        loadLoggingProperties(estConfDir + File.separator + "logging.properties");
         initBackend(estConfDir + File.separator + "backend.conf");
         initRequestAuthorizer(estConfDir + File.separator + "authorizer.conf");
         initRealm(estConfDir + File.separator + "realm.conf");
@@ -85,6 +87,28 @@ public class ESTEngine {
             }
         }
         logger.info("EST engine stopped");
+    }
+
+    public void loadLoggingProperties(String loggingProperties) throws Exception {
+
+        File file = new File(loggingProperties);
+        if (!file.exists()) return;
+
+        logger.info("Loading " + loggingProperties);
+        Properties properties = new Properties();
+        properties.load(new FileReader(file));
+
+        for (String key : properties.stringPropertyNames()) {
+            String value = properties.getProperty(key);
+
+            logger.info("- " + key + ": " + value);
+            if (!key.endsWith(".level")) continue;
+
+            String loggerName = key.substring(0, key.length() - 6);
+            java.util.logging.Level level = java.util.logging.Level.parse(value);
+
+            Logger.getLogger(loggerName).setLevel(level);
+        }
     }
 
     private void initBackend(String filename) throws Throwable {
@@ -136,7 +160,7 @@ public class ESTEngine {
     private void initRealm(String filename) throws Throwable {
         RealmConfig realmConfig = null;
         File realmConfigFile = new File(filename);
-        
+
         if (realmConfigFile.exists()) {
             logger.info("Loading EST realm config from " + realmConfigFile);
             Properties props = new Properties();

--- a/tests/ansible/est/tasks/main.yml
+++ b/tests/ansible/est/tasks/main.yml
@@ -175,6 +175,14 @@
       roles=estclient
     mode: 420      # 0o644
 
+- name: Configure EST logging
+  community.docker.docker_container_copy_into:
+    container: "{{ pki_container }}"
+    container_path: /var/lib/pki/pki-tomcat/conf/est/logging.properties
+    content: |
+      org.jboss.resteasy.level = INFO
+    mode: 420      # 0o644
+
 - name: EST deploy and start
   community.docker.docker_container_exec:
     container: "{{ pki_container }}"
@@ -235,3 +243,10 @@
   failed_when: >
     ('subject=CN = client.example.com' not in enrol_subject_issuer.stdout_lines)  or
     ('issuer=O = EXAMPLE, OU = pki-tomcat, CN = CA Signing Certificate' not in enrol_subject_issuer.stdout_lines)
+
+- name: Check EST debug log
+  community.docker.docker_container_exec:
+    container: "{{ pki_container }}"
+    command: "{{ item }}"
+  loop:
+    - find /var/lib/pki/pki-tomcat/logs/est -name "debug.*" -exec cat {} \;


### PR DESCRIPTION
The `CMSEngine`, `ACMEEngine`, and `ESTEngine` have been modified to support subsystem `logging.properties`. If the file exists, it can be used to configure the logging level in various libraries (e.g. RESTEasy) to help troubleshooting.

The CA, ACME, and EST tests have been modified to create the subsystem `logging.properties` then check the debug log.

https://github.com/dogtagpki/pki/wiki/Configuring-Subsystem-Debug-Log

If RESTEasy logging is enabled, it will show something like this:
```
2025-02-20 17:06:11 [main] INFO: RESTEASY002225: Deploying javax.ws.rs.core.Application: class org.dogtagpki.acme.server.ACMEApplication
2025-02-20 17:06:11 [main] INFO: RESTEASY002200: Adding class resource org.dogtagpki.acme.server.ACMELoginService from Application class org.dogtagpki.acme.server.ACMEApplication
2025-02-20 17:06:11 [main] INFO: RESTEASY002200: Adding class resource org.dogtagpki.acme.server.ACMELogoutService from Application class org.dogtagpki.acme.server.ACMEApplication
2025-02-20 17:06:11 [main] INFO: RESTEASY002200: Adding class resource org.dogtagpki.acme.server.ACMEEnableService from Application class org.dogtagpki.acme.server.ACMEApplication
...
```
