### PR TITLE
Move AuthorityMonitor.authorities into CAEngine

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/AuthorityMonitor.java
+++ b/base/ca/src/main/java/com/netscape/ca/AuthorityMonitor.java
@@ -54,9 +54,6 @@ public class AuthorityMonitor implements Runnable {
     public AsyncLoader loader = new AsyncLoader(10 /* 10s timeout */);
     public boolean foundHostCA;
 
-    public Map<AuthorityID, CertificateAuthority> authorities =
-            Collections.synchronizedSortedMap(new TreeMap<AuthorityID, CertificateAuthority>());
-
     public Map<AuthorityID, Thread> keyRetrievers =
             Collections.synchronizedSortedMap(new TreeMap<AuthorityID, Thread>());
 
@@ -369,11 +366,15 @@ public class AuthorityMonitor implements Runnable {
     }
 
     public void addCA(AuthorityID aid, CertificateAuthority ca) {
-        authorities.put(aid, ca);
+        CAEngine engine = CAEngine.getInstance();
+        engine.addCA(aid, ca);
     }
 
     public void removeCA(AuthorityID aid) {
-        authorities.remove(aid);
+
+        CAEngine engine = CAEngine.getInstance();
+        engine.removeCA(aid);
+
         entryUSNs.remove(aid);
         nsUniqueIds.remove(aid);
     }


### PR DESCRIPTION
The `authorities` map in `AuthorityMonitor` has been moved into `CAEngine` and can only be accessed through synchronized methods to avoid race conditions. Later there might be additional fields that will be moved from `AuthorityMonitor` to `CAEngine `as well.

The `CAEngine.getCA()` has been modified to look for the requested CA object in the map. If the CA object doesn't exist it will be loaded from the database and stored in the map.

The code in `AuthorityMonitor.addCA()` and `remove()` that updates the `authorities` map has been moved into `CAEngine` as well.