### PR TITLE
Fix pki-server ca-audit-event-update-update fails with no attribute 'event_filter' #5135

### DIFF
--- a/base/server/python/pki/server/cli/audit.py
+++ b/base/server/python/pki/server/cli/audit.py
@@ -650,7 +650,7 @@ class AuditEventUpdateCLI(pki.cli.CLI):
             logging.getLogger().setLevel(logging.INFO)
 
         instance_name = args.instance
-        event_filter = args.event_filter
+        event_filter = args.filter
         event_name = args.event_name
 
         if event_name is None:


### PR DESCRIPTION
Fix pki-server ca-audit-event-update-update fails with AttributeError: 'Namespace' object has no attribute 'event_filter'

Added a fix to fix simple argparse issue causing failure in Issue# 5135.
parser.add_argument created the "filter" argument but the execute method was trying to access "args.event_filter"

Fix:  #5135