### PR TITLE
Update TPS container test

### DIFF
--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -558,6 +558,37 @@ jobs:
               tks-user-show \
               admin
 
+      - name: Import KRA transport cert into TKS
+        run: |
+          docker cp kra/certs/kra_transport.crt tks:.
+
+          # import KRA transport cert
+          docker exec tks pki-server cert-import \
+              --input kra_transport.crt \
+              --nickname kra_transport
+
+          # configure TKS to use KRA transport cert
+          docker exec tks pki-server tks-config-set \
+              tks.drm_transport_cert_nickname \
+              kra_transport
+
+      - name: Restart TKS
+        run: |
+          docker restart tks
+          sleep 10
+
+          docker network reload --all
+
+          # wait for TKS to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://tks.example.com:8443
+
       - name: Create TPS subsystem cert
         run: |
           docker exec client pki nss-cert-request \

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -777,7 +777,7 @@ class CertImportCLI(pki.cli.CLI):
     '''
 
     help = '''\
-        Usage: pki-server cert-import [OPTIONS] <Cert ID>
+        Usage: pki-server cert-import [OPTIONS] [Cert ID]
 
           -i, --instance <instance ID>    Instance ID (default: pki-tomcat)
               --token <name>              Token to store the certificate
@@ -820,7 +820,7 @@ class CertImportCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument('cert_id', nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -832,9 +832,15 @@ class PKIDeployer:
                 force=True)
 
             # Merge temporary CS.cfg into /var/lib/pki/<instance>/conf/<subsystem>/CS.cfg
-            # to preserve params in existing CS.cfg
+            # without overwriting existing params
 
-            pki.util.load_properties(tmp_cs_cfg, subsystem.config)
+            tmp_config = {}
+            pki.util.load_properties(tmp_cs_cfg, tmp_config)
+
+            for key, value in tmp_config.items():
+                if key not in subsystem.config:
+                    subsystem.config[key] = value
+
             self.instance.store_properties(subsystem.cs_conf, subsystem.config)
 
         finally:


### PR DESCRIPTION
The TPS container test has been updated to import KRA transport cert into TKS which will be needed later by TPS.

The `pki-server cert-import` and `PKIInstance.cert_import()` have been modified such that the cert ID param is optional to allow the command to be used to import non-system certs into the server's NSS database.

The `PKIDeployer.create_cs_cfg()` has been updated to merge the template `CS.cfg` from `/usr/share/pki` into the existing `CS.cfg` in the instance without overwriting existing params.

https://github.com/dogtagpki/pki/wiki/Setting-up-Token-Management-System