### PR TITLE
Fix pki-server db-schema-upgrade

### DIFF
--- a/.github/workflows/server-upgrade-test.yml
+++ b/.github/workflows/server-upgrade-test.yml
@@ -27,14 +27,23 @@ jobs:
       - name: Create network
         run: docker network create example
 
-      - name: Set up server container
+      - name: Set up DS container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
 
-      - name: Connect server container to network
-        run: docker network connect example pki --alias pki.example.com
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
 
       - name: Add upgrade script
         run: |
@@ -72,19 +81,58 @@ jobs:
               $UPGRADE_DIR/$INDEX-BasicUpgradeScript.py
           docker exec pki ls $UPGRADE_DIR
 
-      - name: Run upgrade without any servers
+      - name: Run pki-server upgrade without any servers
         run: |
-          docker exec pki pki-server upgrade -v | tee output
+          docker exec pki pki-server upgrade \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
 
-          # verify that the upgrade script was not executed
-          grep "BasicUpgradeScript" output | tee actual
-          [ ! -s actual ]
+          # upgrade should fail
+          cat > expected << EOF
+          ERROR: Invalid instance: pki-tomcat
+          EOF
 
-      - name: Create PKI server
+          diff expected stderr
+
+      - name: Run pki-server db-schema-upgrade without any servers
         run: |
-          docker exec pki pki-server create -v
+          docker exec pki pki-server db-schema-upgrade \
+              -w Secret.123 \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
 
-      - name: Run upgrade with one server
+          # upgrade should fail
+          cat > expected << EOF
+          ERROR: Invalid instance: pki-tomcat
+          EOF
+
+          diff expected stderr
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
+              -v
+
+      - name: Check CA admin cert
+        run: |
+          docker exec pki pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Run pki-server upgrade with one server
         run: |
           docker exec pki pki-server upgrade -v | tee output
 
@@ -92,20 +140,19 @@ jobs:
           grep "BasicUpgradeScript:" output | tee actual
           [ -s actual ]
 
-      - name: Remove PKI server
+      - name: Run pki-server db-schema-upgrade with one server
         run: |
-          docker exec pki pki-server remove -v
+          docker exec pki pki-server db-schema-upgrade \
+              -w Secret.123
 
-      - name: Gather artifacts
-        if: always()
+      - name: Restart PKI server after upgrade
         run: |
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
+          docker exec pki pki-server restart --wait
 
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: server-upgrade-test
-          path: |
-            /tmp/artifacts/pki
+      - name: Check CA admin cert after upgrade
+        run: |
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+      - name: Remove CA
+        run: |
+          docker exec pki pkidestroy -s CA -v

--- a/base/server/python/pki/server/cli/db.py
+++ b/base/server/python/pki/server/cli/db.py
@@ -104,13 +104,12 @@ class DBSchemaUpgradeCLI(pki.cli.CLI):
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
+            raise pki.cli.CLIException('Invalid instance: %s' % instance_name)
+
         instance.load()
 
         if not instance.get_subsystems():
-            logger.error('No subsystem in instance %s', instance_name)
-            sys.exit(1)
+            raise pki.cli.CLIException('No subsystem in instance %s' % instance_name)
 
         if not bind_password:
             bind_password = getpass.getpass(prompt='Enter password: ')

--- a/base/server/python/pki/server/cli/upgrade.py
+++ b/base/server/python/pki/server/cli/upgrade.py
@@ -136,7 +136,7 @@ class UpgradeCLI(pki.cli.CLI):
             instance = pki.server.PKIServerFactory.create(instance_name)
 
             if not instance.exists():
-                raise Exception('Invalid instance: %s' % instance_name)
+                raise pki.cli.CLIException('Invalid instance: %s' % instance_name)
 
             instance.load()
             instances = [instance]

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1171,18 +1171,17 @@ class PKISubsystem(object):
         port = self.config['internaldb.ldapconn.port']
         secure = self.config['internaldb.ldapconn.secureConn']
 
+        scheme = 'ldaps' if secure == 'true' else 'ldap'
+        url = '%s://%s:%s' % (scheme, host, port)
+
         cmd = [
             'ldapmodify',
-            '-c',
+            '-H', url,
             '-D', bind_dn,
             '-w', bind_password,
-            '-h', host,
-            '-p', port,
-            '-f', filename
+            '-f', filename,
+            '-c'
         ]
-
-        if secure.lower() == 'true':
-            cmd.append('-Z')
 
         logger.debug('Command: %s', ' '.join(cmd))
         subprocess.check_call(cmd)


### PR DESCRIPTION
The `PKISubsystem.import_ldif()` has been modified to call `ldapmodify` with `-H <URL>` option instead of the obsolete `-h <hostname>` option.

The server upgrade test has been updated to test `pki-server db-schema-upgrade` which is currently just re-importing the DS schema.

Resolves: https://github.com/dogtagpki/pki/issues/5086