### PR TITLE
Fix Azure pipelines

### DIFF
--- a/base/tools/CMakeLists.txt
+++ b/base/tools/CMakeLists.txt
@@ -55,11 +55,24 @@ jar(pki-tools-jar
 add_dependencies(java pki-tools-jar)
 
 if(WITH_JAVA)
+    # install pki-tools.jar in /usr/lib/java/pki
     install(
         FILES
             ${PKI_TOOLS_JAR}
         DESTINATION
-            ${JAVA_JAR_INSTALL_DIR}/pki
+            ${JAVA_LIB_INSTALL_DIR}/pki
+    )
+
+    # create link to pki-tools.jar in /usr/share/java/pki
+    install(
+        CODE "
+            MESSAGE(
+                \"-- Installing: \$ENV{DESTDIR}${JAVA_JAR_INSTALL_DIR}/pki/pki-tools.jar\"
+            )
+            execute_process(
+                COMMAND ln -sf ../../../..${JAVA_LIB_INSTALL_DIR}/pki/pki-tools.jar \$ENV{DESTDIR}${JAVA_JAR_INSTALL_DIR}/pki
+            )
+        "
     )
 endif(WITH_JAVA)
 

--- a/pki.spec
+++ b/pki.spec
@@ -1349,6 +1349,22 @@ pkgs=base\
 %if %{with maven}
 # install Java binaries
 %mvn_install
+
+# Normally JAR files are installed in /usr/share/java/pki.
+# Since pki-tools.jar uses JNI Maven might install it in
+# /usr/lib/java/pki or /usr/share/java/pki depending on the
+# build environment.
+find %{buildroot} -name "*.jar"
+
+# Create link to ensure pki-tools.jar is available at both locations.
+if [ -e %{buildroot}%{_jnidir}/pki/pki-tools.jar ]; then
+   ln -sf ../../../..%{_jnidir}/pki/pki-tools.jar %{buildroot}%{_javadir}/pki
+else
+   mkdir -p %{buildroot}%{_jnidir}/pki
+   ln -sf ../../../..%{_javadir}/pki/pki-tools.jar %{buildroot}%{_jnidir}/pki
+fi
+
+# with maven
 %endif
 
 # install PKI console, Javadoc, and native binaries
@@ -1760,10 +1776,8 @@ fi
 %{_mandir}/man1/PKCS10Client.1.gz
 %{_mandir}/man1/PKICertImport.1.gz
 %{_mandir}/man1/tpsclient.1.gz
-
-%if %{without maven}
-%{_datadir}/java/pki/pki-tools.jar
-%endif
+%{_javadir}/pki/pki-tools.jar
+%{_jnidir}/pki/pki-tools.jar
 
 # with base
 %endif


### PR DESCRIPTION
Previously all JAR files were installed in `/usr/share/java/pki`, but since now `pki-tools.jar` uses JNI Maven might install it in `/usr/lib/java/pki` depending on the build environment (which requires further investigation).

To maintain consistency the CMake script has been modified to install `pki-tools.jar` in `/usr/lib/java/pki` then create a link to it in `/usr/share/java/pki`.

The RPM spec has been modified to check where `pki-tools.jar` is installed then create a link to it from the other location.