### PR TITLE
Using httpclient for GET client connection

### DIFF
--- a/.github/workflows/ca-admin-user-test.yml
+++ b/.github/workflows/ca-admin-user-test.yml
@@ -88,7 +88,7 @@ jobs:
           docker exec pki pki -u caadmin -w wrong ca-user-find \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
-          echo "PKIException: Unauthorized" > expected
+          echo "UnauthorizedException: " > expected
           diff expected stderr
 
       - name: Change CA admin password
@@ -99,7 +99,7 @@ jobs:
           docker exec pki pki -u caadmin -w Secret.123 ca-user-find \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
-          echo "PKIException: Unauthorized" > expected
+          echo "UnauthorizedException: " > expected
           diff expected stderr
 
           # new password should work
@@ -121,14 +121,14 @@ jobs:
           docker exec pki pki -u caadmin -w secret ca-user-find \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
-          echo "PKIException: Unauthorized" > expected
+          echo "UnauthorizedException: " > expected
           diff expected stderr
 
           # blank password should not work
           docker exec pki pki -u caadmin -w "" ca-user-find \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
-          echo "PKIException: Unauthorized" > expected
+          echo "UnauthorizedException: " > expected
           diff expected stderr
 
       - name: Check certs assigned to CA admin user
@@ -165,7 +165,7 @@ jobs:
           docker exec pki pki -n caadmin ca-user-find \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
-          echo "PKIException: Unauthorized" > expected
+          echo "UnauthorizedException: " > expected
           diff expected stderr
 
       - name: Reassign certs to CA admin user

--- a/.github/workflows/ca-ds-connection-test.yml
+++ b/.github/workflows/ca-ds-connection-test.yml
@@ -117,7 +117,7 @@ jobs:
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
           cat > expected << EOF
-          PKIException: Unauthorized
+          UnauthorizedException: 
           EOF
 
           diff expected stderr
@@ -154,7 +154,7 @@ jobs:
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
           cat > expected << EOF
-          PKIException: Unauthorized
+          UnauthorizedException: 
           EOF
 
           diff expected stderr

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -75,7 +75,7 @@ jobs:
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
           # REST API should not return security domain info
-          echo "PKIException: Not Found" > expected
+          echo "ResourceNotFoundException: " > expected
           diff expected stderr
 
       - name: Check CA admin

--- a/.github/workflows/ocsp-standalone-test.yml
+++ b/.github/workflows/ocsp-standalone-test.yml
@@ -76,7 +76,7 @@ jobs:
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
           # REST API should not return security domain info
-          echo "PKIException: Not Found" > expected
+          echo "ResourceNotFoundException: " > expected
           diff expected stderr
 
       - name: Check CA admin

--- a/base/common/src/main/java/com/netscape/certsrv/base/ClientConnectionException.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/ClientConnectionException.java
@@ -1,0 +1,29 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2025 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+package com.netscape.certsrv.base;
+
+public class ClientConnectionException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ClientConnectionException(Throwable cause) {
+        super(cause);
+    }
+
+
+}

--- a/base/common/src/main/java/com/netscape/certsrv/base/MediaType.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/MediaType.java
@@ -16,6 +16,8 @@ public class MediaType {
 
     public static final String APPLICATION_JSON = "application/json";
 
+    public static final String APPLICATION_XML = "application/xml";
+
     public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
 
     public static final String APPLICATION_PKIX_CERT = "application/pkix-cert";

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIClient.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Map;
 
-import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
@@ -45,6 +44,7 @@ import org.dogtagpki.common.Info;
 import org.dogtagpki.common.InfoClient;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 
+import com.netscape.certsrv.base.ClientConnectionException;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.base.ResourceNotFoundException;
 import com.netscape.certsrv.base.UnauthorizedException;
@@ -349,7 +349,7 @@ public class PKIClient implements AutoCloseable {
         try {
             httpResp = connection.getHttpClient().execute(httpGET);
         } catch (Exception ex) {
-            throw new ProcessingException(ex);
+            throw new ClientConnectionException(ex);
         }
         return getEntity(httpResp, responseType);
     }

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
@@ -58,6 +58,9 @@ import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 
 import com.netscape.certsrv.base.PKIException;
 
+/**
+ *
+ */
 public class PKIConnection implements AutoCloseable {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIConnection.class);
@@ -203,6 +206,10 @@ public class PKIConnection implements AutoCloseable {
 
     public void setCallback(SSLCertificateApprovalCallback callback) {
         this.callback = callback;
+    }
+
+    public CloseableHttpClient getHttpClient() {
+        return httpClient;
     }
 
     public void storeRequest(PrintStream out, HttpRequest request) throws IOException {

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
@@ -50,7 +50,6 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.LaxRedirectStrategy;
-import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.protocol.HttpContext;
 import org.dogtagpki.client.JSSSocketFactory;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
@@ -207,9 +206,7 @@ public class PKIConnection implements AutoCloseable {
     }
 
     public void storeRequest(PrintStream out, HttpRequest request) throws IOException {
-
         if (request instanceof HttpEntityEnclosingRequest enclose) {
-
             HttpEntity entity = enclose.getEntity();
             if (entity == null) return;
 
@@ -224,21 +221,15 @@ public class PKIConnection implements AutoCloseable {
     }
 
     public void storeResponse(PrintStream out, HttpResponse response) throws IOException {
+        HttpEntity entity = response.getEntity();
+        if (entity == null) return;
 
-        if (response instanceof BasicHttpResponse) {
-            BasicHttpResponse basicResponse = (BasicHttpResponse) response;
-
-            HttpEntity entity = basicResponse.getEntity();
-            if (entity == null) return;
-
-            if (!entity.isRepeatable()) {
-                BufferedHttpEntity bufferedEntity = new BufferedHttpEntity(entity);
-                basicResponse.setEntity(bufferedEntity);
-                entity = bufferedEntity;
-            }
-
-            storeEntity(out, entity);
+        if (!entity.isRepeatable()) {
+            BufferedHttpEntity bufferedEntity = new BufferedHttpEntity(entity);
+            response.setEntity(bufferedEntity);
+            entity = bufferedEntity;
         }
+        storeEntity(out, entity);
     }
 
     public void storeEntity(OutputStream out, HttpEntity entity) throws IOException {

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -58,6 +58,7 @@ import org.mozilla.jss.ssl.SSLSocket;
 import org.mozilla.jss.util.IncorrectPasswordException;
 import org.mozilla.jss.util.Password;
 
+import com.netscape.certsrv.base.ClientConnectionException;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.ca.CAClient;
 import com.netscape.certsrv.client.ClientConfig;
@@ -703,7 +704,7 @@ public class MainCLI extends CLI {
             // display only the error message
             System.err.println(t.getMessage());
 
-        } else if (t instanceof ProcessingException) {
+        } else if (t instanceof ProcessingException || t instanceof ClientConnectionException) {
             // display the cause of the exception (if available)
             Throwable e = t.getCause();
             if (e == null) e = t;

--- a/tests/ansible/ocsp/tasks/certificate_self_validation_with_crl.yml
+++ b/tests/ansible/ocsp/tasks/certificate_self_validation_with_crl.yml
@@ -485,7 +485,7 @@
     container: "{{ ocsp_container }}"
     command: pki -n ocspadmin ocsp-user-show ocspadmin
   register: ocsp_command
-  failed_when: "'PKIException: Unauthorized' not in ocsp_command.stderr"
+  failed_when: "'UnauthorizedException: ' not in ocsp_command.stderr"
 
 - name: Release the OCSP admin certificate
   community.docker.docker_container_exec:
@@ -528,7 +528,7 @@
     container: "{{ ocsp_container }}"
     command: pki -n ocspadmin ocsp-user-show ocspadmin
   register: ocsp_command
-  failed_when: "'PKIException: Not Found' not in ocsp_command.stderr"
+  failed_when: "'ResourceNotFoundException: ' not in ocsp_command.stderr"
 
 - name: Release the OCSP DS certificate
   community.docker.docker_container_exec:


### PR DESCRIPTION
Get operation rest client has been replaced with httpclient GET operation. It is still used some resteasy class in the process for the path identification but it will be removed when all methods are converted.

There is still a GET operation which need to be converted. It is different because of entity parsing uses RESTeasy client. Will be modified in following PRs.