### PR TITLE
RHCS-5927 [DOC] Asciidoc code block rendering issue with [literal,sub…

### DIFF
--- a/docs/README/README-doc-convention.adoc
+++ b/docs/README/README-doc-convention.adoc
@@ -26,7 +26,7 @@ See installation/ca/installing-ca.adoc for example.
 ** Use “....” for commands or other smaller blocks
 ** Use “----” block brackets for code blocks or content of a file such as pkispawn cfg file samples
 ** Add the following line above beginning of each block:
-*** [literal,subs="+quotes,verbatim"]
+*** [literal]
 * use a pair of backticks around words that are literal such as file names or commands
 * do not use future tense (e.g. 'will', "will be", etc.).  Use present tense instead.
 * Create PR and request for reviews from members of the dogtag pki team (and doc team if applicable)

--- a/docs/admin/configuration-for-server-side-keygen.adoc
+++ b/docs/admin/configuration-for-server-side-keygen.adoc
@@ -126,7 +126,7 @@ NOTE: If cracklibCheck=true is enabled, SELinux may block /usr/sbin/cracklib-che
 
 Apply the necessary SELinux policies:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # setsebool -P domain_can_mmap_files 1
 # ausearch -c 'cracklib-check' --raw | audit2allow -M my-cracklibcheck

--- a/docs/installation/ca/installing-ca-clone-with-hsm.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-hsm.adoc
@@ -15,7 +15,7 @@ However, the CSRs for the system certificates are stored in `CS.cfg` instead of 
 
 They can optionally be exported with the following commands:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export ca_signing \
     --csr-file ca_signing.csr
@@ -36,7 +36,7 @@ Note: It is assumed that the CA signing certificate has been exported into `ca_s
 
 . Prepare a file, for example `ca.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -95,7 +95,7 @@ pki_clone_uri=https://pki.example.com:8443
 
 . If the CSRs are available, they can be specified with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ca_signing_csr_path=ca_signing.csr
 pki_ocsp_signing_csr_path=ca_ocsp_signing.csr
@@ -105,7 +105,7 @@ pki_subsystem_csr_path=subsystem.csr
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca.cfg -s CA
 ....
@@ -120,7 +120,7 @@ It installs a CA subsystem in a Tomcat instance (default is pki-tomcat) and crea
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -134,7 +134,7 @@ ca_audit_signing                                             ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -152,14 +152,14 @@ HSM:sslserver/replica.example.com                            u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the master's admin key and certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -168,7 +168,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA clone by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-connection.adoc
@@ -21,7 +21,7 @@ Some useful tips:
 == Exporting existing CA system certificates 
 
 On the existing system, export the CA system certificates and copy them to the clone system with the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server ca-clone-prepare --pkcs12-file ca-certs.p12 --pkcs12-password Secret.123
 $ pki-server cert-export ca_signing --cert-file ca_signing.crt
@@ -40,7 +40,7 @@ The following certificates (including the certificate chain) and their keys are 
 Note that the existing SSL server certificate is not exported.
 
 If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
@@ -52,14 +52,14 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 == SELinux permissions 
 
 After copying the `ca-certs.p12` to the clone machine, ensure that appropriate SELinux rules are added:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ semanage fcontext -a -t pki_tomcat_cert_t ca-certs.p12
 $ restorecon -R -v ca-certs.p12
 ....
 
 Ensure that the `ca-certs.p12` file is owned by the `pkiuser`
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ chown pkiuser:pkiuser ca-certs.p12
 ....
@@ -73,7 +73,7 @@ Prepare a deployment configuration, for example `ca-secure-ds-secondary.cfg`, to
 The sample pkispawn config file referenced below expects the DS server certificate's signing certificate to be in a file named `ds_signing.crt`.  Since the existing CA is being used as the signing certificate, copy the CA's signing certificate into `ds_signing.crt`:
 // The ds_signing.crt is the same as ca_signing.crt in this case
 // Will that work?
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ cp ca_signing.crt ds_signing.crt
 ....
@@ -94,7 +94,7 @@ It assumes that:
 * The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 
 To start the installation, execute the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-secure-ds-secondary.cfg -s CA
 ....
@@ -102,7 +102,7 @@ $ pkispawn -f ca-secure-ds-secondary.cfg -s CA
 == CA system certificates 
 
 After installation the existing CA system certificates (including the certificate chain) and their keys are stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`), and a new SSL server certificate is created for the new instance. Note that if the ds_signing is the same cert as ca_signing, it does not show in the following `certutil` listing:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -118,7 +118,7 @@ sslserver                                                    u,u,u
 ....
 
 If necessary, the clone CA system certificates can be exported into PEM files with the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -140,14 +140,14 @@ To use the admin certificate, do the following.
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin certificate and key from the master CA into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -156,7 +156,7 @@ $ pki pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA subsystem clone by running the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-clone-with-ldaps-using-bootstrap-ds-certs.adoc
+++ b/docs/installation/ca/installing-ca-clone-with-ldaps-using-bootstrap-ds-certs.adoc
@@ -11,7 +11,7 @@ Prior to installation, please ensure that the xref:../others/installation-prereq
 
 . Once the prerequisites listed above are completed on the clone system, go on the existing system and export the DS signing certificate into `ds_signing.p12` and copy the certificate into clone system with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /etc/dirsrv/slapd-localhost \
 -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
@@ -21,7 +21,7 @@ pkcs12-export --pkcs12-file ds_signing.p12 \
 
 . Import the `ds_signing.p12` into the clone DS instance with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /etc/dirsrv/slapd-localhost \
 -C /etc/dirsrv/slapd-localhost/pwdfile.txt \
@@ -37,7 +37,7 @@ Note that the certificate subject DN should match the clone's hostname, that is,
 
 . After the successful DS restart, export the DS Signing Certificate into 'ds_signing.crt' as follows:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.crt
 ....
@@ -50,7 +50,7 @@ Some useful tips:
 
 . On the existing system, export the CA system certificates and copy to clone system with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server ca-clone-prepare --pkcs12-file ca-certs.p12 --pkcs12-password Secret.123
 $ pki-server cert-export ca_signing --cert-file ca_signing.crt
@@ -68,7 +68,7 @@ Note that the existing SSL server certificate is not exported.
 
 . If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
@@ -81,7 +81,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 
 . After copying the `ca-certs.p12` to the clone machine, ensure that appropriate SELinux rules are added:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ semanage fcontext -a -t pki_tomcat_cert_t ca-certs.p12
 $ restorecon -R -v ca-certs.p12
@@ -89,7 +89,7 @@ $ restorecon -R -v ca-certs.p12
 
 . Ensure that the `ca-certs.p12` file is owned by the `pkiuser`:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ chown pkiuser:pkiuser ca-certs.p12
 ....
@@ -113,7 +113,7 @@ It assumes that:
 * The PKCS #12 password is specified in the `pki_client_pkcs12_password` parameter.
 
 To start the installation execute the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-secure-ds-secondary.cfg -s CA
 ....
@@ -121,7 +121,7 @@ $ pkispawn -f ca-secure-ds-secondary.cfg -s CA
 == CA system certificates 
 
 After installation, the existing CA system certificates (including the certificate chain) and their keys are stored in the server NSS database, that is, `/var/lib/pki/pki-tomcat/conf/alias`) and a new SSL server certificate is created for the new instance:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -137,7 +137,7 @@ sslserver                                                    u,u,u
 ....
 
 If necessary, the clone CA system certificates can be exported into PEM files with the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -158,14 +158,14 @@ To use the admin certificate, do the following.
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -174,7 +174,7 @@ $ pki pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA subsystem clone, execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-clone.adoc
+++ b/docs/installation/ca/installing-ca-clone.adoc
@@ -15,7 +15,7 @@ Additional useful tips:
 == Exporting existing CA system certificates 
 
 On the existing system, export the CA system certificates with the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server ca-clone-prepare \
     --pkcs12-file ca-certs.p12 \
@@ -32,7 +32,7 @@ The command exports the following certificates (including the certificate chain)
 Note that the existing SSL server certificate is not exported.
 
 If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
@@ -42,7 +42,7 @@ $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/pass
 ....
 
 Optionally, the CSRs for the above certificates can be exported as well with the following commands:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export ca_signing \
     --csr-file ca_signing.csr
@@ -60,14 +60,14 @@ $ pki-server cert-export subsystem \
 == SELinux permissions 
 
 After copying the `ca-certs.p12` to the clone machine, ensure that appropriate SELinux rules are added:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ semanage fcontext -a -t pki_tomcat_cert_t ca-certs.p12
 $ restorecon -R -v ca-certs.p12
 ....
 
 Ensure that the `ca-certs.p12` file is owned by the `pkiuser`
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ chown pkiuser:pkiuser ca-certs.p12
 ....
@@ -89,7 +89,7 @@ It assumes that the:
 See xref:installing-ca.adoc[CA installation] for details.
 
 If the CSRs are available, they can be specified with the following parameters:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ca_signing_csr_path=ca_signing.csr
 pki_ocsp_signing_csr_path=ca_ocsp_signing.csr
@@ -98,7 +98,7 @@ pki_subsystem_csr_path=subsystem.csr
 ....
 
 To start the installation, execute the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-clone-w-p12.cfg -s CA
 ....
@@ -108,7 +108,7 @@ $ pkispawn -f ca-clone-w-p12.cfg -s CA
 After installation the existing CA system certificates (including the certificate chain)
 and their keys are stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`),
 and a new SSL server certificate is created for the new instance:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -123,7 +123,7 @@ sslserver                                                    u,u,u
 ....
 
 If necessary, the certificates can be exported into PEM files with the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -144,14 +144,14 @@ To use the admin certificate, do the following.
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -160,7 +160,7 @@ $ pki pkcs12-import \
 
 . To verify that the admin certificate can be used to access the CA subsystem clone, execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-with-custom-ca-signing-key.adoc
+++ b/docs/installation/ca/installing-ca-with-custom-ca-signing-key.adoc
@@ -11,7 +11,7 @@ Prior to installation, please ensure that the xref:../others/installation-prereq
 
 . Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration for step 1:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -51,7 +51,7 @@ pki_external_step_two=False
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-step1.cfg -s CA
 ....
@@ -88,28 +88,28 @@ Prepare another file, for example `ca-step2.cfg`, that contains the deployment c
 
 . Specify step 2 with the following parameter:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the custom CA signing CSR with the following parameter:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ca_signing_csr_path=ca_signing.csr
 ....
 
 . Specify the custom CA signing certificate with the following parameter:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ca_signing_cert_path=ca_signing.crt
 ....
 
 . If the CA signing certificate was issued by an external CA, specify the external CA certificate chain with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_chain_nickname=external
 pki_cert_chain_path=external.crt
@@ -117,7 +117,7 @@ pki_cert_chain_path=external.crt
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-step2.cfg -s CA
 ....
@@ -125,7 +125,7 @@ $ pkispawn -f ca-step2.cfg -s CA
 == Verifying the system certificates 
 
 Verify that the server NSS database contains the following certificates:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -144,21 +144,21 @@ sslserver                                                    u,u,u
 
 . Import the external CA certificate chain:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 client-cert-import --ca-cert external.crt
 ....
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -167,7 +167,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-with-ecc.adoc
+++ b/docs/installation/ca/installing-ca-with-ecc.adoc
@@ -26,7 +26,7 @@ Prepare a deployment configuration, for example `ca-ecc.cfg`, to deploy CA subsy
 A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-ecc.cfg[/usr/share/pki/server/examples/installation/ca-ecc.cfg].
 
 To start the installation execute the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-ecc.cfg -s CA
 ....
@@ -34,7 +34,7 @@ $ pkispawn -f ca-ecc.cfg -s CA
 == CA system certificates 
 
 After installation the CA system certificates and keys are stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`):
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -49,7 +49,7 @@ sslserver                                                    u,u,u
 ....
 
 If necessary, the certificates can be exported into PEM files with the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -72,21 +72,21 @@ To use the admin certificate, do the following.
 
 . Export the CA signing certificate from the server NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export ca_signing --cert-file ca_signing.crt
 ....
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -95,7 +95,7 @@ $ pki pkcs12-import \
 
 . To verify that the admin certificate can be used to access the CA subsystem, execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-with-existing-keys-in-hsm.adoc
+++ b/docs/installation/ca/installing-ca-with-existing-keys-in-hsm.adoc
@@ -13,7 +13,7 @@ Prior to installation, please ensure that the xref:../others/installation-prereq
 
 . Prepare a file, for example `ca-step1.cfg`, that contains the deployment configuration in step 1:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -59,7 +59,7 @@ pki_external_step_two=False
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-step1.cfg -s CA
 ....
@@ -76,7 +76,7 @@ Since there are no CSR path parameters specified, it does not generate CA system
 
 . Export the system certificates from the existing CA with the following commands:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd -n "HSM:ca_signing" -a > ca_signing.crt
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd -n "HSM:ca_ocsp_signing" -a > ca_ocsp_signing.crt
@@ -85,7 +85,7 @@ $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd -n "HSM:ca
 
 . Export the CSRs from the existing CA with the following commands:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export ca_signing \
     --csr-file ca_signing.csr
@@ -103,14 +103,14 @@ Prepare another file, for example `ca-step2.cfg`, that contains the deployment c
 
 . Specify step 2 with the following parameter:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the existing certificates with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ca_signing_cert_path=ca_signing.crt
 pki_ocsp_signing_cert_path=ca_ocsp_signing.crt
@@ -119,7 +119,7 @@ pki_audit_signing_cert_path=ca_audit_signing.crt
 
 . Specify the existing CSRs with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ca_signing_csr_path=ca_signing.csr
 pki_ocsp_signing_csr_path=ca_ocsp_signing.csr
@@ -128,7 +128,7 @@ pki_audit_signing_csr_path=ca_audit_signing.csr
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-step2.cfg -s CA
 ....
@@ -137,7 +137,7 @@ $ pkispawn -f ca-step2.cfg -s CA
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -150,7 +150,7 @@ ca_audit_signing                                             ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -168,14 +168,14 @@ HSM:sslserver/pki.example.com                                u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -184,7 +184,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-with-existing-keys-in-internal-token.adoc
+++ b/docs/installation/ca/installing-ca-with-existing-keys-in-internal-token.adoc
@@ -18,7 +18,7 @@ Prepare a file, for example `ca-existing-certs-step1.cfg`, that contains the fir
 A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-existing-certs-step1.cfg[/usr/share/pki/server/examples/installation/ca-existing-certs-step1.cfg].
 
 Execute the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-existing-certs-step1.cfg -s CA
 ....
@@ -35,7 +35,7 @@ Since there are no CSR path parameters specified, it does not generate CA system
 
 . Export the system keys and certificates from the existing CA into a PKCS #12 file with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /var/lib/pki/pki-tomcat/conf/alias -c Secret.123 pkcs12-export \
   --pkcs12 ca-certs.p12 \
@@ -46,7 +46,7 @@ $ pki pkcs12-cert-del --pkcs12-file ca-certs.p12 --pkcs12-password Secret.123 su
 
 . Copy the CSRs from the existing CA to the pkispawn directory on the host where the new CA will be created, for example:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 cp /etc/pki/pki-tomcat/certs/* /root 
 ....
@@ -57,14 +57,14 @@ cp /etc/pki/pki-tomcat/certs/* /root
 +
 The file can be created from the first file, that is `ca-existing-certs-step1.cfg`, with the following changes:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the existing keys and certificates in the PKCS #12 file with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_pkcs12_path=ca-certs.p12
 pki_pkcs12_password=Secret.123
@@ -72,7 +72,7 @@ pki_pkcs12_password=Secret.123
 
 . Specify the existing CSRs with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ca_signing_csr_path=ca_signing.csr
 pki_ocsp_signing_csr_path=ca_ocsp_signing.csr
@@ -83,7 +83,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-existing-certs-step2.cfg -s CA
 ....
@@ -91,7 +91,7 @@ $ pkispawn -f ca-existing-certs-step2.cfg -s CA
 == Verifying system certificates 
 
 Verify that the server NSS database contains the following certificates:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -109,14 +109,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -125,7 +125,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-with-external-ca-signing-certificate.adoc
+++ b/docs/installation/ca/installing-ca-with-external-ca-signing-certificate.adoc
@@ -16,7 +16,7 @@ Prepare a file, for example `ca-external-cert-step1.cfg`, that contains the firs
 A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca-external-cert-step1.cfg[/usr/share/pki/server/examples/installation/ca-external-cert-step1.cfg]
 
 Execute the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-external-cert-step1.cfg -s CA
 ....
@@ -52,21 +52,21 @@ The certificate chain should include all CA certificates from the root CA to the
 
 . Prepare another file, for example `ca-external-cert-step2.cfg`, that contains the second deployment configuration. The file can be created from the first file, that is `ca-external-cert-step1.cfg`, with the following changes:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the custom CA signing certificate with the following parameter:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ca_signing_cert_path=ca_signing.crt
 ....
 
 . If the CA signing certificate was issued by an external CA, specify the external CA certificate chain with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_chain_nickname=root-ca_signing
 pki_cert_chain_path=root-ca_signing.crt
@@ -76,7 +76,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-external-cert-step2.cfg -s CA
 ....
@@ -84,7 +84,7 @@ $ pkispawn -f ca-external-cert-step2.cfg -s CA
 == Verifying system certificates 
 
 Verify that the server NSS database contains the following certificates:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -103,21 +103,21 @@ sslserver                                                    u,u,u
 
 . Import the external CA certificate chain:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 client-cert-import --ca-cert root-ca_signing.crt
 ....
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -126,7 +126,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-with-hsm.adoc
+++ b/docs/installation/ca/installing-ca-with-hsm.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `ca.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -54,7 +54,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca.cfg -s CA
 ....
@@ -69,7 +69,7 @@ It installs a CA subsystem in a Tomcat instance (default is pki-tomcat) and crea
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -82,7 +82,7 @@ ca_audit_signing                                             ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -100,14 +100,14 @@ HSM:sslserver/pki.example.com                                u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -116,7 +116,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
+++ b/docs/installation/ca/installing-ca-with-ldaps-connection.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 Once the prerequisites listed above are completed, if you chose to use the DS bootstrap certificates during DS instance creation, then export the bootstrap self-signed certificate into `ds_signing.crt` as follows:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.crt
 ....
@@ -24,7 +24,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 To start the installation, execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca-secure-ds.cfg -s CA
 ....
@@ -33,7 +33,7 @@ $ pkispawn -f ca-secure-ds.cfg -s CA
 
 After installation the CA system certificates with their keys are generated and stored in the server NSS database, that is `/var/lib/pki/pki-tomcat/conf/alias`, and the DS signing certificate is imported into the same NSS database:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -50,7 +50,7 @@ sslserver                                                    u,u,u
 
 If necessary, the CA system certificates can be exported into PEM files with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -69,7 +69,7 @@ Note that the `pki-server cert-export` command takes a certificate ID instead of
 
 The CA database configuration can be displayed with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server ca-db-config-show
   Hostname: pki.example.com
@@ -93,21 +93,21 @@ To use the admin certificate, do the following.
 
 . Export the CA signing certificate from the server NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export ca_signing --cert-file ca_signing.crt
 ....
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -116,7 +116,7 @@ $ pki pkcs12-import \
 
 . To verify that the admin certificate can be used to access the CA subsystem, execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-ca-with-random-serial-numbers-v3.adoc
+++ b/docs/installation/ca/installing-ca-with-random-serial-numbers-v3.adoc
@@ -13,7 +13,7 @@ To install CA with random serial numbers v3, follow the normal xref:installing-c
 
 To use random certificate serial numbers, add the following parameters in the `[CA]` section:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_id_generator=random
 ....
@@ -22,7 +22,7 @@ The certificate ID length (in bits) can be specified in the `pki_cert_id_length`
 
 To use random certificate request IDs, add the following parameters in the `[CA]` section:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_request_id_generator=random
 ....
@@ -33,7 +33,7 @@ The certificate request ID length (in bits) can be specified in the `pki_request
 
 After installation the certificates have random serial numbers, for example:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki ca-cert-find
 ---------------
@@ -69,7 +69,7 @@ Number of entries returned 6
 
 The certificate requests will also use random IDs, for example:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-cert-request-find
 -----------------

--- a/docs/installation/ca/installing-ca-with-rsa-pss.adoc
+++ b/docs/installation/ca/installing-ca-with-rsa-pss.adoc
@@ -9,7 +9,7 @@ Follow this process to install a CA subsystem with RSA/PSS.
 
 To install CA subsystem with RSA/PSS, follow the normal xref:installing-ca.adoc[CA installation] procedure, then specify the parameters below.
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 [DEFAULT]
 pki_use_pss_rsa_signing_algorithm=True
@@ -37,7 +37,7 @@ pki_ocsp_signing_signing_algorithm=SHA512withRSA/PSS
 
 To verify that the CA signing certificate was created with RSA/PSS, execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 
 $ pki-server cert-export ca_signing --cert-file ca_signing.crt

--- a/docs/installation/ca/installing-ca.adoc
+++ b/docs/installation/ca/installing-ca.adoc
@@ -14,7 +14,7 @@ Prepare a deployment configuration, for example `ca.cfg`, to deploy CA subsystem
 A sample deployment configuration is available at xref:../../../base/server/examples/installation/ca.cfg[/usr/share/pki/server/examples/installation/ca.cfg].
 
 To start the installation execute the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ca.cfg -s CA
 ....
@@ -22,7 +22,7 @@ $ pkispawn -f ca.cfg -s CA
 == CA system certificates 
 
 After installation, the CA system certificates and keys are stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`):
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -37,7 +37,7 @@ sslserver                                                    u,u,u
 ....
 
 If necessary, the certificates can be exported into PEM files by using the following command:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -63,21 +63,21 @@ To use the admin certificate, do the following.
 
 . Export the CA signing certificate from the server NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export ca_signing --cert-file ca_signing.crt
 ....
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -86,7 +86,7 @@ $ pki pkcs12-import \
 
 . Verify that the admin certificate can be used to access the CA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/ca/installing-subordinate-ca.adoc
+++ b/docs/installation/ca/installing-subordinate-ca.adoc
@@ -17,7 +17,7 @@ It assumes that the root CA is already running at https://root.example.com:8443 
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f subca.cfg -s CA
 ....
@@ -32,7 +32,7 @@ It installs a CA subsystem in a Tomcat instance (default is pki-tomcat) and crea
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -51,14 +51,14 @@ sslserver                                                    u,u,u
 
 . Import the root CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
@@ -67,7 +67,7 @@ $ pki pkcs12-import \
 
 . Verify that the admin certificate can be used to access the subordinate CA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-user-show caadmin
 --------------

--- a/docs/installation/est/configure-est-realm-db.adoc
+++ b/docs/installation/est/configure-est-realm-db.adoc
@@ -9,7 +9,7 @@ If you have chosen to use an LDAP instance for user management, before adding us
 
 The user DB requires a group node for the people and one for the groups. A simple `ldif` file is available in `/usr/share/pki/est/conf/realm/ds/create.ldif`. The base DN in this is `dc=pki,dc=example,dc=com` but it can be modified and the new value specified during the following _EST_ installation. The file can be imported with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 ldapadd -x -H ldap://<ds_server_hostname>:<ds_server_port> \
     -D "cn=Directory Manager"  -w Secret.123 \
@@ -26,7 +26,7 @@ If you have chosen to use *PostgreSQL* for user management, you first need to pr
 
 After the installation, verify the database connection with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ psql -U est -d est
 ....
@@ -34,7 +34,7 @@ $ psql -U est -d est
 To use the _PostreSQL_ DB, the user tables should be created with the sql file provided in `/usr/share/pki/est/conf/realm/postgresql/create.sql` and then filled
 with the user information. The tables can be created with the command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ psql -U est -t -A -f /usr/share/pki/est/conf/realm/postgresql/create.sql
 ....
@@ -47,7 +47,7 @@ It is possible to use different schemas but in this case a custom `statements.co
 Additionally, a Java driver for PostgreSQL needs to be installed in the EST server and linked into library folder of pki:
 
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # dnf install -y postgresql-jdbc
 # ln -s /usr/share/java/postgresql-jdbc/postgresql.jar /usr/share/pki/server/common/lib

--- a/docs/installation/est/installing-est-pki-server.adoc
+++ b/docs/installation/est/installing-est-pki-server.adoc
@@ -10,7 +10,7 @@ link:https://github.com/dogtagpki/pki/wiki/PKI-Server-Create-CLI[here]).
 
 Create the _EST subsystem_ inside the pki server instance:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki-server est-create
 ....
@@ -26,7 +26,7 @@ Configure the issuance backend. The class `org.dogtagpki.est.DogtagRABackend` is
 
 * The enrollment _profile_.
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # cat >/var/lib/pki/pki-tomcat/conf/est/backend.conf <<EOF
 class=org.dogtagpki.est.DogtagRABackend
@@ -49,7 +49,7 @@ An example on how to get the certificate and configure EST with TLS mutual confi
 Configure request authorization. The class `org.dogtagpki.est.ExternalProcessRequestAuthorizer` allows to delegate the authorization to an external process configured with the
 parameter *executable*:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # cat >/var/lib/pki/pki-tomcat/conf/est/authorizer.conf <<EOF
 class=org.dogtagpki.est.ExternalProcessRequestAuthorizer
@@ -62,14 +62,14 @@ more sophisticated authorization framework has to be adopted.
 
 Deploy the EST application:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki-server est-deploy
 ....
 
 Configure the authentication. The authentication allows one to use realms from _Tomcat_ or developed for dogtag. As an example we use an in memory realm:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # cat >/var/lib/pki/pki-tomcat/conf/est/realm.conf <<EOF
 class=com.netscape.cms.realm.PKIInMemoryRealm
@@ -81,7 +81,7 @@ EOF
 
 Finally, restart the server:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki-server restart --wait
 ....

--- a/docs/installation/est/installing-est-pkispawn.adoc
+++ b/docs/installation/est/installing-est-pkispawn.adoc
@@ -10,7 +10,7 @@ Once the prerequisites in xref:../est/installing-est.adoc[Installing EST] are co
 
 An example `pkispawn` installation configuration is provided in `/usr/share/pki/server/examples/installation/est.cfg` with the following content:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 [DEFAULT]
 pki_server_database_password=Secret.123
@@ -30,7 +30,7 @@ The following commands install an EST subsystem on a PKI server instance that al
 
 To install EST in the same instance of the CA and with the DS realm, run the command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pkispawn \
     -f /usr/share/pki/server/examples/installation/est.cfg \
@@ -41,7 +41,7 @@ To install EST in the same instance of the CA and with the DS realm, run the com
 
 Note that the `est_realm_url` points to the user DB. The other configurations that could be modified according to the deployment are:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 est_ca_profile=estServiceCert
 est_ca_user_name=
@@ -72,7 +72,7 @@ The `est_realm_*` options allow one to customize the realm. Possible types are: 
 
 As an example, to install EST with PostgreSQL the command is:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pkispawn \
     -f /usr/share/pki/server/examples/installation/est.cfg \
@@ -101,7 +101,7 @@ It is important that the certificate aliases in the PKCS#12 matches with the nic
 
 To create the PKCS12 with the certificate it is possible to request a server certificate for EST from the CA (and later the RA user certificate) and then export them as shown below:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki nss-cert-request --csr estSSLServer.csr \
     --ext /usr/share/pki/server/certs/sslserver.conf --subject 'CN=est.example.com'
@@ -119,7 +119,7 @@ To create the PKCS12 with the certificate it is possible to request a server cer
 
 Similarly, to generate a subsystem certificate for EST, associate to the EST RA user (est-ra-1) previously configured in the CA, and add in the same PKCS12 of the SSL server certificate:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki nss-cert-request --csr est-ra-1.csr \
     --ext /usr/share/pki/server/certs/admin.conf \
@@ -139,7 +139,7 @@ Similarly, to generate a subsystem certificate for EST, associate to the EST RA 
 
 Using the generated PKCS#12 bundle, the command to deploy EST is:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pkispawn \
     -f /usr/share/pki/server/examples/installation/est.cfg \
@@ -158,14 +158,14 @@ Using the generated PKCS#12 bundle, the command to deploy EST is:
 
 If the PKCS#12 bundle certificates are not provided to `pkispawn`, during the installation, the EST server cert is issued automatically using the profile configured for EST. The connection with the CA uses the credentials (_username/password_) provided in the configuration file. In such a case the CA signing certificate is needed. Retrieving the certificate can be done in the CA server with the command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki-server cert-export ca_signing --cert-file ca_signing.crt
 ....
 
 It is possible to install EST with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pkispawn \
     -f /usr/share/pki/server/examples/installation/est.cfg \
@@ -184,7 +184,7 @@ After the installation it is possible to update the EST server certificates with
 
 To remove the EST subsystem, it is possible to use the `pkidestroy` command as follows:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pkidestroy -s EST -v
 ....

--- a/docs/installation/est/installing-est.adoc
+++ b/docs/installation/est/installing-est.adoc
@@ -6,7 +6,7 @@
 Follow this process to install an _EST subsystem_.
 
 The *EST subsystem* requires the package `dogtag-pki-est` installed on the server where the instance is run:
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # dnf install dogtag-pki-est
 ....
@@ -18,7 +18,7 @@ the CA subsystem and issue certificates on behalf of EST clients.
 
 Note: The commands below assume that the CA is running on the same host with the default port and the nssdb is located in `~/.dogtag/nssdb`. To point to a CA on a different host or with a different port use the options `-h <hostname>`, `-p <port_number>` or `-U <CA_uri`. To use a different nssdb use the option `-d <nssdb_path>`.
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki -n caadmin ca-group-add "EST RA Agents"
 ---------------------------
@@ -42,7 +42,7 @@ Added user "est-ra-1"
 
 Add and enable the EST enrollment profile `estServiceCert.cfg`, which is available in `/usr/share/pki/ca/profiles/ca` if the *dogtag-pki-ca* package is installed:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki -n caadmin ca-profile-add --raw /usr/share/pki/ca/profiles/ca/estServiceCert.cfg
 ----------------------------
@@ -80,7 +80,7 @@ Use `curl` to verify that the *EST subsystem* is deployed and is able to communi
 
 The following command prints the CA signing certificate obtained from the server:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 
 $ curl --cacert ./ca_signing.crt  https://<EST_HOSTNAME>:<EST_PORT>/.well-known/est/cacerts | openssl base64 -d | openssl pkcs7 -inform der -print_certs | openssl x509 -text -noout
@@ -92,7 +92,7 @@ If successful, the server CA certificate chain is printed on standard output and
 
 To test the enrollment using curl, generate a CSR and submit using a user from the EST user DB associated with the realm. The following commands will perform the enrollment and print the final certificate:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-request --csr testServer.csr \
     --ext /usr/share/pki/server/certs/sslserver.conf --subject 'CN=test.example.com'
@@ -109,7 +109,7 @@ Note: The `testServer.p10` file is a base64 encoded pkcs10 DER without header/fo
 
 In case the enrollment is done using mutual TLS authentication in the `curl` command above, the credentials have to be replaced with the certificate and related key as follows:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ curl --cacert ./ca_signing.crt --cert cert.pem --key key-x-x.pem \
     --data-binary @testServer.p10 -H "Content-Type: application/pkcs10"
@@ -118,7 +118,7 @@ $ curl --cacert ./ca_signing.crt --cert cert.pem --key key-x-x.pem \
 
 When mutual TLS authentication is performed, the CSR subject and SAN has to match with the subject and SAN of the certificate used for the authentication in order to get authorized. Differently, using the basic authentication the CSR subject and SAN will be verified with user full name or user id. This check can be disabled for the _simpleenroll_ operation. To disable this check add the following option to the file `/etc/pki/<instance_name>/est/authorizer.conf`:
      
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 enrollMatchTLSSubjSAN=false
 ....

--- a/docs/installation/kra/installing-kra-clone-with-hsm.adoc
+++ b/docs/installation/kra/installing-kra-clone-with-hsm.adoc
@@ -15,7 +15,7 @@ Note: It is assumed that the CA signing certificate has been exported into `ca_s
 
 . Prepare a file, for example `kra.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -73,7 +73,7 @@ pki_clone_uri=https://pki.example.com:8443
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra.cfg -s KRA
 ....
@@ -88,7 +88,7 @@ It installs a KRA subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -102,7 +102,7 @@ kra_audit_signing                                            ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -120,14 +120,14 @@ HSM:sslserver/replica.example.com                            u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -136,7 +136,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin kra-user-show kraadmin
 ---------------
@@ -153,7 +153,7 @@ User "kraadmin"
 
 Verify that the KRA connector is configured in the CA subsystem:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-kraconnector-show
 

--- a/docs/installation/kra/installing-kra-clone.adoc
+++ b/docs/installation/kra/installing-kra-clone.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 On the existing system, export the KRA system certificates with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server kra-clone-prepare \
     --pkcs12-file kra-certs.p12 \
@@ -29,7 +29,7 @@ Note that the existing SSL server certificate is not exported.
 
 If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
@@ -58,7 +58,7 @@ See xref:../ca/installing-ca.adoc[Installing CA] for details.
 
 To start the installation execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra-clone.cfg -s KRA
 ....
@@ -67,7 +67,7 @@ $ pkispawn -f kra-clone.cfg -s KRA
 
 After installation, the existing KRA system certificates (including the certificate chain) and their keys are stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`), and a new SSL server certificate is created for the new instance:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -84,7 +84,7 @@ kra_transport                                                u,u,u
 
 If necessary, the certificates can be exported into PEM files with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -105,14 +105,14 @@ To use the admin certificate, do the following.
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -121,7 +121,7 @@ $ pki pkcs12-import \
 
 . To verify that the admin certificate can be used to access the KRA subsystem clone, execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin kra-user-show kraadmin
 ---------------

--- a/docs/installation/kra/installing-kra-on-separate-instance.adoc
+++ b/docs/installation/kra/installing-kra-on-separate-instance.adoc
@@ -22,7 +22,7 @@ It assumes that the:
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra-separate.cfg -s KRA
 ....
@@ -42,7 +42,7 @@ When the KRA is installed on a new system without any other subsystems, it is ne
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -61,14 +61,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import CA admin key and certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -77,7 +77,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the CA admin certificate can be used to access the KRA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin kra-user-show kraadmin
 ---------------
@@ -94,7 +94,7 @@ User "kraadmin"
 
 Verify that the KRA connector is configured in the CA subsystem:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-kraconnector-show
 

--- a/docs/installation/kra/installing-kra-with-custom-keys.adoc
+++ b/docs/installation/kra/installing-kra-with-custom-keys.adoc
@@ -12,7 +12,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `kra-step1.cfg`, that contains the deployment configuration step 1:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -54,7 +54,7 @@ pki_external_step_two=False
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra-step1.cfg -s KRA
 ....
@@ -106,14 +106,14 @@ Prepare another file, for example `kra-step2.cfg`, that contains the deployment 
 
 . Specify step 2 with the following parameter:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the custom CSRs with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_storage_csr_path=kra_storage.csr
 pki_transport_csr_path=kra_transport.csr
@@ -125,7 +125,7 @@ pki_admin_csr_path=kra_admin.csr
 
 . Specify the custom certificates with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_storage_cert_path=kra_storage.crt
 pki_transport_cert_path=kra_transport.crt
@@ -137,7 +137,7 @@ pki_admin_cert_path=kra_admin.crt
 
 . Specify the external CA certificate chain with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_chain_nickname=ca_signing
 pki_cert_chain_path=ca_signing.crt
@@ -145,7 +145,7 @@ pki_cert_chain_path=ca_signing.crt
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra-step2.cfg -s KRA
 ....
@@ -154,7 +154,7 @@ $ pkispawn -f kra-step2.cfg -s KRA
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -173,14 +173,14 @@ sslserver                                                    u,u,u
 
 . Import the external CA certificate chain:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin key and certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/kra_admin_cert.p12 \
@@ -189,7 +189,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access KRA by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n kraadmin kra-user-show kraadmin
 ---------------

--- a/docs/installation/kra/installing-kra-with-ecc.adoc
+++ b/docs/installation/kra/installing-kra-with-ecc.adoc
@@ -27,7 +27,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `kra.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -89,7 +89,7 @@ pki_subsystem_key_size=nistp521
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra.cfg -s KRA
 ....
@@ -104,7 +104,7 @@ It installs a KRA subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -123,14 +123,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -139,7 +139,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin kra-user-show kraadmin
 --------------

--- a/docs/installation/kra/installing-kra-with-external-certificates.adoc
+++ b/docs/installation/kra/installing-kra-with-external-certificates.adoc
@@ -18,7 +18,7 @@ It assumes that the CA is running at https://ca.example.com:8443, and the CA sig
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra-external-certs-step1.cfg -s KRA
 ....
@@ -50,14 +50,14 @@ Store the external CA certificate chain in a file, for example `ca_signing.crt`.
 
 . Prepare another file, for example `kra-external-certs-step2.cfg`, that contains the second deployment configuration. The file can be created from the first file (i.e. kra-external-certs-step1.cfg) with the following changes:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the external certificates with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_storage_cert_path=kra_storage.crt
 pki_transport_cert_path=kra_transport.crt
@@ -69,7 +69,7 @@ pki_admin_cert_path=kra_admin.crt
 
 . Specify the external CA certificate chain with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_chain_nickname=ca_signing
 pki_cert_chain_path=ca_signing.crt
@@ -79,7 +79,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra-external-certs-step2.cfg -s KRA
 ....
@@ -88,7 +88,7 @@ $ pkispawn -f kra-external-certs-step2.cfg -s KRA
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -107,14 +107,14 @@ sslserver                                                    u,u,u
 
 . Import the CA certificate chain:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin key and certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/kra_admin_cert.p12 \
@@ -123,7 +123,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access KRA by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n kraadmin kra-user-show kraadmin
 ---------------
@@ -140,7 +140,7 @@ User "kraadmin"
 
 Verify that the KRA connector is configured in the CA subsystem:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-kraconnector-show
 

--- a/docs/installation/kra/installing-kra-with-hsm.adoc
+++ b/docs/installation/kra/installing-kra-with-hsm.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `kra.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -57,7 +57,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra.cfg -s KRA
 ....
@@ -72,7 +72,7 @@ It installs a KRA subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -85,7 +85,7 @@ kra_audit_signing                                            ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -103,14 +103,14 @@ HSM:sslserver/pki.example.com                                u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -119,7 +119,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin kra-user-show kraadmin
 ---------------
@@ -136,7 +136,7 @@ User "kraadmin"
 
 Verify that the KRA connector is configured in the CA subsystem:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-kraconnector-show
 

--- a/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
+++ b/docs/installation/kra/installing-kra-with-ldaps-connection.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 Once the prerequisites listed above are configured, if you chose to use the DS bootstrap certificates during DS instance creation, then export the bootstrap self-signed certificate into `ds_signing.crt` as follows:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.crt
 ....
@@ -20,7 +20,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.c
 
 . Prepare a file, for example `kra.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_server_database_password=Secret.123
@@ -56,7 +56,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra.cfg -s KRA
 ....
@@ -71,7 +71,7 @@ It installs a KRA subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -91,7 +91,7 @@ sslserver                                                    u,u,u
 
 Verify that the KRA database is configured with a secure connection:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server kra-db-config-show
   Hostname: pki.example.com
@@ -111,14 +111,14 @@ $ pki-server kra-db-config-show
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -127,7 +127,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin kra-user-show kraadmin
 ---------------
@@ -144,7 +144,7 @@ User "kraadmin"
 
 Verify that the KRA connector is configured in the CA subsystem:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-kraconnector-show
 

--- a/docs/installation/kra/installing-kra.adoc
+++ b/docs/installation/kra/installing-kra.adoc
@@ -13,7 +13,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra.cfg -s KRA
 ....
@@ -33,7 +33,7 @@ When KRA is installed on a new system without any other subsystems, it is necess
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -52,14 +52,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -68,7 +68,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin kra-user-show kraadmin
 ---------------
@@ -85,7 +85,7 @@ User "kraadmin"
 
 Verify that the KRA connector is configured in the CA subsystem:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ca-kraconnector-show
 

--- a/docs/installation/kra/installing-standalone-kra.adoc
+++ b/docs/installation/kra/installing-standalone-kra.adoc
@@ -26,7 +26,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra-standalone-step1.cfg -s KRA
 ....
@@ -55,14 +55,14 @@ Use the CSRs to obtain KRA certificates by submitting the CSRs to an external CA
 
 . Prepare another file, for example `kra-standalone-step2.cfg`, that contains the second deployment configuration. The file can be created from the first file, that is `kra-standalone-step1.cfg`, with the following changes:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the certificate files with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_storage_cert_path=kra_storage.crt
 pki_transport_cert_path=kra_transport.crt
@@ -76,7 +76,7 @@ Each certificate file can contain either a single PEM certificate or a PKCS #7 c
 
 . Specify the CA certificate chain with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_chain_nickname=ca_signing
 pki_cert_chain_path=ca_signing.crt
@@ -88,7 +88,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f kra-standalone-step2.cfg -s KRA
 ....
@@ -97,14 +97,14 @@ $ pkispawn -f kra-standalone-step2.cfg -s KRA
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 kra_admin_cert.p12 \
@@ -113,7 +113,7 @@ $ pki pkcs12-import \
 
 . Verify that the admin certificate can be used to access the KRA subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n kraadmin kra-user-show kraadmin
 ---------------

--- a/docs/installation/ocsp/installing-ocsp-clone-with-hsm.adoc
+++ b/docs/installation/ocsp/installing-ocsp-clone-with-hsm.adoc
@@ -15,7 +15,7 @@ Note: It is assumed that the CA signing certificate has been exported into `ca_s
 
 . Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -72,7 +72,7 @@ pki_clone_uri=https://pki.example.com:8443
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp.cfg -s OCSP
 ....
@@ -87,7 +87,7 @@ It installs a OCSP subsystem in a Tomcat instance (default is pki-tomcat) and cr
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -101,7 +101,7 @@ ocsp_audit_signing                                           ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -118,14 +118,14 @@ HSM:sslserver/replica.example.com                            u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -134,7 +134,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ocsp-user-show ocspadmin
 ----------------
@@ -161,7 +161,7 @@ User "ocspadmin"
 
 . Verify that the OCSPClient can be used to validate a certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ OCSPClient \
  -d /var/lib/pki/pki-tomcat/conf/alias \

--- a/docs/installation/ocsp/installing-ocsp-clone.adoc
+++ b/docs/installation/ocsp/installing-ocsp-clone.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 On the existing system, export the existing OCSP system certificates with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server ocsp-clone-prepare \
     --pkcs12-file ocsp-certs.p12 \
@@ -28,7 +28,7 @@ Note that the existing SSL server certificate is not exported.
 
 If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
@@ -54,7 +54,7 @@ See xref:../ca/installing-ca.adoc[Installing CA] for details.
 
 To start the installation execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp-clone.cfg -s OCSP
 ....
@@ -63,7 +63,7 @@ $ pkispawn -f ocsp-clone.cfg -s OCSP
 
 After installation the existing OCSP system certificates (including the certificate chain) and their keys are stored in the server NSS database, that is `/var/lib/pki/pki-tomcat/conf/alias`, and a new SSL server certificate is created for the new instance:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -79,7 +79,7 @@ ocsp_audit_signing                                           u,u,Pu
 
 If necessary, the certificates can be exported into PEM files with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -99,14 +99,14 @@ To use the admin certificate, do the following.
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -115,7 +115,7 @@ $ pki pkcs12-import \
 
 . To verify that the admin certificate can be used to access the OCSP subsystem clone, execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ocsp-user-show ocspadmin
 ----------------

--- a/docs/installation/ocsp/installing-ocsp-with-custom-keys.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-custom-keys.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `ocsp-step1.cfg`, that contains the deployment configuration step 1:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -52,7 +52,7 @@ pki_external_step_two=False
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp-step1.cfg -s OCSP
 ....
@@ -101,14 +101,14 @@ Prepare another file, for example `ocsp-step2.cfg`, that contains the deployment
 
 . Specify step 2 with the following parameter:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the custom CSRs with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ocsp_signing_csr_path=ocsp_signing.csr
 pki_subsystem_csr_path=subsystem.csr
@@ -119,7 +119,7 @@ pki_admin_csr_path=ocsp_admin.csr
 
 . Specify the custom certificates with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ocsp_signing_cert_path=ocsp_signing.crt
 pki_subsystem_cert_path=subsystem.crt
@@ -130,7 +130,7 @@ pki_admin_cert_path=ocsp_admin.crt
 
 . Specify the external CA certificate chain with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_chain_nickname=ca_signing
 pki_cert_chain_path=ca_signing.crt
@@ -138,7 +138,7 @@ pki_cert_chain_path=ca_signing.crt
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp-step2.cfg -s OCSP
 ....
@@ -147,7 +147,7 @@ $ pkispawn -f ocsp-step2.cfg -s OCSP
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -165,14 +165,14 @@ sslserver                                                    u,u,u
 
 . Import the external CA certificate chain:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin key and certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
@@ -181,7 +181,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n ocspadmin ocsp-user-show ocspadmin
 ----------------

--- a/docs/installation/ocsp/installing-ocsp-with-ecc.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-ecc.adoc
@@ -24,7 +24,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -79,7 +79,7 @@ pki_subsystem_key_size=nistp521
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp.cfg -s OCSP
 ....
@@ -94,7 +94,7 @@ It installs a OCSP subsystem in a Tomcat instance (default is pki-tomcat) and cr
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -112,14 +112,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -128,7 +128,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ocsp-user-show ocspadmin
 --------------

--- a/docs/installation/ocsp/installing-ocsp-with-external-certificates.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-external-certificates.adoc
@@ -17,7 +17,7 @@ It assumes that the CA is running at https://ca.example.com:8443, and the CA sig
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp-external-certs-step1.cfg -s OCSP
 ....
@@ -48,14 +48,14 @@ Store the external CA certificate chain in a file, for example `ca_signing.crt`.
 
 . Prepare another file, for example `ocsp-external-certs-step2.cfg`, that contains the second deployment configuration. The file can be created from the first file (i.e. ocsp-external-certs-step1.cfg) with the following changes:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the custom certificates with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ocsp_signing_cert_path=ocsp_signing.crt
 pki_subsystem_cert_path=subsystem.crt
@@ -66,7 +66,7 @@ pki_admin_cert_path=ocsp_admin.crt
 
 . Specify the external CA certificate chain with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_chain_nickname=ca_signing
 pki_cert_chain_path=ca_signing.crt
@@ -76,7 +76,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp-external-certs-step2.cfg -s OCSP
 ....
@@ -85,7 +85,7 @@ $ pkispawn -f ocsp-external-certs-step2.cfg -s OCSP
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -103,14 +103,14 @@ sslserver                                                    u,u,u
 
 . Import the external CA certificate chain:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import the admin key and certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ~/.dogtag/pki-tomcat/ocsp_admin_cert.p12 \
@@ -119,7 +119,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n ocspadmin ocsp-user-show ocspadmin
 ----------------

--- a/docs/installation/ocsp/installing-ocsp-with-hsm.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-hsm.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -56,7 +56,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp.cfg -s OCSP
 ....
@@ -71,7 +71,7 @@ It installs a OCSP subsystem in a Tomcat instance (default is pki-tomcat) and cr
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -84,7 +84,7 @@ ocsp_audit_signing                                           ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -101,14 +101,14 @@ HSM:sslserver/pki.example.com                                u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -117,7 +117,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ocsp-user-show ocspadmin
 ----------------
@@ -144,7 +144,7 @@ User "ocspadmin"
 
 . Verify that the OCSPClient can be used to validate a certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ OCSPClient \
  -d /var/lib/pki/pki-tomcat/conf/alias \

--- a/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
+++ b/docs/installation/ocsp/installing-ocsp-with-ldaps-connection.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 Once the prerequisites listed above are completed, if you chose to use the DS bootstrap certificates during DS instance creation, then export the bootstrap self-signed certificate into `ds_signing.crt` as follows
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.crt
 ....
@@ -20,7 +20,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.c
 
 . Prepare a file, for example `ocsp.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -62,7 +62,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp.cfg -s OCSP
 ....
@@ -77,7 +77,7 @@ It installs a OCSP subsystem in a Tomcat instance (default is pki-tomcat) and cr
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -96,7 +96,7 @@ sslserver                                                    u,u,u
 
 Verify that the OCSP database is configured with a secure connection:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server ocsp-db-config-show
   Hostname: pki.example.com
@@ -116,14 +116,14 @@ $ pki-server ocsp-db-config-show
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -132,7 +132,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ocsp-user-show ocspadmin
 ----------------
@@ -159,7 +159,7 @@ User "ocspadmin"
 
 . Verify that the OCSPClient can be used to validate a certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ OCSPClient \
  -d /var/lib/pki/pki-tomcat/conf/alias \

--- a/docs/installation/ocsp/installing-ocsp.adoc
+++ b/docs/installation/ocsp/installing-ocsp.adoc
@@ -13,7 +13,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp.cfg -s OCSP
 ....
@@ -33,7 +33,7 @@ When OCSP is installed on a new system without any other subsystems, it is neces
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -51,14 +51,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -67,7 +67,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin ocsp-user-show ocspadmin
 ----------------
@@ -94,7 +94,7 @@ User "ocspadmin"
 
 . Verify that the OCSPClient can be used to validate a certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ OCSPClient \
  -d /var/lib/pki/pki-tomcat/conf/alias \

--- a/docs/installation/ocsp/installing-standalone-ocsp.adoc
+++ b/docs/installation/ocsp/installing-standalone-ocsp.adoc
@@ -23,7 +23,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp-standalone-step1.cfg -s OCSP
 ....
@@ -50,14 +50,14 @@ Use the CSRs to obtain OCSP certificates by submitting the CSRs to an external C
 
 . Prepare another file, for example `ocsp-standalone-step2.cfg`, that contains the second deployment configuration. The file can be created from the first file, that is `ocsp-standalone-step1.cfg`, with the following changes:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_external_step_two=True
 ....
 
 . Specify the certificate files with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_ocsp_signing_cert_path=ocsp_signing.crt
 pki_subsystem_cert_path=subsystem.crt
@@ -70,7 +70,7 @@ Each certificate file can contain either a single PEM certificate or a PKCS #7 c
 
 . Specify the CA certificate chain with the following parameters:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki_cert_chain_nickname=ca_signing
 pki_cert_chain_path=ca_signing.crt
@@ -82,7 +82,7 @@ A sample deployment configuration is available at xref:../../../base/server/exam
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f ocsp-standalone-step2.cfg -s OCSP
 ....
@@ -91,14 +91,14 @@ $ pkispawn -f ocsp-standalone-step2.cfg -s OCSP
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ocsp_admin_cert.p12 \
@@ -107,7 +107,7 @@ $ pki pkcs12-import \
 
 . Verify that the admin certificate can be used to access the OCSP subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n ocspadmin ocsp-user-show ocspadmin
 ----------------

--- a/docs/installation/others/creating-ds-instance.adoc
+++ b/docs/installation/others/creating-ds-instance.adoc
@@ -21,14 +21,14 @@ _If you wish to disable bootstrap certificate generation and SSL connection, set
 
 === Generating a DS configuration file, for example `ds.inf`: 
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dscreate create-template ds.inf
 ....
 
 Customize the DS configuration file as follows:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ sed -i \
     -e "s/^;instance_name = .*/instance_name = localhost/" \
@@ -55,7 +55,7 @@ For more information see the parameter descriptions in the DS configuration file
 
 Finally, create the instance:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dscreate from-file ds.inf
 ....
@@ -66,7 +66,7 @@ Note: The `dc=pki,dc=example,dc=com` subtree is not mandatory, but it's highly r
 
 Initially the DS instance is empty. Use an LDAP client to add a root entry and PKI base entry, for example:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 << EOF
 dn: dc=pki,dc=example,dc=com
@@ -77,7 +77,7 @@ EOF
 
 The subtree for each PKI subsystem is created when the subsystem is installed. When all PKI subsystems are created, the LDAP tree looks like the following:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 dc=example,dc=com
 + dc=pki
@@ -105,7 +105,7 @@ See link:https://github.com/dogtagpki/389-ds-base/wiki/Configuring-DS-Replicatio
 
 To remove DS instance:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dsctl localhost remove --do-it
 ....

--- a/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
+++ b/docs/installation/others/enabling-ssl-connection-in-ds-with-bootstrap-cert.adoc
@@ -17,7 +17,7 @@ This section assumes that a DS instance named `localhost` already exists, it doe
 
 . Generate DS signing CSR with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -30,7 +30,7 @@ $ pki \
 
 . Issue DS signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -43,7 +43,7 @@ $ pki \
 
 . Import DS signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -56,7 +56,7 @@ $ pki \
 
 . Verify the DS signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA
 ...
@@ -81,7 +81,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA
 
 . Generate DS server CSR with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -95,7 +95,7 @@ $ pki \
 
 . Issue DS server certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -109,7 +109,7 @@ $ pki \
 
 . Import DS server certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -121,7 +121,7 @@ $ pki \
 
 . Verify the DS server certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Server-Cert
 ...
@@ -139,21 +139,21 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Server-Cert
 
 . To enable SSL connection in the DS instance:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dsconf localhost config replace nsslapd-security=on
 ....
 
 . Restart the DS instance:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dsctl localhost restart
 ....
 
 . Verify the SSL connection:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ LDAPTLS_REQCERT=never ldapsearch \
     -H ldaps://$HOSTNAME:636 \

--- a/docs/installation/others/fqdn-configuration.adoc
+++ b/docs/installation/others/fqdn-configuration.adoc
@@ -13,7 +13,7 @@ Follow this process to configure the fully qualified domain name on each machine
 
 To verify the current FQDN, execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # hostname
 pki.example.com
@@ -25,21 +25,21 @@ If the host name is not what you expect it to be, run `hostnamectl` to set the h
 
 . Set the hostname of your pki machine as follows:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # hostnamectl set-hostname pki.example.com
 ....
 
 . Set the hostname of your DS machine as follows:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # hostnamectl set-hostname dir.example.com
 ....
 
 . Add both the CS and DS machine IP addresses and new hostnames as entries in `/etc/hosts` of both machines: 
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1 localhost localhost.localdomain localhost6 localhost6.localdomain6
@@ -49,7 +49,7 @@ If the host name is not what you expect it to be, run `hostnamectl` to set the h
 
 . Verify the FQDN again after the change:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # hostname
 ....

--- a/docs/installation/others/getting-ds-cert-issued-by-actual-ca.adoc
+++ b/docs/installation/others/getting-ds-cert-issued-by-actual-ca.adoc
@@ -18,7 +18,7 @@ It is assumed that an actual trusted CA is available for issuing certificates.
 
 == Export the CA signing certificate
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 pki-server cert-export ca_signing --cert-file ca_signing.crt
 ....
@@ -29,7 +29,7 @@ pki-server cert-export ca_signing --cert-file ca_signing.crt
 
 As a DS administrator:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -46,7 +46,7 @@ $ pki \
 
 As a DS admin:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki ca-cert-request-submit --profile caServerCert --csr-file ds_server.csr
 ....
@@ -55,7 +55,7 @@ $ pki ca-cert-request-submit --profile caServerCert --csr-file ds_server.csr
 
 As a PKI agent:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin ca-cert-request-approve <request ID>
 ....
@@ -64,7 +64,7 @@ $ pki -n caadmin ca-cert-request-approve <request ID>
 
 Retrieve the cert as the DS admin user:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $  pki ca-cert-export <certificate ID> --output-file ds_server.crt
 ....
@@ -73,7 +73,7 @@ $  pki ca-cert-export <certificate ID> --output-file ds_server.crt
 
 Stop the DS instance prior to changing the NSS database.
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dsctl localhost stop
 ....
@@ -82,7 +82,7 @@ $ dsctl localhost stop
 
 As a DS administrator, import the CA signing cert into the nssdb of the DS instance.
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 # pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -100,7 +100,7 @@ As a DS administrator, import the CA signing cert into the nssdb of the DS insta
 
 If you already had boostrap DS certificates, delete them:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -F -d /etc/dirsrv/slapd-localhost \
     -f /etc/dirsrv/slapd-localhost/pwdfile.txt \
@@ -112,7 +112,7 @@ $ certutil -D -d /etc/dirsrv/slapd-localhost \
 
 == Import DS server certificate:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki \
     -d /etc/dirsrv/slapd-localhost \
@@ -124,7 +124,7 @@ $ pki \
 
 To verify the DS server certificate:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Server-Cert
 ...
@@ -143,21 +143,21 @@ This section only applies if you did not enable SSL in your DS earlier.
 
 . To enable SSL connection in the DS instance:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dsconf localhost config replace nsslapd-security=on
 ....
 
 . Start the DS instance:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dsctl localhost start
 ....
 
 . Verify the SSL connection:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ LDAPTLS_REQCERT=never ldapsearch \
     -H ldaps://$HOSTNAME:636 \
@@ -172,7 +172,7 @@ $ LDAPTLS_REQCERT=never ldapsearch \
 
 If you are replacing the DS bootstrap certs, as a PKI administrator, stop the PKI then delete the DS bootstrap signing cert from the PKI nssdb as follows.
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -F -d /var/lib/pki/pki-tomcat/conf/alias \
     -f /var/lib/pki/pki-tomcat/conf/alias/pwdfile.txt \

--- a/docs/installation/others/installing-ds-packages.adoc
+++ b/docs/installation/others/installing-ds-packages.adoc
@@ -9,7 +9,7 @@ Prior to installing the Directory Server (DS) instances, one needs to install th
 
 To install DS packages:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dnf install -y 389-ds-base
 ....

--- a/docs/installation/server/installing-basic-pki-server.adoc
+++ b/docs/installation/server/installing-basic-pki-server.adoc
@@ -11,7 +11,7 @@ This would be useful to troubleshoot general server issues, for example SSL.
 
 To install PKI server packages:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ dnf install pki-server
 ....
@@ -20,7 +20,7 @@ $ dnf install pki-server
 
 To create a PKI server:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server create
 ....
@@ -33,7 +33,7 @@ See also link:https://github.com/dogtagpki/pki/wiki/PKI-Server-CLI[PKI Server CL
 
 To start PKI server:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server run
 ....

--- a/docs/installation/server/installing-pki-server-with-custom-nss-databases.adoc
+++ b/docs/installation/server/installing-pki-server-with-custom-nss-databases.adoc
@@ -23,7 +23,7 @@ In those cases the installation can be done in multiple steps:
 
 To create a basic PKI server, execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server create
 ....
@@ -36,14 +36,14 @@ See also link:https://github.com/dogtagpki/pki/wiki/PKI-Server-CLI[PKI Server CL
 
 To create a custom NSS database for the server execute the following commands:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server nss-create --password <server password>
 ....
 
 To enable trust policy:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ modutil \
     -dbdir /var/lib/pki/pki-tomcat/conf/alias \
@@ -57,14 +57,14 @@ See also link:https://github.com/dogtagpki/pki/wiki/PKI-Server-NSS-CLI[PKI Serve
 
 To create a custom NSS database for the admin execute the following commands:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d ~/.dogtag/pki-tomcat/ca/alias -c <client password> nss-create
 ....
 
 To enable trust policy:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ modutil \
     -dbdir ~/.dogtag/pki-tomcat/ca/alias \
@@ -79,7 +79,7 @@ See also link:https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI[PKI NSS CLI].
 To install a PKI subsystem in this server, follow the regular link:https://www.dogtagpki.org/wiki/PKI_10_Installation[installation procedure].
 Make sure to use the same NSS database passwords, for example:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ----
 [DEFAULT]
 pki_server_database_password=<server password>

--- a/docs/installation/tks/installing-tks-clone.adoc
+++ b/docs/installation/tks/installing-tks-clone.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 On the existing system, export the TKS system certificates with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server tks-clone-prepare \
     --pkcs12-file tks-certs.p12 \
@@ -28,7 +28,7 @@ Note that the existing SSL server certificate is not exported.
 
 If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
@@ -57,7 +57,7 @@ See xref:../ca/installing-ca.adoc[Installing CA] for details.
 
 To start the installation execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tks-clone.cfg -s TKS
 ....
@@ -66,7 +66,7 @@ $ pkispawn -f tks-clone.cfg -s TKS
 
 After installation the existing TKS system certificates (including the certificate chain) and their keys are stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`), and a new SSL server certificate is created for the new instance:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -81,7 +81,7 @@ sslserver                                                    u,u,u
 
 If necessary, the certificates can be exported into PEM files with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -100,14 +100,14 @@ To use the admin certificate, do the following.
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -116,7 +116,7 @@ $ pki pkcs12-import \
 
 . To verify that the admin certificate can be used to access the TKS subsystem clone, execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin tks-user-show tksadmin
 ---------------

--- a/docs/installation/tks/installing-tks-with-ecc.adoc
+++ b/docs/installation/tks/installing-tks-with-ecc.adoc
@@ -23,7 +23,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `tks.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 [DEFAULT]
 pki_server_database_password=Secret.123
@@ -65,7 +65,7 @@ pki_subsystem_key_size=nistp521
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tks.cfg -s TKS
 ....
@@ -80,7 +80,7 @@ It installs a TKS subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -97,14 +97,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -113,7 +113,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the TKS subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin tks-user-show tksadmin
 --------------

--- a/docs/installation/tks/installing-tks-with-hsm.adoc
+++ b/docs/installation/tks/installing-tks-with-hsm.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `tks.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -55,7 +55,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tks.cfg -s TKS
 ....
@@ -70,7 +70,7 @@ It installs a TKS subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -83,7 +83,7 @@ tks_audit_signing                                            ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -99,14 +99,14 @@ HSM:sslserver                                                u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -115,7 +115,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the TKS subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin tks-user-show tksadmin
 ---------------

--- a/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
+++ b/docs/installation/tks/installing-tks-with-ldaps-connection.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 Once the prerequisites listed above are completed, if you chose to use the DS bootstrap certificates during DS instance creation, then export the bootstrap self-signed certificate into `ds_signing.crt` as follows:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.crt
 ....
@@ -20,7 +20,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.c
 
 . Prepare a file, for example `tks.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -61,7 +61,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tks.cfg -s TKS
 ....
@@ -76,7 +76,7 @@ It installs a TKS subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -94,7 +94,7 @@ sslserver                                                    u,u,u
 
 Verify that the TKS database is configured with a secure connection:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server tks-db-config-show
   Hostname: pki.example.com
@@ -114,14 +114,14 @@ $ pki-server tks-db-config-show
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -130,7 +130,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the TKS subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin tks-user-show tksadmin
 ---------------

--- a/docs/installation/tks/installing-tks.adoc
+++ b/docs/installation/tks/installing-tks.adoc
@@ -13,7 +13,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tks.cfg -s TKS
 ....
@@ -33,7 +33,7 @@ When TKS is installed on a new system without any other subsystems, it is necess
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -50,14 +50,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -66,7 +66,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the TKS subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin tks-user-show tksadmin
 ---------------

--- a/docs/installation/tps/installing-tps-clone.adoc
+++ b/docs/installation/tps/installing-tps-clone.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 On the existing system, export the TPS system certificates with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server tps-clone-prepare \
     --pkcs12-file tps-certs.p12 \
@@ -27,7 +27,7 @@ Note that the existing SSL server certificate is not exported.
 
 If necessary, third-party certificates, for example trust anchors, can be added into the same PKCS #12 file with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -d /var/lib/pki/pki-tomcat/conf/alias -f /var/lib/pki/pki-tomcat/conf/password.conf \
     pkcs12-cert-import <nickname> \
@@ -56,7 +56,7 @@ See xref:../ca/installing-ca.adoc[Installing CA] for details.
 
 To start the installation execute the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tps-clone.cfg -s TPS
 ....
@@ -65,7 +65,7 @@ $ pkispawn -f tps-clone.cfg -s TPS
 
 After installation the existing TPS system certificates (including the certificate chain) and their keys are stored in the server NSS database, that is `/var/lib/pki/pki-tomcat/conf/alias`, and a new SSL server certificate is created for the new instance:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -80,7 +80,7 @@ tps_audit_signing                                            u,u,Pu
 
 If necessary, the certificates can be exported into PEM files with the following command:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server cert-export <cert ID> --cert-file <filename>
 ....
@@ -99,14 +99,14 @@ To use the admin certificate, do the following.
 
 . Import the CA signing certificate into the client NSS database:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -115,7 +115,7 @@ $ pki pkcs12-import \
 
 . To verify that the admin certificate can be used to access the TPS subsystem clone, execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -n caadmin tps-user-show tpsadmin
 ---------------

--- a/docs/installation/tps/installing-tps-with-hsm.adoc
+++ b/docs/installation/tps/installing-tps-with-hsm.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Prepare a file, for example `tps.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -55,7 +55,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tps.cfg -s TPS
 ....
@@ -70,7 +70,7 @@ It installs a TPS subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 . Verify that the internal token contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -83,7 +83,7 @@ tps_audit_signing                                            ,,P
 
 . Verify that the HSM contains the following certificates:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias -h HSM -f HSM.pwd
 
@@ -99,14 +99,14 @@ HSM:sslserver                                                u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -115,7 +115,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the TPS subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin tps-user-show tpsadmin
 ---------------

--- a/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
+++ b/docs/installation/tps/installing-tps-with-ldaps-connection.adoc
@@ -11,7 +11,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 Once the prerequisites listed above are completed, if you had chosen to use the DS bootstrap certificates during DS instance creation, then export the bootstrap self-signed certificate into `ds_signing.crt` as follows:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.crt
 ....
@@ -20,7 +20,7 @@ $ certutil -L -d /etc/dirsrv/slapd-localhost -n Self-Signed-CA -a > ds_signing.c
 
 . Prepare a file, for example `tps.cfg`, that contains the deployment configuration:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 [DEFAULT]
 pki_instance_name=pki-tomcat
@@ -61,7 +61,7 @@ pki_subsystem_nickname=subsystem
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tps.cfg -s TPS
 ....
@@ -76,7 +76,7 @@ It installs a TPS subsystem in a Tomcat instance (default is pki-tomcat) and cre
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -94,7 +94,7 @@ sslserver                                                    u,u,u
 
 Verify that the TPS database is configured with a secure connection:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki-server tps-db-config-show
   Hostname: pki.example.com
@@ -114,14 +114,14 @@ $ pki-server tps-db-config-show
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -130,7 +130,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the TPS subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin tps-user-show tpsadmin
 ---------------

--- a/docs/installation/tps/installing-tps.adoc
+++ b/docs/installation/tps/installing-tps.adoc
@@ -13,7 +13,7 @@ Prior to installation, ensure that the xref:../others/installation-prerequisites
 
 . Execute the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pkispawn -f tps.cfg -s TPS
 ....
@@ -33,7 +33,7 @@ When TPS is installed on a new system without any other subsystems, it is necess
 
 Verify that the server NSS database contains the following certificates:
 
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ certutil -L -d /var/lib/pki/pki-tomcat/conf/alias
 
@@ -50,14 +50,14 @@ sslserver                                                    u,u,u
 
 . Import the CA signing certificate:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki nss-cert-import --cert ca_signing.crt --trust CT,C,C ca_signing
 ....
 
 . Import admin certificate and key into the client NSS database (by default ~/.dogtag/nssdb) with the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 pkcs12-import \
     --pkcs12 ca_admin_cert.p12 \
@@ -66,7 +66,7 @@ $ pki -c Secret.123 pkcs12-import \
 
 . Verify that the admin certificate can be used to access the TPS subsystem by executing the following command:
 +
-[literal,subs="+quotes,verbatim"]
+[literal]
 ....
 $ pki -c Secret.123 -n caadmin tps-user-show tpsadmin
 ---------------


### PR DESCRIPTION
…s="+quotes,verbatim"]

This patch was re-created after https://github.com/dogtagpki/pki/pull/5077 that was provided by community member vzlamal to address the issue where bold and italic in some cases are mis-interpreted where '*' and '_' are intended to be literally part of the code. Note that there is still a desire to bold the actual commands.  This patch is to be considered a temporary fix.

https://issues.redhat.com/browse/RHCS-5927