### PR TITLE
Add reindex step for setting up ACME database

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -3,6 +3,9 @@ name: Basic ACME
 on: workflow_call
 
 env:
+  # use DS container image by default to create DS with BDB
+  # backend which does not require rebuilding the indexes:
+  # https://github.com/dogtagpki/pki/issues/5160
   DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
 
 jobs:
@@ -39,6 +42,19 @@ jobs:
               --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
+
+          docker exec ds dsconf \
+              localhost \
+              backend \
+              config \
+              get \
+              | tee output
+
+          # DS backend should be BDB
+          echo "nsslapd-backend-implement: bdb" > expected
+          cat output | sed -n "/^nsslapd-backend-implement:/p" > actual
+
+          diff expected actual
 
       - name: Set up PKI container
         run: |
@@ -84,16 +100,28 @@ jobs:
 
       - name: Set up ACME database
         run: |
+          # import ACME schema
           docker exec pki ldapmodify \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/schema.ldif
+
+          # create ACME indexes
           docker exec pki ldapadd \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/index.ldif
+
+          # BDB indexes does not need to be rebuilt
+          # docker exec pki ldapadd \
+          #     -H ldap://ds.example.com:3389 \
+          #     -D "cn=Directory Manager" \
+          #     -w Secret.123 \
+          #     -f /usr/share/pki/acme/database/ds/indextask.ldif
+
+          # create ACME subtree
           docker exec pki ldapadd \
               -H ldap://ds.example.com:3389 \
               -D "cn=Directory Manager" \

--- a/.github/workflows/acme-container-ca-test.yml
+++ b/.github/workflows/acme-container-ca-test.yml
@@ -6,7 +6,10 @@ name: ACME container with CA
 on: workflow_call
 
 env:
-  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+  # use pki-runner image by default to create DS with LMDB
+  # backend which requires rebuilding the indexes:
+  # https://github.com/dogtagpki/pki/issues/5160
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'pki-runner' }}
 
 jobs:
   test:
@@ -60,6 +63,19 @@ jobs:
               --network-alias=cads.example.com \
               --password=Secret.123 \
               cads
+
+          docker exec cads dsconf \
+              localhost \
+              backend \
+              config \
+              get \
+              | tee output
+
+          # CA DS backend should be LMDB
+          echo "nsslapd-backend-implement: mdb" > expected
+          cat output | sed -n "/^nsslapd-backend-implement:/p" > actual
+
+          diff expected actual
 
       - name: Create CA shared folders
         run: |
@@ -191,6 +207,9 @@ jobs:
           docker exec ca pki-server ca-db-init -v
           docker exec ca pki-server ca-db-index-add -v
 
+          # LMDB indexes must be rebuilt
+          docker exec ca pki-server ca-db-index-rebuild -v
+
       - name: Create admin cert
         run: |
           # create cert request
@@ -244,6 +263,17 @@ jobs:
               --network-alias=acmeds.example.com \
               --password=Secret.123 \
               acmeds
+
+          docker exec acmeds dsconf \
+              localhost \
+              backend \
+              config \
+              get \
+              | tee output
+
+          # ACME DS backend should be LMDB
+          echo "nsslapd-backend-implement: mdb" > expected
+          cat output | sed -n "/^nsslapd-backend-implement:/p" > actual
 
       - name: Create ACME shared folders
         run: |
@@ -359,18 +389,52 @@ jobs:
 
       - name: Set up ACME database
         run: |
+          # import ACME schema
           docker exec acme ldapmodify \
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/schema.ldif
 
+          # create ACME indexes
           docker exec acme ldapadd \
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/index.ldif
 
+          # LMDB indexes must be rebuilt
+          docker exec acme ldapadd \
+              -H ldap://acmeds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/database/ds/indextask.ldif
+
+          # wait for rebuild to complete
+          while true; do
+              sleep 1
+
+              docker exec acme ldapsearch \
+                  -H ldap://acmeds.example.com:3389 \
+                  -D "cn=Directory Manager" \
+                  -w Secret.123 \
+                  -b "cn=acme,cn=index,cn=tasks,cn=config" \
+                  -LLL \
+                  nsTaskExitCode \
+                  | tee output
+
+              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
+              cat nsTaskExitCode
+
+              if [ -s nsTaskExitCode ]; then
+                  break
+              fi
+          done
+
+          echo "0" > expected
+          diff expected nsTaskExitCode
+
+          # create ACME subtree
           docker exec acme ldapadd \
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \

--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -3,7 +3,10 @@ name: ACME on separate instance
 on: workflow_call
 
 env:
-  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+  # use pki-runner image by default to create DS with LMDB
+  # backend which requires rebuilding the indexes:
+  # https://github.com/dogtagpki/pki/issues/5160
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'pki-runner' }}
 
 jobs:
   # docs/installation/acme/Installing_PKI_ACME_Responder.md
@@ -38,6 +41,19 @@ jobs:
               --network=example \
               --network-alias=cads.example.com \
               cads
+
+          docker exec cads dsconf \
+              localhost \
+              backend \
+              config \
+              get \
+              | tee output
+
+          # CA DS backend should be LMDB
+          echo "nsslapd-backend-implement: mdb" > expected
+          cat output | sed -n "/^nsslapd-backend-implement:/p" > actual
+
+          diff expected actual
 
       - name: Set up CA container
         run: |
@@ -91,6 +107,19 @@ jobs:
               --network-alias=acmeds.example.com \
               acmeds
 
+          docker exec acmeds dsconf \
+              localhost \
+              backend \
+              config \
+              get \
+              | tee output
+
+          # ACME DS backend should be LMDB
+          echo "nsslapd-backend-implement: mdb" > expected
+          cat output | sed -n "/^nsslapd-backend-implement:/p" > actual
+
+          diff expected actual
+
       - name: Set up ACME container
         run: |
           tests/bin/runner-init.sh \
@@ -101,16 +130,23 @@ jobs:
 
       - name: Set up ACME database
         run: |
+          # import ACME schema
           docker exec acme ldapmodify \
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/schema.ldif
+
+          # create ACME indexes
           docker exec acme ldapadd \
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \
               -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/index.ldif
+
+          # rebuild ACME indexes later
+
+          # create ACME subtree
           docker exec acme ldapadd \
               -H ldap://acmeds.example.com:3389 \
               -D "cn=Directory Manager" \
@@ -127,6 +163,7 @@ jobs:
 
       - name: Install ACME
         run: |
+          # TODO: update pkispawn to set up ACME database and realm
           docker exec acme pkispawn \
               -f /usr/share/pki/server/examples/installation/acme.cfg \
               -s ACME \
@@ -400,7 +437,57 @@ jobs:
               --server http://acme.example.com:8080/acme/directory \
               --email testuser@example.com \
               --agree-tos \
+              --non-interactive \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # registration should fail since ACME indexes has not been rebuilt
+          echo "acme.errors.ClientError: <Response [500]>" > expected
+          cat stderr | sed -n '/^acme.errors.ClientError:/p' > actual
+
+          diff expected actual
+
+      - name: Rebuild ACME indexes
+        run: |
+          # LMDB indexes must be rebuilt
+          docker exec acme ldapadd \
+              -H ldap://acmeds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/database/ds/indextask.ldif
+
+          # wait for rebuild to complete
+          while true; do
+              sleep 1
+
+              docker exec acme ldapsearch \
+                  -H ldap://acmeds.example.com:3389 \
+                  -D "cn=Directory Manager" \
+                  -w Secret.123 \
+                  -b "cn=acme,cn=index,cn=tasks,cn=config" \
+                  -LLL \
+                  nsTaskExitCode \
+                  | tee output
+
+              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
+              cat nsTaskExitCode
+
+              if [ -s nsTaskExitCode ]; then
+                  break
+              fi
+          done
+
+          echo "0" > expected
+          diff expected nsTaskExitCode
+
+      - name: Register ACME account again
+        run: |
+          docker exec client certbot register \
+              --server http://acme.example.com:8080/acme/directory \
+              --email testuser@example.com \
+              --agree-tos \
               --non-interactive
+
+          # registration should work
 
       - name: Check ACME accounts after registration
         run: |

--- a/docs/admin/acme/Configuring-ACME-with-DS-Database.adoc
+++ b/docs/admin/acme/Configuring-ACME-with-DS-Database.adoc
@@ -26,7 +26,7 @@ $ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
 
 **Note:** By default the `index.ldif` will use `userroot` as the DS backend.
 
-If necessary, the database can be reindexed by importing
+With LMDB backend the DS indexes need to be rebuilt by importing
 link:../../../base/acme/database/ds/indextask.ldif[/usr/share/pki/acme/database/ds/indextask.ldif] with the following command:
 
 ----

--- a/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
@@ -109,6 +109,26 @@ $ ldapadd \
     -f /usr/share/pki/acme/database/ds/index.ldif
 ----
 
+With LMDB backend the DS indexes for ACME database need to be rebuilt:
+
+----
+$ ldapadd \
+    -H ldap://ds.example.com:3389 \
+    -D "cn=Directory Manager" \
+    -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/indextask.ldif
+----
+
+The progress of the reindex task can be monitored with the following command:
+
+----
+$ ldapsearch \
+    -H ldap://ds.example.com:3389 \
+    -D "cn=Directory Manager" \
+    -w Secret.123 \
+    -b "cn=acme,cn=index,cn=tasks,cn=config"
+----
+
 To create the DS subtrees for ACME database:
 
 ----

--- a/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
@@ -44,6 +44,26 @@ $ ldapadd \
     -f /usr/share/pki/acme/database/ds/index.ldif
 ----
 
+With LMDB backend the DS indexes for ACME database need to be rebuilt:
+
+----
+$ ldapadd \
+    -H ldap://ds.example.com:3389 \
+    -D "cn=Directory Manager" \
+    -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/indextask.ldif
+----
+
+The progress of the reindex task can be monitored with the following command:
+
+----
+$ ldapsearch \
+    -H ldap://ds.example.com:3389 \
+    -D "cn=Directory Manager" \
+    -w Secret.123 \
+    -b "cn=acme,cn=index,cn=tasks,cn=config"
+----
+
 To create the DS subtrees for ACME database:
 
 ----


### PR DESCRIPTION
As described in issue #5160 with LMDB backend newly added DS indexes always need to be rebuilt. For ACME and other subsystems installed without `pkispawn` this additional step needs to be done manually. In the future this step can be integrated into `pkispawn` for ACME.

Some ACME tests have been modified to create DS instances with LMDB backend to demonstrate the additional reindex step. The ACME docs have been updated as well.

Issue https://github.com/dogtagpki/pki/issues/5160

Docs:
https://github.com/edewata/pki/blob/acme/docs/admin/acme/Configuring-ACME-with-DS-Database.adoc
https://github.com/edewata/pki/blob/acme/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
https://github.com/edewata/pki/blob/acme/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
