### PR TITLE
Fix HSM connection and container in actions

### DIFF
--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Set up HSM client with p11-kit in primary PKI container
         run: |
-          docker exec primary dnf install -y p11-kit-server
+          docker exec primary dnf install -y p11-kit-server p11-kit-client
 
           # register p11-kit-client module
           docker exec -i primary tee /usr/share/p11-kit/modules/p11-kit-client.module << EOF
@@ -262,7 +262,7 @@ jobs:
 
       - name: Set up HSM client with p11-kit in secondary PKI container
         run: |
-          docker exec secondary dnf install -y p11-kit-server
+          docker exec secondary dnf install -y p11-kit-server p11-kit-client
 
           # register p11-kit-client module
           docker exec -i secondary tee /usr/share/p11-kit/modules/p11-kit-client.module << EOF
@@ -459,7 +459,7 @@ jobs:
 
       - name: Set up HSM client with p11-kit in tertiary PKI container
         run: |
-          docker exec tertiary dnf install -y p11-kit-server
+          docker exec tertiary dnf install -y p11-kit-server p11-kit-client
 
           # register p11-kit-client module
           docker exec -i tertiary tee /usr/share/p11-kit/modules/p11-kit-client.module << EOF

--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -83,23 +83,23 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker Catalina
-          drwxrwxrwx docker alias
-          drwxrwxrwx docker ca
-          -rw-rw-rw- docker catalina.policy
-          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx docker certs
-          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- docker jss.conf
-          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- docker password.conf
-          -rw-rw-rw- docker server.xml
-          -rw-rw-rw- docker serverCertNick.conf
-          -rw-rw-rw- docker tomcat.conf
-          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx runner Catalina
+          drwxrwxrwx runner alias
+          drwxrwxrwx runner ca
+          -rw-rw-rw- runner catalina.policy
+          lrwxrwxrwx runner catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx runner certs
+          lrwxrwxrwx runner context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- runner jss.conf
+          lrwxrwxrwx runner logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- runner password.conf
+          -rw-rw-rw- runner server.xml
+          -rw-rw-rw- runner serverCertNick.conf
+          -rw-rw-rw- runner tomcat.conf
+          lrwxrwxrwx runner web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -114,22 +114,22 @@ jobs:
                   -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- docker CS.cfg
-          -rw-rw-rw- docker adminCert.profile
-          drwxrwxrwx docker archives
-          -rw-rw-rw- docker caAuditSigningCert.profile
-          -rw-rw-rw- docker caCert.profile
-          -rw-rw-rw- docker caOCSPCert.profile
-          drwxrwxrwx docker emails
-          -rw-rw-rw- docker flatfile.txt
-          drwxrwxrwx docker profiles
-          -rw-rw-rw- docker proxy.conf
-          -rw-rw-rw- docker registry.cfg
-          -rw-rw-rw- docker serverCert.profile
-          -rw-rw-rw- docker subsystemCert.profile
+          -rw-rw-rw- runner CS.cfg
+          -rw-rw-rw- runner adminCert.profile
+          drwxrwxrwx runner archives
+          -rw-rw-rw- runner caAuditSigningCert.profile
+          -rw-rw-rw- runner caCert.profile
+          -rw-rw-rw- runner caOCSPCert.profile
+          drwxrwxrwx runner emails
+          -rw-rw-rw- runner flatfile.txt
+          drwxrwxrwx runner profiles
+          -rw-rw-rw- runner proxy.conf
+          -rw-rw-rw- runner registry.cfg
+          -rw-rw-rw- runner serverCert.profile
+          -rw-rw-rw- runner subsystemCert.profile
           EOF
 
           diff expected output
@@ -145,17 +145,17 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker backup
-          drwxrwxrwx docker ca
-          -rw-rw-rw- docker catalina.$DATE.log
-          -rw-rw-rw- docker host-manager.$DATE.log
-          -rw-rw-rw- docker localhost.$DATE.log
-          -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-rw- docker manager.$DATE.log
-          drwxrwxrwx docker pki
+          drwxrwxrwx runner backup
+          drwxrwxrwx runner ca
+          -rw-rw-rw- runner catalina.$DATE.log
+          -rw-rw-rw- runner host-manager.$DATE.log
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          -rw-rw-rw- runner manager.$DATE.log
+          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -189,23 +189,23 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker Catalina
-          drwxrwxrwx docker alias
-          drwxrwxrwx docker ca
-          -rw-rw-rw- docker catalina.policy
-          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx docker certs
-          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- docker jss.conf
-          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- docker password.conf
-          -rw-rw-rw- docker server.xml
-          -rw-rw-rw- docker serverCertNick.conf
-          -rw-rw-rw- docker tomcat.conf
-          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx runner Catalina
+          drwxrwxrwx runner alias
+          drwxrwxrwx runner ca
+          -rw-rw-rw- runner catalina.policy
+          lrwxrwxrwx runner catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx runner certs
+          lrwxrwxrwx runner context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- runner jss.conf
+          lrwxrwxrwx runner logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- runner password.conf
+          -rw-rw-rw- runner server.xml
+          -rw-rw-rw- runner serverCertNick.conf
+          -rw-rw-rw- runner tomcat.conf
+          lrwxrwxrwx runner web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -220,22 +220,22 @@ jobs:
                   -e '/^\S* *\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- docker CS.cfg
-          -rw-rw-rw- docker adminCert.profile
-          drwxrwxrwx docker archives
-          -rw-rw-rw- docker caAuditSigningCert.profile
-          -rw-rw-rw- docker caCert.profile
-          -rw-rw-rw- docker caOCSPCert.profile
-          drwxrwxrwx docker emails
-          -rw-rw-rw- docker flatfile.txt
-          drwxrwxrwx docker profiles
-          -rw-rw-rw- docker proxy.conf
-          -rw-rw-rw- docker registry.cfg
-          -rw-rw-rw- docker serverCert.profile
-          -rw-rw-rw- docker subsystemCert.profile
+          -rw-rw-rw- runner CS.cfg
+          -rw-rw-rw- runner adminCert.profile
+          drwxrwxrwx runner archives
+          -rw-rw-rw- runner caAuditSigningCert.profile
+          -rw-rw-rw- runner caCert.profile
+          -rw-rw-rw- runner caOCSPCert.profile
+          drwxrwxrwx runner emails
+          -rw-rw-rw- runner flatfile.txt
+          drwxrwxrwx runner profiles
+          -rw-rw-rw- runner proxy.conf
+          -rw-rw-rw- runner registry.cfg
+          -rw-rw-rw- runner serverCert.profile
+          -rw-rw-rw- runner subsystemCert.profile
           EOF
 
           diff expected output
@@ -251,17 +251,17 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker backup
-          drwxrwxrwx docker ca
-          -rw-rw-rw- docker catalina.$DATE.log
-          -rw-rw-rw- docker host-manager.$DATE.log
-          -rw-rw-rw- docker localhost.$DATE.log
-          -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-rw- docker manager.$DATE.log
-          drwxrwxrwx docker pki
+          drwxrwxrwx runner backup
+          drwxrwxrwx runner ca
+          -rw-rw-rw- runner catalina.$DATE.log
+          -rw-rw-rw- runner host-manager.$DATE.log
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          -rw-rw-rw- runner manager.$DATE.log
+          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-container-existing-config-test.yml
+++ b/.github/workflows/ca-container-existing-config-test.yml
@@ -260,7 +260,7 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by docker group
+          # everything should be owned by root group
           # TODO: review owners/permissions
           cat > expected << EOF
           drwxrwxrwx root backup

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -342,23 +342,23 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker Catalina
-          drwxrwxrwx docker alias
-          -rw-rw-rw- docker catalina.policy
-          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx docker certs
-          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- docker jss.conf
-          drwxrwxrwx docker kra
-          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- docker password.conf
-          -rw-rw-rw- docker server.xml
-          -rw-rw-rw- docker serverCertNick.conf
-          -rw-rw-rw- docker tomcat.conf
-          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx runner Catalina
+          drwxrwxrwx runner alias
+          -rw-rw-rw- runner catalina.policy
+          lrwxrwxrwx runner catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx runner certs
+          lrwxrwxrwx runner context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- runner jss.conf
+          drwxrwxrwx runner kra
+          lrwxrwxrwx runner logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- runner password.conf
+          -rw-rw-rw- runner server.xml
+          -rw-rw-rw- runner serverCertNick.conf
+          -rw-rw-rw- runner tomcat.conf
+          lrwxrwxrwx runner web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -373,12 +373,12 @@ jobs:
                   -e '/^\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- docker CS.cfg
-          drwxrwxrwx docker archives
-          -rw-rw-rw- docker registry.cfg
+          -rw-rw-rw- runner CS.cfg
+          drwxrwxrwx runner archives
+          -rw-rw-rw- runner registry.cfg
           EOF
 
           diff expected output
@@ -394,17 +394,17 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker backup
-          -rw-rw-rw- docker catalina.$DATE.log
-          -rw-rw-rw- docker host-manager.$DATE.log
-          drwxrwxrwx docker kra
-          -rw-rw-rw- docker localhost.$DATE.log
-          -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-rw- docker manager.$DATE.log
-          drwxrwxrwx docker pki
+          drwxrwxrwx runner backup
+          -rw-rw-rw- runner catalina.$DATE.log
+          -rw-rw-rw- runner host-manager.$DATE.log
+          drwxrwxrwx runner kra
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          -rw-rw-rw- runner manager.$DATE.log
+          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/lwca-clone-hsm-test.yml
+++ b/.github/workflows/lwca-clone-hsm-test.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Set up HSM client with p11-kit in primary PKI container
         run: |
-          docker exec primary dnf install -y p11-kit-server
+          docker exec primary dnf install -y p11-kit-server p11-kit-client
 
           # register p11-kit-client module
           docker exec -i primary tee /usr/share/p11-kit/modules/p11-kit-client.module << EOF
@@ -275,7 +275,7 @@ jobs:
 
       - name: Set up HSM client with p11-kit in secondary PKI container
         run: |
-          docker exec secondary dnf install -y p11-kit-server
+          docker exec secondary dnf install -y p11-kit-server p11-kit-client
 
           # register p11-kit-client module
           docker exec -i secondary tee /usr/share/p11-kit/modules/p11-kit-client.module << EOF

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -318,23 +318,23 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker Catalina
-          drwxrwxrwx docker alias
-          -rw-rw-rw- docker catalina.policy
-          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx docker certs
-          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- docker jss.conf
-          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
-          drwxrwxrwx docker ocsp
-          -rw-rw-rw- docker password.conf
-          -rw-rw-rw- docker server.xml
-          -rw-rw-rw- docker serverCertNick.conf
-          -rw-rw-rw- docker tomcat.conf
-          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx runner Catalina
+          drwxrwxrwx runner alias
+          -rw-rw-rw- runner catalina.policy
+          lrwxrwxrwx runner catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx runner certs
+          lrwxrwxrwx runner context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- runner jss.conf
+          lrwxrwxrwx runner logging.properties -> /usr/share/pki/server/conf/logging.properties
+          drwxrwxrwx runner ocsp
+          -rw-rw-rw- runner password.conf
+          -rw-rw-rw- runner server.xml
+          -rw-rw-rw- runner serverCertNick.conf
+          -rw-rw-rw- runner tomcat.conf
+          lrwxrwxrwx runner web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -349,12 +349,12 @@ jobs:
                   -e '/^\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- docker CS.cfg
-          drwxrwxrwx docker archives
-          -rw-rw-rw- docker registry.cfg
+          -rw-rw-rw- runner CS.cfg
+          drwxrwxrwx runner archives
+          -rw-rw-rw- runner registry.cfg
           EOF
 
           diff expected output
@@ -370,17 +370,17 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker backup
-          -rw-rw-rw- docker catalina.$DATE.log
-          -rw-rw-rw- docker host-manager.$DATE.log
-          -rw-rw-rw- docker localhost.$DATE.log
-          -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-rw- docker manager.$DATE.log
-          drwxrwxrwx docker ocsp
-          drwxrwxrwx docker pki
+          drwxrwxrwx runner backup
+          -rw-rw-rw- runner catalina.$DATE.log
+          -rw-rw-rw- runner host-manager.$DATE.log
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          -rw-rw-rw- runner manager.$DATE.log
+          drwxrwxrwx runner ocsp
+          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -81,21 +81,21 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker Catalina
-          drwxrwxrwx docker alias
-          -rw-rw-rw- docker catalina.policy
-          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx docker certs
-          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- docker jss.conf
-          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- docker password.conf
-          -rw-rw-rw- docker server.xml
-          -rw-rw-rw- docker tomcat.conf
-          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx runner Catalina
+          drwxrwxrwx runner alias
+          -rw-rw-rw- runner catalina.policy
+          lrwxrwxrwx runner catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx runner certs
+          lrwxrwxrwx runner context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- runner jss.conf
+          lrwxrwxrwx runner logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- runner password.conf
+          -rw-rw-rw- runner server.xml
+          -rw-rw-rw- runner tomcat.conf
+          lrwxrwxrwx runner web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -111,15 +111,15 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- docker catalina.$DATE.log
-          -rw-rw-rw- docker host-manager.$DATE.log
-          -rw-rw-rw- docker localhost.$DATE.log
-          -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-rw- docker manager.$DATE.log
-          drwxrwxrwx docker pki
+          -rw-rw-rw- runner catalina.$DATE.log
+          -rw-rw-rw- runner host-manager.$DATE.log
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          -rw-rw-rw- runner manager.$DATE.log
+          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/tks-container-test.yml
+++ b/.github/workflows/tks-container-test.yml
@@ -307,23 +307,23 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker Catalina
-          drwxrwxrwx docker alias
-          -rw-rw-rw- docker catalina.policy
-          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx docker certs
-          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- docker jss.conf
-          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- docker password.conf
-          -rw-rw-rw- docker server.xml
-          -rw-rw-rw- docker serverCertNick.conf
-          drwxrwxrwx docker tks
-          -rw-rw-rw- docker tomcat.conf
-          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx runner Catalina
+          drwxrwxrwx runner alias
+          -rw-rw-rw- runner catalina.policy
+          lrwxrwxrwx runner catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx runner certs
+          lrwxrwxrwx runner context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- runner jss.conf
+          lrwxrwxrwx runner logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- runner password.conf
+          -rw-rw-rw- runner server.xml
+          -rw-rw-rw- runner serverCertNick.conf
+          drwxrwxrwx runner tks
+          -rw-rw-rw- runner tomcat.conf
+          lrwxrwxrwx runner web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -338,12 +338,12 @@ jobs:
                   -e '/^\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- docker CS.cfg
-          drwxrwxrwx docker archives
-          -rw-rw-rw- docker registry.cfg
+          -rw-rw-rw- runner CS.cfg
+          drwxrwxrwx runner archives
+          -rw-rw-rw- runner registry.cfg
           EOF
 
           diff expected output
@@ -359,17 +359,17 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker backup
-          -rw-rw-rw- docker catalina.$DATE.log
-          -rw-rw-rw- docker host-manager.$DATE.log
-          -rw-rw-rw- docker localhost.$DATE.log
-          -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-rw- docker manager.$DATE.log
-          drwxrwxrwx docker pki
-          drwxrwxrwx docker tks
+          drwxrwxrwx runner backup
+          -rw-rw-rw- runner catalina.$DATE.log
+          -rw-rw-rw- runner host-manager.$DATE.log
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          -rw-rw-rw- runner manager.$DATE.log
+          drwxrwxrwx runner pki
+          drwxrwxrwx runner tks
           EOF
 
           diff expected output

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -673,23 +673,23 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker Catalina
-          drwxrwxrwx docker alias
-          -rw-rw-rw- docker catalina.policy
-          lrwxrwxrwx docker catalina.properties -> /usr/share/pki/server/conf/catalina.properties
-          drwxrwxrwx docker certs
-          lrwxrwxrwx docker context.xml -> /etc/tomcat/context.xml
-          -rw-rw-rw- docker jss.conf
-          lrwxrwxrwx docker logging.properties -> /usr/share/pki/server/conf/logging.properties
-          -rw-rw-rw- docker password.conf
-          -rw-rw-rw- docker server.xml
-          -rw-rw-rw- docker serverCertNick.conf
-          -rw-rw-rw- docker tomcat.conf
-          drwxrwxrwx docker tps
-          lrwxrwxrwx docker web.xml -> /etc/tomcat/web.xml
+          drwxrwxrwx runner Catalina
+          drwxrwxrwx runner alias
+          -rw-rw-rw- runner catalina.policy
+          lrwxrwxrwx runner catalina.properties -> /usr/share/pki/server/conf/catalina.properties
+          drwxrwxrwx runner certs
+          lrwxrwxrwx runner context.xml -> /etc/tomcat/context.xml
+          -rw-rw-rw- runner jss.conf
+          lrwxrwxrwx runner logging.properties -> /usr/share/pki/server/conf/logging.properties
+          -rw-rw-rw- runner password.conf
+          -rw-rw-rw- runner server.xml
+          -rw-rw-rw- runner serverCertNick.conf
+          -rw-rw-rw- runner tomcat.conf
+          drwxrwxrwx runner tps
+          lrwxrwxrwx runner web.xml -> /etc/tomcat/web.xml
           EOF
 
           diff expected output
@@ -704,13 +704,13 @@ jobs:
                   -e '/^\S* *\S* *CS.cfg.bak /d' \
               | tee output
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          -rw-rw-rw- docker CS.cfg
-          drwxrwxrwx docker archives
-          -rw-rw-rw- docker phoneHome.xml
-          -rw-rw-rw- docker registry.cfg
+          -rw-rw-rw- runner CS.cfg
+          drwxrwxrwx runner archives
+          -rw-rw-rw- runner phoneHome.xml
+          -rw-rw-rw- runner registry.cfg
           EOF
 
           diff expected output
@@ -726,17 +726,17 @@ jobs:
 
           DATE=$(date +'%Y-%m-%d')
 
-          # everything should be owned by docker group
+          # everything should be owned by runner group
           # TODO: review owners/permissions
           cat > expected << EOF
-          drwxrwxrwx docker backup
-          -rw-rw-rw- docker catalina.$DATE.log
-          -rw-rw-rw- docker host-manager.$DATE.log
-          -rw-rw-rw- docker localhost.$DATE.log
-          -rw-rw-rw- docker localhost_access_log.$DATE.txt
-          -rw-rw-rw- docker manager.$DATE.log
-          drwxrwxrwx docker pki
-          drwxrwxrwx docker tps
+          drwxrwxrwx runner backup
+          -rw-rw-rw- runner catalina.$DATE.log
+          -rw-rw-rw- runner host-manager.$DATE.log
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          -rw-rw-rw- runner manager.$DATE.log
+          drwxrwxrwx runner pki
+          drwxrwxrwx runner tps
           EOF
 
           diff expected output


### PR DESCRIPTION
Modify the actions to install the p11-kit-client package. It is needed to connect with remote HSM.

Update owner of podman container generated files when running in the action. They are owned by the _runner_ user.