### PR TITLE
Refactor AuthorityRepository.findAuthorityRecords()

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/AuthorityService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/AuthorityService.java
@@ -383,7 +383,7 @@ public class AuthorityService extends SubsystemService implements AuthorityResou
             auditParams.put("exception", e.toString());
             audit(ILogger.FAILURE, OpDef.OP_DELETE, aidString, auditParams);
             throw new ConflictingOperationException(e.toString());
-        } catch (EBaseException e) {
+        } catch (Exception e) {
             String message = "Error modifying authority: " + e.getMessage();
             logger.error(message, e);
             auditParams.put("exception", e.toString());

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/CertRequestService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/CertRequestService.java
@@ -95,7 +95,7 @@ public class CertRequestService extends PKIService implements CertRequestResourc
     }
 
     @Override
-    public Response enrollCert(String enrollmentRequest, String aidString, String adnString) {
+    public Response enrollCert(String enrollmentRequest, String aidString, String adnString) throws Exception {
 
         logger.info("CertRequestService: Receiving certificate request");
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/CertRequestServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/CertRequestServlet.java
@@ -134,7 +134,11 @@ public class CertRequestServlet extends CAServlet {
         out.println(infos.toJSON());
     }
 
-    private CertRequestInfos enrollCert(HttpServletRequest servletRequest, CertEnrollmentRequest data, String aidString, String adnString) {
+    private CertRequestInfos enrollCert(
+            HttpServletRequest servletRequest,
+            CertEnrollmentRequest data,
+            String aidString,
+            String adnString) throws Exception {
 
         logger.info("CertRequestServlet: Receiving certificate request");
         if (aidString != null && adnString != null)

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertRequestResource.java
@@ -34,7 +34,7 @@ public interface CertRequestResource {
     public Response enrollCert(
         String enrollmentRequest,
         @QueryParam("issuer-id") String caIDString,
-        @QueryParam("issuer-dn") String caDNString);
+        @QueryParam("issuer-dn") String caDNString) throws Exception;
 
     /**
      * Used to retrieve cert request info for a specific request


### PR DESCRIPTION
The `AuthorityRepository.findAuthorityRecords()` has been updated to construct an LDAP search filter from authority ID, authority DN, parent ID, and parent DN if provided.

The `AuthorityRepository.findCAs()` has been updated to provide the search params to `findAuthorityRecords()` instead of filtering out the search results afterwards.

The `CAEngine.getCA()` has been updated to get the authority record using the `findAuthorityRecords()` then call another `getCA()` with the authority ID to get the `CertificateAuthority` object.

The `CAEngine.deleteAuthority()` has been updated to determine whether the authority to be deleted has any descendant using the `findAuthorityRecords()`.