### PR TITLE
Refactor AuthorityRepository.findCAs()

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/AuthorityServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/AuthorityServlet.java
@@ -5,7 +5,6 @@
 //
 package org.dogtagpki.server.ca.rest.v2;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URLEncoder;
@@ -23,7 +22,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.authority.AuthorityData;
-import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.base.MediaType;
 import com.netscape.certsrv.base.RequestNotAcceptable;
 import com.netscape.certsrv.base.WebAction;
@@ -51,13 +49,8 @@ public class AuthorityServlet extends CAServlet {
         logger.info("AuthorityServlet: Finding CAs");
         logger.debug("AuthorityServlet: - session: {}", session.getId());
 
-        List<AuthorityData> authorities;
-        try {
-            AuthorityRepository authorityRepository = engine.getAuthorityRepository();
-            authorities = authorityRepository.findCAs(id, parentID, dn, issuerDN);
-        } catch (IOException e) {
-            throw new BadRequestException("DNs not valid");
-        }
+        AuthorityRepository authorityRepository = engine.getAuthorityRepository();
+        List<AuthorityData> authorities = authorityRepository.findCAs(id, parentID, dn, issuerDN);
 
         PrintWriter out = response.getWriter();
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
Currently the `AuthorityRepository.findCAs()` gets the authority data from the CA objects in the CA engine. The `AuthorityMonitor` creates a CA object for each authority record in LDAP, so it might not scale well with large database and might be expensive to run in cloud.

To address the issue, the `AuthorityRepository.findCAs()` has been modified to get the data from the authority records directly. For now it still uses the CA object to get some additional info, but in the future it might be possible to store those info in LDAP as well.

The `AuthorityService.findCAs()` has been modified to use the `AuthorityRepository.findCAs()`.

The `AuthorityServlet.findCAs()` has been modified to no longer catch the exception and throw a `BadRequestException` since the exception might not necessarily be a client issue.