### PR TITLE
Fix JRE dependency for pki-console

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
 
   - script: |
       docker exec runner \
-          /root/src/build.sh -v rpm
+          /root/src/build.sh -v --with-console rpm
     displayName: Build PKI RPM packages
 
   - script: |
@@ -133,6 +133,7 @@ jobs:
           /root/src/build.sh \
           --work-dir=/root/build \
           --python-dir=/usr/lib/python$PYTHON_VERSION/site-packages \
+          --with-console \
           dist
     displayName: Build PKI with CMake
 
@@ -247,6 +248,14 @@ jobs:
           jar tvf /root/src/base/est/target/pki-est.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort | tee pki-est.maven
       diff pki-est.cmake pki-est.maven
     displayName: Compare pki-est.jar
+
+  - script: |
+      docker exec runner \
+          jar tvf /root/build/dist/pki-console.jar | awk '{print $8;}' | grep -v '/$' | sort | tee pki-console.cmake
+      docker exec runner \
+          jar tvf /root/src/base/console/target/pki-console.jar | awk '{print $8;}' | grep -v -E '^META-INF/maven/|/$' | sort | tee pki-console.maven
+      diff pki-console.cmake pki-console.maven
+    displayName: Compare pki-console.jar
 
   - script: |
       docker exec runner \

--- a/base/console/CMakeLists.txt
+++ b/base/console/CMakeLists.txt
@@ -41,8 +41,6 @@ jar(pki-console-jar
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     INPUT_DIR
         ${CMAKE_CURRENT_SOURCE_DIR}/src/main/resources
-    FILES
-        com/netscape/admin/certsrv/images/*.gif
     DEPENDS
         pki-console-classes
 )

--- a/base/console/src/main/java/com/netscape/admin/certsrv/Console.java
+++ b/base/console/src/main/java/com/netscape/admin/certsrv/Console.java
@@ -1785,7 +1785,7 @@ public class Console implements CommClient {
         CryptoManager manager = null;
         String default_nssdb_path = FilePreferenceManager.getHomePath();
 	String nssdb_path = cmd.getOptionValue("d", default_nssdb_path);
-	String client_cert_nick = cmd.getOptionValue("n", null);
+	String client_cert_nick = cmd.getOptionValue("n");
 	logger.info("NSS database: " + nssdb_path);
         try {
             CryptoManager.initialize(nssdb_path);

--- a/pki.spec
+++ b/pki.spec
@@ -72,6 +72,7 @@ ExcludeArch: i686
 
 %if 0%{?fedora} && 0%{?fedora} <= 39 || 0%{?rhel} && 0%{?rhel} <= 9
 
+%define java_runtime java-17-openjdk
 %define java_devel java-17-openjdk-devel
 %define java_headless java-17-openjdk-headless
 %define java_home %{_jvmdir}/jre-17-openjdk
@@ -79,6 +80,7 @@ ExcludeArch: i686
 
 %else
 
+%define java_runtime java-21-openjdk
 %define java_devel java-21-openjdk-devel
 %define java_headless java-21-openjdk-headless
 %define java_home %{_jvmdir}/jre-21-openjdk
@@ -941,6 +943,7 @@ BuildArch:        noarch
 Obsoletes:        pki-console < %{version}-%{release}
 Provides:         pki-console = %{version}-%{release}
 
+Requires:         %{java_runtime}
 Requires:         %{product_id}-java = %{version}-%{release}
 Requires:         %{product_id}-console-theme = %{version}-%{release}
 


### PR DESCRIPTION
The `pki.spec` has been updated to require `java-<version>-openjdk` for `pki-console` which provides the AWT library needed by the console.

The Azure pipeline has been updated to build the console with `rpmbuild`, CMake, and Maven and compare the binaries.

The CMake script has been updated to include all resource files such that it generates a `pki-console.jar` identical to the one built by Maven.

The `Console.java` has been updated to work with the latest Apache Commons CLI library.