### PR TITLE
Remove resteasy MediaType from PKIClient

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/AuthorityServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/AuthorityServlet.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netscape.certsrv.authority.AuthorityData;
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.base.RequestNotAcceptable;
 import com.netscape.certsrv.base.WebAction;
 import com.netscape.certsrv.util.JSONSerializer;
@@ -88,18 +88,18 @@ public class AuthorityServlet extends CAServlet {
         logger.debug("AuthorityServlet: - session: {}", session.getId());
 
         if (accept == null)
-            accept = MediaType.ANYTYPE;
+            accept = MimeType.ANYTYPE;
 
-        if (accept.contains(MediaType.APPLICATION_X_PEM_FILE)) {
-            response.setContentType(MediaType.APPLICATION_X_PEM_FILE);
+        if (accept.contains(MimeType.APPLICATION_X_PEM_FILE)) {
+            response.setContentType(MimeType.APPLICATION_X_PEM_FILE);
             String cert = authorityRepository.getPemCert(aid);
             PrintWriter out = response.getWriter();
             out.println(cert);
             return;
         }
 
-        if (accept.equals(MediaType.ANYTYPE) || accept.contains(MediaType.APPLICATION_PKIX_CERT)) {
-            response.setContentType(MediaType.APPLICATION_PKIX_CERT);
+        if (accept.equals(MimeType.ANYTYPE) || accept.contains(MimeType.APPLICATION_PKIX_CERT)) {
+            response.setContentType(MimeType.APPLICATION_PKIX_CERT);
             byte[] cert = authorityRepository.getBinaryCert(aid);
             OutputStream out = response.getOutputStream();
             out.write(cert);
@@ -121,20 +121,20 @@ public class AuthorityServlet extends CAServlet {
         logger.debug("AuthorityServlet: - session: {}", session.getId());
 
         if (accept == null)
-            accept = MediaType.ANYTYPE;
+            accept = MimeType.ANYTYPE;
 
         AuthorityRepository authorityRepository = engine.getAuthorityRepository();
 
-        if (accept.contains(MediaType.APPLICATION_X_PEM_FILE)) {
-            response.setContentType(MediaType.APPLICATION_X_PEM_FILE);
+        if (accept.contains(MimeType.APPLICATION_X_PEM_FILE)) {
+            response.setContentType(MimeType.APPLICATION_X_PEM_FILE);
             String cert = authorityRepository.getPemChain(aid);
             PrintWriter out = response.getWriter();
             out.println(cert);
             return;
         }
 
-        if (accept.equals(MediaType.ANYTYPE) || accept.contains(MediaType.APPLICATION_PKCS7)) {
-            response.setContentType(MediaType.APPLICATION_PKCS7);
+        if (accept.equals(MimeType.ANYTYPE) || accept.contains(MimeType.APPLICATION_PKCS7)) {
+            response.setContentType(MimeType.APPLICATION_PKCS7);
             byte[] cert = authorityRepository.getBinaryChain(aid);
             OutputStream out = response.getOutputStream();
             out.write(cert);

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/ProfileServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/ProfileServlet.java
@@ -22,7 +22,7 @@ import org.dogtagpki.server.rest.v2.PKIServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.base.WebAction;
 import com.netscape.certsrv.profile.ProfileData;
 import com.netscape.certsrv.profile.ProfileDataInfos;
@@ -80,7 +80,7 @@ public class ProfileServlet extends CAServlet {
         String[] pathElement = request.getPathInfo().substring(1).split("/");
         String profileId = pathElement[0];
         byte[] rawProfile = profile.retrieveRawProfile(request, profileId);
-        response.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        response.setContentType(MimeType.APPLICATION_OCTET_STREAM);
         OutputStream out = response.getOutputStream();
         out.write(rawProfile);
     }
@@ -115,7 +115,7 @@ public class ProfileServlet extends CAServlet {
         response.setStatus(HttpServletResponse.SC_CREATED);
         response.setHeader("Location", uri.toString());
         byte[] rawProfile = profile.retrieveRawProfile(request, newProfileId);
-        response.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        response.setContentType(MimeType.APPLICATION_OCTET_STREAM);
         OutputStream out = response.getOutputStream();
         out.write(rawProfile);
     }
@@ -153,7 +153,7 @@ public class ProfileServlet extends CAServlet {
         InputStream input = request.getInputStream();
         byte[] data = input.readAllBytes();
         byte[] newRawProfile = profile.modifyProfile(profileId, data);
-        response.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        response.setContentType(MimeType.APPLICATION_OCTET_STREAM);
         OutputStream out = response.getOutputStream();
         out.write(newRawProfile);
     }

--- a/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
@@ -29,7 +29,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 
 import com.netscape.certsrv.base.ClientConnectionException;
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.client.SubsystemClient;
@@ -67,7 +67,7 @@ public class AuthorityClient extends Client {
     public String getChainPEM(String caIDString) throws Exception {
         WebTarget target = target(caIDString + "/chain", null);
         HttpGet httpGET = new HttpGet(target.getUri());
-        httpGET.addHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_X_PEM_FILE);
+        httpGET.addHeader(HttpHeaders.ACCEPT, MimeType.APPLICATION_X_PEM_FILE);
         CloseableHttpResponse httpResp = null;
         try {
             httpResp = client.getConnection().getHttpClient().execute(httpGET);

--- a/base/common/src/main/java/com/netscape/certsrv/base/MimeType.java
+++ b/base/common/src/main/java/com/netscape/certsrv/base/MimeType.java
@@ -8,7 +8,7 @@ package com.netscape.certsrv.base;
 /**
  * @author Marco Fargetta {@literal <mfargett@redhat.com>}
  */
-public class MediaType {
+public class MimeType {
 
     public static final String ANYTYPE = "*/*";
 
@@ -27,4 +27,7 @@ public class MediaType {
     public static final String APPLICATION_X_PEM_FILE = "application/x-pem-file";
 
     public static final String APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded";
+
+    private MimeType() {
+    }
 }

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
@@ -60,7 +60,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.base.PKIException;
 
 /**
@@ -192,10 +192,10 @@ public class PKIConnection implements AutoCloseable {
             List<Header> headers = new ArrayList<>();
 
             if (messageFormat.equals("xml")) {
-                headers.add(new BasicHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML));
+                headers.add(new BasicHeader(HttpHeaders.ACCEPT, MimeType.APPLICATION_XML));
             }
             if (messageFormat.equals("json")) {
-                headers.add(new BasicHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON));
+                headers.add(new BasicHeader(HttpHeaders.ACCEPT, MimeType.APPLICATION_JSON));
             }
             httpClientBuilder.setDefaultHeaders(headers);
         }

--- a/base/common/src/main/java/com/netscape/certsrv/logging/AuditClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/logging/AuditClient.java
@@ -29,7 +29,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 
 import com.netscape.certsrv.base.ClientConnectionException;
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.client.Client;
 import com.netscape.certsrv.client.PKIClient;
 
@@ -64,7 +64,7 @@ public class AuditClient extends Client {
     public InputStream getAuditFile(String filename) throws Exception {
         WebTarget target = target("files/" + filename, null);
         HttpGet httpGET = new HttpGet(target.getUri());
-        httpGET.addHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_OCTET_STREAM);
+        httpGET.addHeader(HttpHeaders.ACCEPT, MimeType.APPLICATION_OCTET_STREAM);
         CloseableHttpResponse httpResp = null;
         try {
             httpResp = client.getConnection().getHttpClient().execute(httpGET);

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v2/KeyRequestServlet.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v2/KeyRequestServlet.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.netscape.certsrv.base.BadRequestException;
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.base.RESTMessage;
 import com.netscape.certsrv.base.WebAction;
 import com.netscape.certsrv.key.KeyRequestInfo;
@@ -85,11 +85,11 @@ public class KeyRequestServlet extends KRAServlet {
         HttpSession session = request.getSession();
         logger.debug("KeyRequestServlet.submitRequest(): session: {}", session.getId());
         RESTMessage data = null;
-        if(request.getContentType() == null || request.getContentType().equals(MediaType.APPLICATION_JSON)) {
+        if(request.getContentType() == null || request.getContentType().equals(MimeType.APPLICATION_JSON)) {
             String requestData = request.getReader().lines().collect(Collectors.joining());
             data = JSONSerializer.fromJSON(requestData, RESTMessage.class);
         }
-        if(request.getContentType().equals(MediaType.APPLICATION_FORM_URLENCODED)) {
+        if(request.getContentType().equals(MimeType.APPLICATION_FORM_URLENCODED)) {
             data = new RESTMessage(request.getParameterMap());
         }
         if(data == null) {

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v2/KeyServlet.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v2/KeyServlet.java
@@ -18,7 +18,7 @@ import org.dogtagpki.server.kra.rest.base.KeyProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.base.WebAction;
 import com.netscape.certsrv.dbs.keydb.KeyId;
 import com.netscape.certsrv.key.KeyData;
@@ -109,11 +109,11 @@ public class KeyServlet extends KRAServlet {
         HttpSession session = request.getSession();
         logger.debug("KeyServlet.retrieveKey(): session: {}", session.getId());
         KeyRecoveryRequest data = null;
-        if(request.getContentType() == null || request.getContentType().equals(MediaType.APPLICATION_JSON)) {
+        if(request.getContentType() == null || request.getContentType().equals(MimeType.APPLICATION_JSON)) {
             String requestData = request.getReader().lines().collect(Collectors.joining());
             data = JSONSerializer.fromJSON(requestData, KeyRecoveryRequest.class);
         }
-        if(request.getContentType().equals(MediaType.APPLICATION_FORM_URLENCODED)) {
+        if(request.getContentType().equals(MimeType.APPLICATION_FORM_URLENCODED)) {
             data = new KeyRecoveryRequest(request.getParameterMap());
         }
         if(data == null) {

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/rest/v2/AppServlet.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/rest/v2/AppServlet.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.cmscore.apps.CMS;
 
 /**
@@ -62,7 +62,7 @@ public class AppServlet extends PKIServlet {
             apps.add(info);
         }
 
-        response.setContentType(MediaType.APPLICATION_JSON);
+        response.setContentType(MimeType.APPLICATION_JSON);
 
         PrintWriter out = response.getWriter();
         ObjectMapper mapper = new ObjectMapper();

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/rest/v2/InfoServlet.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/rest/v2/InfoServlet.java
@@ -15,7 +15,7 @@ import org.dogtagpki.common.Info;
 import org.dogtagpki.server.PKIEngine;
 import org.dogtagpki.server.PKIServlet;
 
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 
 /**
  * @author Endi S. Dewata
@@ -31,7 +31,7 @@ public class InfoServlet extends PKIServlet {
         PKIEngine engine = getPKIEngine();
         Info info = engine.getInfo(request);
 
-        response.setContentType(MediaType.APPLICATION_JSON);
+        response.setContentType(MimeType.APPLICATION_JSON);
 
         PrintWriter out = response.getWriter();
         out.println(info.toJSON());

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v2/PKIServlet.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v2/PKIServlet.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import com.netscape.certsrv.authentication.ExternalAuthToken;
 import com.netscape.certsrv.base.ForbiddenException;
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.base.SessionContext;
 import com.netscape.certsrv.base.WebAction;
@@ -120,7 +120,7 @@ public abstract class PKIServlet extends HttpServlet {
             HttpServletResponse response
             ) throws IOException {
 
-        response.setContentType(MediaType.APPLICATION_JSON);
+        response.setContentType(MimeType.APPLICATION_JSON);
 
         try {
             setSessionContext(request);

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v2/filters/ACLFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v2/filters/ACLFilter.java
@@ -34,7 +34,7 @@ import com.netscape.certsrv.authorization.EAuthzAccessDenied;
 import com.netscape.certsrv.authorization.EAuthzUnknownRealm;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.ForbiddenException;
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.logging.event.AuthzEvent;
@@ -113,7 +113,7 @@ public abstract class ACLFilter extends HttpFilter {
                 chain.doFilter(request, response);
             } catch (ForbiddenException fe) {
                 resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                resp.setContentType(MediaType.APPLICATION_JSON);
+                resp.setContentType(MimeType.APPLICATION_JSON);
                 PrintWriter out = resp.getWriter();
                 out.print(fe.getData().toJSON());
             }

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v2/filters/AuthMethodFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v2/filters/AuthMethodFilter.java
@@ -31,7 +31,7 @@ import org.dogtagpki.server.authentication.AuthToken;
 
 import com.netscape.certsrv.authentication.ExternalAuthToken;
 import com.netscape.certsrv.base.ForbiddenException;
-import com.netscape.certsrv.base.MediaType;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.cms.realm.PKIPrincipal;
 import com.netscape.cmscore.apps.CMS;
@@ -100,7 +100,7 @@ public abstract class AuthMethodFilter extends HttpFilter {
                 chain.doFilter(request, response);
              } catch (ForbiddenException fe) {
                  resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                 resp.setContentType(MediaType.APPLICATION_JSON);
+                 resp.setContentType(MimeType.APPLICATION_JSON);
                  PrintWriter out = resp.getWriter();
                  out.print(fe.getData().toJSON());
             }


### PR DESCRIPTION
The MediaType class in PKI has been renamed to MimeType since it contains only MimeTypes.