### PR TITLE
Convert TPSClientCLI.resetPIN() to Java

### DIFF
--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -289,6 +289,11 @@ jobs:
           docker exec pki pki-server tps-config-set \
               channel.scp01.no.le.byte true
 
+          # reset PIN_RESET after PIN reset
+          docker exec pki pki-server tps-config-set \
+              tokendb.defaultPolicy \
+              "RE_ENROLL=YES;RENEW=NO;FORCE_FORMAT=NO;PIN_RESET=NO;RESET_PIN_RESET_TO_NO=YES"
+
           # restart TPS subsystem
           docker exec pki pki-server tps-redeploy --wait
 
@@ -327,7 +332,11 @@ jobs:
         run: |
           hexdump -v -n "10" -e '1/1 "%02x"' /dev/urandom > cuid
           CUID=$(cat cuid)
-          docker exec pki pki -n caadmin tps-token-add $CUID | tee output
+
+          # allow one-time PIN reset
+          docker exec pki pki -n caadmin tps-token-add \
+              --policy "PIN_RESET=YES" \
+              $CUID | tee output
 
           echo "UNFORMATTED" > expected
           sed -n 's/\s*Status:\s\+\(\S\+\)\s*/\1/p' output > actual
@@ -362,8 +371,26 @@ jobs:
           docker exec pki pki -n caadmin tps-token-show $CUID | tee output
           sed -n 's/\s*Status:\s\+\(\S\+\)\s*/\1/p' output > actual
           diff expected actual
-          
+
           docker exec pki pki -n caadmin tps-cert-find --token $CUID
+
+      - name: Reset PIN for testuser1 token using pki tps-client
+        run: |
+          CUID=$(cat cuid)
+          docker exec pki /usr/share/pki/tps/bin/pki-tps-pin-reset \
+              --user=testuser1 \
+              --password=Secret.123 \
+              --new-password=Secret.456 \
+              $CUID
+
+          # TODO: validate new PIN
+
+          # PIN_RESET should become NO
+          echo "RE_ENROLL=YES;RENEW=NO;FORCE_FORMAT=NO;PIN_RESET=NO;RESET_PIN_RESET_TO_NO=YES;RENEW_KEEP_OLD_ENC_CERTS=YES" > expected
+          docker exec pki pki -n caadmin tps-token-show $CUID | tee output
+          sed -n 's/\s*Policy:\s\+\(\S\+\)\s*/\1/p' output > actual
+
+          diff expected actual
 
       - name: Find testuser1 key in KRA
         run: |          
@@ -378,7 +405,11 @@ jobs:
         run: |
           hexdump -v -n "10" -e '1/1 "%02x"' /dev/urandom > cuid
           CUID=$(cat cuid)
-          docker exec pki pki -n caadmin tps-token-add $CUID | tee output
+
+          # allow one-time PIN reset
+          docker exec pki pki -n caadmin tps-token-add \
+              --policy "PIN_RESET=YES" \
+              $CUID | tee output
 
           echo "UNFORMATTED" > expected
           sed -n 's/\s*Status:\s\+\(\S\+\)\s*/\1/p' output > actual
@@ -417,6 +448,24 @@ jobs:
           diff expected actual
 
           docker exec pki pki -n caadmin tps-cert-find --token $CUID
+
+      - name: Reset PIN for testuser2 token using tpsclient
+        run: |
+          CUID=$(cat cuid)
+          docker exec pki /usr/share/pki/tps/bin/pki-tps-pin-reset \
+              --client=tpsclient \
+              --user=testuser2 \
+              --password=Secret.123 \
+              --new-password=Secret.456 \
+              $CUID
+
+          # TODO: validate new PIN
+
+          # PIN_RESET should become NO
+          echo "RE_ENROLL=YES;RENEW=NO;FORCE_FORMAT=NO;PIN_RESET=NO;RESET_PIN_RESET_TO_NO=YES;RENEW_KEEP_OLD_ENC_CERTS=YES" > expected
+          docker exec pki pki -n caadmin tps-token-show $CUID | tee output
+          sed -n 's/\s*Policy:\s\+\(\S\+\)\s*/\1/p' output > actual
+          diff expected actual
 
       - name: Find testuser2 key in KRA
         run: |

--- a/base/tools/src/main/native/tpsclient/src/include/main/RA_Client.h
+++ b/base/tools/src/main/native/tpsclient/src/include/main/RA_Client.h
@@ -56,7 +56,6 @@ class RA_Client
   public:
 	  int OpHelp(NameValueSet *set);
 	  int OpConnStart(NameValueSet *set, RequestType);
-	  int OpConnResetPin(NameValueSet *set);
 	  int OpConnEnroll(NameValueSet *set);
 	  int OpTokenStatus(NameValueSet *set);
 	  int OpTokenSet(NameValueSet *set);
@@ -87,5 +86,8 @@ typedef struct _ThreadArg
 
 extern "C" void
 ThreadConnUpdate (void *arg);
+
+extern "C" void
+ThreadConnResetPin (void *arg);
 
 #endif /* RA_CLIENT_H */

--- a/base/tools/src/main/native/tpsclient/src/main/RA_Client.cpp
+++ b/base/tools/src/main/native/tpsclient/src/main/RA_Client.cpp
@@ -640,7 +640,7 @@ extern "C"
       }
   }
 
-  static void ThreadConnResetPin (void *arg)
+  void ThreadConnResetPin (void *arg)
   {
     PRTime start, end;
     ThreadArg *targ = (ThreadArg *) arg;
@@ -787,79 +787,6 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
-
-int
-RA_Client::OpConnResetPin (NameValueSet * params)
-{
-  int num_threads = params->GetValueAsInt ((char *) "num_threads", 1);
-  int i;
-  int status = 0;
-  PRThread **threads;
-  ThreadArg *arg;
-
-  threads = (PRThread **) malloc (sizeof (PRThread *) * num_threads);
-  if (threads == NULL)
-    {
-      return 0;
-    }
-  arg = (ThreadArg *) malloc (sizeof (ThreadArg) * num_threads);
-  if (arg == NULL)
-    {
-      if(threads) {
-          free(threads);
-          threads = NULL;
-      }
-      return 0;
-    }
-
-  /* start threads */
-  for (i = 0; i < num_threads; i++)
-    {
-      arg[i].time = 0;
-      arg[i].status = 0;
-      arg[i].client = this;
-      if (i == 0)
-	{
-	  arg[i].token = &this->m_token;
-	}
-      else
-	{
-	  arg[i].token = this->m_token.Clone ();
-	}
-      arg[i].params = params;
-      threads[i] = PR_CreateThread (PR_USER_THREAD, ThreadConnResetPin, &arg[i], PR_PRIORITY_NORMAL,	/* Priority */
-				    PR_GLOBAL_THREAD,	/* Scope */
-				    PR_JOINABLE_THREAD,	/* State */
-				    0	/* Stack Size */
-	);
-    }
-
-  /* join threads */
-  for (i = 0; i < num_threads; i++)
-    {
-      PR_JoinThread (threads[i]);
-    }
-
-  for (i = 0; i < num_threads; i++)
-    {
-      Output ("Thread (%d) status='%d' time='%d msec'", i,
-	      arg[i].status, arg[i].time);
-    }
-
-  status = arg[0].status;
-
-  if(arg) {
-     free(arg);
-     arg = NULL;
-  }
-
-  if(threads) {
-     free(threads);
-     threads = NULL;
-  }
-
-  return status;
-}
 
 #ifdef __cplusplus
 extern "C"

--- a/base/tools/src/main/native/tpsclient/src/main/TPSClientCLI.cpp
+++ b/base/tools/src/main/native/tpsclient/src/main/TPSClientCLI.cpp
@@ -175,18 +175,36 @@ Java_com_netscape_cmstools_tps_TPSClientCLI_newFormatToken
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_netscape_cmstools_tps_TPSClientCLI_resetPIN
+Java_com_netscape_cmstools_tps_TPSClientCLI_performResetPIN
+(JNIEnv* env, jobject object, jlong client, jobject params) {
+
+    RA_Client* cclient = (RA_Client*) client;
+
+    ThreadArg arg;
+    arg.time = 0;
+    arg.status = 0;
+    arg.client = cclient;
+    arg.token = cclient->m_token.Clone();
+    arg.params = convertParams(env, params);
+
+    ThreadConnResetPin(&arg);
+
+    delete arg.params;
+    delete arg.token;
+
+    if (arg.status == 0) {
+        throwCLIException(env, "Unable to reset PIN");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_netscape_cmstools_tps_TPSClientCLI_newResetPIN
 (JNIEnv* env, jobject object, jlong client, jobject params) {
 
     RA_Client* cclient = (RA_Client*) client;
     NameValueSet *set = convertParams(env, params);
 
-    int status;
-    if (cclient->old_style) {
-        status = cclient->OpConnResetPin(set);
-    } else {
-        status = cclient->OpConnStart(set, OP_CLIENT_RESET_PIN);
-    }
+    int status = cclient->OpConnStart(set, OP_CLIENT_RESET_PIN);
 
     delete set;
 

--- a/base/tps/bin/pki-tps-pin-reset
+++ b/base/tps/bin/pki-tps-pin-reset
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+TPS_CLIENT="pki tps-client"
+TPS_HOSTNAME=$HOSTNAME
+TPS_PORT=8080
+TPS_PATH=/tps/tps
+
+MSN=01020304
+APP_VERSION=6FBBC105
+KEY_INFO=0101
+MAJOR_VERSION=0
+MINOR_VERSION=0
+
+AUTH_KEY=404142434445464748494a4b4c4d4e4f
+MAC_KEY=404142434445464748494a4b4c4d4e4f
+KEK_KEY=404142434445464748494a4b4c4d4e4f
+
+THREADS=1
+
+VERBOSE=
+
+while getopts v-: arg ; do
+    case $arg in
+    v)
+        export VERBOSE=true
+        ;;
+    -)
+        LONG_OPTARG="${OPTARG#*=}"
+
+        case $OPTARG in
+        client=?*)
+            TPS_CLIENT="$LONG_OPTARG"
+            ;;
+        hostname=?*)
+            TPS_HOSTNAME="$LONG_OPTARG"
+            ;;
+        port=?*)
+            TPS_PORT="$LONG_OPTARG"
+            ;;
+        user=?*)
+            USERNAME="$LONG_OPTARG"
+            ;;
+        password=?*)
+            PASSWORD="$LONG_OPTARG"
+            ;;
+        new-password=?*)
+            NEW_PASSWORD="$LONG_OPTARG"
+            ;;
+        '')
+            break # "--" terminates argument processing
+            ;;
+        client* | hostname* | port* | user* | password* | new-password*)
+            echo "ERROR: Missing argument for --$OPTARG option" >&2
+            exit 1
+            ;;
+        *)
+            echo "ERROR: Illegal option --$OPTARG" >&2
+            exit 1
+            ;;
+        esac
+        ;;
+    \?)
+        exit 1 # getopts already reported the illegal option
+        ;;
+    esac
+done
+
+# remove parsed options and args from $@ list
+shift $((OPTIND-1))
+
+CUID=$1
+
+$TPS_CLIENT << EOF
+op=var_set name=ra_host value=$TPS_HOSTNAME
+op=var_set name=ra_port value=$TPS_PORT
+op=var_set name=ra_uri value=$TPS_PATH
+
+op=token_set cuid=$CUID
+op=token_set msn=$MSN
+op=token_set app_ver=$APP_VERSION
+op=token_set key_info=$KEY_INFO
+op=token_set major_ver=$MAJOR_VERSION
+op=token_set minor_ver=$MINOR_VERSION
+op=token_set auth_key=$AUTH_KEY
+op=token_set mac_key=$MAC_KEY
+op=token_set kek_key=$KEK_KEY
+
+op=ra_reset_pin uid=$USERNAME pwd=$PASSWORD new_pin=$NEW_PASSWORD num_threads=$THREADS
+
+op=exit
+EOF
+
+rc=$?
+
+if [ "$TPS_CLIENT" == "tpsclient" ]; then
+    # tpsclient returns 1 on success and 0 on failure,
+    # so the return code needs to be inverted
+
+    if [ "$rc" == "0" ]; then
+        exit 1
+    fi
+
+    exit 0
+fi
+
+exit $rc


### PR DESCRIPTION
The `TPSClientCLI.resetPIN()` has been converted into Java. The old style method will use Java threads to call the native code that performs the actual operation. The new style method is still implemented in C++ and might be converted into Java in the future. The `RA_Client::OpConnResetPin()` has been moved into `tpsclient.cpp`.

The basic TPS test has been updated to perform PIN reset.