### PR TITLE
Add key ID file option

### DIFF
--- a/.github/workflows/pki-nss-ecc-test.yml
+++ b/.github/workflows/pki-nss-ecc-test.yml
@@ -33,13 +33,12 @@ jobs:
 
       - name: Create EC key
         run: |
-          docker exec pki pki nss-key-create --key-type EC | tee output
+          docker exec pki pki nss-key-create \
+              --key-type EC \
+              --key-id-file $SHARED/ca_signing.key-id
 
-          # get key ID
-          KEY_ID=$(sed -n 's/^\s*Key ID:\s*\(\S\+\)\s*$/\1/p' output)
-          echo $KEY_ID > ca_signing_key_id
-
-          docker exec pki pki nss-key-show --key-id $KEY_ID
+          docker exec pki pki nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id
 
       - name: Verify key type
         run: |
@@ -57,7 +56,7 @@ jobs:
       - name: Create CA signing cert request with existing EC key
         run: |
           docker exec pki pki nss-cert-request \
-              --key-id $(cat ca_signing_key_id) \
+              --key-id-file $SHARED/ca_signing.key-id \
               --subject "CN=Certificate Authority" \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               --csr ca_signing.csr
@@ -121,7 +120,10 @@ jobs:
 
           # get key ID
           docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^<.*>\s\+\S\+\s\+\(\S\+\)\s\+NSS Certificate DB:sslserver$/\1/p' output > sslserver_key_id
+          sed -n \
+              's/^<.*>\s\+\S\+\s\+\(\S\+\)\s\+NSS Certificate DB:sslserver$/0x\1/p' \
+              output \
+              > sslserver.key-id
 
       - name: Verify trust flags
         run: |
@@ -169,7 +171,7 @@ jobs:
       - name: Create new SSL server cert request with existing EC key
         run: |
           docker exec pki pki nss-cert-request \
-              --key-id "0x`cat sslserver_key_id`" \
+              --key-id-file $SHARED/sslserver.key-id \
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --csr new_sslserver.csr
@@ -217,8 +219,12 @@ jobs:
       - name: Verify key ID
         run: |
           docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^<.*>\s\+\S\+\s\+\(\S\+\)\s\+NSS Certificate DB:new_sslserver$/\1/p' output > new_sslserver_key_id
-          diff sslserver_key_id new_sslserver_key_id
+          sed -n \
+              's/^<.*>\s\+\S\+\s\+\(\S\+\)\s\+NSS Certificate DB:new_sslserver$/0x\1/p' \
+              output \
+              > new_sslserver.key-id
+
+          diff sslserver.key-id new_sslserver.key-id
 
       - name: Delete SSL server cert and key
         run: |

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -62,6 +62,10 @@ public class NSSCertRequestCLI extends CommandCLI {
         option.setArgName("ID");
         options.addOption(option);
 
+        option = new Option(null, "key-id-file", true, "File containing key ID");
+        option.setArgName("path");
+        options.addOption(option);
+
         option = new Option(null, "key-type", true, "Key type: RSA (default), EC");
         option.setArgName("type");
         options.addOption(option);
@@ -134,6 +138,13 @@ public class NSSCertRequestCLI extends CommandCLI {
         boolean subjectEncoding = cmd.hasOption("subject-encoding");
 
         String keyID = cmd.getOptionValue("key-id");
+        String keyIDFile = cmd.getOptionValue("key-id-file");
+
+        if (keyID == null && keyIDFile != null) {
+            // load key ID from file
+            keyID = Files.readString(Paths.get(keyIDFile)).strip();
+        }
+
         String keyType = cmd.getOptionValue("key-type", "RSA");
         String keySize = cmd.getOptionValue("key-size", "2048");
         boolean keyWrap = cmd.hasOption("key-wrap");

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
@@ -18,6 +18,7 @@
 
 package com.netscape.cmstools.nss;
 
+import java.io.FileWriter;
 import java.security.KeyPair;
 
 import org.apache.commons.cli.CommandLine;
@@ -93,6 +94,10 @@ public class NSSKeyCreateCLI extends CommandCLI {
         option.setArgName("usage list");
         options.addOption(option);
 
+        option = new Option(null, "key-id-file", true, "File to store key ID");
+        option.setArgName("path");
+        options.addOption(option);
+
         option = new Option(null, "output-format", true, "Output format: text (default), json.");
         option.setArgName("format");
         options.addOption(option);
@@ -107,7 +112,6 @@ public class NSSKeyCreateCLI extends CommandCLI {
         } else if (cmd.hasOption("verbose")) {
             PKILogger.setLevel(LogLevel.INFO);
         }
-
 
         String[] cmdArgs = cmd.getArgs();
 
@@ -244,6 +248,14 @@ public class NSSKeyCreateCLI extends CommandCLI {
 
         } else {
             throw new Exception("Unsupported key type: " + keyType);
+        }
+
+        String keyIDFile = cmd.getOptionValue("key-id-file");
+        if (keyIDFile != null) {
+            // store key ID to file
+            try (FileWriter out = new FileWriter(keyIDFile)) {
+                out.write(keyInfo.getKeyId().toHexString());
+            }
         }
 
         String outputFormat = cmd.getOptionValue("output-format", "text");

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyShowCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyShowCLI.java
@@ -5,6 +5,9 @@
 //
 package com.netscape.cmstools.nss;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
@@ -47,6 +50,10 @@ public class NSSKeyShowCLI extends CommandCLI {
         option.setArgName("ID");
         options.addOption(option);
 
+        option = new Option(null, "key-id-file", true, "File containing key ID");
+        option.setArgName("path");
+        options.addOption(option);
+
         option = new Option(null, "key-nickname", true, "Key nickname");
         option.setArgName("nickname");
         options.addOption(option);
@@ -82,6 +89,13 @@ public class NSSKeyShowCLI extends CommandCLI {
         mainCLI.init();
 
         String keyID = cmd.getOptionValue("key-id");
+        String keyIDFile = cmd.getOptionValue("key-id-file");
+
+        if (keyID == null && keyIDFile != null) {
+            // load key ID from file
+            keyID = Files.readString(Paths.get(keyIDFile)).strip();
+        }
+
         String keyNickname = cmd.getOptionValue("key-nickname");
         String outputFormat = cmd.getOptionValue("output-format", "text");
 

--- a/docs/changes/v11.9.0/Tools-Changes.adoc
+++ b/docs/changes/v11.9.0/Tools-Changes.adoc
@@ -16,3 +16,12 @@ The `pki-server <subsystem>-group-add` command has been added to create group.
 
 The `pki-server sd-type-add` command has been added to allow the introduction
 of new security domain types.
+
+== New `--key-id-file` option ==
+
+The following commands have been modified to provide an option to specify
+a file to store the ID of a new key or to load the ID of an existing key:
+
+* `pki nss-key-create`
+* `pki nss-key-show`
+* `pki nss-cert-request`


### PR DESCRIPTION
The `pki nss-key-create`, `nss-key-show`, and `nss-cert-request` commands have been modified to provide an option to specify a file to store the ID of a new key or to load the ID of an existing key.

The test for PKI CLI with ECC has been updated to use the new option.

https://github.com/dogtagpki/pki/wiki/PKI-NSS-Key-CLI
https://github.com/dogtagpki/pki/wiki/Generating-Certificate-Request-with-PKI-NSS
https://github.com/edewata/pki/blob/cli/docs/changes/v11.9.0/Tools-Changes.adoc
