### PR TITLE
Make REST API exception return default to JSON

### DIFF
--- a/base/server/src/main/java/org/dogtagpki/server/rest/v1/PKIExceptionMapper.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v1/PKIExceptionMapper.java
@@ -24,15 +24,15 @@ public class PKIExceptionMapper implements ExceptionMapper<PKIException> {
 
         // The exception Data can only be serialised as XML or JSON,
         // so coerce the response content type to one of these.
-        // Default to XML, but consider the Accept header.
-        MediaType contentType = MediaType.APPLICATION_XML_TYPE;
+        // Default to JSON, but consider the Accept header.
+        MediaType contentType = MediaType.APPLICATION_JSON_TYPE;
         for (MediaType acceptType : headers.getAcceptableMediaTypes()) {
-            if (acceptType.isCompatible(MediaType.APPLICATION_XML_TYPE)) {
-                contentType = MediaType.APPLICATION_XML_TYPE;
-                break;
-            }
             if (acceptType.isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
                 contentType = MediaType.APPLICATION_JSON_TYPE;
+                break;
+            }
+            if (acceptType.isCompatible(MediaType.APPLICATION_XML_TYPE)) {
+                contentType = MediaType.APPLICATION_XML_TYPE;
                 break;
             }
         }


### PR DESCRIPTION
REST APIs v1 default format for entity is JSON as defined in [1] but in case an exception is raised the default format is XML.

The PKIException default format is modified to JSON in order to be consistent.

1. https://github.com/dogtagpki/pki/blob/master/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java#L155