### PR TITLE
Fix nuxwdog instances

### DIFF
--- a/.github/workflows/ca-nuxwdog-test.yml
+++ b/.github/workflows/ca-nuxwdog-test.yml
@@ -99,9 +99,6 @@ jobs:
           # remove password.conf temporarily
           docker exec pki mv /var/lib/pki/pki-tomcat/conf/password.conf /tmp
 
-          # install setfacl tool needed for Nuxwdog
-          docker exec pki dnf install -y acl
-
           docker exec pki pki-server nuxwdog-enable
 
       - name: Start CA with Nuxwdog

--- a/base/common/python/pki/keyring.py
+++ b/base/common/python/pki/keyring.py
@@ -36,9 +36,10 @@ class Keyring:
     type `user`
     """
 
-    def __init__(self, keyring='@u', key_type='user'):
+    def __init__(self, keyring='@u', key_type='user', owner=None):
         self.keyring = keyring
         self.key_type = key_type
+        self.user = owner
 
     def put_password(self, key_name, password):
         """
@@ -51,8 +52,11 @@ class Keyring:
         :return: Key ID, Error (if any)
         :rtype: (bytearray, bytearray)
         """
+        cmd = []
+        if self.user:
+            cmd = ['runuser', '-u', self.user, '--']
 
-        cmd = [
+        cmd = cmd + [
             'keyctl',
             'padd',
             self.key_type,
@@ -78,7 +82,11 @@ class Keyring:
         :rtype: int
         """
 
-        cmd = [
+        cmd = []
+        if self.user:
+            cmd = ['runuser', '-u', self.user, '--']
+
+        cmd = cmd + [
             'keyctl',
             'search',
             self.keyring,
@@ -91,8 +99,7 @@ class Keyring:
 
         if result.returncode == 0:
             return result.stdout.decode().strip()
-        else:
-            return None
+        return None
 
     def get_password(self, key_name, output_format='raw'):
         """
@@ -115,7 +122,11 @@ class Keyring:
 
         key_id = self.get_key_id(key_name)
 
-        cmd = [
+        cmd = []
+        if self.user:
+            cmd = ['runuser', '-u', self.user, '--']
+
+        cmd = cmd + [
             'keyctl',
             mode,
             key_id
@@ -132,7 +143,11 @@ class Keyring:
         :rtype: int
         """
 
-        cmd = [
+        cmd = []
+        if self.user:
+            cmd = ['runuser', '-u', self.user, '--']
+
+        cmd = cmd + [
             'keyctl',
             'clear',
             self.keyring

--- a/base/server/scripts/pki-server-nuxwdog
+++ b/base/server/scripts/pki-server-nuxwdog
@@ -26,7 +26,7 @@ Script that prompts user for password during server startup
 and store them on user's keyring
 """
 
-import getopt
+import argparse
 import logging
 import os
 import subprocess
@@ -61,35 +61,30 @@ def print_help():
     print()
 
 
-try:
-    opts, _ = getopt.gnu_getopt(sys.argv, 'v', [
-        'clear', 'verbose', 'debug', 'help'])
+parser = argparse.ArgumentParser(prog='pki-server-nuxwdog',
+            add_help=False)
+parser.add_argument('--clear', action='store_true')
+parser.add_argument('-v', '--verbose', action='store_true')
+parser.add_argument('--debug', action='store_true')
+parser.add_argument('--help', action='store_true')
 
-except getopt.GetoptError as e:
-    logger.error(e)
+args = parser.parse_args(args=sys.argv[1:])
+
+if args.clear:
+    keyring.clear_keyring()
+    sys.exit()
+
+if args.help:
     print_help()
-    sys.exit(1)
+    sys.exit()
 
-for o, a in opts:
 
-    if o == '--clear':
-        keyring.clear_keyring()
-        sys.exit()
+if args.verbose:
+    logging.getLogger().setLevel(logging.INFO)
 
-    elif o in ('-v', '--verbose'):
-        logging.getLogger().setLevel(logging.INFO)
+elif args.debug:
+    logging.getLogger().setLevel(logging.DEBUG)
 
-    elif o == '--debug':
-        logging.getLogger().setLevel(logging.DEBUG)
-
-    elif o == '--help':
-        print_help()
-        sys.exit()
-
-    else:
-        logger.error('option %s not recognized', o)
-        print_help()
-        sys.exit(1)
 
 # 1. Get <instance> name from env variable NAME set in systemd unit file
 instance_name = os.getenv('NAME', 'pki-tomcat')
@@ -100,6 +95,8 @@ instance_name = os.getenv('NAME', 'pki-tomcat')
 # Load the instance
 instance = pki.server.instance.PKIInstance(instance_name)
 instance.load()
+
+keyring = Keyring(owner = instance.user)
 
 subsystems = instance.get_subsystems()
 

--- a/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
@@ -13,15 +13,13 @@ EnvironmentFile=-/etc/sysconfig/%i
 EnvironmentFile=/usr/share/pki/etc/pki.conf
 EnvironmentFile=/etc/pki/pki.conf
 
-ExecStartPre=+/usr/bin/setfacl -m u:pkiuser:wx /run/systemd/ask-password
-ExecStartPre=/usr/bin/pki-server-nuxwdog
+ExecStartPre=+/usr/bin/pki-server-nuxwdog
 ExecStartPre=/usr/sbin/pki-server upgrade %i
 ExecStartPre=/usr/sbin/pki-server migrate %i
 ExecStartPre=/usr/bin/pkidaemon start %i
-ExecStartPost=+/usr/bin/setfacl -x u:pkiuser /run/systemd/ask-password
 ExecStart=/usr/libexec/tomcat/server start
 ExecStop=/usr/libexec/tomcat/server stop
-ExecStopPost=/usr/bin/pki-server-nuxwdog --clear
+ExecStopPost=+/usr/bin/pki-server-nuxwdog --clear
 
 KeyringMode=shared
 SuccessExitStatus=143


### PR DESCRIPTION
Nuxwdog enabled instances are not working with latest release of systemd for permission problems.

With the release of systemd version 257 the command `systemd-ask-password` when executed as user in systemd servive cannot invoke agent for password request because it is missing privileged. At the same time cannot execute as system because pkiuser is not authorised.

The TTY agent alternative is not working properly because it is not linked to the root shell executing the start command.

As a solution the `pki-server-nuxwdog` script is executed with privileged user but it operates on user keyring. This required a new option with user name and the possibility for keyring object to operate for a specific user.

Fix #5085