### PR TITLE
Add issuer_dn to the CertDataInfo

### DIFF
--- a/base/common/python/pki/cert.py
+++ b/base/common/python/pki/cert.py
@@ -98,6 +98,7 @@ class CertDataInfo(object):
         'id': 'serial_number', 'SubjectDN': 'subject_dn', 'Status': 'status',
         'Type': 'type', 'Version': 'version', 'KeyLength': 'key_length',
         'KeyAlgorithmOID': 'key_algorithm_oid',
+        'IssuerDN': 'issuer_dn',
         'NotValidBefore': 'not_valid_before',
         'NotValidAfter': 'not_valid_after', 'IssuedOn': 'issued_on',
         'IssuedBy': 'issued_by'}
@@ -106,6 +107,7 @@ class CertDataInfo(object):
         """ Constructor """
         self.serial_number = None
         self.subject_dn = None
+        self.issuer_dn = None
         self.status = None
         self.type = None
         self.version = None


### PR DESCRIPTION
This is needed by IPA for its cert-find command for backwards compatibility.

I tried not to re-order this list of attribute conversions as little as possible. If you'd prefer to have it with SubjectDN that's fine.

And/or I can re-issue this PR against master, or submit it separately.