### PR TITLE
Remove "_{context}" in adoc id under pki/docs/installation/

### DIFF
--- a/docs/dogtagpki-docs-convention-readme.adoc
+++ b/docs/dogtagpki-docs-convention-readme.adoc
@@ -16,7 +16,7 @@ See installation/ca/installing-ca.adoc for example.
 * Add header including the “id” line at the very beginning of of the file, using the file name. e.g.
 ** :_mod-docs-content-type: PROCEDURE
 ** <blank line>
-** [id="installing-ca_{context}"]
+** [id="installing-ca"]
 * Do not refer to a section as “page”.  If applies, try using the word "section".
 * Do not use “e.g.”.  Use “for example” instead
 * Quoted blocks (“....” v.s. “----”)

--- a/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-acme-responder-using-pki-server-acme-cli_{context}"]
+[id="installing-acme-responder-using-pki-server-acme-cli"]
 = Installing ACME Responder using PKI Server ACME CLI =
 
 

--- a/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-acme-responder-using-pkispawn_{context}"]
+[id="installing-acme-responder-using-pkispawn"]
 = Installing ACME Responder using pkispawn =
 
 Follow this process to install an ACME responder on a PKI server that already has a CA subsystem using `pkispawn` command.

--- a/docs/installation/acme/installing-acme-responder.adoc
+++ b/docs/installation/acme/installing-acme-responder.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-acme-responder_{context}"]
+[id="installing-acme-responder"]
 = Installing ACME Responder =
 
 

--- a/docs/installation/ca/installing-ca-clone-with-hsm.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-clone-with-hsm_{context}"]
+[id="installing-ca-clone-with-hsm"]
 = Installing CA Clone with HSM 
 
 

--- a/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
@@ -1,7 +1,7 @@
 // This original content was copied to installing-ca-clone-with-temp-ldaps-connection.adoc
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-clone-with-ldaps-connection_{context}"]
+[id="installing-ca-clone-with-ldaps-connection"]
 = Installing CA Clone with LDAPS Connection 
 
 Follow this process to install a CA subsystem as clone of an existing CA subsystem with a secure database connection.

--- a/docs/installation/ca/installing-ca-clone-with-ldaps-using-bootstrap-ds-certs.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-using-bootstrap-ds-certs.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-clone-with-ldaps-using-bootstrap-ds-certs_{context}"]
+[id="installing-ca-clone-with-ldaps-using-bootstrap-ds-certs"]
 = Installing CA Clone with LDAPS Using Bootstrap DS Certs
 
 Follow this process to install a CA subsystem as clone of an existing CA subsystem that runs with a bootstrap SSL server certificate.

--- a/docs/installation/ca/installing-ca-clone.adoc
+++ b/docs/installation/ca/installing-ca-clone.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-clone_{context}"]
+[id="installing-ca-clone"]
 = Installing CA Clone 
 
 Follow this process to install a CA subsystem as a clone of an existing CA subsystem.

--- a/docs/installation/ca/installing-ca-with-custom-ca-signing-key.adoc
+++ b/docs/installation/ca/installing-ca-with-custom-ca-signing-key.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-custom-ca-signing-key_{context}"]
+[id="installing-ca-with-custom-ca-signing-key"]
 = Installing CA with Custom CA Signing Key 
 
 Follow this process to install a CA subsystem with a custom CA signing key, CSR, and certificate.

--- a/docs/installation/ca/installing-ca-with-ecc.adoc
+++ b/docs/installation/ca/installing-ca-with-ecc.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-ecc_{context}"]
+[id="installing-ca-with-ecc"]
 = Installing CA with ECC 
 
 Follow this process to install a CA subsystem with ECC self-signed CA signing certificate.

--- a/docs/installation/ca/installing-ca-with-existing-keys-in-hsm.adoc
+++ b/docs/installation/ca/installing-ca-with-existing-keys-in-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-existing-keys-in-hsm_{context}"]
+[id="installing-ca-with-existing-keys-in-hsm"]
 = Installing CA with Existing Keys in HSM 
 
 Follow this process to install a CA subsystem with the system keys, CSRs, and certificates from an existing CA

--- a/docs/installation/ca/installing-ca-with-existing-keys-in-internal-token.adoc
+++ b/docs/installation/ca/installing-ca-with-existing-keys-in-internal-token.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-existing-keys-in-internal-token_{context}"]
+[id="installing-ca-with-existing-keys-in-internal-token"]
 = Installing CA with Existing Keys in Internal Token 
 
 

--- a/docs/installation/ca/installing-ca-with-external-ca-signing-certificate.adoc
+++ b/docs/installation/ca/installing-ca-with-external-ca-signing-certificate.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-external-ca-signing-certificate_{context}"]
+[id="installing-ca-with-external-ca-signing-certificate"]
 = Installing CA with External CA Signing Certificate 
 
 Follow this process to install a CA subsystem with an external CA signing certificate.

--- a/docs/installation/ca/installing-ca-with-hsm.adoc
+++ b/docs/installation/ca/installing-ca-with-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-hsm_{context}"]
+[id="installing-ca-with-hsm"]
 = Installing CA with HSM 
 
 Follow this process to install a CA subsystem with a self-signed CA signing certificate

--- a/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-ldaps-connection_{context}"]
+[id="installing-ca-with-ldaps-connection"]
 = Installing CA with LDAPS Connection
 
 Follow this process to install a CA subsystem with a secure database connection.

--- a/docs/installation/ca/installing-ca-with-random-serial-numbers-v3.adoc
+++ b/docs/installation/ca/installing-ca-with-random-serial-numbers-v3.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-random-serial-numbers-v3_{context}"]
+[id="installing-ca-with-random-serial-numbers-v3"]
 = Overview 
 
 Follow this process to install a CA subsystem with link:https://github.com/dogtagpki/pki/wiki/Random-Certificate-Serial-Numbers-v3[Random Certificate Serial Numbers v3] in PKI 11.2 or later.

--- a/docs/installation/ca/installing-ca-with-rsa-pss.adoc
+++ b/docs/installation/ca/installing-ca-with-rsa-pss.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca-with-rsa-pss_{context}"]
+[id="installing-ca-with-rsa-pss"]
 = Installing CA with RSA/PSS
 
 Follow this process to install a CA subsystem with RSA/PSS.

--- a/docs/installation/ca/installing-ca.adoc
+++ b/docs/installation/ca/installing-ca.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ca_{context}"]
+[id="installing-ca"]
 = Installing CA 
 
 Follow this process to install a CA subsystem instance with a self-signed CA signing certificate. It is also known as a "root CA".

--- a/docs/installation/ca/installing-subordinate-ca.adoc
+++ b/docs/installation/ca/installing-subordinate-ca.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-subordinate-ca_{context}"]
+[id="installing-subordinate-ca"]
 = Installing Subordinate CA 
 
 Follow this process to install a subordinate CA subsystem

--- a/docs/installation/est/configure-est-realm-db.adoc
+++ b/docs/installation/est/configure-est-realm-db.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="configure-est-realm-db_{context}"]
+[id="configure-est-realm-db"]
 = Configure EST Realm DB 
 
 == Preparing DS DB 

--- a/docs/installation/est/installing-est-pki-server.adoc
+++ b/docs/installation/est/installing-est-pki-server.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-est-pki-server_{context}"]
+[id="installing-est-pki-server"]
 = EST installation using `pki-server` 
 
 After the prerequisite in xref:../est/installing-est.adoc[Installing EST], it is

--- a/docs/installation/est/installing-est-pkispawn.adoc
+++ b/docs/installation/est/installing-est-pkispawn.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-est-pkispawn_{context}"]
+[id="installing-est-pkispawn"]
 = EST installation using `pkispawn` 
 
 After the prerequisite in xref:../est/installing-est.adoc[Installing

--- a/docs/installation/est/installing-est.adoc
+++ b/docs/installation/est/installing-est.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-est_{context}"]
+[id="installing-est"]
 // this asciidoc file is converted from Installing_EST.md with needed modifications
 //
 

--- a/docs/installation/kra/installing-kra-clone-with-hsm.adoc
+++ b/docs/installation/kra/installing-kra-clone-with-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-clone-with-hsm_{context}"]
+[id="installing-kra-clone-with-hsm"]
 = Installing KRA Clone with HSM 
 
 

--- a/docs/installation/kra/installing-kra-clone.adoc
+++ b/docs/installation/kra/installing-kra-clone.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-clone_{context}"]
+[id="installing-kra-clone"]
 = Installing KRA Clone 
 
 

--- a/docs/installation/kra/installing-kra-on-separate-instance.adoc
+++ b/docs/installation/kra/installing-kra-on-separate-instance.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-on-separate-instance_{context}"]
+[id="installing-kra-on-separate-instance"]
 = Installing KRA on Separate Instance 
 
 

--- a/docs/installation/kra/installing-kra-with-custom-keys.adoc
+++ b/docs/installation/kra/installing-kra-with-custom-keys.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-with-custom-keys_{context}"]
+[id="installing-kra-with-custom-keys"]
 = Installing KRA with Custom Keys
 
 

--- a/docs/installation/kra/installing-kra-with-ecc.adoc
+++ b/docs/installation/kra/installing-kra-with-ecc.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-with-ecc_{context}"]
+[id="installing-kra-with-ecc"]
 = Installing KRA with ECC
 
 

--- a/docs/installation/kra/installing-kra-with-external-certificates.adoc
+++ b/docs/installation/kra/installing-kra-with-external-certificates.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-with-external-certificates_{context}"]
+[id="installing-kra-with-external-certificates"]
 = Installing KRA with External Certificates
 
 

--- a/docs/installation/kra/installing-kra-with-hsm.adoc
+++ b/docs/installation/kra/installing-kra-with-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-with-hsm_{context}"]
+[id="installing-kra-with-hsm"]
 = Installing KRA with HSM
 
 

--- a/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
+++ b/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-with-ldaps-connection_{context}"]
+[id="installing-kra-with-ldaps-connection"]
 = Installing KRA with LDAPS Connection
 
 

--- a/docs/installation/kra/installing-kra-with-random-serial-numbers-v3.adoc
+++ b/docs/installation/kra/installing-kra-with-random-serial-numbers-v3.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra-with-random-serial-numbers-v3_{context}"]
+[id="installing-kra-with-random-serial-numbers-v3"]
 = Overview 
 
 Follow this process to install a KRA subsystem with random serial numbers in PKI 11.2 or later.

--- a/docs/installation/kra/installing-kra.adoc
+++ b/docs/installation/kra/installing-kra.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-kra_{context}"]
+[id="installing-kra"]
 = Installing KRA 
 
 

--- a/docs/installation/kra/installing-standalone-kra.adoc
+++ b/docs/installation/kra/installing-standalone-kra.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-standalone-kra_{context}"]
+[id="installing-standalone-kra"]
 = Installing Standalone KRA 
 
 

--- a/docs/installation/ocsp/installing-ocsp-clone-with-hsm.adoc
+++ b/docs/installation/ocsp/installing-ocsp-clone-with-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ocsp-clone-with-hsm_{context}"]
+[id="installing-ocsp-clone-with-hsm"]
 = Installing OCSP Clone with HSM 
 
 

--- a/docs/installation/ocsp/installing-ocsp-clone.adoc
+++ b/docs/installation/ocsp/installing-ocsp-clone.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ocsp-clone_{context}"]
+[id="installing-ocsp-clone"]
 = Installing OCSP Clone 
 
 

--- a/docs/installation/ocsp/installing-ocsp-with-custom-keys.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-custom-keys.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ocsp-with-custom-keys_{context}"]
+[id="installing-ocsp-with-custom-keys"]
 = Installing OCSP with Custom Keys 
 
 

--- a/docs/installation/ocsp/installing-ocsp-with-ecc.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-ecc.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ocsp-with-ecc_{context}"]
+[id="installing-ocsp-with-ecc"]
 = Installing OCSP with ECC 
 
 

--- a/docs/installation/ocsp/installing-ocsp-with-external-certificates.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-external-certificates.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ocsp-with-external-certificates_{context}"]
+[id="installing-ocsp-with-external-certificates"]
 = Installing OCSP with External Certificates 
 
 Follow this process to install a OCSP subsystem with external certificates.

--- a/docs/installation/ocsp/installing-ocsp-with-hsm.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ocsp-with-hsm_{context}"]
+[id="installing-ocsp-with-hsm"]
 = Installing OCSP with HSM 
 
 Follow this process to install an OCSP subsystem

--- a/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ocsp-with-ldaps-connection_{context}"]
+[id="installing-ocsp-with-ldaps-connection"]
 = Installing OCSP with LDAPS Connection 
 
 

--- a/docs/installation/ocsp/installing-ocsp.adoc
+++ b/docs/installation/ocsp/installing-ocsp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ocsp_{context}"]
+[id="installing-ocsp"]
 = Installing OCSP 
 
 

--- a/docs/installation/ocsp/installing-standalone-ocsp.adoc
+++ b/docs/installation/ocsp/installing-standalone-ocsp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-standalone-ocsp_{context}"]
+[id="installing-standalone-ocsp"]
 = Installing Standalone OCSP 
 
 

--- a/docs/installation/others/creating-ds-instance.adoc
+++ b/docs/installation/others/creating-ds-instance.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="creating-ds-instance_{context}"]
+[id="creating-ds-instance"]
 // This content is copied and modifed from https://github.com/dogtagpki/pki/wiki/Installing-DS-Server
 //
 = Directory Server Instance Creation 

--- a/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
+++ b/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="enabling-ssl-connection-in-ds-with-bootstrap-cert_{context}"]
+[id="enabling-ssl-connection-in-ds-with-bootstrap-cert"]
 
 // This content was copied and adjusted from https://github.com/dogtagpki/pki/wiki/Enabling-SSL-Connection-in-DS
 

--- a/docs/installation/others/fqdn-configuration.adoc
+++ b/docs/installation/others/fqdn-configuration.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="fqdn-configuration_{context}"]
+[id="fqdn-configuration"]
 // this content was copied and modified from https://github.com/dogtagpki/pki/wiki
 //
 = FQDN Configuration 

--- a/docs/installation/others/getting-ds-cert-issued-by-actual-ca.adoc
+++ b/docs/installation/others/getting-ds-cert-issued-by-actual-ca.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="getting-ds-cert-issued-by-actual-ca_{context}"]
+[id="getting-ds-cert-issued-by-actual-ca"]
 
 // This section is intended for all PKI subsystems
 

--- a/docs/installation/others/installation-prerequisites.adoc
+++ b/docs/installation/others/installation-prerequisites.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installation-prerequisites_{context}"]
+[id="installation-prerequisites"]
 = Installation Prerequisites
 
 This section contains the generic prerequisites required prior to installing a PKI subsystem.  Some installation might need additional or different setups.

--- a/docs/installation/others/installing-ds-packages.adoc
+++ b/docs/installation/others/installing-ds-packages.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-ds-packages_{context}"]
+[id="installing-ds-packages"]
 // This was copied partially from https://github.com/dogtagpki/pki/wiki/Installing-DS-Server
 = Installing DS Packages 
 

--- a/docs/installation/server/installing-basic-pki-server.adoc
+++ b/docs/installation/server/installing-basic-pki-server.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-basic-pki-server_{context}"]
+[id="installing-basic-pki-server"]
 = Installing Basic PKI Server
 
 

--- a/docs/installation/server/installing-pki-server-with-custom-nss-databases.adoc
+++ b/docs/installation/server/installing-pki-server-with-custom-nss-databases.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-pki-server-with-custom-nss-databases_{context}"]
+[id="installing-pki-server-with-custom-nss-databases"]
 = Installing PKI Server with Custom NSS Databases
 
 

--- a/docs/installation/tks/installing-tks-clone.adoc
+++ b/docs/installation/tks/installing-tks-clone.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tks-clone_{context}"]
+[id="installing-tks-clone"]
 = Installing TKS Clone
 
 

--- a/docs/installation/tks/installing-tks-with-ecc.adoc
+++ b/docs/installation/tks/installing-tks-with-ecc.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tks-with-ecc_{context}"]
+[id="installing-tks-with-ecc"]
 = Installing TKS with ECC
 
 

--- a/docs/installation/tks/installing-tks-with-hsm.adoc
+++ b/docs/installation/tks/installing-tks-with-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tks-with-hsm_{context}"]
+[id="installing-tks-with-hsm"]
 = Installing TKS with HSM
 
 

--- a/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
+++ b/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tks-with-ldaps-connection_{context}"]
+[id="installing-tks-with-ldaps-connection"]
 = Installing TKS with LDAPS Connection
 
 

--- a/docs/installation/tks/installing-tks.adoc
+++ b/docs/installation/tks/installing-tks.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tks_{context}"]
+[id="installing-tks"]
 = Installing TKS
 
 

--- a/docs/installation/tps/installing-tps-clone.adoc
+++ b/docs/installation/tps/installing-tps-clone.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tps-clone_{context}"]
+[id="installing-tps-clone"]
 = Installing TPS Clone
 
 

--- a/docs/installation/tps/installing-tps-with-hsm.adoc
+++ b/docs/installation/tps/installing-tps-with-hsm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tps-with-hsm_{context}"]
+[id="installing-tps-with-hsm"]
 = Installing TPS with HSM
 
 

--- a/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
+++ b/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tps-with-ldaps-connection_{context}"]
+[id="installing-tps-with-ldaps-connection"]
 = Installing TPS with LDAPS Connection
 
 Follow this process to install a TPS subsystem a secure database connection.

--- a/docs/installation/tps/installing-tps.adoc
+++ b/docs/installation/tps/installing-tps.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-tps_{context}"]
+[id="installing-tps"]
 = Installing TPS
 
 


### PR DESCRIPTION
- based on the latest changes in upstream rhcs-docs, "_{context}" needs to be removed from the file id [sip ci]