### PR TITLE
ldaps-related setup cleanup, including:

### DIFF
--- a/docs/installation/ca/installing-ca-clone-with-ldaps-using-bootstrap-ds-certs.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-using-bootstrap-ds-certs.adoc
@@ -1,21 +1,42 @@
-// This original content was copied to installing-ca-clone-with-temp-ldaps-connection.adoc
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-clone-with-ldaps-connection_{context}"]
-= Installing CA Clone with LDAPS Connection 
+[id="installing-ca-clone-with-ldaps-using-bootstrap-ds-certs_{context}"]
+= Installing CA Clone with LDAPS Using Bootstrap DS Certs
 
-Follow this process to install a CA subsystem as clone of an existing CA subsystem with a secure database connection.
+Follow this process to install a CA subsystem as clone of an existing CA subsystem that runs with a bootstrap SSL server certificate.
 
 Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration 
 
-Once the prerequisites listed above are completed on the clone system, follow the procedure to xref:../others/enabling-ssl-connection-in-ds.adoc[enable SSL Connection with DS] so that the CA clone's DS is running with SSL enabled wtih a real server certificate issued by the CA.
+Once the prerequisites listed above are completed on the clone system, go on the existing system and export the DS signing certificate into `ds_signing.p12` and copy the certificate into clone system with the following command:
+
+[literal,subs="+quotes,verbatim"]
+....
+$ pki -d /etc/dirsrv/slapd-localhost \
+-C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+pkcs12-export --pkcs12-file ds_signing.p12 \
+--pkcs12-password Secret.123 Self-Signed-CA
+....
+Import the `ds_signing.p12` into the clone DS instance with the following command:
+
+[literal,subs="+quotes,verbatim"]
+....
+$ pki -d /etc/dirsrv/slapd-localhost \
+-C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+pkcs12-import --pkcs12-file ds_signing.p12 \
+--pkcs12-password Secret.123
+....
+In the DS clone, create a boostrap DS server certificate as described in xref:../others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Creating DS Server Certificate].
+Note that the certificate subject DN should match the clone's hostname ( i.e `--subject "CN=secondary.example.com"` ).
+
+Then enable the SSL connection as described in xref:../others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Enabling SSL Connection].
+
+After the successful DS restart, export the DS Signing Certificate into 'ds_signing.crt' as described in link:../others/exporting-ds-certificates.adoc[Exporting DS Signing Certificate].
 
 Some useful tips:
 
- - Make sure the firewall on the master allows external access to LDAP from the clone
- - Make sure the firewall on the clone allows external access to LDAP from the master
+ - Make sure the DS firewall allows access from PKI server and other DS instances.
  - Not having a `dc=pki,dc=example,dc=com` entry in LDAP will give the same error as
        not being able to connect to the LDAP server.
 
@@ -69,15 +90,6 @@ $ chown pkiuser:pkiuser ca-certs.p12
 
 Prepare a deployment configuration, for example `ca-secure-ds-secondary.cfg`, to deploy CA subsystem clone.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
-
-*Note:* The sample pkispawn config file referenced below expects the DS server certificate's signing certificate to be in a file named ds_signing.crt.  Since we are using the existing CA as the signing cert, copy the CA's signing cert into ds_signing.crt:
-// The ds_signing.crt is the same as ca_signing.crt in this case
-// Will that work?
-
-[literal,subs="+quotes,verbatim"]
-....
-$ cp ca_signing.crt ds_signing.crt
-....
 
 A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-secure-ds-secondary.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg].
 It assumes that the existing CA and DS instances are running on primary.example.com, and the new CA and DS clones are being installed on secondary.example.com,

--- a/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
@@ -8,11 +8,9 @@ Follow this process to install a CA subsystem with a secure database connection.
 Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration 
-Once the prerequisites listed above are completed, enable the SSL connection with a self-signed signing certificate as described in
-link:../others/enabling-ssl-connection-in-ds.adoc#enabling-ssl-connection[Enabling SSL Connection].
-
-Then export the signing certificate into `ds_signing.crt` as described in
-link:../others/exporting-ds-certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
+Once the prerequisites listed above are completed, if you had chosen to use the DS bootstrap certificates during DS instance creation,
+then export the bootstrap self-signed certificate into `ds_signing.crt` as described in
+xref:../others/exporting-ds-certificates.adoc[Exporting DS Signing Certificate].
 
 == CA Subsystem Installation 
 Prepare a deployment configuration, for example `ca-secure-ds.cfg`, to deploy CA subsystem.
@@ -133,3 +131,8 @@ User "caadmin"
   Type: adminType
   State: 1
 ....
+
+== Getting Real DS Certificate from the CA
+
+If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+

--- a/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
+++ b/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
@@ -6,9 +6,12 @@
 
 Follow this process to install a KRA subsystem with a secure database connection.
 
-Ensure that the secure connection has been enabled on the directory server.
-Export the signing certificate for the directory server into ds_signing.crt.
-This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
+Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+
+== DS Configuration
+Once the prerequisites listed above are completed, if you had chosen to use the temporary DS bootstrap certificates during DS instance creation,
+then export the bootstrap self-signed certificate into `ds_signing.crt` as described in
+xref:../others/exporting-ds-certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
 
 == KRA Subsystem Installation
 
@@ -156,3 +159,8 @@ Transport Cert:
 
 <base-64 certificate>
 ....
+
+== Getting Real DS Certificate from the CA 
+
+If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+

--- a/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
@@ -8,9 +8,10 @@ Follow this process to install an OCSP subsystem with a secure database connecti
 
 Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
-Additional steps:
-
-Ensure that the secure connection has been enabled on the directory server, and export the signing certificate for the directory server into ds_signing.crt. This step is described link:https://github.com/dogtagpki/389-ds-base/wiki/Configuring-SSL-Connection[here].
+== DS Configuration
+Once the prerequisites listed above are completed, if you had chosen to use the temporary DS bootstrap certificates during DS instance creation,
+then export the bootstrap self-signed certificate into `ds_signing.crt` as described in
+xref:../others/exporting-ds-certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
 
 == OCSP Subsystem Installation 
 
@@ -170,3 +171,8 @@ $ OCSPClient \
 CertID.serialNumber=1
 CertStatus=Good
 ....
+
+== Getting Real DS Certificate from the CA 
+
+If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+

--- a/docs/installation/others/creating-ds-instance.adoc
+++ b/docs/installation/others/creating-ds-instance.adoc
@@ -12,9 +12,9 @@
 
 Follow this process to prepare a local DS instance for PKI server.
 
-*Note:* The DS installation automatically generates a temporary bootstrap self-signed signing certificate which issues a temporary bootstrap server certificate for SSL connection. The PKI installation takes advantage of this security offer to complete its installation. The temporary bootstrap server certificate could be replaced by a server certificate issued by an actual CA at a later step after the installation.
+*Note:* The DS installation automatically generates a bootstrap self-signed signing certificate which issues a bootstrap server certificate for SSL connection. The PKI installation takes advantage of this security offer to complete its installation. The bootstrap server certificate could be replaced by a server certificate issued by an actual CA at a later step after the installation.
 
-_If you wish to have the temporary certificate generation and the SSL connection disabled, set `self_sign_cert = False` in the `sed` command below. You can still enable SSL later by following link:enabling-temp-ssl-connection-in-ds.adoc[Enabling SSL Connection in DS]._
+_If you wish to disable bootstrap certificate generation and SSL connection, set `self_sign_cert = False` in the `sed` command below. You can still enable SSL later by following link:enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Enabling SSL Connection in DS with Bootstrap Cert]._
 
 == Creating a DS Instance 
 
@@ -69,10 +69,10 @@ The subtree for each PKI subsystem is created when the subsystem is installed. S
 
 == Enabling SSL Connection 
 
-If you set `self_sign_cert = False` earlier, and now decide to create temporary certs so that your PKI can be installed using SSL connection to DS,
-follow link:../others/enabling-temp-ssl-connection-in-ds.adoc[Enabling SSL Connection in DS]
+If you set `self_sign_cert = False` earlier, and now decide to create bootstrap certs so that your PKI can be installed using SSL connection to DS,
+follow link:../others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Enabling SSL Connection in DS]
 
-*Note:* The temporary bootstrap server certificate could be replaced by a server certificate issued by an actual CA at a later step after the installation.
+*Note:* The bootstrap server certificate could be replaced by a server certificate issued by an actual CA at a later step after the installation.
 
 == Configuring Replication 
 

--- a/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
+++ b/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
@@ -1,15 +1,15 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="enabling-temp-ssl-connection-in-ds_{context}"]
+[id="enabling-ssl-connection-in-ds-with-bootstrap-cert_{context}"]
 
 // This content was copied and adjusted from https://github.com/dogtagpki/pki/wiki/Enabling-SSL-Connection-in-DS
 
-= Enabling Temporary SSL Connection in DS 
+= Enabling SSL Connection in DS Using Bootstrap Certs
 
 *If you already have an active trusted CA, and you wish to issue a server cert for your DS, please follow link:enabling-ssl-connection-in-ds.adoc[this section] instead.*
 
 Follow this process using `pki` CLI (run `man pki-client`) commands to enable SSL connection in DS
-by creating a temporary DS bootstrap self-signed signing certificate and the bootstrap server certificate issued by it.
+by creating a bootstrap DS self-signed signing certificate and the bootstrap server certificate issued by it.
 
 This section assumes that a DS instance named `localhost` already exists,
 it does not have certificates, and the SSL connection is disabled.
@@ -76,6 +76,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA
             User
 ----
 
+[id="creating-ds-server-certificate_{context}"]
 == Creating DS Server Certificate 
 
 First, generate DS server CSR with the following command:
@@ -129,6 +130,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Server-Cert
             User
 ----
 
+[id="enabling-ssl-connection_{context}"]
 == Enabling SSL Connection 
 
 To enable SSL connection in the DS instance:

--- a/docs/installation/others/enabling-ssl-connection-in-ds.adoc
+++ b/docs/installation/others/enabling-ssl-connection-in-ds.adoc
@@ -2,6 +2,8 @@
 
 [id="enabling-ssl-connection-in-ds_{context}"]
 
+// This section is intended for all PKI subsystems
+
 = Enabling SSL Connection in DS 
 
 Follow this process using `pki` CLI (run `man pki-client`) commands to enable SSL connection in DS.
@@ -10,23 +12,16 @@ This section assumes that a DS instance named `localhost` already exists,
 
 Two conditions are covered by this section:
 
-* The DS instance does not already have any SSL server certificate, temporary or otherwise, and it is time to create an actual server cert for it.
-* The DS instance has a temporary SSL server certificate, and it is time to replace it.
+* The DS instance does not already have any SSL server certificate, bootstrap or otherwise, and it is time to create an actual server cert for it.
+* The DS instance has a bootstrap SSL server certificate, and you wish to replace it.
 
 It is assumed that an actual trusted CA is available for issuing certificates.
 
-== Import the CA signing certificate
-Import the CA signing cert into the nssdb of the DS instance.
+== Export the CA Signing Certificate
 
 [literal,subs="+quotes,verbatim"]
 ....
-# pki \
-    -d /etc/dirsrv/slapd-localhost \
-    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
-    nss-cert-import \
-    --cert ca_signing.crt \
-    --trust CT,C,C \
-    "CA Signing Cert"
+pki-server cert-export ca_signing --cert-file ca_signing.crt
 ....
 
 == Creating DS Server Certificate 
@@ -45,6 +40,8 @@ $ pki \
     --csr ds_server.csr
 ----
 
+*Note:* Make sure the certificate subject DN and SAN matche the system hostname.
+
 === Submit DS Server Certificate Request:
 
 As a DS admin:
@@ -61,7 +58,7 @@ As a PKI agent:
 $ pki -n caadmin ca-cert-request-review <request ID> --action approve
 ----
 
-== Retrieve and Import the Certificate
+== Retrieve the Certificate
 
 Retrieve the cert as the DS admin user:
 
@@ -69,7 +66,48 @@ Retrieve the cert as the DS admin user:
 $  pki ca-cert-export <certificate ID> --output-file ds_server.crt
 ----
 
-Finally, import DS server certificate:
+== Stop the DS instance
+
+Stop the DS instance prior to changing the NSS database.
+
+[literal,subs="+quotes,verbatim"]
+....
+$ dsctl localhost stop
+....
+
+== Import the CA signing certificate
+
+As a DS administrator, import the CA signing cert into the nssdb of the DS instance.
+
+[literal,subs="+quotes,verbatim"]
+....
+# pki \
+    -d /etc/dirsrv/slapd-localhost \
+    -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    nss-cert-import \
+    --cert ca_signing.crt \
+    --trust CT,C,C \
+    "CA Signing Cert"
+....
+
+== Delete DS Bootstrap Certificates
+
+// We could ask them to do a backup before proceeding, but they
+// could just create new bootstrap certs if messed up
+
+If you already had boostrap DS certificates, delete them:
+
+[literal,subs="+quotes,verbatim"]
+....
+$ certutil -F -d /etc/dirsrv/slapd-localhost \
+    -f /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    -n Server-Cert
+$ certutil -F -d /etc/dirsrv/slapd-localhost \
+    -f /etc/dirsrv/slapd-localhost/pwdfile.txt \
+    -n Self-Signed-CA
+....
+
+== Import DS server certificate:
 
 ----
 $ pki \
@@ -96,16 +134,18 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Server-Cert
 
 == Enabling SSL Connection 
 
+This section only applies if you did not enable SSL in your DS earlier.
+
 To enable SSL connection in the DS instance:
 
 ----
 $ dsconf localhost config replace nsslapd-security=on
 ----
 
-Finally, restart the DS instance:
+Finally, start the DS instance:
 
 ----
-$ dsctl localhost restart
+$ dsctl localhost start
 ----
 
 To verify the SSL connection:
@@ -119,6 +159,19 @@ $ LDAPTLS_REQCERT=never ldapsearch \
     -b "" \
     -s base
 ----
+
+== Delete DS Bootstrap Signing Cert from PKI Instance
+
+If you are replacing the DS bootstrap certs, as a PKI administrator, stop the PKI then delete the DS bootstrap signing cert from the PKI nssdb as follows.
+
+[literal,subs="+quotes,verbatim"]
+....
+$ certutil -F -d /var/lib/pki/pki-tomcat/conf/alias \
+    -f /var/lib/pki/pki-tomcat/conf/alias/pwdfile.txt \
+    -n ds_signing
+....
+
+Start the PKI.
 
 == See Also 
 

--- a/docs/installation/others/exporting-ds-certificates.adoc
+++ b/docs/installation/others/exporting-ds-certificates.adoc
@@ -1,17 +1,16 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="exporting-ds-certificates_{context}"]
-// initial content copied from https://github.com/dogtagpki/pki/wiki/Exporting-DS-Certificates
 = Exporting DS Certificates 
 
-
-Follow this process to export the signing certificate and the server certificate from the NSS database of a DS instance.
+Follow this process to export the bootstrap signing certificate and the server certificate from the NSS database of a DS instance.
 
 By default the certificates are generated automatically during installation,
 but they can also be created after installation.
 
 This section assumes that a DS instance named `localhost` is already created and has the certificates.
 
+[id="exporting-ds-signing-certificate_{context}"]
 == Exporting DS Signing Certificate 
 
 To export DS signing certificate:

--- a/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
+++ b/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
@@ -6,9 +6,12 @@
 
 Follow this process to install a TKS subsystem with a secure database connection.
 
-Ensure that the secure connection has been enabled on the directory server.
-Export the signing certificate for the directory server into ds_signing.crt.
-This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
+Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+
+== DS Configuration
+Once the prerequisites listed above are completed, if you had chosen to use the temporary DS bootstrap certificates during DS instance creation,
+then export the bootstrap self-signed certificate into `ds_signing.crt` as described in
+xref:../others/exporting-ds-certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
 
 == TKS Subsystem Installation
 
@@ -142,3 +145,7 @@ User "tksadmin"
   Type: adminType
   State: 1
 ....
+
+== Getting Real DS Certificate from the CA 
+
+If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.

--- a/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
+++ b/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
@@ -3,12 +3,14 @@
 [id="installing-tps-with-ldaps-connection_{context}"]
 = Installing TPS with LDAPS Connection
 
-
 Follow this process to install a TPS subsystem a secure database connection.
 
-Ensure that the secure connection has been enabled on the directory server.
-Export the signing certificate for the directory server into ds_signing.crt.
-This step is described link:https://www.dogtagpki.org/wiki/DS_SSL[here].
+Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+
+== DS Configuration
+Once the prerequisites listed above are completed, if you had chosen to use the temporary DS bootstrap certificates during DS instance creation,
+then export the bootstrap self-signed certificate into `ds_signing.crt` as described in
+xref:../others/exporting-ds-certificates.adoc#exporting-ds-signing-certificate[Exporting DS Signing Certificate].
 
 == TPS Subsystem Installation
 
@@ -144,3 +146,7 @@ User "tpsadmin"
   TPS Profiles:
     All Profiles
 ....
+
+== Getting Real DS Certificate from the CA
+
+If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.


### PR DESCRIPTION
- copying the slightly adjusted installing-ca-clone-with-ldaps-connection.adoc to installing-ca-clone-with-temp-ldaps-connection.adoc for reference.  Using the temporary bootstrap DS server cert shouldn't be a recommended case
- modified installing-ca-clone-with-temp-ldaps-connection.adoc so that it assumes that the existing PKI instance is running withr real DS server cert, and issues a real DS server cert for the DS of the clone
- modified all ldaps installation adoc files to reflect the changes
- some adjustments to the already updated ldaps-related sections under pki/docs/installation/others [skip ci]