### PR TITLE
Don't create audit signing cert by default

### DIFF
--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -52,6 +52,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
 
       - name: Check PKI server base dir after installation
@@ -263,14 +264,6 @@ jobs:
               -in /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr
           docker exec pki openssl x509 -text -noout -in ca_ocsp_signing.crt
 
-      - name: Check CA audit signing cert
-        run: |
-          docker exec pki pki-server cert-export ca_audit_signing \
-              --cert-file ca_audit_signing.crt
-          docker exec pki openssl req -text -noout \
-              -in /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr
-          docker exec pki openssl x509 -text -noout -in ca_audit_signing.crt
-
       - name: Check subsystem cert
         run: |
           docker exec pki pki-server cert-export subsystem \
@@ -298,6 +291,17 @@ jobs:
       - name: Run PKI healthcheck
         run: docker exec pki pki-healthcheck --failures-only
 
+      - name: Install CA admin cert
+        run: |
+          docker exec pki pki nss-cert-import \
+              --cert $SHARED/ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
       - name: Update CA configuration
         run: |
           docker exec pki dnf install -y xmlstarlet
@@ -312,25 +316,58 @@ jobs:
               -v "false" \
               /etc/pki/pki-tomcat/server.xml
 
-          # enable CA signed audit log
-          docker exec pki pki-server ca-config-set log.instance.SignedAudit.logSigning true
+      - name: Enable audit log signing
+        run: |
+          # https://github.com/dogtagpki/pki/wiki/Enabling-Audit-Log-Signing
 
-          # configure RESTEasy logging
+          # check audit config
+          docker exec pki pki-server ca-config-find | grep audit_signing
+          docker exec pki pki-server ca-audit-config-show
+
+          # configure audit signing cert nickname
+          docker exec pki pki-server ca-config-set ca.audit_signing.nickname ca_audit_signing
+          docker exec pki pki-server ca-config-set ca.cert.audit_signing.nickname ca_audit_signing
+
+          # create audit signing CSR
+          docker exec pki pki-server cert-request \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              ca_audit_signing
+
+          # issue audit signing cert
+          docker exec pki pki \
+              -n caadmin \
+              ca-cert-issue \
+              --profile caAuditSigningCert \
+              --csr-file /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr \
+              --output-file /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.crt
+
+          # import audit signing cert
+          docker exec pki pki-server cert-import ca_audit_signing
+
+          # check audit signing cert
+          docker exec pki pki-server cert-show ca_audit_signing
+
+          # enable audit log signing
+          docker exec pki pki-server ca-audit-config-mod \
+              --logSigning true \
+              --signingCert ca_audit_signing
+
+          # check audit config again
+          docker exec pki pki-server ca-config-find | grep audit_signing
+          docker exec pki pki-server ca-audit-config-show
+
+      - name: Configure RESTEasy logging
+        run: |
           docker exec -i pki tee /var/lib/pki/pki-tomcat/conf/ca/logging.properties << EOF
           org.jboss.resteasy.level = INFO
           EOF
 
           docker exec pki chown pkiuser:pkiuser /var/lib/pki/pki-tomcat/conf/ca/logging.properties
 
-          # restart PKI server
-          docker exec pki pki-server restart --wait
-
-      - name: Initialize PKI client
+      - name: Restart PKI server
         run: |
-          docker exec pki pki nss-cert-import \
-              --cert $SHARED/ca_signing.crt \
-              --trust CT,C,C \
-              ca_signing
+          docker exec pki pki-server restart --wait
 
       - name: Check pki info with default API
         run: |
@@ -462,10 +499,6 @@ jobs:
 
       - name: Check pki ca-user-show with default API
         run: |
-          docker exec pki pki pkcs12-import \
-              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password Secret.123
-
           docker exec pki pki -n caadmin ca-user-show caadmin
 
           # check HTTP methods, paths, protocols, status, and authenticated users

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -54,9 +54,8 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
-
-          docker exec pki pki-server cert-find
 
       - name: Check security domain config in CA
         run: |
@@ -111,6 +110,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
 
       - name: Check PKI server base dir after installation
@@ -235,6 +235,10 @@ jobs:
 
           diff expected output
 
+      - name: Check PKI server system certs
+        run: |
+          docker exec pki pki-server cert-find
+
       - name: Check PKI server status
         run: |
           docker exec pki pki-server status | tee output
@@ -274,14 +278,6 @@ jobs:
           docker exec pki openssl req -text -noout \
               -in /var/lib/pki/pki-tomcat/conf/certs/kra_transport.csr
           docker exec pki openssl x509 -text -noout -in kra_transport.crt
-
-      - name: Check KRA audit signing cert
-        run: |
-          docker exec pki pki-server cert-export kra_audit_signing \
-              --cert-file kra_audit_signing.crt
-          docker exec pki openssl req -text -noout \
-              -in /var/lib/pki/pki-tomcat/conf/certs/kra_audit_signing.csr
-          docker exec pki openssl x509 -text -noout -in kra_audit_signing.crt
 
       - name: Check subsystem cert
         run: |

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -54,6 +54,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
 
       - name: Check PKI system certs
@@ -63,7 +64,6 @@ jobs:
           docker exec pki pki-server cert-show ca_ocsp_signing
           docker exec pki pki-server cert-show sslserver
           docker exec pki pki-server cert-show subsystem
-          docker exec pki pki-server cert-show ca_audit_signing
 
       - name: Check CA system certs
         run: |
@@ -72,7 +72,6 @@ jobs:
           docker exec pki pki-server subsystem-cert-show ca ocsp_signing
           docker exec pki pki-server subsystem-cert-show ca sslserver
           docker exec pki pki-server subsystem-cert-show ca subsystem
-          docker exec pki pki-server subsystem-cert-show ca audit_signing
 
       - name: Check security domain config in CA
         run: |
@@ -121,6 +120,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ocsp.cfg \
               -s OCSP \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
 
       - name: Check PKI system certs
@@ -130,9 +130,7 @@ jobs:
           docker exec pki pki-server cert-show ca_ocsp_signing
           docker exec pki pki-server cert-show sslserver
           docker exec pki pki-server cert-show subsystem
-          docker exec pki pki-server cert-show ca_audit_signing
           docker exec pki pki-server cert-show ocsp_signing
-          docker exec pki pki-server cert-show ocsp_audit_signing
 
       - name: Check OCSP system certs
         run: |
@@ -140,7 +138,6 @@ jobs:
           docker exec pki pki-server subsystem-cert-show ocsp signing
           docker exec pki pki-server subsystem-cert-show ocsp sslserver
           docker exec pki pki-server subsystem-cert-show ocsp subsystem
-          docker exec pki pki-server subsystem-cert-show ocsp audit_signing
 
       - name: Check PKI server base dir after installation
         run: |
@@ -295,14 +292,6 @@ jobs:
           docker exec pki openssl req -text -noout \
               -in /var/lib/pki/pki-tomcat/conf/certs/ocsp_signing.csr
           docker exec pki openssl x509 -text -noout -in ocsp_signing.crt
-
-      - name: Check OCSP audit signing cert
-        run: |
-          docker exec pki pki-server cert-export ocsp_audit_signing \
-              --cert-file ocsp_audit_signing.crt
-          docker exec pki openssl req -text -noout \
-              -in /var/lib/pki/pki-tomcat/conf/certs/ocsp_audit_signing.csr
-          docker exec pki openssl x509 -text -noout -in ocsp_audit_signing.crt
 
       - name: Check subsystem cert
         run: |

--- a/.github/workflows/subca-basic-test.yml
+++ b/.github/workflows/subca-basic-test.yml
@@ -54,6 +54,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://rootds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
 
       - name: Check root CA server status
@@ -100,6 +101,7 @@ jobs:
               -s CA \
               -D pki_cert_chain_path=${SHARED}/root-ca_signing.crt \
               -D pki_ds_url=ldap://subds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
 
       - name: Check sub CA server status
@@ -135,14 +137,6 @@ jobs:
           docker exec subordinate openssl req -text -noout \
               -in /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr
           docker exec subordinate openssl x509 -text -noout -in ca_ocsp_signing.crt
-
-      - name: Check CA audit signing cert
-        run: |
-          docker exec subordinate pki-server cert-export ca_audit_signing \
-              --cert-file ca_audit_signing.crt
-          docker exec subordinate openssl req -text -noout \
-              -in /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr
-          docker exec subordinate openssl x509 -text -noout -in ca_audit_signing.crt
 
       - name: Check subsystem cert
         run: |

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -54,9 +54,8 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
-
-          docker exec pki pki-server cert-find
 
       - name: Install TKS
         run: |
@@ -64,6 +63,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
 
       - name: Check PKI server base dir after installation
@@ -198,17 +198,9 @@ jobs:
           sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check TKS system certs
+      - name: Check PKI server system certs
         run: |
           docker exec pki pki-server cert-find
-
-      - name: Check TKS audit signing cert
-        run: |
-          docker exec pki pki-server cert-export tks_audit_signing \
-              --cert-file tks_audit_signing.crt
-          docker exec pki openssl req -text -noout \
-              -in /var/lib/pki/pki-tomcat/conf/certs/tks_audit_signing.csr
-          docker exec pki openssl x509 -text -noout -in tks_audit_signing.crt
 
       - name: Check subsystem cert
         run: |

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -52,9 +52,8 @@ jobs:
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
-
-          docker exec pki pki-server cert-find
 
       - name: Install KRA
         run: |
@@ -62,9 +61,8 @@ jobs:
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
-
-          docker exec pki pki-server cert-find
 
       - name: Install TKS
         run: |
@@ -72,9 +70,8 @@ jobs:
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -v
-
-          docker exec pki pki-server cert-find
 
       - name: Install TPS
         run: |
@@ -82,6 +79,7 @@ jobs:
               -f /usr/share/pki/server/examples/installation/tps.cfg \
               -s TPS \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
               -D pki_authdb_url=ldap://ds.example.com:3389 \
               -D pki_enable_server_side_keygen=True \
               -v
@@ -227,17 +225,9 @@ jobs:
           sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check TPS system certs
+      - name: Check PKI server system certs
         run: |
           docker exec pki pki-server cert-find
-
-      - name: Check TPS audit signing cert
-        run: |
-          docker exec pki pki-server cert-export tps_audit_signing \
-              --cert-file tps_audit_signing.crt
-          docker exec pki openssl req -text -noout \
-              -in /var/lib/pki/pki-tomcat/conf/certs/tps_audit_signing.csr
-          docker exec pki openssl x509 -text -noout -in tps_audit_signing.crt
 
       - name: Check subsystem cert
         run: |

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -335,7 +335,7 @@ pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
 pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_admin_uid=caadmin
 
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s CA
+pki_audit_signing_nickname=
 pki_audit_signing_subject_dn=cn=CA Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 
 pki_ds_setup=True
@@ -462,7 +462,7 @@ pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
 pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_admin_uid=kraadmin
 
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s KRA
+pki_audit_signing_nickname=
 pki_audit_signing_subject_dn=cn=KRA Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 
 pki_ds_setup=True
@@ -555,7 +555,7 @@ pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
 pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_admin_uid=ocspadmin
 
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s OCSP
+pki_audit_signing_nickname=
 pki_audit_signing_subject_dn=cn=OCSP Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 
 pki_ds_setup=True
@@ -585,7 +585,7 @@ pki_admin_name=%(pki_admin_uid)s
 pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
 pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_admin_uid=tksadmin
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s TKS
+pki_audit_signing_nickname=
 pki_audit_signing_subject_dn=cn=TKS Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 
 pki_ds_setup=True
@@ -614,7 +614,7 @@ pki_admin_name=%(pki_admin_uid)s
 pki_admin_nickname=PKI Administrator for %(pki_dns_domainname)s
 pki_admin_subject_dn=cn=PKI Administrator,e=%(pki_admin_email)s,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 pki_admin_uid=tpsadmin
-pki_audit_signing_nickname=auditSigningCert cert-%(pki_instance_name)s TPS
+pki_audit_signing_nickname=
 pki_audit_signing_subject_dn=cn=TPS Audit Signing Certificate,ou=%(pki_instance_name)s,o=%(pki_security_domain_name)s
 
 pki_ds_setup=True

--- a/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/expiration.py
@@ -108,9 +108,18 @@ class CASystemCertExpiryCheck(CertsPlugin):
             logger.info("No CA configured, skipping CA System Cert Expiry check")
             return
 
+        audit_signing_nickname = ca.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = ca.find_system_certs()
 
         for cert in certs:
+            cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
+
             yield check_cert_expiry_date(class_instance=self, cert=cert)
 
 
@@ -136,9 +145,18 @@ class KRASystemCertExpiryCheck(CertsPlugin):
             logger.info("No KRA configured, skipping KRA System Cert Expiry check")
             return
 
+        audit_signing_nickname = kra.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = kra.find_system_certs()
 
         for cert in certs:
+            cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
+
             yield check_cert_expiry_date(class_instance=self, cert=cert)
 
 
@@ -164,9 +182,18 @@ class OCSPSystemCertExpiryCheck(CertsPlugin):
             logger.info("No OCSP configured, skipping OCSP System Cert Expiry check")
             return
 
+        audit_signing_nickname = ocsp.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = ocsp.find_system_certs()
 
         for cert in certs:
+            cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
+
             yield check_cert_expiry_date(class_instance=self, cert=cert)
 
 
@@ -192,9 +219,18 @@ class TKSSystemCertExpiryCheck(CertsPlugin):
             logger.info("No TKS configured, skipping TKS System Cert Expiry check")
             return
 
+        audit_signing_nickname = tks.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = tks.find_system_certs()
 
         for cert in certs:
+            cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
+
             yield check_cert_expiry_date(class_instance=self, cert=cert)
 
 
@@ -220,7 +256,16 @@ class TPSSystemCertExpiryCheck(CertsPlugin):
             logger.info("No TPS configured, skipping TPS System Cert Expiry check")
             return
 
+        audit_signing_nickname = tps.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = tps.find_system_certs()
 
         for cert in certs:
+            cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
+
             yield check_cert_expiry_date(class_instance=self, cert=cert)

--- a/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
+++ b/base/server/healthcheck/pki/server/healthcheck/certs/trustflags.py
@@ -45,11 +45,18 @@ class CASystemCertTrustFlagCheck(CertsPlugin):
             logger.info("No CA configured, skipping CA System Cert Trust Flag check")
             return
 
+        audit_signing_nickname = ca.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = ca.find_system_certs()
 
         # Iterate on CA's all system certificate to check with list of expected trust flags
         for cert in certs:
             cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
 
             # Load cert trust from NSSDB
             with nssdb_connection(self.instance) as nssdb:
@@ -109,11 +116,18 @@ class KRASystemCertTrustFlagCheck(CertsPlugin):
             logger.info("No KRA configured, skipping KRA System Cert Trust Flag check")
             return
 
+        audit_signing_nickname = kra.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = kra.find_system_certs()
 
         # Iterate on KRA's all system certificate to check with list of expected trust flags
         for cert in certs:
             cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
 
             # Load cert trust from NSSDB
             with nssdb_connection(self.instance) as nssdb:
@@ -172,11 +186,18 @@ class OCSPSystemCertTrustFlagCheck(CertsPlugin):
             logger.info("No OCSP configured, skipping OCSP System Cert Trust Flag check")
             return
 
+        audit_signing_nickname = ocsp.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = ocsp.find_system_certs()
 
         # Iterate on OCSP's all system certificate to check with list of expected trust flags
         for cert in certs:
             cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
 
             # Load cert trust from NSSDB
             with nssdb_connection(self.instance) as nssdb:
@@ -234,11 +255,18 @@ class TKSSystemCertTrustFlagCheck(CertsPlugin):
             logger.info("No TKS configured, skipping TKS System Cert Trust Flag check")
             return
 
+        audit_signing_nickname = tks.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = tks.find_system_certs()
 
         # Iterate on TKS's all system certificate to check with list of expected trust flags
         for cert in certs:
             cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
 
             # Load cert trust from NSSDB
             with nssdb_connection(self.instance) as nssdb:
@@ -296,11 +324,18 @@ class TPSSystemCertTrustFlagCheck(CertsPlugin):
             logger.info("No TPS configured, skipping TPS System Cert Trust Flag check")
             return
 
+        audit_signing_nickname = tps.config.get(
+            'log.instance.SignedAudit.signedAuditCertNickname')
+
         certs = tps.find_system_certs()
 
         # Iterate on TPS's all system certificate to check with list of expected trust flags
         for cert in certs:
             cert_id = cert['id']
+
+            # if audit signing nickname not configured, skip
+            if cert_id == 'audit_signing' and not audit_signing_nickname:
+                continue
 
             # Load cert trust from NSSDB
             with nssdb_connection(self.instance) as nssdb:

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -167,16 +167,23 @@ class CertFindCLI(pki.cli.CLI):
 
         for subsystem in instance.get_subsystems():
 
-            # Retrieve the subsystem's system certificate
-            certs = subsystem.find_system_certs()
+            # get cert tags in subsystem
+            cert_tags = subsystem.get_subsystem_certs()
 
-            # Iterate on all subsystem's system certificate to prepend subsystem name to the ID
-            for cert in certs:
+            for cert_tag in cert_tags:
 
+                # get cert config
+                cert = subsystem.get_cert_info(cert_tag)
+
+                # if nickname not available, skip
+                if not cert['nickname']:
+                    continue
+
+                # prepend subsystem name to cert tag creating global cert ID
                 if cert['id'] != 'sslserver' and cert['id'] != 'subsystem':
                     cert['id'] = subsystem.name + '_' + cert['id']
 
-                # Append only unique certificates to other subsystem certificate list
+                # if cert already processed, skip
                 if cert['id'] in results:
                     continue
 
@@ -186,6 +193,11 @@ class CertFindCLI(pki.cli.CLI):
                     first = False
                 else:
                     print()
+
+                # get cert info from NSS database
+                cert_info = subsystem.get_nssdb_cert_info(cert_tag)
+                if cert_info:
+                    cert.update(cert_info)
 
                 CertCLI.print_system_cert(cert, show_all)
 

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -888,21 +888,30 @@ class SubsystemCertFindCLI(pki.cli.CLI):
                          subsystem_name, instance_name)
             sys.exit(1)
 
-        certs = subsystem.get_cert_infos()
-
-        self.print_message('%s entries matched' % len(certs))
+        # get cert tags in subsystem
+        cert_tags = subsystem.get_subsystem_certs()
+        self.print_message('%s entries matched' % len(cert_tags))
 
         first = True
-        for cert in certs:
+        for cert_tag in cert_tags:
+
+            # get cert config
+            cert = subsystem.get_cert_info(cert_tag)
+            logger.info('  nickname: %s', cert['nickname'])
+
+            # if nickname not available, skip
+            if not cert['nickname']:
+                continue
+
             if first:
                 first = False
             else:
                 print()
 
-            if cert['nickname']:
-                cert_info = subsystem.get_nssdb_cert_info(cert['id'])
-                if cert_info:
-                    cert.update(cert_info)
+            # get cert info from NSS database
+            cert_info = subsystem.get_nssdb_cert_info(cert_tag)
+            if cert_info:
+                cert.update(cert_info)
 
             SubsystemCertCLI.print_subsystem_cert(cert, show_all)
 

--- a/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
+++ b/base/server/src/main/java/com/netscape/cmscore/apps/CMSEngine.java
@@ -1944,11 +1944,19 @@ public class CMSEngine {
                 throw new Exception("Missing " + id + ".cert.list in CS.cfg");
             }
 
+            LoggerConfig loggerConfig = config.getLoggingConfig().getLoggersConfig().getLoggerConfig("SignedAudit");
+            String auditSigningNickname = loggerConfig.getSignedAuditCertNickname();
+
             StringTokenizer tokenizer = new StringTokenizer(certlist, ",");
             while (tokenizer.hasMoreTokens()) {
                 String tag = tokenizer.nextToken();
                 tag = tag.trim();
                 logger.debug("CMSEngine: verifySystemCerts() cert tag=" + tag);
+
+                // if audit signing nickname not configured, skip
+                if ("audit_signing".equals(tag) && StringUtils.isEmpty(auditSigningNickname)) {
+                    continue;
+                }
 
                 if (!checkValidityOnly) {
                     verifySystemCertByTag(tag);


### PR DESCRIPTION
Previously the audit signing cert was always created by default during installation, but it's actually only used if log signing is enabled.

To reduce redundancies the default `pki_audit_signing_nickname` has been removed so that `pkispawn` will skip creating the audit signing cert if the nickname is not specified.

The selftest and `pki-healthcheck` have been modified to skip validating the audit signing cert if the nickname is not available.

The `pki-server cert-find` and `pki-server subsystem-cert-find` commands have also been modified to skip displaying the audit signing cert if the nickname is not available.

The basic tests of each subsystem have been updated to install the subsystem without the audit signing cert nickname so it will not create the cert. For basic CA test, it will later create the cert and enable log signing manually.

https://github.com/dogtagpki/pki/wiki/Enabling-Audit-Log-Signing
