### PR TITLE
Handle some cases of uninitialised SigningUnit

### DIFF
--- a/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
+++ b/base/ca/src/main/java/com/netscape/ca/CertificateAuthority.java
@@ -728,6 +728,12 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
             return;
         }
 
+        if (mSigningUnit == null) {
+            // Signing units not initialised.  This can happen when LWCA
+            // key replication has not completed.  Ignore it and return.
+            return;
+        }
+
         X509CertImpl caCertImpl = mSigningUnit.getCertImpl();
         logger.debug("CertificateAuthority: - old serial number: 0x{}", caCertImpl.getSerialNumber().toString(16));
 
@@ -896,9 +902,10 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
     /**
      * Retrieves the CA certificate chain.
      *
-     * @return the CA certificate chain
+     * @return the CA certificate chain or null if the signing unit is not initialised
      */
     public CertificateChain getCACertChain() {
+        if (mSigningUnit == null) return null;
         return mSigningUnit.getCertChain();
     }
 
@@ -946,9 +953,10 @@ public class CertificateAuthority extends Subsystem implements IAuthority, IOCSP
     /**
      * Retrieves the CA certificate.
      *
-     * @return the CA certificate
+     * @return the CA certificate or null if the signing unit is not initialised
      */
     public org.mozilla.jss.crypto.X509Certificate getCaX509Cert() {
+        if (mSigningUnit == null) return null;
         return mSigningUnit.getCert();
     }
 

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/AuthorityRepository.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/AuthorityRepository.java
@@ -493,6 +493,10 @@ public class AuthorityRepository {
     }
 
 
+    /** Get CA certificate as DER byte array
+     *
+     * @return byte[], null if signing unit not initialised
+     */
     public byte[] getBinaryCert(String authId) {
 
         logger.info("AuthorityRepository: Getting cert for authority {}", authId);
@@ -523,11 +527,20 @@ public class AuthorityRepository {
         }
     }
 
+    /** Get CA certificate as PEM string
+     *
+     * @return String, null if signing unit not initialised
+     */
     public String getPemCert(String authId) {
         byte[] der = getBinaryCert(authId);
+        if (der == null) return null;
         return toPem("CERTIFICATE", der);
     }
 
+    /** Get CA certificate chain as DER byte array
+     *
+     * @return byte[], null if signing unit not initialised
+     */
     public byte[] getBinaryChain(String authId) {
 
         logger.info("AuthorityRepository: Getting cert chain for authority {}", authId);
@@ -559,8 +572,13 @@ public class AuthorityRepository {
         return out.toByteArray();
     }
 
+    /** Get CA certificate chain as PEM string
+     *
+     * @return String, null if signing unit not initialised
+     */
     public String getPemChain(String authId) {
         byte[] der = getBinaryChain(authId);
+        if (der == null) return null;
         return toPem("PKCS7", der);
     }
 


### PR DESCRIPTION
The `CertificateAuthority.mSigningUnit` may be `null` in some cases. In particular, when a clone does not yet have the keys for some lightweight CA, its signing unit can be null.  Update a handful of locations to handle this scenario without triggering NPE or similar.

Related: https://issues.redhat.com/browse/RHCS-6003