### PR TITLE
Convert TPSClientCLI.enrollToken() to Java

### DIFF
--- a/base/tools/src/main/native/tpsclient/src/include/main/RA_Client.h
+++ b/base/tools/src/main/native/tpsclient/src/include/main/RA_Client.h
@@ -56,7 +56,6 @@ class RA_Client
   public:
 	  int OpHelp(NameValueSet *set);
 	  int OpConnStart(NameValueSet *set, RequestType);
-	  int OpConnEnroll(NameValueSet *set);
 	  int OpTokenStatus(NameValueSet *set);
 	  int OpTokenSet(NameValueSet *set);
 	  int OpVarList(NameValueSet *set);
@@ -89,5 +88,8 @@ ThreadConnUpdate (void *arg);
 
 extern "C" void
 ThreadConnResetPin (void *arg);
+
+extern "C" void
+ThreadConnEnroll (void *arg);
 
 #endif /* RA_CLIENT_H */

--- a/base/tools/src/main/native/tpsclient/src/main/RA_Client.cpp
+++ b/base/tools/src/main/native/tpsclient/src/main/RA_Client.cpp
@@ -793,7 +793,7 @@ extern "C"
 {
 #endif
 
-  static void ThreadConnEnroll (void *arg)
+  void ThreadConnEnroll (void *arg)
   {
     PRTime start, end;
     ThreadArg *targ = (ThreadArg *) arg;
@@ -940,86 +940,6 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
-
-int
-RA_Client::OpConnEnroll (NameValueSet * params)
-{
-  int num_threads = params->GetValueAsInt ((char *) "num_threads", 1);
-  int i;
-  int status = 0;
-  PRThread **threads;
-  ThreadArg *arg;
-
-  threads = (PRThread **) malloc (sizeof (PRThread *) * num_threads);
-  if (threads == NULL)
-    {
-      return 0;			/* error */
-    }
-  arg = (ThreadArg *) malloc (sizeof (ThreadArg) * num_threads);
-  if (arg == NULL)
-    {
-      if(threads) {
-          free(threads);
-          threads = NULL;
-      }
-      return 0;
-    }
-
-  /* start threads */
-  for (i = 0; i < num_threads; i++)
-    {
-      arg[i].time = 0;
-      arg[i].status = 0;
-      arg[i].client = this;
-      if (i == 0)
-	{
-	  arg[i].token = &this->m_token;
-	}
-      else
-	{
-	  arg[i].token = this->m_token.Clone ();
-	}
-      arg[i].params = params;
-      threads[i] = PR_CreateThread (PR_USER_THREAD, ThreadConnEnroll, &arg[i], PR_PRIORITY_NORMAL,	/* Priority */
-				    PR_GLOBAL_THREAD,	/* Scope */
-				    PR_JOINABLE_THREAD,	/* State */
-				    0	/* Stack Size */
-	);
-    }
-
-  /* join threads */
-  for (i = 0; i < num_threads; i++)
-    {
-      PR_JoinThread (threads[i]);
-    }
-
-  status = 1;
-
-  for (i = 0; i < num_threads; i++)
-    {
-      Output ("Thread (%d) status='%d' time='%d msec'", i,
-	      arg[i].status, arg[i].time);
-      if (arg[i].status != 1)
-	{
-	  // if any thread fails, this operation 
-	  // is considered as failure     
-	  status = arg[i].status;
-	}
-    }
-
-  if(arg) {
-     free(arg);
-     arg = NULL;
-  }
-
-  if(threads) {
-     free(threads);
-     threads = NULL;
-  }
-
-  return status;
-}
-
 
 /*
  * no more than num_threads will be running concurrently

--- a/base/tools/src/main/native/tpsclient/src/main/TPSClientCLI.cpp
+++ b/base/tools/src/main/native/tpsclient/src/main/TPSClientCLI.cpp
@@ -214,18 +214,36 @@ Java_com_netscape_cmstools_tps_TPSClientCLI_newResetPIN
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_netscape_cmstools_tps_TPSClientCLI_enrollToken
+Java_com_netscape_cmstools_tps_TPSClientCLI_performEnrollToken
+(JNIEnv* env, jobject object, jlong client, jobject params) {
+
+    RA_Client* cclient = (RA_Client*) client;
+
+    ThreadArg arg;
+    arg.time = 0;
+    arg.status = 0;
+    arg.client = cclient;
+    arg.token = cclient->m_token.Clone();
+    arg.params = convertParams(env, params);
+
+    ThreadConnEnroll(&arg);
+
+    delete arg.params;
+    delete arg.token;
+
+    if (arg.status == 0) {
+        throwCLIException(env, "Unable to enroll token");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_netscape_cmstools_tps_TPSClientCLI_newEnrollToken
 (JNIEnv* env, jobject object, jlong client, jobject params) {
 
     RA_Client* cclient = (RA_Client*) client;
     NameValueSet *set = convertParams(env, params);
 
-    int status;
-    if (cclient->old_style) {
-        status = cclient->OpConnEnroll(set);
-    } else {
-        status = cclient->OpConnStart(set, OP_CLIENT_ENROLL);
-    }
+    int status = cclient->OpConnStart(set, OP_CLIENT_ENROLL);
 
     delete set;
 

--- a/base/tools/src/main/native/tpsclient/tools/raclient/tpsclient.cpp
+++ b/base/tools/src/main/native/tpsclient/tools/raclient/tpsclient.cpp
@@ -242,6 +242,85 @@ OpConnResetPin (RA_Client* client, NameValueSet * params)
   return status;
 }
 
+int
+OpConnEnroll (RA_Client* client, NameValueSet * params)
+{
+  int num_threads = params->GetValueAsInt ((char *) "num_threads", 1);
+  int i;
+  int status = 0;
+  PRThread **threads;
+  ThreadArg *arg;
+
+  threads = (PRThread **) malloc (sizeof (PRThread *) * num_threads);
+  if (threads == NULL)
+    {
+      return 0;         /* error */
+    }
+  arg = (ThreadArg *) malloc (sizeof (ThreadArg) * num_threads);
+  if (arg == NULL)
+    {
+      if(threads) {
+          free(threads);
+          threads = NULL;
+      }
+      return 0;
+    }
+
+  /* start threads */
+  for (i = 0; i < num_threads; i++)
+    {
+      arg[i].time = 0;
+      arg[i].status = 0;
+      arg[i].client = client;
+      if (i == 0)
+    {
+      arg[i].token = &client->m_token;
+    }
+      else
+    {
+      arg[i].token = client->m_token.Clone ();
+    }
+      arg[i].params = params;
+      threads[i] = PR_CreateThread (PR_USER_THREAD, ThreadConnEnroll, &arg[i], PR_PRIORITY_NORMAL,  /* Priority */
+                    PR_GLOBAL_THREAD,   /* Scope */
+                    PR_JOINABLE_THREAD, /* State */
+                    0   /* Stack Size */
+    );
+    }
+
+  /* join threads */
+  for (i = 0; i < num_threads; i++)
+    {
+      PR_JoinThread (threads[i]);
+    }
+
+  status = 1;
+
+  for (i = 0; i < num_threads; i++)
+    {
+      Output ("Thread (%d) status='%d' time='%d msec'", i,
+          arg[i].status, arg[i].time);
+      if (arg[i].status != 1)
+    {
+      // if any thread fails, this operation
+      // is considered as failure
+      status = arg[i].status;
+    }
+    }
+
+  if(arg) {
+     free(arg);
+     arg = NULL;
+  }
+
+  if(threads) {
+     free(threads);
+     threads = NULL;
+  }
+
+  return status;
+}
+
 /**
  * Invoke operation.
  */
@@ -277,7 +356,7 @@ InvokeOperation (RA_Client* client, char *op, NameValueSet * params)
   else if (strcmp (op, "ra_enroll") == 0)
     {
       if (client->old_style)
-    status = client->OpConnEnroll (params);
+    status = OpConnEnroll (client, params);
       else
     status = client->OpConnStart (params, OP_CLIENT_ENROLL);
     }


### PR DESCRIPTION
The `TPSClientCLI.enrollToken()` has been converted into Java. The old style method will use Java threads to call the native code that performs the actual operation. The new style method is still implemented in C++ and might be converted into Java in the future. The `RA_Client::OpConnEnroll()` has been moved into `tpsclient.cpp`.