### PR TITLE
Update CertClient.list_requests() to support REST API v2

### DIFF
--- a/.github/workflows/python-ca-rest-api-v1-test.yml
+++ b/.github/workflows/python-ca-rest-api-v1-test.yml
@@ -492,7 +492,7 @@ jobs:
               https://ca.example.com:8443
 
       ####################################################################################################
-      # Check Python API against CA that only supports REST API v1
+      # Check PKI server info
 
       - name: Check PKI server info
         run: |
@@ -519,6 +519,42 @@ jobs:
 
           diff expected output
 
+      ####################################################################################################
+      # Check CA cert requests
+
+      - name: Check CA cert requests
+        run: |
+          docker exec client python /usr/share/pki/tests/ca/bin/pki-ca-cert-request-find.py \
+              -U https://ca.example.com:8443 \
+              --ca-bundle $SHARED/certs/ca_signing.crt \
+              --client-cert $SHARED/certs/admin.crt \
+              --client-key $SHARED/certs/admin.key \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec ca find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -5 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 404 -
+          GET /pki/rest/info HTTP/1.1 200 -
+          GET /ca/rest/account/login HTTP/1.1 200 admin
+          GET /ca/rest/agent/certrequests HTTP/1.1 200 admin
+          GET /ca/rest/account/logout HTTP/1.1 204 admin
+          EOF
+
+          diff expected output
+
+      ####################################################################################################
+      # Check CA certs
+
       - name: Check CA certs
         run: |
           docker exec client python /usr/share/pki/tests/ca/bin/pki-ca-cert-find.py \
@@ -542,6 +578,9 @@ jobs:
           GET /pki/rest/info HTTP/1.1 200 -
           POST /ca/rest/certs/search HTTP/1.1 200 -
           EOF
+
+      ####################################################################################################
+      # Check CA users
 
       - name: Check CA users
         run: |

--- a/.github/workflows/python-ca-test.yml
+++ b/.github/workflows/python-ca-test.yml
@@ -98,7 +98,7 @@ jobs:
              -nocerts
 
       ####################################################################################################
-      # Check Python API
+      # Check PKI server info
 
       - name: Check PKI server info
         run: |
@@ -146,6 +146,70 @@ jobs:
           cat > expected << EOF
           GET /pki/v1/info HTTP/1.1 200 -
           EOF
+
+      ####################################################################################################
+      # Check CA cert requests
+
+      - name: Check CA cert requests
+        run: |
+          docker exec pki python /usr/share/pki/tests/ca/bin/pki-ca-cert-request-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v2 by default
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /ca/v2/account/login HTTP/1.1 200 caadmin
+          GET /ca/v2/agent/certrequests HTTP/1.1 200 caadmin
+          GET /ca/v2/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      - name: Check CA cert requests with REST API v1
+        run: |
+          docker exec pki python /usr/share/pki/tests/ca/bin/pki-ca-cert-request-find.py \
+              -U https://pki.example.com:8443 \
+              --ca-bundle $SHARED/ca_signing.crt \
+              --client-cert admin.crt \
+              --client-key admin.key \
+              --api v1 \
+              -v
+
+          sleep 1
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -3 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          # Python API should use REST API v1 as specified
+          cat > expected << EOF
+          GET /ca/v1/account/login HTTP/1.1 200 caadmin
+          GET /ca/v1/agent/certrequests HTTP/1.1 200 caadmin
+          GET /ca/v1/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      ####################################################################################################
+      # Check CA certs
 
       - name: Check CA certs
         run: |
@@ -196,6 +260,9 @@ jobs:
           EOF
 
           diff expected output
+
+      ####################################################################################################
+      # Check CA users
 
       - name: Check CA users
         run: |

--- a/base/common/python/pki/cert.py
+++ b/base/common/python/pki/cert.py
@@ -837,6 +837,16 @@ class CertClient(object):
         Returns a CertRequestInfoCollection object.
         """
 
+        if self.pki_client:
+            api_path = self.pki_client.get_api_path()
+        else:
+            api_path = 'rest'
+
+        path = '/%s/agent/certrequests' % api_path
+
+        if not self.connection.subsystem:
+            path = '/ca' + path
+
         query_params = {
             'requestStatus': request_status,
             'requestType': request_type,
@@ -845,8 +855,9 @@ class CertClient(object):
             'maxResults': max_results,
             'maxTime': max_time
         }
+
         response = self.connection.get(
-            self.agent_cert_requests_url,
+            path,
             self.headers,
             query_params)
 

--- a/tests/ca/bin/pki-ca-cert-request-find.py
+++ b/tests/ca/bin/pki-ca-cert-request-find.py
@@ -1,0 +1,90 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+
+import pki.ca
+import pki.cert
+import pki.client
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '-U',
+    help='Server URL',
+    dest='url')
+parser.add_argument(
+    '--ca-bundle',
+    help='Path to CA bundle',
+    dest='ca_bundle')
+parser.add_argument(
+    '--client-cert',
+    help='Path to client certificate',
+    dest='client_cert')
+parser.add_argument(
+    '--client-key',
+    help='Path to client key',
+    dest='client_key')
+parser.add_argument(
+    '--api',
+    help='API version: v1, v2',
+    dest='api_version')
+parser.add_argument(
+    '-v',
+    '--verbose',
+    help='Run in verbose mode.',
+    dest='verbose',
+    action='store_true')
+parser.add_argument(
+    '--debug',
+    help='Run in debug mode.',
+    dest='debug',
+    action='store_true')
+
+args = parser.parse_args()
+
+if args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+elif args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
+
+pki_client = pki.client.PKIClient(
+    url=args.url,
+    ca_bundle=args.ca_bundle,
+    api_version=args.api_version)
+
+pki_client.set_client_auth(
+    client_cert=args.client_cert,
+    client_key=args.client_key)
+
+ca_client = pki.ca.CAClient(pki_client)
+
+account_client = pki.account.AccountClient(ca_client)
+account_client.login()
+
+cert_client = pki.cert.CertClient(ca_client)
+requests = cert_client.list_requests()
+
+first = True
+
+for request in requests:
+
+    if first:
+        first = False
+    else:
+        print()
+
+    print('  Request ID: ' + request.request_id)
+    print('  Type: ' + request.request_type)
+    print('  Status: ' + request.request_status)
+    print('  Operation Result: ' + request.operation_result)
+    print('  Certificate ID: ' + request.cert_id)
+
+account_client.logout()


### PR DESCRIPTION
The `CertClient.list_requests()` has been updated to use the proper URL for the REST API version.

The CA Python API tests have been updated to list cert requests using the updated Python API.