### PR TITLE
Add pki-server acme-realm-init

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -253,11 +253,7 @@ jobs:
 
       - name: Initialize ACME realm
         run: |
-          docker exec pki ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/realm/ds/create.ldif
+          docker exec pki pki-server acme-realm-init -v
 
       - name: Check initial ACME accounts
         run: |

--- a/.github/workflows/acme-container-ca-test.yml
+++ b/.github/workflows/acme-container-ca-test.yml
@@ -393,11 +393,7 @@ jobs:
 
       - name: Initialize ACME realm
         run: |
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/realm/ds/create.ldif
+          docker exec acme pki-server acme-realm-init -v
 
       - name: Register ACME account
         run: |

--- a/.github/workflows/acme-existing-nssdb-test.yml
+++ b/.github/workflows/acme-existing-nssdb-test.yml
@@ -303,11 +303,7 @@ jobs:
 
       - name: Initialize ACME realm
         run: |
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/realm/ds/create.ldif
+          docker exec acme pki-server acme-realm-init -v
 
       - name: Check initial ACME accounts
         run: |

--- a/.github/workflows/acme-switchover-test.yml
+++ b/.github/workflows/acme-switchover-test.yml
@@ -80,11 +80,7 @@ jobs:
 
       - name: Initialize ACME realm
         run: |
-          docker exec pki ldapadd \
-              -H ldap://ds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/realm/ds/create.ldif
+          docker exec pki pki-server acme-realm-init -v
 
       - name: Set up client container
         run: |

--- a/base/acme/src/main/java/org/dogtagpki/acme/realm/LDAPRealm.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/realm/LDAPRealm.java
@@ -7,8 +7,41 @@ package org.dogtagpki.acme.realm;
 
 import com.netscape.cms.realm.PKILDAPRealm;
 
+import netscape.ldap.LDAPConnection;
+import netscape.ldap.util.LDIF;
+import netscape.ldap.util.LDIFRecord;
+
 /**
  * @author Endi S. Dewata
  */
 public class LDAPRealm extends PKILDAPRealm {
+
+    public void createRealmSubtrees(LDAPConnection connection) throws Exception {
+
+        logger.info("Creating ACME realm subtrees");
+
+        String filename = "/usr/share/pki/acme/realm/ds/create.ldif";
+        LDIF ldif = new LDIF(filename);
+
+        while (true) {
+            LDIFRecord record = ldif.nextRecord();
+            if (record == null) break;
+
+            importLDIFRecord(connection, record);
+        }
+    }
+
+    @Override
+    public void initRealm() throws Exception {
+
+        LDAPConnection connection = null;
+        try {
+            connection = connFactory.getConn();
+
+            createRealmSubtrees(connection);
+
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
 }

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMECLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMECLI.java
@@ -16,5 +16,6 @@ public class ACMECLI extends CLI {
         super("acme", "ACME subsystem management commands", parent);
 
         addModule(new ACMEDatabaseCLI(this));
+        addModule(new ACMERealmCLI(this));
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMERealmCLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMERealmCLI.java
@@ -1,0 +1,20 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.acme.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMERealmCLI extends CLI {
+
+    public ACMERealmCLI(CLI parent) {
+        super("realm", "ACME realm management commands", parent);
+
+        addModule(new ACMERealmInitCLI(this));
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMERealmInitCLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMERealmInitCLI.java
@@ -1,0 +1,86 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.acme.cli;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.Properties;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemCLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cms.realm.RealmCommon;
+import com.netscape.cms.realm.RealmConfig;
+import com.netscape.cmscore.apps.CMS;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMERealmInitCLI extends SubsystemCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(ACMERealmInitCLI.class);
+
+    public ACMERealmInitCLI(CLI parent) {
+        super("init", "Initialize " + parent.getParent().getName().toUpperCase() + " realm", parent);
+    }
+
+    public ACMERealmInitCLI(String name, String description, CLI parent) {
+        super(name, description, parent);
+    }
+
+    @Override
+    public void createOptions() {
+        options.addOption("v", "verbose", false, "Run in verbose mode.");
+        options.addOption(null, "debug", false, "Run in debug mode.");
+        options.addOption(null, "help", false, "Show help message.");
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        initializeTomcatJSS();
+
+        String instanceDir = CMS.getInstanceDir();
+        String serverConfDir = instanceDir + File.separator + "conf";
+        String acmeConfDir = serverConfDir + File.separator + "acme";
+        logger.info("ACME configuration directory: " + acmeConfDir);
+
+        File realmConfigFile = new File(acmeConfDir + File.separator + "realm.conf");
+        RealmConfig realmConfig;
+
+        if (realmConfigFile.exists()) {
+            logger.info("Loading ACME realm config from " + realmConfigFile);
+            Properties realmProps = new Properties();
+            try (FileReader reader = new FileReader(realmConfigFile)) {
+                realmProps.load(reader);
+            }
+            realmConfig = RealmConfig.fromProperties(realmProps);
+
+        } else {
+            logger.info("Loading default ACME realm config");
+            realmConfig = new RealmConfig();
+        }
+
+        String className = realmConfig.getClassName();
+        Class<RealmCommon> realmClass = (Class<RealmCommon>) Class.forName(className);
+
+        RealmCommon realm = realmClass.getDeclaredConstructor().newInstance();
+        realm.setConfig(realmConfig);
+
+        try {
+            realm.initInternal();
+
+            logger.info("Initializing ACME realm");
+            realm.initRealm();
+
+        } finally {
+            realm.stopInternal();
+        }
+    }
+}

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -2207,8 +2207,7 @@ class PKISubsystem(object):
         java_opts = self.instance.config['JAVA_OPTS']
 
         classpath = [
-            pki.server.Tomcat.SHARE_DIR + '/bin/tomcat-juli.jar',
-            '/usr/share/java/tomcat-servlet-api.jar',
+            pki.server.Tomcat.LIB_DIR + '/*',
             pki.server.PKIServer.SHARE_DIR + '/' +
             self.name + '/webapps/' + self.name + '/WEB-INF/lib/*',
             self.instance.common_lib_dir + '/*',
@@ -3317,6 +3316,18 @@ class ACMESubsystem(PKISubsystem):
             as_current_user=False):
 
         cmd = [self.name + '-database-init']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd)
+
+    def init_realm(self):
+
+        cmd = [self.name + '-realm-init']
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')

--- a/base/server/src/main/java/com/netscape/cms/realm/RealmCommon.java
+++ b/base/server/src/main/java/com/netscape/cms/realm/RealmCommon.java
@@ -8,6 +8,7 @@ package com.netscape.cms.realm;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
 
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.realm.RealmBase;
 
 /**
@@ -23,6 +24,20 @@ public abstract class RealmCommon extends RealmBase {
 
     public void setConfig(RealmConfig config) {
         this.config = config;
+    }
+
+    /**
+     * Initialize RealmCommon object
+     */
+    @Override
+    public void initInternal() throws LifecycleException {
+        super.initInternal();
+    }
+
+    /**
+     * Initialize realm
+     */
+    public void initRealm() throws Exception {
     }
 
     @Override
@@ -45,4 +60,8 @@ public abstract class RealmCommon extends RealmBase {
         return null;
     }
 
+    @Override
+    public void stopInternal() throws LifecycleException {
+        super.stopInternal();
+    }
 }

--- a/docs/admin/acme/Configuring-ACME-with-DS-Realm.adoc
+++ b/docs/admin/acme/Configuring-ACME-with-DS-Realm.adoc
@@ -6,17 +6,7 @@ This document describes the process to configure ACME responder to use a DS data
 It assumes that the DS database has been installed as described in
 link:../others/Creating_DS_instance.adoc[Creating DS instance].
 
-## Initializing DS Realm
-
-Prepare subtrees for ACME users and groups in DS.
-A sample LDIF file is available at link:../../../base/acme/realm/ds/create.ldif[/usr/share/pki/acme/realm/ds/create.ldif].
-This example uses `dc=acme,dc=pki,dc=example,dc=com` as the base DN.
-Import the file with the following command:
-
-----
-$ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
-    -f /usr/share/pki/acme/realm/ds/create.ldif
-----
+## Configuring ACME Realm
 
 A sample realm configuration is available at
 link:../../../base/acme/realm/ds/realm.conf[/usr/share/pki/acme/realm/ds/realm.conf].
@@ -48,6 +38,24 @@ class=org.dogtagpki.acme.realm.DSRealm
 configFile=conf/ca/CS.cfg
 usersDN=ou=people,dc=ca,dc=pki,dc=example,dc=com
 groupsDN=ou=groups,dc=ca,dc=pki,dc=example,dc=com
+----
+
+## Initializing DS Realm
+
+Once the ACME realm is configured, it can be initialized with the following command:
+
+----
+$ pki-server acme-realm-init
+----
+
+Alternatively, the ACME realm can be initialized manually with LDAP tools.
+
+Create the DS subtrees for ACME realm by importing
+link:../../../base/acme/realm/ds/create.ldif[/usr/share/pki/acme/realm/ds/create.ldif] with the following command:
+
+----
+$ ldapadd -H ldap://$HOSTNAME -x -D "cn=Directory Manager" -w Secret.123 \
+    -f /usr/share/pki/acme/realm/ds/create.ldif
 ----
 
 ## See Also

--- a/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
@@ -219,6 +219,14 @@ Enter the base DN for the ACME groups subtree.
   Groups DN [ou=groups,dc=acme,dc=pki,dc=example,dc=com]:
 ----
 
+Once the ACME realm is configured, it can be initialized with the following command:
+
+----
+$ pki-server acme-realm-init
+----
+
+Alternatively, the ACME realm can be initialized manually with LDAP tools.
+
 To create DS subtrees for ACME realm:
 
 ----

--- a/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
+++ b/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
@@ -101,6 +101,14 @@ $ ldapadd \
 
 == Initializing ACME Realm ==
 
+The ACME realm can be initialized with the following command:
+
+----
+$ pki-server acme-realm-init
+----
+
+Alternatively, the ACME realm can be initialized manually with LDAP tools.
+
 To create the DS subtrees for ACME realm:
 
 ----


### PR DESCRIPTION
The `pki-server acme-realm-init` has been added to simplify ACME realm initialization which includes creating the DS subtrees for the realm.

The `RealmCommon.initRealm()` has been added to initialize the realm. The `LDAPRealm` has been updated to implement this method for initializing ACME realm.

The `PKISubsystem.run()` has been modified to include the entire Tomcat library which defines the realm classes.

Some ACME tests have been changed to initialize the realm using this command.

Issue https://github.com/dogtagpki/pki/issues/5160

Docs:
https://github.com/edewata/pki/blob/acme/docs/installation/acme/installing-acme-responder-using-pkispawn.adoc
https://github.com/edewata/pki/blob/acme/docs/installation/acme/installing-acme-responder-using-pki-server-acme-cli.adoc
https://github.com/edewata/pki/blob/acme/docs/admin/acme/Configuring-ACME-with-DS-Realm.adoc
