### PR TITLE
Implement client GET collections with httpclient

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
@@ -17,13 +17,12 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.authority;
 
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -44,18 +43,17 @@ public class AuthorityClient extends Client {
         super(client, subsystem, "authorities");
     }
 
-    public List<AuthorityData> listCAs() throws Exception {
+    public Collection<AuthorityData> listCAs() throws Exception {
         return findCAs(null, null, null, null);
     }
 
-    public List<AuthorityData> findCAs(String id, String parentID, String dn, String issuerDN) throws Exception {
+    public Collection<AuthorityData> findCAs(String id, String parentID, String dn, String issuerDN) throws Exception {
         Map<String, Object> params = new HashMap<>();
         if (id != null) params.put("id", id);
         if (parentID != null) params.put("parentID", parentID);
         if (dn != null) params.put("dn", dn);
         if (issuerDN != null) params.put("issuerDN", issuerDN);
-        GenericType<List<AuthorityData>> type = new GenericType<>() {};
-        return get(null, params, type);
+        return getCollection(null, params, AuthorityData.class);
     }
 
     public AuthorityData getCA(String caIDString) throws Exception {

--- a/base/common/src/main/java/com/netscape/certsrv/client/Client.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/Client.java
@@ -17,12 +17,12 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.client;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
 
 /**
  * @author Endi S. Dewata
@@ -111,9 +111,12 @@ public class Client {
         return client.get(path, params, responseType);
     }
 
-    public <T> T get(String suffix, Map<String, Object> params, GenericType<T> responseType) throws Exception {
+    public <T> Collection<T> getCollection(String suffix, Map<String, Object> params, Class<T> responseType) throws Exception {
         String path = getTargetPath(suffix);
-        return client.get(path, params, responseType);
+        Collection<?> coll = client.getCollection(path, params, responseType);
+        return coll.stream().
+                filter(responseType::isInstance).
+                map(responseType::cast).toList();
     }
 
     public <T> T post(Class<T> responseType) throws Exception {

--- a/base/common/src/main/java/com/netscape/certsrv/system/FeatureClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/system/FeatureClient.java
@@ -17,9 +17,7 @@
 //--- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.system;
 
-import java.util.List;
-
-import javax.ws.rs.core.GenericType;
+import java.util.Collection;
 
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
@@ -33,9 +31,8 @@ public class FeatureClient extends Client {
         super(client, subsystem, "config/features");
     }
 
-    public List<Feature> listFeatures() throws Exception {
-        GenericType<List<Feature>> type = new GenericType<>() {};
-        return get(null, null, type);
+    public Collection<Feature> listFeatures() throws Exception {
+        return getCollection(null, null, Feature.class);
     }
 
     public Feature getFeature(String featureID) throws Exception {

--- a/base/common/src/main/java/com/netscape/certsrv/system/SecurityDomainClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/system/SecurityDomainClient.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericType;
 
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
@@ -49,8 +48,7 @@ public class SecurityDomainClient extends Client {
     }
 
     public Collection<SecurityDomainHost> getHosts() throws Exception {
-        GenericType<Collection<SecurityDomainHost>> responseType = new GenericType<>() {};
-        return get("hosts", null, responseType);
+        return getCollection("hosts", null,  SecurityDomainHost.class);
     }
 
     public SecurityDomainHost getHost(String hostID) throws Exception {

--- a/base/tools/src/main/java/com/netscape/cmstools/authority/AuthorityFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/authority/AuthorityFindCLI.java
@@ -1,6 +1,6 @@
 package com.netscape.cmstools.authority;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -55,7 +55,7 @@ public class AuthorityFindCLI extends CommandCLI {
         mainCLI.init();
 
         AuthorityClient authorityClient = authorityCLI.getAuthorityClient();
-        List<AuthorityData> datas = authorityClient.findCAs(id, parentID, dn, issuerDN);
+        Collection<AuthorityData> datas = authorityClient.findCAs(id, parentID, dn, issuerDN);
 
         MainCLI.printMessage(datas.size() + " entries matched");
         if (datas.size() == 0) return;

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACertStatusCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACertStatusCLI.java
@@ -20,7 +20,7 @@ package com.netscape.cmstools.ca;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
-import java.util.List;
+import java.util.Collection;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -108,7 +108,7 @@ public class CACertStatusCLI extends CommandCLI {
         String issuerDN = certData.getIssuerDN();
 
         // find CA that issued the cert
-        List<AuthorityData> authorities = authorityClient.findCAs(null, null, issuerDN, null);
+        Collection<AuthorityData> authorities = authorityClient.findCAs(null, null, issuerDN, null);
 
         if (authorities.size() == 0) {
             throw new CLIException("Unknown certificate issuer: " + issuerDN, 1);

--- a/base/tools/src/main/java/com/netscape/cmstools/feature/FeatureFindCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/feature/FeatureFindCLI.java
@@ -17,7 +17,7 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cmstools.feature;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.apache.commons.cli.CommandLine;
 import org.dogtagpki.cli.CommandCLI;
@@ -47,7 +47,7 @@ public class FeatureFindCLI extends CommandCLI {
         mainCLI.init();
 
         FeatureClient featureClient = featureCLI.getFeatureClient();
-        List<Feature> features = featureClient.listFeatures();
+        Collection<Feature> features = featureClient.listFeatures();
 
         MainCLI.printMessage(features.size() + " entries matched");
         if (features.size() == 0) return;


### PR DESCRIPTION
Collections have no explicit mapping so they require additional steps for their serialisation.

Note: XML message are not generated from the server for a bug so the client to handle them has not been implemented.