### PR TITLE
Fix pki CLI help commands list

### DIFF
--- a/base/common/python/pki/cli/__init__.py
+++ b/base/common/python/pki/cli/__init__.py
@@ -38,6 +38,7 @@ class CLI(object):
 
         self.modules = collections.OrderedDict()
         self.parser = None
+        self.extra_commands = None
 
     def get_full_name(self):
         if self.parent:
@@ -67,14 +68,20 @@ class CLI(object):
     def print_help(self):
 
         print('Commands:')
+        commands = {}
+
+        if self.extra_commands:
+            commands = self.extra_commands.copy()
 
         for module in itervalues(self.modules):
 
             if module.deprecated:
                 continue
 
-            full_name = module.get_full_name()
-            print(' {:32}{:30}'.format(full_name, module.description))
+            commands[module.get_full_name()] = module.description
+
+        for command, description in commands.items():
+            print(' {:32}{:30}'.format(command, description))
 
         first = True
 

--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -35,6 +35,23 @@ logger = logging.getLogger(__name__)
 
 PYTHON_COMMANDS = ['password-generate', 'pkcs12-import']
 
+JAVA_COMMANDS = {
+    'help': 'Show help messages',
+    'client': 'Client management commands',
+    'nss': 'NSS management commands',
+    'info': 'Display server info',
+    'securitydomain': 'Security domain commands',
+    'acme': 'ACME management commands',
+    'ca': 'CA management commands',
+    'kra': 'KRA management commands',
+    'ocsp': 'OCSP management commands',
+    'tks': 'TKS management commands',
+    'tps': 'TPS management commands',
+    'pkcs7': 'PKCS #7 utilities',
+    'pkcs11': 'PKCS #11 utilities',
+    'pkcs12': 'PKCS #12 utilities'
+}
+
 
 class PKICLI(pki.cli.CLI):
 
@@ -71,6 +88,8 @@ class PKICLI(pki.cli.CLI):
 
         self.add_module(pki.cli.password.PasswordCLI())
         self.add_module(pki.cli.pkcs12.PKCS12CLI())
+
+        self.extra_commands = JAVA_COMMANDS.copy()
 
     def create_parser(self, subparsers=None):
 


### PR DESCRIPTION
A list of java commands is included in the python code to be included in the help.

The pki help command, or when no command is provided, returns a list of commands based on the initialised python CLI modules ignoring the commands implemented by the java CLI. The new list include these and it is printed in the help so all possible commands are shown.

Fixes: #5061