### PR TITLE
replace "e.g." with "for example" under pki/docs/installation [skip ci]

### DIFF
--- a/docs/installation/ca/Installing_CA.adoc
+++ b/docs/installation/ca/Installing_CA.adoc
@@ -6,7 +6,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == CA Subsystem Installation 
 
-Prepare a deployment configuration (e.g. `ca.cfg`) to deploy CA subsystem.
+Prepare a deployment configuration, for example `ca.cfg`, to deploy CA subsystem.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca.cfg[/usr/share/pki/server/examples/installation/ca.cfg].

--- a/docs/installation/ca/Installing_CA.adoc
+++ b/docs/installation/ca/Installing_CA.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 == CA Subsystem Installation 
 
 Prepare a deployment configuration, for example `ca.cfg`, to deploy CA subsystem.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca.cfg[/usr/share/pki/server/examples/installation/ca.cfg].
 

--- a/docs/installation/ca/Installing_CA_Clone.adoc
+++ b/docs/installation/ca/Installing_CA_Clone.adoc
@@ -30,7 +30,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -75,7 +75,7 @@ $ chown pkiuser:pkiuser ca-certs.p12
 
 == CA Subsystem Installation 
 
-Prepare a deployment configuration (e.g. `ca-clone.cfg`) to deploy CA subsystem clone.
+Prepare a deployment configuration, for example `ca-clone.cfg`, to deploy CA subsystem clone.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-clone.cfg[/usr/share/pki/server/examples/installation/ca-clone.cfg].

--- a/docs/installation/ca/Installing_CA_Clone.adoc
+++ b/docs/installation/ca/Installing_CA_Clone.adoc
@@ -30,7 +30,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -76,7 +76,7 @@ $ chown pkiuser:pkiuser ca-certs.p12
 == CA Subsystem Installation 
 
 Prepare a deployment configuration, for example `ca-clone.cfg`, to deploy CA subsystem clone.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-clone.cfg[/usr/share/pki/server/examples/installation/ca-clone.cfg].
 It assumes that the primary CA subsystem is running at https://primary.example.com:8443,

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.adoc
@@ -33,7 +33,7 @@ $ pki-server cert-export subsystem \
 
 Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt`
 
-Prepare a file, for example `ca.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `ca.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_Clone_with_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_Clone_with_HSM.adoc
@@ -33,7 +33,7 @@ $ pki-server cert-export subsystem \
 
 Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt`
 
-Prepare a file (e.g. ca.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `ca.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -148,7 +148,7 @@ HSM:sslserver/replica.example.com                            u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.adoc
+++ b/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.adoc
@@ -57,9 +57,9 @@ The command will export the following certificates (including the certificate ch
 * audit signing certificate
 * subsystem certificate
 
-Note that the existing SSL server certificate will not be exported.
+Note that the existing SSL server certificate is not exported.
 
-If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -88,7 +88,7 @@ $ chown pkiuser:pkiuser ca-certs.p12
 == CA Subsystem Installation 
 
 Prepare a deployment configuration, for example `ca-secure-ds-secondary.cfg`, to deploy CA subsystem clone.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-secure-ds-secondary.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg].
 It assumes that the existing CA and DS instances are running on primary.example.com, and the new CA and DS clones are being installed on secondary.example.com,

--- a/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.adoc
+++ b/docs/installation/ca/Installing_CA_Clone_with_Secure_Database_Connection.adoc
@@ -59,7 +59,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -87,7 +87,7 @@ $ chown pkiuser:pkiuser ca-certs.p12
 
 == CA Subsystem Installation 
 
-Prepare a deployment configuration (e.g. `ca-secure-ds-secondary.cfg`) to deploy CA subsystem clone.
+Prepare a deployment configuration, for example `ca-secure-ds-secondary.cfg`, to deploy CA subsystem clone.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-secure-ds-secondary.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg].

--- a/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.adoc
+++ b/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.adoc
@@ -5,7 +5,7 @@ Follow this process to install a CA subsystem with a custom CA signing key, CSR,
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
-Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration step 1, for example:
+Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration step 1:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.adoc
+++ b/docs/installation/ca/Installing_CA_with_Custom_CA_Signing_Key.adoc
@@ -5,7 +5,7 @@ Follow this process to install a CA subsystem with a custom CA signing key, CSR,
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
-Prepare a file (e.g. ca-step1.cfg) that contains the deployment configuration step 1, for example:
+Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration step 1, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -60,16 +60,16 @@ It will install CA subsystem in a Tomcat instance (default is pki-tomcat) and cr
 Since there is no CSR path parameter specified, it will not generate the CA signing key by default.
 
 == Generating CA Signing Key, CSR, and Certificate 
-Generate a custom CA signing key in the server NSS database, then generate a CSR and store it in a file (e.g. ca_signing.csr).
+Generate a custom CA signing key in the server NSS database, then generate a CSR and store it in a file, for example `ca_signing.csr`.
 
 Use the CSR to issue the CA signing certificate:
 
 * for root CA installation, generate a self-signed CA signing certificate
 * for subordinate CA installation, submit the CSR to an external CA to issue the CA signing certificate
 
-Store the CA signing certificate in a file (e.g. ca_signing.crt). The CA signing certificate can be specified as a single certificate or a PKCS #7 certificate chain in PEM format.
+Store the CA signing certificate in a file, for example `ca_signing.crt`. The CA signing certificate can be specified as a single certificate or a PKCS #7 certificate chain in PEM format.
 
-If the CA signing certificate was issued by an external CA, store the external CA certificate chain in a file (e.g. external.crt). The certificate chain can be specified as a single certificate or a PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the CA signing certificate, but it should not include the CA signing certificate itself.
+If the CA signing certificate was issued by an external CA, store the external CA certificate chain in a file, for example `external.crt`. The certificate chain can be specified as a single certificate or a PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the CA signing certificate, but it should not include the CA signing certificate itself.
 
 // See also:
 // AI: the following page and the links within need to be converted and brought under the repository
@@ -77,7 +77,7 @@ If the CA signing certificate was issued by an external CA, store the external C
 // * link:https://github.com/dogtagpki/pki/wiki/Generating-CA-Signing-Certificate[Generating CA Signing Certificate]
 
 == Finishing CA Subsystem Installation 
-Prepare another file (e.g. ca-step2.cfg) that contains the deployment configuration step 2. The file can be copied from step 1 (i.e. ca-step1.cfg) with additional changes below.
+Prepare another file, for example `ca-step2.cfg`, that contains the deployment configuration step 2. The file can be copied from step 1 (i.e. ca-step1.cfg) with additional changes below.
 
 Specify step 2 with the following parameter:
 
@@ -134,7 +134,7 @@ sslserver                                                    u,u,u
 ....
 
 == Verifying Admin Certificate 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_with_ECC.adoc
+++ b/docs/installation/ca/Installing_CA_with_ECC.adoc
@@ -18,7 +18,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == CA Subsystem Installation 
 
-Prepare a deployment configuration (e.g. `ca-ecc.cfg`) to deploy CA subsystem.
+Prepare a deployment configuration, for example `ca-ecc.cfg`, to deploy CA subsystem.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-ecc.cfg[/usr/share/pki/server/examples/installation/ca-ecc.cfg].

--- a/docs/installation/ca/Installing_CA_with_ECC.adoc
+++ b/docs/installation/ca/Installing_CA_with_ECC.adoc
@@ -19,7 +19,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 == CA Subsystem Installation 
 
 Prepare a deployment configuration, for example `ca-ecc.cfg`, to deploy CA subsystem.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-ecc.cfg[/usr/share/pki/server/examples/installation/ca-ecc.cfg].
 

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.adoc
@@ -9,7 +9,7 @@ so they will not be included in the installation process.
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
-Prepare a file (e.g. ca-step1.cfg) that contains the deployment configuration step 1, for example:
+Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration step 1, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -97,7 +97,7 @@ $ echo "-----END CERTIFICATE REQUEST-----" >> ca_audit_signing.csr
 ....
 
 == Finishing CA Subsystem Installation 
-Prepare another file (e.g. ca-step2.cfg) that contains the deployment configuration step 2.
+Prepare another file, for example `ca-step2.cfg`, that contains the deployment configuration step 2.
 The file can be copied from step 1 (i.e. ca-step1.cfg) with additional changes below.
 
 Specify step 2 with the following parameter:
@@ -170,7 +170,7 @@ HSM:sslserver/pki.example.com                                u,u,u
 ....
 
 == Verifying Admin Certificate 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_HSM.adoc
@@ -9,7 +9,7 @@ so they will not be included in the installation process.
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
-Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration step 1, for example:
+Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration step 1:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.adoc
+++ b/docs/installation/ca/Installing_CA_with_Existing_Keys_in_Internal_Token.adoc
@@ -10,7 +10,7 @@ so they will not be included in the installation process.
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
-Prepare a file (e.g. ca-existing-certs-step1.cfg) that contains the first deployment configuration.
+Prepare a file, for example `ca-existing-certs-step1.cfg`, that contains the first deployment configuration.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-existing-certs-step1.cfg[/usr/share/pki/server/examples/installation/ca-existing-certs-step1.cfg].
 
@@ -58,7 +58,7 @@ $ echo "-----END CERTIFICATE REQUEST-----" >> ca_audit_signing.csr
 ....
 
 == Finishing CA Subsystem Installation 
-Prepare another file (e.g. ca-existing-certs-step2.cfg) that contains the second deployment configuration.
+Prepare another file, for example `ca-existing-certs-step2.cfg`, that contains the second deployment configuration.
 The file can be created from the first file (i.e. ca-existing-certs-step1.cfg) with the following changes:
 
 [literal,subs="+quotes,verbatim"]
@@ -117,7 +117,7 @@ sslserver                                                    u,u,u
 ....
 
 == Verifying Admin Certificate 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.adoc
+++ b/docs/installation/ca/Installing_CA_with_External_CA_Signing_Certificate.adoc
@@ -5,7 +5,7 @@ Follow this process to install a CA subsystem with an external CA signing certif
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
-Prepare a file (e.g. ca-external-cert-step1.cfg) that contains the first deployment configuration.
+Prepare a file, for example `ca-external-cert-step1.cfg`, that contains the first deployment configuration.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-external-cert-step1.cfg[/usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg]
 
@@ -29,10 +29,10 @@ Use the CSR to issue the CA signing certificate:
 * for root CA installation, generate a self-signed CA signing certificate
 * for subordinate CA installation, submit the CSR to an external CA to issue the CA signing certificate
 
-Store the CA signing certificate in a file (e.g. ca_signing.crt).
+Store the CA signing certificate in a file, for example `ca_signing.crt`.
 The CA signing certificate can be specified as a single certificate or a PKCS #7 certificate chain in PEM format.
 
-If the CA signing certificate was issued by an external CA, store the external CA certificate chain in a file (e.g. root-ca_signing.crt).
+If the CA signing certificate was issued by an external CA, store the external CA certificate chain in a file, for example `root-ca_signing.crt`.
 The certificate chain can be specified as a single certificate or a PKCS #7 certificate chain in PEM format.
 The certificate chain should include all CA certificates from the root CA to the external CA that issued the CA signing certificate,
 but it should not include the CA signing certificate itself.
@@ -42,7 +42,7 @@ but it should not include the CA signing certificate itself.
 // * link:https://github.com/dogtagpki/pki/wiki/Generating-CA-Signing-Certificate[Generating CA Signing Certificate]
 
 == Finishing CA Subsystem Installation 
-Prepare another file (e.g. ca-external-cert-step2.cfg) that contains the second deployment configuration.
+Prepare another file, for example `ca-external-cert-step2.cfg`, that contains the second deployment configuration.
 The file can be created from the first file (i.e. ca-external-cert-step1.cfg) with the following changes:
 
 [literal,subs="+quotes,verbatim"]
@@ -94,7 +94,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_with_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_with_HSM.adoc
@@ -6,7 +6,7 @@ where the system certificates and their keys will be stored in HSM.
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == CA Subsystem Installation 
-Prepare a file, for example `ca.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `ca.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_with_HSM.adoc
+++ b/docs/installation/ca/Installing_CA_with_HSM.adoc
@@ -6,7 +6,7 @@ where the system certificates and their keys will be stored in HSM.
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == CA Subsystem Installation 
-Prepare a file (e.g. ca.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `ca.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -92,7 +92,7 @@ HSM:sslserver/pki.example.com                                u,u,u
 ....
 
 == Verifying Admin Certificate 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.adoc
+++ b/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.adoc
@@ -12,7 +12,7 @@ link:../others/Exporting-DS-Certificates.adoc#exporting-ds-signing-certificate[E
 
 == CA Subsystem Installation 
 Prepare a deployment configuration, for example `ca-secure-ds.cfg`, to deploy CA subsystem.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-secure-ds.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds.cfg].
 

--- a/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.adoc
+++ b/docs/installation/ca/Installing_CA_with_Secure_Database_Connection.adoc
@@ -11,7 +11,7 @@ Then export the signing certificate into `ds_signing.crt` as described in
 link:../others/Exporting-DS-Certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
 
 == CA Subsystem Installation 
-Prepare a deployment configuration (e.g. `ca-secure-ds.cfg`) to deploy CA subsystem.
+Prepare a deployment configuration, for example `ca-secure-ds.cfg`, to deploy CA subsystem.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-secure-ds.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds.cfg].

--- a/docs/installation/ca/Installing_Subordinate_CA.adoc
+++ b/docs/installation/ca/Installing_Subordinate_CA.adoc
@@ -6,7 +6,7 @@ with a signing certificate issued by a root CA.
 Prior to installation, please ensure that the link:../others/Installation_Prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Subordinate CA Subsystem Installation 
-Prepare a file (e.g. subca.cfg) that contains the deployment configuration.
+Prepare a file, for example `subca.cfg`, that contains the deployment configuration.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/subca.cfg[/usr/share/pki/server/examples/installation/subca.cfg].
 It assumes that the root CA is already running at https://root.example.com:8443
@@ -44,7 +44,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/est/Set-Up-Realm-DB.adoc
+++ b/docs/installation/est/Set-Up-Realm-DB.adoc
@@ -30,7 +30,7 @@ require to modify the authorization script
 
 
 If you have chosen to use *PostgreSQL* for user management, you first
-need to prepare a database (e.g. est) to access the
+need to prepare a database, for example `est`, to access the
 database. Installation instructions can be found
 link:https://www.postgresql.org/download/linux[here].
 

--- a/docs/installation/kra/Installing_KRA.adoc
+++ b/docs/installation/kra/Installing_KRA.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == KRA Subsystem Installation 
 
-Prepare a file (e.g. kra.cfg) that contains the deployment configuration.
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration.
 A sample deployment configuration is available at link:../../../base/server/examples/installation/kra.cfg[/usr/share/pki/server/examples/installation/kra.cfg].
 
 Then execute the following command:
@@ -50,7 +50,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_Clone.adoc
+++ b/docs/installation/kra/Installing_KRA_Clone.adoc
@@ -25,7 +25,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -39,7 +39,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 == KRA Subsystem Installation 
 
 Prepare a deployment configuration, for example `kra-clone.cfg`, to deploy KRA subsystem clone.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-clone.cfg[/usr/share/pki/server/examples/installation/kra-clone.cfg].
 It assumes that the primary CA and KRA subsystems are running at https://primary.example.com:8443,

--- a/docs/installation/kra/Installing_KRA_Clone.adoc
+++ b/docs/installation/kra/Installing_KRA_Clone.adoc
@@ -25,7 +25,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -38,7 +38,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 
 == KRA Subsystem Installation 
 
-Prepare a deployment configuration (e.g. `kra-clone.cfg`) to deploy KRA subsystem clone.
+Prepare a deployment configuration, for example `kra-clone.cfg`, to deploy KRA subsystem clone.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-clone.cfg[/usr/share/pki/server/examples/installation/kra-clone.cfg].

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.adoc
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.adoc
@@ -13,7 +13,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt`
 
-Prepare a file, for example `kra.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_Clone_with_HSM.adoc
+++ b/docs/installation/kra/Installing_KRA_Clone_with_HSM.adoc
@@ -13,7 +13,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt`
 
-Prepare a file (e.g. kra.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -117,7 +117,7 @@ HSM:sslserver/replica.example.com                            u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_on_Separate_Instance.adoc
+++ b/docs/installation/kra/Installing_KRA_on_Separate_Instance.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == KRA Subsystem Installation 
 
-Prepare a file (e.g. kra-separate.cfg) that contains the deployment configuration.
+Prepare a file, for example `kra-separate.cfg`, that contains the deployment configuration.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-separate.cfg[/usr/share/pki/server/examples/installation/kra-separate.cfg].
 It assumes that the CA is running at https://ca.example.com:8443,
@@ -54,7 +54,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_with_Custom_Keys.adoc
+++ b/docs/installation/kra/Installing_KRA_with_Custom_Keys.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == Starting KRA Subsystem Installation
 
-Prepare a file (e.g. kra-step1.cfg) that contains the deployment configuration step 1, for example:
+Prepare a file, for example `kra-step1.cfg`, that contains the deployment configuration step 1, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -85,7 +85,7 @@ Submit the CSRs to an external CA to issue the certificates, then store the cert
 
 The certificates can be specified as single certificates or PKCS #7 certificate chains in PEM format.
 
-Store the external CA certificate chain in a file (e.g. ca_signing.crt). The certificate chain can be specified as a single certificate or PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the KRA system and admin certificates.
+Store the external CA certificate chain in a file, for example `ca_signing.crt`. The certificate chain can be specified as a single certificate or PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the KRA system and admin certificates.
 
 See also:
 
@@ -98,7 +98,7 @@ See also:
 
 == Finishing KRA Subsystem Installation
 
-Prepare another file (e.g. kra-step2.cfg) that contains the deployment configuration step 2. The file can be copied from step 1 (i.e. kra-step1.cfg) with additional changes below.
+Prepare another file, for example `kra-step2.cfg`, that contains the deployment configuration step 2. The file can be copied from step 1 (i.e. kra-step1.cfg) with additional changes below.
 
 Specify step 2 with the following parameter:
 
@@ -167,7 +167,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_with_Custom_Keys.adoc
+++ b/docs/installation/kra/Installing_KRA_with_Custom_Keys.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == Starting KRA Subsystem Installation
 
-Prepare a file, for example `kra-step1.cfg`, that contains the deployment configuration step 1, for example:
+Prepare a file, for example `kra-step1.cfg`, that contains the deployment configuration step 1:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_with_ECC.adoc
+++ b/docs/installation/kra/Installing_KRA_with_ECC.adoc
@@ -19,7 +19,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == KRA Subsystem Installation
 
-Prepare a file (e.g. kra.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration, for example:
 [literal,subs="+quotes,verbatim"]
 ....
 [DEFAULT]
@@ -113,7 +113,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_with_ECC.adoc
+++ b/docs/installation/kra/Installing_KRA_with_ECC.adoc
@@ -19,7 +19,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == KRA Subsystem Installation
 
-Prepare a file, for example `kra.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration:
 [literal,subs="+quotes,verbatim"]
 ....
 [DEFAULT]

--- a/docs/installation/kra/Installing_KRA_with_External_Certificates.adoc
+++ b/docs/installation/kra/Installing_KRA_with_External_Certificates.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == Starting KRA Subsystem Installation
 
-Prepare a file (e.g. kra-external-certs-step1.cfg) that contains the first deployment configuration.
+Prepare a file, for example `kra-external-certs-step1.cfg`, that contains the first deployment configuration.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-external-certs-step1.cfg[/usr/share/pki/server/examples/installation/kra-external-certs-step1.cfg].
 It assumes that the CA is running at https://ca.example.com:8443,
@@ -40,11 +40,11 @@ Submit the CSRs to an external CA to issue the certificates, then store the cert
 
 The certificates can be specified as single certificates or PKCS #7 certificate chains in PEM format.
 
-Store the external CA certificate chain in a file (e.g. ca_signing.crt). The certificate chain can be specified as a single certificate or PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the KRA system and admin certificates.
+Store the external CA certificate chain in a file, for example `ca_signing.crt`. The certificate chain can be specified as a single certificate or PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the KRA system and admin certificates.
 
 == Finishing KRA Subsystem Installation
 
-Prepare another file (e.g. kra-external-certs-step2.cfg) that contains the second deployment configuration.
+Prepare another file, for example `kra-external-certs-step2.cfg`, that contains the second deployment configuration.
 The file can be created from the first file (i.e. kra-external-certs-step1.cfg) with the following changes:
 
 [literal,subs="+quotes,verbatim"]
@@ -102,7 +102,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_with_HSM.adoc
+++ b/docs/installation/kra/Installing_KRA_with_HSM.adoc
@@ -8,7 +8,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == KRA Subsystem Installation
 
-Prepare a file (e.g. kra.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -99,7 +99,7 @@ HSM:sslserver/pki.example.com                                u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_with_HSM.adoc
+++ b/docs/installation/kra/Installing_KRA_with_HSM.adoc
@@ -8,7 +8,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == KRA Subsystem Installation
 
-Prepare a file, for example `kra.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.adoc
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.adoc
@@ -9,7 +9,7 @@ This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
 
 == KRA Subsystem Installation
 
-Prepare a file (e.g. kra.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -98,7 +98,7 @@ $ pki-server kra-db-config-show
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.adoc
+++ b/docs/installation/kra/Installing_KRA_with_Secure_Database_Connection.adoc
@@ -9,7 +9,7 @@ This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
 
 == KRA Subsystem Installation
 
-Prepare a file, for example `kra.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `kra.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/kra/Installing_Standalone_KRA.adoc
+++ b/docs/installation/kra/Installing_Standalone_KRA.adoc
@@ -13,7 +13,7 @@ The installation process consists multiple steps:
 
 == Generating Certificate Requests 
 
-Prepare a file (e.g. kra-standalone-step1.cfg) that contains the first deployment configuration.
+Prepare a file, for example `kra-standalone-step1.cfg`, that contains the first deployment configuration.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-standalone-step1.cfg[/usr/share/pki/server/examples/installation/kra-standalone-step1.cfg].
 
@@ -38,7 +38,7 @@ Use the CSRs to obtain KRA certificates:
 
 == Completing Installation 
 
-Prepare another file (e.g. kra-standalone-step2.cfg) that contains the second deployment configuration.
+Prepare another file, for example `kra-standalone-step2.cfg`, that contains the second deployment configuration.
 The file can be created from the first file (i.e. kra-standalone-step1.cfg) with the following changes:
 
 ----

--- a/docs/installation/ocsp/Installing_OCSP.adoc
+++ b/docs/installation/ocsp/Installing_OCSP.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == OCSP Subsystem Installation 
 
-Prepare a file (e.g. ocsp.cfg) that contains the deployment configuration.
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration.
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp.cfg[/usr/share/pki/server/examples/installation/ocsp.cfg].
 
 Then execute the following command:
@@ -49,7 +49,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_Clone.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_Clone.adoc
@@ -24,7 +24,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -37,7 +37,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 
 == OCSP Subsystem Installation 
 
-Prepare a deployment configuration (e.g. `ocsp-clone.cfg`) to deploy OCSP subsystem clone.
+Prepare a deployment configuration, for example `ocsp-clone.cfg`, to deploy OCSP subsystem clone.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-clone.cfg[/usr/share/pki/server/examples/installation/ocsp-clone.cfg].

--- a/docs/installation/ocsp/Installing_OCSP_Clone.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_Clone.adoc
@@ -24,7 +24,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -38,7 +38,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 == OCSP Subsystem Installation 
 
 Prepare a deployment configuration, for example `ocsp-clone.cfg`, to deploy OCSP subsystem clone.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-clone.cfg[/usr/share/pki/server/examples/installation/ocsp-clone.cfg].
 It assumes that the primary CA and OCSP subsystems are running at https://primary.example.com:8443,

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.adoc
@@ -14,7 +14,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt
 
-Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_Clone_with_HSM.adoc
@@ -14,7 +14,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 Note: It is assumed that the CA signing certificate has been exported into `ca_signing.crt
 
-Prepare a file (e.g. ocsp.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -116,7 +116,7 @@ HSM:sslserver/replica.example.com                            u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.adoc
@@ -8,7 +8,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == Starting OCSP Subsystem Installation 
 
-Prepare a file, for example `ocsp-step1.cfg`, that contains the deployment configuration step 1, for example:
+Prepare a file, for example `ocsp-step1.cfg`, that contains the deployment configuration step 1:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_Custom_Keys.adoc
@@ -8,7 +8,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == Starting OCSP Subsystem Installation 
 
-Prepare a file (e.g. ocsp-step1.cfg) that contains the deployment configuration step 1, for example:
+Prepare a file, for example `ocsp-step1.cfg`, that contains the deployment configuration step 1, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -83,7 +83,7 @@ Submit the CSRs to an external CA to issue the certificates, then store the cert
 
 The certificates can be specified as single certificates or PKCS #7 certificate chains in PEM format.
 
-Store the external CA certificate chain in a file (e.g. ca_signing.crt). The certificate chain can be specified as a single certificate or PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the OCSP system and admin certificates.
+Store the external CA certificate chain in a file, for example `ca_signing.crt`. The certificate chain can be specified as a single certificate or PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the OCSP system and admin certificates.
 
 See also:
 
@@ -95,7 +95,7 @@ See also:
 
 == Finishing OCSP Subsystem Installation 
 
-Prepare another file (e.g. ocsp-step2.cfg) that contains the deployment configuration step 2. The file can be copied from step 1 (i.e. ocsp-step1.cfg) with additional changes below.
+Prepare another file, for example `ocsp-step2.cfg`, that contains the deployment configuration step 2. The file can be copied from step 1 (i.e. ocsp-step1.cfg) with additional changes below.
 
 Specify step 2 with the following parameter:
 
@@ -161,7 +161,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_ECC.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_ECC.adoc
@@ -19,7 +19,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == OCSP Subsystem Installation 
 
-Prepare a file (e.g. ocsp.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -105,7 +105,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_ECC.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_ECC.adoc
@@ -19,7 +19,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == OCSP Subsystem Installation 
 
-Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_External_Certificates.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_External_Certificates.adoc
@@ -6,7 +6,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == Starting OCSP Subsystem Installation 
 
-Prepare a file (e.g. ocsp-external-certs-step1.cfg) that contains the first deployment configuration.
+Prepare a file, for example `ocsp-external-certs-step1.cfg`, that contains the first deployment configuration.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-external-certs-step1.cfg[/usr/share/pki/server/examples/installation/ocsp-external-certs-step1.cfg].
 It assumes that the CA is running at https://ca.example.com:8443,
@@ -38,11 +38,11 @@ Submit the CSRs to an external CA to issue the certificates, then store the cert
 
 The certificates can be specified as single certificates or PKCS #7 certificate chains in PEM format.
 
-Store the external CA certificate chain in a file (e.g. ca_signing.crt). The certificate chain can be specified as a single certificate or PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the OCSP system and admin certificates.
+Store the external CA certificate chain in a file, for example `ca_signing.crt`. The certificate chain can be specified as a single certificate or PKCS #7 certificate chain in PEM format. The certificate chain should include all CA certificates from the root CA to the external CA that issued the OCSP system and admin certificates.
 
 == Finishing OCSP Subsystem Installation 
 
-Prepare another file (e.g. ocsp-external-certs-step2.cfg) that contains the second deployment configuration.
+Prepare another file, for example `ocsp-external-certs-step2.cfg`, that contains the second deployment configuration.
 The file can be created from the first file (i.e. ocsp-external-certs-step1.cfg) with the following changes:
 
 [literal,subs="+quotes,verbatim"]
@@ -98,7 +98,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == OCSP Subsystem Installation 
 
-Prepare a file (e.g. ocsp.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -96,7 +96,7 @@ HSM:sslserver/pki.example.com                                u,u,u
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_HSM.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_HSM.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == OCSP Subsystem Installation 
 
-Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.adoc
@@ -11,7 +11,7 @@ Ensure that the secure connection has been enabled on the directory server, and 
 
 == OCSP Subsystem Installation 
 
-Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.adoc
+++ b/docs/installation/ocsp/Installing_OCSP_with_Secure_Database_Connection.adoc
@@ -11,7 +11,7 @@ Ensure that the secure connection has been enabled on the directory server, and 
 
 == OCSP Subsystem Installation 
 
-Prepare a file (e.g. ocsp.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -106,7 +106,7 @@ $ pki-server ocsp-db-config-show
 
 == Verifying Admin Certificate 
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/ocsp/Installing_Standalone_OCSP.adoc
+++ b/docs/installation/ocsp/Installing_Standalone_OCSP.adoc
@@ -13,7 +13,7 @@ The installation process consists multiple steps:
 
 == Generating Certificate Requests 
 
-Prepare a file (e.g. ocsp-standalone-step1.cfg) that contains the first deployment configuration.
+Prepare a file, for example `ocsp-standalone-step1.cfg`, that contains the first deployment configuration.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-standalone-step1.cfg[/usr/share/pki/server/examples/installation/ocsp-standalone-step1.cfg].
 
@@ -37,7 +37,7 @@ Use the CSRs to obtain OCSP certificates:
 
 == Completing Installation 
 
-Prepare another file (e.g. ocsp-standalone-step2.cfg) that contains the second deployment configuration.
+Prepare another file, for example `ocsp-standalone-step2.cfg`, that contains the second deployment configuration.
 The file can be created from the first file (i.e. ocsp-standalone-step1.cfg) with the following changes:
 
 ----

--- a/docs/installation/others/Creating_DS_instance.adoc
+++ b/docs/installation/others/Creating_DS_instance.adoc
@@ -12,7 +12,7 @@ but it can be enabled after installation if necessary.
 
 == Creating a DS Instance 
 
-=== Generate a DS configuration file (e.g. `ds.inf`): 
+=== Generate a DS configuration file, for example `ds.inf`: 
 
 ----
 $ dscreate create-template ds.inf

--- a/docs/installation/server/Installing_Basic_PKI_Server.adoc
+++ b/docs/installation/server/Installing_Basic_PKI_Server.adoc
@@ -2,7 +2,7 @@
 
 
 Follow this process to create and configure a basic PKI server without any of the PKI subsystems.
-This would be useful to troubleshoot general server issues (e.g. SSL).
+This would be useful to troubleshoot general server issues, for example `SSL`.
 
 == Installation
 

--- a/docs/installation/server/Installing_Basic_PKI_Server.adoc
+++ b/docs/installation/server/Installing_Basic_PKI_Server.adoc
@@ -2,7 +2,7 @@
 
 
 Follow this process to create and configure a basic PKI server without any of the PKI subsystems.
-This would be useful to troubleshoot general server issues, for example `SSL`.
+This would be useful to troubleshoot general server issues, for example SSL.
 
 == Installation
 

--- a/docs/installation/server/Installing_PKI_Server_with_Custom_NSS_Databases.adoc
+++ b/docs/installation/server/Installing_PKI_Server_with_Custom_NSS_Databases.adoc
@@ -3,12 +3,12 @@
 
 Follow this process to create a PKI server with custom NSS databases.
 
-Normally, when installing a PKI subsystem, for example `CA`, some NSS databases will be created by default, for example:
+Normally, when installing a PKI subsystem, for example CA, some NSS databases will be created by default:
 
 * server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
-Under some circumstances the admin may want to use custom NSS databases, for example `with trust policy`.
+Under some circumstances the admin may want to use custom NSS databases, for example with trust policy.
 In those cases the installation can be done in multiple steps:
 
 * create a basic PKI server

--- a/docs/installation/server/Installing_PKI_Server_with_Custom_NSS_Databases.adoc
+++ b/docs/installation/server/Installing_PKI_Server_with_Custom_NSS_Databases.adoc
@@ -3,12 +3,12 @@
 
 Follow this process to create a PKI server with custom NSS databases.
 
-Normally, when installing a PKI subsystem (e.g. CA) some NSS databases will be created by default, for example:
+Normally, when installing a PKI subsystem, for example `CA`, some NSS databases will be created by default, for example:
 
 * server NSS database: /var/lib/pki/pki-tomcat/conf/alias
 * admin NSS database: ~/.dogtag/pki-tomcat/ca/alias
 
-Under some circumstances the admin may want to use custom NSS databases (e.g. with trust policy).
+Under some circumstances the admin may want to use custom NSS databases, for example `with trust policy`.
 In those cases the installation can be done in multiple steps:
 
 * create a basic PKI server

--- a/docs/installation/tks/Installing_TKS.adoc
+++ b/docs/installation/tks/Installing_TKS.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == TKS Subsystem Installation
 
-Prepare a file (e.g. tks.cfg) that contains the deployment configuration.
+Prepare a file, for example `tks.cfg`, that contains the deployment configuration.
 A sample deployment configuration is available at link:../../../base/server/examples/installation/tks.cfg[/usr/share/pki/server/examples/installation/tks.cfg].
 
 Then execute the following command:
@@ -48,7 +48,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tks/Installing_TKS_Clone.adoc
+++ b/docs/installation/tks/Installing_TKS_Clone.adoc
@@ -23,7 +23,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -36,7 +36,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 
 == TKS Subsystem Installation
 
-Prepare a deployment configuration (e.g. `tks-clone.cfg`) to deploy TKS subsystem clone.
+Prepare a deployment configuration, for example `tks-clone.cfg`, to deploy TKS subsystem clone.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/tks-clone.cfg[/usr/share/pki/server/examples/installation/tks-clone.cfg].

--- a/docs/installation/tks/Installing_TKS_Clone.adoc
+++ b/docs/installation/tks/Installing_TKS_Clone.adoc
@@ -23,7 +23,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -37,7 +37,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 == TKS Subsystem Installation
 
 Prepare a deployment configuration, for example `tks-clone.cfg`, to deploy TKS subsystem clone.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/tks-clone.cfg[/usr/share/pki/server/examples/installation/tks-clone.cfg].
 It assumes that the primary CA and TKS are running at https://primary.example.com:8443,

--- a/docs/installation/tks/Installing_TKS_with_ECC.adoc
+++ b/docs/installation/tks/Installing_TKS_with_ECC.adoc
@@ -19,7 +19,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == TKS Subsystem Installation
 
-Prepare a file, for example `tks.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `tks.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tks/Installing_TKS_with_ECC.adoc
+++ b/docs/installation/tks/Installing_TKS_with_ECC.adoc
@@ -19,7 +19,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == TKS Subsystem Installation
 
-Prepare a file (e.g. tks.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `tks.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -93,7 +93,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tks/Installing_TKS_with_HSM.adoc
+++ b/docs/installation/tks/Installing_TKS_with_HSM.adoc
@@ -8,7 +8,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == TKS Subsystem Installation
 
-Prepare a file (e.g. tks.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `tks.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -95,7 +95,7 @@ HSM:sslserver                                                u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tks/Installing_TKS_with_HSM.adoc
+++ b/docs/installation/tks/Installing_TKS_with_HSM.adoc
@@ -8,7 +8,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == TKS Subsystem Installation
 
-Prepare a file, for example `tks.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `tks.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.adoc
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.adoc
@@ -9,7 +9,7 @@ This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
 
 == TKS Subsystem Installation
 
-Prepare a file (e.g. tks.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `tks.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -102,7 +102,7 @@ $ pki-server tks-db-config-show
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.adoc
+++ b/docs/installation/tks/Installing_TKS_with_Secure_Database_Connection.adoc
@@ -9,7 +9,7 @@ This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
 
 == TKS Subsystem Installation
 
-Prepare a file, for example `tks.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `tks.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tps/Installing_TPS.adoc
+++ b/docs/installation/tps/Installing_TPS.adoc
@@ -7,7 +7,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == TPS Subsystem Installation
 
-Prepare a file (e.g. tps.cfg) that contains the deployment configuration.
+Prepare a file, for example `tps.cfg`, that contains the deployment configuration.
 A sample deployment configuration is available at link:../../../base/server/examples/installation/tps.cfg[/usr/share/pki/server/examples/installation/tps.cfg].
 
 Then execute the following command:
@@ -48,7 +48,7 @@ sslserver                                                    u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tps/Installing_TPS_Clone.adoc
+++ b/docs/installation/tps/Installing_TPS_Clone.adoc
@@ -24,7 +24,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -38,7 +38,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 == TPS Subsystem Installation
 
 Prepare a deployment configuration, for example `tps-clone.cfg`, to deploy TPS subsystem clone.
-By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
+By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/tps-clone.cfg[/usr/share/pki/server/examples/installation/tps-clone.cfg].
 It assumes that the primary CA, KRA, TKS, and TPS subsystems are running at https://primary.example.com:8443,

--- a/docs/installation/tps/Installing_TPS_Clone.adoc
+++ b/docs/installation/tps/Installing_TPS_Clone.adoc
@@ -24,7 +24,7 @@ The command will export the following certificates (including the certificate ch
 
 Note that the existing SSL server certificate will not be exported.
 
-If necessary, third-party certificates (e.g. trust anchors) can be added into the same PKCS #12 file with the following command:
+If necessary, third-party certificates, for example `trust anchors`, can be added into the same PKCS #12 file with the following command:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -37,7 +37,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 
 == TPS Subsystem Installation
 
-Prepare a deployment configuration (e.g. `tps-clone.cfg`) to deploy TPS subsystem clone.
+Prepare a deployment configuration, for example `tps-clone.cfg`, to deploy TPS subsystem clone.
 By default the subsystem will be deployed into a Tomcat instance called `pki-tomcat`.
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/tps-clone.cfg[/usr/share/pki/server/examples/installation/tps-clone.cfg].

--- a/docs/installation/tps/Installing_TPS_with_HSM.adoc
+++ b/docs/installation/tps/Installing_TPS_with_HSM.adoc
@@ -8,7 +8,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == TPS Subsystem Installation
 
-Prepare a file (e.g. tps.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `tps.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -95,7 +95,7 @@ HSM:sslserver                                                u,u,u
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tps/Installing_TPS_with_HSM.adoc
+++ b/docs/installation/tps/Installing_TPS_with_HSM.adoc
@@ -8,7 +8,7 @@ Prior to installation, please ensure that the link:../others/Installation_Prereq
 
 == TPS Subsystem Installation
 
-Prepare a file, for example `tps.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `tps.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.adoc
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.adoc
@@ -9,7 +9,7 @@ This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
 
 == TPS Subsystem Installation
 
-Prepare a file (e.g. tps.cfg) that contains the deployment configuration, for example:
+Prepare a file, for example `tps.cfg`, that contains the deployment configuration, for example:
 
 [literal,subs="+quotes,verbatim"]
 ....
@@ -102,7 +102,7 @@ $ pki-server tps-db-config-show
 
 == Verifying Admin Certificate
 
-Prepare a client NSS database (e.g. ~/.dogtag/nssdb):
+Prepare a client NSS database, for example `~/.dogtag/nssdb`:
 
 [literal,subs="+quotes,verbatim"]
 ....

--- a/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.adoc
+++ b/docs/installation/tps/Installing_TPS_with_Secure_Database_Connection.adoc
@@ -9,7 +9,7 @@ This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
 
 == TPS Subsystem Installation
 
-Prepare a file, for example `tps.cfg`, that contains the deployment configuration, for example:
+Prepare a file, for example `tps.cfg`, that contains the deployment configuration:
 
 [literal,subs="+quotes,verbatim"]
 ....


### PR DESCRIPTION
result of my new script, replace_eg3.py, which replaces "e.g." with "for example". It also handles punctuation so that if any occurs after ')' the ')' is simply removed.