### PR TITLE
Convert TPSClientCLI.invokeOperation() to Java

### DIFF
--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -292,6 +292,37 @@ jobs:
           # restart TPS subsystem
           docker exec pki pki-server tps-redeploy --wait
 
+      - name: Check pki tps-client
+        run: |
+          cat > script << EOF
+          op=help
+
+          op=var_set name=ra_host value=pki.example.com
+          op=var_set name=ra_port value=8080
+          op=var_set name=ra_uri value=/tps/tps
+          op=var_list
+
+          op=token_set cuid=ef890c6baf38e41a5cac
+          op=token_set msn=01020304
+          op=token_set app_ver=6FBBC105
+          op=token_set key_info=0101
+          op=token_set major_ver=0
+          op=token_set minor_ver=0
+          op=token_set auth_key=404142434445464748494a4b4c4d4e4f
+          op=token_set mac_key=404142434445464748494a4b4c4d4e4f
+          op=token_set kek_key=404142434445464748494a4b4c4d4e4f
+          op=token_status
+
+          op=exit
+          EOF
+
+          cat script | docker exec -i pki pki tps-client
+
+      - name: Check tpsclient
+        run: |
+          # ignore return code
+          cat script | docker exec -i pki tpsclient || true
+
       - name: Add token for testuser1
         run: |
           hexdump -v -n "10" -e '1/1 "%02x"' /dev/urandom > cuid

--- a/base/tools/src/main/java/com/netscape/cmstools/tps/TPSClientCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tps/TPSClientCLI.java
@@ -60,11 +60,69 @@ public class TPSClientCLI extends CommandCLI {
     public native long createClient() throws Exception;
     public native void removeClient(long client) throws Exception;
 
-    public native void invokeOperation(
+    public native boolean getOldStyle(long client) throws Exception;
+    public native void setOldStyle(long client, boolean value) throws Exception;
+
+    public native void displayHelp(long client) throws Exception;
+    public native void formatToken(long client, Map<String, String> params) throws Exception;
+    public native void resetPIN(long client, Map<String, String> params) throws Exception;
+    public native void enrollToken(long client, Map<String, String> params) throws Exception;
+    public native void displayToken(long client, Map<String, String> params) throws Exception;
+    public native void setupToken(long client, Map<String, String> params) throws Exception;
+
+    public native void setupDebug(long client, Map<String, String> params) throws Exception;
+    public native void setVariable(long client, Map<String, String> params) throws Exception;
+    public native void displayVariable(long client, Map<String, String> params) throws Exception;
+    public native void listVariables(long client) throws Exception;
+
+    public void invokeOperation(
             long client,
             String op,
             Map<String, String> params)
-            throws Exception;
+            throws Exception {
+
+        String value = params.get("max_ops");
+        int maxOps = value == null ? 0 : Integer.parseInt(value);
+
+        if (maxOps != 0) {
+            setOldStyle(client, false);
+        }
+
+        if ("help".equals(op)) {
+            displayHelp(client);
+
+        } else if ("ra_format".equals(op)) {
+            formatToken(client, params);
+
+        } else if ("ra_reset_pin".equals(op)) {
+            resetPIN(client, params);
+
+        } else if ("ra_enroll".equals(op)) {
+            enrollToken(client, params);
+
+        } else if ("token_status".equals(op)) {
+            displayToken(client, params);
+
+        } else if ("token_set".equals(op)) {
+            setupToken(client, params);
+
+        } else if ("debug".equals(op)) {
+            setupDebug(client, params);
+
+        } else if ("var_set".equals(op)) {
+            setVariable(client, params);
+
+        } else if ("var_get".equals(op)) {
+            displayVariable(client, params);
+
+        } else if ("var_list".equals(op)) {
+            listVariables(client);
+
+        } else {
+            logger.error("Unsupported operation: " + op);
+            // continue to the next operation
+        }
+    }
 
     @Override
     public void execute(CommandLine cmd) throws Exception {

--- a/base/tools/src/main/native/tpsclient/src/include/main/RA_Client.h
+++ b/base/tools/src/main/native/tpsclient/src/include/main/RA_Client.h
@@ -68,10 +68,10 @@ class RA_Client
 	  int OpExit(NameValueSet *set);
   public:
 	  void Debug(const char *func_name, const char *fmt, ...);
-	  void InvokeOperation(char *op, NameValueSet *set);
   public:
 	  RA_Token m_token;
 	  NameValueSet m_vars;
+	  PRBool old_style = PR_TRUE;
 };
 
 #endif /* RA_CLIENT_H */

--- a/base/tps/bin/pki-tps-enroll
+++ b/base/tps/bin/pki-tps-enroll
@@ -73,8 +73,12 @@ op=var_set name=ra_host value=$TPS_HOSTNAME
 op=var_set name=ra_port value=$TPS_PORT
 op=var_set name=ra_uri value=$TPS_PATH
 
-op=token_set cuid=$CUID msn=$MSN app_ver=$APP_VERSION key_info=$KEY_INFO major_ver=$MAJOR_VERSION minor_ver=$MINOR_VERSION
-
+op=token_set cuid=$CUID
+op=token_set msn=$MSN
+op=token_set app_ver=$APP_VERSION
+op=token_set key_info=$KEY_INFO
+op=token_set major_ver=$MAJOR_VERSION
+op=token_set minor_ver=$MINOR_VERSION
 op=token_set auth_key=$AUTH_KEY
 op=token_set mac_key=$MAC_KEY
 op=token_set kek_key=$KEK_KEY

--- a/base/tps/bin/pki-tps-format
+++ b/base/tps/bin/pki-tps-format
@@ -71,8 +71,12 @@ op=var_set name=ra_host value=$TPS_HOSTNAME
 op=var_set name=ra_port value=$TPS_PORT
 op=var_set name=ra_uri value=$TPS_PATH
 
-op=token_set cuid=$CUID msn=$MSN app_ver=$APP_VERSION key_info=$KEY_INFO major_ver=$MAJOR_VERSION minor_ver=$MINOR_VERSION
-
+op=token_set cuid=$CUID
+op=token_set msn=$MSN
+op=token_set app_ver=$APP_VERSION
+op=token_set key_info=$KEY_INFO
+op=token_set major_ver=$MAJOR_VERSION
+op=token_set minor_ver=$MINOR_VERSION
 op=token_set auth_key=$AUTH_KEY
 op=token_set mac_key=$MAC_KEY
 op=token_set kek_key=$KEK_KEY


### PR DESCRIPTION
The `TPSClientCLI.invokeOperation()` has been converted into Java which will use native methods to call `RA_Client` methods. The `RA_Client::InvokeOperation()` has been moved to `tpsclient.cpp`. The `old_style` variable has been moved into `RA_Client` class to make it more accessible.

The basic TPS test has been updated to test basic operations using `pki tps-client` and `tpsclient`.