### PR TITLE
adding missing note to assume export of CA signing cert to ca_signing…

### DIFF
--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.adoc
@@ -31,6 +31,8 @@ $ pki-server cert-export subsystem \
 
 == CA Subsystem Installation 
 
+Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt`
+
 Prepare a file (e.g. ca.cfg) that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.adoc
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.adoc
@@ -11,6 +11,8 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == KRA Subsystem Installation 
 
+Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt`
+
 Prepare a file (e.g. kra.cfg) that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.adoc
@@ -12,6 +12,8 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == OCSP Subsystem Installation 
 
+Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt
+
 Prepare a file (e.g. ocsp.cfg) that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]


### PR DESCRIPTION
….crt prior to cloning kra and ocsp with HSM [skip ci]

This is related to https://issues.redhat.com/browse/RHCS-3679
Need to mention what ca_singning.crt is and that it's assumed to have been created prior to pkispawn cfg.
I'm only addressing the cloning with HSM docs ca, ocsp, and kra.