### PR TITLE
Refactor CertStatus

### DIFF
--- a/base/common/src/main/java/com/netscape/cmsutil/ocsp/CertStatus.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/ocsp/CertStatus.java
@@ -28,8 +28,20 @@ import org.mozilla.jss.asn1.ASN1Value;
  *  revoked             [1]     IMPLICIT RevokedInfo,
  *  unknown             [2]     IMPLICIT UnknownInfo }
  * </pre>
- *
- * @version $Revision$ $Date$
  */
-public interface CertStatus extends ASN1Value {
+public abstract class CertStatus implements ASN1Value {
+
+    public String label;
+
+    public CertStatus(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String toString() {
+        return label;
+    }
 }

--- a/base/common/src/main/java/com/netscape/cmsutil/ocsp/GoodInfo.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/ocsp/GoodInfo.java
@@ -37,13 +37,12 @@ import org.mozilla.jss.asn1.Tag;
  *  revoked             [1]     IMPLICIT RevokedInfo,
  *  unknown             [2]     IMPLICIT UnknownInfo }
  * </pre>
- *
- * @version $Revision$ $Date$
  */
-public class GoodInfo implements CertStatus {
+public class GoodInfo extends CertStatus {
     private static final Tag TAG = SEQUENCE.TAG;
 
     public GoodInfo() {
+        super("Good");
     }
 
     @Override

--- a/base/common/src/main/java/com/netscape/cmsutil/ocsp/RevokedInfo.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/ocsp/RevokedInfo.java
@@ -38,15 +38,14 @@ import org.mozilla.jss.asn1.Tag;
  *  revocationTime              GeneralizedTime,
  *  revocationReason    [0]     EXPLICIT CRLReason OPTIONAL }
  * </pre>
- *
- * @version $Revision$ $Date$
  */
-public class RevokedInfo implements CertStatus {
+public class RevokedInfo extends CertStatus {
     private static final Tag TAG = SEQUENCE.TAG;
 
     private GeneralizedTime mRevokedAt;
 
     public RevokedInfo(GeneralizedTime revokedAt) {
+        super("Revoked");
         mRevokedAt = revokedAt;
     }
 
@@ -115,5 +114,9 @@ public class RevokedInfo implements CertStatus {
             return new RevokedInfo(revokedAt);
 
         }
+    }
+
+    public String toString() {
+        return label + " (" + mRevokedAt.toDate() + ")";
     }
 }

--- a/base/common/src/main/java/com/netscape/cmsutil/ocsp/UnknownInfo.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/ocsp/UnknownInfo.java
@@ -34,13 +34,12 @@ import org.mozilla.jss.asn1.Tag;
  * <pre>
  * UnknownInfo ::= NULL -- this can be replaced with an enumeration
  * </pre>
- *
- * @version $Revision$ $Date$
  */
-public class UnknownInfo implements CertStatus {
+public class UnknownInfo extends CertStatus {
     private static final Tag TAG = SEQUENCE.TAG;
 
     public UnknownInfo() {
+        super("Unknown");
     }
 
     @Override

--- a/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
@@ -36,15 +36,12 @@ import org.mozilla.jss.CryptoManager;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.cmsutil.ocsp.BasicOCSPResponse;
 import com.netscape.cmsutil.ocsp.CertStatus;
-import com.netscape.cmsutil.ocsp.GoodInfo;
 import com.netscape.cmsutil.ocsp.OCSPProcessor;
 import com.netscape.cmsutil.ocsp.OCSPRequest;
 import com.netscape.cmsutil.ocsp.OCSPResponse;
 import com.netscape.cmsutil.ocsp.ResponseBytes;
 import com.netscape.cmsutil.ocsp.ResponseData;
-import com.netscape.cmsutil.ocsp.RevokedInfo;
 import com.netscape.cmsutil.ocsp.SingleResponse;
-import com.netscape.cmsutil.ocsp.UnknownInfo;
 
 /**
  * This class implements an OCSP command line interface.
@@ -120,6 +117,15 @@ public class OCSPClient {
         System.out.println("  -v, --verbose        Run in verbose mode.");
         System.out.println("      --debug          Run in debug mode.");
         System.out.println("      --help           Show help message.");
+    }
+
+    public void printSingleResponse(SingleResponse sr) {
+        BigInteger serialNumber = sr.getCertID().getSerialNumber();
+        CertId certID = new CertId(serialNumber);
+        System.out.println("CertID.serialNumber=" + certID.toHexString());
+
+        CertStatus status = sr.getCertStatus();
+        System.out.println("CertStatus=" + status.getLabel());
     }
 
     public void execute(String args[]) throws Exception {
@@ -203,20 +209,7 @@ public class OCSPClient {
                         throw new Exception("No OCSP Response data.");
                     }
 
-                    BigInteger serialNumber = sr.getCertID().getSerialNumber();
-                    CertId certID = new CertId(serialNumber);
-                    System.out.println("CertID.serialNumber=" + certID.toHexString());
-
-                    CertStatus status = sr.getCertStatus();
-                    if (status instanceof GoodInfo) {
-                        System.out.println("CertStatus=Good");
-
-                    } else if (status instanceof UnknownInfo) {
-                        System.out.println("CertStatus=Unknown");
-
-                    } else if (status instanceof RevokedInfo) {
-                        System.out.println("CertStatus=Revoked");
-                    }
+                    printSingleResponse(sr);
                 }
             }
 

--- a/base/tools/src/main/java/com/netscape/cmstools/ocsp/OCSPCertVerifyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ocsp/OCSPCertVerifyCLI.java
@@ -23,14 +23,12 @@ import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmsutil.ocsp.BasicOCSPResponse;
 import com.netscape.cmsutil.ocsp.CertID;
 import com.netscape.cmsutil.ocsp.CertStatus;
-import com.netscape.cmsutil.ocsp.GoodInfo;
 import com.netscape.cmsutil.ocsp.OCSPProcessor;
 import com.netscape.cmsutil.ocsp.OCSPRequest;
 import com.netscape.cmsutil.ocsp.OCSPResponse;
 import com.netscape.cmsutil.ocsp.ResponseData;
 import com.netscape.cmsutil.ocsp.RevokedInfo;
 import com.netscape.cmsutil.ocsp.SingleResponse;
-import com.netscape.cmsutil.ocsp.UnknownInfo;
 
 /**
  * @author Endi S. Dewata
@@ -64,6 +62,29 @@ public class OCSPCertVerifyCLI extends CommandCLI {
         option = new Option(null, "request", true, "Path to DER-encoded OCSP request");
         option.setArgName("path");
         options.addOption(option);
+    }
+
+    public void printSingleResponse(SingleResponse sr) {
+        CertID certID = sr.getCertID();
+        INTEGER serialNumber = certID.getSerialNumber();
+        System.out.println("  Serial Number: " + new CertId(serialNumber).toHexString());
+
+        CertStatus status = sr.getCertStatus();
+        System.out.println("  Status: " + status.getLabel());
+
+        if (status instanceof RevokedInfo info) {
+            System.out.println("  Revoked On: " + info.getRevocationTime().toDate());
+        }
+
+        GeneralizedTime thisUpdate = sr.getThisUpdate();
+        if (thisUpdate != null) {
+            System.out.println("  This Update: " + thisUpdate.toDate());
+        }
+
+        GeneralizedTime nextUpdate = sr.getNextUpdate();
+        if (nextUpdate != null) {
+            System.out.println("  Next Update: " + nextUpdate.toDate());
+        }
     }
 
     @Override
@@ -126,38 +147,8 @@ public class OCSPCertVerifyCLI extends CommandCLI {
         int count = rd.getResponseCount();
 
         for (int i = 0; i < count; i++) {
-            SingleResponse sr = rd.getResponseAt(i);
-
-            if (i > 0) {
-                System.out.println();
-            }
-
-            CertID certID = sr.getCertID();
-            INTEGER serialNumber = certID.getSerialNumber();
-            System.out.println("  Serial Number: " + new CertId(serialNumber).toHexString());
-
-            CertStatus status = sr.getCertStatus();
-            if (status instanceof GoodInfo) {
-                System.out.println("  Status: Good");
-
-            } else if (status instanceof UnknownInfo) {
-                System.out.println("  Status: Unknown");
-
-            } else if (status instanceof RevokedInfo) {
-                System.out.println("  Status: Revoked");
-                RevokedInfo info = (RevokedInfo) status;
-                System.out.println("  Revoked On: " + info.getRevocationTime().toDate());
-            }
-
-            GeneralizedTime thisUpdate = sr.getThisUpdate();
-            if (thisUpdate != null) {
-                System.out.println("  This Update: " + thisUpdate.toDate());
-            }
-
-            GeneralizedTime nextUpdate = sr.getNextUpdate();
-            if (nextUpdate != null) {
-                System.out.println("  Next Update: " + nextUpdate.toDate());
-            }
+            if (i > 0) System.out.println();
+            printSingleResponse(rd.getResponseAt(i));
         }
     }
 }


### PR DESCRIPTION
The `CertStatus` interface has been converted into a base class which stores the label of the cert status. The code that uses `CertStatus` has been updated to use the labels.

See also PR #5126.