### PR TITLE
Add pki ca-crl-update

### DIFF
--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -341,14 +341,8 @@ jobs:
 
       - name: Force CRL update after user 2 cert expiration
         run: |
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec pki curl \
-              --cert-type P12 \
-              --cert /root/.dogtag/pki-tomcat/ca_admin_cert.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://pki.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec pki pki -n caadmin ca-crl-update
 
           # wait for CRL update
           sleep 10

--- a/.github/workflows/ca-publishing-crl-file-test.yml
+++ b/.github/workflows/ca-publishing-crl-file-test.yml
@@ -273,14 +273,8 @@ jobs:
 
       - name: Check CRL after update
         run: |
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec pki curl \
-              --cert-type P12 \
-              --cert /root/.dogtag/pki-tomcat/ca_admin_cert.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://pki.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec pki pki -n caadmin ca-crl-update
 
           # wait for CRL update
           sleep 10

--- a/.github/workflows/ca-publishing-crl-ldap-test.yml
+++ b/.github/workflows/ca-publishing-crl-ldap-test.yml
@@ -182,14 +182,8 @@ jobs:
 
       - name: Check CRL after update
         run: |
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec pki curl \
-              --cert-type P12 \
-              --cert /root/.dogtag/pki-tomcat/ca_admin_cert.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://pki.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec pki pki -n caadmin ca-crl-update
 
           # wait for CRL update
           sleep 10

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -528,14 +528,11 @@ jobs:
               --password Secret.123 \
               admin
 
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec client curl \
-              --cert-type P12 \
-              --cert admin.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://ca.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-crl-update
 
           # wait for CRL update
           sleep 10
@@ -571,14 +568,11 @@ jobs:
           sed -n "s/^\s*Status:\s*\(\S*\)$/\1/p" output > actual
           diff expected actual
 
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec client curl \
-              --cert-type P12 \
-              --cert admin.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://ca.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-crl-update
 
           # wait for CRL update
           sleep 10
@@ -614,14 +608,11 @@ jobs:
           sed -n "s/^\s*Status:\s*\(\S*\)$/\1/p" output > actual
           diff expected actual
 
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec client curl \
-              --cert-type P12 \
-              --cert admin.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://ca.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec client pki \
+              -U https://ca.example.com:8443 \
+              -n admin \
+              ca-crl-update
 
           # wait for CRL update
           sleep 10

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -305,14 +305,8 @@ jobs:
           docker exec ca pki nss-cert-show caagent | tee output
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec ca curl \
-              --cert-type P12 \
-              --cert /root/.dogtag/pki-tomcat/ca_admin_cert.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://ca.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec ca pki -n caadmin ca-crl-update
 
           # wait for CRL update
           sleep 10
@@ -348,14 +342,8 @@ jobs:
           # revoke CA agent cert
           docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-cert-revoke.sh
 
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec ca curl \
-              --cert-type P12 \
-              --cert /root/.dogtag/pki-tomcat/ca_admin_cert.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://ca.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec ca pki -n caadmin ca-crl-update
 
           # wait for CRL update
           sleep 10
@@ -395,14 +383,8 @@ jobs:
           # unrevoke CA agent cert
           docker exec ca /usr/share/pki/tests/ca/bin/ca-agent-cert-unrevoke.sh
 
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec ca curl \
-              --cert-type P12 \
-              --cert /root/.dogtag/pki-tomcat/ca_admin_cert.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://ca.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec ca pki -n caadmin ca-crl-update
 
           # wait for CRL update
           sleep 10

--- a/.github/workflows/ocsp-crl-ldap-test.yml
+++ b/.github/workflows/ocsp-crl-ldap-test.yml
@@ -370,14 +370,8 @@ jobs:
           docker exec ca pki nss-cert-show caagent | tee output
           CERT_ID=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
 
-          # https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
-          docker exec ca curl \
-              --cert-type P12 \
-              --cert /root/.dogtag/pki-tomcat/ca_admin_cert.p12:Secret.123 \
-              -sk \
-              -d "xml=true" \
-              https://ca.example.com:8443/ca/agent/ca/updateCRL \
-              | xmllint --format -
+          # force CRL update
+          docker exec ca pki -n caadmin ca-crl-update
 
           # wait for CRL update and cache refresh
           sleep 10

--- a/base/common/src/main/java/com/netscape/certsrv/ca/CACRLClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/ca/CACRLClient.java
@@ -1,0 +1,119 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.certsrv.ca;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import com.netscape.certsrv.base.PKIException;
+import com.netscape.certsrv.client.Client;
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.cmsutil.xml.XMLObject;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class CACRLClient extends Client {
+
+    public final static Logger logger = LoggerFactory.getLogger(CACRLClient.class);
+
+    public CACRLClient(CAClient caClient) throws Exception {
+        this(caClient.client, caClient.getName());
+    }
+
+    public CACRLClient(PKIClient client, String subsystem) throws Exception {
+        super(client, subsystem, "crls");
+    }
+
+    public void updateCRL() throws Exception {
+
+        List<NameValuePair> content = new ArrayList<>();
+        content.add(new BasicNameValuePair("xml", "true"));
+
+        String response = client.post(
+                "ca/agent/ca/updateCRL",
+                content,
+                String.class);
+        logger.info("Response:\n" + response);
+
+        ByteArrayInputStream bis = new ByteArrayInputStream(response.getBytes());
+        XMLObject parser = new XMLObject(bis);
+        Document doc = parser.getDocument();
+        Element root = doc.getDocumentElement();
+
+        // https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service
+        //
+        // Success:
+        // <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        // <xml>
+        //   <header>
+        //     <crlIssuingPoint>MasterCRL</crlIssuingPoint>
+        //     <crlUpdate>Scheduled</crlUpdate>
+        //   </header>
+        //   <fixed/>
+        //   <records/>
+        // </xml>
+        //
+        // Failure:
+        // <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        // <xml>
+        //   <header/>
+        //   <fixed>
+        //     <authorityName>Certificate Manager</authorityName>
+        //     <unexpectedError>You did not provide a valid certificate for this operation</unexpectedError>
+        //     <requestStatus>7</requestStatus>
+        //   </fixed>
+        //   <records/>
+        // </xml>
+
+        int status = 0;
+        String errorMessage = null;
+
+        NodeList fixedList = root.getElementsByTagName("fixed");
+        if (fixedList.getLength() > 0) {
+            Element fixed = (Element) fixedList.item(0);
+
+            NodeList requestStatusList = fixed.getElementsByTagName("requestStatus");
+            if (requestStatusList.getLength() > 0) {
+                String value = requestStatusList.item(0).getTextContent();
+                status = Integer.parseInt(value);
+            }
+
+            NodeList unexpectedErrorList = fixed.getElementsByTagName("unexpectedError");
+            if (unexpectedErrorList.getLength() > 0) {
+                errorMessage = unexpectedErrorList.item(0).getTextContent();
+            }
+        }
+
+        logger.info("Status: " + status);
+        logger.info("Error message: " + errorMessage);
+
+        // Status is defined in CMSRequest:
+        // 1 = UNAUTHORIZED
+        // 2 = SUCCESS
+        // 3 = PENDING
+        // 4 = SVC_PENDING
+        // 5 = REJECTED
+        // 6 = ERROR
+        // 7 = EXCEPTION
+
+        if (status == 1 || status >= 5) {
+            if (errorMessage == null) {
+                errorMessage = "status=" + status;
+            }
+            throw new PKIException("Unable to update CRL: " + errorMessage);
+        }
+    }
+}

--- a/base/common/src/main/java/com/netscape/cmsutil/xml/XMLObject.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/xml/XMLObject.java
@@ -45,8 +45,6 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.xml.sax.SAXException;
 
-// Use JSONObject instead
-@Deprecated(since = "11.0.0", forRemoval = true)
 public class XMLObject {
     private Document mDoc = null;
 

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACLI.java
@@ -48,6 +48,7 @@ public class CACLI extends SubsystemCLI {
         addModule(new AuthorityCLI(this));
         addModule(new AuditCLI(this));
         addModule(new CACertCLI(this));
+        addModule(new CACRLCLI(this));
         addModule(new ConfigCLI(this));
         addModule(new FeatureCLI(this));
         addModule(new GroupCLI(this));

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACRLCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACRLCLI.java
@@ -1,0 +1,26 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.ca;
+
+import org.dogtagpki.cli.CLI;
+
+import com.netscape.certsrv.ca.CACertClient;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class CACRLCLI extends CLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CACRLCLI.class);
+
+    public CACertClient certClient;
+
+    public CACRLCLI(CLI parent) {
+        super("crl", "CRL management commands", parent);
+
+        addModule(new CACRLUpdateCLI(this));
+    }
+}

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACRLUpdateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACRLUpdateCLI.java
@@ -1,0 +1,42 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.ca;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CommandCLI;
+
+import com.netscape.certsrv.ca.CACRLClient;
+import com.netscape.certsrv.ca.CAClient;
+import com.netscape.certsrv.client.PKIClient;
+import com.netscape.cmstools.cli.MainCLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class CACRLUpdateCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CACRLUpdateCLI.class);
+
+    public CACRLCLI crlCLI;
+
+    public CACRLUpdateCLI(CACRLCLI crlCLI) {
+        super("update", "Update CRL", crlCLI);
+        this.crlCLI = crlCLI;
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        PKIClient client = mainCLI.getClient();
+        CAClient caClient = new CAClient(client);
+        CACRLClient crlClient = new CACRLClient(caClient);
+
+        crlClient.updateCRL();
+    }
+}


### PR DESCRIPTION
The `pki ca-crl-update` has been added to simplify manual CRL update.

The deprecation of `XMLObject` has been removed since the class is still used in multiple places and generates deprecation warnings. Once the migration to REST API v2 is complete the class might be deprecated again.

https://github.com/dogtagpki/pki/wiki/PKI-CA-CRL-CLI
https://github.com/dogtagpki/pki/wiki/UpdateCRL-Service