### PR TITLE
Add new pki-server <subsystem>-db-acl command group

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACLI.java
@@ -20,6 +20,7 @@ package org.dogtagpki.server.ca.cli;
 
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.server.cli.SDCLI;
+import org.dogtagpki.server.cli.SubsystemACLCLI;
 import org.dogtagpki.server.cli.SubsystemGroupCLI;
 import org.dogtagpki.server.cli.SubsystemUserCLI;
 
@@ -34,6 +35,7 @@ public class CACLI extends CLI {
         addModule(new CACertCLI(this));
         addModule(new CACRLCLI(this));
         addModule(new CADBCLI(this));
+        addModule(new SubsystemACLCLI(this));
         addModule(new SubsystemGroupCLI(this));
         addModule(new CAProfileCLI(this));
         addModule(new CARangeCLI(this));

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRACLI.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/cli/KRACLI.java
@@ -20,6 +20,7 @@ package org.dogtagpki.server.kra.cli;
 
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.server.cli.SDCLI;
+import org.dogtagpki.server.cli.SubsystemACLCLI;
 import org.dogtagpki.server.cli.SubsystemGroupCLI;
 import org.dogtagpki.server.cli.SubsystemUserCLI;
 
@@ -33,6 +34,7 @@ public class KRACLI extends CLI {
 
         addModule(new KRADBCLI(this));
         addModule(new SubsystemGroupCLI(this));
+        addModule(new SubsystemACLCLI(this));
         addModule(new KRARangeCLI(this));
         addModule(new KRAIdCLI(this));
         addModule(new SubsystemUserCLI(this));

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/cli/OCSPCLI.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/cli/OCSPCLI.java
@@ -20,6 +20,7 @@ package org.dogtagpki.server.ocsp.cli;
 
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.server.cli.SDCLI;
+import org.dogtagpki.server.cli.SubsystemACLCLI;
 import org.dogtagpki.server.cli.SubsystemDBCLI;
 import org.dogtagpki.server.cli.SubsystemGroupCLI;
 import org.dogtagpki.server.cli.SubsystemUserCLI;
@@ -36,6 +37,7 @@ public class OCSPCLI extends CLI {
         addModule(new SubsystemDBCLI(this));
         addModule(new SubsystemGroupCLI(this));
         addModule(new SubsystemUserCLI(this));
+        addModule(new SubsystemACLCLI(this));
         addModule(new SDCLI(this));
     }
 }

--- a/base/server/python/pki/server/cli/acl.py
+++ b/base/server/python/pki/server/cli/acl.py
@@ -1,0 +1,274 @@
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+import argparse
+import logging
+import sys
+
+import pki.cli
+
+logger = logging.getLogger(__name__)
+
+
+class SubsystemACLCLI(pki.cli.CLI):
+
+    def __init__(self, parent):
+        super().__init__(
+            'acl', '%s ACL management commands' % parent.name.upper())
+
+        self.parent = parent
+        self.add_module(SubsystemACLFindCLI(self))
+        self.add_module(SubsystemACLAddCLI(self))
+        self.add_module(SubsystemACLDeleteCLI(self))
+
+
+class SubsystemACLFindCLI(pki.cli.CLI):
+
+    def __init__(self, parent):
+        super(SubsystemACLFindCLI, self).__init__(
+            'find',
+            'Find %s ACLs' % parent.parent.name.upper())
+
+        self.parent = parent
+
+    def create_parser(self, subparsers=None):
+
+        self.parser = argparse.ArgumentParser(
+            self.get_full_name(),
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+
+    def print_help(self):
+        print('Usage: pki-server %s-acl-find [OPTIONS]' % self.parent.parent.name)
+        print()
+        print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('      --as-current-user              Run as current user.')
+        print('  -v, --verbose                      Run in verbose mode.')
+        print('      --debug                        Run in debug mode.')
+        print('      --help                         Show help message.')
+        print()
+
+    def execute(self, argv, args=None):
+
+        if not args:
+            args = self.parser.parse_args(args=argv)
+
+        if args.help:
+            self.print_help()
+            return
+
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
+        subsystem_name = self.parent.parent.name
+        as_current_user = args.as_current_user
+
+        instance = pki.server.instance.PKIInstance(instance_name)
+
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s.',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        subsystem.find_acl(as_current_user=as_current_user)
+
+
+class SubsystemACLAddCLI(pki.cli.CLI):
+
+    def __init__(self, parent):
+        super(SubsystemACLAddCLI, self).__init__(
+            'add',
+            'Add %s ACL' % parent.parent.name.upper())
+
+        self.parent = parent
+
+    def create_parser(self, subparsers=None):
+
+        self.parser = argparse.ArgumentParser(
+            self.get_full_name(),
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'acl',
+            nargs='?')
+
+    def print_help(self):
+        print('Usage: pki-server %s-acl-add [OPTIONS] <acl>' % self.parent.parent.name)
+        print()
+        print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('      --as-current-user              Run as current user.')
+        print('  -v, --verbose                      Run in verbose mode.')
+        print('      --debug                        Run in debug mode.')
+        print('      --help                         Show help message.')
+        print()
+
+    def execute(self, argv, args=None):
+
+        if not args:
+            args = self.parser.parse_args(args=argv)
+
+        if args.help:
+            self.print_help()
+            return
+
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
+        subsystem_name = self.parent.parent.name
+        as_current_user = args.as_current_user
+        acl = args.acl
+        instance = pki.server.instance.PKIInstance(instance_name)
+
+        if acl is None:
+            raise pki.cli.CLIException('Missing ACL')
+
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s.',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        subsystem.add_acl(acl, as_current_user=as_current_user)
+
+
+class SubsystemACLDeleteCLI(pki.cli.CLI):
+
+    def __init__(self, parent):
+        super(SubsystemACLDeleteCLI, self).__init__(
+            'del',
+            'Delete %s ACL' % parent.parent.name.upper())
+
+        self.parent = parent
+
+    def create_parser(self, subparsers=None):
+
+        self.parser = argparse.ArgumentParser(
+            self.get_full_name(),
+            add_help=False)
+        self.parser.add_argument(
+            '-i',
+            '--instance',
+            default='pki-tomcat')
+        self.parser.add_argument(
+            '--as-current-user',
+            action='store_true')
+        self.parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true')
+        self.parser.add_argument(
+            '--debug',
+            action='store_true')
+        self.parser.add_argument(
+            '--help',
+            action='store_true')
+        self.parser.add_argument(
+            'acl',
+            nargs='?')
+
+    def print_help(self):
+        print('Usage: pki-server %s-acl-del [OPTIONS] <acl>' % self.parent.parent.name)
+        print()
+        print('  -i, --instance <instance ID>       Instance ID (default: pki-tomcat).')
+        print('      --as-current-user              Run as current user.')
+        print('  -v, --verbose                      Run in verbose mode.')
+        print('      --debug                        Run in debug mode.')
+        print('      --help                         Show help message.')
+        print()
+
+    def execute(self, argv, args=None):
+
+        if not args:
+            args = self.parser.parse_args(args=argv)
+
+        if args.help:
+            self.print_help()
+            return
+
+        if args.debug:
+            logging.getLogger().setLevel(logging.DEBUG)
+
+        elif args.verbose:
+            logging.getLogger().setLevel(logging.INFO)
+
+        instance_name = args.instance
+        subsystem_name = self.parent.parent.name
+        as_current_user = args.as_current_user
+        acl = args.acl
+        instance = pki.server.instance.PKIInstance(instance_name)
+
+        if acl is None:
+            raise pki.cli.CLIException('Missing ACL')
+
+        if not instance.exists():
+            logger.error('Invalid instance: %s', instance_name)
+            sys.exit(1)
+
+        instance.load()
+
+        subsystem = instance.get_subsystem(subsystem_name)
+
+        if not subsystem:
+            logger.error('No %s subsystem in instance %s.',
+                         subsystem_name.upper(), instance_name)
+            sys.exit(1)
+
+        subsystem.delete_acl(acl, as_current_user=as_current_user)

--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -31,6 +31,7 @@ import urllib
 
 import pki.cli
 import pki.server
+import pki.server.cli.acl
 import pki.server.cli.audit
 import pki.server.cli.config
 import pki.server.cli.db
@@ -64,6 +65,7 @@ class CACLI(pki.cli.CLI):
         self.add_module(pki.server.cli.range.RangeCLI(self))
         self.add_module(pki.server.cli.id.IdCLI(self))
         self.add_module(pki.server.cli.user.UserCLI(self))
+        self.add_module(pki.server.cli.acl.SubsystemACLCLI(self))
 
 
 class CACertCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/cli/kra.py
+++ b/base/server/python/pki/server/cli/kra.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 
 import pki.cli
+import pki.server.cli.acl
 import pki.server.cli.audit
 import pki.server.cli.config
 import pki.server.cli.db
@@ -54,6 +55,7 @@ class KRACLI(pki.cli.CLI):
         self.add_module(pki.server.cli.group.GroupCLI(self))
         self.add_module(pki.server.cli.range.RangeCLI(self))
         self.add_module(pki.server.cli.user.UserCLI(self))
+        self.add_module(pki.server.cli.acl.SubsystemACLCLI(self))
 
 
 class KRACloneCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/cli/ocsp.py
+++ b/base/server/python/pki/server/cli/ocsp.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 
 import pki.cli
+import pki.server.cli.acl
 import pki.server.cli.audit
 import pki.server.cli.config
 import pki.server.cli.db
@@ -53,6 +54,7 @@ class OCSPCLI(pki.cli.CLI):
         self.add_module(pki.server.cli.db.SubsystemDBCLI(self))
         self.add_module(pki.server.cli.group.GroupCLI(self))
         self.add_module(pki.server.cli.user.UserCLI(self))
+        self.add_module(pki.server.cli.acl.SubsystemACLCLI(self))
 
 
 class OCSPCloneCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/cli/tks.py
+++ b/base/server/python/pki/server/cli/tks.py
@@ -30,6 +30,7 @@ import textwrap
 import urllib.parse
 
 import pki.cli
+import pki.server.cli.acl
 import pki.server.cli.audit
 import pki.server.cli.config
 import pki.server.cli.db
@@ -56,6 +57,7 @@ class TKSCLI(pki.cli.CLI):
         self.add_module(pki.server.cli.db.SubsystemDBCLI(self))
         self.add_module(pki.server.cli.group.GroupCLI(self))
         self.add_module(pki.server.cli.user.UserCLI(self))
+        self.add_module(pki.server.cli.acl.SubsystemACLCLI(self))
 
 
 class TKSCloneCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/cli/tps.py
+++ b/base/server/python/pki/server/cli/tps.py
@@ -30,6 +30,7 @@ import textwrap
 import urllib.parse
 
 import pki.cli
+import pki.server.cli.acl
 import pki.server.cli.audit
 import pki.server.cli.config
 import pki.server.cli.db
@@ -56,6 +57,7 @@ class TPSCLI(pki.cli.CLI):
         self.add_module(pki.server.cli.db.SubsystemDBCLI(self))
         self.add_module(pki.server.cli.group.GroupCLI(self))
         self.add_module(pki.server.cli.user.UserCLI(self))
+        self.add_module(pki.server.cli.acl.SubsystemACLCLI(self))
 
 
 class TPSCloneCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1408,6 +1408,46 @@ class PKISubsystem(object):
         finally:
             shutil.rmtree(tmpdir)
 
+    def find_acl(self, as_current_user=False):
+
+        cmd = [self.name + '-acl-find']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd, as_current_user=as_current_user)
+
+    def add_acl(self, acl, as_current_user=False):
+
+        cmd = [self.name + '-acl-add']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(acl)
+
+        self.run(cmd, as_current_user=as_current_user)
+
+    def delete_acl(self, acl, as_current_user=False):
+
+        cmd = [self.name + '-acl-del']
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        cmd.append(acl)
+
+        self.run(cmd, as_current_user=as_current_user)
+
     def find_vlv(self, as_current_user=False):
 
         cmd = [self.name + '-db-vlv-find']

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
@@ -308,6 +308,44 @@ public class LDAPConfigurator {
             }
         }
     }
+    
+    public void deleteAttribute(String dn, String attribute, String value) throws Exception {
+        try {
+            logger.info("Deleting attribute {} from {} with value: {}",attribute, dn, value);
+            LDAPAttribute attr = new LDAPAttribute(attribute, value);
+            LDAPModification mod = new LDAPModification(LDAPModification.DELETE, attr);
+            connection.modify(dn, mod);
+        } catch (LDAPException e) {
+
+            if (e.getLDAPResultCode() == LDAPException.NO_SUCH_OBJECT) {
+                logger.info("Entry not found: " + dn);
+
+            } else {
+                String message = "Unable to delete " + dn + ": " + e;
+                logger.error(message);
+                throw new Exception(message, e);
+            }
+        }
+    }
+
+    public void addAttribute(String dn, String attribute, String value) throws Exception {
+        try {
+            logger.info("Adding attribute {} in {} with value: {}",attribute, dn, value);
+            LDAPAttribute attr = new LDAPAttribute(attribute, value);
+            LDAPModification mod = new LDAPModification(LDAPModification.ADD, attr);
+            connection.modify(dn, mod);
+        } catch (LDAPException e) {
+
+            if (e.getLDAPResultCode() == LDAPException.NO_SUCH_OBJECT) {
+                logger.info("Entry not found: " + dn);
+
+            } else {
+                String message = "Unable to delete " + dn + ": " + e;
+                logger.error(message);
+                throw new Exception(message, e);
+            }
+        }
+    }
 
     public void waitForTask(String dn) throws Exception {
 

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemACLAddCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemACLAddCLI.java
@@ -1,0 +1,80 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
+import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapAuthInfo;
+import com.netscape.cmscore.ldapconn.LdapBoundConnection;
+import com.netscape.cmscore.ldapconn.LdapConnInfo;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ */
+public class SubsystemACLAddCLI extends SubsystemCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(SubsystemACLAddCLI.class);
+
+    public SubsystemACLAddCLI(CLI parent) {
+        super("add", "Add " + parent.parent.getName().toUpperCase() + " ACL", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+        String[] cmdArgs = cmd.getArgs();
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing ACL");
+        }
+
+        String acl = cmdArgs[0];
+
+        initializeTomcatJSS();
+        String subsystem = parent.parent.getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        LDAPConfig ldapConfig = cs.getInternalDBConfig();
+        String instanceId = CMS.getInstanceID();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = CMS.createPasswordStore(psc);
+
+        LDAPConnectionConfig connConfig = ldapConfig.getConnectionConfig();
+
+        LdapConnInfo connInfo = new LdapConnInfo(connConfig);
+        LdapAuthInfo authInfo = getAuthInfo(passwordStore, connInfo, ldapConfig);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PKISocketFactory socketFactory = new PKISocketFactory();
+        socketFactory.setSecure(connInfo.getSecure());
+        if (authInfo.getAuthType() == LdapAuthInfo.LDAP_AUTHTYPE_SSLCLIENTAUTH) {
+            socketFactory.setClientCertNickname(authInfo.getClientCertNickname());
+        }
+        socketFactory.init(socketConfig);
+
+        LdapBoundConnection conn = new LdapBoundConnection(socketFactory, connInfo, authInfo);
+        LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, ldapConfig, instanceId);
+
+        try {
+            ldapConfigurator.addAttribute("cn=aclResources," + ldapConfig.getBaseDN(), "resourceACLS", acl);
+
+        } finally {
+            conn.disconnect();
+        }
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemACLCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemACLCLI.java
@@ -1,0 +1,21 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ */
+public class SubsystemACLCLI extends CLI {
+
+    public SubsystemACLCLI(CLI parent) {
+        super("acl", parent.name.toUpperCase() + " ACL management commands", parent);
+
+        addModule(new SubsystemACLFindCLI(this));
+        addModule(new SubsystemACLAddCLI(this));
+        addModule(new SubsystemACLDeleteCLI(this));
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemACLDeleteCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemACLDeleteCLI.java
@@ -1,0 +1,81 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
+import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapAuthInfo;
+import com.netscape.cmscore.ldapconn.LdapBoundConnection;
+import com.netscape.cmscore.ldapconn.LdapConnInfo;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+/**
+ */
+public class SubsystemACLDeleteCLI extends SubsystemCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(SubsystemACLDeleteCLI.class);
+
+    public SubsystemACLDeleteCLI(CLI parent) {
+        super("del", "Delete " + parent.parent.getName().toUpperCase() + " ACL", parent);
+    }
+
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+        String[] cmdArgs = cmd.getArgs();
+        if (cmdArgs.length < 1) {
+            throw new Exception("Missing ACL");
+        }
+
+        String acl = cmdArgs[0];
+
+        initializeTomcatJSS();
+        String subsystem = parent.parent.getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        LDAPConfig ldapConfig = cs.getInternalDBConfig();
+        String instanceId = CMS.getInstanceID();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = CMS.createPasswordStore(psc);
+
+        LDAPConnectionConfig connConfig = ldapConfig.getConnectionConfig();
+
+        LdapConnInfo connInfo = new LdapConnInfo(connConfig);
+        LdapAuthInfo authInfo = getAuthInfo(passwordStore, connInfo, ldapConfig);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PKISocketFactory socketFactory = new PKISocketFactory();
+        socketFactory.setSecure(connInfo.getSecure());
+        if (authInfo.getAuthType() == LdapAuthInfo.LDAP_AUTHTYPE_SSLCLIENTAUTH) {
+            socketFactory.setClientCertNickname(authInfo.getClientCertNickname());
+        }
+        socketFactory.init(socketConfig);
+
+        LdapBoundConnection conn = new LdapBoundConnection(socketFactory, connInfo, authInfo);
+        LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, ldapConfig, instanceId);
+
+        try {
+            ldapConfigurator.deleteAttribute("cn=aclResources," + ldapConfig.getBaseDN(), "resourceACLS", acl);
+
+        } finally {
+            conn.disconnect();
+        }
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemACLFindCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemACLFindCLI.java
@@ -1,0 +1,94 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.cli;
+
+import java.util.Enumeration;
+
+import org.apache.commons.cli.CommandLine;
+import org.dogtagpki.cli.CLI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cms.servlet.csadmin.LDAPConfigurator;
+import com.netscape.cmscore.apps.CMS;
+import com.netscape.cmscore.apps.EngineConfig;
+import com.netscape.cmscore.ldapconn.LDAPConfig;
+import com.netscape.cmscore.ldapconn.LDAPConnectionConfig;
+import com.netscape.cmscore.ldapconn.LdapAuthInfo;
+import com.netscape.cmscore.ldapconn.LdapBoundConnection;
+import com.netscape.cmscore.ldapconn.LdapConnInfo;
+import com.netscape.cmscore.ldapconn.PKISocketConfig;
+import com.netscape.cmscore.ldapconn.PKISocketFactory;
+import com.netscape.cmsutil.password.PasswordStore;
+import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+import netscape.ldap.LDAPAttribute;
+import netscape.ldap.LDAPEntry;
+
+/**
+ */
+public class SubsystemACLFindCLI extends SubsystemCLI {
+
+    public static Logger logger = LoggerFactory.getLogger(SubsystemACLFindCLI.class);
+
+    public SubsystemACLFindCLI(CLI parent) {
+        super("find", "Find " + parent.parent.getName().toUpperCase() + " ACLs", parent);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        initializeTomcatJSS();
+        String subsystem = parent.parent.getName();
+        EngineConfig cs = getEngineConfig(subsystem);
+        cs.load();
+
+        LDAPConfig ldapConfig = cs.getInternalDBConfig();
+        String instanceId = CMS.getInstanceID();
+
+        PasswordStoreConfig psc = cs.getPasswordStoreConfig();
+        PasswordStore passwordStore = CMS.createPasswordStore(psc);
+
+        LDAPConnectionConfig connConfig = ldapConfig.getConnectionConfig();
+
+        LdapConnInfo connInfo = new LdapConnInfo(connConfig);
+        LdapAuthInfo authInfo = getAuthInfo(passwordStore, connInfo, ldapConfig);
+
+        PKISocketConfig socketConfig = cs.getSocketConfig();
+
+        PKISocketFactory socketFactory = new PKISocketFactory();
+        socketFactory.setSecure(connInfo.getSecure());
+        if (authInfo.getAuthType() == LdapAuthInfo.LDAP_AUTHTYPE_SSLCLIENTAUTH) {
+            socketFactory.setClientCertNickname(authInfo.getClientCertNickname());
+        }
+        socketFactory.init(socketConfig);
+
+        LdapBoundConnection conn = new LdapBoundConnection(socketFactory, connInfo, authInfo);
+        LDAPConfigurator ldapConfigurator = new LDAPConfigurator(conn, ldapConfig, instanceId);
+
+        try {
+            LDAPEntry entry = ldapConfigurator.getEntry("cn=aclResources," + ldapConfig.getBaseDN());
+
+            System.out.println("  dn: " + entry.getDN());
+
+            Enumeration<LDAPAttribute> attrs = entry.getAttributeSet().getAttributes();
+            while (attrs.hasMoreElements()) {
+                LDAPAttribute attr = attrs.nextElement();
+                String name = attr.getName();
+                if (name.equalsIgnoreCase("resourceACLS")){
+                    Enumeration<String> values = attr.getStringValues();
+                    while (values.hasMoreElements()) {
+                        String value = values.nextElement();
+                        System.out.println("  " + name + ": " + value);
+                    }
+                }
+            }
+
+        } finally {
+            conn.disconnect();
+        }
+    }
+}

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/cli/TKSCLI.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/cli/TKSCLI.java
@@ -19,6 +19,7 @@
 package org.dogtagpki.server.tks.cli;
 
 import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemACLCLI;
 import org.dogtagpki.server.cli.SubsystemDBCLI;
 import org.dogtagpki.server.cli.SubsystemGroupCLI;
 import org.dogtagpki.server.cli.SubsystemUserCLI;
@@ -34,5 +35,6 @@ public class TKSCLI extends CLI {
         addModule(new SubsystemDBCLI(this));
         addModule(new SubsystemGroupCLI(this));
         addModule(new SubsystemUserCLI(this));
+        addModule(new SubsystemACLCLI(this));
     }
 }

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/cli/TPSCLI.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/cli/TPSCLI.java
@@ -19,6 +19,7 @@
 package org.dogtagpki.server.tps.cli;
 
 import org.dogtagpki.cli.CLI;
+import org.dogtagpki.server.cli.SubsystemACLCLI;
 import org.dogtagpki.server.cli.SubsystemDBCLI;
 import org.dogtagpki.server.cli.SubsystemGroupCLI;
 import org.dogtagpki.server.cli.SubsystemUserCLI;
@@ -34,5 +35,6 @@ public class TPSCLI extends CLI {
         addModule(new SubsystemDBCLI(this));
         addModule(new SubsystemGroupCLI(this));
         addModule(new SubsystemUserCLI(this));
+        addModule(new SubsystemACLCLI(this));
     }
 }


### PR DESCRIPTION
Add the CLI to allow the administrator to modify the ACL. The command includes the operation to find, add and delete ACL.

The operation are:

pki-server <subsystem>-db-acl-find

pki-server <subsystem>-db-acl-add <acl>

pki-server <subsystem>-db-acl-del <acl>

To remove the acl it has to exactly match the one in use.