### PR TITLE
Add stale automation for issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          stale-pr-message: 'This PR is stale because it has been open 365 days with no activity. Remove stale label, comment, update or this will be closed in 30 days.'
+          close-issue-message: 'This issue will be closed for inactivity. If the problem is still present reopen this or create a new issue.'
+          close-pr-message: 'This PR will be closed for inactivity. If the code should be merged reopen the PR and ask for review.'
+          days-before-issue-stale: 365
+          days-before-pr-stale: 365
+          days-before-issue-close: 30
+          days-before-pr-close: 30
+          enable-statistics: true
+          debug-only: true
+          


### PR DESCRIPTION
Since there are many old issues/PRs we could close them with `Stale` label.

I have added this automation which should mark stale after 365 days and close after toehr 30 days.
For the moment it does dry-run but logs all the action it should perform so we can verify if it work properly and tune the parameter before going live.


See https://github.com/actions/stale