### PR TITLE
Cover two conditions:

### DIFF
--- a/docs/installation/others/creating-ds-instance.adoc
+++ b/docs/installation/others/creating-ds-instance.adoc
@@ -5,13 +5,16 @@
 //
 = Directory Server Instance Creation 
 
-*Note: Prior to installing DS instances, make sure the procedure for link:installing-ds-packages.adoc[installing DS packages] has been performed on the host system.*
+*Note: Prior to installing DS instances, make sure the following procedures are done:*
+
+* link:installing-ds-packages.adoc[installing DS packages] - done on the DS host system
+* link:fqdn-configuration.adoc[Setting the FQDN of the host system] - done on the host systems of DS and PKI
 
 Follow this process to prepare a local DS instance for PKI server.
 
-Normally the DS installation will automatically generate a self-signed signing certificate and a server certificate for SSL connection.
-In this procedure the certificate generation and the SSL connection is disabled by default,
-but it can be enabled after installation if necessary.
+*Note:* The DS installation automatically generates a temporary bootstrap self-signed signing certificate which issues a temporary bootstrap server certificate for SSL connection. The PKI installation takes advantage of this security offer to complete its installation. The temporary bootstrap server certificate could be replaced by a server certificate issued by an actual CA at a later step after the installation.
+
+_If you wish to have the temporary certificate generation and the SSL connection disabled, set `self_sign_cert = False` in the `sed` command below. You can still enable SSL later by following link:enabling-temp-ssl-connection-in-ds.adoc[Enabling SSL Connection in DS]._
 
 == Creating a DS Instance 
 
@@ -29,7 +32,7 @@ $ sed -i \
     -e "s/;root_password = .*/root_password = Secret.123/g" \
     -e "s/;suffix = .*/suffix = dc=example,dc=com/g" \
     -e "s/;create_suffix_entry = .*/create_suffix_entry = True/g" \
-    -e "s/;self_sign_cert = .*/self_sign_cert = False/g" \
+    -e "s/;self_sign_cert = .*/self_sign_cert = True/g" \
     ds.inf
 ----
 
@@ -38,7 +41,7 @@ where
 * *instance_name* specifies the name of the DS instance. In this example it's set to `localhost`.
 * *root_password* specifies the password for DS admin (i.e. `cn=Directory Manager`). In this example it's set to `Secret.123`.
 * *suffix* specifies the namespace for the DS instance. In this example it's set to `dc=example,dc=com`.
-* *self_sign_cert* specifies whether to create self-signed certificates for SSL connection. In this example it's set to `False`. The SSL connection can be enabled after installation in link:https://github.com/dogtagpki/389-ds-base/wiki/Configuring-SSL-Connection.adoc[this document].
+* *self_sign_cert* specifies whether to create self-signed certificates for SSL connection. In this example it's set to `True`. The SSL connection is enabled.
 
 For more information see the parameter descriptions in the DS configuration file itself (i.e. `ds.inf`) and in link:https://directory.fedoraproject.org/docs/389ds/design/dsadm-dsconf.html[DS documentation].
 
@@ -66,9 +69,10 @@ The subtree for each PKI subsystem is created when the subsystem is installed. S
 
 == Enabling SSL Connection 
 
-If required, PKI can use SSL connection to DS.
+If you set `self_sign_cert = False` earlier, and now decide to create temporary certs so that your PKI can be installed using SSL connection to DS,
+follow link:../others/enabling-temp-ssl-connection-in-ds.adoc[Enabling SSL Connection in DS]
 
-To enable SSL connection in DS, see link:../others/enabling-ssl-connection-in-ds.adoc[Enabling SSL Connection in DS].
+*Note:* The temporary bootstrap server certificate could be replaced by a server certificate issued by an actual CA at a later step after the installation.
 
 == Configuring Replication 
 
@@ -90,10 +94,6 @@ DS log files are available in `/var/log/dirsrv/slapd-localhost`:
 * audit
 * errors
 
-== See Also 
+== See Also
 
-* link:https://www.dogtagpki.org/wiki/DS[DS]
-* link:https://www.dogtagpki.org/wiki/DS_SSL[DS SSL]
-* link:https://www.dogtagpki.org/wiki/PKI_LDAP[PKI LDAP]
-* link:Enabling-SSL-Connection-with-Internal-Database[Enabling SSL Connection with Internal Database]
-* link:https://directory.fedoraproject.org[389 Directory Server]
+* link:https://www.port389.org/docs/389ds/howto/howto-ssl.html[Configuring TLS/SSL Enabled 389 Directory Server]

--- a/docs/installation/others/enabling-ssl-connection-in-ds.adoc
+++ b/docs/installation/others/enabling-ssl-connection-in-ds.adoc
@@ -1,103 +1,72 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="enabling-ssl-connection-in-ds_{context}"]
-// This content was copied and adjusted from https://github.com/dogtagpki/pki/wiki/Enabling-SSL-Connection-in-DS
+
 = Enabling SSL Connection in DS 
 
-Follow this process to enable SSL connection in DS
-using a self-signed signing certificate and server certificate
-created using link:PKI-NSS-CLI.adoc[PKI NSS CLI] commands.
+Follow this process using `pki` CLI (run `man pki-client`) commands to enable SSL connection in DS.
 
 This section assumes that a DS instance named `localhost` already exists,
-it does not have certificates, and the SSL connection is disabled.
 
-*Note:* In newer DS versions the certificates are created and the SSL connection is enabled by default,
-so it's not necessary to follow this procedure.
+Two conditions are covered by this section:
 
-== Creating DS Signing Certificate 
+* The DS instance does not already have any SSL server certificate, temporary or otherwise, and it is time to create an actual server cert for it.
+* The DS instance has a temporary SSL server certificate, and it is time to replace it.
 
-First, generate DS signing CSR with the following command:
+It is assumed that an actual trusted CA is available for issuing certificates.
 
-----
-$ pki \
-    -d /etc/dirsrv/slapd-localhost \
-    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
-    nss-cert-request \
-    --subject "CN=DS Signing Certificate" \
-    --ext /usr/share/pki/server/certs/ca_signing.conf \
-    --csr ds_signing.csr
-----
+== Import the CA signing certificate
+Import the CA signing cert into the nssdb of the DS instance.
 
-Next, issue DS signing certificate:
-
-----
-$ pki \
-    -d /etc/dirsrv/slapd-localhost \
-    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
-    nss-cert-issue \
-    --csr ds_signing.csr \
-    --ext /usr/share/pki/server/certs/ca_signing.conf \
-    --cert ds_signing.crt
-----
-
-Finally, import DS signing certificate:
-
-----
-$ pki \
+[literal,subs="+quotes,verbatim"]
+....
+# pki \
     -d /etc/dirsrv/slapd-localhost \
     -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
     nss-cert-import \
-    --cert ds_signing.crt \
+    --cert ca_signing.crt \
     --trust CT,C,C \
-    Self-Signed-CA
-----
-
-To verify the DS signing certificate:
-
-----
-$ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA
-...
-    Certificate Trust Flags:
-        SSL Flags:
-            Valid CA
-            Trusted CA
-            User
-            Trusted Client CA
-        Email Flags:
-            Valid CA
-            Trusted CA
-            User
-        Object Signing Flags:
-            Valid CA
-            Trusted CA
-            User
-----
+    "CA Signing Cert"
+....
 
 == Creating DS Server Certificate 
 
-First, generate DS server CSR with the following command:
+=== Generate DS server CSR
+
+As a DS administrator:
 
 ----
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
     -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
     nss-cert-request \
-    --subject "CN=$HOSTNAME" \
-    --ext /usr/share/pki/server/certs/sslserver.conf \
+    --subject "CN=server.example.com" \
+    --subjectAltName "critical, DNS:server.example.com" \
     --csr ds_server.csr
 ----
 
-Next, issue DS server certificate:
+=== Submit DS Server Certificate Request:
+
+As a DS admin:
 
 ----
-$ pki \
-    -d /etc/dirsrv/slapd-localhost \
-    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
-    nss-cert-issue \
-    --issuer Self-Signed-CA \
-    --csr ds_server.csr \
-    --ext /usr/share/pki/server/certs/sslserver.conf \
-    --cert ds_server.crt
+$ pki ca-cert-request-submit --profile caServerCert --csr-file ds_server.csr
+----
+
+=== Approve the Certificate Request:
+
+As a PKI agent:
+
+----
+$ pki -n caadmin ca-cert-request-review <request ID> --action approve
+----
+
+== Retrieve and Import the Certificate
+
+Retrieve the cert as the DS admin user:
+
+----
+$  pki ca-cert-export <certificate ID> --output-file ds_server.crt
 ----
 
 Finally, import DS server certificate:

--- a/docs/installation/others/enabling-temp-ssl-connection-in-ds.adoc
+++ b/docs/installation/others/enabling-temp-ssl-connection-in-ds.adoc
@@ -1,0 +1,161 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="enabling-temp-ssl-connection-in-ds_{context}"]
+
+// This content was copied and adjusted from https://github.com/dogtagpki/pki/wiki/Enabling-SSL-Connection-in-DS
+
+= Enabling Temporary SSL Connection in DS 
+
+*If you already have an active trusted CA, and you wish to issue a server cert for your DS, please follow link:enabling-ssl-connection-in-ds.adoc[this section] instead.*
+
+Follow this process using `pki` CLI (run `man pki-client`) commands to enable SSL connection in DS
+by creating a temporary DS bootstrap self-signed signing certificate and the bootstrap server certificate issued by it.
+
+This section assumes that a DS instance named `localhost` already exists,
+it does not have certificates, and the SSL connection is disabled.
+
+*Note:* In newer DS versions the certificates are created and the SSL connection is enabled by default,
+so in general it is not necessary to follow this procedure.
+
+== Creating DS Signing Certificate 
+
+First, generate DS signing CSR with the following command:
+
+----
+$ pki \
+    -d /etc/dirsrv/slapd-localhost \
+    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    nss-cert-request \
+    --subject "CN=DS Signing Certificate" \
+    --ext /usr/share/pki/server/certs/ca_signing.conf \
+    --csr ds_signing.csr
+----
+
+Next, issue DS signing certificate:
+
+----
+$ pki \
+    -d /etc/dirsrv/slapd-localhost \
+    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    nss-cert-issue \
+    --csr ds_signing.csr \
+    --ext /usr/share/pki/server/certs/ca_signing.conf \
+    --cert ds_signing.crt
+----
+
+Finally, import DS signing certificate:
+
+----
+$ pki \
+    -d /etc/dirsrv/slapd-localhost \
+    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    nss-cert-import \
+    --cert ds_signing.crt \
+    --trust CT,C,C \
+    Self-Signed-CA
+----
+
+To verify the DS signing certificate:
+
+----
+$ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA
+...
+    Certificate Trust Flags:
+        SSL Flags:
+            Valid CA
+            Trusted CA
+            User
+            Trusted Client CA
+        Email Flags:
+            Valid CA
+            Trusted CA
+            User
+        Object Signing Flags:
+            Valid CA
+            Trusted CA
+            User
+----
+
+== Creating DS Server Certificate 
+
+First, generate DS server CSR with the following command:
+
+----
+$ pki \
+    -d /etc/dirsrv/slapd-localhost \
+    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    nss-cert-request \
+    --subject "CN=$HOSTNAME" \
+    --subjectAltName "critical, DNS:$HOSTNAME" \
+    --ext /usr/share/pki/server/certs/sslserver.conf \
+    --csr ds_server.csr
+----
+
+Next, issue DS server certificate:
+
+----
+$ pki \
+    -d /etc/dirsrv/slapd-localhost \
+    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    nss-cert-issue \
+    --issuer Self-Signed-CA \
+    --csr ds_server.csr \
+    --ext /usr/share/pki/server/certs/sslserver.conf \
+    --cert ds_server.crt
+----
+
+Finally, import DS server certificate:
+
+----
+$ pki \
+    -d /etc/dirsrv/slapd-localhost \
+    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    nss-cert-import \
+    --cert ds_server.crt \
+    Server-Cert
+----
+
+To verify the DS server certificate:
+
+----
+$ certutil -L -d /etc/dirsrv/slapd-localhost -n Server-Cert
+...
+    Certificate Trust Flags:
+        SSL Flags:
+            User
+        Email Flags:
+            User
+        Object Signing Flags:
+            User
+----
+
+== Enabling SSL Connection 
+
+To enable SSL connection in the DS instance:
+
+----
+$ dsconf localhost config replace nsslapd-security=on
+----
+
+Finally, restart the DS instance:
+
+----
+$ dsctl localhost restart
+----
+
+To verify the SSL connection:
+
+----
+$ LDAPTLS_REQCERT=never ldapsearch \
+    -H ldaps://$HOSTNAME:636 \
+    -x \
+    -D "cn=Directory Manager" \
+    -w Secret.123 \
+    -b "" \
+    -s base
+----
+
+== See Also 
+
+* link:https://www.port389.org/docs/389ds/howto/howto-ssl.html[Configuring TLS/SSL Enabled 389 Directory Server]
+* link:https://access.redhat.com/documentation/en-us/red_hat_directory_server/11/html/administration_guide/enabling_tls#doc-wrapper[RHDS 11: Enabling TLS]


### PR DESCRIPTION
- using ds bootstrap certs
- using certs issued by a real CA

These are meant to be used bo the files in pki/docs/installation [skip ci]