### PR TITLE
Update TPS container test

### DIFF
--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -68,8 +68,6 @@ jobs:
               -v $PWD/ca/certs:/certs \
               -v $PWD/ca/conf:/conf \
               -v $PWD/ca/logs:/logs \
-              -e PKI_DS_URL=ldap://cads.example.com:3389 \
-              -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
               pki-ca
 
@@ -111,8 +109,16 @@ jobs:
               cads
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-CA-Database
-      - name: Initialize CA database
+      - name: Set up CA database
         run: |
+          docker exec ca pki-server ca-db-config-mod \
+              --secure false \
+              --hostname cads.example.com \
+              --port 3389
+          docker exec ca pki-server password-set \
+              --password Secret.123 \
+              internaldb
+
           docker exec ca pki-server ca-db-init -v
           docker exec ca pki-server ca-db-index-add -v
           docker exec ca pki-server ca-db-index-rebuild -v
@@ -198,14 +204,6 @@ jobs:
         run: |
           docker exec ca pki-server ca-user-role-add admin "Administrators"
           docker exec ca pki-server ca-user-role-add admin "Certificate Manager Agents"
-
-      - name: Check CA admin user
-        run: |
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              -n admin \
-              ca-user-show \
-              admin
 
       - name: Create KRA storage cert
         run: |
@@ -323,8 +321,6 @@ jobs:
               -v $PWD/kra/certs:/certs \
               -v $PWD/kra/conf:/conf \
               -v $PWD/kra/logs:/logs \
-              -e PKI_DS_URL=ldap://krads.example.com:3389 \
-              -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
               pki-kra
 
@@ -339,6 +335,12 @@ jobs:
               -o /dev/null \
               https://kra.example.com:8443
 
+      - name: Check KRA info
+        run: |
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              info
+
       - name: Set up KRA DS container
         run: |
           tests/bin/ds-create.sh \
@@ -352,6 +354,14 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-KRA-Database
       - name: Set up KRA database
         run: |
+          docker exec kra pki-server kra-db-config-mod \
+              --secure false \
+              --hostname krads.example.com \
+              --port 3389
+          docker exec kra pki-server password-set \
+              --password Secret.123 \
+              internaldb
+
           docker exec kra pki-server kra-db-init -v
           docker exec kra pki-server kra-db-index-add -v
           docker exec kra pki-server kra-db-index-rebuild  -v
@@ -371,14 +381,6 @@ jobs:
         run: |
           docker exec kra pki-server kra-user-role-add admin "Administrators"
           docker exec kra pki-server kra-user-role-add admin "Data Recovery Manager Agents"
-
-      - name: Check KRA admin user
-        run: |
-          docker exec client pki \
-              -U https://kra.example.com:8443 \
-              -n admin \
-              kra-user-show \
-              admin
 
       # https://github.com/dogtagpki/pki/wiki/Setting-up-Subsystem-User
       - name: Add CA subsystem user in KRA
@@ -402,23 +404,6 @@ jobs:
              --nickname subsystem \
              --transport-cert kra_transport.crt \
              KRA
-
-      - name: Restart CA
-        run: |
-          docker restart ca
-          sleep 10
-
-          docker network reload --all
-
-          # wait for CA to restart
-          docker exec client curl \
-              --retry 180 \
-              --retry-delay 0 \
-              --retry-connrefused \
-              -s \
-              -k \
-              -o /dev/null \
-              https://ca.example.com:8443
 
       - name: Create TKS subsystem cert
         run: |
@@ -496,8 +481,6 @@ jobs:
               -v $PWD/tks/certs:/certs \
               -v $PWD/tks/conf:/conf \
               -v $PWD/tks/logs:/logs \
-              -e PKI_DS_URL=ldap://tksds.example.com:3389 \
-              -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
               pki-tks
 
@@ -512,6 +495,12 @@ jobs:
               -o /dev/null \
               https://tks.example.com:8443
 
+      - name: Check TKS info
+        run: |
+          docker exec client pki \
+              -U https://tks.example.com:8443 \
+              info
+
       - name: Set up TKS DS container
         run: |
           tests/bin/ds-create.sh \
@@ -525,6 +514,14 @@ jobs:
       # https://github.com/dogtagpki/pki/wiki/Setting-up-TKS-Database
       - name: Set up TKS database
         run: |
+          docker exec tks pki-server tks-db-config-mod \
+              --secure false \
+              --hostname tksds.example.com \
+              --port 3389
+          docker exec tks pki-server password-set \
+              --password Secret.123 \
+              internaldb
+
           docker exec tks pki-server tks-db-init -v
           docker exec tks pki-server tks-db-index-add -v
           docker exec tks pki-server tks-db-index-rebuild  -v
@@ -544,14 +541,6 @@ jobs:
         run: |
           docker exec tks pki-server tks-user-role-add admin "Administrators"
           docker exec tks pki-server tks-user-role-add admin "Token Key Service Manager Agents"
-
-      - name: Check TKS admin user
-        run: |
-          docker exec client pki \
-              -U https://tks.example.com:8443 \
-              -n admin \
-              tks-user-show \
-              admin
 
       - name: Import KRA transport cert into TKS
         run: |
@@ -584,37 +573,6 @@ jobs:
              --nickname "TPS-tps.example.com-8443 sharedSecret" \
              --uid TPS-tps.example.com-8443 \
              0
-
-      - name: Restart TKS
-        run: |
-          docker restart tks
-          sleep 10
-
-          docker network reload --all
-
-          # wait for TKS to restart
-          docker exec client curl \
-              --retry 180 \
-              --retry-delay 0 \
-              --retry-connrefused \
-              -s \
-              -k \
-              -o /dev/null \
-              https://tks.example.com:8443
-
-      - name: Check TPS connector in TKS after restart
-        run: |
-          docker exec tks pki-server tks-config-find | grep ^tps. | sort | tee output
-
-          cat > expected << EOF
-          tps.0.host=tps.example.com
-          tps.0.nickname=TPS-tps.example.com-8443 sharedSecret
-          tps.0.port=8443
-          tps.0.userid=TPS-tps.example.com-8443
-          tps.list=0
-          EOF
-
-          diff expected output
 
       - name: Create TPS subsystem cert
         run: |
@@ -692,8 +650,6 @@ jobs:
               -v $PWD/tps/certs:/certs \
               -v $PWD/tps/conf:/conf \
               -v $PWD/tps/logs:/logs \
-              -e PKI_DS_URL=ldap://tpsds.example.com:3389 \
-              -e PKI_DS_PASSWORD=Secret.123 \
               --detach \
               pki-tps
 
@@ -801,9 +757,17 @@ jobs:
               --password=Secret.123 \
               tpsds
 
-      # https://github.com/dogtagpki/pki/wiki/Setting-up-TKS-Database
+      # https://github.com/dogtagpki/pki/wiki/Setting-up-TPS-Database
       - name: Set up TPS database
         run: |
+          docker exec tps pki-server tps-db-config-mod \
+              --secure false \
+              --hostname tpsds.example.com \
+              --port 3389
+          docker exec tps pki-server password-set \
+              --password Secret.123 \
+              internaldb
+
           docker exec tps pki-server tps-db-init -v
           docker exec tps pki-server tps-db-index-add -v
           docker exec tps pki-server tps-db-index-rebuild  -v
@@ -826,14 +790,6 @@ jobs:
           docker exec tps pki-server tps-user-role-add admin "Administrators"
           docker exec tps pki-server tps-user-role-add admin "TPS Agents"
           docker exec tps pki-server tps-user-role-add admin "TPS Operators"
-
-      - name: Check TPS admin user
-        run: |
-          docker exec client pki \
-              -U https://tps.example.com:8443 \
-              -n admin \
-              tps-user-show \
-              admin
 
       - name: Add TPS subsystem user in CA
         run: |
@@ -975,6 +931,95 @@ jobs:
           docker exec tps pki-server tps-config-set \
               tokendb.defaultPolicy \
               "RE_ENROLL=YES;RENEW=NO;FORCE_FORMAT=NO;PIN_RESET=NO;RESET_PIN_RESET_TO_NO=YES"
+
+      - name: Restart CA
+        run: |
+          docker restart ca
+          sleep 10
+
+          docker network reload --all
+
+          # wait for CA to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://ca.example.com:8443
+
+      - name: Check CA admin user after restart
+        run: |
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-user-show \
+              admin
+
+      - name: Restart KRA
+        run: |
+          docker restart kra
+          sleep 10
+
+          docker network reload --all
+
+          # wait for KRA to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://kra.example.com:8443
+
+      - name: Check KRA admin user after restart
+        run: |
+          docker exec client pki \
+              -U https://kra.example.com:8443 \
+              -n admin \
+              kra-user-show \
+              admin
+
+      - name: Restart TKS
+        run: |
+          docker restart tks
+          sleep 10
+
+          docker network reload --all
+
+          # wait for TKS to restart
+          docker exec client curl \
+              --retry 180 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://tks.example.com:8443
+
+      - name: Check TKS admin user after restart
+        run: |
+          docker exec client pki \
+              -U https://tks.example.com:8443 \
+              -n admin \
+              tks-user-show \
+              admin
+
+      - name: Check TPS connector in TKS after restart
+        run: |
+          docker exec tks pki-server tks-config-find | grep ^tps. | sort | tee output
+
+          cat > expected << EOF
+          tps.0.host=tps.example.com
+          tps.0.nickname=TPS-tps.example.com-8443 sharedSecret
+          tps.0.port=8443
+          tps.0.userid=TPS-tps.example.com-8443
+          tps.list=0
+          EOF
+
+          diff expected output
 
       - name: Restart TPS
         run: |


### PR DESCRIPTION
The TPS container test has been modified to no longer specify the `PKI_DS_URL` and `PKI_DS_PASSWORD` params for each container which will make it easier to start and set up the containers. Instead, the internal database hostnames, port numbers, and passwords will be configured in the `CS.cfg` directly, then all containers will be restarted before running the test.

The `PKIDeployer.get_ds_url()` has been modified to return `None` if the internal database URL is blank.

The `PKIDeployer.configure_internal_database()` has been updated to configure the internal database params in `CS.cfg` only if the corresponding `pkispawn` params exist.