### PR TITLE
Add MCP_TESTS_ENABLED variable

### DIFF
--- a/.github/workflows/server-mcp-test.yml
+++ b/.github/workflows/server-mcp-test.yml
@@ -113,8 +113,8 @@ jobs:
               --prompt "show me all users in CA subsystem" \
               | tee output
 
-          # get usernames
-          sed -n 's/^\*\s\+\(\S\+\)\s\+.*$/\1/p' output > actual
+          # get usernames from bulleted or numbered list
+          sed -n 's/^[\*0-9]\+\.\?\s\+\(\S\+\)\s\+.*$/\1/p' output > actual
 
           cat > expected << EOF
           CA-pki.example.com-8443

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -50,5 +50,6 @@ jobs:
 
   server-mcp-test:
     name: MCP server
+    if: vars.MCP_TESTS_ENABLED == 'true'
     needs: build
     uses: ./.github/workflows/server-mcp-test.yml


### PR DESCRIPTION
The MCP server test has been modified to run only if the `MCP_TESTS_ENABLED` variable is set to 'true'.

The test has also been updated to use a regex that will work with bulleted and numbered list.

https://github.com/dogtagpki/pki/wiki/Model-Context-Protocol
