### PR TITLE
Revert Misc fixes provided to cope with last minute tomcat 10.1.36 s…

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -138,7 +138,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -189,8 +189,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -826,8 +826,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/acme-existing-nssdb-test.yml
+++ b/.github/workflows/acme-existing-nssdb-test.yml
@@ -249,8 +249,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser acme
           drwxr-x--- pkiuser pkiuser backup
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -831,8 +831,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser acme
           drwxr-x--- pkiuser pkiuser backup
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -155,7 +155,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -205,8 +205,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser backup
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -793,8 +793,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser backup
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -74,7 +74,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -128,8 +128,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -629,8 +629,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-existing-config-test.yml
+++ b/.github/workflows/ca-existing-config-test.yml
@@ -201,8 +201,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/est-ds-realm-separate-test.yml
+++ b/.github/workflows/est-ds-realm-separate-test.yml
@@ -139,7 +139,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -188,8 +188,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser est
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -333,8 +333,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser est
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/est-ds-realm-test.yml
+++ b/.github/workflows/est-ds-realm-test.yml
@@ -149,7 +149,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -200,8 +200,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -559,8 +559,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/est-postgresql-realm-test.yml
+++ b/.github/workflows/est-postgresql-realm-test.yml
@@ -220,7 +220,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -271,8 +271,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -309,7 +309,7 @@ jobs:
 
       - name: Add EST user
         run: |
-          DIGEST=$(docker exec pki /usr/share/tomcat/bin/digest.sh Secret.123 | sed 's/.*://')
+          DIGEST=$(docker exec pki tomcat-digest Secret.123 | sed 's/.*://')
 
           docker exec postgresql psql -U est -t -A -c "INSERT INTO users VALUES ('est-test-user', 'test.example.com', '$DIGEST');"  est
           docker exec postgresql psql -U est -t -A -c "INSERT INTO group_members VALUES ('EST Users', 'est-test-user');"  est
@@ -553,8 +553,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/est-separate-provided-certs-test.yml
+++ b/.github/workflows/est-separate-provided-certs-test.yml
@@ -173,7 +173,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -222,8 +222,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser est
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -367,8 +367,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser est
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -131,7 +131,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -187,8 +187,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -886,8 +886,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/kra-existing-config-test.yml
+++ b/.github/workflows/kra-existing-config-test.yml
@@ -109,7 +109,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -165,8 +165,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -167,7 +167,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser ocsp
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -222,9 +222,9 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
-          drwxr-x--- pkiuser pkiuser pki
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -883,9 +883,9 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
-          drwxr-x--- pkiuser pkiuser pki
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ocsp-existing-config-test.yml
+++ b/.github/workflows/ocsp-existing-config-test.yml
@@ -109,7 +109,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -164,9 +164,9 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
-          drwxr-x--- pkiuser pkiuser pki
+          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -28,7 +28,7 @@ jobs:
           HOSTNAME: pki.example.com
 
       - name: Run Python lint
-        if: false 
+        if: always()
         run: |
           docker exec pki pylint-3 --version
           docker exec pki /usr/share/pki/tests/bin/python-lint.py

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -154,7 +154,7 @@ jobs:
           # TODO: review permissions
           cat > expected << EOF
           drwxr-x--- pkiuser pkiuser backup
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           EOF
 
           diff expected output
@@ -269,7 +269,7 @@ jobs:
           # TODO: review permissions
           cat > expected << EOF
           drwxr-x--- pkiuser pkiuser backup
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           EOF
 
           diff expected output

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -86,7 +86,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
           drwxrwx--- pkiuser pkiuser tks
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -141,8 +141,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           EOF
 
@@ -309,8 +309,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           EOF
 

--- a/.github/workflows/tks-existing-config-test.yml
+++ b/.github/workflows/tks-existing-config-test.yml
@@ -109,7 +109,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -164,8 +164,8 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           EOF
 

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -106,7 +106,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser temp
           drwxrwx--- pkiuser pkiuser tks
           drwxrwx--- pkiuser pkiuser tps
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -164,8 +164,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           drwxrwx--- pkiuser pkiuser tps
           EOF
@@ -574,8 +574,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           drwxrwx--- pkiuser pkiuser tps
           EOF

--- a/.github/workflows/tps-existing-config-test.yml
+++ b/.github/workflows/tps-existing-config-test.yml
@@ -129,7 +129,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxrwx--- pkiuser pkiuser temp
           drwxrwx--- pkiuser pkiuser tks
-          drwxrwx--- pkiuser pkiuser webapps
+          drwxr-xr-x pkiuser pkiuser webapps
           drwxrwx--- pkiuser pkiuser work
           EOF
 
@@ -187,8 +187,8 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-r----- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-x--- pkiuser pkiuser pki
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           drwxrwx--- pkiuser pkiuser tps
           EOF

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -453,9 +453,6 @@ if (RESTEASY_VERSION)
     set(RESTEASY_JAXRS_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/resteasy-jaxrs-${RESTEASY_VERSION}.jar")
     set(RESTEASY_JAXRS_LINK "resteasy-jaxrs-${RESTEASY_VERSION}.jar")
 
-    set(RESTEASY_CLIENT_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/resteasy-client-${RESTEASY_VERSION}.jar")
-    set(RESTEASY_CLIENT_LINK "resteasy-client-${RESTEASY_VERSION}.jar")
-
     set(RESTEASY_JACKSON_PROVIDER_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/resteasy-jackson2-provider-${RESTEASY_VERSION}.jar")
     set(RESTEASY_JACKSON_PROVIDER_LINK "resteasy-jackson2-provider-${RESTEASY_VERSION}.jar")
 

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -141,7 +141,6 @@ add_custom_command(
     COMMAND ln -sf ../../../..${P11_KIT_TRUST} lib/p11-kit-trust.so
     COMMAND ln -sf ../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-common.jar lib/pki-common.jar
     COMMAND ln -sf ../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tools.jar lib/pki-tools.jar
-    COMMAND ln -sf ${RESTEASY_CLIENT_LINK} lib/resteasy-client.jar
     COMMAND ln -sf ${RESTEASY_JACKSON_PROVIDER_LINK} lib/resteasy-jackson2-provider.jar
     COMMAND ln -sf ${RESTEASY_JAXRS_LINK} lib/resteasy-jaxrs.jar
     COMMAND ln -sf ../../../..${SERVLET_JAR} lib/servlet.jar

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -76,15 +76,14 @@ class Tomcat(object):
     CONF_DIR = '/etc/tomcat'
     LIB_DIR = '/usr/share/java/tomcat'
     SHARE_DIR = '/usr/share/tomcat'
-    EXECUTABLE = '/usr/share/tomcat/bin/catalina.sh'
+    EXECUTABLE = '/usr/sbin/tomcat'
     UNIT_FILE = '/lib/systemd/system/tomcat@.service'
     SERVER_XML = CONF_DIR + '/server.xml'
     TOMCAT_CONF = CONF_DIR + '/tomcat.conf'
 
     @classmethod
     def get_version(cls):
-        # run "catalina.sh version"
-
+        # run "tomcat version"
         output = subprocess.check_output([Tomcat.EXECUTABLE, 'version'])
         output = output.decode('utf-8')
 
@@ -369,7 +368,7 @@ class PKIServer(object):
             content = f.read()
 
         # add Tomcat's default policy
-        filename = '/usr/share/tomcat/user-instance/conf/catalina.policy'
+        filename = '/usr/share/tomcat/conf/catalina.policy'
         logger.info('Appending %s', filename)
         with open(filename, 'r', encoding='utf-8') as f:
             content += f.read()

--- a/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
+++ b/base/server/python/pki/server/deployment/scriptlets/instance_layout.py
@@ -67,9 +67,6 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
         instance.with_maven_deps = deployer.with_maven_deps
         instance.create_libs(force=True)
 
-        # Create /var/lib/pki/<instance>/webapps
-        instance.makedirs(instance.webapps_dir, exist_ok=True)
-
         # Create /var/lib/pki/<instance>/temp
         instance.makedirs(instance.temp_dir, exist_ok=True)
 

--- a/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
@@ -13,18 +13,12 @@ EnvironmentFile=-/etc/sysconfig/%i
 EnvironmentFile=/usr/share/pki/etc/pki.conf
 EnvironmentFile=/etc/pki/pki.conf
 
-Environment="CATALINA_HOME=/usr/share/tomcat"
-Environment="CATALINA_BASE=/var/lib/tomcat"
-Environment="CATALINA_TMPDIR=/tmp"
-
-
 ExecStartPre=+/usr/bin/pki-server-nuxwdog
 ExecStartPre=/usr/sbin/pki-server upgrade %i
 ExecStartPre=/usr/sbin/pki-server migrate %i
 ExecStartPre=/usr/bin/pkidaemon start %i
-
-ExecStart=/bin/sh /usr/libexec/tomcat/tomcat-run.sh
-
+ExecStart=/usr/libexec/tomcat/server start
+ExecStop=/usr/libexec/tomcat/server stop
 ExecStopPost=+/usr/bin/pki-server-nuxwdog --clear
 
 KeyringMode=shared

--- a/base/server/share/lib/systemd/system/pki-tomcatd@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd@.service
@@ -11,23 +11,15 @@ EnvironmentFile=-/etc/sysconfig/%i
 EnvironmentFile=/usr/share/pki/etc/pki.conf
 EnvironmentFile=/etc/pki/pki.conf
 
-Environment="CATALINA_HOME=/usr/share/tomcat"
-Environment="CATALINA_BASE=/var/lib/tomcat"
-Environment="CATALINA_TMPDIR=/tmp"
-
 ExecStartPre=/usr/sbin/pki-server upgrade %i
 ExecStartPre=/usr/sbin/pki-server migrate %i
 ExecStartPre=/usr/bin/pkidaemon start %i
+ExecStart=/usr/libexec/tomcat/server start
+ExecStop=/usr/libexec/tomcat/server stop
 
-ExecStart=/bin/sh /usr/libexec/tomcat/tomcat-run.sh
-	
 SuccessExitStatus=143
-	
-Restart=on-abort
-
 User=pkiuser
 Group=pkiuser
-
 
 [Install]
 WantedBy=pki-tomcatd.target

--- a/base/tomcat-10.1/pom.xml
+++ b/base/tomcat-10.1/pom.xml
@@ -19,25 +19,25 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>10.1.36</version>
+            <version>10.1.43</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-servlet-api</artifactId>
-            <version>10.1.36</version>
+            <version>10.1.43</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jaspic-api</artifactId>
-            <version>10.1.36</version>
+            <version>10.1.43</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-util-scan</artifactId>
-            <version>10.1.36</version>
+            <version>10.1.43</version>
         </dependency>
 
         <dependency>

--- a/pki.spec
+++ b/pki.spec
@@ -16,13 +16,13 @@ Name:             pki
 # Downstream release number:
 # - development/stabilization (unsupported): 0.<n> where n >= 1
 # - GA/update (supported): <n> where n >= 1
-%global           release_number 0.2
+%global           release_number 0.3
 
 # Development phase:
 # - development (unsupported): alpha<n> where n >= 1
 # - stabilization (unsupported): beta<n> where n >= 1
 # - GA/update (supported): <none>
-%global           phase beta2
+%global           phase beta3
 
 %undefine         timestamp
 %undefine         commit_id
@@ -150,8 +150,6 @@ ExcludeArch: i686
 %define pki_groupname pkiuser
 %define pki_gid 17
 
-%define tomcat_groupname tomcat
-
 # Create a home directory for PKI user at /home/pkiuser
 # to store rootless Podman container.
 %define pki_homedir /home/%{pki_username}
@@ -246,10 +244,10 @@ BuildRequires:    mvn(org.jboss.resteasy:resteasy-servlet-initializer)
 
 %endif
 
-BuildRequires:    mvn(org.apache.tomcat:tomcat-catalina) >= 10.1.36
-BuildRequires:    mvn(org.apache.tomcat:tomcat-servlet-api) >= 10.1.36
-BuildRequires:    mvn(org.apache.tomcat:tomcat-jaspic-api) >= 10.1.36
-BuildRequires:    mvn(org.apache.tomcat:tomcat-util-scan) >= 10.0.36
+BuildRequires:    mvn(org.apache.tomcat:tomcat-catalina) >= 10.1.43
+BuildRequires:    mvn(org.apache.tomcat:tomcat-servlet-api) >= 10.1.43
+BuildRequires:    mvn(org.apache.tomcat:tomcat-jaspic-api) >= 10.1.43
+BuildRequires:    mvn(org.apache.tomcat:tomcat-util-scan) >= 10.0.43
 
 BuildRequires:    mvn(org.dogtagpki.jss:jss-base) >= 5.8
 BuildRequires:    mvn(org.dogtagpki.jss:jss-tomcat) >= 5.8
@@ -666,9 +664,7 @@ Requires:         mvn(org.jboss.resteasy:resteasy-servlet-initializer)
 Provides:         bundled(resteasy-servlet-initializer)
 %endif
 
-Requires:         tomcat >= 1:10.1.36
-Requires:         tomcat-user-instance >= 1:10.1.36
-Requires:         tomcat-jakartaee-migration
+Requires:         tomcat >= 1:10.1.43
 
 Requires:         mvn(org.dogtagpki.jss:jss-tomcat) >= 5.8
 
@@ -1032,6 +1028,7 @@ BuildArch:        noarch
 Obsoletes:        pki-tests < %{version}-%{release}
 Provides:         pki-tests = %{version}-%{release}
 
+Requires:         python3-pylint
 Requires:         python3-flake8
 
 %description -n   %{product_id}-tests
@@ -1255,13 +1252,9 @@ fi
 %if 0%{?fedora}
 # Create a sysusers.d config file
 
-# Add pkiuser to the tomcat group for now to get things working
-# while we investigate the issue.
-
 cat > %{product_id}.sysusers.conf <<EOF
 g %{pki_username} %{pki_gid}
 u %{pki_groupname} %{pki_uid} 'Certificate System' %{pki_homedir} -
-m %{pki_username} %{tomcat_groupname}
 EOF
 
 %endif
@@ -1591,8 +1584,10 @@ xmlstarlet edit --inplace \
 %if %{with server}
 
 %if 0%{?fedora}
+
 install -m0644 -D %{product_id}.sysusers.conf %{buildroot}%{_sysusersdir}/%{product_id}.conf
 %pre -n %{product_id}-server
+
 %else
 
 %pre -n %{product_id}-server
@@ -1604,9 +1599,7 @@ getent group %{pki_groupname} >/dev/null || groupadd -f -g %{pki_gid} -r %{pki_g
 if ! getent passwd %{pki_username} >/dev/null ; then
     useradd -r -u %{pki_uid} -g %{pki_groupname} -d %{pki_homedir} -s /sbin/nologin -c "Certificate System" %{pki_username}
 fi
-# Add pkiuser to the tomcat group for now to get things working
-# while we investigate the issue.
-usermod -a -G %{tomcat_groupname} %{pki_username}
+
 %endif
 
 # create PKI home directory if it doesn't exist


### PR DESCRIPTION
…urprises. (#5153)"

This reverts commit b58e282a357e7664526c38db8c95d2f6089e916f.

This essentially allows pki to run under a tomcat that behaves like tomcat-10.1-34. This is in anticipation of a new version 36 tomcat build reverted to version 34 behavior.

Update requires to tomcat-10.1-43, which has been rebuilt to version 34 contents.