### PR TITLE
Add basic test for pki-server CLI

### DIFF
--- a/.github/workflows/pki-server-basic-test.yml
+++ b/.github/workflows/pki-server-basic-test.yml
@@ -1,0 +1,202 @@
+name: Basic PKI Server CLI
+# https://github.com/dogtagpki/pki/wiki/PKI-Server-CLI
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Set up runner container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              pki
+
+      - name: Check pki-server CLI help message
+        run: |
+          docker exec pki pki-server
+          docker exec pki pki-server --help
+
+      - name: Check pki-server CLI version
+        run: |
+          docker exec pki pki-server --version
+
+      - name: Check pki-server CLI with wrong option
+        run: |
+          docker exec pki pki-server --wrong \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          sed -n \
+              -e '/^pki-server:/p' \
+              stderr > actual
+
+          cat > expected << EOF
+          pki-server: error: unrecognized arguments: --wrong
+          EOF
+
+          diff expected actual
+
+      - name: Check pki-server CLI with wrong sub-command
+        run: |
+          docker exec pki pki-server wrong \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          cat > expected << EOF
+          ERROR: Invalid module "wrong".
+          EOF
+
+          diff expected stderr
+
+      - name: Check pki-server instance help messages
+        run: |
+          docker exec pki pki-server instance-find --help
+          docker exec pki pki-server instance-show --help
+
+      - name: Check pki-server password help messages
+        run: |
+          docker exec pki pki-server password-find --help
+          docker exec pki pki-server password-set --help
+          docker exec pki pki-server password-unset --help
+
+      - name: Check pki-server cert help messages
+        run: |
+          docker exec pki pki-server cert-find --help
+          docker exec pki pki-server cert-show --help
+          docker exec pki pki-server cert-validate --help
+          docker exec pki pki-server cert-update --help
+          docker exec pki pki-server cert-request --help
+          docker exec pki pki-server cert-create --help
+          docker exec pki pki-server cert-import --help
+          docker exec pki pki-server cert-export --help
+          docker exec pki pki-server cert-del --help
+          docker exec pki pki-server cert-fix --help
+
+      - name: Check pki-server http-connector help messages
+        run: |
+          docker exec pki pki-server http-connector-find --help
+          docker exec pki pki-server http-connector-show --help
+          docker exec pki pki-server http-connector-add --help
+          docker exec pki pki-server http-connector-mod --help
+          docker exec pki pki-server http-connector-del --help
+
+      - name: Check pki-server http-connector-host help messages
+        run: |
+          docker exec pki pki-server http-connector-host-find --help
+          docker exec pki pki-server http-connector-host-show --help
+          docker exec pki pki-server http-connector-host-add --help
+          docker exec pki pki-server http-connector-host-mod --help
+          docker exec pki pki-server http-connector-host-del --help
+
+      - name: Check pki-server http-connector-cert help messages
+        run: |
+          docker exec pki pki-server http-connector-cert-find --help
+          docker exec pki pki-server http-connector-cert-add --help
+          docker exec pki pki-server http-connector-cert-del --help
+
+      - name: Check pki-server webapp help messages
+        run: |
+          docker exec pki pki-server webapp-find --help
+          docker exec pki pki-server webapp-show --help
+          docker exec pki pki-server webapp-deploy --help
+          docker exec pki pki-server webapp-undeploy --help
+
+      - name: Check pki-server subsystem help messages
+        run: |
+          docker exec pki pki-server subsystem-find --help
+          docker exec pki pki-server subsystem-show --help
+          docker exec pki pki-server subsystem-enable --help
+          docker exec pki pki-server subsystem-disable --help
+
+      - name: Check pki-server sd help messages
+        run: |
+          docker exec pki pki-server sd-create --help
+
+      - name: Check pki-server sd-subsystem help messages
+        run: |
+          docker exec pki pki-server sd-subsystem-find --help
+          docker exec pki pki-server sd-subsystem-add --help
+          docker exec pki pki-server sd-subsystem-del --help
+
+      - name: Check pki-server ca-config help messages
+        run: |
+          docker exec pki pki-server ca-config-find --help
+          docker exec pki pki-server ca-config-show --help
+          docker exec pki pki-server ca-config-set --help
+          docker exec pki pki-server ca-config-unset --help
+
+      - name: Check pki-server ca-user help messages
+        run: |
+          docker exec pki pki-server ca-user-find --help
+          docker exec pki pki-server ca-user-show --help
+          docker exec pki pki-server ca-user-add --help
+          docker exec pki pki-server ca-user-mod --help
+          docker exec pki pki-server ca-user-del --help
+
+      - name: Check pki-server ca-user-cert help messages
+        run: |
+          docker exec pki pki-server ca-user-cert-find --help
+          docker exec pki pki-server ca-user-cert-add --help
+          docker exec pki pki-server ca-user-cert-del --help
+
+      - name: Check pki-server ca-user-role help messages
+        run: |
+          docker exec pki pki-server ca-user-role-find --help
+          docker exec pki pki-server ca-user-role-add --help
+          docker exec pki pki-server ca-user-role-del --help
+
+      - name: Check pki-server ca-group help messages
+        run: |
+          docker exec pki pki-server ca-group-find --help
+
+      - name: Check pki-server ca-group-member help messages
+        run: |
+          docker exec pki pki-server ca-group-member-find --help
+          docker exec pki pki-server ca-group-member-add --help
+          docker exec pki pki-server ca-group-member-del --help
+
+      - name: Check pki-server ca-id-generator help messages
+        run: |
+          docker exec pki pki-server ca-id-generator-show --help
+          docker exec pki pki-server ca-id-generator-update --help
+
+      - name: Check pki-server ca-db-access help messages
+        run: |
+          docker exec pki pki-server ca-db-access-grant --help
+          docker exec pki pki-server ca-db-access-revoke --help
+
+      - name: Check pki-server ca-audit-config help messages
+        run: |
+          docker exec pki pki-server ca-audit-config-show --help
+          docker exec pki pki-server ca-audit-config-mod --help
+
+      - name: Check pki-server ca-audit-event help messages
+        run: |
+          docker exec pki pki-server ca-audit-event-find --help
+          docker exec pki pki-server ca-audit-event-show --help
+          docker exec pki pki-server ca-audit-event-enable --help
+          docker exec pki pki-server ca-audit-event-disable --help
+          docker exec pki pki-server ca-audit-event-update --help
+
+      - name: Check pki-server ca-audit-file help messages
+        run: |
+          docker exec pki pki-server ca-audit-file-find --help
+          docker exec pki pki-server ca-audit-file-verify --help

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -63,6 +63,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/pki-pkcs12-test.yml
 
+  pki-server-basic-test:
+    name: Basic PKI Server CLI
+    needs: build
+    uses: ./.github/workflows/pki-server-basic-test.yml
+
   rpminspect-test:
     name: rpminspect
     needs: build

--- a/base/server/python/pki/server/cli/audit.py
+++ b/base/server/python/pki/server/cli/audit.py
@@ -443,7 +443,9 @@ class AuditEventShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('event_name')
+        self.parser.add_argument(
+            'event_name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-audit-event-show [OPTIONS] <event name>'
@@ -472,6 +474,9 @@ class AuditEventShowCLI(pki.cli.CLI):
 
         instance_name = args.instance
         event_name = args.event_name
+
+        if event_name is None:
+            raise pki.cli.CLIException('Missing event name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -518,7 +523,9 @@ class AuditEventEnableCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('event_name')
+        self.parser.add_argument(
+            'event_name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-audit-event-enable [OPTIONS] <event_name>'
@@ -547,6 +554,9 @@ class AuditEventEnableCLI(pki.cli.CLI):
 
         instance_name = args.instance
         event_name = args.event_name
+
+        if event_name is None:
+            raise pki.cli.CLIException('Missing event name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -609,7 +619,9 @@ class AuditEventUpdateCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('event_name')
+        self.parser.add_argument(
+            'event_name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-audit-event-update <event_name> '
@@ -640,6 +652,9 @@ class AuditEventUpdateCLI(pki.cli.CLI):
         instance_name = args.instance
         event_filter = args.event_filter
         event_name = args.event_name
+
+        if event_name is None:
+            raise pki.cli.CLIException('Missing event name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -688,7 +703,9 @@ class AuditEventDisableCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('event_name')
+        self.parser.add_argument(
+            'event_name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-audit-event-disable [OPTIONS] <event_name>'
@@ -717,6 +734,9 @@ class AuditEventDisableCLI(pki.cli.CLI):
 
         instance_name = args.instance
         event_name = args.event_name
+
+        if event_name is None:
+            raise pki.cli.CLIException('Missing event name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -437,7 +437,9 @@ class CACertRemoveCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('serial_number')
+        self.parser.add_argument(
+            'serial_number',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server ca-cert-remove [OPTIONS] <serial number>')
@@ -465,6 +467,9 @@ class CACertRemoveCLI(pki.cli.CLI):
 
         instance_name = args.instance
         serial_number = args.serial_number
+
+        if serial_number is None:
+            raise pki.cli.CLIException('Missing serial number')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -721,7 +726,9 @@ class CACertRequestShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('request_id')
+        self.parser.add_argument(
+            'request_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server ca-cert-request-show [OPTIONS] <request ID>')
@@ -751,6 +758,9 @@ class CACertRequestShowCLI(pki.cli.CLI):
         instance_name = args.instance
         output_file = args.output_file
         request_id = args.request_id
+
+        if request_id is None:
+            raise pki.cli.CLIException('Missing request ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -1122,7 +1132,9 @@ class CACRLIPShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('id')
+        self.parser.add_argument(
+            'id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -1144,6 +1156,9 @@ class CACRLIPShowCLI(pki.cli.CLI):
 
         instance_name = args.instance
         ip_id = args.id
+
+        if ip_id is None:
+            raise pki.cli.CLIException('Missing CRL issuing point ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -1209,7 +1224,9 @@ class CACRLIPModifyCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('id')
+        self.parser.add_argument(
+            'id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -1231,6 +1248,9 @@ class CACRLIPModifyCLI(pki.cli.CLI):
 
         instance_name = args.instance
         ip_id = args.id
+
+        if ip_id is None:
+            raise pki.cli.CLIException('Missing CRL issuing point ID')
 
         config = {}
         for param in args.D:
@@ -1563,7 +1583,9 @@ class CAConnectorAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('connector_id')
+        self.parser.add_argument(
+            'connector_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server ca-connector-add [OPTIONS] <connector ID>')
@@ -1594,6 +1616,9 @@ class CAConnectorAddCLI(pki.cli.CLI):
 
         instance_name = args.instance
         connector_id = args.connector_id
+
+        if connector_id is None:
+            raise pki.cli.CLIException('Missing connector ID')
 
         urls = []
         for url in args.url:
@@ -1848,7 +1873,9 @@ class CAProfileModifyCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('profile_id')
+        self.parser.add_argument(
+            'profile_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -1876,6 +1903,9 @@ class CAProfileModifyCLI(pki.cli.CLI):
         profile_enabled = args.enabled
 
         profile_id = args.profile_id
+
+        if profile_id is None:
+            raise pki.cli.CLIException('Missing profile ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/cert.py
+++ b/base/server/python/pki/server/cli/cert.py
@@ -232,7 +232,9 @@ class CertShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server cert-show [OPTIONS] <cert ID>')
@@ -264,6 +266,9 @@ class CertShowCLI(pki.cli.CLI):
         show_all = args.show_all
         pretty_print = args.pretty_print
         cert_id = args.cert_id
+
+        if cert_id is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -341,7 +346,9 @@ class CertValidateCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -363,6 +370,9 @@ class CertValidateCLI(pki.cli.CLI):
 
         instance_name = args.instance
         cert_id = args.cert_id
+
+        if cert_id is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -411,7 +421,9 @@ class CertUpdateCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server cert-update [OPTIONS] <cert ID>')
@@ -439,6 +451,9 @@ class CertUpdateCLI(pki.cli.CLI):
 
         instance_name = args.instance
         cert_id = args.cert_id
+
+        if cert_id is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -556,7 +571,9 @@ class CertRequestCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -581,6 +598,9 @@ class CertRequestCLI(pki.cli.CLI):
         subject_dn = args.subject
         ext_conf = args.ext
         cert_id = args.cert_id
+
+        if cert_id is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         if subject_dn is None:
             raise Exception('Missing subject DN')
@@ -684,7 +704,9 @@ class CertCreateCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -728,6 +750,9 @@ class CertCreateCLI(pki.cli.CLI):
         agent_password = args.w
         agent_password_file = args.W
         cert_id = args.cert_id
+
+        if cert_id is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         if client_cert and agent_username:
             logger.error('-n cannot be used with -u')
@@ -821,7 +846,9 @@ class CertImportCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id', nargs='?')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -910,7 +937,9 @@ class CertExportCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server cert-export [OPTIONS] <Cert ID>')
@@ -978,6 +1007,9 @@ class CertExportCLI(pki.cli.CLI):
         include_key = not args.no_key
         include_chain = not args.no_chain
         cert_id = args.cert_id
+
+        if cert_id is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         if not (cert_file or csr_file or pkcs12_file):
             logger.error('missing output file')
@@ -1132,7 +1164,9 @@ class CertRemoveCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server cert-del [OPTIONS] <Cert ID>')
@@ -1165,6 +1199,9 @@ class CertRemoveCLI(pki.cli.CLI):
         instance_name = args.instance
         remove_key = args.remove_key
         cert_id = args.cert_id
+
+        if cert_id is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 

--- a/base/server/python/pki/server/cli/config.py
+++ b/base/server/python/pki/server/cli/config.py
@@ -138,7 +138,9 @@ class SubsystemConfigShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-config-show [OPTIONS] <name>' % self.parent.parent.name)
@@ -166,6 +168,9 @@ class SubsystemConfigShowCLI(pki.cli.CLI):
 
         instance_name = args.instance
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing parameter name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -218,8 +223,12 @@ class SubsystemConfigSetCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
-        self.parser.add_argument('value')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
+        self.parser.add_argument(
+            'value',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-config-set [OPTIONS] <name> <value>'
@@ -249,6 +258,12 @@ class SubsystemConfigSetCLI(pki.cli.CLI):
         instance_name = args.instance
         name = args.name
         value = args.value
+
+        if name is None:
+            raise pki.cli.CLIException('Missing parameter name')
+
+        if value is None:
+            raise pki.cli.CLIException('Missing parameter value')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -294,7 +309,9 @@ class SubsystemConfigUnsetCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-config-unset [OPTIONS] <name>'
@@ -323,6 +340,9 @@ class SubsystemConfigUnsetCLI(pki.cli.CLI):
 
         instance_name = args.instance
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing parameter name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/db.py
+++ b/base/server/python/pki/server/cli/db.py
@@ -1112,7 +1112,9 @@ class SubsystemDBAccessGrantCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('dn')
+        self.parser.add_argument(
+            'dn',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -1137,6 +1139,9 @@ class SubsystemDBAccessGrantCLI(pki.cli.CLI):
         subsystem_name = self.parent.parent.parent.name
         as_current_user = args.as_current_user
         dn = args.dn
+
+        if dn is None:
+            raise pki.cli.CLIException('Missing DN')
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1201,7 +1206,9 @@ class SubsystemDBAccessRevokeCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('dn')
+        self.parser.add_argument(
+            'dn',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -1226,6 +1233,9 @@ class SubsystemDBAccessRevokeCLI(pki.cli.CLI):
         subsystem_name = self.parent.parent.parent.name
         as_current_user = args.as_current_user
         dn = args.dn
+
+        if dn is None:
+            raise pki.cli.CLIException('Missing DN')
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1645,7 +1655,9 @@ class SubsystemDBReplicationAgreementAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -1677,6 +1689,9 @@ class SubsystemDBReplicationAgreementAddCLI(pki.cli.CLI):
         replication_security = args.replication_security
         suffix = args.suffix
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing replication agreement name')
 
         instance = pki.server.instance.PKIInstance(instance_name)
 
@@ -1767,7 +1782,9 @@ class SubsystemDBReplicationAgreementInitCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -1795,6 +1812,9 @@ class SubsystemDBReplicationAgreementInitCLI(pki.cli.CLI):
         bind_password = args.bind_password
         suffix = args.suffix
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing replication agreement name')
 
         instance = pki.server.instance.PKIInstance(instance_name)
 

--- a/base/server/python/pki/server/cli/group.py
+++ b/base/server/python/pki/server/cli/group.py
@@ -140,7 +140,9 @@ class GroupMemberFindCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('group_id')
+        self.parser.add_argument(
+            'group_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-group-member-find [OPTIONS] <group ID>'
@@ -170,6 +172,9 @@ class GroupMemberFindCLI(pki.cli.CLI):
         instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
         group_id = args.group_id
+
+        if group_id is None:
+            raise pki.cli.CLIException('Missing group ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -226,8 +231,12 @@ class GroupMemberAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('group_id')
-        self.parser.add_argument('member_id')
+        self.parser.add_argument(
+            'group_id',
+            nargs='?')
+        self.parser.add_argument(
+            'member_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-group-member-add [OPTIONS] <group ID> <member ID>'
@@ -258,6 +267,12 @@ class GroupMemberAddCLI(pki.cli.CLI):
         subsystem_name = self.parent.parent.parent.name
         group_id = args.group_id
         member_id = args.member_id
+
+        if group_id is None:
+            raise pki.cli.CLIException('Missing group ID')
+
+        if member_id is None:
+            raise pki.cli.CLIException('Missing group member ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -305,8 +320,12 @@ class GroupMemberRemoveCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('group_id')
-        self.parser.add_argument('member_id')
+        self.parser.add_argument(
+            'group_id',
+            nargs='?')
+        self.parser.add_argument(
+            'member_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-group-member-del [OPTIONS] <group ID> <member ID>'
@@ -337,6 +356,12 @@ class GroupMemberRemoveCLI(pki.cli.CLI):
         subsystem_name = self.parent.parent.parent.name
         group_id = args.group_id
         member_id = args.member_id
+
+        if group_id is None:
+            raise pki.cli.CLIException('Missing group ID')
+
+        if member_id is None:
+            raise pki.cli.CLIException('Missing group member ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/http.py
+++ b/base/server/python/pki/server/cli/http.py
@@ -123,7 +123,9 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server http-connector-add [OPTIONS] <connector ID>')
@@ -169,6 +171,9 @@ class HTTPConnectorAddCLI(pki.cli.CLI):
         certVerification = args.certVerification
         trustManager = args.trustManager
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing connector name')
 
         if port is None:
             raise Exception('Missing port number')
@@ -232,7 +237,9 @@ class HTTPConnectorDeleteCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server http-connector-del [OPTIONS] <connector ID>')
@@ -260,6 +267,9 @@ class HTTPConnectorDeleteCLI(pki.cli.CLI):
 
         instance_name = args.instance
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing connector name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -373,7 +383,9 @@ class HTTPConnectorShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server http-connector-show [OPTIONS] <connector ID>')
@@ -401,6 +413,9 @@ class HTTPConnectorShowCLI(pki.cli.CLI):
 
         instance_name = args.instance
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing connector name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -458,7 +473,9 @@ class HTTPConnectorModCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server http-connector-mod [OPTIONS] <connector ID>')
@@ -510,6 +527,9 @@ class HTTPConnectorModCLI(pki.cli.CLI):
         sslEnabled = args.sslEnabled
         sslImpl = args.sslImpl
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing connector name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -636,8 +656,12 @@ class SSLHostAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('connector_name')
-        self.parser.add_argument('hostname')
+        self.parser.add_argument(
+            'connector_name',
+            nargs='?')
+        self.parser.add_argument(
+            'hostname',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server http-connector-host-add [OPTIONS] <connector ID> <hostname>')
@@ -672,6 +696,12 @@ class SSLHostAddCLI(pki.cli.CLI):
         trustManager = args.trustManager
         connector_name = args.connector_name
         hostname = args.hostname
+
+        if connector_name is None:
+            raise pki.cli.CLIException('Missing connector name')
+
+        if hostname is None:
+            raise pki.cli.CLIException('Missing hostname')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -727,8 +757,12 @@ class SSLHostDeleteCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('connector_name')
-        self.parser.add_argument('hostname')
+        self.parser.add_argument(
+            'connector_name',
+            nargs='?')
+        self.parser.add_argument(
+            'hostname',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server http-connector-host-del [OPTIONS] <connector ID> <hostname>')
@@ -757,6 +791,12 @@ class SSLHostDeleteCLI(pki.cli.CLI):
         instance_name = args.instance
         connector_name = args.connector_name
         hostname = args.hostname
+
+        if connector_name is None:
+            raise pki.cli.CLIException('Missing connector name')
+
+        if hostname is None:
+            raise pki.cli.CLIException('Missing hostname')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -801,7 +841,9 @@ class SSLHostFindCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('connector_name')
+        self.parser.add_argument(
+            'connector_name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server http-connector-sslhost-find [OPTIONS] <connector ID>')
@@ -829,6 +871,9 @@ class SSLHostFindCLI(pki.cli.CLI):
 
         instance_name = args.instance
         connector_name = args.connector_name
+
+        if connector_name is None:
+            raise pki.cli.CLIException('Missing connector name')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -901,8 +946,12 @@ class SSLHostModifyCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('connector_name')
-        self.parser.add_argument('hostname')
+        self.parser.add_argument(
+            'connector_name',
+            nargs='?')
+        self.parser.add_argument(
+            'hostname',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -928,6 +977,12 @@ class SSLHostModifyCLI(pki.cli.CLI):
         trustManager = args.trustManager
         connector_name = args.connector_name
         hostname = args.hostname
+
+        if connector_name is None:
+            raise pki.cli.CLIException('Missing connector name')
+
+        if hostname is None:
+            raise pki.cli.CLIException('Missing hostname')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -995,8 +1050,12 @@ class SSLHostShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('connector_name')
-        self.parser.add_argument('hostname')
+        self.parser.add_argument(
+            'connector_name',
+            nargs='?')
+        self.parser.add_argument(
+            'hostname',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -1019,6 +1078,12 @@ class SSLHostShowCLI(pki.cli.CLI):
         instance_name = args.instance
         connector_name = args.connector_name
         hostname = args.hostname
+
+        if connector_name is None:
+            raise pki.cli.CLIException('Missing connector name')
+
+        if hostname is None:
+            raise pki.cli.CLIException('Missing hostname')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 

--- a/base/server/python/pki/server/cli/id.py
+++ b/base/server/python/pki/server/cli/id.py
@@ -136,7 +136,9 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('object_name')
+        self.parser.add_argument(
+            'object_name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-id-generator-update [OPTIONS] <object>' %
@@ -171,6 +173,9 @@ class IdGeneratorUpdateCLI(pki.cli.CLI):
         generator_object = args.object_name
         generator = args.type
         range_object = args.range
+
+        if generator_object is None:
+            raise pki.cli.CLIException('Missing ID generator name')
 
         if not generator:
             logger.error('No <generator type> specified')

--- a/base/server/python/pki/server/cli/instance.py
+++ b/base/server/python/pki/server/cli/instance.py
@@ -270,7 +270,9 @@ class InstanceShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('instance_id')
+        self.parser.add_argument(
+            'instance_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server instance-show [OPTIONS] <instance ID>')
@@ -296,6 +298,9 @@ class InstanceShowCLI(pki.cli.CLI):
             logging.getLogger().setLevel(logging.INFO)
 
         instance_name = args.instance_id
+
+        if instance_name is None:
+            raise pki.cli.CLIException('Missing instance ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -328,7 +333,9 @@ class InstanceStartCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('instance_id')
+        self.parser.add_argument(
+            'instance_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server instance-start [OPTIONS] <instance ID>')
@@ -354,6 +361,9 @@ class InstanceStartCLI(pki.cli.CLI):
             logging.getLogger().setLevel(logging.INFO)
 
         instance_name = args.instance_id
+
+        if instance_name is None:
+            raise pki.cli.CLIException('Missing instance ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -391,7 +401,9 @@ class InstanceStopCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('instance_id')
+        self.parser.add_argument(
+            'instance_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server instance-stop [OPTIONS] <instance ID>')
@@ -417,6 +429,9 @@ class InstanceStopCLI(pki.cli.CLI):
             logging.getLogger().setLevel(logging.INFO)
 
         instance_name = args.instance_id
+
+        if instance_name is None:
+            raise pki.cli.CLIException('Missing instance ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -455,7 +470,9 @@ class InstanceMigrateCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('instance_id')
+        self.parser.add_argument(
+            'instance_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server instance-migrate [OPTIONS] <instance ID>')
@@ -487,6 +504,9 @@ class InstanceMigrateCLI(pki.cli.CLI):
             tomcat_version = pki.server.Tomcat.get_version()
 
         instance_name = args.instance_id
+
+        if instance_name is None:
+            raise pki.cli.CLIException('Missing instance ID')
 
         logger.info('Migrating to Tomcat %s', tomcat_version)
 
@@ -527,7 +547,9 @@ class InstanceNuxwdogEnableCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('instance_id')
+        self.parser.add_argument(
+            'instance_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server instance-nuxwdog-enable [OPTIONS] <instance ID>')
@@ -553,6 +575,9 @@ class InstanceNuxwdogEnableCLI(pki.cli.CLI):
             logging.getLogger().setLevel(logging.INFO)
 
         instance_name = args.instance_id
+
+        if instance_name is None:
+            raise pki.cli.CLIException('Missing instance ID')
 
         module = self.get_top_module().find_module('nuxwdog-enable')
         module = pki.server.cli.nuxwdog.NuxwdogEnableCLI()
@@ -590,7 +615,9 @@ class InstanceNuxwdogDisableCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('instance_id')
+        self.parser.add_argument(
+            'instance_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server instance-nuxwdog-disable [OPTIONS] <instance ID>')
@@ -616,6 +643,9 @@ class InstanceNuxwdogDisableCLI(pki.cli.CLI):
             logging.getLogger().setLevel(logging.INFO)
 
         instance_name = args.instance_id
+
+        if instance_name is None:
+            raise pki.cli.CLIException('Missing instance ID')
 
         module = self.get_top_module().find_module('nuxwdog-disable')
 

--- a/base/server/python/pki/server/cli/password.py
+++ b/base/server/python/pki/server/cli/password.py
@@ -138,7 +138,9 @@ class PasswordAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server password-add [OPTIONS] <password ID>')
@@ -172,6 +174,9 @@ class PasswordAddCLI(pki.cli.CLI):
         instance_name = args.instance
         password = args.password
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing password ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -211,7 +216,9 @@ class PasswordRemoveCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server password-del [OPTIONS] <password ID>')
@@ -243,6 +250,9 @@ class PasswordRemoveCLI(pki.cli.CLI):
 
         instance_name = args.instance
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing password ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -281,7 +291,9 @@ class PasswordSetCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server password-set [OPTIONS] <password ID>')
@@ -313,6 +325,9 @@ class PasswordSetCLI(pki.cli.CLI):
         password = args.password
         password_file = args.password_file
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing password ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -359,7 +374,9 @@ class PasswordUnsetCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('name')
+        self.parser.add_argument(
+            'name',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server password-unset [OPTIONS] <password ID>')
@@ -387,6 +404,9 @@ class PasswordUnsetCLI(pki.cli.CLI):
 
         instance_name = args.instance
         name = args.name
+
+        if name is None:
+            raise pki.cli.CLIException('Missing password ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 

--- a/base/server/python/pki/server/cli/sd.py
+++ b/base/server/python/pki/server/cli/sd.py
@@ -204,7 +204,9 @@ class SDSubsystemAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server sd-subsystem-add [OPTIONS] <subsystem ID>')
@@ -244,6 +246,9 @@ class SDSubsystemAddCLI(pki.cli.CLI):
         domain_manager = args.domain_manager
         clone = args.clone
         subsystem_id = args.subsystem_id
+
+        if subsystem_id is None:
+            raise pki.cli.CLIException('Missing subsystem ID')
 
         if not subsystem_type:
             logger.error('Missing subsystem type')
@@ -301,7 +306,9 @@ class SDSubsystemRemoveCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server sd-subsystem-del [OPTIONS] <subsystem ID>')
@@ -329,6 +336,9 @@ class SDSubsystemRemoveCLI(pki.cli.CLI):
 
         instance_name = args.instance
         subsystem_id = args.subsystem_id
+
+        if subsystem_id is None:
+            raise pki.cli.CLIException('Missing subsystem ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -80,7 +80,7 @@ class SubsystemFindCLI(pki.cli.CLI):
             '--help',
             action='store_true')
 
-    def usage(self):
+    def print_help(self):
         print('Usage: pki-server subsystem-find [OPTIONS]')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
@@ -150,9 +150,11 @@ class SubsystemShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
 
-    def usage(self):
+    def print_help(self):
         print('Usage: pki-server subsystem-show [OPTIONS] <subsystem ID>')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
@@ -178,6 +180,9 @@ class SubsystemShowCLI(pki.cli.CLI):
 
         instance_name = args.instance
         subsystem_name = args.subsystem_id
+
+        if subsystem_name is None:
+            raise pki.cli.CLIException('Missing subsystem ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -611,7 +616,7 @@ class SubsystemEnableCLI(pki.cli.CLI):
             'subsystem_id',
             nargs='?')
 
-    def usage(self):
+    def print_help(self):
         print('Usage: pki-server subsystem-enable [OPTIONS] [<subsystem ID>]')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
@@ -661,7 +666,7 @@ class SubsystemEnableCLI(pki.cli.CLI):
 
         if not args.subsystem_id:
             logger.error('Missing subsystem ID')
-            self.usage()
+            self.print_help()
             sys.exit(1)
 
         subsystem_name = args.subsystem_id
@@ -716,7 +721,7 @@ class SubsystemDisableCLI(pki.cli.CLI):
             'subsystem_id',
             nargs='?')
 
-    def usage(self):
+    def print_help(self):
         print('Usage: pki-server subsystem-disable [OPTIONS] [<subsystem ID>]')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
@@ -763,7 +768,7 @@ class SubsystemDisableCLI(pki.cli.CLI):
 
         if not args.subsystem_id:
             logger.error('Missing subsystem ID')
-            self.usage()
+            self.print_help()
             sys.exit(1)
 
         subsystem_name = args.subsystem_id
@@ -839,7 +844,9 @@ class SubsystemCertFindCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server subsystem-cert-find [OPTIONS] <subsystem ID>')
@@ -873,6 +880,9 @@ class SubsystemCertFindCLI(pki.cli.CLI):
         instance_name = args.instance
         show_all = args.show_all
         subsystem_name = args.subsystem_id
+
+        if subsystem_name is None:
+            raise pki.cli.CLIException('Missing subsystem ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -943,10 +953,14 @@ class SubsystemCertShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('subsystem_id')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
-    def usage(self):
+    def print_help(self):
         print('Usage: pki-server subsystem-cert-show [OPTIONS] <subsystem ID> <cert ID>')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
@@ -980,6 +994,12 @@ class SubsystemCertShowCLI(pki.cli.CLI):
 
         subsystem_name = args.subsystem_id
         cert_tag = args.cert_id
+
+        if subsystem_name is None:
+            raise pki.cli.CLIException('Missing subsystem ID')
+
+        if cert_tag is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -1040,7 +1060,9 @@ class SubsystemCertExportCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
         self.parser.add_argument(
             'cert_id',
             nargs='?')
@@ -1095,6 +1117,9 @@ class SubsystemCertExportCLI(pki.cli.CLI):
 
         subsystem_name = args.subsystem_id
         cert_tag = args.cert_id
+
+        if subsystem_name is None:
+            raise pki.cli.CLIException('Missing subsystem ID')
 
         if not (cert_file or csr_file or pkcs12_file):
             logger.error('Missing output file')
@@ -1201,10 +1226,14 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('subsystem_id')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
-    def usage(self):
+    def print_help(self):
         print('Usage: pki-server subsystem-cert-update [OPTIONS] <subsystem ID> <cert ID>')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
@@ -1235,6 +1264,12 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
         subsystem_name = args.subsystem_id
         cert_tag = args.cert_id
 
+        if subsystem_name is None:
+            raise pki.cli.CLIException('Missing subsystem ID')
+
+        if cert_tag is None:
+            raise pki.cli.CLIException('Missing certificate ID')
+
         instance = pki.server.PKIServerFactory.create(instance_name)
 
         if not instance.exists():
@@ -1259,7 +1294,7 @@ class SubsystemCertUpdateCLI(pki.cli.CLI):
         if cert_file:
             if not os.path.isfile(cert_file):
                 logger.error('%s certificate does not exist.', cert_file)
-                self.usage()
+                self.print_help()
                 sys.exit(1)
 
             data = nssdb.get_cert(
@@ -1348,12 +1383,14 @@ class SubsystemCertValidateCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('subsystem_id')
+        self.parser.add_argument(
+            'subsystem_id',
+            nargs='?')
         self.parser.add_argument(
             'cert_id',
             nargs='?')
 
-    def usage(self):
+    def print_help(self):
         print('Usage: pki-server subsystem-cert-validate [OPTIONS] <subsystem ID> [cert ID]')
         print()
         print('  -i, --instance <instance ID>    Instance ID (default: pki-tomcat).')
@@ -1384,6 +1421,9 @@ class SubsystemCertValidateCLI(pki.cli.CLI):
         instance_name = args.instance
         subsystem_name = args.subsystem_id
         cert_tag = args.cert_id
+
+        if subsystem_name is None:
+            raise pki.cli.CLIException('Missing subsystem ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 

--- a/base/server/python/pki/server/cli/tks.py
+++ b/base/server/python/pki/server/cli/tks.py
@@ -323,7 +323,9 @@ class TKSConnectorAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('connector_id')
+        self.parser.add_argument(
+            'connector_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server tks-connector-add [OPTIONS] <connector ID>')
@@ -357,6 +359,9 @@ class TKSConnectorAddCLI(pki.cli.CLI):
         url = urllib.parse.urlparse(args.url)
         nickname = args.nickname
         uid = args.uid
+
+        if connector_id is None:
+            raise pki.cli.CLIException('Missing connector ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/tps.py
+++ b/base/server/python/pki/server/cli/tps.py
@@ -347,7 +347,9 @@ class TPSConnectorAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('connector_id')
+        self.parser.add_argument(
+            'connector_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server tps-connector-add [OPTIONS] <connector ID>')
@@ -383,6 +385,9 @@ class TPSConnectorAddCLI(pki.cli.CLI):
         url = urllib.parse.urlparse(args.url)
         nickname = args.nickname
         keygen = args.keygen
+
+        if connector_id is None:
+            raise pki.cli.CLIException('Missing connector ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -97,7 +97,9 @@ class UserAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -136,6 +138,9 @@ class UserAddCLI(pki.cli.CLI):
 
         ignore_duplicate = args.ignore_duplicate
         user_id = args.user_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
 
         if not full_name:
             logger.error('Missing full name')
@@ -310,7 +315,9 @@ class UserModifyCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-user-mod [OPTIONS] <user ID>' % self.parent.parent.name)
@@ -347,6 +354,9 @@ class UserModifyCLI(pki.cli.CLI):
         add_see_also = args.add_see_also
         del_see_also = args.del_see_also
         user_id = args.user_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -411,7 +421,9 @@ class UserRemoveCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -435,6 +447,9 @@ class UserRemoveCLI(pki.cli.CLI):
         instance_name = args.instance
         subsystem_name = self.parent.parent.name
         user_id = args.user_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -479,7 +494,9 @@ class UserShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-user-show [OPTIONS] <user ID>' % self.parent.parent.name)
@@ -508,6 +525,9 @@ class UserShowCLI(pki.cli.CLI):
         instance_name = args.instance
         subsystem_name = self.parent.parent.name
         user_id = args.user_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -585,7 +605,9 @@ class UserCertFindCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-user-cert-find [OPTIONS] <user ID>'
@@ -615,6 +637,9 @@ class UserCertFindCLI(pki.cli.CLI):
         instance_name = args.instance
         subsystem_name = self.parent.parent.parent.name
         user_id = args.user_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -666,7 +691,9 @@ class UserCertAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server %s-user-cert-add [OPTIONS] <user ID>'
@@ -702,6 +729,9 @@ class UserCertAddCLI(pki.cli.CLI):
         cert_format = args.format
         ignore_duplicate = args.ignore_duplicate
         user_id = args.user_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -765,8 +795,12 @@ class UserCertRemoveCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
-        self.parser.add_argument('cert_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
+        self.parser.add_argument(
+            'cert_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -791,6 +825,12 @@ class UserCertRemoveCLI(pki.cli.CLI):
         subsystem_name = self.parent.parent.parent.name
         user_id = args.user_id
         cert_id = args.cert_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
+
+        if cert_id is None:
+            raise pki.cli.CLIException('Missing certificate ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -863,7 +903,9 @@ class UserRoleFindCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -888,6 +930,9 @@ class UserRoleFindCLI(pki.cli.CLI):
         subsystem_name = self.parent.parent.parent.name
         output_format = args.output_format
         user_id = args.user_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -947,8 +992,12 @@ class UserRoleAddCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
-        self.parser.add_argument('role_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
+        self.parser.add_argument(
+            'role_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -974,6 +1023,12 @@ class UserRoleAddCLI(pki.cli.CLI):
 
         user_id = args.user_id
         role_id = args.role_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
+
+        if role_id is None:
+            raise pki.cli.CLIException('Missing role ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():
@@ -1033,8 +1088,12 @@ class UserRoleRemoveCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('user_id')
-        self.parser.add_argument('role_id')
+        self.parser.add_argument(
+            'user_id',
+            nargs='?')
+        self.parser.add_argument(
+            'role_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
@@ -1060,6 +1119,12 @@ class UserRoleRemoveCLI(pki.cli.CLI):
 
         user_id = args.user_id
         role_id = args.role_id
+
+        if user_id is None:
+            raise pki.cli.CLIException('Missing user ID')
+
+        if role_id is None:
+            raise pki.cli.CLIException('Missing role ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
         if not instance.exists():

--- a/base/server/python/pki/server/cli/webapp.py
+++ b/base/server/python/pki/server/cli/webapp.py
@@ -157,7 +157,9 @@ class WebappShowCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('webapp_id')
+        self.parser.add_argument(
+            'webapp_id',
+            nargs='?')
 
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
@@ -179,6 +181,9 @@ class WebappShowCLI(pki.cli.CLI):
 
         instance_name = args.instance
         webapp_id = args.webapp_id
+
+        if webapp_id is None:
+            raise pki.cli.CLIException('Missing web application ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -231,7 +236,9 @@ class WebappDeployCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('webapp_id')
+        self.parser.add_argument(
+            'webapp_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server webapp-deploy [OPTIONS] <webapp ID>')
@@ -269,6 +276,9 @@ class WebappDeployCLI(pki.cli.CLI):
         max_wait = args.max_wait
         timeout = args.timeout
         webapp_id = args.webapp_id
+
+        if webapp_id is None:
+            raise pki.cli.CLIException('Missing web application ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 
@@ -318,7 +328,9 @@ class WebappUndeployCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
-        self.parser.add_argument('webapp_id')
+        self.parser.add_argument(
+            'webapp_id',
+            nargs='?')
 
     def print_help(self):
         print('Usage: pki-server webapp-undeploy [OPTIONS] [<webapp ID>]')
@@ -352,6 +364,9 @@ class WebappUndeployCLI(pki.cli.CLI):
         max_wait = args.max_wait
         timeout = args.timeout
         webapp_id = args.webapp_id
+
+        if webapp_id is None:
+            raise pki.cli.CLIException('Missing web application ID')
 
         instance = pki.server.PKIServerFactory.create(instance_name)
 


### PR DESCRIPTION
The mandatory positional arguments for `pki-server` subcommands have been changed to become optional such that the `--help` option can be parsed properly.

A new test has been added to check `pki-server` help messages.

Resolves: https://github.com/dogtagpki/pki/issues/4952