### PR TITLE
Refactor AuthorityRepository.getCA()

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/AuthorityService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/AuthorityService.java
@@ -94,34 +94,19 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
     }
 
     @Override
-    public Response getCA(String aidString) {
+    public Response getCA(String aidString) throws Exception {
 
-        logger.info("AuthorityService: getting authority " + aidString + ":");
+        logger.info("AuthorityService: Getting CA {}", aidString);
 
         CAEngine engine = CAEngine.getInstance();
-        CertificateAuthority ca = engine.getCA();
+        AuthorityRepository authorityRepository = engine.getAuthorityRepository();
+        AuthorityData authority = authorityRepository.getCA(aidString);
 
-        if (!AuthorityResource.HOST_AUTHORITY.equals(aidString)) {
-            AuthorityID aid;
-            try {
-                aid = new AuthorityID(aidString);
-            } catch (IllegalArgumentException e) {
-                throw new BadRequestException("Bad AuthorityID: " + aidString);
-            }
-
-            ca = engine.getCA(aid);
-
-            if (ca == null)
-                throw new ResourceNotFoundException("CA \"" + aidString + "\" not found");
-        }
-
-        AuthorityData authority = readAuthorityData(ca);
-
-        logger.info("AuthorityService:   DN: " + authority.getDN());
+        logger.debug("AuthorityService: - DN: {}", authority.getDN());
         if (authority.getParentID() != null) {
-            logger.info("AuthorityService:   Parent ID: " + authority.getParentID());
+            logger.debug("AuthorityService: - parent ID: {}", authority.getParentID());
         }
-        logger.info("AuthorityService:   Issuer DN: " + authority.getIssuerDN());
+        logger.debug("AuthorityService: - issuer DN: {}", authority.getIssuerDN());
 
         return createOKResponse(authority);
     }

--- a/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityResource.java
@@ -32,7 +32,7 @@ public interface AuthorityResource {
 
     @GET
     @Path("{id}")
-    public Response getCA(@PathParam("id") String caIDString);
+    public Response getCA(@PathParam("id") String caIDString) throws Exception;
 
     @GET
     @Path("{id}/cert")


### PR DESCRIPTION
The `AuthorityRepository.getCA()` has been modified to get the authority data from the authority record directly. For now it still uses the CA object to get some additional info, but in the future it might be possible to store those info in LDAP as well.

The `AuthorityRepository.readAuthorityData()` has been modified to get the issuer DN from the CA cert to match the original behavior of the code.

The `AuthorityService.getCA()` has been modified to use the `AuthorityRepository.getCA()`.