### PR TITLE
Update standalone KRA test

### DIFF
--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -1,4 +1,9 @@
 name: Standalone KRA
+# This test will install a standalone CA and a standalone KRA without
+# the security domain, enroll a cert without KRA connector, then enroll
+# another cert with KRA connector.
+#
+# https://github.com/dogtagpki/pki/wiki/Installing-Standalone-KRA
 
 on: workflow_call
 
@@ -27,25 +32,30 @@ jobs:
       - name: Create network
         run: docker network create example
 
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              client
+
       - name: Set up DS container
         run: |
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up CA container
         run: |
-          tests/bin/runner-init.sh ca
-        env:
-          HOSTNAME: ca.example.com
-
-      - name: Connect CA container to network
-        run: docker network connect example ca --alias ca.example.com
+          tests/bin/runner-init.sh \
+              --hostname=ca.example.com \
+              --network=example \
+              --network-alias=ca.example.com \
+              ca
 
       - name: Install standalone CA
         run: |
@@ -56,43 +66,74 @@ jobs:
               -D pki_security_domain_setup=False \
               -v
 
-          docker exec ca pki-server cert-find
+      - name: Import CA certs into client
+        run: |
+          # export CA signing cert
+          docker exec ca pki-server cert-export \
+              --cert-file $SHARED/ca_signing.crt \
+              ca_signing
+
+          # import CA signing cert
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/ca_signing.crt \
+              --trust CT,C,C
+
+          # export CA admin cert and key
+          docker exec ca cp \
+              /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              $SHARED/ca_admin_cert.p12
+
+          # import CA admin cert and key
+          docker exec client pki pkcs12-import \
+              --pkcs12 $SHARED/ca_admin_cert.p12 \
+              --password Secret.123
+
+      - name: Check CA admin
+        run: |
+          # check CA admin user
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-user-show \
+              caadmin
+
+          # check CA admin roles
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-user-membership-find \
+              caadmin
+
+      - name: Check CA users
+        run: |
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-user-find
 
       - name: Check CA security domain
         run: |
-          # security domain should be disabled
           docker exec ca pki-server ca-config-find | grep ^securitydomain. | sort | tee actual
+
+          # security domain should be disabled
           diff /dev/null actual
 
-          docker exec ca pki-server cert-export ca_signing --cert-file ${SHARED}/ca_signing.crt
-
-          docker exec ca pki nss-cert-import \
-              --cert $SHARED/ca_signing.crt \
-              --trust CT,C,C \
-              ca_signing
-
-          docker exec ca pki securitydomain-show \
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              securitydomain-show \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
           # REST API should not return security domain info
           echo "ResourceNotFoundException: " > expected
           diff expected stderr
 
-      - name: Check CA admin
-        run: |
-          docker exec ca pki pkcs12-import \
-              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
-              --pkcs12-password Secret.123
-          docker exec ca pki -n caadmin ca-user-show caadmin
-
       - name: Set up KRA container
         run: |
-          tests/bin/runner-init.sh kra
-        env:
-          HOSTNAME: kra.example.com
-
-      - name: Connect KRA container to network
-        run: docker network connect example kra --alias kra.example.com
+          tests/bin/runner-init.sh \
+              --hostname=kra.example.com \
+              --network=example \
+              --network-alias=kra.example.com \
+              kra
 
       - name: Install standalone KRA (step 1)
         run: |
@@ -107,73 +148,96 @@ jobs:
               -D pki_sslserver_csr_path=${SHARED}/sslserver.csr \
               -D pki_audit_signing_csr_path=${SHARED}/kra_audit_signing.csr \
               -D pki_admin_csr_path=${SHARED}/kra_admin.csr \
+              -D pki_security_domain_setup=False \
               -v
 
       - name: Issue KRA storage cert
         run: |
-          docker exec ca openssl req -text -noout -in ${SHARED}/kra_storage.csr
-          docker exec ca pki \
+          docker exec client openssl req -text -noout -in ${SHARED}/kra_storage.csr
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
               -n caadmin \
               ca-cert-issue \
               --profile caStorageCert \
               --csr-file ${SHARED}/kra_storage.csr \
               --output-file ${SHARED}/kra_storage.crt
-          docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_storage.crt
+
+          docker exec client openssl x509 -text -noout -in ${SHARED}/kra_storage.crt
 
       - name: Issue KRA transport cert
         run: |
-          docker exec ca openssl req -text -noout -in ${SHARED}/kra_transport.csr
-          docker exec ca pki \
+          docker exec client openssl req -text -noout -in ${SHARED}/kra_transport.csr
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
               -n caadmin \
               ca-cert-issue \
               --profile caTransportCert \
               --csr-file ${SHARED}/kra_transport.csr \
               --output-file ${SHARED}/kra_transport.crt
-          docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_transport.crt
+
+          docker exec client openssl x509 -text -noout -in ${SHARED}/kra_transport.crt
 
       - name: Issue subsystem cert
         run: |
-          docker exec ca openssl req -text -noout -in ${SHARED}/subsystem.csr
-          docker exec ca pki \
+          docker exec client openssl req -text -noout -in ${SHARED}/subsystem.csr
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
               -n caadmin \
               ca-cert-issue \
               --profile caSubsystemCert \
               --csr-file ${SHARED}/subsystem.csr \
               --output-file ${SHARED}/subsystem.crt
-          docker exec ca openssl x509 -text -noout -in ${SHARED}/subsystem.crt
+
+          docker exec client openssl x509 -text -noout -in ${SHARED}/subsystem.crt
 
       - name: Issue SSL server cert
         run: |
-          docker exec ca openssl req -text -noout -in ${SHARED}/sslserver.csr
-          docker exec ca pki \
+          docker exec client openssl req -text -noout -in ${SHARED}/sslserver.csr
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
               -n caadmin \
               ca-cert-issue \
               --profile caServerCert \
               --csr-file ${SHARED}/sslserver.csr \
               --output-file ${SHARED}/sslserver.crt
-          docker exec ca openssl x509 -text -noout -in ${SHARED}/sslserver.crt
+
+          docker exec client openssl x509 -text -noout -in ${SHARED}/sslserver.crt
 
       - name: Issue KRA audit signing cert
         run: |
-          docker exec ca openssl req -text -noout -in ${SHARED}/kra_audit_signing.csr
-          docker exec ca pki \
+          docker exec client openssl req -text -noout -in ${SHARED}/kra_audit_signing.csr
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
               -n caadmin \
               ca-cert-issue \
               --profile caAuditSigningCert \
               --csr-file ${SHARED}/kra_audit_signing.csr \
               --output-file ${SHARED}/kra_audit_signing.crt
-          docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_audit_signing.crt
+
+          docker exec client openssl x509 -text -noout -in ${SHARED}/kra_audit_signing.crt
 
       - name: Issue KRA admin cert
         run: |
-          docker exec ca openssl req -text -noout -in ${SHARED}/kra_admin.csr
-          docker exec ca pki \
+          docker exec client openssl req -text -noout -in ${SHARED}/kra_admin.csr
+
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
               -n caadmin \
               ca-cert-issue \
               --profile AdminCert \
               --csr-file ${SHARED}/kra_admin.csr \
               --output-file ${SHARED}/kra_admin.crt
-          docker exec ca openssl x509 -text -noout -in ${SHARED}/kra_admin.crt
+
+          docker exec client openssl x509 -text -noout -in ${SHARED}/kra_admin.crt
+
+      - name: Stop CA
+        run: |
+          docker exec ca pki-server stop --wait
 
       - name: Install standalone KRA (step 2)
         run: |
@@ -194,84 +258,207 @@ jobs:
               -D pki_sslserver_cert_path=${SHARED}/sslserver.crt \
               -D pki_audit_signing_cert_path=${SHARED}/kra_audit_signing.crt \
               -D pki_admin_cert_path=${SHARED}/kra_admin.crt \
+              -D pki_security_domain_setup=False \
               -v
 
       - name: Check KRA server status
         run: |
           docker exec kra pki-server status | tee output
 
-          # standalone KRA should be a domain manager
-          echo "True" > expected
-          sed -n 's/^ *SD Manager: *\(.*\)$/\1/p' output > actual
-          diff expected actual
+          sed -n \
+            -e '/^ *SD Manager:/p' \
+            -e '/^ *SD Name:/p' \
+            -e '/^ *SD Registration URL:/p' \
+            output > actual
+
+          # security domain should be disabled
+          diff /dev/null actual
 
       - name: Check KRA system certs
         run: |
           docker exec kra pki-server cert-find
 
-      # TODO: Fix DogtagKRAConnectivityCheck to work without CA
-      # - name: Run PKI healthcheck
-      #   run: docker exec kra pki-healthcheck --failures-only
+      - name: Run PKI healthcheck
+        run: docker exec kra pki-healthcheck --failures-only
+
+      - name: Start CA
+        run: |
+          docker exec ca pki-server start --wait
+
+      - name: Import KRA certs into client
+        run: |
+          # import transport cert
+          docker exec client pki nss-cert-import \
+              --cert $SHARED/kra_transport.crt \
+              kra_transport
+
+          # export KRA admin cert and key
+          docker exec kra cp \
+              /root/.dogtag/pki-tomcat/kra_admin_cert.p12 \
+              $SHARED/kra_admin_cert.p12
+
+          # import KRA admin cert and key
+          docker exec client pki pkcs12-import \
+              --pkcs12 $SHARED/kra_admin_cert.p12 \
+              --password Secret.123
 
       - name: Check KRA admin
         run: |
-          docker exec kra pki nss-cert-import \
-              --cert $SHARED/ca_signing.crt \
-              --trust CT,C,C \
-              ca_signing
+          # check KRA admin user
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n kraadmin \
+              kra-user-show \
+              kraadmin
 
-          docker exec kra pki pkcs12-import \
-              --pkcs12 /root/.dogtag/pki-tomcat/kra_admin_cert.p12 \
-              --pkcs12-password Secret.123
-          docker exec kra pki -n kraadmin kra-user-show kraadmin
+          # check KRA admin roles
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n kraadmin \
+              kra-user-membership-find \
+              kraadmin
 
       - name: Check KRA users
         run: |
-          docker exec kra pki -n kraadmin kra-user-find
-
-          docker exec kra pki -n kraadmin kra-user-show CA-ca.example.com-8443 \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
-
-          # standalone KRA should not have CA user
-          echo "UserNotFoundException: User CA-ca.example.com-8443 not found" > expected
-          diff expected stderr
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n kraadmin \
+              kra-user-find
 
       - name: Check KRA security domain
         run: |
-          # security domain should be enabled (i.e. securitydomain.select=new)
-          cat > expected << EOF
-          securitydomain.checkIP=false
-          securitydomain.checkinterval=300000
-          securitydomain.flushinterval=86400000
-          securitydomain.host=kra.example.com
-          securitydomain.httpport=8080
-          securitydomain.httpsadminport=8443
-          securitydomain.name=example.com Security Domain
-          securitydomain.select=new
-          securitydomain.source=ldap
-          EOF
-
           docker exec kra pki-server kra-config-find | grep ^securitydomain. | sort | tee actual
-          diff expected actual
 
-          # TODO: Fix pki securitydomain-show to work with standalone KRA
-          # docker exec kra pki securitydomain-show \
-          #     > >(tee stdout) 2> >(tee stderr >&2) || true
-
-          # standalone KRA should return security domain info
+          # security domain should be disabled
+          diff /dev/null actual
 
       - name: Check KRA connector in CA
         run: |
+          # allow CA admin to manage KRA connector
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-user-membership-add \
+              caadmin \
+              "Enterprise KRA Administrators"
+
           # KRA connector should not be configured
           echo -n > expected
           docker exec ca pki-server ca-config-find | grep ^ca.connector.KRA. | tee actual
           diff expected actual
 
-          # REST API should not return KRA connector info
-          echo "ForbiddenException: Authorization Error" > expected
-          docker exec ca pki -n caadmin ca-kraconnector-show \
+          # get KRA connector info via REST API
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-kraconnector-show \
               > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # REST API should not return KRA connector info
+          echo "ConnectorNotFoundException: No KRA connectors" > expected
           diff expected stderr
+
+      - name: Check cert enrollment without KRA
+        run: |
+          # generate key and cert request
+          docker exec client pki \
+              nss-cert-request \
+              --type crmf \
+              --subject UID=testuser1 \
+              --transport kra_transport \
+              --csr testuser1.csr
+
+          # issue cert
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -u caadmin \
+              -w Secret.123 \
+              ca-cert-issue \
+              --request-type crmf \
+              --profile caUserCert \
+              --subject UID=testuser1 \
+              --csr-file testuser1.csr \
+              --output-file testuser1.crt \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # operation should fail
+          echo "PKIException: Server Internal Error: KRA connector not configured" > expected
+          diff expected stderr
+
+      - name: Add CA subsystem user in KRA
+        run: |
+          # export CA subsystem cert
+          docker exec ca pki-server cert-export \
+              --cert-file $SHARED/ca_subsystem.crt \
+              subsystem
+
+          # create CA subsystem user in KRA
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n kraadmin \
+              kra-user-add \
+              --fullName "CA" \
+              --type agentType \
+              --cert-file $SHARED/ca_subsystem.crt \
+              CA
+
+          # allow CA to archive key in KRA
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n kraadmin \
+              kra-user-membership-add \
+              CA \
+              "Trusted Managers"
+
+      - name: Add KRA connector in CA
+        run: |
+          # export transport cert
+          TRANSPORT_CERT=$(docker exec client pki nss-cert-export \
+              --format DER \
+              kra_transport \
+              | base64 --wrap=0)
+
+          tee input.json << EOF
+          {
+              "host": "kra.example.com",
+              "port": "8443",
+              "transportCert": "$TRANSPORT_CERT"
+          }
+          EOF
+
+          # add KRA connector
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n caadmin \
+              ca-kraconnector-add \
+              --input-file $SHARED/input.json
+
+      - name: Check cert enrollment with KRA
+        run: |
+          # generate key and cert request
+          docker exec client pki \
+              nss-cert-request \
+              --type crmf \
+              --subject UID=testuser2 \
+              --transport kra_transport \
+              --csr testuser2.csr
+
+          # issue cert
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -u caadmin \
+              -w Secret.123 \
+              ca-cert-issue \
+              --request-type crmf \
+              --profile caUserCert \
+              --subject UID=testuser2 \
+              --csr-file testuser2.csr \
+              --output-file testuser2.crt
+
+          docker exec client openssl x509 \
+              -text \
+              -noout \
+              -in testuser2.crt
 
       - name: Remove KRA
         run: docker exec kra pkidestroy -s KRA -v
@@ -279,37 +466,32 @@ jobs:
       - name: Remove CA
         run: docker exec ca pkidestroy -s CA -v
 
-      - name: Check PKI server systemd journal in CA container
+      - name: Check CA systemd journal
         if: always()
         run: |
           docker exec ca journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA access log
+        if: always()
+        run: |
+          docker exec ca find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
 
       - name: Check CA debug log
         if: always()
         run: |
           docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
-      - name: Check PKI server systemd journal in KRA container
+      - name: Check KRA systemd journal
         if: always()
         run: |
           docker exec kra journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check KRA access log
+        if: always()
+        run: |
+          docker exec kra find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
 
       - name: Check KRA debug log
         if: always()
         run: |
           docker exec kra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh ca
-          tests/bin/pki-artifacts-save.sh kra
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: kra-standalone
-          path: /tmp/artifacts

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -238,13 +238,18 @@ class PKIServerCLI(pki.cli.CLI):
             print()
             print('  KRA Subsystem:')
 
-            domain_manager = kra.config.get('securitydomain.select') == 'new'
-            print('    SD Manager:          %s' % domain_manager)
-            print('    SD Name:             %s' % kra.config['securitydomain.name'])
-            url = 'https://%s:%s' % (
-                kra.config['securitydomain.host'],
-                kra.config['securitydomain.httpsadminport'])
-            print('    SD Registration URL: %s' % url)
+            sd_type = kra.config.get('securitydomain.select')
+            if sd_type:
+                domain_manager = sd_type == 'new'
+                print('    SD Manager:          %s' % domain_manager)
+
+                sd_name = kra.config['securitydomain.name']
+                print('    SD Name:             %s' % sd_name)
+
+                url = 'https://%s:%s' % (
+                    kra.config['securitydomain.host'],
+                    kra.config['securitydomain.httpsadminport'])
+                print('    SD Registration URL: %s' % url)
 
             enabled = kra.is_enabled()
             print('    Enabled:             %s' % enabled)


### PR DESCRIPTION
The test for standalone KRA has been updated to install the KRA without a security domain while the CA is down. The KRA connector in CA and the CA subsystem user in KRA will be set up after installation by the admin user from a separate client container.

In the future all KRA installations might be done this way to reduce the complexity of the installation code and to make it more reliable (i.e. less dependent on a running CA).

The `pki-server status` has also been updated to support KRA that does not have any security domain params.

https://github.com/dogtagpki/pki/wiki/Setting-up-KRA-Connector
