### PR TITLE
Add pki-server acme-database-init

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -98,44 +98,6 @@ jobs:
           grep "Serial Number:" output | wc -l > actual
           diff expected actual
 
-      - name: Set up ACME database
-        run: |
-          # import ACME schema
-          docker exec pki ldapmodify \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/schema.ldif
-
-          # create ACME indexes
-          docker exec pki ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/index.ldif
-
-          # BDB indexes does not need to be rebuilt
-          # docker exec pki ldapadd \
-          #     -H ldap://ds.example.com:3389 \
-          #     -D "cn=Directory Manager" \
-          #     -w Secret.123 \
-          #     -f /usr/share/pki/acme/database/ds/indextask.ldif
-
-          # create ACME subtree
-          docker exec pki ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/create.ldif
-
-      - name: Set up ACME realm
-        run: |
-          docker exec pki ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/realm/ds/create.ldif
-
       - name: Install ACME in PKI container
         run: |
           docker exec pki pkispawn \
@@ -281,6 +243,21 @@ jobs:
         if: always()
         run: |
           docker exec pki ls -l /var/log/pki/pki-tomcat/acme
+
+      - name: Initialize ACME database
+        run: |
+          # this command will rebuild the indexes which is
+          # not required for BDB backend but should not cause
+          # any problem
+          docker exec pki pki-server acme-database-init -v
+
+      - name: Initialize ACME realm
+        run: |
+          docker exec pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/realm/ds/create.ldif
 
       - name: Check initial ACME accounts
         run: |

--- a/.github/workflows/acme-container-ca-test.yml
+++ b/.github/workflows/acme-container-ca-test.yml
@@ -387,61 +387,11 @@ jobs:
               -U https://acme.example.com:8443 \
               acme-info
 
-      - name: Set up ACME database
+      - name: Initialize ACME database
         run: |
-          # import ACME schema
-          docker exec acme ldapmodify \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/schema.ldif
+          docker exec acme pki-server acme-database-init -v
 
-          # create ACME indexes
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/index.ldif
-
-          # LMDB indexes must be rebuilt
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/indextask.ldif
-
-          # wait for rebuild to complete
-          while true; do
-              sleep 1
-
-              docker exec acme ldapsearch \
-                  -H ldap://acmeds.example.com:3389 \
-                  -D "cn=Directory Manager" \
-                  -w Secret.123 \
-                  -b "cn=acme,cn=index,cn=tasks,cn=config" \
-                  -LLL \
-                  nsTaskExitCode \
-                  | tee output
-
-              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
-              cat nsTaskExitCode
-
-              if [ -s nsTaskExitCode ]; then
-                  break
-              fi
-          done
-
-          echo "0" > expected
-          diff expected nsTaskExitCode
-
-          # create ACME subtree
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/create.ldif
-
-      - name: Set up ACME realm
+      - name: Initialize ACME realm
         run: |
           docker exec acme ldapadd \
               -H ldap://acmeds.example.com:3389 \

--- a/.github/workflows/acme-existing-nssdb-test.yml
+++ b/.github/workflows/acme-existing-nssdb-test.yml
@@ -143,32 +143,6 @@ jobs:
               --input /var/lib/pki/pki-tomcat/conf/certs/sslserver.crt \
               sslserver
 
-      - name: Set up ACME database
-        run: |
-          docker exec acme ldapmodify \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/schema.ldif
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/index.ldif
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/create.ldif
-
-      - name: Set up ACME realm
-        run: |
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/realm/ds/create.ldif
-
       - name: Install ACME
         run: |
           docker exec acme pkispawn \
@@ -322,6 +296,18 @@ jobs:
               -d /etc/pki/pki-tomcat/alias \
               -f /etc/pki/pki-tomcat/password.conf \
               nss-cert-find
+
+      - name: Initialize ACME database
+        run: |
+          docker exec acme pki-server acme-database-init -v
+
+      - name: Initialize ACME realm
+        run: |
+          docker exec acme ldapadd \
+              -H ldap://acmeds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/realm/ds/create.ldif
 
       - name: Check initial ACME accounts
         run: |

--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -128,7 +128,7 @@ jobs:
               --network-alias=acme.example.com \
               acme
 
-      - name: Set up ACME database
+      - name: Initialize ACME database
         run: |
           # import ACME schema
           docker exec acme ldapmodify \
@@ -153,7 +153,7 @@ jobs:
               -w Secret.123 \
               -f /usr/share/pki/acme/database/ds/create.ldif
 
-      - name: Set up ACME realm
+      - name: Initialize ACME realm
         run: |
           docker exec acme ldapadd \
               -H ldap://acmeds.example.com:3389 \
@@ -163,7 +163,7 @@ jobs:
 
       - name: Install ACME
         run: |
-          # TODO: update pkispawn to set up ACME database and realm
+          # TODO: update pkispawn to initialize ACME database and realm
           docker exec acme pkispawn \
               -f /usr/share/pki/server/examples/installation/acme.cfg \
               -s ACME \

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -56,32 +56,6 @@ jobs:
               -D pki_ds_url=ldap://ds.example.com:3389 \
               -v
 
-      - name: Set up ACME database
-        run: |
-          docker exec pki ldapmodify \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/schema.ldif
-          docker exec pki ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/index.ldif
-          docker exec pki ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/create.ldif
-
-      - name: Set up ACME realm
-        run: |
-          docker exec pki ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/realm/ds/create.ldif
-
       - name: Install ACME in PKI container
         run: |
           docker exec pki pki-server acme-create
@@ -99,6 +73,18 @@ jobs:
               -D bindPassword=Secret.123
           docker exec pki bash -c "echo baseURL=http://server1.example.com:8080/acme >> /var/lib/pki/pki-tomcat/conf/acme/engine.conf"
           docker exec pki pki-server acme-deploy --wait
+
+      - name: Initialize ACME database
+        run: |
+          docker exec pki pki-server acme-database-init -v
+
+      - name: Initialize ACME realm
+        run: |
+          docker exec pki ldapadd \
+              -H ldap://ds.example.com:3389 \
+              -D "cn=Directory Manager" \
+              -w Secret.123 \
+              -f /usr/share/pki/acme/realm/ds/create.ldif
 
       - name: Set up client container
         run: |

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/ACMEDatabase.java
@@ -31,10 +31,19 @@ public abstract class ACMEDatabase {
         this.config = config;
     }
 
+    /**
+     * Initialize ACMEDatabase object
+     */
     public void init() throws Exception {
     }
 
     public void close() throws Exception {
+    }
+
+    /**
+     * Initialize ACME database
+     */
+    public void initDatabase() throws Exception {
     }
 
     public Boolean getEnabled() throws Exception {

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMECLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMECLI.java
@@ -1,0 +1,20 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.acme.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMECLI extends CLI {
+
+    public ACMECLI(CLI parent) {
+        super("acme", "ACME subsystem management commands", parent);
+
+        addModule(new ACMEDatabaseCLI(this));
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseCLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseCLI.java
@@ -1,0 +1,20 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.acme.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMEDatabaseCLI extends CLI {
+
+    public ACMEDatabaseCLI(CLI parent) {
+        super("database", "ACME database management commands", parent);
+
+        addModule(new ACMEDatabaseInitCLI(this));
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseInitCLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseInitCLI.java
@@ -1,0 +1,86 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.acme.cli;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.Properties;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.acme.database.ACMEDatabase;
+import org.dogtagpki.acme.database.ACMEDatabaseConfig;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemCLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmscore.apps.CMS;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMEDatabaseInitCLI extends SubsystemCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(ACMEDatabaseInitCLI.class);
+
+    public ACMEDatabaseInitCLI(CLI parent) {
+        super("init", "Initialize " + parent.getParent().getName().toUpperCase() + " database", parent);
+    }
+
+    public ACMEDatabaseInitCLI(String name, String description, CLI parent) {
+        super(name, description, parent);
+    }
+
+    @Override
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        initializeTomcatJSS();
+
+        String instanceDir = CMS.getInstanceDir();
+        String serverConfDir = instanceDir + File.separator + "conf";
+        String acmeConfDir = serverConfDir + File.separator + "acme";
+        logger.info("ACME configuration directory: " + acmeConfDir);
+
+        File databaseConfigFile = new File(acmeConfDir + File.separator + "database.conf");
+        ACMEDatabaseConfig databaseConfig;
+
+        if (databaseConfigFile.exists()) {
+            logger.info("Loading ACME database config from " + databaseConfigFile);
+            Properties dbProps = new Properties();
+            try (FileReader reader = new FileReader(databaseConfigFile)) {
+                dbProps.load(reader);
+            }
+            databaseConfig = ACMEDatabaseConfig.fromProperties(dbProps);
+
+        } else {
+            logger.info("Loading default ACME database config");
+            databaseConfig = new ACMEDatabaseConfig();
+        }
+
+        String className = databaseConfig.getClassName();
+        Class<ACMEDatabase> databaseClass = (Class<ACMEDatabase>) Class.forName(className);
+
+        ACMEDatabase database = databaseClass.getDeclaredConstructor().newInstance();
+        database.setConfig(databaseConfig);
+
+        try {
+            database.init();
+
+            logger.info("Initializing ACME database");
+            database.initDatabase();
+
+        } finally {
+            database.close();
+        }
+    }
+}

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -3308,6 +3308,24 @@ class ACMESubsystem(PKISubsystem):
 
         pass
 
+    def init_database(
+            self,
+            skip_config=False,
+            skip_schema=False,
+            skip_base=False,
+            skip_containers=False,
+            as_current_user=False):
+
+        cmd = [self.name + '-database-init']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd)
+
 
 class ESTSubsystem(PKISubsystem):
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/PKIServerCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/PKIServerCLI.java
@@ -42,6 +42,7 @@ public class PKIServerCLI extends CLI {
         addModule("ocsp", "org.dogtagpki.server.ocsp.cli.OCSPCLI");
         addModule("tks", "org.dogtagpki.server.tks.cli.TKSCLI");
         addModule("tps", "org.dogtagpki.server.tps.cli.TPSCLI");
+        addModule("acme", "org.dogtagpki.server.acme.cli.ACMECLI");
 
         createOptions();
     }

--- a/docs/admin/acme/Configuring-ACME-with-DS-Database.adoc
+++ b/docs/admin/acme/Configuring-ACME-with-DS-Database.adoc
@@ -6,51 +6,6 @@ This document describes the process to configure ACME responder to use a DS data
 It assumes that the DS database has been installed as described in
 link:../others/Creating_DS_instance.adoc[Creating DS instance].
 
-## Initializing DS Database
-
-First, add the ACME DS schema by importing
-link:../../../base/acme/database/ds/schema.ldif[/usr/share/pki/acme/database/ds/schema.ldif] with the following command:
-
-----
-$ ldapmodify -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ds/schema.ldif
-----
-
-Next, create the ACME DS indexes by importing
-link:../../../base/acme/database/ds/index.ldif[/usr/share/pki/acme/database/ds/index.ldif] with the following command:
-
-----
-$ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ds/index.ldif
-----
-
-**Note:** By default the `index.ldif` will use `userroot` as the DS backend.
-
-With LMDB backend the DS indexes need to be rebuilt by importing
-link:../../../base/acme/database/ds/indextask.ldif[/usr/share/pki/acme/database/ds/indextask.ldif] with the following command:
-
-----
-$ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ds/indextask.ldif
-----
-
-The progress of the reindex task can be monitored with the following command:
-
-----
-$ ldapsearch -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -b "cn=acme,cn=index,cn=tasks,cn=config"
-----
-
-Once the indexes are ready, create the ACME subtree by importing
-link:../../../base/acme/database/ds/create.ldif[/usr/share/pki/acme/database/ds/create.ldif] with the following command:
-
-----
-$ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/database/ds/create.ldif
-----
-
-**Note:** By default the `create.ldif` will create the subtree under `dc=pki,dc=example,dc=com` which is mapped to `userroot` DS backend.
-
 ## Configuring ACME Database
 
 A sample database configuration is available at
@@ -89,3 +44,56 @@ It can be enabled with the following parameter:
 ----
 monitor.enabled=true
 ----
+
+## Initializing ACME Database
+
+Once the ACME database is configured, it can be initialized with the following command:
+
+----
+$ pki-server acme-database-init
+----
+
+Alternatively, the ACME database can be initialized manually with LDAP tools.
+
+First, add the ACME DS schema by importing
+link:../../../base/acme/database/ds/schema.ldif[/usr/share/pki/acme/database/ds/schema.ldif] with the following command:
+
+----
+$ ldapmodify -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/schema.ldif
+----
+
+Next, create the ACME DS indexes by importing
+link:../../../base/acme/database/ds/index.ldif[/usr/share/pki/acme/database/ds/index.ldif] with the following command:
+
+----
+$ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/index.ldif
+----
+
+**Note:** By default the `index.ldif` will use `userroot` as the DS backend.
+
+With LMDB backend the DS indexes need to be rebuilt by importing
+link:../../../base/acme/database/ds/indextask.ldif[/usr/share/pki/acme/database/ds/indextask.ldif] with the following command:
+
+----
+$ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/indextask.ldif
+----
+
+The progress of the reindex task can be monitored with the following command:
+
+----
+$ ldapsearch -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -b "cn=acme,cn=index,cn=tasks,cn=config"
+----
+
+Once the indexes are ready, create the ACME database subtree by importing
+link:../../../base/acme/database/ds/create.ldif[/usr/share/pki/acme/database/ds/create.ldif] with the following command:
+
+----
+$ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/database/ds/create.ldif
+----
+
+**Note:** By default the `create.ldif` will create the subtree under `dc=pki,dc=example,dc=com` which is mapped to `userroot` DS backend.

--- a/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
@@ -89,6 +89,14 @@ Enter the base DN for the ACME subtree.
   Base DN [dc=acme,dc=pki,dc=example,dc=com]:
 ----
 
+Once the ACME database is configured, it can be initialized with the following command:
+
+----
+$ pki-server acme-database-init
+----
+
+Alternatively, the ACME database can be initialized manually with LDAP tools.
+
 To import the DS schema for ACME database:
 
 ----

--- a/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
@@ -22,7 +22,32 @@ It also assumes that the following CA service is available to use as ACME issuer
 * Username: `caadmin`
 * Password: `Secret.123`
 
-== Setting Up ACME Database ==
+== Installing ACME Responder ==
+
+To create and deploy ACME responder in PKI server execute the following command:
+
+----
+$ pkispawn \
+    -f /usr/share/pki/server/examples/installation/acme.cfg \
+    -s ACME \
+    -D acme_database_url=ldap://ds.example.com:3389 \
+    -D acme_issuer_url=https://pki.example.com:8443 \
+    -D acme_realm_url=ldap://ds.example.com:3389
+----
+
+The configuration files are available in `/var/lib/pki/pki-tomcat/conf/acme` folder.
+
+See also xref:../../admin/acme/Configuring-ACME-Responder.adoc[Configuring ACME Responder].
+
+== Initializing ACME Database ==
+
+The ACME database can be initialized with the following command:
+
+----
+$ pki-server acme-database-init
+----
+
+Alternatively, the ACME database can be initialized manually with LDAP tools.
 
 To import the DS schema for ACME database:
 
@@ -74,7 +99,7 @@ $ ldapadd \
     -f /usr/share/pki/acme/database/ds/create.ldif
 ----
 
-== Setting Up ACME Realm ==
+== Initializing ACME Realm ==
 
 To create the DS subtrees for ACME realm:
 
@@ -85,23 +110,6 @@ $ ldapadd \
     -w Secret.123 \
     -f /usr/share/pki/acme/realm/ds/create.ldif
 ----
-
-== Installing ACME Responder ==
-
-To create and deploy ACME responder in PKI server execute the following command:
-
-----
-$ pkispawn \
-    -f /usr/share/pki/server/examples/installation/acme.cfg \
-    -s ACME \
-    -D acme_database_url=ldap://ds.example.com:3389 \
-    -D acme_issuer_url=https://pki.example.com:8443 \
-    -D acme_realm_url=ldap://ds.example.com:3389
-----
-
-The configuration files are available in `/var/lib/pki/pki-tomcat/conf/acme` folder.
-
-See also xref:../../admin/acme/Configuring-ACME-Responder.adoc[Configuring ACME Responder].
 
 == Verifying ACME Responder ==
 


### PR DESCRIPTION
The `pki-server acme-database-init` has been added to simplify ACME database initialization which includes importing the schema, creating indexes, rebuilding indexes, and creating the subtree.

The command can only be used after the database is configured, so some ACME tests have been changed to initialize the database after the ACME subsystem is created.

Issue https://github.com/dogtagpki/pki/issues/5160

Docs:
https://github.com/edewata/pki/blob/acme/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
https://github.com/edewata/pki/blob/acme/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
https://github.com/edewata/pki/blob/acme/docs/admin/acme/Configuring-ACME-with-DS-Database.adoc
