### PR TITLE
Add pki-server tps-connector-add

### DIFF
--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -807,6 +807,77 @@ jobs:
               tps-user-show \
               admin
 
+      - name: Add TPS subsystem user in CA
+        run: |
+          docker cp tps/certs/subsystem.crt ca:tps_subsystem.crt
+
+          docker exec ca pki-server ca-user-add \
+              --full-name "TPS-tps.example.com-8443" \
+              --type agentType \
+              --cert tps_subsystem.crt \
+              TPS-tps.example.com-8443
+
+          docker exec ca pki-server ca-user-role-add \
+              TPS-tps.example.com-8443 \
+              "Certificate Manager Agents"
+
+          docker exec ca pki-server ca-user-role-add \
+              TPS-tps.example.com-8443 \
+              "Subsystem Group"
+
+      - name: Add CA connector in TPS
+        run: |
+          docker exec tps pki-server tps-connector-add \
+              --type CA \
+              --url https://ca.example.com:8443 \
+              --nickname subsystem \
+              ca1
+
+      - name: Add TPS subsystem user in KRA
+        run: |
+          docker cp tps/certs/subsystem.crt kra:tps_subsystem.crt
+
+          docker exec kra pki-server kra-user-add \
+              --full-name "TPS-tps.example.com-8443" \
+              --type agentType \
+              --cert tps_subsystem.crt \
+              TPS-tps.example.com-8443
+
+          docker exec kra pki-server kra-user-role-add \
+              TPS-tps.example.com-8443 \
+              "Data Recovery Manager Agents"
+
+      - name: Add KRA connector in TPS
+        run: |
+          docker exec tps pki-server tps-connector-add \
+             --type KRA \
+             --url https://kra.example.com:8443 \
+             --nickname subsystem \
+             kra1
+
+      - name: Add TPS subsystem user in TKS
+        run: |
+          docker cp tps/certs/subsystem.crt tks:tps_subsystem.crt
+
+          docker exec tks pki-server tks-user-add \
+              --full-name "TPS-tps.example.com-8443" \
+              --type agentType \
+              --cert tps_subsystem.crt \
+              TPS-tps.example.com-8443
+
+          docker exec tks pki-server tks-user-role-add \
+              TPS-tps.example.com-8443 \
+              "Token Key Service Manager Agents"
+
+      - name: Add TKS connector in TPS
+        run: |
+          docker exec tps pki-server tps-connector-add \
+             --type TKS \
+             --url https://tks.example.com:8443 \
+             --nickname subsystem \
+             --keygen \
+             tks1
+
       - name: Restart TPS
         run: |
           docker restart tps
@@ -824,7 +895,7 @@ jobs:
               -o /dev/null \
               https://tps.example.com:8443
 
-      - name: Check TPS admin user again
+      - name: Check TPS admin user after restart
         run: |
           docker exec client pki \
               -U https://tps.example.com:8443 \
@@ -832,8 +903,86 @@ jobs:
               tps-user-show \
               admin
 
+      - name: Check TPS subsystem user in CA after restart
+        run: |
+          docker exec ca pki-server ca-user-show TPS-tps.example.com-8443
+          docker exec ca pki-server ca-user-role-find TPS-tps.example.com-8443
+
+      - name: Check CA connector in TPS after restart
+        run: |
+          docker exec tps pki-server tps-config-find | grep ^tps.connector.ca1. | tee output
+
+          cat > expected << EOF
+          tps.connector.ca1.enable=true
+          tps.connector.ca1.host=ca.example.com
+          tps.connector.ca1.maxHttpConns=15
+          tps.connector.ca1.minHttpConns=1
+          tps.connector.ca1.nickName=subsystem
+          tps.connector.ca1.port=8443
+          tps.connector.ca1.timeout=30
+          tps.connector.ca1.uri.enrollment=/ca/ee/ca/profileSubmitSSLClient
+          tps.connector.ca1.uri.getcert=/ca/ee/ca/displayBySerial
+          tps.connector.ca1.uri.renewal=/ca/ee/ca/profileSubmitSSLClient
+          tps.connector.ca1.uri.revoke=/ca/ee/subsystem/ca/doRevoke
+          tps.connector.ca1.uri.unrevoke=/ca/ee/subsystem/ca/doUnrevoke
+          EOF
+
+          diff expected output
+
+      - name: Check TPS subsystem user in KRA after restart
+        run: |
+          docker exec kra pki-server kra-user-show TPS-tps.example.com-8443
+          docker exec kra pki-server kra-user-role-find TPS-tps.example.com-8443
+
+      - name: Check KRA connector in TPS after restart
+        run: |
+          docker exec tps pki-server tps-config-find | grep ^tps.connector.kra1. | tee output
+
+          cat > expected << EOF
+          tps.connector.kra1.enable=true
+          tps.connector.kra1.host=kra.example.com
+          tps.connector.kra1.maxHttpConns=15
+          tps.connector.kra1.minHttpConns=1
+          tps.connector.kra1.nickName=subsystem
+          tps.connector.kra1.port=8443
+          tps.connector.kra1.timeout=30
+          tps.connector.kra1.uri.GenerateKeyPair=/kra/agent/kra/GenerateKeyPair
+          tps.connector.kra1.uri.TokenKeyRecovery=/kra/agent/kra/TokenKeyRecovery
+          EOF
+
+          diff expected output
+
+      - name: Check TPS subsystem user in TKS after restart
+        run: |
+          docker exec tks pki-server tks-user-show TPS-tps.example.com-8443
+          docker exec tks pki-server tks-user-role-find TPS-tps.example.com-8443
+
+      - name: Check TKS connector in TPS after restart
+        run: |
+          docker exec tps pki-server tps-config-find | grep ^tps.connector.tks1. | tee output
+
+          cat > expected << EOF
+          tps.connector.tks1.enable=true
+          tps.connector.tks1.generateHostChallenge=true
+          tps.connector.tks1.host=tks.example.com
+          tps.connector.tks1.keySet=defKeySet
+          tps.connector.tks1.maxHttpConns=15
+          tps.connector.tks1.minHttpConns=1
+          tps.connector.tks1.nickName=subsystem
+          tps.connector.tks1.port=8443
+          tps.connector.tks1.serverKeygen=true
+          tps.connector.tks1.timeout=30
+          tps.connector.tks1.tksSharedSymKeyName=sharedSecret
+          tps.connector.tks1.uri.computeRandomData=/tks/agent/tks/computeRandomData
+          tps.connector.tks1.uri.computeSessionKey=/tks/agent/tks/computeSessionKey
+          tps.connector.tks1.uri.createKeySetData=/tks/agent/tks/createKeySetData
+          tps.connector.tks1.uri.encryptData=/tks/agent/tks/encryptData
+          EOF
+
+          diff expected output
+
       # TODO:
-      # - set up connectors
+      # - set up TPS connector in TKS
       # - set up shared secret
       # - test token format and enroll operations
 

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -225,6 +225,21 @@ jobs:
           docker exec tps pki -n caadmin --ignore-banner \
               tps-user-show tpsadmin
 
+      - name: Check TPS subsystem user in CA
+        run: |
+          docker exec ca pki-server ca-user-show TPS-tps.example.com-8443
+          docker exec ca pki-server ca-user-role-find TPS-tps.example.com-8443
+
+      - name: Check TPS subsystem user in KRA
+        run: |
+          docker exec kra pki-server kra-user-show TPS-tps.example.com-8443
+          docker exec kra pki-server kra-user-role-find TPS-tps.example.com-8443
+
+      - name: Check TPS subsystem user in TKS
+        run: |
+          docker exec tks pki-server tks-user-show TPS-tps.example.com-8443
+          docker exec tks pki-server tks-user-role-find TPS-tps.example.com-8443
+
       - name: Check TPS users
         run: |
           docker exec tps pki-server tps-user-find

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1377,112 +1377,6 @@ class PKIDeployer:
             logger.debug('Setting ephemeral requests to true')
             subsystem.set_config('kra.ephemeralRequests', 'true')
 
-    def add_tps_ca_connector(self, name, ca_url, subsystem, fullname, timestamp):
-
-        subsystem.set_config('tps.connector.%s.enable' % name, 'true')
-        subsystem.set_config('tps.connector.%s.host' % name, ca_url.hostname)
-        subsystem.set_config('tps.connector.%s.port' % name, str(ca_url.port))
-        subsystem.set_config('tps.connector.%s.minHttpConns' % name, '1')
-        subsystem.set_config('tps.connector.%s.maxHttpConns' % name, '15')
-        subsystem.set_config('tps.connector.%s.nickName' % name, fullname)
-        subsystem.set_config('tps.connector.%s.timeout' % name, '30')
-
-        subsystem.set_config(
-            'tps.connector.%s.uri.enrollment' % name,
-            '/ca/ee/ca/profileSubmitSSLClient')
-        subsystem.set_config(
-            'tps.connector.%s.uri.getcert' % name,
-            '/ca/ee/ca/displayBySerial')
-        subsystem.set_config(
-            'tps.connector.%s.uri.renewal' % name,
-            '/ca/ee/ca/profileSubmitSSLClient')
-        subsystem.set_config(
-            'tps.connector.%s.uri.revoke' % name,
-            '/ca/ee/subsystem/ca/doRevoke')
-        subsystem.set_config(
-            'tps.connector.%s.uri.unrevoke' % name,
-            '/ca/ee/subsystem/ca/doUnrevoke')
-
-        subsystem.set_config('config.Subsystem_Connections.%s.state' % name, 'Enabled')
-        subsystem.set_config('config.Subsystem_Connections.%s.timestamp' % name, timestamp)
-
-        cons = subsystem.config.get('target.Subsystem_Connections.list', '').split(',')
-        if len(cons) == 1 and not cons[0]:
-            # drop default blank value
-            cons = [name]
-        elif name not in cons:
-            # add new connector
-            cons.append(name)
-        subsystem.set_config('target.Subsystem_Connections.list', ','.join(cons))
-
-    def add_tps_kra_connector(self, name, kra_url, subsystem, fullname, timestamp):
-
-        subsystem.set_config('tps.connector.%s.enable' % name, 'true')
-        subsystem.set_config('tps.connector.%s.host' % name, kra_url.hostname)
-        subsystem.set_config('tps.connector.%s.port' % name, str(kra_url.port))
-        subsystem.set_config('tps.connector.%s.minHttpConns' % name, '1')
-        subsystem.set_config('tps.connector.%s.maxHttpConns' % name, '15')
-        subsystem.set_config('tps.connector.%s.nickName' % name, fullname)
-        subsystem.set_config('tps.connector.%s.timeout' % name, '30')
-
-        subsystem.set_config(
-            'tps.connector.%s.uri.GenerateKeyPair' % name,
-            '/kra/agent/kra/GenerateKeyPair')
-        subsystem.set_config(
-            'tps.connector.%s.uri.TokenKeyRecovery' % name,
-            '/kra/agent/kra/TokenKeyRecovery')
-
-        subsystem.set_config('config.Subsystem_Connections.%s.state' % name, 'Enabled')
-        subsystem.set_config('config.Subsystem_Connections.%s.timestamp' % name, timestamp)
-
-        cons = subsystem.config.get('target.Subsystem_Connections.list', '').split(',')
-        if len(cons) == 1 and not cons[0]:
-            # drop default blank value
-            cons = [name]
-        elif name not in cons:
-            # add new connector
-            cons.append(name)
-        subsystem.set_config('target.Subsystem_Connections.list', ','.join(cons))
-
-    def add_tps_tks_connector(self, name, tks_url, subsystem, fullname, timestamp):
-
-        subsystem.set_config('tps.connector.%s.enable' % name, 'true')
-        subsystem.set_config('tps.connector.%s.host' % name, tks_url.hostname)
-        subsystem.set_config('tps.connector.%s.port' % name, str(tks_url.port))
-        subsystem.set_config('tps.connector.%s.minHttpConns' % name, '1')
-        subsystem.set_config('tps.connector.%s.maxHttpConns' % name, '15')
-        subsystem.set_config('tps.connector.%s.nickName' % name, fullname)
-        subsystem.set_config('tps.connector.%s.timeout' % name, '30')
-        subsystem.set_config('tps.connector.%s.generateHostChallenge' % name, 'true')
-        subsystem.set_config('tps.connector.%s.serverKeygen' % name, 'false')
-        subsystem.set_config('tps.connector.%s.keySet' % name, 'defKeySet')
-        subsystem.set_config('tps.connector.%s.tksSharedSymKeyName' % name, 'sharedSecret')
-
-        subsystem.set_config(
-            'tps.connector.%s.uri.computeRandomData' % name,
-            '/tks/agent/tks/computeRandomData')
-        subsystem.set_config(
-            'tps.connector.%s.uri.computeSessionKey' % name,
-            '/tks/agent/tks/computeSessionKey')
-        subsystem.set_config(
-            'tps.connector.%s.uri.createKeySetData' % name,
-            '/tks/agent/tks/createKeySetData')
-        subsystem.set_config(
-            'tps.connector.%s.uri.encryptData' % name,
-            '/tks/agent/tks/encryptData')
-
-        subsystem.set_config('config.Subsystem_Connections.%s.state' % name, 'Enabled')
-        subsystem.set_config('config.Subsystem_Connections.%s.timestamp' % name, timestamp)
-
-        cons = subsystem.config.get('target.Subsystem_Connections.list', '').split(',')
-        if len(cons) == 1 and not cons[0]:
-            # drop default blank value
-            cons = [name]
-        elif name not in cons:
-            # add new connector
-            cons.append(name)
-        subsystem.set_config('target.Subsystem_Connections.list', ','.join(cons))
-
     def configure_tps(self, subsystem):
 
         baseDN = subsystem.config['internaldb.basedn']
@@ -1500,29 +1394,37 @@ class PKIDeployer:
         else:
             fullname = token + ':' + nickname
 
-        timestamp = round(time.time() * 1000 * 1000)
-
-        if self.mdict['pki_ca_uri']:
-            logger.info('Configuring CA connector')
-            ca_url = urllib.parse.urlparse(self.mdict['pki_ca_uri'])
-            self.add_tps_ca_connector('ca1', ca_url, subsystem, fullname, timestamp)
-
-        if self.mdict['pki_tks_uri']:
-            logger.info('Configuring TKS connector')
-            tks_url = urllib.parse.urlparse(self.mdict['pki_tks_uri'])
-            self.add_tps_tks_connector('tks1', tks_url, subsystem, fullname, timestamp)
-
         keygen = config.str2bool(self.mdict['pki_enable_server_side_keygen'])
 
+        if self.mdict['pki_ca_uri'] and not subsystem.get_connector('ca1'):
+
+            logger.info('Configuring CA connector')
+            subsystem.add_connector(
+                connector_id='ca1',
+                connector_type='CA',
+                url=urllib.parse.urlparse(self.mdict['pki_ca_uri']),
+                nickname=fullname)
+
+        if self.mdict['pki_tks_uri'] and not subsystem.get_connector('tks1'):
+
+            logger.info('Configuring TKS connector')
+            subsystem.add_connector(
+                connector_id='tks1',
+                connector_type='TKS',
+                url=urllib.parse.urlparse(self.mdict['pki_tks_uri']),
+                nickname=fullname,
+                keygen=keygen)
+
+        if keygen and self.mdict['pki_kra_uri'] and not subsystem.get_connector('kra1'):
+
+            logger.info('Configuring KRA connector')
+            subsystem.add_connector(
+                connector_id='kra1',
+                connector_type='KRA',
+                url=urllib.parse.urlparse(self.mdict['pki_kra_uri']),
+                nickname=fullname)
+
         if keygen:
-            if self.mdict['pki_kra_uri']:
-                logger.info('Configuring KRA connector')
-                kra_url = urllib.parse.urlparse(self.mdict['pki_kra_uri'])
-                self.add_tps_kra_connector('kra1', kra_url, subsystem, fullname, timestamp)
-
-            if self.mdict['pki_tks_uri']:
-                subsystem.set_config('tps.connector.tks1.serverKeygen', 'true')
-
             # TODO: see if there are other profiles need to be configured
             subsystem.set_config(
                 'op.enroll.delegateIEtoken.keyGen.encryption.serverKeygen.enable',


### PR DESCRIPTION
The `pki-server tps-connector-add` has been added to create CA, KRA, and TKS connectors in TPS.

The TPS container test has been updated to create TPS subsystem users in CA, KRA, and TKS and the corresponding connectors in TPS.

The code that creates the connectors in `PKIDeployment` has been moved into `TPSSubsystem.add_connector()`.

The `TPSSubsystem.get_connector()` has been modified to return `None` if the connector doesn't exist.

https://github.com/dogtagpki/pki/wiki/Setting-up-Token-Management-System
