### PR TITLE
Refactor CAEngine.validate()

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/servlet/ocsp/CAOCSPServlet.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/ocsp/CAOCSPServlet.java
@@ -25,7 +25,6 @@ import javax.servlet.annotation.WebServlet;
 import org.dogtagpki.server.ca.CAEngine;
 
 import com.netscape.ca.CertificateAuthority;
-import com.netscape.certsrv.base.EBaseException;
 import com.netscape.cmsutil.ocsp.OCSPRequest;
 import com.netscape.cmsutil.ocsp.OCSPResponse;
 
@@ -56,7 +55,7 @@ public class CAOCSPServlet extends OCSPServlet {
         ca = (CertificateAuthority) mAuthority;
     }
 
-    public OCSPResponse validate(OCSPRequest ocspRequest) throws EBaseException {
+    public OCSPResponse validate(OCSPRequest ocspRequest) throws Exception {
         CAEngine engine = (CAEngine) getCMSEngine();
         return engine.validate(ca, ocspRequest);
     }

--- a/base/server/src/main/java/com/netscape/cms/servlet/ocsp/OCSPServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/ocsp/OCSPServlet.java
@@ -91,7 +91,7 @@ public class OCSPServlet extends CMSServlet {
 
     }
 
-    public OCSPResponse validate(OCSPRequest ocspRequest) throws EBaseException {
+    public OCSPResponse validate(OCSPRequest ocspRequest) throws Exception {
         return null;
     }
 


### PR DESCRIPTION
The `CAEngine.validate()` has been updated to get the cert record using the cert serial number from the OCSP request, then find the authority records that might have issued the cert using the cert issuer name, then finally validate the request against the CA object that matches the hash value from the request.

The `CAEngine.getCAs()` is no longer used so it has been removed.