### PR TITLE
Add support for pki-server ca-user-show --attr +

### DIFF
--- a/.github/workflows/ipa-basic-test.yml
+++ b/.github/workflows/ipa-basic-test.yml
@@ -183,10 +183,21 @@ jobs:
       - name: Check PKI database user
         run: |
           docker exec ipa pki-server ca-user-show \
-              --attr nsPagedSizeLimit \
-              --attr nsPagedLookThroughLimit \
+              --attr + \
               pkidbuser \
               | tee output
+
+          # normalize output
+          sed -i \
+              -e "s/^\(  createTimestamp: \).*/\1\*\*\*\*\*/" \
+              -e "s/^\(  modifyTimestamp: \).*/\1\*\*\*\*\*/" \
+              -e "s/^\(  nsUniqueId: \).*/\1\*\*\*\*\*/" \
+              -e "s/^\(  parentid: \).*/\1\*\*\*\*\*/" \
+              -e "s/^\(  entryid: \).*/\1\*\*\*\*\*/" \
+              -e "s/^\(  entryUUID: \).*/\1\*\*\*\*\*/" \
+              -e "s/^\(  entryusn: \).*/\1\*\*\*\*\*/" \
+              -e "s/^\(  description: .*;\).*\(;.*;.*\)/\1\*\*\*\*\*\2/" \
+              output
 
           # by default nsPagedSizeLimit should be -1
           # and nsPagedLookThroughLimit should not exist
@@ -195,7 +206,22 @@ jobs:
             Full Name: pkidbuser
             Type: agentType
             State: 1
+            objectClass: top
+            sn: pkidbuser
             nsPagedSizeLimit: -1
+            creatorsName: cn=directory manager
+            modifiersName: cn=directory manager
+            createTimestamp: *****
+            modifyTimestamp: *****
+            nsUniqueId: *****
+            parentid: *****
+            entryid: *****
+            entryUUID: *****
+            entryusn: *****
+            description: 2;*****;CN=Certificate Authority,O=EXAMPLE.COM;CN=CA Subsystem,O=EXAMPLE.COM
+            seeAlso: CN=CA Subsystem,O=EXAMPLE.COM
+            dsEntryDN: uid=pkidbuser,ou=People,o=ipaca
+            entrydn: uid=pkidbuser,ou=people,o=ipaca
           EOF
 
           diff expected output

--- a/.github/workflows/ipa-clone-test.yml
+++ b/.github/workflows/ipa-clone-test.yml
@@ -694,6 +694,46 @@ jobs:
       - name: Run PKI healthcheck in secondary container
         run: docker exec secondary pki-healthcheck --failures-only
 
+      - name: Check PKI database user in primary CA
+        run: |
+          docker exec primary pki-server ca-user-show \
+              --attr nsPagedSizeLimit \
+              --attr nsPagedLookThroughLimit \
+              pkidbuser \
+              | tee output
+
+          cat > expected << EOF
+            User ID: pkidbuser
+            Full Name: pkidbuser
+            Type: agentType
+            State: 1
+            nsPagedSizeLimit: -1
+          EOF
+
+          diff expected output
+
+          docker exec primary pki-server ca-user-cert-find pkidbuser
+
+      - name: Check PKI database user in secondary CA
+        run: |
+          docker exec secondary pki-server ca-user-show \
+              --attr nsPagedSizeLimit \
+              --attr nsPagedLookThroughLimit \
+              pkidbuser \
+              | tee output
+
+          cat > expected << EOF
+            User ID: pkidbuser
+            Full Name: pkidbuser
+            Type: agentType
+            State: 1
+            nsPagedSizeLimit: -1
+          EOF
+
+          diff expected output
+
+          docker exec secondary pki-server ca-user-cert-find pkidbuser
+
       - name: Verify CA admin
         run: |
           docker exec primary cp /root/ca-agent.p12 ${SHARED}/ca-agent.p12

--- a/base/server/python/pki/server/cli/user.py
+++ b/base/server/python/pki/server/cli/user.py
@@ -590,7 +590,12 @@ class UserShowCLI(pki.cli.CLI):
         attrs = user.get('attributes')
 
         if args.attr:
-            for name in args.attr:
+            # if + is specified, display all non-empty atributes
+            # otherwise, display the specified non-empty attributes only
+            if '+' not in args.attr:
+                attrs = {k: v for k, v in attrs.items() if k in args.attr and v}
+
+            for name in attrs:
                 value = attrs.get(name)
                 if value:
                     print('  {}: {}'.format(name, value))


### PR DESCRIPTION
The `pki-server ca-user-show` has been modified to provide a way to display all operational attributes in the user's LDAP entry.

https://github.com/dogtagpki/pki/wiki/PKI-Server-Subsystem-User-CLI