### PR TITLE
Add pki-server acme-database-index-rebuild

### DIFF
--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -128,39 +128,6 @@ jobs:
               --network-alias=acme.example.com \
               acme
 
-      - name: Initialize ACME database
-        run: |
-          # import ACME schema
-          docker exec acme ldapmodify \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/schema.ldif
-
-          # create ACME indexes
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/index.ldif
-
-          # rebuild ACME indexes later
-
-          # create ACME subtree
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/create.ldif
-
-      - name: Initialize ACME realm
-        run: |
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/realm/ds/create.ldif
-
       - name: Install ACME
         run: |
           # TODO: update pkispawn to initialize ACME database and realm
@@ -319,6 +286,16 @@ jobs:
               -f /etc/pki/pki-tomcat/password.conf \
               nss-cert-find
 
+      - name: Initialize ACME database
+        run: |
+          # rebuild ACME indexes later
+          docker exec acme pki-server acme-database-init -v \
+              --skip-reindex
+
+      - name: Initialize ACME realm
+        run: |
+          docker exec acme pki-server acme-realm-init -v
+
       - name: Check initial ACME accounts
         run: |
           docker exec acmeds ldapsearch \
@@ -452,35 +429,7 @@ jobs:
       - name: Rebuild ACME indexes
         run: |
           # LMDB indexes must be rebuilt
-          docker exec acme ldapadd \
-              -H ldap://acmeds.example.com:3389 \
-              -D "cn=Directory Manager" \
-              -w Secret.123 \
-              -f /usr/share/pki/acme/database/ds/indextask.ldif
-
-          # wait for rebuild to complete
-          while true; do
-              sleep 1
-
-              docker exec acme ldapsearch \
-                  -H ldap://acmeds.example.com:3389 \
-                  -D "cn=Directory Manager" \
-                  -w Secret.123 \
-                  -b "cn=acme,cn=index,cn=tasks,cn=config" \
-                  -LLL \
-                  nsTaskExitCode \
-                  | tee output
-
-              sed -n -e 's/nsTaskExitCode:\s*\(.*\)/\1/p' output > nsTaskExitCode
-              cat nsTaskExitCode
-
-              if [ -s nsTaskExitCode ]; then
-                  break
-              fi
-          done
-
-          echo "0" > expected
-          diff expected nsTaskExitCode
+          docker exec acme pki-server acme-database-index-rebuild -v
 
       - name: Register ACME account again
         run: |

--- a/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/database/LDAPDatabase.java
@@ -437,6 +437,54 @@ public class LDAPDatabase extends ACMEDatabase {
         }
     }
 
+    public void importSchema() throws Exception {
+
+        LDAPConnection connection = null;
+        try {
+            connection = connFactory.getConn();
+            importSchema(connection);
+
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    public void createIndexes() throws Exception {
+
+        LDAPConnection connection = null;
+        try {
+            connection = connFactory.getConn();
+            createIndexes(connection);
+
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    public void rebuildIndexes() throws Exception {
+
+        LDAPConnection connection = null;
+        try {
+            connection = connFactory.getConn();
+            rebuildIndexes(connection);
+
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    public void createSubtree() throws Exception {
+
+        LDAPConnection connection = null;
+        try {
+            connection = connFactory.getConn();
+            createSubtree(connection);
+
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
     @Override
     public void initDatabase() throws Exception {
 

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseCLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseCLI.java
@@ -16,5 +16,7 @@ public class ACMEDatabaseCLI extends CLI {
         super("database", "ACME database management commands", parent);
 
         addModule(new ACMEDatabaseInitCLI(this));
+
+        addModule(new ACMEDatabaseIndexCLI(this));
     }
 }

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseIndexCLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseIndexCLI.java
@@ -1,0 +1,20 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.acme.cli;
+
+import org.dogtagpki.cli.CLI;
+
+/**
+ * @author Endi S. Dewata
+ */
+public class ACMEDatabaseIndexCLI extends CLI {
+
+    public ACMEDatabaseIndexCLI(CLI parent) {
+        super("index", "ACME database index management commands", parent);
+
+        addModule(new ACMEDatabaseIndexRebuildCLI(this));
+    }
+}

--- a/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseIndexRebuildCLI.java
+++ b/base/acme/src/main/java/org/dogtagpki/server/acme/cli/ACMEDatabaseIndexRebuildCLI.java
@@ -14,6 +14,7 @@ import org.dogtagpki.acme.database.ACMEDatabase;
 import org.dogtagpki.acme.database.ACMEDatabaseConfig;
 import org.dogtagpki.acme.database.LDAPDatabase;
 import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.server.cli.SubsystemCLI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,22 +24,20 @@ import com.netscape.cmscore.apps.CMS;
 /**
  * @author Endi S. Dewata
  */
-public class ACMEDatabaseInitCLI extends SubsystemCLI {
+public class ACMEDatabaseIndexRebuildCLI extends SubsystemCLI {
 
-    public static Logger logger = LoggerFactory.getLogger(ACMEDatabaseInitCLI.class);
+    public static Logger logger = LoggerFactory.getLogger(ACMEDatabaseIndexRebuildCLI.class);
 
-    public ACMEDatabaseInitCLI(CLI parent) {
-        super("init", "Initialize " + parent.getParent().getName().toUpperCase() + " database", parent);
+    public ACMEDatabaseIndexRebuildCLI(CLI parent) {
+        super("rebuild", "Rebuild " + parent.getParent().getParent().getName().toUpperCase() + " database indexes", parent);
     }
 
-    public ACMEDatabaseInitCLI(String name, String description, CLI parent) {
+    public ACMEDatabaseIndexRebuildCLI(String name, String description, CLI parent) {
         super(name, description, parent);
     }
 
     @Override
     public void createOptions() {
-        options.addOption(null, "skip-reindex", false, "Skip database reindex.");
-
         options.addOption("v", "verbose", false, "Run in verbose mode.");
         options.addOption(null, "debug", false, "Run in debug mode.");
         options.addOption(null, "help", false, "Show help message.");
@@ -80,20 +79,11 @@ public class ACMEDatabaseInitCLI extends SubsystemCLI {
             database.init();
 
             if (database instanceof LDAPDatabase ldapDatabase) {
-                // perform LDAP-specific database initialization
-
-                ldapDatabase.importSchema();
-                ldapDatabase.createIndexes();
-
-                if (!cmd.hasOption("skip-reindex")) {
-                    ldapDatabase.rebuildIndexes();
-                }
-
-                ldapDatabase.createSubtree();
+                // perform LDAP-specific reindex
+                ldapDatabase.rebuildIndexes();
 
             } else {
-                // perform generic database initialization
-                database.initDatabase();
+                throw new CLIException("Operation not supported by " + className);
             }
 
         } finally {

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1172,12 +1172,14 @@ class PKISubsystem(object):
 
         self.run(cmd)
 
+    # pylint: disable=W0613
     def init_database(
             self,
             skip_config=False,
             skip_schema=False,
             skip_base=False,
             skip_containers=False,
+            skip_reindex=False,
             as_current_user=False):
 
         cmd = [self.name + '-db-init']
@@ -3313,9 +3315,25 @@ class ACMESubsystem(PKISubsystem):
             skip_schema=False,
             skip_base=False,
             skip_containers=False,
+            skip_reindex=False,
             as_current_user=False):
 
         cmd = [self.name + '-database-init']
+
+        if skip_reindex:
+            cmd.append('--skip-reindex')
+
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
+
+        self.run(cmd)
+
+    def rebuild_indexes(self):
+
+        cmd = [self.name + '-database-index-rebuild']
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')


### PR DESCRIPTION
The `pki-server acme-database-index-rebuild` has been added to simplify rebuilding ACME database indexes. This command can be used to repair existing instances that are experiencing issue #5160.

The `pki-server acme-database-init` has been updated to provide a `--skip-reindex` option to demonstrate the issue.

Issue https://github.com/dogtagpki/pki/issues/5160