### PR TITLE
Add internationalization test

### DIFF
--- a/.github/workflows/ca-profile-custom-test.yml
+++ b/.github/workflows/ca-profile-custom-test.yml
@@ -1,0 +1,337 @@
+name: CA with custom profile
+# The test will perform the following:
+# - create a custom profile with wide chars in the name and description
+# - enroll a cert with wide chars in the subject DN
+# - create a user with wide chars in the full name
+# - authenticate as the user using the cert
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install xmlstarlet
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -v
+
+      - name: Install CA admin cert
+        run: |
+          docker exec pki pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --password Secret.123
+
+      - name: Retrieve caUserCert profile
+        run: |
+          # export caUserCert profile
+          docker exec pki pki \
+              -n caadmin \
+              ca-profile-show \
+              --output $SHARED/profile.xml \
+              caUserCert
+
+          cat profile.xml
+
+      - name: Create custom profile
+        run: |
+          # allow updates
+          sudo chmod go+w profile.xml
+
+          # update profile ID
+          xmlstarlet edit --inplace \
+              -u "/Profile/@id" \
+              -v "custom" \
+              profile.xml
+
+          # update profile name
+          xmlstarlet edit --inplace \
+              -u "/Profile/name" \
+              -v "五輪真弓" \
+              profile.xml
+
+          # update profile description
+          xmlstarlet edit --inplace \
+              -u "/Profile/description" \
+              -v "Certificate profile for 五輪真弓" \
+              profile.xml
+
+          cat profile.xml
+
+      - name: Add custom profile
+        run: |
+          # add custom profile
+          docker exec pki pki \
+              -n caadmin \
+              ca-profile-add \
+              $SHARED/profile.xml
+
+          # enable custom profile
+          docker exec pki pki \
+              -n caadmin \
+              ca-profile-enable \
+              custom
+
+      - name: Check custom profile info
+        run: |
+          docker exec pki pki \
+              -n caadmin \
+              ca-profile-show \
+              custom \
+              | tee output
+
+          sed -n \
+              -e "/^\s*Name:/p" \
+              -e "/^\s*Description:/p" \
+              output > actual
+
+          cat > expected << EOF
+            Name: 五輪真弓
+            Description: Certificate profile for 五輪真弓
+          EOF
+
+          diff expected actual
+
+      - name: Check custom profile config
+        run: |
+          docker exec pki pki \
+              -n caadmin \
+              ca-profile-show \
+              --raw \
+              custom \
+              | tee output
+
+          sed -n \
+              -e "/^name=/p" \
+              -e "/^desc=/p" \
+              output > actual
+
+          cat > expected << EOF
+          desc=Certificate profile for 五輪真弓
+          name=五輪真弓
+          EOF
+
+      - name: Check custom profile config file
+        run: |
+          docker exec pki cat /var/lib/pki/pki-tomcat/ca/profiles/ca/custom.cfg \
+              | tee output
+
+          sed -n \
+              -e "/^name=/p" \
+              -e "/^desc=/p" \
+              output > actual
+
+          cat > expected << EOF
+          desc=Certificate profile for 五輪真弓
+          name=五輪真弓
+          EOF
+
+          diff expected actual
+
+      - name: Create user cert using custom profile
+        run: |
+          # create cert request
+          docker exec pki pki nss-cert-request \
+              --subject "UID=testuser,CN=五輪真弓" \
+              --ext /usr/share/pki/tools/examples/certs/testuser.conf \
+              --csr testuser.csr
+
+          # submit cert request
+          docker exec pki pki ca-cert-request-submit \
+              --profile custom \
+              --csr-file testuser.csr \
+              | tee output
+
+          REQUEST_ID=$(sed -n "s/^\s*Request ID:\s*\(\S*\)$/\1/p" output)
+
+          # approve cert request
+          docker exec pki pki \
+              -n caadmin \
+              ca-cert-request-approve \
+              --force \
+              $REQUEST_ID \
+              | tee output
+
+          CERT_ID=$(sed -n "s/^\s*Certificate ID:\s*\(\S*\)$/\1/p" output)
+          echo $CERT_ID > cert.id
+
+      - name: Check user cert
+        run: |
+          CERT_ID=$(cat cert.id)
+
+          docker exec pki pki ca-cert-show $CERT_ID | tee output
+
+          sed -n \
+              -e "/^\s*Subject DN:/p" \
+              output > actual
+
+          cat > expected << EOF
+            Subject DN: UID=testuser,CN=五輪真弓
+          EOF
+
+          diff expected actual
+
+      - name: Create user using user cert
+        run: |
+          CERT_ID=$(cat cert.id)
+
+          # export cert
+          docker exec pki pki ca-cert-export \
+              --output-file testuser.crt \
+              $CERT_ID
+
+          docker exec pki pki \
+              -n caadmin \
+              ca-user-add \
+              --full-name "五輪真弓" \
+              --type adminType \
+              --cert-file testuser.crt \
+              testuser
+
+          docker exec pki pki \
+              -n caadmin \
+              ca-user-membership-add \
+              testuser \
+              "Administrators"
+
+      - name: Check user using pki ca-user-show
+        run: |
+          docker exec pki pki \
+              -n caadmin \
+              ca-user-show \
+              testuser \
+              | tee output
+
+          cat > expected << EOF
+          ---------------
+          User "testuser"
+          ---------------
+            User ID: testuser
+            Full name: 五輪真弓
+            Type: adminType
+          EOF
+
+          diff expected output
+
+      - name: Check user using pki-server ca-user-show
+        run: |
+          docker exec pki pki-server ca-user-show \
+              testuser \
+              | tee output
+
+          cat > expected << EOF
+            User ID: testuser
+            Full Name: 五輪真弓
+            Type: adminType
+          EOF
+
+          diff expected output
+
+      - name: Check authentication using user cert
+        run: |
+          # import cert
+          docker exec pki pki nss-cert-import \
+              --cert testuser.crt \
+              testuser
+
+          # authenticate as test user
+          docker exec pki pki \
+              -n testuser \
+              ca-user-show \
+              testuser \
+              | tee output
+
+          cat > expected << EOF
+          ---------------
+          User "testuser"
+          ---------------
+            User ID: testuser
+            Full name: 五輪真弓
+            Type: adminType
+          EOF
+
+          diff expected output
+
+      - name: Remove CA
+        run: docker exec pki pkidestroy -s CA -v
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check PKI server access log
+        if: always()
+        run: |
+          docker exec pki find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -68,6 +68,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/ca-ds-connection-test.yml
 
+  ca-secure-ds-test:
+    name: CA with secure DS
+    needs: build
+    uses: ./.github/workflows/ca-secure-ds-test.yml
+
   ca-rsnv1-test:
     name: CA with RSNv1
     needs: build

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -23,6 +23,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/ca-profile-caServerCert-test.yml
 
+  ca-profile-custom-test:
+    name: CA with custom profile
+    needs: build
+    uses: ./.github/workflows/ca-profile-custom-test.yml
+
   ca-renewal-manual-test:
     name: CA manual renewal
     needs: build
@@ -47,11 +52,6 @@ jobs:
     name: CA cert revocation
     needs: build
     uses: ./.github/workflows/ca-cert-revocation-test.yml
-
-  ca-secure-ds-test:
-    name: CA with secure DS
-    needs: build
-    uses: ./.github/workflows/ca-secure-ds-test.yml
 
   ca-crl-test:
     name: CA CRL database

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/ProfileBase.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/ProfileBase.java
@@ -265,8 +265,15 @@ public class ProfileBase {
         try {
             // load data and read profileId and classId
             properties.load(new ByteArrayInputStream(data));
+
             profileId = properties.remove("profileId");
+            logger.info("ProfileBase: - profileId: " + profileId);
+
             classId = properties.remove("classId");
+            logger.info("ProfileBase: - classId: " + classId);
+
+            logger.info("ProfileBase: - name: " + properties.get("name"));
+            logger.info("ProfileBase: - description: " + properties.get("desc"));
 
         } catch (IOException e) {
             String message = "Unable to create profile: " + e.getMessage();

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/ProfileService.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/ProfileService.java
@@ -559,7 +559,7 @@ public class ProfileService extends SubsystemService implements ProfileResource 
     }
 
     @Override
-    public Response createProfileRaw(byte[] data) {
+    public Response createProfileRaw(byte[] data) throws Exception {
 
         if (data == null) {
             String message = "Unable to create profile: Missing profile data";
@@ -583,8 +583,15 @@ public class ProfileService extends SubsystemService implements ProfileResource 
         try {
             // load data and read profileId and classId
             properties.load(new ByteArrayInputStream(data));
+
             profileId = properties.remove("profileId");
+            logger.info("ProfileService: - profileId: " + profileId);
+
             classId = properties.remove("classId");
+            logger.info("ProfileService: - classId: " + classId);
+
+            logger.info("ProfileService: - name: " + properties.get("name"));
+            logger.info("ProfileService: - description: " + properties.get("desc"));
 
         } catch (IOException e) {
             String message = "Unable to create profile: " + e.getMessage();

--- a/base/common/src/main/java/com/netscape/certsrv/client/PKIClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/PKIClient.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -151,7 +152,7 @@ public class PKIClient implements AutoCloseable {
             return null;
         }
 
-        String response = EntityUtils.toString(entity);
+        String response = EntityUtils.toString(entity, StandardCharsets.UTF_8);
         if (response == null || response.isBlank()) {
             return null;
         }
@@ -269,9 +270,11 @@ public class PKIClient implements AutoCloseable {
                     .build();
         }
 
+        byte[] bytes = marshall(object).getBytes(StandardCharsets.UTF_8);
+
         return EntityBuilder.create()
-                .setText(marshall(object))
                 .setContentType(ContentType.create(defaultMimeType))
+                .setBinary(bytes)
                 .build();
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/profile/ProfileResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/profile/ProfileResource.java
@@ -42,7 +42,7 @@ public interface ProfileResource {
     @POST
     @Path("raw")
     @ACLMapping("profiles.create")
-    public Response createProfileRaw(byte[] data);
+    public Response createProfileRaw(byte[] data) throws Exception;
 
     @POST
     @Path("{id}")

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -527,11 +527,11 @@ class UserShowCLI(pki.cli.CLI):
 
         print('  User ID: {}'.format(user['id']))
 
-        full_name = user.get('fullName')
+        full_name = user.get('FullName')
         if full_name:
             print('  Full Name: {}'.format(full_name))
 
-        email = user.get('email')
+        email = user.get('Email')
         if email:
             print('  Email: {}'.format(email))
 

--- a/base/server/src/main/java/com/netscape/cmscore/base/ConfigStore.java
+++ b/base/server/src/main/java/com/netscape/cmscore/base/ConfigStore.java
@@ -27,6 +27,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Map;
@@ -309,7 +310,7 @@ public class ConfigStore implements Cloneable {
      * @param out outputstream where the properties are saved
      */
     public synchronized void store(OutputStream out) throws Exception {
-        try (PrintWriter pw = new PrintWriter(out)) {
+        try (PrintWriter pw = new PrintWriter(out, true, StandardCharsets.UTF_8)) {
             Map<String, String> map = getProperties();
             for (String name : map.keySet()) {
                 String value = map.get(name);

--- a/base/server/src/main/java/com/netscape/cmscore/base/SimpleProperties.java
+++ b/base/server/src/main/java/com/netscape/cmscore/base/SimpleProperties.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -164,7 +165,7 @@ public class SimpleProperties extends Hashtable<String, String> {
      */
     public synchronized void load(InputStream inStream) throws IOException {
 
-        BufferedReader in = new BufferedReader(new InputStreamReader(inStream, "8859_1"));
+        BufferedReader in = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8));
 
         while (true) {
             // Get next line
@@ -318,7 +319,7 @@ public class SimpleProperties extends Hashtable<String, String> {
             throws IOException {
         BufferedWriter awriter;
 
-        awriter = new BufferedWriter(new OutputStreamWriter(out, "8859_1"));
+        awriter = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         if (header != null)
             writeln(awriter, "#" + header);
         writeln(awriter, "#" + new Date().toString());

--- a/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/profile/ProfileCLI.java
@@ -87,8 +87,8 @@ public class ProfileCLI extends CLI {
 
         for (ProfileInput input: data.getInputs()) {
             System.out.println();
-            System.out.println("  Name: " + input.getName());
-            System.out.println("  Class: " + input.getClassId());
+            System.out.println("  Input Name: " + input.getName());
+            System.out.println("  Input Class: " + input.getClassId());
             for (ProfileAttribute attr : input.getAttributes()) {
                 System.out.println();
                 System.out.println("    Attribute Name: " + attr.getName());
@@ -101,8 +101,8 @@ public class ProfileCLI extends CLI {
 
         for (ProfileOutput output: data.getOutputs()) {
             System.out.println();
-            System.out.println("  Name: " + output.getName());
-            System.out.println("  Class: " + output.getClassId());
+            System.out.println("  Output Name: " + output.getName());
+            System.out.println("  Output Class: " + output.getClassId());
             for (ProfileAttribute attr: output.getAttrs()) {
                 System.out.println();
                 System.out.println("    Attribute Name: " + attr.getName());

--- a/base/tools/src/main/java/com/netscape/cmstools/user/UserAddCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/user/UserAddCLI.java
@@ -57,8 +57,12 @@ public class UserAddCLI extends CommandCLI {
 
     @Override
     public void createOptions() {
-        Option option = new Option(null, "fullName", true, "Full name");
-        option.setArgName("fullName");
+        Option option = new Option(null, "fullName", true, "DEPRECATED: Full name");
+        option.setArgName("full name");
+        options.addOption(option);
+
+        option = new Option(null, "full-name", true, "Full name");
+        option.setArgName("full name");
         options.addOption(option);
 
         option = new Option(null, "email", true, "Email");
@@ -73,7 +77,7 @@ public class UserAddCLI extends CommandCLI {
         option.setArgName("phone");
         options.addOption(option);
 
-        option = new Option(null, "type", true, "Type");
+        option = new Option(null, "type", true, "Type: userType, agentType, adminType, subsystemType");
         option.setArgName("type");
         options.addOption(option);
 
@@ -112,7 +116,14 @@ public class UserAddCLI extends CommandCLI {
         }
 
         String userID = cmdArgs[0];
-        String fullName = cmd.getOptionValue("fullName");
+        String fullName = cmd.getOptionValue("full-name");
+
+        if (fullName == null) {
+            fullName = cmd.getOptionValue("fullName");
+            if (fullName != null) {
+                logger.warn("The --fullName option has been deprecated. Use --full-name instead.");
+            }
+        }
 
         if (fullName == null) {
             throw new Exception("Missing full name");

--- a/docs/changes/v11.7.0/Tools-Changes.adoc
+++ b/docs/changes/v11.7.0/Tools-Changes.adoc
@@ -21,3 +21,8 @@ and the reported status error.
 The CA parameter `pki_kra_connector_verify_cert` set corresponding
 `CS.cfg` paramater `ca.connector.KRA.certRevocationCheck` for KRA
 connector. The default value is `True`.
+
+== Deprecate pki <subsystem>-user-add --fullName ==
+
+The `--fullName` option for `pki <subsystem>-user-add` command has been deprecated.
+Use `--full-name` instead.


### PR DESCRIPTION
The `PKIClient.entity()` and `unmarshall()` has been updated to create the request object and to parse the response object with UTF-8 encoding.

The `SimpleProperties.load()` and `store()` has been updated to load and to store the profile config file with UTF-8 encoding.

The `ConfigStore.store()` has been updated to export the profile config into a raw format with UTF-8 encoding.

The `pki <subsystem>-user-add` has been modified to accept a `--full-name` option for consistency with the `pki-server <subsystem>-user-add` command.

The `UserShowCLI` has been modified to retrieve the correct fields from the JSON object.

A new test has been added to create a cert profile, enroll a cert, create a user, then perform client cert auth with wide characters.

https://github.com/edewata/pki/blob/i18n/docs/changes/v11.7.0/Tools-Changes.adoc

Resolves: https://github.com/dogtagpki/pki/issues/5067
