### PR TITLE
Replace httpclient deprecated code

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
@@ -37,25 +37,23 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
-import org.apache.http.ProtocolException;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.params.HttpClientParams;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeLayeredSocketFactory;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
 import org.apache.http.entity.BufferedHttpEntity;
-import org.apache.http.impl.client.ClientParamsStack;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
-import org.apache.http.impl.client.DefaultRedirectStrategy;
-import org.apache.http.impl.client.EntityEnclosingRequestWrapper;
-import org.apache.http.impl.client.RequestWrapper;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.message.BasicHttpResponse;
-import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 import org.dogtagpki.client.JSSSocketFactory;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
+
+import com.netscape.certsrv.base.PKIException;
 
 public class PKIConnection implements AutoCloseable {
 
@@ -63,9 +61,9 @@ public class PKIConnection implements AutoCloseable {
 
     ClientConfig config;
 
-    DefaultHttpClient httpClient = new DefaultHttpClient();
+    CloseableHttpClient httpClient;
     SSLCertificateApprovalCallback callback;
-    SchemeLayeredSocketFactory socketFactory;
+    LayeredConnectionSocketFactory socketFactory;
 
     ApacheHttpClient4Engine engine;
     javax.ws.rs.client.Client client;
@@ -86,20 +84,18 @@ public class PKIConnection implements AutoCloseable {
                 JSSSocketFactory.class.getName());
         logger.info("PKIConnection: Socket factory: " + className);
 
-        Class<? extends SchemeLayeredSocketFactory> clazz =
-                Class.forName(className).asSubclass(SchemeLayeredSocketFactory.class);
+        Class<? extends LayeredConnectionSocketFactory> clazz =
+                Class.forName(className).asSubclass(LayeredConnectionSocketFactory.class);
 
         socketFactory = clazz.getConstructor(PKIConnection.class).newInstance(this);
 
-        // Register https scheme.
-        Scheme scheme = new Scheme("https", 443, socketFactory);
-
-        httpClient.getConnectionManager().getSchemeRegistry().register(scheme);
+        HttpClientBuilder httpClientBuilder = HttpClients.custom().setSSLSocketFactory(socketFactory);
 
         // Don't retry operations.
-        httpClient.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(0, false));
+        httpClientBuilder.setRetryHandler(new DefaultHttpRequestRetryHandler(0, false));
 
-        httpClient.addRequestInterceptor(new HttpRequestInterceptor() {
+
+        httpClientBuilder.addInterceptorFirst(new HttpRequestInterceptor() {
             @Override
             public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
 
@@ -132,17 +128,17 @@ public class PKIConnection implements AutoCloseable {
                     logger.debug("Request:\n" + os.toString("UTF-8"));
                 }
 
-                // Set the request parameter to follow redirections.
-                HttpParams params = request.getParams();
-                if (params instanceof ClientParamsStack) {
-                    ClientParamsStack paramsStack = (ClientParamsStack)request.getParams();
-                    params = paramsStack.getRequestParams();
+                if (context instanceof HttpClientContext clientContext) {
+                    RequestConfig reqConfig = RequestConfig.copy(clientContext.getRequestConfig())
+                            .setRedirectsEnabled(true)
+                            .setRelativeRedirectsAllowed(true)
+                            .build();
+                    clientContext.setRequestConfig(reqConfig);
                 }
-                HttpClientParams.setRedirecting(params, true);
             }
         });
 
-        httpClient.addResponseInterceptor(new HttpResponseInterceptor() {
+        httpClientBuilder.addInterceptorFirst(new HttpResponseInterceptor() {
             @Override
             public void process(HttpResponse response, HttpContext context) throws HttpException, IOException {
 
@@ -170,38 +166,9 @@ public class PKIConnection implements AutoCloseable {
             }
         });
 
-        httpClient.setRedirectStrategy(new DefaultRedirectStrategy() {
-            @Override
-            public HttpUriRequest getRedirect(HttpRequest request, HttpResponse response, HttpContext context)
-                    throws ProtocolException {
+        httpClientBuilder.setRedirectStrategy(new LaxRedirectStrategy());
 
-                HttpUriRequest uriRequest = super.getRedirect(request, response, context);
-
-                URI uri = uriRequest.getURI();
-                logger.info("HTTP redirect: "+uri);
-
-                // Redirect the original request to the new URI.
-                RequestWrapper wrapper;
-                if (request instanceof HttpEntityEnclosingRequest) {
-                    wrapper = new EntityEnclosingRequestWrapper((HttpEntityEnclosingRequest)request);
-                } else {
-                    wrapper = new RequestWrapper(request);
-                }
-                wrapper.setURI(uri);
-
-                return wrapper;
-            }
-
-            @Override
-            public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context)
-                    throws ProtocolException {
-
-                // The default redirection policy does not redirect POST or PUT.
-                // This overrides the policy to follow redirections for all HTTP methods.
-                return response.getStatusLine().getStatusCode() == 302;
-            }
-        });
-
+        httpClient = httpClientBuilder.build();
         engine = new ApacheHttpClient4Engine(httpClient);
 
         client = new ResteasyClientBuilder().httpEngine(engine).build();
@@ -227,15 +194,14 @@ public class PKIConnection implements AutoCloseable {
 
     public void storeRequest(PrintStream out, HttpRequest request) throws IOException {
 
-        if (request instanceof EntityEnclosingRequestWrapper) {
-            EntityEnclosingRequestWrapper wrapper = (EntityEnclosingRequestWrapper) request;
+        if (request instanceof HttpEntityEnclosingRequest enclose) {
 
-            HttpEntity entity = wrapper.getEntity();
+            HttpEntity entity = enclose.getEntity();
             if (entity == null) return;
 
             if (!entity.isRepeatable()) {
                 BufferedHttpEntity bufferedEntity = new BufferedHttpEntity(entity);
-                wrapper.setEntity(bufferedEntity);
+                enclose.setEntity(bufferedEntity);
                 entity = bufferedEntity;
             }
 
@@ -289,6 +255,11 @@ public class PKIConnection implements AutoCloseable {
     public void close() {
         client.close();
         engine.close();
-        httpClient.close();
+        try {
+            httpClient.close();
+        } catch (IOException e) {
+            logger.error("PKIConnection: cannot close httpClient - {}", e.getMessage());
+            throw new PKIException(e);
+        }
     }
 }

--- a/base/common/src/main/java/org/dogtagpki/client/SSLSocketFactory.java
+++ b/base/common/src/main/java/org/dogtagpki/client/SSLSocketFactory.java
@@ -6,13 +6,15 @@
 package org.dogtagpki.client;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 
-import org.apache.http.conn.scheme.SchemeLayeredSocketFactory;
-import org.apache.http.params.HttpParams;
+import javax.net.SocketFactory;
+
+import org.apache.http.HttpHost;
+import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
 import org.mozilla.jss.ssl.SSLAlertDescription;
 import org.mozilla.jss.ssl.SSLAlertEvent;
 import org.mozilla.jss.ssl.SSLAlertLevel;
@@ -25,7 +27,7 @@ import com.netscape.certsrv.client.PKIConnection;
 /**
  * This class provides blocking socket factory for PKIConnection based on SSLSocket.
  */
-public class SSLSocketFactory implements SchemeLayeredSocketFactory {
+public class SSLSocketFactory implements LayeredConnectionSocketFactory {
 
     PKIConnection connection;
 
@@ -34,45 +36,27 @@ public class SSLSocketFactory implements SchemeLayeredSocketFactory {
     }
 
     @Override
-    public Socket createSocket(HttpParams params) throws IOException {
-        return null;
+    public Socket createSocket(HttpContext arg0) throws IOException {
+        return SocketFactory.getDefault().createSocket();
     }
 
     @Override
-    public Socket connectSocket(
-            Socket sock,
-            InetSocketAddress remoteAddress,
-            InetSocketAddress localAddress,
-            HttpParams params)
-            throws IOException,
-            UnknownHostException {
+    public Socket createLayeredSocket(Socket sock, String remoteHost, int port, HttpContext context)
+            throws IOException, UnknownHostException {
 
-        String hostName = null;
-        int port = 0;
-        if (remoteAddress != null) {
-            hostName = remoteAddress.getHostName();
-            port = remoteAddress.getPort();
-        }
 
-        int localPort = 0;
-        InetAddress localAddr = null;
-
-        if (localAddress != null) {
-            localPort = localAddress.getPort();
-            localAddr = localAddress.getAddress();
-        }
 
         SSLSocket socket;
         if (sock == null) {
-            socket = new SSLSocket(InetAddress.getByName(hostName),
+            socket = new SSLSocket(remoteHost,
                     port,
-                    localAddr,
-                    localPort,
+                    null,
+                    0,
                     connection.getCallback(),
                     null);
 
         } else {
-            socket = new SSLSocket(sock, hostName, connection.getCallback(), null);
+            socket = new SSLSocket(sock, remoteHost, connection.getCallback(), null);
         }
 
         String certNickname = connection.getConfig().getCertNickname();
@@ -120,15 +104,39 @@ public class SSLSocketFactory implements SchemeLayeredSocketFactory {
     }
 
     @Override
-    public boolean isSecure(Socket sock) {
-        // We only use this factory in the case of SSL Connections.
-        return true;
-    }
+    public Socket connectSocket(
+            int connTimeout,
+            Socket socket,
+            HttpHost host,
+            InetSocketAddress remoteAddress,
+            InetSocketAddress localAddress,
+            HttpContext context)
+            throws IOException,
+            UnknownHostException {
 
-    @Override
-    public Socket createLayeredSocket(Socket socket, String target, int port, HttpParams params)
-            throws IOException, UnknownHostException {
-        // This method implementation is required to get SSL working.
-        return null;
+        String hostname = null;
+        int port = 0;
+
+        if (host != null) {
+            hostname = host.getHostName();
+            port = host.getPort();
+        } else if(remoteAddress != null) {
+            hostname = remoteAddress.getHostName();
+            port = remoteAddress.getPort();
+        }
+
+        if (socket == null) {
+            socket = new Socket();
+        }
+        if (!socket.isConnected()) {
+            if (localAddress != null) {
+                socket.bind(localAddress);
+            }
+            if (remoteAddress != null) {
+                socket.connect(remoteAddress, connTimeout);
+            }
+        }
+
+        return createLayeredSocket(socket, hostname, port, context);
     }
 }


### PR DESCRIPTION
PKI client connection are based on "DefaultHttpClient" and "SchemeLayeredSocketFactory" but these classes have been deprecated and will be removed so the code is updated to use their replacement.