### PR TITLE
Move some logging.info to logging.debug to suppress some output

### DIFF
--- a/base/common/python/pki/client.py
+++ b/base/common/python/pki/client.py
@@ -421,7 +421,7 @@ class PKIClient:
 
     def connect(self):
 
-        logger.info('Connecting to %s', urllib.parse.urlunparse(self.url))
+        logger.debug('Connecting to %s', urllib.parse.urlunparse(self.url))
 
         self.info = self.info_client.get_info()
 

--- a/base/common/python/pki/info.py
+++ b/base/common/python/pki/info.py
@@ -140,7 +140,7 @@ class InfoClient(object):
         for api_path in api_paths:
             try:
                 path = '/pki/%s/info' % api_path
-                logger.info('Getting PKI server info from %s', path)
+                logger.debug('Getting PKI server info from %s', path)
 
                 response = self.connection.get(path, headers)
                 # REST API path available -> done


### PR DESCRIPTION
This generates quite a lot of extraneous output during an IPA server installation:

  [26/33]: importing IPA certificate profiles
Connecting to https://localhost:8443
Getting PKI server info from /pki/v2/info
Connecting to https://localhost:8443
Getting PKI server info from /pki/v2/info
Connecting to https://localhost:8443
Getting PKI server info from /pki/v2/info
Connecting to https://localhost:8443
Getting PKI server info from /pki/v2/info
Connecting to https://localhost:8443
Getting PKI server info from /pki/v2/info
  [27/33]: migrating certificate profiles to LDAP
  [28/33]: adding default CA ACL
  [29/33]: adding 'ipa' CA entry
Connecting to https://localhost:8443
Getting PKI server info from /pki/v2/info
  [30/33]: Recording random serial number state
  [31/33]: Recording HSM configuration state
  [32/33]: configuring certmonger renewal for lightweight CAs
  [33/33]: deploying ACME service
Done configuring certificate server (pki-tomcatd). Configuring directory server (dirsrv)
  [1/3]: configuring TLS for DS instance
Connecting to https://localhost:8443
Getting PKI server info from /pki/v2/info
  [2/3]: adding CA certificate entry
  [3/3]: restarting directory server