### PR TITLE
Fix pki-server <subsystem>-clone-prepare

### DIFF
--- a/.github/workflows/ca-clone-test.yml
+++ b/.github/workflows/ca-clone-test.yml
@@ -33,26 +33,25 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=primaryds.example.com \
+              --network=example \
+              --network-alias=primaryds.example.com \
               --password=Secret.123 \
               primaryds
 
-      - name: Connect primary DS container to network
-        run: docker network connect example primaryds --alias primaryds.example.com
-
       - name: Set up primary PKI container
         run: |
-          tests/bin/runner-init.sh primary
-        env:
-          HOSTNAME: primary.example.com
-
-      - name: Connect primary PKI container to network
-        run: docker network connect example primary --alias primary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=primary.example.com \
+              --network=example \
+              --network-alias=primary.example.com \
+              primary
 
       - name: Install CA in primary PKI container
         run: |
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -93,33 +92,35 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=secondaryds.example.com \
+              --network=example \
+              --network-alias=secondaryds.example.com \
               --password=Secret.123 \
               secondaryds
 
-      - name: Connect secondary DS container to network
-        run: docker network connect example secondaryds --alias secondaryds.example.com
-
       - name: Set up secondary PKI container
         run: |
-          tests/bin/runner-init.sh secondary
-        env:
-          HOSTNAME: secondary.example.com
-
-      - name: Connect secondary PKI container to network
-        run: docker network connect example secondary --alias secondary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=secondary.example.com \
+              --network=example \
+              --network-alias=secondary.example.com \
+              secondary
 
       - name: Install CA in secondary PKI container
         run: |
           # get CS.cfg from primary CA before cloning
           docker cp primary:/var/lib/pki/pki-tomcat/conf/ca/CS.cfg CS.cfg.primary
 
-          docker exec primary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+          docker exec primary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -340,26 +341,24 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=tertiaryds.example.com \
+              --network=example \
+              --network-alias=tertiaryds.example.com \
               --password=Secret.123 \
               tertiaryds
 
-      - name: Connect tertiary DS container to network
-        run: docker network connect example tertiaryds --alias tertiaryds.example.com
-
       - name: Set up tertiary PKI container
         run: |
-          tests/bin/runner-init.sh tertiary
-        env:
-          HOSTNAME: tertiary.example.com
-
-      - name: Connect tertiary PKI container to network
-        run: docker network connect example tertiary --alias tertiary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=tertiary.example.com \
+              --network=example \
+              --network-alias=tertiary.example.com \
+              tertiary
 
       - name: Install CA in tertiary PKI container
         run: |
           # export system certs and keys (except sslserver)
           docker exec secondary pki-server ca-clone-prepare \
-              --pkcs12-file ${SHARED}/ca-certs.p12 \
+              --pkcs12-file $SHARED/ca-certs.p12 \
               --pkcs12-password Secret.123
 
           # export CA signing CSR
@@ -369,10 +368,6 @@ jobs:
           # export CA OCSP signing CSR
           docker exec secondary pki-server cert-export ca_ocsp_signing \
               --csr-file ${SHARED}/ca_ocsp_signing.csr
-
-          # export CA audit signing CSR
-          docker exec secondary pki-server cert-export ca_audit_signing \
-              --csr-file ${SHARED}/ca_audit_signing.csr
 
           # export subsystem CSR
           docker exec secondary pki-server cert-export subsystem \
@@ -386,8 +381,8 @@ jobs:
               -D pki_clone_pkcs12_password=Secret.123 \
               -D pki_ca_signing_csr_path=${SHARED}/ca_signing.csr \
               -D pki_ocsp_signing_csr_path=${SHARED}/ca_ocsp_signing.csr \
-              -D pki_audit_signing_csr_path=${SHARED}/ca_audit_signing.csr \
               -D pki_subsystem_csr_path=${SHARED}/subsystem.csr \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 

--- a/.github/workflows/kra-clone-test.yml
+++ b/.github/workflows/kra-clone-test.yml
@@ -33,26 +33,25 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=primaryds.example.com \
+              --network=example \
+              --network-alias=primaryds.example.com \
               --password=Secret.123 \
               primaryds
 
-      - name: Connect primary DS container to network
-        run: docker network connect example primaryds --alias primaryds.example.com
-
       - name: Set up primary PKI container
         run: |
-          tests/bin/runner-init.sh primary
-        env:
-          HOSTNAME: primary.example.com
-
-      - name: Connect primary PKI container to network
-        run: docker network connect example primary --alias primary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=primary.example.com \
+              --network=example \
+              --network-alias=primary.example.com \
+              primary
 
       - name: Install primary CA in primary PKI container
         run: |
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -63,6 +62,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -73,31 +73,34 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=secondaryds.example.com \
+              --network=example \
+              --network-alias=secondaryds.example.com \
               --password=Secret.123 \
               secondaryds
 
-      - name: Connect secondary DS container to network
-        run: docker network connect example secondaryds --alias secondaryds.example.com
-
       - name: Set up secondary PKI container
         run: |
-          tests/bin/runner-init.sh secondary
-        env:
-          HOSTNAME: secondary.example.com
-
-      - name: Connect secondary PKI container to network
-        run: docker network connect example secondary --alias secondary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=secondary.example.com \
+              --network=example \
+              --network-alias=secondary.example.com \
+              secondary
 
       - name: Install CA in secondary PKI container
         run: |
           docker exec primary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-          docker exec primary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+
+          docker exec primary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -105,13 +108,17 @@ jobs:
 
       - name: Install KRA in secondary PKI container
         run: |
-          docker exec primary pki-server kra-clone-prepare --pkcs12-file ${SHARED}/kra-certs.p12 --pkcs12-password Secret.123
+          docker exec primary pki-server kra-clone-prepare \
+              --pkcs12-file $SHARED/kra-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra-clone.cfg \
               -s KRA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -136,31 +143,34 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=tertiaryds.example.com \
+              --network=example \
+              --network-alias=tertiaryds.example.com \
               --password=Secret.123 \
               tertiaryds
 
-      - name: Connect tertiary DS container to network
-        run: docker network connect example tertiaryds --alias tertiaryds.example.com
-
       - name: Set up tertiary PKI container
         run: |
-          tests/bin/runner-init.sh tertiary
-        env:
-          HOSTNAME: tertiary.example.com
-
-      - name: Connect tertiary PKI container to network
-        run: docker network connect example tertiary --alias tertiary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=tertiary.example.com \
+              --network=example \
+              --network-alias=tertiary.example.com \
+              tertiary
 
       - name: Install CA in tertiary PKI container
         run: |
           docker exec secondary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-          docker exec secondary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+
+          docker exec secondary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec tertiary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone-of-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 
@@ -168,13 +178,17 @@ jobs:
 
       - name: Install KRA in tertiary PKI container
         run: |
-          docker exec secondary pki-server kra-clone-prepare --pkcs12-file ${SHARED}/kra-certs.p12 --pkcs12-password Secret.123
+          docker exec secondary pki-server kra-clone-prepare \
+              --pkcs12-file $SHARED/kra-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec tertiary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra-clone-of-clone.cfg \
               -s KRA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 

--- a/.github/workflows/ocsp-clone-test.yml
+++ b/.github/workflows/ocsp-clone-test.yml
@@ -33,26 +33,25 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=primaryds.example.com \
+              --network=example \
+              --network-alias=primaryds.example.com \
               --password=Secret.123 \
               primaryds
 
-      - name: Connect primary DS container to network
-        run: docker network connect example primaryds --alias primaryds.example.com
-
       - name: Set up primary PKI container
         run: |
-          tests/bin/runner-init.sh primary
-        env:
-          HOSTNAME: primary.example.com
-
-      - name: Connect primary PKI container to network
-        run: docker network connect example primary --alias primary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=primary.example.com \
+              --network=example \
+              --network-alias=primary.example.com \
+              primary
 
       - name: Install CA in primary PKI container
         run: |
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -63,6 +62,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ocsp.cfg \
               -s OCSP \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -73,31 +73,34 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=secondaryds.example.com \
+              --network=example \
+              --network-alias=secondaryds.example.com \
               --password=Secret.123 \
               secondaryds
 
-      - name: Connect secondary DS container to network
-        run: docker network connect example secondaryds --alias secondaryds.example.com
-
       - name: Set up secondary PKI container
         run: |
-          tests/bin/runner-init.sh secondary
-        env:
-          HOSTNAME: secondary.example.com
-
-      - name: Connect secondary PKI container to network
-        run: docker network connect example secondary --alias secondary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=secondary.example.com \
+              --network=example \
+              --network-alias=secondary.example.com \
+              secondary
 
       - name: Install CA in secondary PKI container
         run: |
           docker exec primary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-          docker exec primary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+
+          docker exec primary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -105,13 +108,17 @@ jobs:
 
       - name: Install OCSP in secondary PKI container
         run: |
-          docker exec primary pki-server ocsp-clone-prepare --pkcs12-file ${SHARED}/ocsp-certs.p12 --pkcs12-password Secret.123
+          docker exec primary pki-server ocsp-clone-prepare \
+              --pkcs12-file $SHARED/ocsp-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ocsp-clone.cfg \
               -s OCSP \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ocsp-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -136,31 +143,34 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=tertiaryds.example.com \
+              --network=example \
+              --network-alias=tertiaryds.example.com \
               --password=Secret.123 \
               tertiaryds
 
-      - name: Connect tertiary DS container to network
-        run: docker network connect example tertiaryds --alias tertiaryds.example.com
-
       - name: Set up tertiary PKI container
         run: |
-          tests/bin/runner-init.sh tertiary
-        env:
-          HOSTNAME: tertiary.example.com
-
-      - name: Connect tertiary PKI container to network
-        run: docker network connect example tertiary --alias tertiary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=tertiary.example.com \
+              --network=example \
+              --network-alias=tertiary.example.com \
+              tertiary
 
       - name: Install CA in tertiary PKI container
         run: |
           docker exec secondary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-          docker exec secondary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+
+          docker exec secondary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec tertiary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone-of-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 
@@ -168,13 +178,17 @@ jobs:
 
       - name: Install OCSP in tertiary PKI container
         run: |
-          docker exec secondary pki-server ocsp-clone-prepare --pkcs12-file ${SHARED}/ocsp-certs.p12 --pkcs12-password Secret.123
+          docker exec secondary pki-server ocsp-clone-prepare \
+              --pkcs12-file $SHARED/ocsp-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec tertiary pkispawn \
               -f /usr/share/pki/server/examples/installation/ocsp-clone-of-clone.cfg \
               -s OCSP \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ocsp-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 

--- a/.github/workflows/tks-clone-test.yml
+++ b/.github/workflows/tks-clone-test.yml
@@ -35,26 +35,25 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=primaryds.example.com \
+              --network=example \
+              --network-alias=primaryds.example.com \
               --password=Secret.123 \
               primaryds
 
-      - name: Connect primary DS container to network
-        run: docker network connect example primaryds --alias primaryds.example.com
-
       - name: Set up primary PKI container
         run: |
-          tests/bin/runner-init.sh primary
-        env:
-          HOSTNAME: primary.example.com
-
-      - name: Connect primary PKI container to network
-        run: docker network connect example primary --alias primary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=primary.example.com \
+              --network=example \
+              --network-alias=primary.example.com \
+              primary
 
       - name: Install CA in primary PKI container
         run: |
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -65,6 +64,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -75,31 +75,34 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=secondaryds.example.com \
+              --network=example \
+              --network-alias=secondaryds.example.com \
               --password=Secret.123 \
               secondaryds
 
-      - name: Connect secondary DS container to network
-        run: docker network connect example secondaryds --alias secondaryds.example.com
-
       - name: Set up secondary PKI container
         run: |
-          tests/bin/runner-init.sh secondary
-        env:
-          HOSTNAME: secondary.example.com
-
-      - name: Connect secondary PKI container to network
-        run: docker network connect example secondary --alias secondary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=secondary.example.com \
+              --network=example \
+              --network-alias=secondary.example.com \
+              secondary
 
       - name: Install CA in secondary PKI container
         run: |
           docker exec primary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-          docker exec primary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+
+          docker exec primary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -107,13 +110,17 @@ jobs:
 
       - name: Install TKS in secondary PKI container
         run: |
-          docker exec primary pki-server tks-clone-prepare --pkcs12-file ${SHARED}/tks-certs.p12 --pkcs12-password Secret.123
+          docker exec primary pki-server tks-clone-prepare \
+              --pkcs12-file $SHARED/tks-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/tks-clone.cfg \
               -s TKS \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/tks-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -138,31 +145,34 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=tertiaryds.example.com \
+              --network=example \
+              --network-alias=tertiaryds.example.com \
               --password=Secret.123 \
               tertiaryds
 
-      - name: Connect tertiary DS container to network
-        run: docker network connect example tertiaryds --alias tertiaryds.example.com
-
       - name: Set up tertiary PKI container
         run: |
-          tests/bin/runner-init.sh tertiary
-        env:
-          HOSTNAME: tertiary.example.com
-
-      - name: Connect tertiary PKI container to network
-        run: docker network connect example tertiary --alias tertiary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=tertiary.example.com \
+              --network=example \
+              --network-alias=tertiary.example.com \
+              tertiary
 
       - name: Install CA in tertiary PKI container
         run: |
           docker exec secondary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-          docker exec secondary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+
+          docker exec secondary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec tertiary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone-of-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 
@@ -170,13 +180,17 @@ jobs:
 
       - name: Install TKS in tertiary PKI container
         run: |
-          docker exec secondary pki-server tks-clone-prepare --pkcs12-file ${SHARED}/tks-certs.p12 --pkcs12-password Secret.123
+          docker exec secondary pki-server tks-clone-prepare \
+              --pkcs12-file $SHARED/tks-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec tertiary pkispawn \
               -f /usr/share/pki/server/examples/installation/tks-clone-of-clone.cfg \
               -s TKS \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/tks-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://tertiaryds.example.com:3389 \
               -v
 

--- a/.github/workflows/tps-clone-test.yml
+++ b/.github/workflows/tps-clone-test.yml
@@ -35,26 +35,25 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=primaryds.example.com \
+              --network=example \
+              --network-alias=primaryds.example.com \
               --password=Secret.123 \
               primaryds
 
-      - name: Connect primary DS container to network
-        run: docker network connect example primaryds --alias primaryds.example.com
-
       - name: Set up primary PKI container
         run: |
-          tests/bin/runner-init.sh primary
-        env:
-          HOSTNAME: primary.example.com
-
-      - name: Connect primary PKI container to network
-        run: docker network connect example primary --alias primary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=primary.example.com \
+              --network=example \
+              --network-alias=primary.example.com \
+              primary
 
       - name: Install CA in primary PKI container
         run: |
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca.cfg \
               -s CA \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -65,6 +64,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra.cfg \
               -s KRA \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -75,6 +75,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/tks.cfg \
               -s TKS \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -v
 
@@ -85,6 +86,7 @@ jobs:
           docker exec primary pkispawn \
               -f /usr/share/pki/server/examples/installation/tps.cfg \
               -s TPS \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://primaryds.example.com:3389 \
               -D pki_authdb_url=ldap://primaryds.example.com:3389 \
               -D pki_enable_server_side_keygen=True \
@@ -97,31 +99,34 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=secondaryds.example.com \
+              --network=example \
+              --network-alias=secondaryds.example.com \
               --password=Secret.123 \
               secondaryds
 
-      - name: Connect secondary DS container to network
-        run: docker network connect example secondaryds --alias secondaryds.example.com
-
       - name: Set up secondary PKI container
         run: |
-          tests/bin/runner-init.sh secondary
-        env:
-          HOSTNAME: secondary.example.com
-
-      - name: Connect secondary PKI container to network
-        run: docker network connect example secondary --alias secondary.example.com
+          tests/bin/runner-init.sh \
+              --hostname=secondary.example.com \
+              --network=example \
+              --network-alias=secondary.example.com \
+              secondary
 
       - name: Install CA in secondary PKI container
         run: |
           docker exec primary pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-          docker exec primary pki-server ca-clone-prepare --pkcs12-file ${SHARED}/ca-certs.p12 --pkcs12-password Secret.123
+
+          docker exec primary pki-server ca-clone-prepare \
+              --pkcs12-file $SHARED/ca-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/ca-clone.cfg \
               -s CA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/ca-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -129,13 +134,17 @@ jobs:
 
       - name: Install KRA in secondary PKI container
         run: |
-          docker exec primary pki-server kra-clone-prepare --pkcs12-file ${SHARED}/kra-certs.p12 --pkcs12-password Secret.123
+          docker exec primary pki-server kra-clone-prepare \
+              --pkcs12-file $SHARED/kra-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/kra-clone.cfg \
               -s KRA \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/kra-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -143,13 +152,17 @@ jobs:
 
       - name: Install TKS in secondary PKI container
         run: |
-          docker exec primary pki-server tks-clone-prepare --pkcs12-file ${SHARED}/tks-certs.p12 --pkcs12-password Secret.123
+          docker exec primary pki-server tks-clone-prepare \
+              --pkcs12-file $SHARED/tks-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/tks-clone.cfg \
               -s TKS \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/tks-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -v
 
@@ -157,13 +170,17 @@ jobs:
 
       - name: Install TPS in secondary PKI container
         run: |
-          docker exec primary pki-server tps-clone-prepare --pkcs12-file ${SHARED}/tps-certs.p12 --pkcs12-password Secret.123
+          docker exec primary pki-server tps-clone-prepare \
+              --pkcs12-file $SHARED/tps-certs.p12 \
+              --pkcs12-password Secret.123
+
           docker exec secondary pkispawn \
               -f /usr/share/pki/server/examples/installation/tps-clone.cfg \
               -s TPS \
               -D pki_cert_chain_path=${SHARED}/ca_signing.crt \
               -D pki_clone_pkcs12_path=${SHARED}/tps-certs.p12 \
               -D pki_clone_pkcs12_password=Secret.123 \
+              -D pki_audit_signing_nickname= \
               -D pki_ds_url=ldap://secondaryds.example.com:3389 \
               -D pki_authdb_url=ldap://secondaryds.example.com:3389 \
               -D pki_enable_server_side_keygen=True \

--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -1369,8 +1369,19 @@ class CAClonePrepareCLI(pki.cli.CLI):
                 'signing', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
             subsystem.export_system_cert(
                 'ocsp_signing', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
-            subsystem.export_system_cert(
-                'audit_signing', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
+
+            # audit signing cert is optional
+            cert = subsystem.get_subsystem_cert('audit_signing')
+
+            # export audit signing cert if available (i.e. has nickname)
+            if cert['nickname']:
+                subsystem.export_system_cert(
+                    'audit_signing',
+                    pkcs12_file,
+                    pkcs12_password_file,
+                    no_key=no_key,
+                    append=True)
+
             instance.export_external_certs(
                 pkcs12_file, pkcs12_password_file, append=True)
 

--- a/base/server/python/pki/server/cli/kra.py
+++ b/base/server/python/pki/server/cli/kra.py
@@ -171,8 +171,19 @@ class KRAClonePrepareCLI(pki.cli.CLI):
                 'transport', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
             subsystem.export_system_cert(
                 'storage', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
-            subsystem.export_system_cert(
-                'audit_signing', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
+
+            # audit signing cert is optional
+            cert = subsystem.get_subsystem_cert('audit_signing')
+
+            # export audit signing cert if available (i.e. has nickname)
+            if cert['nickname']:
+                subsystem.export_system_cert(
+                    'audit_signing',
+                    pkcs12_file,
+                    pkcs12_password_file,
+                    no_key=no_key,
+                    append=True)
+
             instance.export_external_certs(
                 pkcs12_file, pkcs12_password_file, append=True)
 

--- a/base/server/python/pki/server/cli/ocsp.py
+++ b/base/server/python/pki/server/cli/ocsp.py
@@ -168,8 +168,19 @@ class OCSPClonePrepareCLI(pki.cli.CLI):
                 'subsystem', pkcs12_file, pkcs12_password_file, no_key=no_key)
             subsystem.export_system_cert(
                 'signing', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
-            subsystem.export_system_cert(
-                'audit_signing', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
+
+            # audit signing cert is optional
+            cert = subsystem.get_subsystem_cert('audit_signing')
+
+            # export audit signing cert if available (i.e. has nickname)
+            if cert['nickname']:
+                subsystem.export_system_cert(
+                    'audit_signing',
+                    pkcs12_file,
+                    pkcs12_password_file,
+                    no_key=no_key,
+                    append=True)
+
             instance.export_external_certs(
                 pkcs12_file, pkcs12_password_file, append=True)
 

--- a/base/server/python/pki/server/cli/tks.py
+++ b/base/server/python/pki/server/cli/tks.py
@@ -166,8 +166,19 @@ class TKSClonePrepareCLI(pki.cli.CLI):
 
             subsystem.export_system_cert(
                 'subsystem', pkcs12_file, pkcs12_password_file, no_key=no_key)
-            subsystem.export_system_cert(
-                'audit_signing', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
+
+            # audit signing cert is optional
+            cert = subsystem.get_subsystem_cert('audit_signing')
+
+            # export audit signing cert if available (i.e. has nickname)
+            if cert['nickname']:
+                subsystem.export_system_cert(
+                    'audit_signing',
+                    pkcs12_file,
+                    pkcs12_password_file,
+                    no_key=no_key,
+                    append=True)
+
             instance.export_external_certs(
                 pkcs12_file, pkcs12_password_file, append=True)
 

--- a/base/server/python/pki/server/cli/tps.py
+++ b/base/server/python/pki/server/cli/tps.py
@@ -165,8 +165,19 @@ class TPSClonePrepareCLI(pki.cli.CLI):
 
             subsystem.export_system_cert(
                 'subsystem', pkcs12_file, pkcs12_password_file, no_key=no_key)
-            subsystem.export_system_cert(
-                'audit_signing', pkcs12_file, pkcs12_password_file, no_key=no_key, append=True)
+
+            # audit signing cert is optional
+            cert = subsystem.get_subsystem_cert('audit_signing')
+
+            # export audit signing cert if available (i.e. has nickname)
+            if cert['nickname']:
+                subsystem.export_system_cert(
+                    'audit_signing',
+                    pkcs12_file,
+                    pkcs12_password_file,
+                    no_key=no_key,
+                    append=True)
+
             instance.export_external_certs(
                 pkcs12_file, pkcs12_password_file, append=True)
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -479,7 +479,11 @@ class PKISubsystem(object):
             append=False):
 
         cert = self.get_subsystem_cert(cert_tag)
+
         nickname = cert['nickname']
+        if not nickname:
+            raise pki.cli.CLIException('Missing nickname for %s certificate' % cert_tag)
+
         token = pki.nssdb.normalize_token(cert['token'])
 
         if token:


### PR DESCRIPTION
The `pki-server <subsystem>-clone-prepare` has been updated to support optional audit signing cert.

The `PKISubsystem.export_system_cert()` has been modified to generate a more user-friendly error message.

The basic clone tests have been updated to no longer use audit signing certs.

Resolves: https://github.com/dogtagpki/pki/issues/5053

**Note:** This PR does not modify the sample `*.cfg` files since it might require updating a lot of tests. They will be updated separately later.