### PR TITLE
Add upgrade script to enable URL rewrite

### DIFF
--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -250,7 +250,7 @@ jobs:
           cat > expected << EOF
             Server URL: https://pki.example.com:8443
             Server Name: Dogtag Certificate System
-            Server Version: 11.6.1
+            Server Version: 11.6.2
           EOF
 
           diff expected stdout
@@ -300,7 +300,7 @@ jobs:
           cat > expected << EOF
             Server URL: https://server.example.com:8443
             Server Name: Dogtag Certificate System
-            Server Version: 11.6.1
+            Server Version: 11.6.2
           EOF
 
           diff expected stdout
@@ -325,7 +325,7 @@ jobs:
           cat > expected << EOF
             Server URL: https://pki.example.com:8443
             Server Name: Dogtag Certificate System
-            Server Version: 11.6.1
+            Server Version: 11.6.2
           EOF
 
           diff expected stdout

--- a/.github/workflows/server-https-pkcs12-test.yml
+++ b/.github/workflows/server-https-pkcs12-test.yml
@@ -268,7 +268,7 @@ jobs:
           cat > expected << EOF
             Server URL: https://pki.example.com:8443
             Server Name: Dogtag Certificate System
-            Server Version: 11.6.1
+            Server Version: 11.6.2
           EOF
 
           diff expected stdout
@@ -317,7 +317,7 @@ jobs:
           cat > expected << EOF
             Server URL: https://server.example.com:8443
             Server Name: Dogtag Certificate System
-            Server Version: 11.6.1
+            Server Version: 11.6.2
           EOF
 
           diff expected stdout
@@ -341,7 +341,7 @@ jobs:
           cat > expected << EOF
             Server URL: https://pki.example.com:8443
             Server Name: Dogtag Certificate System
-            Server Version: 11.6.1
+            Server Version: 11.6.2
           EOF
 
           diff expected stdout

--- a/base/acme/pom.xml
+++ b/base/acme/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-acme</artifactId>

--- a/base/ca/pom.xml
+++ b/base/ca/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-ca</artifactId>

--- a/base/common/pom.xml
+++ b/base/common/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-common</artifactId>

--- a/base/console/pom.xml
+++ b/base/console/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-console</artifactId>

--- a/base/est/pom.xml
+++ b/base/est/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-est</artifactId>

--- a/base/kra/pom.xml
+++ b/base/kra/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-kra</artifactId>

--- a/base/ocsp/pom.xml
+++ b/base/ocsp/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-ocsp</artifactId>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-base-parent</artifactId>

--- a/base/server-webapp/pom.xml
+++ b/base/server-webapp/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-server-webapp</artifactId>

--- a/base/server/pom.xml
+++ b/base/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-server</artifactId>

--- a/base/server/upgrade/11.6.2/01-EnableURLRewrite.py
+++ b/base/server/upgrade/11.6.2/01-EnableURLRewrite.py
@@ -1,0 +1,19 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+import pki.server.upgrade
+
+
+class EnableURLRewrite(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Enable URL rewrite'
+
+    def upgrade_instance(self, instance):
+
+        self.backup(instance.server_xml)
+
+        instance.enable_rewrite(exist_ok=True)

--- a/base/tks/pom.xml
+++ b/base/tks/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tks</artifactId>

--- a/base/tomcat-9.0/pom.xml
+++ b/base/tomcat-9.0/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tomcat-9.0</artifactId>

--- a/base/tomcat/pom.xml
+++ b/base/tomcat/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tomcat</artifactId>

--- a/base/tools/pom.xml
+++ b/base/tools/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tools</artifactId>

--- a/base/tps/pom.xml
+++ b/base/tps/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.dogtagpki.pki</groupId>
         <artifactId>pki-base-parent</artifactId>
-        <version>11.6.1-SNAPSHOT</version>
+        <version>11.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pki-tps</artifactId>

--- a/pki.spec
+++ b/pki.spec
@@ -11,7 +11,7 @@ Name:             pki
 # Upstream version number:
 %global           major_version 11
 %global           minor_version 6
-%global           update_version 1
+%global           update_version 2
 
 # Downstream release number:
 # - development/stabilization (unsupported): 0.<n> where n >= 1

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dogtagpki.pki</groupId>
     <artifactId>pki-parent</artifactId>
-    <version>11.6.1-SNAPSHOT</version>
+    <version>11.6.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
An upgrade script has been added to add a `RewriteValve` and create a link to `rewrite.config` that are missing in instances created prior to PKI 11.3.

The version number has also been updated to 11.6.2.

See also:
* https://github.com/dogtagpki/pki/commit/f95df455c5f062ef024b91f5bfc95d919c91cfb7
* https://github.com/dogtagpki/pki/commit/994d932100c7d335752fe817a7d8757f62439b08