### PR TITLE
Add test for LWCA clone with HSM

### DIFF
--- a/.github/workflows/lwca-basic-test.yml
+++ b/.github/workflows/lwca-basic-test.yml
@@ -1,4 +1,4 @@
-name: Lightweight CA
+name: Basic LWCA
 
 on: workflow_call
 
@@ -48,39 +48,12 @@ jobs:
       - name: Connect PKI container to network
         run: docker network connect example pki --alias pki.example.com
 
-      - name: Install dependencies
-        run: |
-          docker exec pki dnf install -y softhsm
-
-      - name: Create SoftHSM token
-        run: |
-          # allow PKI user to access SoftHSM files
-          docker exec pki usermod pkiuser -a -G ods
-
-          # create SoftHSM token for PKI server
-          docker exec pki runuser -u pkiuser -- \
-              softhsm2-util \
-              --init-token \
-              --label HSM \
-              --so-pin Secret.HSM \
-              --pin Secret.HSM \
-              --free
-
       - name: Install CA
         run: |
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
-              -D pki_hsm_enable=True \
-              -D pki_token_name=HSM \
-              -D pki_token_password=Secret.HSM \
-              -D pki_server_database_password=Secret.123 \
-              -D pki_ca_signing_token=HSM \
-              -D pki_ocsp_signing_token=HSM \
-              -D pki_audit_signing_token=HSM \
-              -D pki_subsystem_token=HSM \
-              -D pki_sslserver_token=internal \
               -v
 
       - name: Check admin user
@@ -118,11 +91,11 @@ jobs:
           echo "HOSTCA_ID: $HOSTCA_ID"
 
           # check authorityKeyNickname
-          echo "HSM:ca_signing" > expected
+          echo "ca_signing" > expected
           sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check certs and keys in internal token
+      - name: Check certs and keys in NSS database
         run: |
           docker exec pki pki \
               -d /var/lib/pki/pki-tomcat/conf/alias \
@@ -139,32 +112,8 @@ jobs:
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
-          # there should be 1 key
-          echo "1" > expected
-          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
-          diff expected actual
-
-      - name: Check certs and keys in HSM
-        run: |
-          docker exec pki pki \
-              -d /var/lib/pki/pki-tomcat/conf/alias \
-              -f /var/lib/pki/pki-tomcat/conf/password.conf \
-              --token HSM \
-              nss-cert-find | tee output
-
-          # there should be 4 certs now
-          echo "4" > expected
-          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
-          diff expected actual
-
-          docker exec pki pki \
-              -d /var/lib/pki/pki-tomcat/conf/alias \
-              -f /var/lib/pki/pki-tomcat/conf/password.conf \
-              --token HSM \
-              nss-key-find | tee output
-
-          # there should be 4 keys now
-          echo "4" > expected
+          # there should be 5 keys
+          echo "5" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -186,30 +135,30 @@ jobs:
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
           diff hostca-id actual
 
-      - name: Create lightweight CA
+      - name: Create lightweight CAs
         run: |
           HOSTCA_ID=$(cat hostca-id)
 
-          # create a LWCA under the host CA
-          docker exec pki pki -n caadmin ca-authority-create \
-              --parent $HOSTCA_ID \
-              CN="Lightweight CA" | tee output
+          # create 20 LWCAs under the host CA
+          for i in {1..20}
+          do
+              docker exec pki pki -n caadmin ca-authority-create \
+                  --parent $HOSTCA_ID \
+                  CN="Lightweight CA $i" | tee output
 
-          # store LWCA ID
-          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > lwca-id
-          LWCA_ID=$(cat lwca-id)
+              # store LWCA ID
+              sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output >> lwca-id
+          done
 
           docker exec pki pki -n caadmin ca-authority-find | tee output
 
-          # there should be 2 authorities now
-          echo -e "$HOSTCA_ID\n$LWCA_ID" | sort > expected
+          # there should be 21 authorities now
+          echo -e "$HOSTCA_ID\n$(cat lwca-id)" | sort > expected
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
-      - name: Check lightweight CA's LDAP entry
+      - name: Check authority LDAP entries
         run: |
-          LWCA_ID=$(cat lwca-id)
-
           docker exec pki ldapsearch \
               -H ldap://ds.example.com:3389 \
               -x \
@@ -225,20 +174,26 @@ jobs:
               nsUniqueId \
               | tee output
 
-          # check authorityKeyNickname
-          echo -e "HSM:ca_signing\nHSM:ca_signing $LWCA_ID" | sort > expected
+          # check authorityKeyNicknames
+          echo "ca_signing" > expected
+          for LWCA_ID in $(cat lwca-id)
+          do
+              echo -e "ca_signing $LWCA_ID" >> expected
+          done
+          sort -o expected expected
+
           sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
-      - name: Check certs and keys in internal token
+      - name: Check certs and keys in NSS database
         run: |
           docker exec pki pki \
               -d /var/lib/pki/pki-tomcat/conf/alias \
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
-          # there should still be 5 certs
-          echo "5" > expected
+          # there should be 25 certs now
+          echo "25" > expected
           sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -247,38 +202,19 @@ jobs:
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
-          # there should still be 1 key
-          echo "1" > expected
-          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
-          diff expected actual
-
-      - name: Check certs and keys in HSM
-        run: |
-          docker exec pki pki \
-              -d /var/lib/pki/pki-tomcat/conf/alias \
-              -f /var/lib/pki/pki-tomcat/conf/password.conf \
-              --token HSM \
-              nss-cert-find | tee output
-
-          # there should be 5 certs now
-          echo "5" > expected
-          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
-          diff expected actual
-
-          docker exec pki pki \
-              -d /var/lib/pki/pki-tomcat/conf/alias \
-              -f /var/lib/pki/pki-tomcat/conf/password.conf \
-              --token HSM \
-              nss-key-find | tee output
-
-          # there should be 5 keys now
-          echo "5" > expected
+          # there should be 25 keys now
+          echo "25" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
       - name: Check enrollment against lightweight CA
         run: |
-          LWCA_ID=$(cat lwca-id)
+          # use the first LWCA
+          LWCA_ID=$(head -1 lwca-id)
+
+          # get LWCA's DN
+          docker exec pki pki -n caadmin ca-authority-show $LWCA_ID | tee output
+          sed -n -e 's/^\s*Authority DN:\s*\(.*\)$/\1/p' output > expected
 
           # submit enrollment request against LWCA
           docker exec pki pki client-cert-request \
@@ -301,20 +237,21 @@ jobs:
           docker exec pki pki ca-cert-show $CERT_ID | tee output
 
           # verify that it's signed by LWCA
-          echo "CN=Lightweight CA" > expected
           sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Remove lightweight CA
+      - name: Remove lightweight CAs
         run: |
           HOSTCA_ID=$(cat hostca-id)
-          LWCA_ID=$(cat lwca-id)
 
-          docker exec pki pki -n caadmin ca-authority-disable $LWCA_ID
+          for LWCA_ID in $(cat lwca-id)
+          do
+              docker exec pki pki -n caadmin ca-authority-disable $LWCA_ID
 
-          docker exec pki pki -n caadmin ca-authority-del \
-              --force \
-              $LWCA_ID | tee output
+              docker exec pki pki -n caadmin ca-authority-del \
+                  --force \
+                  $LWCA_ID
+          done
 
           docker exec pki pki -n caadmin ca-authority-find | tee output
 
@@ -323,7 +260,7 @@ jobs:
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check lightweight CA's LDAP entry
+      - name: Check authority LDAP entries
         run: |
           HOSTCA_ID=$(cat hostca-id)
 
@@ -343,18 +280,17 @@ jobs:
               | tee output
 
           # there should be 1 entry now
-          echo "$HOSTCA_ID" > expected
           sed -n 's/^\s*cn:\s*\(.*\)$/\1/p' output > actual
-          diff expected actual
+          diff hostca-id actual
 
-      - name: Check certs and keys in internal token
+      - name: Check certs and keys in NSS database
         run: |
           docker exec pki pki \
               -d /var/lib/pki/pki-tomcat/conf/alias \
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
-          # there should be 5 certs
+          # there should be 5 certs now
           echo "5" > expected
           sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
@@ -364,32 +300,8 @@ jobs:
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
-          # there should be 1 key
-          echo "1" > expected
-          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
-          diff expected actual
-
-      - name: Check certs and keys in HSM
-        run: |
-          docker exec pki pki \
-              -d /var/lib/pki/pki-tomcat/conf/alias \
-              -f /var/lib/pki/pki-tomcat/conf/password.conf \
-              --token HSM \
-              nss-cert-find | tee output
-
-          # there should be 4 certs now
-          echo "4" > expected
-          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
-          diff expected actual
-
-          docker exec pki pki \
-              -d /var/lib/pki/pki-tomcat/conf/alias \
-              -f /var/lib/pki/pki-tomcat/conf/password.conf \
-              --token HSM \
-              nss-key-find | tee output
-
-          # there should be 4 keys now
-          echo "4" > expected
+          # there should be 5 keys now
+          echo "5" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -408,14 +320,9 @@ jobs:
       - name: Remove CA
         run: docker exec pki pkidestroy -s CA -v
 
-      - name: Remove SoftHSM token
-        run: |
-          docker exec pki ls -laR /var/lib/softhsm/tokens
-          docker exec pki runuser -u pkiuser -- softhsm2-util --delete-token --token HSM
-
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ca-lightweight-hsm
+          name: ca-lightweight
           path: /tmp/artifacts

--- a/.github/workflows/lwca-clone-hsm-test.yml
+++ b/.github/workflows/lwca-clone-hsm-test.yml
@@ -1,0 +1,571 @@
+name: LWCA clone with HSM
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    # SSH with public key auth doesn't work with the latest Ubuntu
+    runs-on: ubuntu-22.04
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up HSM container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=hsm.example.com \
+              --network=example \
+              --network-alias=hsm.example.com \
+              hsm
+
+      - name: Set up SoftHSM in HSM container
+        run: |
+          docker exec hsm dnf install -y softhsm
+
+          docker exec hsm softhsm2-util \
+              --init-token \
+              --label HSM \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
+              --free
+
+          docker exec hsm softhsm2-util --show-slots
+
+      - name: Set up SSH server in HSM container
+        run: |
+          docker exec hsm dnf install -y openssh-server openssh-clients
+
+          # remove default SSH server config to allow public key auth
+          docker exec hsm ls -l /etc/ssh/sshd_config.d
+          docker exec hsm rm -f /etc/ssh/sshd_config.d/40-redhat-crypto-policies.conf
+          docker exec hsm rm -f /etc/ssh/sshd_config.d/50-redhat.conf
+
+          # configure SSH server to allow root access with public key auth
+          docker exec hsm cat /etc/ssh/sshd_config
+          docker exec -i hsm tee /etc/ssh/sshd_config.d/root-login.conf << EOF
+          PermitRootLogin yes
+          PubkeyAuthentication yes
+          AuthenticationMethods publickey
+          EOF
+
+          # start SSH server
+          docker exec hsm systemctl start sshd
+
+          # generate SSH client key
+          docker exec hsm ssh-keygen -f /root/.ssh/id_ed25519 -N ""
+          docker exec hsm cp /root/.ssh/id_ed25519.pub /root/.ssh/authorized_keys
+          docker exec hsm chmod 600 /root/.ssh/authorized_keys
+
+          # retrieve SSH client key
+          docker cp hsm:/root/.ssh/id_ed25519 .
+          docker cp hsm:/root/.ssh/id_ed25519.pub .
+
+          # retrieve SSH server key
+          docker exec hsm ssh-keyscan -H hsm.example.com \
+              | tee known_hosts
+
+      - name: Set up primary DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=primaryds.example.com \
+              --network=example \
+              --network-alias=primaryds.example.com \
+              --password=Secret.123 \
+              primaryds
+
+      - name: Set up primary PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=primary.example.com \
+              --network=example \
+              --network-alias=primary.example.com \
+              primary
+
+      - name: Set up SSH client in primary PKI container
+        run: |
+          docker exec primary dnf install -y openssh-clients
+
+          # set up SSH client for root
+          docker exec primary mkdir -p /root/.ssh
+          docker exec primary chmod 700 /root/.ssh
+
+          docker cp id_ed25519 primary:/root/.ssh
+          docker exec primary chmod 600 /root/.ssh/id_ed25519
+
+          docker cp id_ed25519.pub primary:/root/.ssh
+
+          docker cp known_hosts primary:/root/.ssh
+
+          # check SSH client for root
+          docker exec primary \
+              ssh \
+              root@hsm.example.com \
+              hostname
+
+          # set up SSH client for pkiuser
+          docker exec primary mkdir -p /home/pkiuser/.ssh
+          docker exec primary chmod 700 /home/pkiuser/.ssh
+          docker exec primary chown pkiuser:pkiuser /home/pkiuser/.ssh
+
+          docker cp id_ed25519 primary:/home/pkiuser/.ssh
+          docker exec primary chmod 600 /home/pkiuser/.ssh/id_ed25519
+          docker exec primary chown pkiuser:pkiuser /home/pkiuser/.ssh/id_ed25519
+
+          docker cp id_ed25519.pub primary:/home/pkiuser/.ssh
+          docker exec primary chown pkiuser:pkiuser /home/pkiuser/.ssh/id_ed25519.pub
+
+          docker cp known_hosts primary:/home/pkiuser/.ssh
+
+          # enable login shell for pkiuser (needed by pkispawn)
+          docker exec primary usermod -s /bin/bash pkiuser
+
+          # check SSH client for pkiuser
+          docker exec primary sudo -i -u pkiuser \
+              ssh \
+              root@hsm.example.com \
+              hostname
+
+      - name: Set up HSM client with p11-kit in primary PKI container
+        run: |
+          docker exec primary dnf install -y p11-kit-server
+
+          # register p11-kit-client module
+          docker exec -i primary tee /usr/share/p11-kit/modules/p11-kit-client.module << EOF
+          module: /usr/lib64/pkcs11/p11-kit-client.so
+          remote: |ssh root@hsm.example.com p11-kit remote /usr/lib64/pkcs11/libsofthsm2.so
+          EOF
+
+          # check registered PKCS #11 modules
+          docker exec primary sudo -i -u pkiuser p11-kit list-modules
+
+      - name: Install CA in primary PKI container
+        run: |
+          docker exec primary pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://primaryds.example.com:3389 \
+              -D pki_hsm_enable=True \
+              -D pki_hsm_modulename=p11-kit-client \
+              -D pki_hsm_libfile=/usr/lib64/pkcs11/p11-kit-client.so \
+              -D pki_token_name=HSM \
+              -D pki_token_password=Secret.HSM \
+              -D pki_ca_signing_token=HSM \
+              -D pki_ocsp_signing_token=HSM \
+              -D pki_audit_signing_token=HSM \
+              -D pki_subsystem_token=HSM \
+              -D pki_sslserver_token=internal \
+              -v
+
+      - name: Install CA admin cert in primary PKI container
+        run: |
+          docker exec primary pki-server cert-export \
+              --cert-file $SHARED/ca_signing.crt \
+              ca_signing
+
+          docker exec primary pki nss-cert-import \
+              --cert $SHARED/ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec primary pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --password Secret.123
+
+      - name: Check authorities in primary CA
+        run: |
+          docker exec primary pki \
+              -n caadmin \
+              ca-authority-find \
+              | tee output
+
+          # there should be 1 authority initially
+          echo "1" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+
+          diff expected actual
+
+          # it should be a host CA
+          echo "true" > expected
+          sed -n 's/^\s*Host authority:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          # store host CA ID
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > hostca-id
+
+      - name: Set up secondary DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=secondaryds.example.com \
+              --network=example \
+              --network-alias=secondaryds.example.com \
+              --password=Secret.123 \
+              secondaryds
+
+      - name: Set up secondary PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=secondary.example.com \
+              --network=example \
+              --network-alias=secondary.example.com \
+              secondary
+
+      - name: Set up SSH client in secondary PKI container
+        run: |
+          docker exec secondary dnf install -y openssh-clients
+
+          # set up SSH client for root
+          docker exec secondary mkdir -p /root/.ssh
+          docker exec secondary chmod 700 /root/.ssh
+
+          docker cp id_ed25519 secondary:/root/.ssh
+          docker exec secondary chmod 600 /root/.ssh/id_ed25519
+
+          docker cp id_ed25519.pub secondary:/root/.ssh
+
+          docker cp known_hosts secondary:/root/.ssh
+
+          # check SSH client for root
+          docker exec secondary \
+              ssh \
+              root@hsm.example.com \
+              hostname
+
+          # set up SSH client for pkiuser
+          docker exec secondary mkdir -p /home/pkiuser/.ssh
+          docker exec secondary chmod 700 /home/pkiuser/.ssh
+          docker exec secondary chown pkiuser:pkiuser /home/pkiuser/.ssh
+
+          docker cp id_ed25519 secondary:/home/pkiuser/.ssh
+          docker exec secondary chmod 600 /home/pkiuser/.ssh/id_ed25519
+          docker exec secondary chown pkiuser:pkiuser /home/pkiuser/.ssh/id_ed25519
+
+          docker cp id_ed25519.pub secondary:/home/pkiuser/.ssh
+          docker exec secondary chown pkiuser:pkiuser /home/pkiuser/.ssh/id_ed25519.pub
+
+          docker cp known_hosts secondary:/home/pkiuser/.ssh
+
+          # enable login shell for pkiuser (needed by pkispawn)
+          docker exec secondary usermod -s /bin/bash pkiuser
+
+          # check SSH client for pkiuser
+          docker exec secondary sudo -i -u pkiuser \
+              ssh \
+              root@hsm.example.com \
+              hostname
+
+      - name: Set up HSM client with p11-kit in secondary PKI container
+        run: |
+          docker exec secondary dnf install -y p11-kit-server
+
+          # register p11-kit-client module
+          docker exec -i secondary tee /usr/share/p11-kit/modules/p11-kit-client.module << EOF
+          module: /usr/lib64/pkcs11/p11-kit-client.so
+          remote: |ssh root@hsm.example.com p11-kit remote /usr/lib64/pkcs11/libsofthsm2.so
+          EOF
+
+          # check registered PKCS #11 modules
+          docker exec secondary sudo -i -u pkiuser p11-kit list-modules
+
+      - name: Install CA in secondary PKI container
+        run: |
+          # export CA signing cert
+          docker exec primary pki-server cert-export \
+              --cert-file ${SHARED}/ca_signing.crt \
+              ca_signing
+
+          docker exec secondary pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
+              -s CA \
+              -D pki_cert_chain_path=$SHARED/ca_signing.crt \
+              -D pki_ds_url=ldap://secondaryds.example.com:3389 \
+              -D pki_hsm_enable=True \
+              -D pki_hsm_modulename=p11-kit-client \
+              -D pki_hsm_libfile=/usr/lib64/pkcs11/p11-kit-client.so \
+              -D pki_token_name=HSM \
+              -D pki_token_password=Secret.HSM \
+              -D pki_ca_signing_token=HSM \
+              -D pki_ocsp_signing_token=HSM \
+              -D pki_audit_signing_token=HSM \
+              -D pki_subsystem_token=HSM \
+              -D pki_sslserver_token=internal \
+              -v
+
+      - name: Install CA admin cert in secondary PKI container
+        run: |
+          docker exec secondary pki nss-cert-import \
+              --cert $SHARED/ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec primary cp \
+              /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              $SHARED/ca_admin_cert.p12
+
+          docker exec secondary pki pkcs12-import \
+              --pkcs12 $SHARED/ca_admin_cert.p12 \
+              --password Secret.123
+
+      - name: Check authorities in secondary CA
+        run: |
+          docker exec secondary pki \
+              -n caadmin \
+              ca-authority-find \
+              | tee output
+
+          # there should be 1 authority initially
+          echo "1" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+
+          diff expected actual
+
+          # it should be a host CA
+          echo "true" > expected
+          sed -n 's/^\s*Host authority:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+          # check host CA ID
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
+          diff hostca-id actual
+
+      - name: Create LWCA in primary CA
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+
+          docker exec primary pki \
+              -n caadmin \
+              ca-authority-create \
+              --parent $HOSTCA_ID \
+              CN=LWCA \
+              | tee output
+
+          # store LWCA ID
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > lwca-id
+          LWCA_ID=$(cat lwca-id)
+
+      - name: Check authorities in primary CA
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+          LWCA_ID=$(cat lwca-id)
+
+          docker exec primary pki \
+              -n caadmin \
+              ca-authority-find \
+              | tee output
+
+          # there should be 2 authorities
+          echo -e "$HOSTCA_ID\n$LWCA_ID" | sort > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | sort > actual
+          diff expected actual
+
+      - name: Check authorities in secondary CA
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+          LWCA_ID=$(cat lwca-id)
+
+          docker exec secondary pki \
+              -n caadmin \
+              ca-authority-find \
+              | tee output
+
+          # there should be 2 authorities
+          echo -e "$HOSTCA_ID\n$LWCA_ID" | sort > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | sort > actual
+          diff expected actual
+
+      - name: Enroll with LWCA in primary CA
+        run: |
+          LWCA_ID=$(cat lwca-id)
+
+          # get LWCA's DN
+          docker exec primary pki \
+              -n caadmin \
+              ca-authority-show \
+              $LWCA_ID \
+              | tee output
+          LWCA_DN=$(sed -n -e 's/^\s*Authority DN:\s*\(.*\)$/\1/p' output)
+
+          # submit enrollment request against LWCA
+          docker exec primary pki \
+              client-cert-request \
+              --issuer-id $LWCA_ID \
+              UID=testuser | tee output
+          REQUEST_ID=$(sed -n -e 's/^\s*Request ID:\s*\(.*\)$/\1/p' output)
+
+          # approve request
+          docker exec primary pki \
+              -n caadmin \
+              ca-cert-request-approve \
+              $REQUEST_ID \
+              --force \
+              | tee output
+          CERT_ID=$(sed -n -e 's/^\s*Certificate ID:\s*\(.*\)$/\1/p' output)
+
+          docker exec primary pki ca-cert-show $CERT_ID | tee output
+
+          # check issuer DN
+          echo "$LWCA_DN" > expected
+          sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Enroll with LWCA in secondary CA
+        run: |
+          LWCA_ID=$(cat lwca-id)
+
+          # get LWCA's DN
+          docker exec secondary pki \
+              -n caadmin \
+              ca-authority-show \
+              $LWCA_ID \
+              | tee output
+          LWCA_DN=$(sed -n -e 's/^\s*Authority DN:\s*\(.*\)$/\1/p' output)
+
+          # submit enrollment request against LWCA
+          docker exec secondary pki \
+              client-cert-request \
+              --issuer-id $LWCA_ID \
+              UID=testuser | tee output
+          REQUEST_ID=$(sed -n -e 's/^\s*Request ID:\s*\(.*\)$/\1/p' output)
+
+          # approve request
+          docker exec secondary pki \
+              -n caadmin \
+              ca-cert-request-approve \
+              $REQUEST_ID \
+              --force \
+              | tee output
+          CERT_ID=$(sed -n -e 's/^\s*Certificate ID:\s*\(.*\)$/\1/p' output)
+
+          docker exec secondary pki ca-cert-show $CERT_ID | tee output
+
+          # check issuer DN
+          echo "$LWCA_DN" > expected
+          sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Remove LWCA from secondary CA
+        run: |
+          LWCA_ID=$(cat lwca-id)
+
+          # disable LWCA
+          docker exec secondary pki \
+              -n caadmin \
+              ca-authority-disable \
+              $LWCA_ID
+
+          # remove LWCA
+          docker exec secondary pki \
+              -n caadmin \
+              ca-authority-del \
+              --force \
+              $LWCA_ID
+
+      - name: Check authorities in secondary CA
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+
+          docker exec secondary pki \
+              -n caadmin \
+              ca-authority-find \
+              | tee output
+
+          # there should be 1 authority
+          echo "$HOSTCA_ID" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Check authorities in primary CA
+        run: |
+          HOSTCA_ID=$(cat hostca-id)
+
+          docker exec primary pki \
+              -n caadmin \
+              ca-authority-find \
+              | tee output
+
+          # there should be 1 authority
+          echo "$HOSTCA_ID" > expected
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
+          diff expected actual
+
+      - name: Remove secondary CA
+        run: |
+          docker exec secondary pkidestroy -s CA -v
+
+      - name: Remove primary CA
+        run: |
+          docker exec primary pkidestroy -s CA -v
+
+      - name: Check SSH systemd journal in HSM container
+        if: always()
+        run: |
+          docker exec hsm journalctl -x --no-pager -u sshd.service
+
+      - name: Check primary DS server systemd journal
+        if: always()
+        run: |
+          docker exec primaryds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check primary DS container logs
+        if: always()
+        run: |
+          docker logs primaryds
+
+      - name: Check primary PKI server systemd journal
+        if: always()
+        run: |
+          docker exec primary journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check primary PKI server access log
+        if: always()
+        run: |
+          docker exec primary find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check primary CA debug log
+        if: always()
+        run: |
+          docker exec primary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check secondary DS server systemd journal
+        if: always()
+        run: |
+          docker exec secondaryds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check secondary DS container logs
+        if: always()
+        run: |
+          docker logs secondaryds
+
+      - name: Check secondary PKI server systemd journal
+        if: always()
+        run: |
+          docker exec secondary journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check secondary PKI server access log
+        if: always()
+        run: |
+          docker exec secondary find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check secondary CA debug log
+        if: always()
+        run: |
+          docker exec secondary find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;

--- a/.github/workflows/lwca-hsm-test.yml
+++ b/.github/workflows/lwca-hsm-test.yml
@@ -1,4 +1,4 @@
-name: Lightweight CA
+name: LWCA with HSM
 
 on: workflow_call
 
@@ -48,12 +48,39 @@ jobs:
       - name: Connect PKI container to network
         run: docker network connect example pki --alias pki.example.com
 
+      - name: Install dependencies
+        run: |
+          docker exec pki dnf install -y softhsm
+
+      - name: Create SoftHSM token
+        run: |
+          # allow PKI user to access SoftHSM files
+          docker exec pki usermod pkiuser -a -G ods
+
+          # create SoftHSM token for PKI server
+          docker exec pki runuser -u pkiuser -- \
+              softhsm2-util \
+              --init-token \
+              --label HSM \
+              --so-pin Secret.HSM \
+              --pin Secret.HSM \
+              --free
+
       - name: Install CA
         run: |
           docker exec pki pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
               -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_hsm_enable=True \
+              -D pki_token_name=HSM \
+              -D pki_token_password=Secret.HSM \
+              -D pki_server_database_password=Secret.123 \
+              -D pki_ca_signing_token=HSM \
+              -D pki_ocsp_signing_token=HSM \
+              -D pki_audit_signing_token=HSM \
+              -D pki_subsystem_token=HSM \
+              -D pki_sslserver_token=internal \
               -v
 
       - name: Check admin user
@@ -91,11 +118,11 @@ jobs:
           echo "HOSTCA_ID: $HOSTCA_ID"
 
           # check authorityKeyNickname
-          echo "ca_signing" > expected
+          echo "HSM:ca_signing" > expected
           sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check certs and keys in NSS database
+      - name: Check certs and keys in internal token
         run: |
           docker exec pki pki \
               -d /var/lib/pki/pki-tomcat/conf/alias \
@@ -112,8 +139,32 @@ jobs:
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
-          # there should be 5 keys
-          echo "5" > expected
+          # there should be 1 key
+          echo "1" > expected
+          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Check certs and keys in HSM
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              --token HSM \
+              nss-cert-find | tee output
+
+          # there should be 4 certs now
+          echo "4" > expected
+          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              --token HSM \
+              nss-key-find | tee output
+
+          # there should be 4 keys now
+          echo "4" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -135,30 +186,30 @@ jobs:
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
           diff hostca-id actual
 
-      - name: Create lightweight CAs
+      - name: Create lightweight CA
         run: |
           HOSTCA_ID=$(cat hostca-id)
 
-          # create 20 LWCAs under the host CA
-          for i in {1..20}
-          do
-              docker exec pki pki -n caadmin ca-authority-create \
-                  --parent $HOSTCA_ID \
-                  CN="Lightweight CA $i" | tee output
+          # create a LWCA under the host CA
+          docker exec pki pki -n caadmin ca-authority-create \
+              --parent $HOSTCA_ID \
+              CN="Lightweight CA" | tee output
 
-              # store LWCA ID
-              sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output >> lwca-id
-          done
+          # store LWCA ID
+          sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > lwca-id
+          LWCA_ID=$(cat lwca-id)
 
           docker exec pki pki -n caadmin ca-authority-find | tee output
 
-          # there should be 21 authorities now
-          echo -e "$HOSTCA_ID\n$(cat lwca-id)" | sort > expected
+          # there should be 2 authorities now
+          echo -e "$HOSTCA_ID\n$LWCA_ID" | sort > expected
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
-      - name: Check authority LDAP entries
+      - name: Check lightweight CA's LDAP entry
         run: |
+          LWCA_ID=$(cat lwca-id)
+
           docker exec pki ldapsearch \
               -H ldap://ds.example.com:3389 \
               -x \
@@ -174,26 +225,20 @@ jobs:
               nsUniqueId \
               | tee output
 
-          # check authorityKeyNicknames
-          echo "ca_signing" > expected
-          for LWCA_ID in $(cat lwca-id)
-          do
-              echo -e "ca_signing $LWCA_ID" >> expected
-          done
-          sort -o expected expected
-
+          # check authorityKeyNickname
+          echo -e "HSM:ca_signing\nHSM:ca_signing $LWCA_ID" | sort > expected
           sed -n 's/^authorityKeyNickname:\s*\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
-      - name: Check certs and keys in NSS database
+      - name: Check certs and keys in internal token
         run: |
           docker exec pki pki \
               -d /var/lib/pki/pki-tomcat/conf/alias \
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
-          # there should be 25 certs now
-          echo "25" > expected
+          # there should still be 5 certs
+          echo "5" > expected
           sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -202,19 +247,38 @@ jobs:
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
-          # there should be 25 keys now
-          echo "25" > expected
+          # there should still be 1 key
+          echo "1" > expected
+          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Check certs and keys in HSM
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              --token HSM \
+              nss-cert-find | tee output
+
+          # there should be 5 certs now
+          echo "5" > expected
+          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              --token HSM \
+              nss-key-find | tee output
+
+          # there should be 5 keys now
+          echo "5" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
       - name: Check enrollment against lightweight CA
         run: |
-          # use the first LWCA
-          LWCA_ID=$(head -1 lwca-id)
-
-          # get LWCA's DN
-          docker exec pki pki -n caadmin ca-authority-show $LWCA_ID | tee output
-          sed -n -e 's/^\s*Authority DN:\s*\(.*\)$/\1/p' output > expected
+          LWCA_ID=$(cat lwca-id)
 
           # submit enrollment request against LWCA
           docker exec pki pki client-cert-request \
@@ -237,21 +301,20 @@ jobs:
           docker exec pki pki ca-cert-show $CERT_ID | tee output
 
           # verify that it's signed by LWCA
+          echo "CN=Lightweight CA" > expected
           sed -n -e 's/^\s*Issuer DN:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Remove lightweight CAs
+      - name: Remove lightweight CA
         run: |
           HOSTCA_ID=$(cat hostca-id)
+          LWCA_ID=$(cat lwca-id)
 
-          for LWCA_ID in $(cat lwca-id)
-          do
-              docker exec pki pki -n caadmin ca-authority-disable $LWCA_ID
+          docker exec pki pki -n caadmin ca-authority-disable $LWCA_ID
 
-              docker exec pki pki -n caadmin ca-authority-del \
-                  --force \
-                  $LWCA_ID
-          done
+          docker exec pki pki -n caadmin ca-authority-del \
+              --force \
+              $LWCA_ID | tee output
 
           docker exec pki pki -n caadmin ca-authority-find | tee output
 
@@ -260,7 +323,7 @@ jobs:
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output > actual
           diff expected actual
 
-      - name: Check authority LDAP entries
+      - name: Check lightweight CA's LDAP entry
         run: |
           HOSTCA_ID=$(cat hostca-id)
 
@@ -280,17 +343,18 @@ jobs:
               | tee output
 
           # there should be 1 entry now
+          echo "$HOSTCA_ID" > expected
           sed -n 's/^\s*cn:\s*\(.*\)$/\1/p' output > actual
-          diff hostca-id actual
+          diff expected actual
 
-      - name: Check certs and keys in NSS database
+      - name: Check certs and keys in internal token
         run: |
           docker exec pki pki \
               -d /var/lib/pki/pki-tomcat/conf/alias \
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-cert-find | tee output
 
-          # there should be 5 certs now
+          # there should be 5 certs
           echo "5" > expected
           sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
@@ -300,8 +364,32 @@ jobs:
               -f /var/lib/pki/pki-tomcat/conf/password.conf \
               nss-key-find | tee output
 
-          # there should be 5 keys now
-          echo "5" > expected
+          # there should be 1 key
+          echo "1" > expected
+          sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+      - name: Check certs and keys in HSM
+        run: |
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              --token HSM \
+              nss-cert-find | tee output
+
+          # there should be 4 certs now
+          echo "4" > expected
+          sed -n 's/^\s*Nickname:\s*\(.*\)$/\1/p' output | wc -l > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              --token HSM \
+              nss-key-find | tee output
+
+          # there should be 4 keys now
+          echo "4" > expected
           sed -n 's/^\s*Key ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
@@ -320,9 +408,14 @@ jobs:
       - name: Remove CA
         run: docker exec pki pkidestroy -s CA -v
 
+      - name: Remove SoftHSM token
+        run: |
+          docker exec pki ls -laR /var/lib/softhsm/tokens
+          docker exec pki runuser -u pkiuser -- softhsm2-util --delete-token --token HSM
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ca-lightweight
+          name: ca-lightweight-hsm
           path: /tmp/artifacts

--- a/.github/workflows/subca-tests.yml
+++ b/.github/workflows/subca-tests.yml
@@ -38,12 +38,17 @@ jobs:
     needs: build
     uses: ./.github/workflows/subca-clone-hsm-test.yml
 
-  subca-lightweight-test:
-    name: Lightweight SubCA
+  lwca-test:
+    name: Basic LWCA
     needs: build
-    uses: ./.github/workflows/subca-lightweight-test.yml
+    uses: ./.github/workflows/lwca-basic-test.yml
 
-  subca-lightweight-hsm-test:
-    name: Lightweight SubCA with HSM
+  lwca-hsm-test:
+    name: LWCA with HSM
     needs: build
-    uses: ./.github/workflows/subca-lightweight-hsm-test.yml
+    uses: ./.github/workflows/lwca-hsm-test.yml
+
+  lwca-clone-hsm-test:
+    name: LWCA clone with HSM
+    needs: build
+    uses: ./.github/workflows/lwca-clone-hsm-test.yml


### PR DESCRIPTION
A new test has been added to create two CA replicas with a shared HSM, create an LWCA in one, enroll certs in both, then remove the LWCA from the other one. Since the HSM is shared the LWCA can be used immediately on any replica without having to transfer the signing key.