### PR TITLE
Update TPS container

### DIFF
--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -694,8 +694,6 @@ jobs:
               -v $PWD/tps/logs:/logs \
               -e PKI_DS_URL=ldap://tpsds.example.com:3389 \
               -e PKI_DS_PASSWORD=Secret.123 \
-              -e PKI_AUTHDB_URL=ldap://tpsds.example.com:3389 \
-              -e PKI_AUTHDB_BASEDN=ou=people,dc=example,dc=com \
               --detach \
               pki-tps
 
@@ -938,6 +936,20 @@ jobs:
 
       - name: Set up user auth database for TPS
         run: |
+          # configure connection to auth database
+          docker exec tps pki-server tps-config-set \
+              auths.instance.ldap1.ldap.ldapconn.secureConn \
+              false
+          docker exec tps pki-server tps-config-set \
+              auths.instance.ldap1.ldap.ldapconn.host \
+              tpsds.example.com
+          docker exec tps pki-server tps-config-set \
+              auths.instance.ldap1.ldap.ldapconn.port \
+              3389
+          docker exec tps pki-server tps-config-set \
+              auths.instance.ldap1.ldap.basedn \
+              ou=people,dc=example,dc=com
+
           # import base entry
           docker exec tps ldapadd \
               -H ldap://tpsds.example.com:3389 \

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1162,21 +1162,22 @@ class PKIDeployer:
             authdb_url = self.get_authdb_url()
             authdb_basedn = self.mdict.get('pki_authdb_basedn')
 
-            subsystem.set_config(
-                'auths.instance.ldap1.ldap.basedn',
-                authdb_basedn)
-            subsystem.set_config(
-                'auths.instance.ldap1.ldap.ldapconn.host',
-                authdb_url.hostname)
-            subsystem.set_config(
-                'auths.instance.ldap1.ldap.ldapconn.port',
-                str(authdb_url.port))
-            subsystem.set_config(
-                'auths.instance.ldap1.ldap.ldapconn.secureConn',
-                str(authdb_url.scheme == 'ldaps').lower())
-            subsystem.set_config(
-                'auths.instance.ldap1.ldap.ldapauth.clientCertNickname',
-                self.mdict['pki_subsystem_nickname'])
+            if authdb_basedn:
+                subsystem.set_config(
+                    'auths.instance.ldap1.ldap.basedn',
+                    authdb_basedn)
+                subsystem.set_config(
+                    'auths.instance.ldap1.ldap.ldapconn.host',
+                    authdb_url.hostname)
+                subsystem.set_config(
+                    'auths.instance.ldap1.ldap.ldapconn.port',
+                    str(authdb_url.port))
+                subsystem.set_config(
+                    'auths.instance.ldap1.ldap.ldapconn.secureConn',
+                    str(authdb_url.scheme == 'ldaps').lower())
+                subsystem.set_config(
+                    'auths.instance.ldap1.ldap.ldapauth.clientCertNickname',
+                    self.mdict['pki_subsystem_nickname'])
 
     def configure_ca(self, subsystem):
 

--- a/base/tps/bin/pki-tps-run
+++ b/base/tps/bin/pki-tps-run
@@ -136,8 +136,21 @@ OPTIONS+=(-D pki_security_manager=False)
 OPTIONS+=(-D pki_ca_uri=)
 OPTIONS+=(-D pki_kra_uri=)
 OPTIONS+=(-D pki_tks_uri=)
-OPTIONS+=(-D pki_authdb_url=$PKI_AUTHDB_URL)
-OPTIONS+=(-D pki_authdb_basedn=$PKI_AUTHDB_BASEDN)
+
+if [ "$PKI_AUTHDB_URL" = "" ]
+then
+    OPTIONS+=(-D pki_authdb_url=)
+else
+    OPTIONS+=(-D pki_authdb_url=$PKI_AUTHDB_URL)
+fi
+
+if [ "$PKI_AUTHDB_BASEDN" = "" ]
+then
+    OPTIONS+=(-D pki_authdb_basedn=)
+else
+    OPTIONS+=(-D pki_authdb_basedn=$PKI_AUTHDB_BASEDN)
+fi
+
 OPTIONS+=(-D pki_enable_server_side_keygen=True)
 
 OPTIONS+=(-D pki_systemd_service_create=False)
@@ -151,6 +164,7 @@ echo "##########################################################################
 echo "INFO: Configuring TPS server"
 
 pki-server tps-config-set internaldb.minConns 0
+pki-server tps-config-set auths.instance.ldap1.ldap.minConns 0
 
 echo "################################################################################"
 echo "INFO: Updating owners and permissions"


### PR DESCRIPTION
The `pki-tps-run` script has been modified to no longer require the authorization database URL and base DN params. Instead, these params can be configured directly in the `CS.cfg`. This will reduce the number of params required to start the TPS container.

The `PKIDeployer.init_subsystem()` has been modified to set up the connection to the authentication database only if the base DN is specified.

The default minimum connection param in TPS's `CS.cfg` has been changed to `0` such that the TPS container can start without creating a connection to the authentication database.