### PR TITLE
RHCS-4734 Fix CA validity date is not extended on renewal

### DIFF
--- a/base/ca/shared/conf/CS.cfg
+++ b/base/ca/shared/conf/CS.cfg
@@ -15,6 +15,13 @@ agent.interface.uri=ca/agent/ca
 machineName=[pki_hostname]
 pidDir=/var/run/pki/tomcat
 preop.pin=[pki_one_time_pin]
+ca._000=##
+ca._001=## ca.enablePastCATime_caCert is meant for renewal of the CA
+ca._002=## signing cert that has the same keys
+ca._003=##   ca.enablePastCATime_caCert=true
+ca._004=## Note that the CA profile (see profile for details) will need
+ca._005=##   bypassCAnotafter=true
+ca._006=##
 ca.cert.list=signing,ocsp_signing,sslserver,subsystem,audit_signing
 ca.cert.signing.certusage=SSLCA
 ca.cert.ocsp_signing.certusage=StatusResponder

--- a/base/ca/shared/profiles/ca/caCACert.cfg
+++ b/base/ca/shared/profiles/ca/caCACert.cfg
@@ -27,6 +27,13 @@ policyset.caCertSet.2.default.class_id=caValidityDefaultImpl
 policyset.caCertSet.2.default.name=CA Certificate Validity Default
 policyset.caCertSet.2.default.params.range=7305
 policyset.caCertSet.2.default.params.startTime=0
+#
+# The bypassCAnotafter is meant for renewal of the CA signing cert
+# with the same keys.
+# You will also need to enable ca.enablePastCATime_caCert in CS.cfg.
+#
+#policyset.caCertSet.2.default.params.bypassCAnotafter=true
+#
 policyset.caCertSet.3.constraint.class_id=keyConstraintImpl
 policyset.caCertSet.3.constraint.name=Key Constraint
 policyset.caCertSet.3.constraint.params.keyType=-

--- a/base/ca/shared/profiles/ca/caCrossSignedCACert.cfg
+++ b/base/ca/shared/profiles/ca/caCrossSignedCACert.cfg
@@ -24,6 +24,13 @@ policyset.caCertSet.2.default.class_id=caValidityDefaultImpl
 policyset.caCertSet.2.default.name=CA Certificate Validity Default
 policyset.caCertSet.2.default.params.range=7305
 policyset.caCertSet.2.default.params.startTime=0
+#
+# The bypassCAnotafter is meant for renewal of the CA signing cert
+# with the same keys. 
+# You will also need to enable ca.enablePastCATime_caCert in CS.cfg.
+#
+#policyset.caCertSet.2.default.params.bypassCAnotafter=true
+#
 policyset.caCertSet.3.constraint.class_id=keyConstraintImpl
 policyset.caCertSet.3.constraint.name=Key Constraint
 policyset.caCertSet.3.constraint.params.keyType=-

--- a/base/ca/shared/profiles/ca/caInstallCACert.cfg
+++ b/base/ca/shared/profiles/ca/caInstallCACert.cfg
@@ -24,10 +24,17 @@ policyset.caCertSet.2.constraint.name=Validity Constraint
 policyset.caCertSet.2.constraint.params.range=6940
 policyset.caCertSet.2.constraint.params.notBeforeCheck=false
 policyset.caCertSet.2.constraint.params.notAfterCheck=false
-policyset.caCertSet.2.default.class_id=validityDefaultImpl
-policyset.caCertSet.2.default.name=Validity Default
+policyset.caCertSet.2.default.class_id=caValidityDefaultImpl
+policyset.caCertSet.2.default.name=CA Certificate Validity Default
 policyset.caCertSet.2.default.params.range=6940
 policyset.caCertSet.2.default.params.startTime=0
+#
+# The bypassCAnotafter is meant for renewal of the CA signing cert
+# with the same keys. 
+# You will also need to enable ca.enablePastCATime_caCert in CS.cfg.
+#
+#policyset.caCertSet.2.default.params.bypassCAnotafter=true
+#
 policyset.caCertSet.3.constraint.class_id=keyConstraintImpl
 policyset.caCertSet.3.constraint.name=Key Constraint
 policyset.caCertSet.3.constraint.params.keyType=-


### PR DESCRIPTION
This patch is to add comments to explain how to allow CA cert issuance to bypass validity restriction while renewing the CA signing cert with the same keys.  It should only affect CA certs and not others.

Fixes https://issues.redhat.com/browse/RHCS-4734