### PR TITLE
replacing "link:" with 'xref:" for links not begin with "http"

### DIFF
--- a/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
@@ -6,7 +6,7 @@
 
 This document describes the process to install an ACME responder on a PKI server that already has a CA subsystem using `pki-server acme` commands.
 
-In general `pki-server acme` commands provide a more flexible way compared to link:installing-acme-responder-using-pkispawn.adoc[`pkispawn`] for installing ACME responder.
+In general `pki-server acme` commands provide a more flexible way compared to xref:installing-acme-responder-using-pkispawn.adoc[`pkispawn`] for installing ACME responder.
 If there is a problem during installation, usually only the failing step needs to be fixed, then the installation can be resumed.
 
 == Prerequisites ==
@@ -57,7 +57,7 @@ Enter true/false whether an external account is required.
   External Account Required [false]:
 ----
 
-See also link:../../admin/acme/Configuring-ACME-Metadata.adoc[Configuring ACME Metadata].
+See also xref:../../admin/acme/Configuring-ACME-Metadata.adoc[Configuring ACME Metadata].
 
 == Setting Up ACME Database ==
 
@@ -119,7 +119,7 @@ $ ldapadd \
     -f /usr/share/pki/acme/database/ds/create.ldif
 ----
 
-See also link:../../admin/acme/Configuring-ACME-Database.adoc[Configuring ACME Database].
+See also xref:../../admin/acme/Configuring-ACME-Database.adoc[Configuring ACME Database].
 
 == Setting up ACME Issuer ==
 
@@ -156,7 +156,7 @@ Enter the certificate profile for issuing ACME certificates (e.g. acmeServerCert
   Certificate Profile [acmeServerCert]:
 ----
 
-See also link:../../admin/acme/Configuring-ACME-Issuer.adoc[Configuring ACME Issuer].
+See also xref:../../admin/acme/Configuring-ACME-Issuer.adoc[Configuring ACME Issuer].
 
 == Setting Up ACME Realm ==
 
@@ -201,7 +201,7 @@ $ ldapadd \
     -f /usr/share/pki/acme/realm/ds/create.ldif
 ----
 
-See also link:../../admin/acme/Configuring-ACME-Realm.adoc[Configuring ACME Realm].
+See also xref:../../admin/acme/Configuring-ACME-Realm.adoc[Configuring ACME Realm].
 
 == Deploying ACME Responder ==
 
@@ -263,4 +263,4 @@ $ pki-server acme-remove
 
 == See Also ==
 
-* link:../../manuals/man8/pki-server-acme.8.md[pki-server-acme(8)]
+* xref:../../manuals/man8/pki-server-acme.8.md[pki-server-acme(8)]

--- a/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
@@ -5,7 +5,7 @@
 
 Follow this process to install an ACME responder on a PKI server that already has a CA subsystem using `pkispawn` command.
 
-In general `pkispawn` provides a simpler way compared to link:installing-acme-responder-using-pki-server-acme-cli.adoc[`pki-server acme`] for installing ACME responder.
+In general `pkispawn` provides a simpler way compared to xref:installing-acme-responder-using-pki-server-acme-cli.adoc[`pki-server acme`] for installing ACME responder.
 If there is a problem during installation, the entire process might need to be restarted.
 
 == Prerequisites ==
@@ -81,7 +81,7 @@ $ pkispawn \
 
 The configuration files are available in `/var/lib/pki/pki-tomcat/conf/acme` folder.
 
-See also link:../../admin/acme/Configuring-ACME-Responder.adoc[Configuring ACME Responder].
+See also xref:../../admin/acme/Configuring-ACME-Responder.adoc[Configuring ACME Responder].
 
 == Verifying ACME Responder ==
 
@@ -115,4 +115,4 @@ $ pkidestroy -s ACME
 
 == See Also ==
 
-* link:../../manuals/man8/pkispawn.8.md[pkispawn(8)]
+* xref:../../manuals/man8/pkispawn.8.md[pkispawn(8)]

--- a/docs/installation/acme/installing-acme-responder.adoc
+++ b/docs/installation/acme/installing-acme-responder.adoc
@@ -11,12 +11,12 @@ It assumes that the CA was installed with the default instance name (i.e. `pki-t
 
 There are two ways to install the ACME responder:
 
-* link:installing-acme-responder-using-pkispawn.adoc[Installing ACME Responder using pkispawn]
-* link:installing-acme-responder-using-pki-server-acme-cli.adoc[Installing ACME Responder using pki-server acme CLI]
+* xref:installing-acme-responder-using-pkispawn.adoc[Installing ACME Responder using pkispawn]
+* xref:installing-acme-responder-using-pki-server-acme-cli.adoc[Installing ACME Responder using pki-server acme CLI]
 
 
 == See Also ==
 
-* link:../ca/Installing_CA.md[Installing CA]
-* link:../../admin/acme/Managing_PKI_ACME_Responder.md[Managing ACME Responder]
-* link:../../user/acme/Using_PKI_ACME_Responder.md[Using ACME Responder]
+* xref:../ca/Installing_CA.md[Installing CA]
+* xref:../../admin/acme/Managing_PKI_ACME_Responder.md[Managing ACME Responder]
+* xref:../../user/acme/Using_PKI_ACME_Responder.md[Using ACME Responder]

--- a/docs/installation/ca/installing-ca-clone-with-hsm.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-hsm.adoc
@@ -7,7 +7,7 @@
 Follow this process to install a CA subsystem as a clone of an existing CA subsystem
 where the system certificates and their keys are stored in HSM.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Exporting Existing System Certificates 
 

--- a/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install a CA subsystem as clone of an existing CA subsystem with a secure database connection.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration 
 
@@ -79,7 +79,7 @@ By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 $ cp ca_signing.crt ds_signing.crt
 ....
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-secure-ds-secondary.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-secure-ds-secondary.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg].
 It assumes that the existing CA and DS instances are running on primary.example.com, and the new CA and DS clones are being installed on secondary.example.com,
 the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate and key have been exported into `ca_admin_cert.p12`.

--- a/docs/installation/ca/installing-ca-clone-with-ldaps-using-bootstrap-ds-certs.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-using-bootstrap-ds-certs.adoc
@@ -5,7 +5,7 @@
 
 Follow this process to install a CA subsystem as clone of an existing CA subsystem that runs with a bootstrap SSL server certificate.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration 
 
@@ -27,7 +27,7 @@ $ pki -d /etc/dirsrv/slapd-localhost \
 pkcs12-import --pkcs12-file ds_signing.p12 \
 --pkcs12-password Secret.123
 ....
-In the DS clone, create a boostrap DS server certificate as described in xref:../others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Creating DS Server Certificate].
+In the DS clone, create a boostrap DS server certificate as described in xref:../others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc#creating-ds-server-certificate[Creating DS Server Certificate].
 Note that the certificate subject DN should match the clone's hostname ( i.e `--subject "CN=secondary.example.com"` ).
 
 Then enable the SSL connection as described in xref:../others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc#enabling-ssl-connection[Enabling SSL Connection].
@@ -96,7 +96,7 @@ $ chown pkiuser:pkiuser ca-certs.p12
 Prepare a deployment configuration, for example `ca-secure-ds-secondary.cfg`, to deploy CA subsystem clone.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-secure-ds-secondary.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-secure-ds-secondary.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds-secondary.cfg].
 It assumes that the existing CA and DS instances are running on primary.example.com, and the new CA and DS clones are being installed on secondary.example.com,
 the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate and key have been exported into `ca_admin_cert.p12`.

--- a/docs/installation/ca/installing-ca-clone.adoc
+++ b/docs/installation/ca/installing-ca-clone.adoc
@@ -5,7 +5,7 @@
 
 Follow this process to install a CA subsystem as a clone of an existing CA subsystem.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 Additional useful tips:
 
@@ -81,12 +81,12 @@ $ chown pkiuser:pkiuser ca-certs.p12
 Prepare a deployment configuration, for example `ca-clone.cfg`, to deploy CA subsystem clone.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-clone.cfg[/usr/share/pki/server/examples/installation/ca-clone.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-clone.cfg[/usr/share/pki/server/examples/installation/ca-clone.cfg].
 It assumes that the primary CA subsystem is running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate and key have been exported into `ca_admin_cert.p12`.
 The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
-See link:installing-ca.adoc[CA installation] for details.
+See xref:installing-ca.adoc[CA installation] for details.
 
 If the CSRs are available, they can be specified with the following parameters:
 

--- a/docs/installation/ca/installing-ca-with-custom-ca-signing-key.adoc
+++ b/docs/installation/ca/installing-ca-with-custom-ca-signing-key.adoc
@@ -5,7 +5,7 @@
 
 Follow this process to install a CA subsystem with a custom CA signing key, CSR, and certificate.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
 Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration step 1:

--- a/docs/installation/ca/installing-ca-with-ecc.adoc
+++ b/docs/installation/ca/installing-ca-with-ecc.adoc
@@ -17,14 +17,14 @@ Supported ECC key algorithms:
 - SHA384withEC
 - SHA512withEC
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == CA Subsystem Installation 
 
 Prepare a deployment configuration, for example `ca-ecc.cfg`, to deploy CA subsystem.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-ecc.cfg[/usr/share/pki/server/examples/installation/ca-ecc.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-ecc.cfg[/usr/share/pki/server/examples/installation/ca-ecc.cfg].
 
 To start the installation execute the following command:
 

--- a/docs/installation/ca/installing-ca-with-existing-keys-in-hsm.adoc
+++ b/docs/installation/ca/installing-ca-with-existing-keys-in-hsm.adoc
@@ -9,7 +9,7 @@ where the keys are stored in HSM.
 To avoid conflicts with the existing CA subsystem, the new CA subsystem will use new SSL server and subsystem certificates,
 so they will not be included in the installation process.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
 Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration step 1:

--- a/docs/installation/ca/installing-ca-with-existing-keys-in-internal-token.adoc
+++ b/docs/installation/ca/installing-ca-with-existing-keys-in-internal-token.adoc
@@ -10,12 +10,12 @@ where the keys are stored in internal token.
 To avoid conflicts with the existing CA subsystem, the new CA subsystem will use new SSL server and subsystem certificates,
 so they will not be included in the installation process.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
 Prepare a file, for example `ca-existing-certs-step1.cfg`, that contains the first deployment configuration.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-existing-certs-step1.cfg[/usr/share/pki/server/examples/installation/ca-existing-certs-step1.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-existing-certs-step1.cfg[/usr/share/pki/server/examples/installation/ca-existing-certs-step1.cfg].
 
 Then execute the following command:
 
@@ -93,7 +93,7 @@ Specify the serial number starting range such that new certificates will not con
 pki_serial_number_range_start=4
 ....
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-existing-certs-step2.cfg[/usr/share/pki/server/examples/installation/ca-existing-certs-step2.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-existing-certs-step2.cfg[/usr/share/pki/server/examples/installation/ca-existing-certs-step2.cfg].
 
 Finally, execute the following command:
 

--- a/docs/installation/ca/installing-ca-with-external-ca-signing-certificate.adoc
+++ b/docs/installation/ca/installing-ca-with-external-ca-signing-certificate.adoc
@@ -5,12 +5,12 @@
 
 Follow this process to install a CA subsystem with an external CA signing certificate.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting CA Subsystem Installation 
 Prepare a file, for example `ca-external-cert-step1.cfg`, that contains the first deployment configuration.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-external-cert-step1.cfg[/usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg]
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-external-cert-step1.cfg[/usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg]
 
 Then execute the following command:
 
@@ -68,7 +68,7 @@ pki_cert_chain_nickname=root-ca_signing
 pki_cert_chain_path=root-ca_signing.crt
 ....
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-external-cert-step2.cfg[/usr/share/pki/server/examples/installation/ca-external-cert-step2.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-external-cert-step2.cfg[/usr/share/pki/server/examples/installation/ca-external-cert-step2.cfg].
 
 Finally, execute the following command:
 

--- a/docs/installation/ca/installing-ca-with-hsm.adoc
+++ b/docs/installation/ca/installing-ca-with-hsm.adoc
@@ -6,7 +6,7 @@
 Follow this process to install a CA subsystem with a self-signed CA signing certificate
 where the system certificates and their keys are stored in HSM.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == CA Subsystem Installation 
 Prepare a file, for example `ca.cfg`, that contains the deployment configuration:

--- a/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
@@ -5,7 +5,7 @@
 
 Follow this process to install a CA subsystem with a secure database connection.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration 
 Once the prerequisites listed above are completed, if you had chosen to use the DS bootstrap certificates during DS instance creation,
@@ -20,7 +20,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.c
 Prepare a deployment configuration, for example `ca-secure-ds.cfg`, to deploy CA subsystem.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca-secure-ds.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-secure-ds.cfg[/usr/share/pki/server/examples/installation/ca-secure-ds.cfg].
 
 To start the installation execute the following command:
 
@@ -138,5 +138,5 @@ User "caadmin"
 
 == Getting Real DS Certificate from the CA
 
-If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
 

--- a/docs/installation/ca/installing-ca-with-random-serial-numbers-v3.adoc
+++ b/docs/installation/ca/installing-ca-with-random-serial-numbers-v3.adoc
@@ -9,7 +9,7 @@ NOTE: RSNv3 is enabled by default since PKI 11.5.
 
 = Installation Procedure 
 
-To install CA with random serial numbers v3, follow the normal link:installing-ca.adoc[CA installation] procedure, then specify the parameters below.
+To install CA with random serial numbers v3, follow the normal xref:installing-ca.adoc[CA installation] procedure, then specify the parameters below.
 
 To use random certificate serial numbers, add the following parameters in the `[CA]` section:
 

--- a/docs/installation/ca/installing-ca-with-rsa-pss.adoc
+++ b/docs/installation/ca/installing-ca-with-rsa-pss.adoc
@@ -7,7 +7,7 @@ Follow this process to install a CA subsystem with RSA/PSS.
 
 = Installation Procedure 
 
-To install CA subsystem with RSA/PSS, follow the normal link:installing-ca.adoc[CA installation] procedure, then specify the parameters below.
+To install CA subsystem with RSA/PSS, follow the normal xref:installing-ca.adoc[CA installation] procedure, then specify the parameters below.
 
 ----
 [DEFAULT]

--- a/docs/installation/ca/installing-ca.adoc
+++ b/docs/installation/ca/installing-ca.adoc
@@ -5,14 +5,14 @@
 
 Follow this process to install a CA subsystem instance with a self-signed CA signing certificate. It is also known as a "root CA".
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == CA Subsystem Installation 
 
 Prepare a deployment configuration, for example `ca.cfg`, to deploy CA subsystem.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ca.cfg[/usr/share/pki/server/examples/installation/ca.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca.cfg[/usr/share/pki/server/examples/installation/ca.cfg].
 
 To start the installation execute the following command:
 [literal,subs="+quotes,verbatim"]

--- a/docs/installation/ca/installing-subordinate-ca.adoc
+++ b/docs/installation/ca/installing-subordinate-ca.adoc
@@ -6,12 +6,12 @@
 Follow this process to install a subordinate CA subsystem
 with a signing certificate issued by a root CA.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Subordinate CA Subsystem Installation 
 Prepare a file, for example `subca.cfg`, that contains the deployment configuration.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/subca.cfg[/usr/share/pki/server/examples/installation/subca.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/subca.cfg[/usr/share/pki/server/examples/installation/subca.cfg].
 It assumes that the root CA is already running at https://root.example.com:8443
 and the root CA signing certificate has been exported into `root-ca_signing.crt`.
 

--- a/docs/installation/est/configure-est-realm-db.adoc
+++ b/docs/installation/est/configure-est-realm-db.adoc
@@ -8,7 +8,7 @@
 If you have chosen to use an LDAP instance for user management, before
 adding users, please ensure that you have configured the directory
 server and added base entries. Directory server setup instructions can be found 
-in the link:../others/installation-prerequisites.adoc[Installation Prerequisites].
+in the xref:../others/installation-prerequisites.adoc[Installation Prerequisites].
 
 The user DB requires a group node for the people and one for the
 groups.  A simple dif file is available in

--- a/docs/installation/est/installing-est-pki-server.adoc
+++ b/docs/installation/est/installing-est-pki-server.adoc
@@ -64,7 +64,7 @@ EOF
 ----
 
 The executable script in this example performs a simple check of the user role and it
-is available link:/base/est/bin/estauthz[here]. It can be replaced if a
+is available xref:/base/est/bin/estauthz[here]. It can be replaced if a
 more sophisticated authorization framework has to be adopted.
 
 

--- a/docs/installation/kra/installing-kra-clone-with-hsm.adoc
+++ b/docs/installation/kra/installing-kra-clone-with-hsm.adoc
@@ -10,7 +10,7 @@ where the system certificates and their keys are stored in HSM.
 Since the certificates and the keys are already in HSM, it's not necessary to export them into a
 PKCS #12 file to create a clone.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == KRA Subsystem Installation 
 

--- a/docs/installation/kra/installing-kra-clone.adoc
+++ b/docs/installation/kra/installing-kra-clone.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install a KRA subsystem as a clone of an existing KRA subsystem.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Exporting Existing KRA System Certificates 
 
@@ -44,12 +44,12 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 Prepare a deployment configuration, for example `kra-clone.cfg`, to deploy KRA subsystem clone.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-clone.cfg[/usr/share/pki/server/examples/installation/kra-clone.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/kra-clone.cfg[/usr/share/pki/server/examples/installation/kra-clone.cfg].
 It assumes that the primary CA and KRA subsystems are running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate and key have been exported into `ca_admin_cert.p12`.
 The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
-See link:../ca/Installing_CA.md[Installing CA] for details.
+See xref:../ca/Installing_CA.md[Installing CA] for details.
 
 To start the installation execute the following command:
 

--- a/docs/installation/kra/installing-kra-on-separate-instance.adoc
+++ b/docs/installation/kra/installing-kra-on-separate-instance.adoc
@@ -6,13 +6,13 @@
 
 Follow this process to install a KRA subsystem on an instance/host separate from the CA.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == KRA Subsystem Installation 
 
 Prepare a file, for example `kra-separate.cfg`, that contains the deployment configuration.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-separate.cfg[/usr/share/pki/server/examples/installation/kra-separate.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/kra-separate.cfg[/usr/share/pki/server/examples/installation/kra-separate.cfg].
 It assumes that the CA is running at https://ca.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate has been exported into `ca_admin.cert`.

--- a/docs/installation/kra/installing-kra-with-custom-keys.adoc
+++ b/docs/installation/kra/installing-kra-with-custom-keys.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install a KRA subsystem with custom KRA system and admin keys, CSRs, and certificates.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting KRA Subsystem Installation
 

--- a/docs/installation/kra/installing-kra-with-ecc.adoc
+++ b/docs/installation/kra/installing-kra-with-ecc.adoc
@@ -18,7 +18,7 @@ Supported ECC key algorithms:
 - SHA384withEC
 - SHA512withEC
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == KRA Subsystem Installation
 

--- a/docs/installation/kra/installing-kra-with-external-certificates.adoc
+++ b/docs/installation/kra/installing-kra-with-external-certificates.adoc
@@ -6,13 +6,13 @@
 
 Follow this process to install a KRA subsystem with external certificates.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting KRA Subsystem Installation
 
 Prepare a file, for example `kra-external-certs-step1.cfg`, that contains the first deployment configuration.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-external-certs-step1.cfg[/usr/share/pki/server/examples/installation/kra-external-certs-step1.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/kra-external-certs-step1.cfg[/usr/share/pki/server/examples/installation/kra-external-certs-step1.cfg].
 It assumes that the CA is running at https://ca.example.com:8443,
 and the CA signing certificate has been exported into `ca_signing.crt`.
 
@@ -75,7 +75,7 @@ pki_cert_chain_nickname=ca_signing
 pki_cert_chain_path=ca_signing.crt
 ....
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-external-certs-step2.cfg[/usr/share/pki/server/examples/installation/kra-external-certs-step2.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/kra-external-certs-step2.cfg[/usr/share/pki/server/examples/installation/kra-external-certs-step2.cfg].
 
 Finally, execute the following command:
 

--- a/docs/installation/kra/installing-kra-with-hsm.adoc
+++ b/docs/installation/kra/installing-kra-with-hsm.adoc
@@ -7,7 +7,7 @@
 Follow this process to install a KRA subsystem
 where the system certificates and their keys are stored in HSM.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == KRA Subsystem Installation
 

--- a/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
+++ b/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install a KRA subsystem with a secure database connection.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration
 Once the prerequisites listed above are completed, if you had chosen to use the temporary DS bootstrap certificates during DS instance creation,
@@ -166,5 +166,5 @@ Transport Cert:
 
 == Getting Real DS Certificate from the CA 
 
-If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
 

--- a/docs/installation/kra/installing-kra-with-random-serial-numbers-v3.adoc
+++ b/docs/installation/kra/installing-kra-with-random-serial-numbers-v3.adoc
@@ -9,7 +9,7 @@ NOTE: RSNv3 is enabled by default since PKI 11.5.
 
 = Installation Procedure 
 
-To install KRA with random serial numbers, follow the normal link:Installing_KRA.md[KRA installation] procedure, then specify the following parameter:
+To install KRA with random serial numbers, follow the normal xref:Installing_KRA.md[KRA installation] procedure, then specify the following parameter:
 
 To use random key IDs, add the following parameters in the `[KRA]` section:
 

--- a/docs/installation/kra/installing-kra.adoc
+++ b/docs/installation/kra/installing-kra.adoc
@@ -6,12 +6,12 @@
 
 Follow this process to install a KRA subsystem.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == KRA Subsystem Installation 
 
 Prepare a file, for example `kra.cfg`, that contains the deployment configuration.
-A sample deployment configuration is available at link:../../../base/server/examples/installation/kra.cfg[/usr/share/pki/server/examples/installation/kra.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/kra.cfg[/usr/share/pki/server/examples/installation/kra.cfg].
 
 Then execute the following command:
 

--- a/docs/installation/kra/installing-standalone-kra.adoc
+++ b/docs/installation/kra/installing-standalone-kra.adoc
@@ -5,7 +5,7 @@
 
 
 Follow this process to install a standalone KRA subsystem.
-In link:Installing_KRA.md[regular KRA installation] the KRA certificates are issued automatically by the CA and the KRA will join the CA's security domain.
+In xref:Installing_KRA.md[regular KRA installation] the KRA certificates are issued automatically by the CA and the KRA will join the CA's security domain.
 In standalone KRA installation, the KRA certificates are issued manually and the KRA have its own security domain.
 
 The installation process consists multiple steps:
@@ -18,7 +18,7 @@ The installation process consists multiple steps:
 
 Prepare a file, for example `kra-standalone-step1.cfg`, that contains the first deployment configuration.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-standalone-step1.cfg[/usr/share/pki/server/examples/installation/kra-standalone-step1.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/kra-standalone-step1.cfg[/usr/share/pki/server/examples/installation/kra-standalone-step1.cfg].
 
 Then execute the following command:
 
@@ -71,7 +71,7 @@ pki_cert_chain_path=ca_signing.crt
 
 The CA certificate chain file can contain either a single PEM certificate or a PKCS #7 certificate chain as well.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/kra-standalone-step2.cfg[/usr/share/pki/server/examples/installation/kra-standalone-step2.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/kra-standalone-step2.cfg[/usr/share/pki/server/examples/installation/kra-standalone-step2.cfg].
 
 Finally, execute the following command:
 

--- a/docs/installation/ocsp/installing-ocsp-clone-with-hsm.adoc
+++ b/docs/installation/ocsp/installing-ocsp-clone-with-hsm.adoc
@@ -10,7 +10,7 @@ where the system certificates and their keys are stored in HSM.
 Since the certificates and the keys are already in HSM, it's not necessary to export them into a
 PKCS #12 file to create a clone.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == OCSP Subsystem Installation 
 

--- a/docs/installation/ocsp/installing-ocsp-clone.adoc
+++ b/docs/installation/ocsp/installing-ocsp-clone.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install a OCSP subsystem as a clone of an existing OCSP subsystem.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Exporting Existing OCSP System Certificates 
 
@@ -43,12 +43,12 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 Prepare a deployment configuration, for example `ocsp-clone.cfg`, to deploy OCSP subsystem clone.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-clone.cfg[/usr/share/pki/server/examples/installation/ocsp-clone.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ocsp-clone.cfg[/usr/share/pki/server/examples/installation/ocsp-clone.cfg].
 It assumes that the primary CA and OCSP subsystems are running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate and key have been exported into `ca_admin_cert.p12`.
 The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
-See link:../ca/installing-ca.adoc[Installing CA] for details.
+See xref:../ca/installing-ca.adoc[Installing CA] for details.
 
 To start the installation execute the following command:
 

--- a/docs/installation/ocsp/installing-ocsp-with-custom-keys.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-custom-keys.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install a OCSP subsystem with custom OCSP system and admin keys, CSRs, and certificates.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting OCSP Subsystem Installation 
 

--- a/docs/installation/ocsp/installing-ocsp-with-ecc.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-ecc.adoc
@@ -18,7 +18,7 @@ Supported ECC key algorithms:
 - SHA384withEC
 - SHA512withEC
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == OCSP Subsystem Installation 
 

--- a/docs/installation/ocsp/installing-ocsp-with-external-certificates.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-external-certificates.adoc
@@ -5,13 +5,13 @@
 
 Follow this process to install a OCSP subsystem with external certificates.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Starting OCSP Subsystem Installation 
 
 Prepare a file, for example `ocsp-external-certs-step1.cfg`, that contains the first deployment configuration.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-external-certs-step1.cfg[/usr/share/pki/server/examples/installation/ocsp-external-certs-step1.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ocsp-external-certs-step1.cfg[/usr/share/pki/server/examples/installation/ocsp-external-certs-step1.cfg].
 It assumes that the CA is running at https://ca.example.com:8443,
 and the CA signing certificate has been exported into `ca_signing.crt`.
 
@@ -72,7 +72,7 @@ pki_cert_chain_nickname=ca_signing
 pki_cert_chain_path=ca_signing.crt
 ....
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-external-certs-step2.cfg[/usr/share/pki/server/examples/installation/ocsp-external-certs-step2.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ocsp-external-certs-step2.cfg[/usr/share/pki/server/examples/installation/ocsp-external-certs-step2.cfg].
 
 Finally, execute the following command:
 

--- a/docs/installation/ocsp/installing-ocsp-with-hsm.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-hsm.adoc
@@ -6,7 +6,7 @@
 Follow this process to install an OCSP subsystem
 where the system certificates and their keys are stored in HSM.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == OCSP Subsystem Installation 
 

--- a/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install an OCSP subsystem with a secure database connection.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration
 Once the prerequisites listed above are completed, if you had chosen to use the temporary DS bootstrap certificates during DS instance creation,
@@ -178,5 +178,5 @@ CertStatus=Good
 
 == Getting Real DS Certificate from the CA 
 
-If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
 

--- a/docs/installation/ocsp/installing-ocsp.adoc
+++ b/docs/installation/ocsp/installing-ocsp.adoc
@@ -6,12 +6,12 @@
 
 Follow this process to install an OCSP subsystem.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == OCSP Subsystem Installation 
 
 Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration.
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp.cfg[/usr/share/pki/server/examples/installation/ocsp.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ocsp.cfg[/usr/share/pki/server/examples/installation/ocsp.cfg].
 
 Then execute the following command:
 

--- a/docs/installation/ocsp/installing-standalone-ocsp.adoc
+++ b/docs/installation/ocsp/installing-standalone-ocsp.adoc
@@ -5,7 +5,7 @@
 
 
 Follow this process to install a standalone OCSP subsystem.
-In link:installing-ocsp.adoc[regular OCSP installation] the OCSP certificates are issued automatically by the CA and the OCSP will join the CA's security domain.
+In xref:installing-ocsp.adoc[regular OCSP installation] the OCSP certificates are issued automatically by the CA and the OCSP will join the CA's security domain.
 In standalone OCSP installation, the OCSP certificates are issued manually and the OCSP have its own security domain.
 
 The installation process consists multiple steps:
@@ -18,7 +18,7 @@ The installation process consists multiple steps:
 
 Prepare a file, for example `ocsp-standalone-step1.cfg`, that contains the first deployment configuration.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-standalone-step1.cfg[/usr/share/pki/server/examples/installation/ocsp-standalone-step1.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ocsp-standalone-step1.cfg[/usr/share/pki/server/examples/installation/ocsp-standalone-step1.cfg].
 
 Then execute the following command:
 
@@ -69,7 +69,7 @@ pki_cert_chain_path=ca_signing.crt
 
 The CA certificate chain file can contain either a single PEM certificate or a PKCS #7 certificate chain as well.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/ocsp-standalone-step2.cfg[/usr/share/pki/server/examples/installation/ocsp-standalone-step2.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/ocsp-standalone-step2.cfg[/usr/share/pki/server/examples/installation/ocsp-standalone-step2.cfg].
 
 Finally, execute the following command:
 

--- a/docs/installation/others/creating-ds-instance.adoc
+++ b/docs/installation/others/creating-ds-instance.adoc
@@ -7,14 +7,14 @@
 
 *Note: Prior to installing DS instances, make sure the following procedures are done:*
 
-* link:installing-ds-packages.adoc[installing DS packages] - done on the DS host system
-* link:fqdn-configuration.adoc[Setting the FQDN of the host system] - done on the host systems of DS and PKI
+* xref:installing-ds-packages.adoc[installing DS packages] - done on the DS host system
+* xref:fqdn-configuration.adoc[Setting the FQDN of the host system] - done on the host systems of DS and PKI
 
 Follow this process to prepare a local DS instance for PKI server.
 
 *Note:* The DS installation automatically generates a bootstrap self-signed signing certificate which issues a bootstrap server certificate for SSL connection. The PKI installation takes advantage of this security offer to complete its installation. The bootstrap server certificate could be replaced by a server certificate issued by an actual CA at a later step after the installation.
 
-_If you wish to disable bootstrap certificate generation and SSL connection, set `self_sign_cert = False` in the `sed` command below. You can still enable SSL later by following link:enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Enabling SSL Connection in DS with Bootstrap Cert]._
+_If you wish to disable bootstrap certificate generation and SSL connection, set `self_sign_cert = False` in the `sed` command below. You can still enable SSL later by following xref:enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Enabling SSL Connection in DS with Bootstrap Cert]._
 
 == Creating a DS Instance 
 
@@ -65,12 +65,12 @@ dc: pki
 EOF
 ----
 
-The subtree for each PKI subsystem is created when the subsystem is installed. See link:../others/pki-ldap-tree.adoc[PKI LDAP Tree].
+The subtree for each PKI subsystem is created when the subsystem is installed. See xref:../others/pki-ldap-tree.adoc[PKI LDAP Tree].
 
 == Enabling SSL Connection 
 
 If you set `self_sign_cert = False` earlier, and now decide to create bootstrap certs so that your PKI can be installed using SSL connection to DS,
-follow link:../others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Enabling SSL Connection in DS]
+follow xref:../others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc[Enabling SSL Connection in DS]
 
 *Note:* The bootstrap server certificate could be replaced by a server certificate issued by an actual CA at a later step after the installation.
 

--- a/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
+++ b/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
@@ -6,7 +6,7 @@
 
 = Enabling SSL Connection in DS Using Bootstrap Certs
 
-*If you already have an active trusted CA, and you wish to issue a server cert for your DS, please follow link:enabling-ssl-connection-in-ds.adoc[this section] instead.*
+*If you already have an active trusted CA, and you wish to issue a server cert for your DS, please follow xref:enabling-ssl-connection-in-ds.adoc[this section] instead.*
 
 Follow this process using `pki` CLI (run `man pki-client`) commands to enable SSL connection in DS
 by creating a bootstrap DS self-signed signing certificate and the bootstrap server certificate issued by it.
@@ -76,7 +76,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA
             User
 ----
 
-[id="creating-ds-server-certificate_{context}"]
+[id="creating-ds-server-certificate"]
 == Creating DS Server Certificate 
 
 First, generate DS server CSR with the following command:

--- a/docs/installation/others/installation-prerequisites.adoc
+++ b/docs/installation/others/installation-prerequisites.adoc
@@ -5,7 +5,7 @@
 
 This section contains the generic prerequisites required prior to installing a PKI subsystem.  Some installation might need additional or different setups.
 
-* link:fqdn-configuration.adoc[Setting the FQDN of the host system]
+* xref:fqdn-configuration.adoc[Setting the FQDN of the host system]
 
-* link:creating-ds-instance.adoc[Creating a directory server instance and adding base entries]
+* xref:creating-ds-instance.adoc[Creating a directory server instance and adding base entries]
 

--- a/docs/installation/others/installing-ds-packages.adoc
+++ b/docs/installation/others/installing-ds-packages.adoc
@@ -11,4 +11,4 @@ To install DS packages:
 $ dnf install -y 389-ds-base
 ----
 
-After successfully installing the DS packages, follow the instructions to link:creating-ds-instance.adoc[install DS instances].
+After successfully installing the DS packages, follow the instructions to xref:creating-ds-instance.adoc[install DS instances].

--- a/docs/installation/server/installing-basic-pki-server.adoc
+++ b/docs/installation/server/installing-basic-pki-server.adoc
@@ -42,4 +42,4 @@ To stop the server, press Ctrl-C.
 
 == See Also
 
-- link:../../admin/server/Configuring-HTTPS-Connector.adoc[Configuring HTTPS Connector]
+- xref:../../admin/server/Configuring-HTTPS-Connector.adoc[Configuring HTTPS Connector]

--- a/docs/installation/tks/installing-tks-clone.adoc
+++ b/docs/installation/tks/installing-tks-clone.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install a TKS subsystem as a clone of an existing TKS subsystem.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Exporting Existing TKS System Certificates
 
@@ -42,12 +42,12 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 Prepare a deployment configuration, for example `tks-clone.cfg`, to deploy TKS subsystem clone.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/tks-clone.cfg[/usr/share/pki/server/examples/installation/tks-clone.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/tks-clone.cfg[/usr/share/pki/server/examples/installation/tks-clone.cfg].
 It assumes that the primary CA and TKS are running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate and key have been exported into `ca_admin_cert.p12`.
 The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
-See link:../ca/Installing_CA.md[Installing CA] for details.
+See xref:../ca/Installing_CA.md[Installing CA] for details.
 
 To start the installation execute the following command:
 

--- a/docs/installation/tks/installing-tks-with-ecc.adoc
+++ b/docs/installation/tks/installing-tks-with-ecc.adoc
@@ -18,7 +18,7 @@ Supported ECC key algorithms:
 - SHA384withEC
 - SHA512withEC
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == TKS Subsystem Installation
 

--- a/docs/installation/tks/installing-tks-with-hsm.adoc
+++ b/docs/installation/tks/installing-tks-with-hsm.adoc
@@ -7,7 +7,7 @@
 Follow this process to install a TKS subsystem
 where the system certificates and their keys are stored in HSM.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == TKS Subsystem Installation
 

--- a/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
+++ b/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
@@ -6,7 +6,7 @@
 
 Follow this process to install a TKS subsystem with a secure database connection.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration
 Once the prerequisites listed above are completed, if you had chosen to use the temporary DS bootstrap certificates during DS instance creation,
@@ -152,4 +152,4 @@ User "tksadmin"
 
 == Getting Real DS Certificate from the CA 
 
-If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.

--- a/docs/installation/tks/installing-tks.adoc
+++ b/docs/installation/tks/installing-tks.adoc
@@ -6,12 +6,12 @@
 
 Follow this process to install a TKS subsystem.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == TKS Subsystem Installation
 
 Prepare a file, for example `tks.cfg`, that contains the deployment configuration.
-A sample deployment configuration is available at link:../../../base/server/examples/installation/tks.cfg[/usr/share/pki/server/examples/installation/tks.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/tks.cfg[/usr/share/pki/server/examples/installation/tks.cfg].
 
 Then execute the following command:
 

--- a/docs/installation/tps/installing-tps-clone.adoc
+++ b/docs/installation/tps/installing-tps-clone.adoc
@@ -7,7 +7,7 @@
 Follow this process to install a TPS subsystem as a clone of an existing TPS subsystem
 where the system certificates and their keys are stored in internal NSS token.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == Exporting Existing TPS System Certificates
 
@@ -43,12 +43,12 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 Prepare a deployment configuration, for example `tps-clone.cfg`, to deploy TPS subsystem clone.
 By default the subsystem is deployed into a Tomcat instance called `pki-tomcat`.
 
-A sample deployment configuration is available at link:../../../base/server/examples/installation/tps-clone.cfg[/usr/share/pki/server/examples/installation/tps-clone.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/tps-clone.cfg[/usr/share/pki/server/examples/installation/tps-clone.cfg].
 It assumes that the primary CA, KRA, TKS, and TPS subsystems are running at https://primary.example.com:8443,
 the CA signing certificate has been exported into `ca_signing.crt`,
 and the admin certificate and key have been exported into `ca_admin_cert.p12`.
 The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
-See link:../ca/Installing_CA.md[Installing CA] for details.
+See xref:../ca/Installing_CA.md[Installing CA] for details.
 
 To start the installation execute the following command:
 

--- a/docs/installation/tps/installing-tps-with-hsm.adoc
+++ b/docs/installation/tps/installing-tps-with-hsm.adoc
@@ -7,7 +7,7 @@
 Follow this process to install a TPS subsystem
 where the system certificates and their keys are stored in HSM.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == TPS Subsystem Installation
 

--- a/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
+++ b/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
@@ -5,7 +5,7 @@
 
 Follow this process to install a TPS subsystem a secure database connection.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == DS Configuration
 Once the prerequisites listed above are completed, if you had chosen to use the temporary DS bootstrap certificates during DS instance creation,
@@ -153,4 +153,4 @@ User "tpsadmin"
 
 == Getting Real DS Certificate from the CA
 
-If desired, follow link:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.

--- a/docs/installation/tps/installing-tps.adoc
+++ b/docs/installation/tps/installing-tps.adoc
@@ -6,12 +6,12 @@
 
 Follow this process to install a TPS subsystem.
 
-Prior to installation, please ensure that the link:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
+Prior to installation, please ensure that the xref:../others/installation-prerequisites.adoc[Installation Prerequisites] are configured.
 
 == TPS Subsystem Installation
 
 Prepare a file, for example `tps.cfg`, that contains the deployment configuration.
-A sample deployment configuration is available at link:../../../base/server/examples/installation/tps.cfg[/usr/share/pki/server/examples/installation/tps.cfg].
+A sample deployment configuration is available at xref:../../../base/server/examples/installation/tps.cfg[/usr/share/pki/server/examples/installation/tps.cfg].
 
 Then execute the following command:
 


### PR DESCRIPTION
- to allow asciidoc processor to do intelligent substitution (supposedly). [skip ci]