### PR TITLE
Revert CertificateAuthority update in KeyRetrieverRunner

### DIFF
--- a/.github/workflows/ipa-subca-test.yml
+++ b/.github/workflows/ipa-subca-test.yml
@@ -149,6 +149,16 @@ jobs:
           sed -n 's/^\s*ID:\s*\(.*\)$/\1/p' output | wc -l > actual
           diff expected actual
 
+      - name: Generate certificate in the CAs
+        run: |
+          for i in {1..20}
+          do
+              docker exec ipa ipa caacl-add-ca hosts_services_caIPAserviceCert --cas=lwca$i
+              docker exec ipa mkdir /tmp/lwca$i
+              docker exec ipa ipa-getcert request -w -k /tmp/lwca$i/test$i.key -f /tmp/lwca$i/test$i.pem -X lwca$i
+              docker exec ipa openssl x509 -in /tmp/lwca$i/test$i.pem -noout -subject -issuer
+          done
+
       - name: Remove lightweight CAs
         run: |
           for i in {1..20}

--- a/base/ca/src/main/java/com/netscape/ca/KeyRetrieverRunner.java
+++ b/base/ca/src/main/java/com/netscape/ca/KeyRetrieverRunner.java
@@ -131,6 +131,18 @@ public class KeyRetrieverRunner implements Runnable {
             return false;
         }
 
+        /* While we were retrieving the key and cert, the
+         * CA instance in the CAEngine might
+         * have been replaced, so look it up afresh.
+         */
+        ca = engine.getCA(aid);
+        if (ca == null) {
+            /* We got the key, but the authority has been
+             * deleted.  Do not retry.
+             */
+            logger.debug("Authority was deleted; returning.");
+            return true;
+        }
         logger.info("KeyRetrieverRunner: Initializing CA " + aid);
         boolean initSigUnitSucceeded = false;
         try {


### PR DESCRIPTION
During execution of KeyRetrieverRunner the CertificateAuthority could be updated and the signing unit will not get properly initialised.

This is the case in IPA setup where an external key retriever is configured as default.

Problem described in https://issues.redhat.com/browse/RHEL-108293