### PR TITLE
Handle a missing request_url in the cert request REST output

### DIFF
--- a/base/common/python/pki/cert.py
+++ b/base/common/python/pki/cert.py
@@ -219,9 +219,12 @@ class CertRequestInfo(object):
             else:
                 setattr(cert_request_info, k, v)
 
-        cert_request_info.request_id = \
-            str(cert_request_info.request_url)[(str(
-                cert_request_info.request_url).rfind("/") + 1):]
+        if cert_request_info.request_url:
+            cert_request_info.request_id = \
+                str(cert_request_info.request_url)[(str(
+                    cert_request_info.request_url).rfind("/") + 1):]
+        else:
+            cert_request_info.request_id = attr_list.get('requestID')
 
         return cert_request_info
 


### PR DESCRIPTION
In the class request_url defaults to None. If it isn't present in in the json attributes the request_id can't be determined and ends up as the string 'None'.

If request_url isn't present then use requestID instead.