### PR TITLE
Update installing with ldaps connection

### DIFF
--- a/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
@@ -6,6 +6,9 @@
 Follow this process to install a CA subsystem as clone of an existing CA subsystem with a secure database connection.
 
 Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+// when creating a clone DS, set self_sign_cert = False
+
+This section assumes that the existing CA has already been set up with LDAPS connection to its internal ldap database, and that the DS bootstrap server cert has not yet been replaced.
 
 == DS Configuration 
 
@@ -27,12 +30,13 @@ $ pki -d /etc/dirsrv/slapd-localhost \
 pkcs12-import --pkcs12-file ds_signing.p12 \
 --pkcs12-password Secret.123
 ....
-In the DS clone, create a DS server certificate as described in link:../others/enabling-ssl-connection-in-ds.adoc#creating-ds-server-certificate[Creating DS Server Certificate].
+In the DS clone, create a DS server certificate as described in xref:../others/enabling-ssl-connection-in-ds.adoc#creating-ds-server-certificate[Creating DS Server Certificate].
+
 Note that the certificate subject DN should match the clone's hostname ( i.e `--subject "CN=secondary.example.com"` ).
 
 Then enable the SSL connection as described in link:../others/enabling-ssl-connection-in-ds.adoc#enabling-ssl-connection[Enabling SSL Connection].
 
-After the successful DS restart, Export the DS Signing Certificate into 'ds_signing.crt' as described in link:../others/exporting-ds-certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
+After the successful DS restart, Export the DS Signing Certificate into `ds_signing.crt` as described in link:../others/exporting-ds-certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
 
 Some useful tips:
 

--- a/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
@@ -8,11 +8,13 @@ Follow this process to install a CA subsystem with a secure database connection.
 Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration 
-Once the prerequisites listed above are completed, enable the SSL connection with a self-signed signing certificate as described in
-link:../others/enabling-ssl-connection-in-ds.adoc#enabling-ssl-connection[Enabling SSL Connection].
 
-Then export the signing certificate into `ds_signing.crt` as described in
+If you had followed link:../others/installation-prerequisites.adoc[Installation Prerequisites] and set up a LDAP database with SSL connection, simply
+export the bootstrap signing certificate into `ds_signing.crt` as described in
 link:../others/exporting-ds-certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
+
+//If you did not set up secure LDAP and wish to enable the SSL connection, follow the instructions described in 
+//link:../others/enabling-ssl-connection-in-ds.adoc#enabling-ssl-connection[Enabling SSL Connection].
 
 == CA Subsystem Installation 
 Prepare a deployment configuration, for example `ca-secure-ds.cfg`, to deploy CA subsystem.

--- a/docs/installation/others/creating-ds-instance.adoc
+++ b/docs/installation/others/creating-ds-instance.adoc
@@ -5,13 +5,16 @@
 //
 = Directory Server Instance Creation 
 
-*Note: Prior to installing DS instances, make sure the procedure for link:installing-ds-packages.adoc[installing DS packages] has been performed on the host system.*
+*Note: Prior to installing DS instances, make sure the following procedures are done:*
+
+* link:installing-ds-packages.adoc[installing DS packages] - done on the DS host system
+* link:fqdn-configuration.adoc[Setting the FQDN of the host system] - done on the host systems of DS and PKI
 
 Follow this process to prepare a local DS instance for PKI server.
 
-Normally the DS installation will automatically generate a self-signed signing certificate and a server certificate for SSL connection.
-In this procedure the certificate generation and the SSL connection is disabled by default,
-but it can be enabled after installation if necessary.
+*Note:* The DS installation automatically generates a bootstrap self-signed signing certificate and a bootstrap server certificate for SSL connection. If desired, the bootstrap server certificate could be replaced by a server certificate issued by a CA at a later step.
+
+_If you wish to have the certificate generation and the SSL connection disabled (*such as for the case of creating a DS instance for a pki clone*), set `self_sign_cert = False` in the `sed` command below. You can still enable SSL later by following link:enabling-ssl-connection-in-ds.adoc[Enabling SSL Connection in DS]._
 
 == Creating a DS Instance 
 
@@ -29,7 +32,7 @@ $ sed -i \
     -e "s/;root_password = .*/root_password = Secret.123/g" \
     -e "s/;suffix = .*/suffix = dc=example,dc=com/g" \
     -e "s/;create_suffix_entry = .*/create_suffix_entry = True/g" \
-    -e "s/;self_sign_cert = .*/self_sign_cert = False/g" \
+    -e "s/;self_sign_cert = .*/self_sign_cert = True/g" \
     ds.inf
 ----
 
@@ -37,8 +40,8 @@ where
 
 * *instance_name* specifies the name of the DS instance. In this example it's set to `localhost`.
 * *root_password* specifies the password for DS admin (i.e. `cn=Directory Manager`). In this example it's set to `Secret.123`.
-* *suffix* specifies the namespace for the DS instance. In this example it's set to `dc=example,dc=com`.
-* *self_sign_cert* specifies whether to create self-signed certificates for SSL connection. In this example it's set to `False`. The SSL connection can be enabled after installation in link:https://github.com/dogtagpki/389-ds-base/wiki/Configuring-SSL-Connection.adoc[this document].
+* *suffix* specifies the namespace for the DS instance. In this example it's set to `dc=example,dc=com`. *It is important that the `suffix` and the host FQDN matches*.
+* *self_sign_cert* specifies whether to create self-signed certificates for SSL connection. In this example it's set to `True`. The SSL connection is enabled.
 
 For more information see the parameter descriptions in the DS configuration file itself (i.e. `ds.inf`) and in link:https://directory.fedoraproject.org/docs/389ds/design/dsadm-dsconf.html[DS documentation].
 
@@ -66,9 +69,8 @@ The subtree for each PKI subsystem is created when the subsystem is installed. S
 
 == Enabling SSL Connection 
 
-If required, PKI can use SSL connection to DS.
-
-To enable SSL connection in DS, see link:../others/enabling-ssl-connection-in-ds.adoc[Enabling SSL Connection in DS].
+If you set `self_sign_cert = False` earlier, and are now ready to have your PKI configured to use SSL connection to DS,
+follow link:../others/enabling-ssl-connection-in-ds.adoc[Enabling SSL Connection in DS]
 
 == Configuring Replication 
 
@@ -90,10 +92,6 @@ DS log files are available in `/var/log/dirsrv/slapd-localhost`:
 * audit
 * errors
 
-== See Also 
+== See Also
 
-* link:https://www.dogtagpki.org/wiki/DS[DS]
-* link:https://www.dogtagpki.org/wiki/DS_SSL[DS SSL]
-* link:https://www.dogtagpki.org/wiki/PKI_LDAP[PKI LDAP]
-* link:Enabling-SSL-Connection-with-Internal-Database[Enabling SSL Connection with Internal Database]
-* link:https://directory.fedoraproject.org[389 Directory Server]
+* link:https://www.port389.org/docs/389ds/howto/howto-ssl.html[Configuring TLS/SSL Enabled 389 Directory Server]

--- a/docs/installation/others/enabling-ssl-connection-in-ds.adoc
+++ b/docs/installation/others/enabling-ssl-connection-in-ds.adoc
@@ -1,22 +1,19 @@
-:_mod-docs-content-type: PROCEDURE
-
-[id="enabling-ssl-connection-in-ds_{context}"]
 // This content was copied and adjusted from https://github.com/dogtagpki/pki/wiki/Enabling-SSL-Connection-in-DS
 = Enabling SSL Connection in DS 
 
-Follow this process to enable SSL connection in DS
-using a self-signed signing certificate and server certificate
-created using link:PKI-NSS-CLI.adoc[PKI NSS CLI] commands.
+Follow this process using link:PKI-NSS-CLI.adoc[PKI NSS CLI] commands to enable SSL connection in DS
+using the DS bootstrap self-signed signing certificate and the bootstrap server certificate.
 
 This section assumes that a DS instance named `localhost` already exists,
 it does not have certificates, and the SSL connection is disabled.
 
-*Note:* In newer DS versions the certificates are created and the SSL connection is enabled by default,
-so it's not necessary to follow this procedure.
+*Note:* In newer DS versions the certificates are created and the SSL connection is enabled by default. Therefore, _you only need to follow this procedure if you had chosen to set `self_sign_cert = False` earlier_.
 
 == Creating DS Signing Certificate 
 
-First, generate DS signing CSR with the following command:
+If you already have a DS self-signed signing certificate, you can skip this step, and go directly to *Creating DS Server Certificate*.
+
+Generate DS signing CSR with the following command:
 
 ----
 $ pki \

--- a/docs/installation/others/exporting-ds-certificates.adoc
+++ b/docs/installation/others/exporting-ds-certificates.adoc
@@ -4,8 +4,7 @@
 // initial content copied from https://github.com/dogtagpki/pki/wiki/Exporting-DS-Certificates
 = Exporting DS Certificates 
 
-
-Follow this process to export the signing certificate and the server certificate from the NSS database of a DS instance.
+Follow this process to export the DS bootstrap signing certificate and the server certificate from the NSS database of a DS instance.
 
 By default the certificates are generated automatically during installation,
 but they can also be created after installation.


### PR DESCRIPTION
- use default ds bootstrap self-signed cert and server-cert with ldaps enabled
- bound by the pkispawn cfg files hardcoded with the ds bootstrap certs, did not add steps to replace the ds server cert (only mentioned the possibility)
- links to external web pages still exist

[skip ci]