### PR TITLE
Disable password console callback if file provided

### DIFF
--- a/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -395,6 +395,17 @@ public class CryptoUtil {
         return cm.getTokenByName(name);
     }
 
+    /**
+     * Retrieves handle to a key store token.
+     */
+    public static Enumeration<CryptoToken> getExternalTokens()
+            throws NotInitializedException, NoSuchTokenException {
+
+        CryptoManager cm = CryptoManager.getInstance();
+
+        return cm.getExternalTokens();
+    }
+
     public static KeyPair generateRSAKeyPair(
             CryptoToken token,
             int keySize) throws Exception {

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -31,6 +31,7 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -56,6 +57,7 @@ import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.ssl.SSLCertificateApprovalCallback;
 import org.mozilla.jss.ssl.SSLSocket;
 import org.mozilla.jss.util.IncorrectPasswordException;
+import org.mozilla.jss.util.NullPasswordCallback;
 import org.mozilla.jss.util.Password;
 
 import com.netscape.certsrv.base.ClientConnectionException;
@@ -566,7 +568,6 @@ public class MainCLI extends CLI {
 
                 CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
                 Password password = new Password(passwords.get(tokenName).toCharArray());
-
                 try {
                     token.login(password);
 
@@ -576,6 +577,14 @@ public class MainCLI extends CLI {
 
                 } finally {
                     password.clear();
+                }
+            }
+            manager.setPasswordCallback(new NullPasswordCallback());
+            Enumeration<CryptoToken> externalTokens = CryptoUtil.getExternalTokens();
+            while (externalTokens!=null && externalTokens.hasMoreElements()) {
+                CryptoToken extToken = externalTokens.nextElement();
+                if (!extToken.isLoggedIn()) {
+                    logger.info("Password for token '{}' has not been provided, it will be skipped.", extToken.getName());
                 }
             }
         }


### PR DESCRIPTION
When a password file is provided to the CLI then all password are read from that file and no requests are done to the user if a token misses password.

Missing password tokens are reported in verbose or debug mode.

The console password callback is still used if the user provides password for individual tokens.

Fix issue #5045.