### PR TITLE
Update pki ca-cert-issue to support CRMF

### DIFF
--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -357,31 +357,19 @@ jobs:
 
           docker exec pki cat testuser.csr
 
-          # submit cert request
-          # https://github.com/dogtagpki/pki/wiki/Submitting-Certificate-Request-with-Key-Archival
-          docker exec pki pki \
-              ca-cert-request-submit \
-              --request-type crmf \
-              --csr-file testuser.csr \
-              --profile caUserCert \
-              --subject UID=testuser | tee output
-
-          REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" output)
-          echo "Request ID: $REQUEST_ID"
-
           # issue cert
+          # https://github.com/dogtagpki/pki/wiki/Issuing-Certificates
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
-              ca-cert-request-approve \
-              --force \
-              $REQUEST_ID | tee output
-
-          CERT_ID=$(sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" output)
-          echo "Cert ID: $CERT_ID"
+              ca-cert-issue \
+              --request-type crmf \
+              --profile caUserCert \
+              --subject UID=testuser \
+              --csr-file testuser.csr \
+              --output-file testuser.crt
 
           # import cert into NSS database
-          docker exec pki pki ca-cert-export --output-file testuser.crt $CERT_ID
           docker exec pki pki nss-cert-import --cert testuser.crt testuser
 
           # the cert should match the key (trust flags must be u,u,u)

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -514,42 +514,21 @@ jobs:
 
           docker exec client cat testuser.csr
 
-          # submit cert request
-          # https://github.com/dogtagpki/pki/wiki/Submitting-Certificate-Request-with-Key-Archival
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              ca-cert-request-submit \
-              --request-type crmf \
-              --csr-file testuser.csr \
-              --profile caUserCert \
-              --subject UID=testuser | tee output
-
-          REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" output)
-          echo "Request ID: $REQUEST_ID"
-          echo "$REQUEST_ID" > request.id
-
       - name: Issue cert with key archival
         run: |
-          REQUEST_ID=$(cat request.id)
-
           # issue cert
+          # https://github.com/dogtagpki/pki/wiki/Issuing-Certificates
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n admin \
-              ca-cert-request-approve \
-              --force \
-              $REQUEST_ID | tee output
-
-          CERT_ID=$(sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" output)
-          echo "Cert ID: $CERT_ID"
+              ca-cert-issue \
+              --request-type crmf \
+              --profile caUserCert \
+              --subject UID=testuser \
+              --csr-file testuser.csr \
+              --output-file testuser.crt
 
           # import cert into NSS database
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              ca-cert-export \
-              --output-file testuser.crt \
-              $CERT_ID
-
           docker exec client pki nss-cert-import --cert testuser.crt testuser
 
           # the cert should match the key (trust flags must be u,u,u)

--- a/.github/workflows/kra-migration-test.yml
+++ b/.github/workflows/kra-migration-test.yml
@@ -109,31 +109,19 @@ jobs:
 
           docker exec pki1 cat testuser.csr
 
-          # submit cert request
-          # https://github.com/dogtagpki/pki/wiki/Submitting-Certificate-Request-with-Key-Archival
-          docker exec pki1 pki \
-              ca-cert-request-submit \
-              --request-type crmf \
-              --csr-file testuser.csr \
-              --profile caUserCert \
-              --subject UID=testuser | tee output
-
-          REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)\s*$/\1/p" output)
-          echo "Request ID: $REQUEST_ID"
-
           # issue cert
+          # https://github.com/dogtagpki/pki/wiki/Issuing-Certificates
           docker exec pki1 pki \
               -u caadmin \
               -w Secret.123 \
-              ca-cert-request-approve \
-              --force \
-              $REQUEST_ID | tee output
-
-          CERT_ID=$(sed -n "s/^\s*Certificate ID:\s*\(\S*\)\s*$/\1/p" output)
-          echo "Cert ID: $CERT_ID"
+              ca-cert-issue \
+              --request-type crmf \
+              --profile caUserCert \
+              --subject UID=testuser \
+              --csr-file testuser.csr \
+              --output-file $SHARED/testuser.crt
 
           # import cert into NSS database
-          docker exec pki1 pki ca-cert-export --output-file $SHARED/testuser.crt $CERT_ID
           docker exec pki1 pki nss-cert-import --cert $SHARED/testuser.crt testuser
 
           # the cert should match the key (trust flags must be u,u,u)


### PR DESCRIPTION
The `pki ca-cert-issue` has been modified to support submitting an existing CRMF request, approving the request, and retrieving the issued cert in one step.

Some KRA tests have been simplified using this command.

https://github.com/dogtagpki/pki/wiki/Issuing-Certificates

**Note:** Right now the command requires `--subject` to be specified for CRMF request. Ideally it should be able to obtain the subject name from the request itself. It will be fixed separately later.