### PR TITLE
Add pki-server ca-connector-* commands

### DIFF
--- a/.github/workflows/ipa-acme-test.yml
+++ b/.github/workflows/ipa-acme-test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install KRA in IPA container
         run: |
           docker exec ipa ipa-kra-install -p Secret.123
-          docker exec ipa pki-server ca-config-find | grep ca.connector.KRA
+          docker exec ipa pki-server ca-connector-find
 
       - name: Verify CA admin in IPA container
         run: |

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -137,15 +137,17 @@ jobs:
 
       - name: Check KRA connector config
         run: |
-          # KRA connector should be enabled
-          echo "true" > expected
-          docker exec primary pki-server ca-config-show ca.connector.KRA.enable | tee actual
-          diff expected actual
+          docker exec primary pki-server ca-connector-find | tee output
 
-          # KRA connector points to primary KRA
-          echo "primary.example.com" > expected
-          docker exec primary pki-server ca-config-show ca.connector.KRA.host | tee actual
-          diff expected actual
+          # KRA connector should be enabled and point to primary KRA
+          cat > expected << EOF
+            Connector ID: KRA
+            Enabled: true
+            URL: https://primary.example.com:8443
+            Nickname: subsystem
+          EOF
+
+          diff expected output
 
       - name: Check primary IPA server config after KRA installation
         run: |
@@ -439,27 +441,33 @@ jobs:
               -o ldif_wrap=no \
               -LLL
 
-      - name: Check KRA connector config
+      - name: Check KRA connector config in primary CA
         run: |
-          # KRA connector should be enabled in primary CA
-          echo "true" > expected
-          docker exec primary pki-server ca-config-show ca.connector.KRA.enable | tee actual
-          diff expected actual
+          docker exec primary pki-server ca-connector-find | tee output
 
-           # KRA connector should be enabled in secondary CA
-          echo "true" > expected
-          docker exec secondary pki-server ca-config-show ca.connector.KRA.enable | tee actual
-          diff expected actual
+          # KRA connector should be enabled and point to primary KRA
+          cat > expected << EOF
+            Connector ID: KRA
+            Enabled: true
+            URL: https://primary.example.com:8443
+            Nickname: subsystem
+          EOF
 
-          # KRA connector points to primary KRA in primary CA
-          echo "primary.example.com" > expected
-          docker exec primary pki-server ca-config-show ca.connector.KRA.host | tee actual
-          diff expected actual
+          diff expected output
 
-          # KRA connector points to both KRAs in secondary CA
-          echo "primary.example.com:8443 secondary.example.com:8443" > expected
-          docker exec secondary pki-server ca-config-show ca.connector.KRA.host | tee actual
-          diff expected actual
+      - name: Check KRA connector config in secondary CA
+        run: |
+          docker exec secondary pki-server ca-connector-find | tee output
+
+          # KRA connector should be enabled and point to both KRAs
+          cat > expected << EOF
+            Connector ID: KRA
+            Enabled: true
+            URL: https://primary.example.com:8443 https://secondary.example.com:8443
+            Nickname: subsystem
+          EOF
+
+          diff expected output
 
           # KRA connectors should be consistent
           # https://pagure.io/freeipa/issue/9432
@@ -771,12 +779,19 @@ jobs:
 
       - name: Check KRA connector after removing primary server
         run: |
-          # KRA connector should only point to secondary KRA,
-          # but currently primary KRA is still listed
+          docker exec secondary pki-server ca-connector-find | tee output
+
+          # KRA connector should point to secondary KRA
+          cat > expected << EOF
+            Connector ID: KRA
+            Enabled: true
+            URL: https://secondary.example.com:8443
+            Nickname: subsystem
+          EOF
+
+          # currently it points to primary KRA
           # https://pagure.io/freeipa/issue/9432
-          echo "secondary.example.com" > expected
-          docker exec secondary pki-server ca-config-show ca.connector.KRA.host | tee actual
-          diff expected actual || true
+          diff expected output || true
 
       - name: Check IPA CA install log in secondary container
         if: always()

--- a/.github/workflows/ipa-kra-test.yml
+++ b/.github/workflows/ipa-kra-test.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install KRA
         run: |
           docker exec ipa ipa-kra-install -p Secret.123
-          docker exec ipa pki-server ca-config-find | grep ca.connector.KRA
+          docker exec ipa pki-server ca-connector-find
 
       - name: Check PKI certs and keys
         run: |

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -318,20 +318,17 @@ jobs:
 
       - name: Check KRA connector in CA
         run: |
-          docker exec pki pki-server ca-config-find | grep ^ca.connector.KRA. | sort | tee output
+          docker exec pki pki-server ca-connector-find | tee output
 
           # KRA connector should be configured
           cat > expected << EOF
-          ca.connector.KRA.enable=true
-          ca.connector.KRA.host=pki.example.com
-          ca.connector.KRA.local=false
-          ca.connector.KRA.nickName=subsystem
-          ca.connector.KRA.port=8443
-          ca.connector.KRA.timeout=30
-          ca.connector.KRA.uri=/kra/agent/kra/connector
+            Connector ID: KRA
+            Enabled: true
+            URL: https://pki.example.com:8443
+            Nickname: subsystem
           EOF
-          sed -e '/^ca.connector.KRA.transportCert=/d' output > actual
-          diff expected actual
+
+          diff expected output
 
           # REST API should return KRA connector info
           docker exec pki pki -n caadmin ca-kraconnector-show | tee output

--- a/.github/workflows/kra-clone-failover-test.yml
+++ b/.github/workflows/kra-clone-failover-test.yml
@@ -166,25 +166,16 @@ jobs:
 
       - name: Check KRA connector in CA
         run: |
-          docker exec ca pki-server ca-config-find \
-              | grep ^ca.connector.KRA. \
-              | sort \
-              | tee output
-
-          # exclude transport cert
-          sed -e '/^ca.connector.KRA.transportCert=/d' output > actual
+          docker exec ca pki-server ca-connector-find | tee output
 
           cat > expected << EOF
-          ca.connector.KRA.enable=true
-          ca.connector.KRA.host=primarykra.example.com
-          ca.connector.KRA.local=false
-          ca.connector.KRA.nickName=subsystem
-          ca.connector.KRA.port=8443
-          ca.connector.KRA.timeout=30
-          ca.connector.KRA.uri=/kra/agent/kra/connector
+            Connector ID: KRA
+            Enabled: true
+            URL: https://primarykra.example.com:8443
+            Nickname: subsystem
           EOF
 
-          diff expected actual
+          diff expected output
 
       - name: Import certs for client
         run: |
@@ -304,26 +295,17 @@ jobs:
 
       - name: Check KRA connector in CA
         run: |
-          docker exec ca pki-server ca-config-find \
-              | grep ^ca.connector.KRA. \
-              | sort \
-              | tee output
-
-          # exclude transport cert
-          sed -e '/^ca.connector.KRA.transportCert=/d' output > actual
+          docker exec ca pki-server ca-connector-find | tee output
 
           # KRA connector should have multiple KRAs
           cat > expected << EOF
-          ca.connector.KRA.enable=true
-          ca.connector.KRA.host=primarykra.example.com:8443 secondarykra.example.com:8443
-          ca.connector.KRA.local=false
-          ca.connector.KRA.nickName=subsystem
-          ca.connector.KRA.port=8443
-          ca.connector.KRA.timeout=30
-          ca.connector.KRA.uri=/kra/agent/kra/connector
+            Connector ID: KRA
+            Enabled: true
+            URL: https://primarykra.example.com:8443 https://secondarykra.example.com:8443
+            Nickname: subsystem
           EOF
 
-          diff expected actual
+          diff expected output
 
       - name: Check admin access to secondary KRA
         run: |

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -472,17 +472,12 @@ jobs:
 
       - name: Configure KRA connector in CA
         run: |
-          docker exec ca pki-server ca-config-set ca.connector.KRA.enable true
-          docker exec ca pki-server ca-config-set ca.connector.KRA.host kra.example.com
-          docker exec ca pki-server ca-config-set ca.connector.KRA.local false
-          docker exec ca pki-server ca-config-set ca.connector.KRA.nickName subsystem
-          docker exec ca pki-server ca-config-set ca.connector.KRA.port 8443
-          docker exec ca pki-server ca-config-set ca.connector.KRA.timeout 30
-          docker exec ca pki-server ca-config-set ca.connector.KRA.uri /kra/agent/kra/connector
-
-          TRANSPORT_CERT=$(openssl x509 -outform der -in kra/certs/kra_transport.crt | base64 --wrap=0)
-          echo "Transport cert: $TRANSPORT_CERT"
-          docker exec ca pki-server ca-config-set ca.connector.KRA.transportCert $TRANSPORT_CERT
+          docker cp kra/certs/kra_transport.crt ca:.
+          docker exec ca pki-server ca-connector-add \
+             --url https://kra.example.com:8443 \
+             --nickname subsystem \
+             --transport-cert kra_transport.crt \
+             KRA
 
       - name: Restart CA
         run: |

--- a/.github/workflows/kra-existing-ds-test.yml
+++ b/.github/workflows/kra-existing-ds-test.yml
@@ -531,20 +531,17 @@ jobs:
 
       - name: Check KRA connector in CA
         run: |
-          docker exec ca pki-server ca-config-find | grep ^ca.connector.KRA. | sort | tee output
+          docker exec ca pki-server ca-connector-find | tee output
 
           # KRA connector should be configured
           cat > expected << EOF
-          ca.connector.KRA.enable=true
-          ca.connector.KRA.host=kra.example.com
-          ca.connector.KRA.local=false
-          ca.connector.KRA.nickName=subsystem
-          ca.connector.KRA.port=8443
-          ca.connector.KRA.timeout=30
-          ca.connector.KRA.uri=/kra/agent/kra/connector
+            Connector ID: KRA
+            Enabled: true
+            URL: https://kra.example.com:8443
+            Nickname: subsystem
           EOF
-          sed -e '/^ca.connector.KRA.transportCert=/d' output > actual
-          diff expected actual
+
+          diff expected output
 
           # REST API should return KRA connector info
           docker exec ca pki -n caadmin ca-kraconnector-show | tee output

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -343,9 +343,8 @@ jobs:
               "Enterprise KRA Administrators"
 
           # KRA connector should not be configured
-          echo -n > expected
-          docker exec ca pki-server ca-config-find | grep ^ca.connector.KRA. | tee actual
-          diff expected actual
+          docker exec ca pki-server ca-connector-find | tee output
+          diff /dev/null output
 
           # get KRA connector info via REST API
           docker exec client pki \

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -396,17 +396,12 @@ jobs:
 
       - name: Configure KRA connector in CA
         run: |
-          docker exec ca pki-server ca-config-set ca.connector.KRA.enable true
-          docker exec ca pki-server ca-config-set ca.connector.KRA.host kra.example.com
-          docker exec ca pki-server ca-config-set ca.connector.KRA.local false
-          docker exec ca pki-server ca-config-set ca.connector.KRA.nickName subsystem
-          docker exec ca pki-server ca-config-set ca.connector.KRA.port 8443
-          docker exec ca pki-server ca-config-set ca.connector.KRA.timeout 30
-          docker exec ca pki-server ca-config-set ca.connector.KRA.uri /kra/agent/kra/connector
-
-          TRANSPORT_CERT=$(openssl x509 -outform der -in kra/certs/kra_transport.crt | base64 --wrap=0)
-          echo "Transport cert: $TRANSPORT_CERT"
-          docker exec ca pki-server ca-config-set ca.connector.KRA.transportCert $TRANSPORT_CERT
+          docker cp kra/certs/kra_transport.crt ca:.
+          docker exec ca pki-server ca-connector-add \
+             --url https://kra.example.com:8443 \
+             --nickname subsystem \
+             --transport-cert kra_transport.crt \
+             KRA
 
       - name: Restart CA
         run: |


### PR DESCRIPTION
The `pki-server ca-connector-find` and `ca-connector-add` commands have been added to manage connectors in CA. Some tests have been updated to use these commands.