### PR TITLE
Update KeyClient to support archieval/retrieval with REST API v2

### DIFF
--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -499,6 +499,7 @@ jobs:
               -n caadmin \
               kra-key-retrieve \
               --input $SHARED/request.json \
+              --transport kra_transport \
               --output-data archived.p12
 
           # import PKCS #12 file into NSS database with the passphrase
@@ -648,6 +649,178 @@ jobs:
             Algorithm: 1.2.840.113549.1.1.1
             Size: 2048
             Owner: UID=testuser
+          EOF
+
+          diff expected output
+
+      # https://github.com/dogtagpki/pki/wiki/Archiving-Key-in-KRA
+      - name: Archive secret
+        run: |
+          # generate random secret
+          head -c 1K < /dev/urandom > secret.archived
+
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-archive \
+              --clientKeyID testuser \
+              --transport kra_transport \
+              --input-data $SHARED/secret.archived \
+              -v
+
+          docker exec pki pki -n caadmin kra-key-find | tee output
+
+          # there should be 2 keys
+          echo "2" > expected
+          grep "^ *Key ID:" output | wc -l > actual
+          diff expected actual
+
+          # get key ID
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-find \
+              --clientKeyID testuser | tee output
+
+          sed -n 's/^ *Key ID: *\(.*\)$/\1/p' output > key.id
+
+      - name: Check key requests and keys after secret archival
+        run: |
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-request-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/entries matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 3 key requests
+          cat > expected << EOF
+            Type: enrollment
+            Status: complete
+
+            Type: recovery
+            Status: complete
+
+            Type: securityDataEnrollment
+            Status: complete
+          EOF
+
+          diff expected output
+
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/key(s) matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 2 keys
+          cat > expected << EOF
+            Status: inactive
+            Algorithm: 1.2.840.113549.1.1.1
+            Size: 2048
+            Owner: UID=testuser
+
+            Client Key ID: testuser
+            Status: active
+            Owner: kraadmin
+          EOF
+
+          diff expected output
+
+      # https://github.com/dogtagpki/pki/wiki/Retrieving-Archived-Key
+      - name: Retrieve secret
+        run: |
+          KEY_ID=$(cat key.id)
+          echo "KEY_ID: $KEY_ID"
+
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-retrieve \
+              --keyID $KEY_ID \
+              --transport kra_transport \
+              --output-data $SHARED/secret.retrieved \
+              -v
+
+          diff secret.archived secret.retrieved
+
+      - name: Check key requests and keys after secret retrieval
+        run: |
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-request-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/entries matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 4 key requests
+          cat > expected << EOF
+            Type: enrollment
+            Status: complete
+
+            Type: recovery
+            Status: complete
+
+            Type: securityDataEnrollment
+            Status: complete
+
+            Type: securityDataRecovery
+            Status: complete
+          EOF
+
+          diff expected output
+
+          docker exec pki pki \
+              -n caadmin \
+              kra-key-find \
+              | tee output
+
+          # normalize output
+          sed -i \
+              -e '/-----/d' \
+              -e '/key(s) matched/d' \
+              -e '/Number of entries returned/d' \
+              -e '/^ *Request ID:/d' \
+              -e '/^ *Key ID:/d' \
+              -e '/^ *Creation Time:/d' \
+              -e '/^ *Modification Time:/d' \
+              output
+
+          # there should be 2 keys
+          cat > expected << EOF
+            Status: inactive
+            Algorithm: 1.2.840.113549.1.1.1
+            Size: 2048
+            Owner: UID=testuser
+
+            Client Key ID: testuser
+            Status: active
+            Owner: kraadmin
           EOF
 
           diff expected output

--- a/.github/workflows/python-kra-test.yml
+++ b/.github/workflows/python-kra-test.yml
@@ -459,6 +459,146 @@ jobs:
 
           diff expected output
 
+      ####################################################################################################
+      # Archive secret
+
+      - name: Archive secret
+        run: |
+          # generate random secret
+          head -c 1K < /dev/urandom > secret.archived
+
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-archive.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --client-key-id testuser1 \
+              --transport kra_transport.crt \
+              --input $SHARED/secret.archived \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /kra/v2/account/login HTTP/1.1 200 kraadmin
+          POST /kra/v2/agent/keyrequests HTTP/1.1 201 kraadmin
+          GET /kra/v2/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      - name: Retrieve secret
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-retrieve.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --client-key-id testuser1 \
+              --transport kra_transport.crt \
+              --output $SHARED/secret.retrieved \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -5 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /kra/v2/account/login HTTP/1.1 200 kraadmin
+          GET /kra/v2/agent/keys?clientKeyID=testuser1 HTTP/1.1 200 kraadmin
+          POST /kra/v2/agent/keys/retrieve HTTP/1.1 200 kraadmin
+          GET /kra/v2/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+          diff secret.archived secret.retrieved
+
+      - name: Archive secret with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-archive.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --api v1 \
+              --client-key-id testuser2 \
+              --transport kra_transport.crt \
+              --input $SHARED/secret.archived \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -3 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1
+          cat > expected << EOF
+          GET /kra/v1/account/login HTTP/1.1 200 kraadmin
+          POST /kra/v1/agent/keyrequests HTTP/1.1 201 kraadmin
+          GET /kra/v1/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+      - name: Retrieve secret with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/kra/bin/pki-kra-key-retrieve.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --api v1 \
+              --client-key-id testuser2 \
+              --transport kra_transport.crt \
+              --output $SHARED/secret.retrieved \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1
+          cat > expected << EOF
+          GET /kra/v1/account/login HTTP/1.1 200 kraadmin
+          GET /kra/v1/agent/keys?clientKeyID=testuser2 HTTP/1.1 200 kraadmin
+          POST /kra/v1/agent/keys/retrieve HTTP/1.1 200 kraadmin
+          GET /kra/v1/account/logout HTTP/1.1 204 kraadmin
+          EOF
+
+          diff expected output
+
+          diff secret.archived secret.retrieved
+
       - name: Check DS server systemd journal
         if: always()
         run: |

--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -119,7 +119,7 @@ class CryptographyCryptoProvider(CryptoProvider):
     Note that all inputs and outputs are unencoded.
     """
 
-    def __init__(self, transport_cert_nick, transport_cert,
+    def __init__(self, transport_cert_nick=None, transport_cert=None,
                  backend=default_backend()):
         """ Initialize python-cryptography
         """
@@ -134,7 +134,8 @@ class CryptographyCryptoProvider(CryptoProvider):
                 transport_pem,
                 backend)
 
-        self.certs[transport_cert_nick] = transport_cert
+        if transport_cert_nick:
+            self.certs[transport_cert_nick] = transport_cert
 
         # default to AES
         self.encrypt_alg = algorithms.AES

--- a/base/common/python/pki/key.py
+++ b/base/common/python/pki/key.py
@@ -766,10 +766,19 @@ class KeyClient:
         if request is None:
             raise TypeError("Request must be specified")
 
-        url = self.key_requests_url
+        if self.pki_client:
+            api_path = self.pki_client.get_api_path()
+        else:
+            api_path = 'rest'
+
+        path = '/%s/agent/keyrequests' % api_path
+
+        if not self.connection.subsystem:
+            path = '/kra' + path
+
         key_request = json.dumps(request, cls=encoder.CustomTypeEncoder,
                                  sort_keys=True)
-        response = self.connection.post(url, key_request, self.headers)
+        response = self.connection.post(path, key_request, self.headers)
 
         json_response = response.json()
         logger.debug('Response:\n%s', json.dumps(json_response, indent=4))
@@ -1077,10 +1086,19 @@ class KeyClient:
         if data is None:
             raise TypeError("Key Recovery Request must be specified")
 
-        url = self.key_url + '/retrieve'
+        if self.pki_client:
+            api_path = self.pki_client.get_api_path()
+        else:
+            api_path = 'rest'
+
+        path = '/%s/agent/keys/retrieve' % api_path
+
+        if not self.connection.subsystem:
+            path = '/kra' + path
+
         key_request = json.dumps(data, cls=encoder.CustomTypeEncoder,
                                  sort_keys=True)
-        response = self.connection.post(url, key_request, self.headers)
+        response = self.connection.post(path, key_request, self.headers)
 
         json_response = response.json()
         logger.debug('Response:\n%s', json.dumps(json_response, indent=4))

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/base/KeyRequestProcessor.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/base/KeyRequestProcessor.java
@@ -473,9 +473,12 @@ public class KeyRequestProcessor {
             throw new BadRequestException("Invalid key archival request.");
         }
 
+        String algorithmOID = data.getAlgorithmOID();
+        logger.info("KeyRequestProcessor: algorithm OID: " + algorithmOID);
+
         if (data.getWrappedPrivateData() != null) {
             if (data.getTransWrappedSessionKey() == null ||
-                data.getAlgorithmOID() == null ||
+                algorithmOID == null ||
                 data.getSymmetricAlgorithmParams() == null) {
                 throw new BadRequestException(
                         "Invalid key archival request.  " +
@@ -486,9 +489,15 @@ public class KeyRequestProcessor {
                     "Invalid key archival request.  No data to archive");
         }
 
-        if (data.getDataType().equals(KeyRequestResource.SYMMETRIC_KEY_TYPE) && (data.getKeyAlgorithm() == null) ||
-                (!SYMKEY_TYPES.containsKey(data.getKeyAlgorithm()))) {
-            throw new BadRequestException("Invalid key archival request.  Bad algorithm.");
+        String dataType = data.getDataType();
+        logger.info("KeyRequestProcessor: data type: " + dataType);
+
+        String keyAlgorithm = data.getKeyAlgorithm();
+        logger.info("KeyRequestProcessor: key algorithm: " + keyAlgorithm);
+
+        if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE) &&
+                (keyAlgorithm == null || !SYMKEY_TYPES.containsKey(keyAlgorithm))) {
+            throw new BadRequestException("Invalid symmetric key algorithm: " + keyAlgorithm);
         }
 
         KeyRequestResponse response;

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v1/KeyRequestService.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v1/KeyRequestService.java
@@ -129,9 +129,12 @@ public class KeyRequestService extends SubsystemService implements KeyRequestRes
             throw new BadRequestException("Invalid key archival request.");
         }
 
+        String algorithmOID = data.getAlgorithmOID();
+        logger.info("KeyRequestService: algorithm OID: " + algorithmOID);
+
         if (data.getWrappedPrivateData() != null) {
             if (data.getTransWrappedSessionKey() == null ||
-                data.getAlgorithmOID() == null ||
+                algorithmOID == null ||
                 data.getSymmetricAlgorithmParams() == null) {
                 throw new BadRequestException(
                         "Invalid key archival request.  " +
@@ -142,11 +145,15 @@ public class KeyRequestService extends SubsystemService implements KeyRequestRes
                     "Invalid key archival request.  No data to archive");
         }
 
-        if (data.getDataType().equals(KeyRequestResource.SYMMETRIC_KEY_TYPE)) {
-            if ((data.getKeyAlgorithm() == null) ||
-                (! SYMKEY_TYPES.containsKey(data.getKeyAlgorithm()))) {
-                throw new BadRequestException("Invalid key archival request.  Bad algorithm.");
-            }
+        String dataType = data.getDataType();
+        logger.info("KeyRequestService: data type: " + dataType);
+
+        String keyAlgorithm = data.getKeyAlgorithm();
+        logger.info("KeyRequestService: key algorithm: " + keyAlgorithm);
+
+        if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE) &&
+                (keyAlgorithm == null || !SYMKEY_TYPES.containsKey(keyAlgorithm))) {
+            throw new BadRequestException("Invalid symmetric key algorithm: " + keyAlgorithm);
         }
 
         KRAEngine engine = (KRAEngine) getCMSEngine();

--- a/tests/kra/bin/pki-kra-key-archive.py
+++ b/tests/kra/bin/pki-kra-key-archive.py
@@ -1,0 +1,130 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+import os
+
+import cryptography.hazmat.backends
+import cryptography.hazmat.primitives.padding
+import cryptography.x509
+
+import pki.kra
+import pki.account
+import pki.client
+import pki.crypto
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--client-cert',
+    help='Path to client certificate',
+    dest='client_cert')
+parser.add_argument(
+    '--client-key',
+    help='Path to client key',
+    dest='client_key')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '--client-key-id',
+    help='Client key ID',
+    dest='client_key_id')
+parser.add_argument(
+    '--transport',
+    help='Transport certificate filename',
+    dest='transport')
+parser.add_argument(
+    '--input',
+    help='Input filename',
+    dest='input_filename')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+with open(args.transport, 'rb') as f:
+    transport_pem = f.read()
+
+with open(args.input_filename, 'rb') as f:
+    input_data = f.read()
+
+transport_cert = cryptography.x509.load_pem_x509_certificate(
+    transport_pem,
+    cryptography.hazmat.backends.default_backend())
+
+crypto = pki.crypto.CryptographyCryptoProvider(
+    transport_cert=transport_cert)
+crypto.initialize()
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+pki_client.set_client_auth(
+    client_cert=args.client_cert,
+    client_key=args.client_key)
+
+kra_client = pki.kra.KRAClient(pki_client)
+
+account_client = pki.account.AccountClient(kra_client)
+account_client.login()
+
+key_client = pki.key.KeyClient(kra_client)
+
+nonce_iv = crypto.generate_nonce_iv()
+session_key = crypto.generate_session_key()
+
+encrypted_data = crypto.symmetric_wrap(
+    input_data,
+    session_key,
+    nonce_iv=nonce_iv)
+
+wrapped_session_key = crypto.asymmetric_wrap(
+    session_key,
+    transport_cert)
+
+# use AES_128_CBC to match pki kra-key-archve
+# see Java KeyClient.getEncryptAlgorithmOID()
+algorithm_oid = pki.crypto.AES_128_CBC_OID
+
+key_client.archive_encrypted_data(
+    args.client_key_id,
+    pki.key.KeyClient.PASS_PHRASE_TYPE,
+    encrypted_data,
+    wrapped_session_key,
+    algorithm_oid=algorithm_oid,
+    nonce_iv=nonce_iv)
+
+account_client.logout()

--- a/tests/kra/bin/pki-kra-key-retrieve.py
+++ b/tests/kra/bin/pki-kra-key-retrieve.py
@@ -1,0 +1,130 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+import os
+
+import cryptography.hazmat.backends
+import cryptography.hazmat.primitives.padding
+import cryptography.x509
+
+import pki.kra
+import pki.account
+import pki.client
+import pki.crypto
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--client-cert',
+    help='Path to client certificate',
+    dest='client_cert')
+parser.add_argument(
+    '--client-key',
+    help='Path to client key',
+    dest='client_key')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '--client-key-id',
+    help='Client key ID',
+    dest='client_key_id')
+parser.add_argument(
+    '--transport',
+    help='Transport certificate filename',
+    dest='transport')
+parser.add_argument(
+    '--output',
+    help='Output filename',
+    dest='output_filename')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+with open(args.transport, 'rb') as f:
+    transport_pem = f.read()
+
+transport_cert = cryptography.x509.load_pem_x509_certificate(
+    transport_pem,
+    cryptography.hazmat.backends.default_backend())
+
+crypto = pki.crypto.CryptographyCryptoProvider(
+    transport_cert=transport_cert)
+crypto.initialize()
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+pki_client.set_client_auth(
+    client_cert=args.client_cert,
+    client_key=args.client_key)
+
+kra_client = pki.kra.KRAClient(pki_client)
+
+account_client = pki.account.AccountClient(kra_client)
+account_client.login()
+
+key_client = pki.key.KeyClient(kra_client)
+
+# find key ID from client's key ID
+result = key_client.list_keys(client_key_id=args.client_key_id)
+key_info = result.key_infos[0]
+key_id = key_info.get_key_id()
+
+session_key = crypto.generate_session_key()
+
+wrapped_session_key = crypto.asymmetric_wrap(
+    session_key,
+    transport_cert)
+
+# use AES_128_CBC to match pki kra-key-retrieve
+# see Java KeyClient.getEncryptAlgorithmOID()
+key_client.encrypt_alg_oid = pki.crypto.AES_128_CBC_OID
+
+key = key_client.retrieve_key(
+    key_id,
+    wrapped_session_key)
+
+account_client.logout()
+
+key_data = crypto.symmetric_unwrap(
+    key.encrypted_data,
+    session_key,
+    nonce_iv=key.nonce_data)
+
+with open(args.output_filename, 'wb') as f:
+    f.write(key_data)


### PR DESCRIPTION
The `KeyClient.submit_request()` and `retrieve_key_data()` have been updated to use the proper URL for the REST API version.

The `CryptographyCryptoProvider`'s constructor has been updated such that the transport cert nickname is optional.

The `KeyRequestProcessor.archiveKey()` has been updated to use the same condition as in `KeyRequestService.archiveKey()` to validate the key algorithm for symmetric key.

The basic KRA test has been updated to archive a secret then retrieve it using `pki` CLI.

The KRA Python API test has been updated to archive a secret then retrieve it using the updated Python API.