### PR TITLE
Fix GET authority APIs

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/AuthorityRepository.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/AuthorityRepository.java
@@ -218,6 +218,9 @@ public class AuthorityRepository {
             return getAuthorityRecord(entry);
 
         } catch (LDAPException e) {
+            if (e.getLDAPResultCode() == LDAPException.NO_SUCH_OBJECT) {
+                return null;
+            }
             throw new DBException("Unable to retrieve authority: " + e.getMessage(), e);
 
         } finally {


### PR DESCRIPTION
When the authority id cannot be found a 404 error message has to be sent. It was reporting internal server error to the user.