### PR TITLE
Fix: RHCS-5675

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3042,7 +3042,7 @@ class PKIDeployer:
             if not request.systemCert.keySize:
                 request.systemCert.keySize = subsystem.config['keys.rsa.keysize.default']
 
-            if tag == 'transport' or tag == 'storage':
+            if tag == 'transport' or tag == 'storage' or tag == 'subsystem':
                 request.systemCert.keyWrap = True
             else:
                 request.systemCert.keyWrap = False


### PR DESCRIPTION
Bug 2351094 - TPS subsystem cert unable to unwrap shared secret and TPS install fails with pki_import_shared_secret=True config.

This fix allows the auto imporation of the shared secret into TPS when using the HSM to succeed.

Change-Id: I0259e2dbe49c042598e018ec5a3a8e8834c3f9e8