### PR TITLE
Change nsPagedSizeLimit default value

### DIFF
--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -168,27 +168,95 @@ jobs:
         run: |
           docker exec ipa pki-server ca-user-find
 
-          # check CA subsystem user
+      - name: Check CA subsystem user
+        run: |
           docker exec ipa pki-server ca-user-show CA-ipa.example.com-8443
           docker exec ipa pki-server ca-user-cert-find CA-ipa.example.com-8443
           docker exec ipa pki-server ca-user-role-find CA-ipa.example.com-8443
 
-          # check CA admin user
+      - name: Check CA admin user
+        run: |
           docker exec ipa pki-server ca-user-show admin
           docker exec ipa pki-server ca-user-cert-find admin
           docker exec ipa pki-server ca-user-role-find admin
 
-          # check PKI database user
-          docker exec ipa pki-server ca-user-show pkidbuser
+      - name: Check PKI database user
+        run: |
+          docker exec ipa pki-server ca-user-show \
+              --attr nsPagedSizeLimit \
+              --attr nsPagedLookThroughLimit \
+              pkidbuser \
+              | tee output
+
+          # by default nsPagedSizeLimit should be -1
+          # and nsPagedLookThroughLimit should not exist
+          cat > expected << EOF
+            User ID: pkidbuser
+            Full Name: pkidbuser
+            Type: agentType
+            State: 1
+            nsPagedSizeLimit: -1
+          EOF
+
+          diff expected output
+
+          # update nsPagedSizeLimit and nsPagedLookThroughLimit
+          docker exec ipa pki-server ca-user-mod \
+              --attr nsPagedSizeLimit=10000 \
+              --attr nsPagedLookThroughLimit=20000 \
+              pkidbuser
+
+          docker exec ipa pki-server ca-user-show \
+              --attr nsPagedSizeLimit \
+              --attr nsPagedLookThroughLimit \
+              pkidbuser \
+              | tee output
+
+          # nsPagedSizeLimit and nsPagedLookThroughLimit should be updated
+          cat > expected << EOF
+            User ID: pkidbuser
+            Full Name: pkidbuser
+            Type: agentType
+            State: 1
+            nsPagedSizeLimit: 10000
+            nsPagedLookThroughLimit: 20000
+          EOF
+
+          diff expected output
+
+          # remove nsPagedSizeLimit and nsPagedLookThroughLimit
+          docker exec ipa pki-server ca-user-mod \
+              --attr nsPagedSizeLimit= \
+              --attr nsPagedLookThroughLimit= \
+              pkidbuser
+
+          docker exec ipa pki-server ca-user-show \
+              --attr nsPagedSizeLimit \
+              --attr nsPagedLookThroughLimit \
+              pkidbuser \
+              | tee output
+
+          # nsPagedSizeLimit and nsPagedLookThroughLimit should be removed
+          cat > expected << EOF
+            User ID: pkidbuser
+            Full Name: pkidbuser
+            Type: agentType
+            State: 1
+          EOF
+
+          diff expected output
+
           docker exec ipa pki-server ca-user-cert-find pkidbuser
           docker exec ipa pki-server ca-user-role-find pkidbuser
 
-          # check IPA RA user
+      - name: Check IPA RA user
+        run: |
           docker exec ipa pki-server ca-user-show ipara
           docker exec ipa pki-server ca-user-cert-find ipara
           docker exec ipa pki-server ca-user-role-find ipara
 
-          # check ACME subsystem user
+      - name: Check ACME subsystem user
+        run: |
           docker exec ipa pki-server ca-user-show acme-ipa.example.com
           docker exec ipa pki-server ca-user-cert-find acme-ipa.example.com
           docker exec ipa pki-server ca-user-role-find acme-ipa.example.com

--- a/base/common/src/main/java/com/netscape/certsrv/user/UserData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/user/UserData.java
@@ -50,6 +50,15 @@ public class UserData implements JSONSerializer {
 
     Map<String, String> attributes = new LinkedHashMap<>();
 
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes.clear();
+        this.attributes.putAll(attributes);
+    }
+
     public String getAttribute(String name) {
         return attributes.get(name);
     }

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -4180,7 +4180,7 @@ class PKIDeployer:
             user_type='agentType',
             state='1',
             attributes={
-                'nsPagedSizeLimit': '20000'
+                'nsPagedSizeLimit': '-1'
             },
             ignore_duplicate=True)
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1973,12 +1973,24 @@ class PKISubsystem(object):
 
         return json.loads(result.stdout.decode())
 
-    def get_user(self, user_id, as_current_user=False):
+    def get_user(
+            self,
+            user_id,
+            attrs=None,
+            as_current_user=False):
 
         cmd = [self.name + '-user-show']
 
+        if attrs:
+            for name in attrs:
+                cmd.append('--attr')
+                cmd.append(name)
+
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
+
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
 
         cmd.append('--output-format')
         cmd.append('json')
@@ -2078,6 +2090,7 @@ class PKISubsystem(object):
             user_id,
             password=None,
             password_file=None,
+            attrs=None,
             add_see_also=None,
             del_see_also=None,
             as_current_user=False):
@@ -2089,6 +2102,12 @@ class PKISubsystem(object):
 
         if password_file is not None:
             cmd.extend(['--password-file', password_file])
+
+        if attrs:
+            for name in attrs:
+                value = attrs[name]
+                cmd.append('--attr')
+                cmd.append('{}={}'.format(name, value))
 
         if add_see_also:
             cmd.append('--add-see-also')

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserModifyCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemUserModifyCLI.java
@@ -7,6 +7,8 @@ package org.dogtagpki.server.cli;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -24,6 +26,8 @@ import com.netscape.cmscore.usrgrp.UGSubsystemConfig;
 import com.netscape.cmscore.usrgrp.User;
 import com.netscape.cmsutil.password.PasswordStore;
 import com.netscape.cmsutil.password.PasswordStoreConfig;
+
+import netscape.ldap.LDAPAttribute;
 
 /**
  * @author Endi S. Dewata
@@ -45,6 +49,10 @@ public class SubsystemUserModifyCLI extends SubsystemCLI {
 
         option = new Option(null, "password-file", true, "User password file");
         option.setArgName("password-file");
+        options.addOption(option);
+
+        option = new Option(null, "attr", true, "Update attribute.");
+        option.setArgName("name=value");
         options.addOption(option);
 
         option = new Option(null, "add-see-also", true, "Link user to a certificate.");
@@ -92,6 +100,8 @@ public class SubsystemUserModifyCLI extends SubsystemCLI {
             }
         }
 
+        String[] attrNameValuePairs = cmd.getOptionValues("attr");
+
         String addSeeAlso = cmd.getOptionValue("add-see-also");
         String delSeeAlso = cmd.getOptionValue("del-see-also");
 
@@ -105,6 +115,20 @@ public class SubsystemUserModifyCLI extends SubsystemCLI {
 
             if (password != null) {
                 user.setPassword(password);
+            }
+
+            if (attrNameValuePairs != null) {
+                // store attributes to be changed in the user object
+                List<LDAPAttribute> ldapAttrs = new ArrayList<>();
+                for (String attrValuePair : attrNameValuePairs) {
+                    String[] parts = attrValuePair.split("=", 2);
+                    LDAPAttribute ldapAttr = new LDAPAttribute(parts[0], parts[1]);
+                    ldapAttrs.add(ldapAttr);
+                }
+                user.setAttributes(ldapAttrs);
+            }
+
+            if (password != null || attrNameValuePairs != null) {
                 ugSubsystem.modifyUser(user);
             }
 

--- a/docs/changes/v11.9.0/Server-Changes.adoc
+++ b/docs/changes/v11.9.0/Server-Changes.adoc
@@ -1,0 +1,14 @@
+= Server Changes =
+
+== Change nsPagedSizeLimit default value ==
+
+The default value for `nsPagedSizeLimit` has been changed to `-1` to avoid
+issues while cloning a CA or KRA that uses sequential serial numbers and
+the CA or KRA is configured to access the database using an LDAP user.
+
+Existing CA or KRA instances will need to be updated manually.
+
+See also:
+
+* link:https://github.com/dogtagpki/pki/issues/5133[PKI Issue #5133]
+* link:../../upgrade/v11.9/Upgrading-PKI-Database.adoc[Upgrading PKI 11.9 Database]

--- a/docs/upgrade/README.adoc
+++ b/docs/upgrade/README.adoc
@@ -34,6 +34,7 @@ Currently the upgrade process has to be done manually:
 * link:v10.7/Upgrading_PKI_Database.adoc[Upgrading PKI 10.7 Database]
 * link:v10.8/Upgrading_PKI_Database.adoc[Upgrading PKI 10.8 Database]
 * link:v10.9/Upgrading_PKI_Database.adoc[Upgrading PKI 10.9 Database]
+* link:v11.9/Upgrading-PKI-Database.adoc[Upgrading PKI 11.9 Database]
 
 = Restarting PKI Server =
 

--- a/docs/upgrade/v11.9/Upgrading-PKI-Database.adoc
+++ b/docs/upgrade/v11.9/Upgrading-PKI-Database.adoc
@@ -1,0 +1,22 @@
+= Overview =
+
+This page describes the process to upgrade an older PKI database into a PKI 11.9 database.
+
+== Updating nsPagedSizeLimit ==
+
+If the existing CA or KRA is configured to use Sequential Serial Numbers
+and it's also configured to use an LDAP user (e.g. `pkidbuser`) to access
+the database, update the `nsPagedSizeLimit` with the following command:
+
+----
+$ pki-server ca-user-mod \
+    --attr nsPagedSizeLimit=-1 \
+    pkidbuser
+----
+
+The change will be replicated automatically to other replicas.
+
+See also:
+
+* link:https://github.com/dogtagpki/pki/issues/5133[PKI Issue #5133]
+* link:../../changes/v11.9.0/Server-Changes.adoc[PKI 11.9.0 Server Changes]


### PR DESCRIPTION
The default value for `nsPagedSizeLimit` in `pkidbuser` has been changed to `-1` to avoid issues when cloning CA or KRA that uses Sequential Serial Numbers as reported in PKI Issue #5133.

The `pki-server <subsystem>-user-show` and `<subsystem>-user-mod` have been updated to provide options to inspect and modify the user's operational attributes including `nsPagedSizeLimit` and `nsPagedLookThroughLimit`.

The basic IPA test has been updated to verify that these attributes can be inspected and modified using these tools after installation.

For existing CA instances, the attribute needs to be updated manually since the current upgrade mechanism cannot reliably update the database (e.g. the database might not be running when the automated upgrade runs which happens when PKI server is started).

https://github.com/dogtagpki/pki/wiki/PKI-Server-Subsystem-User-CLI
https://github.com/edewata/pki/blob/IDM-2246/docs/changes/v11.9.0/Server-Changes.adoc
https://github.com/edewata/pki/blob/IDM-2246/docs/upgrade/v11.9/Upgrading-PKI-Database.adoc

Resolves: https://github.com/dogtagpki/pki/issues/5133