### PR TITLE
Update AuthorityRepository.createCA()

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/CAEngine.java
@@ -1391,27 +1391,6 @@ public class CAEngine extends CMSEngine {
         return record;
     }
 
-    /**
-     * Create a new certificate authority.
-     *
-     * @param subjectDN Subject DN for new CA
-     * @param parentAID ID of parent CA
-     * @param description Optional string description of CA
-     */
-    public CertificateAuthority createCA(
-            AuthorityID parentAID,
-            AuthToken authToken,
-            String subjectDN,
-            String description)
-            throws Exception {
-
-        AuthorityRecord record = createAuthorityRecord(parentAID, authToken, subjectDN, description);
-        CertificateAuthority ca = createCA(record);
-        authorityMonitor.authorities.put(ca.getAuthorityID(), ca);
-
-        return ca;
-    }
-
     public CertificateAuthority createCA(AuthorityRecord record) throws Exception {
 
         CertId certID = record.getSerialNumber();

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/AuthorityRepository.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/AuthorityRepository.java
@@ -589,14 +589,14 @@ public class AuthorityRepository {
 
         AuthToken authToken = (AuthToken) SessionContext.getContext().get(SessionContext.AUTH_TOKEN);
         try {
-            CertificateAuthority subCA = engine.createCA(
+            AuthorityRecord record = engine.createAuthorityRecord(
                     parentAID,
                     authToken,
                     data.getDN(),
                     data.getDescription());
             audit(ILogger.SUCCESS, OpDef.OP_ADD,
-                    subCA.getAuthorityID().toString(), auditParams);
-            return readAuthorityData(subCA);
+                    record.getAuthorityID().toString(), auditParams);
+            return readAuthorityData(record);
         } catch (IllegalArgumentException | BadRequestDataException e) {
             throw new BadRequestException(e.toString());
         } catch (CANotFoundException e) {


### PR DESCRIPTION
The `AuthorityRepository.createCA()` has been modified to create just the authority record and the signing cert, but the CA object will only be created later by the `AuthorityMonitor` when it detects the new authority record in DS.

The `AuthorityService.createCA()` has been updated to call `AuthorityRepository.createCA()` as well.

The `CAEngine.createCA()` is no longer used so it has been removed.