### PR TITLE
Add pki-server tks-connector-* commands

### DIFF
--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -572,6 +572,24 @@ jobs:
               tks.drm_transport_cert_nickname \
               kra_transport
 
+      - name: Create shared secret in TKS
+        run: |
+          docker exec tks pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              nss-key-create \
+              --key-type AES \
+              --op-flags WRAP,UNWRAP,ENCRYPT,ENCRYPT \
+              "TPS-tps.example.com-8443 sharedSecret"
+
+      - name: Add TPS connector in TKS
+        run: |
+          docker exec tks pki-server tks-connector-add \
+             --url https://tps.example.com:8443 \
+             --nickname "TPS-tps.example.com-8443 sharedSecret" \
+             --uid TPS-tps.example.com-8443 \
+             0
+
       - name: Restart TKS
         run: |
           docker restart tks
@@ -588,6 +606,20 @@ jobs:
               -k \
               -o /dev/null \
               https://tks.example.com:8443
+
+      - name: Check TPS connector in TKS after restart
+        run: |
+          docker exec tks pki-server tks-config-find | grep ^tps. | sort | tee output
+
+          cat > expected << EOF
+          tps.0.host=tps.example.com
+          tps.0.nickname=TPS-tps.example.com-8443 sharedSecret
+          tps.0.port=8443
+          tps.0.userid=TPS-tps.example.com-8443
+          tps.list=0
+          EOF
+
+          diff expected output
 
       - name: Create TPS subsystem cert
         run: |
@@ -878,6 +910,34 @@ jobs:
              --keygen \
              tks1
 
+      - name: Import shared secret into TPS
+        run: |
+          # export shared secret from TKS
+          docker exec tks pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              nss-key-export \
+              --wrapper-cert tps_subsystem.crt \
+              --output shared-secret.json \
+              "TPS-tps.example.com-8443 sharedSecret"
+
+          docker cp tks:shared-secret.json .
+          docker cp shared-secret.json tps:.
+
+          # import shared secret into TPS
+          docker exec tps pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              nss-key-import \
+              --input shared-secret.json \
+              --wrapper subsystem \
+              "TPS-tps.example.com-8443 sharedSecret"
+
+          # configure shared secret in TPS
+          docker exec tps pki-server tps-config-set \
+              conn.tks1.tksSharedSymKeyName \
+              "TPS-tps.example.com-8443 sharedSecret"
+
       - name: Restart TPS
         run: |
           docker restart tps
@@ -981,9 +1041,22 @@ jobs:
 
           diff expected output
 
+      - name: Check shared secret in TPS after restart
+        run: |
+          docker exec tps pki \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -f /var/lib/pki/pki-tomcat/conf/password.conf \
+              nss-key-find
+
+          docker exec tps pki-server tps-config-find | grep ^conn. | tee output
+
+          cat > expected << EOF
+          conn.tks1.tksSharedSymKeyName=TPS-tps.example.com-8443 sharedSecret
+          EOF
+
+          diff expected output
+
       # TODO:
-      # - set up TPS connector in TKS
-      # - set up shared secret
       # - test token format and enroll operations
 
       - name: Check CA DS server systemd journal

--- a/.github/workflows/tps-separate-test.yml
+++ b/.github/workflows/tps-separate-test.yml
@@ -270,6 +270,19 @@ jobs:
 
           diff expected output
 
+      - name: Check TPS connector in TKS
+        run: |
+          docker exec tks pki-server tks-connector-find | tee output
+
+          cat > expected << EOF
+            Connector ID: 0
+            URL: https://tps.example.com:8443
+            Nickname: TPS-tps.example.com-8443 sharedSecret
+            User ID: TPS-tps.example.com-8443
+          EOF
+
+          diff expected output
+
       - name: Remove TPS
         run: docker exec tps pkidestroy -s TPS -v
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -2774,6 +2774,69 @@ class TKSSubsystem(PKISubsystem):
     def __init__(self, instance):
         super().__init__(instance, 'tks')
 
+    def get_connector_ids(self):
+
+        connector_ids = self.config.get('tps.list', '').split(',')
+
+        # if first ID is not empty, return all IDs
+        if len(connector_ids) > 0 and connector_ids[0]:
+            return sorted(connector_ids)
+
+        # otherwise, return empty list
+        return []
+
+    def get_connectors(self):
+
+        connectors = []
+
+        for connector_id in self.get_connector_ids():
+            connector = self.get_connector(connector_id)
+            connectors.append(connector)
+
+        return connectors
+
+    def get_connector(self, connector_id):
+
+        connector = {}
+
+        connector['id'] = connector_id
+
+        host = self.config.get('tps.%s.host' % connector_id)
+        port = self.config.get('tps.%s.port' % connector_id)
+        connector['url'] = 'https://{}:{}'.format(host, port)
+
+        connector['nickname'] = self.config.get('tps.%s.nickname' % connector_id)
+        connector['uid'] = self.config.get('tps.%s.userid' % connector_id)
+
+        return connector
+
+    def add_connector(
+            self,
+            connector_id,
+            url,
+            nickname,
+            uid):
+
+        self.set_config('tps.%s.host' % connector_id, url.hostname)
+        self.set_config('tps.%s.port' % connector_id, str(url.port))
+        self.set_config('tps.%s.nickname' % connector_id, nickname)
+        self.set_config('tps.%s.userid' % connector_id, uid)
+
+        cons = self.config.get('tps.list', '').split(',')
+
+        if len(cons) == 1 and not cons[0]:
+            # drop default blank value
+            cons = [connector_id]
+
+        elif connector_id not in cons:
+            # add new connector
+            cons.append(connector_id)
+
+        else:
+            raise Exception('Connector already exists: {}'.format(connector_id))
+
+        self.set_config('tps.list', ','.join(cons))
+
 
 class TPSSubsystem(PKISubsystem):
 


### PR DESCRIPTION
The `pki-server tks-connector-find` and `tks-connector-add` commands have been added to manage connectors in TKS.

The TPS container test has been updated to add a TPS connector in TKS and create a shared secret for TKS and TPS.

https://github.com/dogtagpki/pki/wiki/Setting-up-Token-Management-System