### PR TITLE
Add SELinux workaround note for cracklibCheck

### DIFF
--- a/docs/admin/ServerSideKeygen.adoc
+++ b/docs/admin/ServerSideKeygen.adoc
@@ -121,6 +121,9 @@ profile can overwrite to allow stronger or weaker passwords.
 
 NOTE: If cracklibCheck=true is enabled, SELinux may block /usr/sbin/cracklib-check, preventing it from functioning correctly. This can result in unexpected failures during password strength validation. To resolve this issue, apply the necessary SELinux policies using the following commands, which adjust SELinux settings to allow cracklib-check to execute as expected.
 
+Apply the necessary SELinux policies:
+
+[literal]
  # setsebool -P domain_can_mmap_files 1
  # ausearch -c 'cracklib-check' --raw | audit2allow -M my-cracklibcheck
  # semodule -X 300 -i my-cracklibcheck.pp

--- a/docs/admin/ServerSideKeygen.adoc
+++ b/docs/admin/ServerSideKeygen.adoc
@@ -123,10 +123,12 @@ NOTE: If cracklibCheck=true is enabled, SELinux may block /usr/sbin/cracklib-che
 
 Apply the necessary SELinux policies:
 
-[literal]
- # setsebool -P domain_can_mmap_files 1
- # ausearch -c 'cracklib-check' --raw | audit2allow -M my-cracklibcheck
- # semodule -X 300 -i my-cracklibcheck.pp
+[literal,subs="+quotes,verbatim"]
+....
+# setsebool -P domain_can_mmap_files 1
+# ausearch -c 'cracklib-check' --raw | audit2allow -M my-cracklibcheck
+# semodule -X 300 -i my-cracklibcheck.pp
+....
 
 
 Key type and key size parameters can be configured as exemplified below:

--- a/docs/admin/ServerSideKeygen.adoc
+++ b/docs/admin/ServerSideKeygen.adoc
@@ -119,6 +119,11 @@ configuration in `CS.cfg` are used for all the passwords but each
 profile can overwrite to allow stronger or weaker passwords.
 
 
+NOTE: If cracklibCheck=true is enabled, SELinux may block /usr/sbin/cracklib-check, preventing it from functioning correctly. This can result in unexpected failures during password strength validation. To resolve this issue, apply the necessary SELinux policies using the following commands, which adjust SELinux settings to allow cracklib-check to execute as expected.
+
+ # setsebool -P domain_can_mmap_files 1
+ # ausearch -c 'cracklib-check' --raw | audit2allow -M my-cracklibcheck
+ # semodule -X 300 -i my-cracklibcheck.pp
 
 
 Key type and key size parameters can be configured as exemplified below:


### PR DESCRIPTION
When cracklibCheck=true is enabled, SELinux prevents its execution and in this case cracklib not function as expected, So adding workaround to trust and allow this module in SELinux policy.