### PR TITLE
Update KeyClient.modify_key_status() to support REST API v2

### DIFF
--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -378,13 +378,65 @@ jobs:
           sed -n "s/^\s*Trust Flags:\s*\(\S*\)$/\1/p" output > actual
           diff expected actual
 
-      - name: Check archived key
+      - name: Check key requests and keys after enrollment
+        run: |
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-request-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/entries matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 1 key request
+          cat > expected << EOF
+            Type: enrollment
+            Status: complete
+          EOF
+
+          diff expected output
+
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/key(s) matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 1 key
+          cat > expected << EOF
+            Algorithm: 1.2.840.113549.1.1.1
+            Size: 2048
+            Owner: UID=testuser
+          EOF
+
+          diff expected output
+
+      - name: Check archived cert key
         run: |
           # find archived key by owner
           docker exec pki pki \
-              -u kraadmin \
-              -w Secret.123 \
-              kra-key-find --owner UID=testuser | tee output
+              -n caadmin \
+              kra-key-find \
+              --owner UID=testuser \
+              | tee output
 
           KEY_ID=$(sed -n "s/^\s*Key ID:\s*\(\S*\)$/\1/p" output)
           echo "Key ID: $KEY_ID"
@@ -413,14 +465,16 @@ jobs:
           sed -n 's/^metaInfo:\s*payloadWrapAlgorithm:\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check key retrieval
+      - name: Check cert key retrieval
         run: |
           KEY_ID=$(cat key.id)
           echo "Key ID: $KEY_ID"
 
+          # export cert into Base64-encoded format
           BASE64_CERT=$(docker exec pki pki nss-cert-export --format DER testuser | base64 --wrap=0)
           echo "Cert: $BASE64_CERT"
 
+          # create retrieval request with key ID, cert, and passphrase
           cat > request.json <<EOF
           {
             "ClassName" : "com.netscape.certsrv.key.KeyRecoveryRequest",
@@ -447,7 +501,7 @@ jobs:
               --input $SHARED/request.json \
               --output-data archived.p12
 
-          # import PKCS #12 file into NSS database
+          # import PKCS #12 file into NSS database with the passphrase
           docker exec pki pki \
               -d nssdb \
               pkcs12-import \
@@ -465,6 +519,138 @@ jobs:
           docker exec pki pki -d nssdb nss-cert-show testuser | tee output
           sed -n "s/^\s*Trust Flags:\s*\(\S*\)$/\1/p" output > actual
           diff expected actual
+
+      - name: Check key requests and keys after retrieval
+        run: |
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-request-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/entries matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 2 key requests
+          cat > expected << EOF
+            Type: enrollment
+            Status: complete
+
+            Type: recovery
+            Status: complete
+          EOF
+
+          diff expected output
+
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/key(s) matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 1 key
+          cat > expected << EOF
+            Algorithm: 1.2.840.113549.1.1.1
+            Size: 2048
+            Owner: UID=testuser
+          EOF
+
+          diff expected output
+
+      # https://github.com/dogtagpki/pki/wiki/Changing-Archived-Key-Status
+      - name: Deactivate cert key
+        run: |
+          KEY_ID=$(cat key.id)
+          echo "KEY_ID: $KEY_ID"
+
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-mod \
+              --status inactive \
+              $KEY_ID \
+              | tee output
+
+          cat > expected << EOF
+            Key ID: $KEY_ID
+            Status: inactive
+            Algorithm: 1.2.840.113549.1.1.1
+            Size: 2048
+            Owner: UID=testuser
+          EOF
+
+          diff expected output
+
+      - name: Check key requests and keys after deactivation
+        run: |
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-request-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/entries matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 2 key requests
+          cat > expected << EOF
+            Type: enrollment
+            Status: complete
+
+            Type: recovery
+            Status: complete
+          EOF
+
+          diff expected output
+
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/key(s) matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 1 key which is inactive
+          cat > expected << EOF
+            Status: inactive
+            Algorithm: 1.2.840.113549.1.1.1
+            Size: 2048
+            Owner: UID=testuser
+          EOF
+
+          diff expected output
 
       - name: Remove KRA
         run: docker exec pki pkidestroy -s KRA -v
@@ -548,6 +734,11 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check PKI server access log
+        if: always()
+        run: |
+          docker exec pki find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
 
       - name: Check CA debug log
         if: always()

--- a/.github/workflows/python-kra-test.yml
+++ b/.github/workflows/python-kra-test.yml
@@ -332,7 +332,12 @@ jobs:
               --ca-bundle ca_signing.crt \
               --client-cert admin.crt \
               --client-key admin.key \
-              -v
+              -v \
+              | tee output
+
+          KEY_ID=$(sed -n "s/^\s*Key ID:\s*\(\S*\)$/\1/p" output)
+          echo "Key ID: $KEY_ID"
+          echo $KEY_ID > key.id
 
           sleep 1
 
@@ -378,6 +383,77 @@ jobs:
           cat > expected << EOF
           GET /kra/v1/account/login HTTP/1.1 200 kraadmin
           GET /kra/v1/agent/keys HTTP/1.1 200 kraadmin
+          GET /kra/v1/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      ####################################################################################################
+      # Change key status
+
+      - name: Change key status
+        run: |
+          KEY_ID=$(cat key.id)
+          echo "Key ID: $KEY_ID"
+
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-mod.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --status inactive \
+              $KEY_ID \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /kra/v2/account/login HTTP/1.1 200 kraadmin
+          POST /kra/v2/agent/keys/$KEY_ID?status=inactive HTTP/1.1 204 kraadmin
+          GET /kra/v2/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      - name: Change key status with REST API v1
+        run: |
+          KEY_ID=$(cat key.id)
+          echo "Key ID: $KEY_ID"
+
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-mod.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --api v1 \
+              --status inactive \
+              $KEY_ID \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -3 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1
+          cat > expected << EOF
+          GET /kra/v1/account/login HTTP/1.1 200 kraadmin
+          POST /kra/v1/agent/keys/$KEY_ID?status=inactive HTTP/1.1 204 kraadmin
           GET /kra/v1/account/logout HTTP/1.1 204 kraadmin
           EOF
 

--- a/base/common/python/pki/key.py
+++ b/base/common/python/pki/key.py
@@ -710,9 +710,20 @@ class KeyClient:
         if (key_id is None) or (status is None):
             raise TypeError("Key ID and status must be specified")
 
-        url = self.key_url + '/' + key_id
+        if self.pki_client:
+            api_path = self.pki_client.get_api_path()
+        else:
+            api_path = 'rest'
+
+        path = '/%s/agent/keys/%s' % (api_path, key_id)
+
+        # in legacy code the PKIConnection object might already have the subsystem name
+        # in newer code the subsystem name needs to be included in the path
+        if not self.connection.subsystem:
+            path = '/kra' + path
+
         params = {'status': status}
-        self.connection.post(url, None, headers=self.headers, params=params)
+        self.connection.post(path, None, headers=self.headers, params=params)
 
     @pki.handle_exceptions()
     def approve_request(self, request_id):

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyCLI.java
@@ -123,7 +123,7 @@ public class KRAKeyCLI extends CLI {
         return keyClient;
     }
 
-    public static void printKeyInfo(KeyInfo info) {
+    public static void printKeyInfo(KeyInfo info, boolean showPublicKey) {
         System.out.println("  Key ID: "+info.getKeyId().toHexString());
         if (info.getClientKeyID() != null) System.out.println("  Client Key ID: "+info.getClientKeyID());
         if (info.getStatus() != null) System.out.println("  Status: "+info.getStatus());
@@ -131,7 +131,8 @@ public class KRAKeyCLI extends CLI {
         if (info.getSize() != null) System.out.println("  Size: "+info.getSize());
         if (info.getOwnerName() != null) System.out.println("  Owner: "+info.getOwnerName());
         if (info.getRealm() != null) System.out.println("  Realm: " + info.getRealm());
-        if (info.getPublicKey() != null) {
+
+        if (info.getPublicKey() != null && showPublicKey) {
             // Print out the Base64 encoded public key in the form of a blob,
             // where the max line length is 64.
             System.out.println("  Public Key: \n");

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyFindCLI.java
@@ -138,7 +138,7 @@ public class KRAKeyFindCLI extends CommandCLI {
                     System.out.println();
                 }
 
-                KRAKeyCLI.printKeyInfo(info);
+                KRAKeyCLI.printKeyInfo(info, false);
             }
 
             MainCLI.printMessage("Number of entries returned " + entries.size());

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyModifyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyModifyCLI.java
@@ -45,7 +45,7 @@ public class KRAKeyModifyCLI extends CommandCLI {
 
     @Override
     public void createOptions() {
-        Option option = new Option(null, "status", true, "Status of the key.\nValid values: active, inactive");
+        Option option = new Option(null, "status", true, "Key status: active, inactive");
         option.setArgName("status");
         options.addOption(option);
     }
@@ -74,6 +74,6 @@ public class KRAKeyModifyCLI extends CommandCLI {
         keyClient.modifyKeyStatus(keyId, status);
 
         KeyInfo keyInfo = keyClient.getKeyInfo(keyId);
-        KRAKeyCLI.printKeyInfo(keyInfo);
+        KRAKeyCLI.printKeyInfo(keyInfo, false);
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyShowCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyShowCLI.java
@@ -73,6 +73,6 @@ public class KRAKeyShowCLI extends CommandCLI {
             throw new Exception("Missing Key ID or Client Key ID.");
         }
 
-        KRAKeyCLI.printKeyInfo(keyInfo);
+        KRAKeyCLI.printKeyInfo(keyInfo, true);
     }
 }

--- a/tests/kra/bin/pki-kra-key-mod.py
+++ b/tests/kra/bin/pki-kra-key-mod.py
@@ -1,0 +1,80 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+
+import pki.kra
+import pki.account
+import pki.client
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--client-cert',
+    help='Path to client certificate',
+    dest='client_cert')
+parser.add_argument(
+    '--client-key',
+    help='Path to client key',
+    dest='client_key')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '--status',
+    help='Key status: active, inactive',
+    dest='status')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+parser.add_argument('key_id')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+pki_client.set_client_auth(
+    client_cert=args.client_cert,
+    client_key=args.client_key)
+
+kra_client = pki.kra.KRAClient(pki_client)
+
+account_client = pki.account.AccountClient(kra_client)
+account_client.login()
+
+key_client = pki.key.KeyClient(kra_client)
+key_client.modify_key_status(args.key_id, args.status)
+
+account_client.logout()


### PR DESCRIPTION
A new test has been added to modify the status of a key using `KeyClient.modify_key_status()`. The basic KRA test has also been modified to perform the same test using `pki kra-key-mod`.

The `pki kra-key-find` and `pki kra-key-mod` have been modified to no longer show the public key data. The `pki kra-key-show` will continue to show the public key data.