### PR TITLE
Renaming enabling-ssl-connection-in-ds.adoc to getting-ds-cert-issued…

### DIFF
--- a/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
@@ -10,7 +10,7 @@ Prior to installation, please ensure that the xref:../others/installation-prereq
 
 == DS Configuration 
 
-Once the prerequisites listed above are completed on the clone system, follow the procedure to xref:../others/enabling-ssl-connection-in-ds.adoc[enable SSL Connection with DS] so that the CA clone's DS is running with SSL enabled wtih a real server certificate issued by the CA.
+Once the prerequisites listed above are completed on the clone system, follow the procedure to xref:../others/getting-ds-cert-issued-by-actual-ca.adoc[enable SSL Connection with DS] so that the CA clone's DS is running with SSL enabled wtih a real server certificate issued by the CA.
 
 Some useful tips:
 

--- a/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
@@ -138,5 +138,5 @@ User "caadmin"
 
 == Getting Real DS Certificate from the CA
 
-If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/getting-ds-cert-issued-by-actual-ca.adoc[this procedure] to get real DS certificate issued by the CA.
 

--- a/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
+++ b/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
@@ -166,5 +166,5 @@ Transport Cert:
 
 == Getting Real DS Certificate from the CA 
 
-If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/getting-ds-cert-issued-by-actual-ca.adoc[this procedure] to get real DS certificate issued by the CA.
 

--- a/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
@@ -178,5 +178,5 @@ CertStatus=Good
 
 == Getting Real DS Certificate from the CA 
 
-If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/getting-ds-cert-issued-by-actual-ca.adoc[this procedure] to get real DS certificate issued by the CA.
 

--- a/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
+++ b/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
@@ -6,7 +6,7 @@
 
 = Enabling SSL Connection in DS Using Bootstrap Certs
 
-*If you already have an active trusted CA, and you wish to issue a server cert for your DS, please follow xref:enabling-ssl-connection-in-ds.adoc[this section] instead.*
+*If you already have an active trusted CA, and you wish to issue a server cert for your DS, please follow xref:getting-ds-cert-issued-by-actual-ca.adoc[this section] instead.*
 
 Follow this process using `pki` CLI (run `man pki-client`) commands to enable SSL connection in DS
 by creating a bootstrap DS self-signed signing certificate and the bootstrap server certificate issued by it.

--- a/docs/installation/others/getting-ds-cert-issued-by-actual-ca.adoc
+++ b/docs/installation/others/getting-ds-cert-issued-by-actual-ca.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="enabling-ssl-connection-in-ds_{context}"]
+[id="getting-ds-cert-issued-by-actual-ca_{context}"]
 
 // This section is intended for all PKI subsystems
 
-= Enabling SSL Connection in DS 
+= Getting DS Certificate Issued by Actual CA
 
-Follow this process using `pki` CLI (run `man pki-client`) commands to enable SSL connection in DS.
+Follow this process using `pki` CLI (run `man pki-client`) commands to get DS certificate issued by the actual CA.
 
 This section assumes that a DS instance named `localhost` already exists,
 

--- a/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
+++ b/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
@@ -152,4 +152,4 @@ User "tksadmin"
 
 == Getting Real DS Certificate from the CA 
 
-If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/getting-ds-cert-issued-by-actual-ca.adoc[this procedure] to get real DS certificate issued by the CA.

--- a/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
+++ b/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
@@ -153,4 +153,4 @@ User "tpsadmin"
 
 == Getting Real DS Certificate from the CA
 
-If desired, follow xref:../others/enabling-ssl-connection-in-ds.adoc[this procedure] to get real DS certificate issued by the CA.
+If desired, follow xref:../others/getting-ds-cert-issued-by-actual-ca.adoc[this procedure] to get real DS certificate issued by the CA.


### PR DESCRIPTION
…-by-actual-ca.adoc so that it fits in the downstream post-install section more nicely.

[skip ci]