### PR TITLE
Replace SSLSocket with JSSSocket in CLI

### DIFF
--- a/.github/workflows/ca-container-existing-config-test.yml
+++ b/.github/workflows/ca-container-existing-config-test.yml
@@ -277,9 +277,11 @@ jobs:
 
       - name: Check CA admin user again
         run: |
+          #TODO: OCSPServlet fails since AuthorityMonitor is disabled in container
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n caadmin \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               ca-user-show \
               caadmin
 
@@ -287,6 +289,7 @@ jobs:
         run: |
           docker exec client pki \
               -U https://ca.example.com:8443 \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               client-cert-request \
               uid=testuser | tee output
 
@@ -296,6 +299,7 @@ jobs:
           docker exec client pki \
               -U https://ca.example.com:8443 \
               -n caadmin \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               ca-cert-request-approve \
               $REQUEST_ID \
               --force

--- a/.github/workflows/ca-container-migration-test.yml
+++ b/.github/workflows/ca-container-migration-test.yml
@@ -289,9 +289,11 @@ jobs:
 
       - name: Check CA admin user
         run: |
+          #TODO: after migration the OCSPServlet is failing and has to be fixed
           docker exec client pki \
               -U https://pki.example.com:8443 \
               -n caadmin \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               ca-user-show \
               caadmin
 
@@ -299,6 +301,7 @@ jobs:
         run: |
           docker exec client pki \
               -U https://pki.example.com:8443 \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               client-cert-request \
               uid=testuser | tee output
 
@@ -308,6 +311,7 @@ jobs:
           docker exec client pki \
               -U https://pki.example.com:8443 \
               -n caadmin \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               ca-cert-request-approve \
               $REQUEST_ID \
               --force

--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -109,6 +109,7 @@ jobs:
           # enrollment should fail
           docker exec pki pki \
               -n caadmin \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               ca-cert-issue \
               --profile caServerCert \
               --csr-file sslserver.csr \
@@ -145,6 +146,7 @@ jobs:
           # enrollment should fail
           docker exec pki pki \
               -n caadmin \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               ca-cert-issue \
               --profile caServerCert \
               --csr-file sslserver.csr \
@@ -163,8 +165,10 @@ jobs:
           sleep 60
 
           # enrollment should work
+          # OCSP is not working because the authorityMonitor is disabled
           docker exec pki pki \
               -n caadmin \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               ca-cert-issue \
               --profile caServerCert \
               --csr-file sslserver.csr \

--- a/.github/workflows/ca-renewal-system-certs-hsm-test.yml
+++ b/.github/workflows/ca-renewal-system-certs-hsm-test.yml
@@ -268,9 +268,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \
@@ -293,9 +295,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \
@@ -335,9 +339,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \
@@ -360,9 +366,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \
@@ -385,9 +393,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \

--- a/.github/workflows/ca-renewal-system-certs-test.yml
+++ b/.github/workflows/ca-renewal-system-certs-test.yml
@@ -231,9 +231,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \
@@ -256,9 +258,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \
@@ -298,9 +302,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \
@@ -323,9 +329,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \
@@ -348,9 +356,11 @@ jobs:
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
           # renew cert
+          # NOTE: since OCSP cert is expired certificate validation fails and marked as revoked
           docker exec pki pki \
               -u caadmin \
               -w Secret.123 \
+              --ignore-cert-status REVOKED_CERTIFICATE \
               ca-cert-issue \
               --profile caManualRenewal \
               --serial $CERT_ID \

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -207,7 +207,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ca-agent
 
           # CA admin should be able to access PKI users
-          docker exec ipa pki -n ipa-ca-agent ca-user-find
+          docker exec ipa pki -n ipa-ca-agent --ignore-cert-status OCSP_SERVER_ERROR ca-user-find
 
       - name: Check RA agent cert
         run: |
@@ -231,7 +231,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ra-agent
 
           # RA agent should be able to access cert requests
-          docker exec ipa pki -n ipa-ra-agent ca-cert-request-find
+          docker exec ipa pki -n ipa-ra-agent --ignore-cert-status OCSP_SERVER_ERROR ca-cert-request-find
 
       - name: Check HTTPD certs
         run: |

--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -34,6 +34,7 @@ jobs:
               --hostname=ipa.example.com \
               --network=example \
               --network-alias=ipa.example.com \
+              --network-alias=ipa-ca.example.com \
               ipa
 
       - name: Install IPA server
@@ -207,7 +208,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ca-agent
 
           # CA admin should be able to access PKI users
-          docker exec ipa pki -n ipa-ca-agent --ignore-cert-status OCSP_SERVER_ERROR ca-user-find
+          docker exec ipa pki -n ipa-ca-agent ca-user-find
 
       - name: Check RA agent cert
         run: |
@@ -231,7 +232,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ra-agent
 
           # RA agent should be able to access cert requests
-          docker exec ipa pki -n ipa-ra-agent --ignore-cert-status OCSP_SERVER_ERROR ca-cert-request-find
+          docker exec ipa pki -n ipa-ra-agent ca-cert-request-find
 
       - name: Check HTTPD certs
         run: |

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -631,7 +631,9 @@ jobs:
           docker exec secondary pki pkcs12-import \
               --pkcs12 ${SHARED}/ca-agent.p12 \
               --pkcs12-password Secret.123
-          docker exec secondary pki -n ipa-ca-agent ca-user-show admin
+          docker exec secondary pki -n ipa-ca-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
+              ca-user-show admin
 
       - name: Check subca replication from primary
         run: |

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -34,6 +34,7 @@ jobs:
               --hostname=primary.example.com \
               --network=example \
               --network-alias=primary.example.com \
+              --network-alias=ipa-ca.example.com \
               primary
 
       - name: Install IPA server in primary container
@@ -632,7 +633,6 @@ jobs:
               --pkcs12 ${SHARED}/ca-agent.p12 \
               --pkcs12-password Secret.123
           docker exec secondary pki -n ipa-ca-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
               ca-user-show admin
 
       - name: Check subca replication from primary

--- a/.github/workflows/ipa-kra-test.yml
+++ b/.github/workflows/ipa-kra-test.yml
@@ -151,7 +151,9 @@ jobs:
       - name: Check RA agent cert
         run: |
           # RA agent should be able to access key requests
-          docker exec ipa pki -n ipa-ra-agent kra-key-request-find
+          docker exec ipa pki -n ipa-ra-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
+              kra-key-request-find
 
       - name: Check webapps
         run: |
@@ -212,6 +214,7 @@ jobs:
           echo "active" > expected
           docker exec ipa pki \
               -n ipa-ra-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               kra-key-find \
               --clientKeyID ipa:/users/admin/testvault | tee output
           sed -n 's/^\s*Status:\s*\(.*\)$/\1/p' output > actual
@@ -242,6 +245,7 @@ jobs:
           echo "active" >> expected
           docker exec ipa pki \
               -n ipa-ra-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
               kra-key-find \
               --clientKeyID ipa:/users/admin/testvault | tee output
           sed -n 's/^\s*Status:\s*\(.*\)$/\1/p' output > actual

--- a/.github/workflows/ipa-kra-test.yml
+++ b/.github/workflows/ipa-kra-test.yml
@@ -34,6 +34,7 @@ jobs:
               --hostname=ipa.example.com \
               --network=example \
               --network-alias=ipa.example.com \
+              --network-alias=ipa-ca.example.com \
               ipa
 
       - name: Install IPA server
@@ -151,9 +152,7 @@ jobs:
       - name: Check RA agent cert
         run: |
           # RA agent should be able to access key requests
-          docker exec ipa pki -n ipa-ra-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
-              kra-key-request-find
+          docker exec ipa pki -n ipa-ra-agent kra-key-request-find
 
       - name: Check webapps
         run: |
@@ -214,7 +213,6 @@ jobs:
           echo "active" > expected
           docker exec ipa pki \
               -n ipa-ra-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
               kra-key-find \
               --clientKeyID ipa:/users/admin/testvault | tee output
           sed -n 's/^\s*Status:\s*\(.*\)$/\1/p' output > actual
@@ -245,7 +243,6 @@ jobs:
           echo "active" >> expected
           docker exec ipa pki \
               -n ipa-ra-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
               kra-key-find \
               --clientKeyID ipa:/users/admin/testvault | tee output
           sed -n 's/^\s*Status:\s*\(.*\)$/\1/p' output > actual

--- a/.github/workflows/ipa-reinstall-test.yml
+++ b/.github/workflows/ipa-reinstall-test.yml
@@ -34,6 +34,7 @@ jobs:
               --hostname=ipa.example.com \
               --network=example \
               --network-alias=ipa.example.com \
+              --network-alias=ipa-ca.example.com \
               ipa
 
       - name: Install IPA server
@@ -94,7 +95,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ca-agent | tee ipa-ca-agent.orig
 
           # CA agent should be able to access CA users
-          docker exec ipa pki -n ipa-ca-agent --ignore-cert-status OCSP_SERVER_ERROR ca-user-find
+          docker exec ipa pki -n ipa-ca-agent ca-user-find
 
       - name: Check RA agent cert
         run: |
@@ -116,9 +117,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ra-agent | tee ipa-ra-agent.orig
 
           # RA agent should be able to access cert requests
-          docker exec ipa pki -n ipa-ra-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
-              ca-cert-request-find
+          docker exec ipa pki -n ipa-ra-agent ca-cert-request-find
 
       - name: Install KRA
         run: |
@@ -127,9 +126,7 @@ jobs:
       - name: Check KRA users
         run: |
           # CA agent should be able to access KRA users
-          docker exec ipa pki -n ipa-ca-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
-              kra-user-find
+          docker exec ipa pki -n ipa-ca-agent kra-user-find
 
       - name: Check IPA CA install log
         if: always()
@@ -237,9 +234,7 @@ jobs:
           [ $rc -ne 0 ]
 
           # CA agent should be able to access CA users
-          docker exec ipa pki -n ipa-ca-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
-              ca-user-find
+          docker exec ipa pki -n ipa-ca-agent ca-user-find
 
       - name: Check RA agent cert again
         run: |
@@ -267,9 +262,7 @@ jobs:
           [ $rc -ne 0 ]
 
           # RA agent should be able to access cert requests
-          docker exec ipa pki -n ipa-ra-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
-              ca-cert-request-find
+          docker exec ipa pki -n ipa-ra-agent ca-cert-request-find
 
       - name: Install KRA again
         run: |
@@ -278,9 +271,7 @@ jobs:
       - name: Check KRA users again
         run: |
           # CA agent should be able to access KRA users
-          docker exec ipa pki -n ipa-ca-agent \
-              --ignore-cert-status OCSP_SERVER_ERROR \
-              kra-user-find
+          docker exec ipa pki -n ipa-ca-agent kra-user-find
 
       - name: Check IPA CA install log
         if: always()

--- a/.github/workflows/ipa-reinstall-test.yml
+++ b/.github/workflows/ipa-reinstall-test.yml
@@ -94,7 +94,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ca-agent | tee ipa-ca-agent.orig
 
           # CA agent should be able to access CA users
-          docker exec ipa pki -n ipa-ca-agent ca-user-find
+          docker exec ipa pki -n ipa-ca-agent --ignore-cert-status OCSP_SERVER_ERROR ca-user-find
 
       - name: Check RA agent cert
         run: |
@@ -116,7 +116,9 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ra-agent | tee ipa-ra-agent.orig
 
           # RA agent should be able to access cert requests
-          docker exec ipa pki -n ipa-ra-agent ca-cert-request-find
+          docker exec ipa pki -n ipa-ra-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
+              ca-cert-request-find
 
       - name: Install KRA
         run: |
@@ -125,7 +127,9 @@ jobs:
       - name: Check KRA users
         run: |
           # CA agent should be able to access KRA users
-          docker exec ipa pki -n ipa-ca-agent kra-user-find
+          docker exec ipa pki -n ipa-ca-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
+              kra-user-find
 
       - name: Check IPA CA install log
         if: always()
@@ -233,7 +237,9 @@ jobs:
           [ $rc -ne 0 ]
 
           # CA agent should be able to access CA users
-          docker exec ipa pki -n ipa-ca-agent ca-user-find
+          docker exec ipa pki -n ipa-ca-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
+              ca-user-find
 
       - name: Check RA agent cert again
         run: |
@@ -261,7 +267,9 @@ jobs:
           [ $rc -ne 0 ]
 
           # RA agent should be able to access cert requests
-          docker exec ipa pki -n ipa-ra-agent ca-cert-request-find
+          docker exec ipa pki -n ipa-ra-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
+              ca-cert-request-find
 
       - name: Install KRA again
         run: |
@@ -270,7 +278,9 @@ jobs:
       - name: Check KRA users again
         run: |
           # CA agent should be able to access KRA users
-          docker exec ipa pki -n ipa-ca-agent kra-user-find
+          docker exec ipa pki -n ipa-ca-agent \
+              --ignore-cert-status OCSP_SERVER_ERROR \
+              kra-user-find
 
       - name: Check IPA CA install log
         if: always()

--- a/.github/workflows/ipa-renewal-test.yml
+++ b/.github/workflows/ipa-renewal-test.yml
@@ -34,6 +34,7 @@ jobs:
               --hostname=ipa.example.com \
               --network=example \
               --network-alias=ipa.example.com \
+              --network-alias=ipa-ca.example.com \
               ipa
 
       - name: Configure short-lived SSL server cert profile
@@ -187,7 +188,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ca-agent
 
           # CA admin should be able to access PKI users
-          docker exec ipa pki -n ipa-ca-agent --skip-revocation-check ca-user-find
+          docker exec ipa pki -n ipa-ca-agent --ignore-cert-status EXPIRED_CERTIFICATE ca-user-find
 
       - name: Check RA agent cert
         run: |
@@ -211,7 +212,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ra-agent
 
           # RA agent should be able to access cert requests
-          docker exec ipa pki -n ipa-ra-agent --skip-revocation-check ca-cert-request-find
+          docker exec ipa pki -n ipa-ra-agent --ignore-cert-status EXPIRED_CERTIFICATE ca-cert-request-find
 
       - name: Run PKI healthcheck
         run: |

--- a/.github/workflows/ipa-renewal-test.yml
+++ b/.github/workflows/ipa-renewal-test.yml
@@ -187,7 +187,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ca-agent
 
           # CA admin should be able to access PKI users
-          docker exec ipa pki -n ipa-ca-agent ca-user-find
+          docker exec ipa pki -n ipa-ca-agent --skip-revocation-check ca-user-find
 
       - name: Check RA agent cert
         run: |
@@ -211,7 +211,7 @@ jobs:
           docker exec ipa pki nss-cert-show ipa-ra-agent
 
           # RA agent should be able to access cert requests
-          docker exec ipa pki -n ipa-ra-agent ca-cert-request-find
+          docker exec ipa pki -n ipa-ra-agent --skip-revocation-check ca-cert-request-find
 
       - name: Run PKI healthcheck
         run: |

--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -180,7 +180,6 @@ jobs:
         run: |
           # run PKI CLI but don't trust the cert
           echo n | docker exec -i client pki \
-              -D org.dogtagpki.client.socketFactory=org.dogtagpki.client.NonBlockingSocketFactory \
               -U https://pki.example.com:8443 \
               info \
               > >(tee stdout) 2> >(tee stderr >&2) || true
@@ -210,7 +209,6 @@ jobs:
         run: |
           # run PKI CLI with wrong hostname
           echo n | docker exec -i client pki \
-              -D org.dogtagpki.client.socketFactory=org.dogtagpki.client.NonBlockingSocketFactory \
               -U https://server.example.com:8443 \
               info \
               > >(tee stdout) 2> >(tee stderr >&2) || true
@@ -241,7 +239,6 @@ jobs:
         run: |
           # run PKI CLI and trust the cert
           echo y | docker exec -i client pki \
-              -D org.dogtagpki.client.socketFactory=org.dogtagpki.client.NonBlockingSocketFactory \
               -U https://pki.example.com:8443 \
               info \
               > >(tee stdout) 2> >(tee stderr >&2) || true
@@ -291,7 +288,6 @@ jobs:
         run: |
           # run PKI CLI with wrong hostname
           docker exec client pki \
-              -D org.dogtagpki.client.socketFactory=org.dogtagpki.client.NonBlockingSocketFactory \
               -U https://server.example.com:8443 \
               info \
               > >(tee stdout) 2> >(tee stderr >&2) || true
@@ -316,7 +312,6 @@ jobs:
         run: |
           # run PKI CLI with correct hostname
           docker exec client pki \
-              -D org.dogtagpki.client.socketFactory=org.dogtagpki.client.NonBlockingSocketFactory \
               -U https://pki.example.com:8443 \
               info \
               > >(tee stdout) 2> >(tee stderr >&2) || true
@@ -338,7 +333,6 @@ jobs:
           sleep 120
 
           docker exec client pki \
-              -D org.dogtagpki.client.socketFactory=org.dogtagpki.client.NonBlockingSocketFactory \
               -U https://pki.example.com:8443 \
               info \
               > >(tee stdout) 2> >(tee stderr >&2) || true

--- a/.github/workflows/server-https-pkcs12-test.yml
+++ b/.github/workflows/server-https-pkcs12-test.yml
@@ -215,8 +215,8 @@ jobs:
           # check stderr
           cat > expected << EOF
           WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
-          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: BAD_CERTIFICATE
-          IOException: Unable to write to socket: Failed to write to socket: (-5987) Invalid function argument.
+          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: UNKNOWN_CA
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Unknown issuer: CN=CA Signing Certificate
           EOF
 
           diff expected stderr
@@ -243,10 +243,10 @@ jobs:
 
           # check stderr
           cat > expected << EOF
-          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
           WARNING: BAD_CERT_DOMAIN encountered on 'CN=pki.example.com' indicates a common-name mismatch
-          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: BAD_CERTIFICATE
-          IOException: Unable to write to socket: Failed to write to socket: (-12276) Unable to communicate securely with peer: requested domain name does not match the server's certificate.
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
+          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: ACCESS_DENIED
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Bad certificate domain: CN=pki.example.com
           EOF
 
           diff expected stderr
@@ -368,8 +368,8 @@ jobs:
           # check stderr
           cat > expected << EOF
           ERROR: EXPIRED_CERTIFICATE encountered on 'CN=pki.example.com' results in a denied SSL server cert!
-          SEVERE: FATAL: SSL alert sent: BAD_CERTIFICATE
-          IOException: Unable to write to socket: Failed to write to socket: (-5987) Invalid function argument.
+          SEVERE: FATAL: SSL alert sent: CERTIFICATE_EXPIRED
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Expired certificate: CN=pki.example.com
           EOF
 
           diff expected stderr

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -48,23 +48,15 @@ jobs:
         run: docker network connect example ca --alias ca.example.com
 
       - name: Install CA in CA container
+        # HTTP connector is needed in CA because if internal OCSP
         run: |
           docker exec ca pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://cads.example.com:3389 \
-              -D pki_http_enable=False \
               -v
 
           docker exec ca pki-server cert-find
-
-      - name: Verify there is no plain HTTP connectors in CA
-        run: |
-          docker exec ca pki-server http-connector-find | tee output
-
-          echo "Secure" > expected
-          sed -n -e "s/^ *Connector ID: *\(.*\)$/\1/p" output > actual
-          diff expected actual
 
       - name: Install banner in CA container
         run: docker exec ca cp /usr/share/pki/server/examples/banner/banner.txt /var/lib/pki/pki-tomcat/conf
@@ -211,11 +203,11 @@ jobs:
           sed -n -e "s/^ *Connector ID: *\(.*\)$/\1/p" output > actual
           diff expected actual
 
-      - name: Verify there is no plain HTTP ports in security domain
+      - name: Verify there is no plain HTTP ports in security domain but CA
         run: |
           docker exec ca pki-server sd-subsystem-find | tee output
 
-          echo -n "" > expected
+          echo "  Port: 8080" > expected
           sed -ne "/^ *Port:/p" output > actual
           diff expected actual
 
@@ -237,7 +229,9 @@ jobs:
           docker exec tps pki pkcs12-import \
               --pkcs12 ${SHARED}/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
-          docker exec tps pki -n caadmin --ignore-banner tps-user-show tpsadmin
+
+          docker exec tps pki -n caadmin --ignore-banner \
+              tps-user-show tpsadmin
 
       - name: Gather artifacts from CA containers
         if: always()

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -2669,6 +2669,7 @@ public class CAEngine extends CMSEngine {
         }
         config.setCertNickname(nickname);
 
+        config.setCertRevocationVerify(caConfig.getBoolean("clientRevocationCheck", false));
         return new PKIClient(config);
     }
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -2669,7 +2669,7 @@ public class CAEngine extends CMSEngine {
         }
         config.setCertNickname(nickname);
 
-        config.setCertRevocationVerify(caConfig.getBoolean("clientRevocationCheck", false));
+        config.setCertRevocationVerify(kraConnectorConfig.getBoolean("certRevocationCheck", true));
         return new PKIClient(config);
     }
 

--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -67,6 +67,7 @@ class PKICLI(pki.cli.CLI):
         self.reject_cert_status = False
         self.ignore_cert_status = False
         self.ignore_banner = False
+        self.skip_revocation_check = False
 
         self.add_module(pki.cli.password.PasswordCLI())
         self.add_module(pki.cli.pkcs12.PKCS12CLI())
@@ -108,7 +109,9 @@ class PKICLI(pki.cli.CLI):
         self.parser.add_argument(
             '--ignore-banner',
             action='store_true')
-
+        self.parser.add_argument(
+            '--skip-revocation-check',
+            action='store_true')
         self.parser.add_argument(
             '-v',
             '--verbose',
@@ -173,6 +176,7 @@ class PKICLI(pki.cli.CLI):
         print('      --ignore-cert-status       Comma-separated list of ignored ' +
               'certificate validity statuses')
         print('      --ignore-banner            Ignore banner')
+        print('      --skip-revocation-check    Do not perform revocation check')
         print()
         print('  -v, --verbose                  Run in verbose mode.')
         print('      --debug                    Show debug messages.')
@@ -289,6 +293,9 @@ class PKICLI(pki.cli.CLI):
         if self.ignore_cert_status:
             cmd.extend(['--ignore-cert-status', self.ignore_cert_status])
 
+        if self.skip_revocation_check:
+            cmd.extend(['--skip-revocation-check'])
+
         if self.ignore_banner:
             cmd.extend(['--ignore-banner'])
 
@@ -357,6 +364,7 @@ class PKICLI(pki.cli.CLI):
         self.reject_cert_status = args.reject_cert_status
         self.ignore_cert_status = args.ignore_cert_status
         self.ignore_banner = args.ignore_banner
+        self.skip_revocation_check = args.skip_revocation_check
 
         command = None
         if len(args.remainder) > 0:

--- a/base/common/src/main/java/com/netscape/certsrv/client/ClientConfig.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/ClientConfig.java
@@ -53,6 +53,8 @@ public class ClientConfig implements JSONSerializer {
 
     String messageFormat;
 
+    boolean certRevocationVerify;
+
     public ClientConfig() {
     }
 
@@ -72,6 +74,9 @@ public class ClientConfig implements JSONSerializer {
         password = config.password;
 
         messageFormat = config.messageFormat;
+
+        certRevocationVerify = config.isCertRevocationVerify();
+
     }
 
     public void setServerURI(URI serverUri) {
@@ -211,6 +216,15 @@ public class ClientConfig implements JSONSerializer {
         this.messageFormat = messageFormat;
     }
 
+
+    public boolean isCertRevocationVerify() {
+        return certRevocationVerify;
+    }
+
+    public void setCertRevocationVerify(boolean certRevocationVerify) {
+        this.certRevocationVerify = certRevocationVerify;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -224,6 +238,7 @@ public class ClientConfig implements JSONSerializer {
         result = prime * result + ((serverURL == null) ? 0 : serverURL.hashCode());
         result = prime * result + ((tokenName == null) ? 0 : tokenName.hashCode());
         result = prime * result + ((username == null) ? 0 : username.hashCode());
+        result = result + (certRevocationVerify ? 0 : 1);
         return result;
     }
 
@@ -280,6 +295,8 @@ public class ClientConfig implements JSONSerializer {
             if (other.username != null)
                 return false;
         } else if (!username.equals(other.username))
+            return false;
+        if (certRevocationVerify != other.certRevocationVerify)
             return false;
         return true;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
@@ -52,7 +52,7 @@ import org.apache.http.impl.client.RequestWrapper;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
-import org.dogtagpki.client.DefaultSocketFactory;
+import org.dogtagpki.client.JSSSocketFactory;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
@@ -83,7 +83,7 @@ public class PKIConnection implements AutoCloseable {
         // create socket factory
         String className = System.getProperty(
                 "org.dogtagpki.client.socketFactory",
-                DefaultSocketFactory.class.getName());
+                JSSSocketFactory.class.getName());
         logger.info("PKIConnection: Socket factory: " + className);
 
         Class<? extends SchemeLayeredSocketFactory> clazz =

--- a/base/common/src/main/java/org/dogtagpki/client/JSSSocketFactory.java
+++ b/base/common/src/main/java/org/dogtagpki/client/JSSSocketFactory.java
@@ -85,7 +85,7 @@ public class JSSSocketFactory implements SchemeLayeredSocketFactory {
             JSSTrustManager trustManager = new JSSTrustManager();
             trustManager.setHostname(hostname);
             trustManager.setCallback(connection.getCallback());
-            trustManager.setEnableCertRevokeVerify(true);
+            trustManager.setEnableCertRevokeVerify(connection.getConfig().isCertRevocationVerify());
 
             TrustManager[] tms = new TrustManager[] { trustManager };
 

--- a/base/common/src/main/java/org/dogtagpki/client/JSSSocketFactory.java
+++ b/base/common/src/main/java/org/dogtagpki/client/JSSSocketFactory.java
@@ -32,15 +32,18 @@ import org.mozilla.jss.ssl.javax.JSSSocket;
 import com.netscape.certsrv.client.PKIConnection;
 
 /**
- * This class provides non-blocking socket factory for PKIConnection.
+ * This class provides a ocket factory for PKIConnection based on JSSSocket.
+ *
+ * JSSSocket support both communication models: sync and async. The model is
+ * defined in the initial socket and if not specified it is sync.
  */
-public class NonBlockingSocketFactory implements SchemeLayeredSocketFactory {
+public class JSSSocketFactory implements SchemeLayeredSocketFactory {
 
-    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NonBlockingSocketFactory.class);
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(JSSSocketFactory.class);
 
     PKIConnection connection;
 
-    public NonBlockingSocketFactory(PKIConnection connection) {
+    public JSSSocketFactory(PKIConnection connection) {
         this.connection = connection;
     }
 
@@ -82,7 +85,7 @@ public class NonBlockingSocketFactory implements SchemeLayeredSocketFactory {
             JSSTrustManager trustManager = new JSSTrustManager();
             trustManager.setHostname(hostname);
             trustManager.setCallback(connection.getCallback());
-	    trustManager.setEnableCertRevokeVerify(true);
+            trustManager.setEnableCertRevokeVerify(true);
 
             TrustManager[] tms = new TrustManager[] { trustManager };
 

--- a/base/common/src/main/java/org/dogtagpki/client/SSLSocketFactory.java
+++ b/base/common/src/main/java/org/dogtagpki/client/SSLSocketFactory.java
@@ -23,13 +23,13 @@ import org.mozilla.jss.ssl.SSLSocketListener;
 import com.netscape.certsrv.client.PKIConnection;
 
 /**
- * This class provides blocking socket factory for PKIConnection.
+ * This class provides blocking socket factory for PKIConnection based on SSLSocket.
  */
-public class DefaultSocketFactory implements SchemeLayeredSocketFactory {
+public class SSLSocketFactory implements SchemeLayeredSocketFactory {
 
     PKIConnection connection;
 
-    public DefaultSocketFactory(PKIConnection connection) {
+    public SSLSocketFactory(PKIConnection connection) {
         this.connection = connection;
     }
 

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -384,6 +384,8 @@ pki_request_id_length=128
 pki_security_domain_setup=True
 pki_registry_enable=True
 
+pki_client_verify_cert=False
+
 ###############################################################################
 ##  KRA Configuration:                                                       ##
 ##                                                                           ##

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -384,8 +384,7 @@ pki_request_id_length=128
 pki_security_domain_setup=True
 pki_registry_enable=True
 
-pki_client_verify_cert=False
-
+pki_kra_connector_verify_cert=True
 ###############################################################################
 ##  KRA Configuration:                                                       ##
 ##                                                                           ##

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -2754,6 +2754,7 @@ class PKIDeployer:
             https_port = proxy_secure_port
 
         host_id = '%s %s %s' % (subsystem.type, hostname, https_port)
+        subordinate = config.str2bool(self.mdict['pki_subordinate'])
 
         logger.info(
             'Removing %s from security domain at %s',
@@ -2765,7 +2766,8 @@ class PKIDeployer:
                 sd_url,
                 host_id,
                 hostname,
-                https_port)
+                https_port,
+                subordinate)
 
         except subprocess.CalledProcessError:
             logger.error(
@@ -4436,6 +4438,7 @@ class PKIDeployer:
             '-U', ca_url,
             '--ignore-cert-status', 'UNTRUSTED_ISSUER,UNKNOWN_ISSUER',
             '--ignore-banner',
+            '--skip-revocation-check',
             'ca-cert-signing-export',
             '--pkcs7'
         ]

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1314,6 +1314,9 @@ class PKIDeployer:
         if ocsp_uri:
             subsystem.set_config('ca.defaultOcspUri', ocsp_uri)
 
+        if config.str2bool(self.mdict['pki_client_verify_cert']):
+            subsystem.set_config('ca.clientRevocationCheck', 'true')
+
     def configure_kra(self, subsystem):
 
         if config.str2bool(self.mdict['pki_use_oaep_rsa_keywrap']):
@@ -2754,7 +2757,6 @@ class PKIDeployer:
             https_port = proxy_secure_port
 
         host_id = '%s %s %s' % (subsystem.type, hostname, https_port)
-        subordinate = config.str2bool(self.mdict['pki_subordinate'])
 
         logger.info(
             'Removing %s from security domain at %s',
@@ -2766,8 +2768,7 @@ class PKIDeployer:
                 sd_url,
                 host_id,
                 hostname,
-                https_port,
-                subordinate)
+                https_port)
 
         except subprocess.CalledProcessError:
             logger.error(
@@ -3754,6 +3755,7 @@ class PKIDeployer:
                 '-d', self.instance.nssdb_dir,
                 '-f', self.instance.password_conf,
                 '-U', url,
+                '--skip-revocation-check'
             ]
 
             if credentials:
@@ -4404,6 +4406,7 @@ class PKIDeployer:
                 '-f', self.instance.password_conf,
                 '-U', subsystem_url,
                 '--ignore-banner',
+                '--skip-revocation-check',
                 '%s-user-add' % subsystem_type,
                 uid,
                 '--security-domain', sd_url,
@@ -4462,6 +4465,7 @@ class PKIDeployer:
             '-f', self.instance.password_conf,
             '-U', ca_url,
             '--ignore-banner',
+            '--skip-revocation-check',
             'ca-cert-subsystem-export'
         ]
 
@@ -4507,6 +4511,7 @@ class PKIDeployer:
                 '-f', self.instance.password_conf,
                 '-U', ca_url,
                 '--ignore-banner',
+                '--skip-revocation-check',
                 'ca-kraconnector-add',
                 '--url', kra_url,
                 '--subsystem-cert', subsystem_cert_file,
@@ -4581,6 +4586,7 @@ class PKIDeployer:
             '-f', self.instance.password_conf,
             '-U', kra_url,
             '--ignore-banner',
+            '--skip-revocation-check',
             'kra-cert-transport-export'
         ]
 
@@ -4620,6 +4626,7 @@ class PKIDeployer:
                 '-f', self.instance.password_conf,
                 '-U', tks_url,
                 '--ignore-banner',
+                '--skip-revocation-check',
                 'tks-cert-transport-import',
                 '--security-domain', sd_url,
                 '--install-token', install_token,
@@ -4667,6 +4674,7 @@ class PKIDeployer:
             '-f', self.instance.password_conf,
             '-n', nickname,
             '--ignore-banner',
+            '--skip-revocation-check',
             'tks-tpsconnector-show',
             '--host', self.mdict['pki_hostname'],
             '--port', https_port
@@ -4701,6 +4709,7 @@ class PKIDeployer:
             '-f', self.instance.password_conf,
             '-n', nickname,
             '--ignore-banner',
+            '--skip-revocation-check',
             'tks-tpsconnector-add',
             '--host', self.mdict['pki_hostname'],
             '--port', https_port,
@@ -4733,6 +4742,7 @@ class PKIDeployer:
             '-f', self.instance.password_conf,
             '-n', nickname,
             '--ignore-banner',
+            '--skip-revocation-check',
             'tks-key-export', tps_connector_id
         ]
 
@@ -4762,6 +4772,7 @@ class PKIDeployer:
             '-f', self.instance.password_conf,
             '-n', nickname,
             '--ignore-banner',
+            '--skip-revocation-check',
             'tks-key-create', tps_connector_id,
             '--output-format', 'json'
         ]
@@ -4792,6 +4803,7 @@ class PKIDeployer:
             '-f', self.instance.password_conf,
             '-n', nickname,
             '--ignore-banner',
+            '--skip-revocation-check',
             'tks-key-replace', tps_connector_id,
             '--output-format', 'json'
         ]

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1314,8 +1314,8 @@ class PKIDeployer:
         if ocsp_uri:
             subsystem.set_config('ca.defaultOcspUri', ocsp_uri)
 
-        if config.str2bool(self.mdict['pki_client_verify_cert']):
-            subsystem.set_config('ca.clientRevocationCheck', 'true')
+        if not config.str2bool(self.mdict['pki_kra_connector_verify_cert']):
+            subsystem.set_config('ca.connector.KRA.certRevocationCheck', 'false')
 
     def configure_kra(self, subsystem):
 

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -937,6 +937,7 @@ class TPSConnector:
                    "-d", instance.nssdb_dir,
                    "-f", password_conf,
                    "--ignore-banner",
+                   "--skip-revocation-check",
                    "tks-tpsconnector-del",
                    "--host", tpshost,
                    "--port", str(tpsport)]

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1799,10 +1799,11 @@ class PKISubsystem(object):
             sd_url,
             host_id,
             hostname,
-            secure_port):
+            secure_port,
+            subordinate=False):
 
         nickname = self.config.get('%s.cert.subsystem.nickname' % self.name)
-
+        
         cmd = [
             'pki',
             '-d', self.instance.nssdb_dir,
@@ -1815,6 +1816,9 @@ class PKISubsystem(object):
             '--hostname', hostname,
             '--secure-port', secure_port
         ]
+
+        if subordinate:
+            cmd.insert(1, '--skip-revocation-check')
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1494,6 +1494,7 @@ class PKISubsystem(object):
                 '-f', self.instance.password_conf,
                 '-U', master_url,
                 '--ignore-banner',
+                '--skip-revocation-check',
                 '%s-range-request' % self.name,
                 range_type,
                 '--install-token', install_token,
@@ -1603,6 +1604,7 @@ class PKISubsystem(object):
                 '-f', self.instance.password_conf,
                 '-U', master_url,
                 '--ignore-banner',
+                '--skip-revocation-check',
                 '%s-config-export' % self.name,
                 '--names', ','.join(names),
                 '--substores', ','.join(substores),
@@ -1764,6 +1766,7 @@ class PKISubsystem(object):
                 '-f', self.instance.password_conf,
                 '-U', sd_url,
                 '--ignore-banner',
+                '--skip-revocation-check',
                 'securitydomain-join',
                 '--install-token', install_token,
                 '--type', self.type,
@@ -1799,11 +1802,10 @@ class PKISubsystem(object):
             sd_url,
             host_id,
             hostname,
-            secure_port,
-            subordinate=False):
+            secure_port):
 
         nickname = self.config.get('%s.cert.subsystem.nickname' % self.name)
-        
+
         cmd = [
             'pki',
             '-d', self.instance.nssdb_dir,
@@ -1811,14 +1813,12 @@ class PKISubsystem(object):
             '-n', nickname,
             '-U', sd_url,
             '--ignore-banner',
+            '--skip-revocation-check',
             'securitydomain-leave',
             '--type', self.type,
             '--hostname', hostname,
             '--secure-port', secure_port
         ]
-
-        if subordinate:
-            cmd.insert(1, '--skip-revocation-check')
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -226,6 +226,9 @@ public class MainCLI extends CLI {
         option.setArgName("folder");
         options.addOption(option);
 
+        option = new Option(null, "skip-revocation-check", false, "Do not perform revocation check");
+        options.addOption(option);
+
         option = new Option(null, "reject-cert-status", true, "Comma-separated list of rejected certificate validity statuses");
         option.setArgName("list");
         options.addOption(option);
@@ -477,6 +480,7 @@ public class MainCLI extends CLI {
         config.setMessageFormat(messageFormat);
         logger.debug("Message format: " + messageFormat);
 
+        config.setCertRevocationVerify(!cmd.hasOption("skip-revocation-check"));
         optionsParsed = true;
     }
 

--- a/docs/changes/v11.7.0/Server-Changes.adoc
+++ b/docs/changes/v11.7.0/Server-Changes.adoc
@@ -21,3 +21,9 @@ Name will not change.
 Standalone OCSP ResponderID has changed the default value from Subject
 name to Key hash. Running instance usinf DefStore will keep their
 current configuration.
+
+== Add pki_client_verify_cert parameter ==
+
+A new parameter `pki_client_verify_cert` has been added to
+enable/disable the certificate revocation check for the CA acting as
+client. The default value is `False` which disables the check.

--- a/docs/changes/v11.7.0/Server-Changes.adoc
+++ b/docs/changes/v11.7.0/Server-Changes.adoc
@@ -22,8 +22,8 @@ Standalone OCSP ResponderID has changed the default value from Subject
 name to Key hash. Running instance usinf DefStore will keep their
 current configuration.
 
-== Add pki_client_verify_cert parameter ==
+== Add ca.connector.KRA.certRevocationCheck parameter ==
 
-A new parameter `pki_client_verify_cert` has been added to
-enable/disable the certificate revocation check for the CA acting as
-client. The default value is `False` which disables the check.
+A new `CS.cfg` parameter `ca.connector.KRA.certRevocationCheck` has
+been added to enable/disable the certificate revocation check for the
+CA acting as KRA client. The default value is `true`.

--- a/docs/changes/v11.7.0/Tools-Changes.adoc
+++ b/docs/changes/v11.7.0/Tools-Changes.adoc
@@ -3,3 +3,14 @@
 == Deprecate tpsclient ==
 
 `tpsclient` has been deprecated. Use `pki tps-client` instead.
+
+== New --skip-revocation-check option in pki ==
+
+`pki` command has been modified to use JSSSocket. This enable by
+default revocation check of server certificates, either with AIA or
+CRL-DP. The new option `--skip-revocation-check` allows to skip the
+check in situation where the OCSP server or the CRLs cannot be
+accessed.
+
+Alternatively, the generated error can be ignored using the option
+`--ignore-cert-status` and the reported status error.

--- a/docs/changes/v11.7.0/Tools-Changes.adoc
+++ b/docs/changes/v11.7.0/Tools-Changes.adoc
@@ -12,5 +12,12 @@ CRL-DP. The new option `--skip-revocation-check` allows to skip the
 check in situation where the OCSP server or the CRLs cannot be
 accessed.
 
-Alternatively, the generated error can be ignored using the option
-`--ignore-cert-status` and the reported status error.
+Alternatively, the revocation check will still happen, but the
+generated error can be ignored using the option `--ignore-cert-status`
+and the reported status error.
+
+== New pkispawn option pki_kra_connector_verify_cert ==
+
+The CA parameter `pki_kra_connector_verify_cert` set corresponding
+`CS.cfg` paramater `ca.connector.KRA.certRevocationCheck` for KRA
+connector. The default value is `True`.


### PR DESCRIPTION
The JSSSocket allows both sync and async communication used by modern framework.

The main difference when used with current clients is related to certificate verification. JSSSocket enables OCSP and CRL-DP verification. This could be a problem in some scenario where the server cannot be accessed for the verification. Although it is possible to ignore the error using the `pki` option `--ignore-cert-status <status>` a new option allows to skip the verification: `--skip-revocation-check`.

The client enable the revocation check by default but there are problem when the CA act as a client to perform some operation. For this reason a new option is added, `ca.clientRevocationCheck`, which default to false. This can be configured with pkispawn using the option `pki_client_verify_cert` (default `False`).

The client operations performed during `pkispawn`/`pkidestroy` have the revocation check disabled.

An option to control the revocation check during installation and deletion, and some workflow to verify they are working, will be done in separate PR.
