### PR TITLE
Replace WebTarget with URIBuilder in PKI client

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -31,8 +31,8 @@
 	<classpathentry kind="var" path="M2_REPO/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"/>
 	<classpathentry kind="var" path="M2_REPO/commons-net/commons-net/3.6/commons-net-3.6.jar"/>
 	<classpathentry kind="var" path="M2_REPO/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/apache/httpcomponents/httpcore/4.4.10/httpcore-4.4.10.jar"/>
-	<classpathentry kind="var" path="M2_REPO/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar"/>
+	<classpathentry kind="var" path="M2_REPO/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar"/>
 	<classpathentry kind="var" path="M2_REPO/jakarta/activation/jakarta.activation-api/2.1.0/jakarta.activation-api-2.1.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/jakarta/xml/bind/jakarta.xml.bind-api/4.0.0/jakarta.xml.bind-api-4.0.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/org/apache/tomcat/tomcat-api/9.0.62/tomcat-api-9.0.62.jar"/>

--- a/base/common/pom.xml
+++ b/base/common/pom.xml
@@ -67,13 +67,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.10</version>
+            <version>4.4.16</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
+            <version>4.5.14</version>
         </dependency>
 
         <dependency>

--- a/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/authority/AuthorityClient.java
@@ -21,12 +21,11 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.client.WebTarget;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
 
 import com.netscape.certsrv.base.ClientConnectionException;
 import com.netscape.certsrv.base.MimeType;
@@ -65,8 +64,8 @@ public class AuthorityClient extends Client {
     }
 
     public String getChainPEM(String caIDString) throws Exception {
-        WebTarget target = target(caIDString + "/chain", null);
-        HttpGet httpGET = new HttpGet(target.getUri());
+        URIBuilder target = target(caIDString + "/chain", null);
+        HttpGet httpGET = new HttpGet(target.build());
         httpGET.addHeader(HttpHeaders.ACCEPT, MimeType.APPLICATION_X_PEM_FILE);
         CloseableHttpResponse httpResp = null;
         try {

--- a/base/common/src/main/java/com/netscape/certsrv/client/Client.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/Client.java
@@ -21,9 +21,8 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.ws.rs.client.WebTarget;
-
 import org.apache.http.HttpEntity;
+import org.apache.http.client.utils.URIBuilder;
 
 /**
  * @author Endi S. Dewata
@@ -94,7 +93,7 @@ public class Client {
         return sb.toString();
     }
 
-    public WebTarget target(String suffix, Map<String, Object> params) {
+    public URIBuilder target(String suffix, Map<String, Object> params) {
         String path = getTargetPath(suffix);
         return client.target(path, params);
     }

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIConnection.java
@@ -29,8 +29,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.client.WebTarget;
-
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
@@ -56,8 +54,6 @@ import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
 import org.dogtagpki.client.JSSSocketFactory;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 
 import com.netscape.certsrv.base.MimeType;
@@ -76,9 +72,7 @@ public class PKIConnection implements AutoCloseable {
     SSLCertificateApprovalCallback callback;
     LayeredConnectionSocketFactory socketFactory;
 
-    ApacheHttpClient4Engine engine;
-    javax.ws.rs.client.Client client;
-    WebTarget target;
+    URI target;
 
     int requestCounter;
     int responseCounter;
@@ -201,14 +195,7 @@ public class PKIConnection implements AutoCloseable {
         }
         httpClient = httpClientBuilder.build();
 
-        engine = new ApacheHttpClient4Engine(httpClient);
-
-        client = new ResteasyClientBuilder().httpEngine(engine).build();
-
-        client.register(PKIRESTProvider.class);
-
-        URI uri = config.getServerURL().toURI();
-        target = client.target(uri);
+        target = config.getServerURL().toURI();
     }
 
     public ClientConfig getConfig() {
@@ -266,8 +253,8 @@ public class PKIConnection implements AutoCloseable {
         }
     }
 
-    public WebTarget target(String path) {
-        return target.path(path);
+    public URI getTarget() {
+        return target;
     }
 
     public File getOutput() {
@@ -280,8 +267,6 @@ public class PKIConnection implements AutoCloseable {
 
     @Override
     public void close() {
-        client.close();
-        engine.close();
         try {
             httpClient.close();
         } catch (IOException e) {

--- a/base/common/src/main/java/com/netscape/certsrv/logging/AuditClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/logging/AuditClient.java
@@ -21,12 +21,11 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.client.WebTarget;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
 
 import com.netscape.certsrv.base.ClientConnectionException;
 import com.netscape.certsrv.base.MimeType;
@@ -62,8 +61,8 @@ public class AuditClient extends Client {
     }
 
     public InputStream getAuditFile(String filename) throws Exception {
-        WebTarget target = target("files/" + filename, null);
-        HttpGet httpGET = new HttpGet(target.getUri());
+        URIBuilder target = target("files/" + filename, null);
+        HttpGet httpGET = new HttpGet(target.build());
         httpGET.addHeader(HttpHeaders.ACCEPT, MimeType.APPLICATION_OCTET_STREAM);
         CloseableHttpResponse httpResp = null;
         try {


### PR DESCRIPTION
PKI client URL are built from the initial URI using the httpcomponent-client URIBuilder.