### PR TITLE
Fix empty parameter in CLI

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -310,6 +310,7 @@ class NSSDatabase(object):
             text=None,
             runas=False):
 
+        cmd = list(filter(None, cmd))
         logger.debug('Command: %s', ' '.join(cmd))
 
         if runas and self.user is not None:


### PR DESCRIPTION
Fix for empty parameter in CLI described in
https://github.com/dogtagpki/pki/issues/4992