### PR TITLE
trust option needs to be preceded by two '--' instead of '-'.

### DIFF
--- a/docs/installation/kra/installing-standalone-kra.adoc
+++ b/docs/installation/kra/installing-standalone-kra.adoc
@@ -99,7 +99,7 @@ $ pkispawn -f kra-standalone-step2.cfg -s KRA
 +
 [literal,subs="+quotes,verbatim"]
 ....
-$ pki nss-cert-import --cert ca_signing.crt -trust CT,C,C ca_signing
+$ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:

--- a/docs/installation/ocsp/installing-standalone-ocsp.adoc
+++ b/docs/installation/ocsp/installing-standalone-ocsp.adoc
@@ -93,7 +93,7 @@ $ pkispawn -f ocsp-standalone-step2.cfg -s OCSP
 +
 [literal,subs="+quotes,verbatim"]
 ....
-$ pki nss-cert-import --cert ca_signing.crt -trust CT,C,C ca_signing
+$ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:


### PR DESCRIPTION
I noticed that this was fixed downstream but not upstream. 