### PR TITLE
Convert TPSClientCLI.formatToken() to Java

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/tps/TPSClientCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/tps/TPSClientCLI.java
@@ -64,7 +64,63 @@ public class TPSClientCLI extends CommandCLI {
     public native void setOldStyle(long client, boolean value) throws Exception;
 
     public native void displayHelp(long client) throws Exception;
-    public native void formatToken(long client, Map<String, String> params) throws Exception;
+
+    public native void performFormatToken(long client, Map<String, String> params) throws Exception;
+
+    public void oldFormatToken(
+            long client,
+            Map<String, String> params)
+            throws Exception {
+
+        String value = params.get("num_threads");
+        int numThreads = value == null ? 1 : Integer.parseInt(value);
+
+        Thread[] threads = new Thread[numThreads];
+        Exception[] exceptions = new Exception[numThreads];
+
+        // start threads
+        for (int i=0; i<numThreads; i++) {
+
+            int index = i;
+
+            threads[i] = new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        performFormatToken(client, params);
+                    } catch (Exception e) {
+                        exceptions[index] = e;
+                    }
+                }
+            });
+
+            threads[i].start();
+        }
+
+        // wait for threads to complete
+        for (int i=0; i<numThreads; i++) {
+            threads[i].join();
+        }
+
+        // check for exceptions
+        for (int i=0; i<numThreads; i++) {
+            if (exceptions[i] != null) throw exceptions[i];
+        }
+    }
+
+    public native void newFormatToken(long client, Map<String, String> params) throws Exception;
+
+    public void formatToken(
+            long client,
+            Map<String, String> params)
+            throws Exception {
+
+        if (getOldStyle(client)) {
+            oldFormatToken(client, params);
+        } else {
+            newFormatToken(client, params);
+        }
+    }
+
     public native void resetPIN(long client, Map<String, String> params) throws Exception;
     public native void enrollToken(long client, Map<String, String> params) throws Exception;
     public native void displayToken(long client, Map<String, String> params) throws Exception;

--- a/base/tools/src/main/native/tpsclient/src/include/main/RA_Client.h
+++ b/base/tools/src/main/native/tpsclient/src/include/main/RA_Client.h
@@ -58,7 +58,6 @@ class RA_Client
 	  int OpConnStart(NameValueSet *set, RequestType);
 	  int OpConnResetPin(NameValueSet *set);
 	  int OpConnEnroll(NameValueSet *set);
-	  int OpConnUpdate(NameValueSet *set);
 	  int OpTokenStatus(NameValueSet *set);
 	  int OpTokenSet(NameValueSet *set);
 	  int OpVarList(NameValueSet *set);
@@ -73,5 +72,20 @@ class RA_Client
 	  NameValueSet m_vars;
 	  PRBool old_style = PR_TRUE;
 };
+
+typedef struct _ThreadArg
+{
+  PRTime time;          /* processing time */
+  int status;           /* status result */
+  NameValueSet *params;     /* parameters */
+  RA_Client *client;        /* client */
+  RA_Token *token;      /* token */
+
+  PRLock *donelock;     /* lock */
+  int done;         /* are we done? */
+} ThreadArg;
+
+extern "C" void
+ThreadConnUpdate (void *arg);
 
 #endif /* RA_CLIENT_H */

--- a/base/tools/src/main/native/tpsclient/src/main/TPSClientCLI.cpp
+++ b/base/tools/src/main/native/tpsclient/src/main/TPSClientCLI.cpp
@@ -136,18 +136,36 @@ Java_com_netscape_cmstools_tps_TPSClientCLI_displayHelp
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_netscape_cmstools_tps_TPSClientCLI_formatToken
+Java_com_netscape_cmstools_tps_TPSClientCLI_performFormatToken
+(JNIEnv* env, jobject object, jlong client, jobject params) {
+
+    RA_Client* cclient = (RA_Client*) client;
+
+    ThreadArg arg;
+    arg.time = 0;
+    arg.status = 0;
+    arg.client = cclient;
+    arg.token = cclient->m_token.Clone();
+    arg.params = convertParams(env, params);
+
+    ThreadConnUpdate(&arg);
+
+    delete arg.params;
+    delete arg.token;
+
+    if (arg.status == 0) {
+        throwCLIException(env, "Unable to format token");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_netscape_cmstools_tps_TPSClientCLI_newFormatToken
 (JNIEnv* env, jobject object, jlong client, jobject params) {
 
     RA_Client* cclient = (RA_Client*) client;
     NameValueSet *set = convertParams(env, params);
 
-    int status;
-    if (cclient->old_style) {
-        status = cclient->OpConnUpdate(set);
-    } else {
-        status = cclient->OpConnStart(set, OP_CLIENT_FORMAT);
-    }
+    int status = cclient->OpConnStart(set, OP_CLIENT_FORMAT);
 
     delete set;
 

--- a/base/tools/src/main/native/tpsclient/tools/raclient/tpsclient.cpp
+++ b/base/tools/src/main/native/tpsclient/tools/raclient/tpsclient.cpp
@@ -64,6 +64,17 @@ ReadLine (char *buf, int len)
 }
 
 static void
+Output (const char *fmt, ...)
+{
+  va_list ap;
+  va_start (ap, fmt);
+  printf ("Output> ");
+  vprintf (fmt, ap);
+  printf ("\n");
+  va_end (ap);
+}
+
+static void
 OutputSuccess (const char *fmt, ...)
 {
   va_list ap;
@@ -83,6 +94,79 @@ OutputError (const char *fmt, ...)
   vprintf (fmt, ap);
   printf ("\n");
   va_end (ap);
+}
+
+int
+OpConnUpdate (RA_Client* client, NameValueSet * params)
+{
+  int num_threads = params->GetValueAsInt ((char *) "num_threads", 1);
+  int i;
+  int status = 0;
+  PRThread **threads;
+  ThreadArg *arg;
+
+  threads = (PRThread **) malloc (sizeof (PRThread *) * num_threads);
+  if (threads == NULL)
+    {
+      return 0;
+    }
+  arg = (ThreadArg *) malloc (sizeof (ThreadArg) * num_threads);
+  if (arg == NULL)
+    {
+      if(threads) {
+          free(threads);
+          threads = NULL;
+      }
+      return 0;
+    }
+
+  /* start threads */
+  for (i = 0; i < num_threads; i++)
+    {
+      arg[i].time = 0;
+      arg[i].status = 0;
+      arg[i].client = client;
+      if (i == 0)
+    {
+      arg[i].token = &client->m_token;
+    }
+      else
+    {
+      arg[i].token = client->m_token.Clone ();
+    }
+      arg[i].params = params;
+      threads[i] = PR_CreateThread (PR_USER_THREAD, ThreadConnUpdate, &arg[i], PR_PRIORITY_NORMAL,  /* Priority */
+                    PR_GLOBAL_THREAD,   /* Scope */
+                    PR_JOINABLE_THREAD, /* State */
+                    0   /* Stack Size */
+    );
+    }
+
+  /* join threads */
+  for (i = 0; i < num_threads; i++)
+    {
+      PR_JoinThread (threads[i]);
+    }
+
+  for (i = 0; i < num_threads; i++)
+    {
+      Output ("Thread (%d) status='%d' time='%d msec'", i,
+          arg[i].status, arg[i].time);
+    }
+
+  status = arg[0].status;
+
+  if(arg) {
+     free(arg);
+     arg = NULL;
+  }
+
+  if(threads) {
+     free(threads);
+     threads = NULL;
+  }
+
+  return status;
 }
 
 /**
@@ -106,7 +190,7 @@ InvokeOperation (RA_Client* client, char *op, NameValueSet * params)
   else if (strcmp (op, "ra_format") == 0)
     {
       if (client->old_style)
-    status = client->OpConnUpdate (params);
+    status = OpConnUpdate (client, params);
       else
     status = client->OpConnStart (params, OP_CLIENT_FORMAT);
     }


### PR DESCRIPTION
The `TPSClientCLI.formatToken()` has been converted into Java. The old style method will use Java threads to call the native code that performs the actual operation. The new style method is still implemented in C++ and might be converted into Java in the future. The `RA_Client::OpConnUpdate()` has been moved into `tpsclient.cpp`.