### PR TITLE
Update KeyClient.list_requests() and list_keys() to support REST API v2

### DIFF
--- a/.github/workflows/python-kra-test.yml
+++ b/.github/workflows/python-kra-test.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           # export CA signing cert
           docker exec pki pki-server cert-export \
-              --cert-file $SHARED/ca_signing.crt \
+              --cert-file ca_signing.crt \
               ca_signing
 
           # export admin cert
@@ -106,13 +106,13 @@ jobs:
              -nocerts
 
       ####################################################################################################
-      # Check Python API
+      # Check PKI server info
 
       - name: Check PKI server info
         run: |
           docker exec pki python /usr/share/pki/tests/bin/pki-info.py \
               -U https://pki.example.com:8443 \
-              --ca-bundle $SHARED/ca_signing.crt \
+              --ca-bundle ca_signing.crt \
               -v
 
           sleep 1
@@ -136,7 +136,7 @@ jobs:
         run: |
           docker exec pki python /usr/share/pki/tests/bin/pki-info.py \
               -U https://pki.example.com:8443 \
-              --ca-bundle $SHARED/ca_signing.crt \
+              --ca-bundle ca_signing.crt \
               --api v1 \
               -v
 
@@ -155,11 +155,14 @@ jobs:
           GET /pki/v1/info HTTP/1.1 200 -
           EOF
 
+      ####################################################################################################
+      # Check KRA users
+
       - name: Check KRA users
         run: |
           docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-user-find.py \
               -U https://pki.example.com:8443 \
-              --ca-bundle $SHARED/ca_signing.crt \
+              --ca-bundle ca_signing.crt \
               --client-cert admin.crt \
               --client-key admin.key \
               -v
@@ -188,7 +191,7 @@ jobs:
         run: |
           docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-user-find.py \
               -U https://pki.example.com:8443 \
-              --ca-bundle $SHARED/ca_signing.crt \
+              --ca-bundle ca_signing.crt \
               --client-cert admin.crt \
               --client-key admin.key \
               --api v1 \
@@ -208,6 +211,173 @@ jobs:
           cat > expected << EOF
           GET /kra/v1/account/login HTTP/1.1 200 kraadmin
           GET /kra/v1/admin/users HTTP/1.1 200 kraadmin
+          GET /kra/v1/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      ####################################################################################################
+      # Enroll certs with key archival
+
+      - name: Enroll cert with key archival
+        run: |
+          docker exec pki pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          # get transport cert
+          docker exec pki pki-server cert-export \
+              --cert-file kra_transport.crt \
+              kra_transport
+
+          docker exec pki pki nss-cert-import \
+              --cert kra_transport.crt \
+              kra_transport
+
+          # create request
+          docker exec pki pki nss-cert-request \
+              --type crmf \
+              --format DER \
+              --subject "UID=testuser" \
+              --transport kra_transport \
+              --csr testuser.csr \
+              --debug
+
+          # issue cert
+          docker exec pki pki \
+              -u caadmin \
+              -w Secret.123 \
+              ca-cert-issue \
+              --request-type crmf \
+              --request-format DER \
+              --csr-file testuser.csr \
+              --profile caUserCert \
+              --subject "UID=testuser" \
+              --output-file testuser.crt \
+              --debug
+
+      ####################################################################################################
+      # Check key requests
+
+      - name: Check key requests
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-request-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /kra/v2/account/login HTTP/1.1 200 kraadmin
+          GET /kra/v2/agent/keyrequests HTTP/1.1 200 kraadmin
+          GET /kra/v2/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      - name: Check key requests with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-request-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --api v1 \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -3 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1
+          cat > expected << EOF
+          GET /kra/v1/account/login HTTP/1.1 200 kraadmin
+          GET /kra/v1/agent/keyrequests HTTP/1.1 200 kraadmin
+          GET /kra/v1/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      ####################################################################################################
+      # Check archived keys
+
+      - name: Check archived keys
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /kra/v2/account/login HTTP/1.1 200 kraadmin
+          GET /kra/v2/agent/keys HTTP/1.1 200 kraadmin
+          GET /kra/v2/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      - name: Check archived keys with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --api v1 \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -3 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1
+          cat > expected << EOF
+          GET /kra/v1/account/login HTTP/1.1 200 kraadmin
+          GET /kra/v1/agent/keys HTTP/1.1 200 kraadmin
           GET /kra/v1/account/logout HTTP/1.1 204 kraadmin
           EOF
 

--- a/tests/kra/bin/pki-kra-key-find.py
+++ b/tests/kra/bin/pki-kra-key-find.py
@@ -1,0 +1,96 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+
+import pki.kra
+import pki.account
+import pki.client
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--client-cert',
+    help='Path to client certificate',
+    dest='client_cert')
+parser.add_argument(
+    '--client-key',
+    help='Path to client key',
+    dest='client_key')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+pki_client.set_client_auth(
+    client_cert=args.client_cert,
+    client_key=args.client_key)
+
+kra_client = pki.kra.KRAClient(pki_client)
+
+account_client = pki.account.AccountClient(kra_client)
+account_client.login()
+
+key_client = pki.key.KeyClient(kra_client)
+result = key_client.list_keys()
+
+first = True
+
+for key_info in result.key_infos:
+
+    if first:
+        first = False
+    else:
+        print()
+
+    print('  Key ID: %s' % key_info.get_key_id())
+
+    if key_info.client_key_id:
+        print('  Client Key ID: %s' % key_info.client_key_id)
+
+    print('  Algorithm: %s' % key_info.algorithm)
+    print('  Size: %s' % key_info.size)
+    print('  Owner: %s' % key_info.owner_name)
+
+    if key_info.status:
+        print('  Status: %s' % key_info.status)
+
+account_client.logout()

--- a/tests/kra/bin/pki-kra-key-request-find.py
+++ b/tests/kra/bin/pki-kra-key-request-find.py
@@ -1,0 +1,91 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+
+import pki.kra
+import pki.account
+import pki.client
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--client-cert',
+    help='Path to client certificate',
+    dest='client_cert')
+parser.add_argument(
+    '--client-key',
+    help='Path to client key',
+    dest='client_key')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+pki_client.set_client_auth(
+    client_cert=args.client_cert,
+    client_key=args.client_key)
+
+kra_client = pki.kra.KRAClient(pki_client)
+
+account_client = pki.account.AccountClient(kra_client)
+account_client.login()
+
+key_client = pki.key.KeyClient(kra_client)
+result = key_client.list_requests()
+
+first = True
+
+for key_request in result.key_requests:
+
+    if first:
+        first = False
+    else:
+        print()
+
+    print('  Request ID: %s' % key_request.get_request_id())
+    print('  Request Type: %s' % key_request.request_type)
+    print('  Key ID: %s' % key_request.get_key_id())
+
+    if key_request.request_status:
+        print('  Status: %s' % key_request.request_status)
+
+account_client.logout()


### PR DESCRIPTION
The `KeyClient.list_requests()` and `list_keys()` have been modified to use the `PKIClient` object to determine the proper path of the REST API.

The `KeyClient.__init__()` has also been modified so that it can be called without the crypto object and transport cert nickname. These parameters are only needed for key archival/retrieval.

The Python test for KRA has been modified to test these methods with REST API v1 and v2.