### PR TITLE
Remove hard-coded pkidbuser

### DIFF
--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -70,26 +70,6 @@ jobs:
 
           diff expected actual
 
-      - name: Check DS user
-        run: |
-            cat > expected << EOF
-            dn: uid=pkidbuser,ou=People,dc=ca,dc=pki,dc=example,dc=com
-            nsPagedSizeLimit: 20000
-
-            EOF
-
-            docker exec ds ldapsearch \
-                -H ldap://ds.example.com:3389 \
-                -D "cn=Directory Manager" \
-                -w Secret.123 \
-                -o ldif_wrap=no \
-                -LLL \
-                -b "uid=pkidbuser,ou=People,dc=ca,dc=pki,dc=example,dc=com" \
-                nsPagedSizeLimit \
-                | tee actual
-
-            diff expected actual
-
       - name: Initialize PKI client
         run: |
           docker exec pki pki-server cert-export ca_signing --cert-file ca_signing.crt

--- a/.github/workflows/ca-existing-ds-test.yml
+++ b/.github/workflows/ca-existing-ds-test.yml
@@ -251,25 +251,6 @@ jobs:
               --csr admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile
 
-      # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database-User
-      - name: Add database user
-        run: |
-          docker exec pki pki-server ca-user-add \
-              --full-name pkidbuser \
-              --type agentType \
-              --cert /var/lib/pki/pki-tomcat/conf/certs/subsystem.crt \
-              pkidbuser
-
-      - name: Assign roles to database user
-        run: |
-          docker exec pki pki-server ca-user-role-add pkidbuser "Subsystem Group"
-          docker exec pki pki-server ca-user-role-add pkidbuser "Certificate Manager Agents"
-
-      - name: Grant database access to database user
-        run: |
-          docker exec pki pki-server ca-db-access-grant \
-              uid=pkidbuser,ou=people,dc=ca,dc=pki,dc=example,dc=com
-
       # https://github.com/dogtagpki/pki/wiki/Setting-up-Security-Domain
       - name: Create security domain database
         run: |

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -474,7 +474,6 @@ pki_ds_hostname=%(pki_hostname)s
 
 pki_subsystem_name=KRA %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 # Key ID generator: legacy, random
 pki_key_id_generator=random
@@ -568,7 +567,6 @@ pki_ds_hostname=%(pki_hostname)s
 
 pki_subsystem_name=OCSP %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 pki_security_domain_setup=True
 pki_registry_enable=True
@@ -599,7 +597,6 @@ pki_ds_hostname=%(pki_hostname)s
 
 pki_subsystem_name=TKS %(pki_hostname)s %(pki_https_port)s
 pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 
 pki_security_domain_setup=True
 pki_registry_enable=True
@@ -637,7 +634,6 @@ pki_tks_uri=https://%(pki_hostname)s:%(pki_https_port)s
 pki_enable_server_side_keygen=False
 pki_import_shared_secret=False
 pki_share_db=True
-pki_share_dbuser_dn=uid=pkidbuser,ou=people,%(pki_ds_base_dn)s
 pki_source_phone_home_xml=/usr/share/pki/%(pki_subsystem_type)s/conf/phoneHome.xml
 
 pki_security_domain_setup=True


### PR DESCRIPTION
The `pkidbuser` is mainly used by PKI in IPA to access DS using client cert auth. Regular (non-IPA) PKI generally do not use this user but currently the user is created by default during installation and the username is hard-coded in PKI.

To simplify the installation the code that sets up the database user has been consolidated into `configuration.py` and the default `pki_share_dbuser_dn` has been removed so it will no longer create the user by default. IPA defines the `pki_share_dbuser_dn` during installation so it will not be affected by this change.

The non-IPA tests have been updated to no longer check `pkidbuser`.

There are still some references to `pkidbuser` in `CertFixCLI` (which is mainly used by IPA). They will be cleaned up separately later.