### PR TITLE
Fix build failure

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -3,7 +3,7 @@ name: ACME Tests
 on: [push, pull_request]
 
 env:
-  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:latest' }}
+  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:41' }}
   COPR_REPO: ${{ vars.COPR_REPO }}
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build PKI
 on: [push, pull_request]
 
 env:
-  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:latest' }}
+  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:41' }}
   COPR_REPO: ${{ vars.COPR_REPO }}
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || 'dogtagpki' }}
 

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -3,7 +3,7 @@ name: IPA Tests
 on: [push, pull_request]
 
 env:
-  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:latest' }}
+  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:41' }}
   COPR_REPO: ${{ vars.COPR_REPO }}
 
 jobs:

--- a/.github/workflows/sonarcloud-pull.yml
+++ b/.github/workflows/sonarcloud-pull.yml
@@ -6,7 +6,7 @@ on:
       - completed
 
 env:
-  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:latest' }}
+  BASE_IMAGE: ${{ vars.BASE_IMAGE || 'registry.fedoraproject.org/fedora:41' }}
   COPR_REPO: ${{ vars.COPR_REPO }}
   NAMESPACE: ${{ vars.REGISTRY_NAMESPACE || 'dogtagpki' }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG COMPONENT="dogtag-pki"
 ARG LICENSE="GPLv2 and LGPLv2"
 ARG ARCH="x86_64"
 ARG VERSION="0"
-ARG BASE_IMAGE="registry.fedoraproject.org/fedora:latest"
+ARG BASE_IMAGE="registry.fedoraproject.org/fedora:41"
 ARG COPR_REPO=""
 ARG BUILD_OPTS=""
 
@@ -48,7 +48,7 @@ WORKDIR /root/pki
 # Install PKI build dependencies
 RUN dnf install -y rpm-build \
     && dnf builddep -y --skip-unavailable pki.spec \
-    && rpm -e --nodeps $(rpm -qa | grep -E "^dogtag-|^python3-dogtag-") \
+    && dnf remove -y dogtag-* python3-dogtag-* \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
@@ -58,10 +58,10 @@ FROM pki-builder-deps AS pki-builder
 ARG BUILD_OPTS
 
 # Import JSS packages
-COPY --from=quay.io/dogtagpki/jss-dist:latest /root/RPMS /tmp/RPMS/
+COPY --from=quay.io/dogtagpki/jss-dist:5.6 /root/RPMS /tmp/RPMS/
 
 # Import LDAP SDK packages
-COPY --from=quay.io/dogtagpki/ldapjdk-dist:latest /root/RPMS /tmp/RPMS/
+COPY --from=quay.io/dogtagpki/ldapjdk-dist:5.6 /root/RPMS /tmp/RPMS/
 
 # Install build dependencies
 RUN dnf install -y /tmp/RPMS/* \
@@ -86,10 +86,10 @@ COPY --from=pki-builder /root/pki/build/RPMS /root/RPMS/
 FROM pki-deps AS pki-runner
 
 # Import JSS packages
-COPY --from=quay.io/dogtagpki/jss-dist:latest /root/RPMS /tmp/RPMS/
+COPY --from=quay.io/dogtagpki/jss-dist:5.6 /root/RPMS /tmp/RPMS/
 
 # Import LDAP SDK packages
-COPY --from=quay.io/dogtagpki/ldapjdk-dist:latest /root/RPMS /tmp/RPMS/
+COPY --from=quay.io/dogtagpki/ldapjdk-dist:5.6 /root/RPMS /tmp/RPMS/
 
 # Import PKI packages
 COPY --from=pki-dist /root/RPMS /tmp/RPMS/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
         import os
         import re
 
-        value = os.getenv('BASE_IMAGE', 'registry.fedoraproject.org/fedora:latest')
+        value = os.getenv('BASE_IMAGE', 'registry.fedoraproject.org/fedora:41')
         print('BASE_IMAGE: {value}'.format(value=value))
         print('##vso[task.setvariable variable=BASE_IMAGE]{value}'.format(value=value))
 
@@ -30,7 +30,7 @@ jobs:
       docker build \
           --build-arg BASE_IMAGE=$BASE_IMAGE \
           --target pki-base \
-          --tag pki-base:latest \
+          --tag pki-base:11.6 \
           .
 
       docker run \
@@ -38,7 +38,7 @@ jobs:
           -v $BUILD_SOURCESDIRECTORY:/root/src \
           --privileged \
           --detach \
-          pki-base:latest
+          pki-base:11.6
 
       while :
       do
@@ -54,11 +54,11 @@ jobs:
       docker exec runner dnf install -y dnf-plugins-core rpm-build
       if [ -n "$COPR_REPO" ]; then docker exec runner dnf copr enable -y $COPR_REPO; fi
 
-      docker create --name=jss-dist quay.io/$NAMESPACE/jss-dist:latest
+      docker create --name=jss-dist quay.io/$NAMESPACE/jss-dist:5.6
       docker cp jss-dist:/root/RPMS/. /tmp/RPMS
       docker rm -f jss-dist
 
-      docker create --name=ldapjdk-dist quay.io/$NAMESPACE/ldapjdk-dist:latest
+      docker create --name=ldapjdk-dist quay.io/$NAMESPACE/ldapjdk-dist:5.6
       docker cp ldapjdk-dist:/root/RPMS/. /tmp/RPMS
       docker rm -f ldapjdk-dist
 

--- a/base/acme/Dockerfile
+++ b/base/acme/Dockerfile
@@ -5,7 +5,7 @@
 #
 # https://docs.fedoraproject.org/en-US/containers/guidelines/guidelines/
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:41
 
 ARG NAME="pki-acme"
 ARG SUMMARY="Dogtag PKI ACME Responder"

--- a/base/ca/Dockerfile
+++ b/base/ca/Dockerfile
@@ -5,7 +5,7 @@
 #
 # https://docs.fedoraproject.org/en-US/containers/guidelines/guidelines/
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:41
 
 ARG NAME="pki-ca"
 ARG SUMMARY="Dogtag PKI Certificate Authority"


### PR DESCRIPTION
The `Dockerfile` has been modified to use `dnf` instead of `rpm` to remove existing Dogtag packages since it will work even if it does not find any package to remove.

The `Dockerfile`, Azure pipelines, and GH workflows have also been updated to use the proper Fedora, JSS, and LDAP SDK versions for PKI 11.6.