### PR TITLE
Add shell/batch mode for PKI CLI

### DIFF
--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -151,92 +151,72 @@ jobs:
               -D pki_security_domain_setup=False \
               -v
 
-      - name: Issue KRA storage cert
+      - name: Check KRA system and admin CSRs
         run: |
-          docker exec client openssl req -text -noout -in ${SHARED}/kra_storage.csr
+          docker exec client openssl req -text -noout -in $SHARED/kra_storage.csr
+          docker exec client openssl req -text -noout -in $SHARED/kra_transport.csr
+          docker exec client openssl req -text -noout -in $SHARED/subsystem.csr
+          docker exec client openssl req -text -noout -in $SHARED/sslserver.csr
+          docker exec client openssl req -text -noout -in $SHARED/kra_audit_signing.csr
+          docker exec client openssl req -text -noout -in $SHARED/kra_admin.csr
 
-          docker exec client pki \
+      - name: Issue KRA system and admin certs
+        run: |
+          docker exec -i client pki \
+              -v \
               -U https://ca.example.com:8443 \
               -n caadmin \
-              ca-cert-issue \
+              - << EOF
+
+          # issue KRA storage cert
+          ca-cert-issue \
               --profile caStorageCert \
-              --csr-file ${SHARED}/kra_storage.csr \
-              --output-file ${SHARED}/kra_storage.crt
+              --csr-file $SHARED/kra_storage.csr \
+              --output-file $SHARED/kra_storage.crt
 
-          docker exec client openssl x509 -text -noout -in ${SHARED}/kra_storage.crt
-
-      - name: Issue KRA transport cert
-        run: |
-          docker exec client openssl req -text -noout -in ${SHARED}/kra_transport.csr
-
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              -n caadmin \
-              ca-cert-issue \
+          # issue KRA transport cert
+          ca-cert-issue \
               --profile caTransportCert \
-              --csr-file ${SHARED}/kra_transport.csr \
-              --output-file ${SHARED}/kra_transport.crt
+              --csr-file $SHARED/kra_transport.csr \
+              --output-file $SHARED/kra_transport.crt
 
-          docker exec client openssl x509 -text -noout -in ${SHARED}/kra_transport.crt
-
-      - name: Issue subsystem cert
-        run: |
-          docker exec client openssl req -text -noout -in ${SHARED}/subsystem.csr
-
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              -n caadmin \
-              ca-cert-issue \
+          # issue subsystem cert
+          ca-cert-issue \
               --profile caSubsystemCert \
-              --csr-file ${SHARED}/subsystem.csr \
-              --output-file ${SHARED}/subsystem.crt
+              --csr-file $SHARED/subsystem.csr \
+              --output-file $SHARED/subsystem.crt
 
-          docker exec client openssl x509 -text -noout -in ${SHARED}/subsystem.crt
-
-      - name: Issue SSL server cert
-        run: |
-          docker exec client openssl req -text -noout -in ${SHARED}/sslserver.csr
-
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              -n caadmin \
-              ca-cert-issue \
+          # issue SSL server cert
+          ca-cert-issue \
               --profile caServerCert \
-              --csr-file ${SHARED}/sslserver.csr \
-              --output-file ${SHARED}/sslserver.crt
+              --csr-file $SHARED/sslserver.csr \
+              --output-file $SHARED/sslserver.crt
 
-          docker exec client openssl x509 -text -noout -in ${SHARED}/sslserver.crt
-
-      - name: Issue KRA audit signing cert
-        run: |
-          docker exec client openssl req -text -noout -in ${SHARED}/kra_audit_signing.csr
-
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              -n caadmin \
-              ca-cert-issue \
+          # issue KRA audit signing cert
+          ca-cert-issue \
               --profile caAuditSigningCert \
-              --csr-file ${SHARED}/kra_audit_signing.csr \
-              --output-file ${SHARED}/kra_audit_signing.crt
+              --csr-file $SHARED/kra_audit_signing.csr \
+              --output-file $SHARED/kra_audit_signing.crt
 
-          docker exec client openssl x509 -text -noout -in ${SHARED}/kra_audit_signing.crt
-
-      - name: Issue KRA admin cert
-        run: |
-          docker exec client openssl req -text -noout -in ${SHARED}/kra_admin.csr
-
-          docker exec client pki \
-              -U https://ca.example.com:8443 \
-              -n caadmin \
-              ca-cert-issue \
+          # issue KRA admin cert
+          ca-cert-issue \
               --profile AdminCert \
-              --csr-file ${SHARED}/kra_admin.csr \
-              --output-file ${SHARED}/kra_admin.crt
+              --csr-file $SHARED/kra_admin.csr \
+              --output-file $SHARED/kra_admin.crt
+          EOF
 
-          docker exec client openssl x509 -text -noout -in ${SHARED}/kra_admin.crt
+      - name: Check KRA system and admin certs
+        run: |
+          docker exec client openssl x509 -text -noout -in $SHARED/kra_storage.crt
+          docker exec client openssl x509 -text -noout -in $SHARED/kra_transport.crt
+          docker exec client openssl x509 -text -noout -in $SHARED/subsystem.crt
+          docker exec client openssl x509 -text -noout -in $SHARED/sslserver.crt
+          docker exec client openssl x509 -text -noout -in $SHARED/kra_audit_signing.crt
+          docker exec client openssl x509 -text -noout -in $SHARED/kra_admin.crt
 
       - name: Stop CA
         run: |
+          # ensure KRA installation can complete without a running CA
           docker exec ca pki-server stop --wait
 
       - name: Install standalone KRA (step 2)

--- a/.github/workflows/pki-basic-test.yml
+++ b/.github/workflows/pki-basic-test.yml
@@ -13,6 +13,11 @@ jobs:
     env:
       SHARED: /tmp/workdir/pki
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install xmlstarlet
+
       - name: Clone repository
         uses: actions/checkout@v4
 
@@ -33,7 +38,6 @@ jobs:
 
       - name: Check pki CLI help message
         run: |
-          docker exec pki pki
           docker exec pki pki --help
 
           # TODO: validate output
@@ -68,3 +72,43 @@ jobs:
           docker exec pki pki nss --help
 
           # TODO: validate output
+
+      - name: Check pki CLI in shell mode (with prompts)
+        run: |
+          VERSION=$(xmlstarlet sel -t -v '/_:project/_:version' pom.xml)
+
+          docker exec -i pki pki << EOF \
+              > >(tee stdout) 2> >(tee stderr >&2)
+          nss-cert-find
+          nss-key-find
+          exit
+          EOF
+
+          cat > expected << EOF
+          PKI Command-Line Interface $VERSION
+          EOF
+
+          diff expected stdout
+
+          # there should be 1 prompt for each input line
+          cp /dev/null expected
+          echo -n "pki> " >> expected
+          echo -n "pki> " >> expected
+          echo -n "pki> " >> expected
+
+          diff expected stderr
+
+      - name: Check pki CLI in batch mode (without prompts)
+        run: |
+          docker exec -i pki pki - << EOF \
+              > >(tee stdout) 2> >(tee stderr >&2)
+          # check certs
+          nss-cert-find
+
+          # check keys
+          nss-key-find
+          EOF
+
+          # there should be no prompts
+          diff /dev/null stdout
+          diff /dev/null stderr

--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -395,10 +395,6 @@ class PKICLI(pki.cli.CLI):
             command = args.remainder[0]
         logger.debug('CLI Command: %s', command)
 
-        if not command:
-            self.print_help()
-            return
-
         if client_type == 'python' or command in PYTHON_COMMANDS:
             module = self.find_module(command)
             logger.debug('Module: %s', module.get_full_name())

--- a/base/common/src/main/java/org/dogtagpki/cli/CLI.java
+++ b/base/common/src/main/java/org/dogtagpki/cli/CLI.java
@@ -386,4 +386,71 @@ public class CLI {
             throw new CLIException("Command failed. RC: " + rc, rc);
         }
     }
+
+    /**
+     * Parse a command line into an array of tokens.
+     *
+     * For example:
+     *   nss-cert-request --subject "CN=Certificate Authority"
+     * should be parsed into:
+     *   ["nss-cert-request", "--subject", "CN=Certificate Authority"]
+     */
+    public String[] parseLine(String line) throws Exception {
+
+        List<String> tokens = new ArrayList<>();
+        StringBuilder token = null;
+        boolean quotedString = false;
+
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+
+            if (token == null) { // not parsing token
+
+                if (c == '"') { // found opening quote
+                    // start parsing token
+                    token = new StringBuilder();
+                    quotedString = true;
+
+                } else if (c == ' ') { // found delimiters
+                    // discard delimiters
+
+                } else {
+                    // start parsing token
+                    token = new StringBuilder();
+                    // add char into token
+                    token.append(c);
+                }
+
+            } else { // parsing token
+
+                if (c == '"') { // found closing quote
+                    // store current token
+                    tokens.add(token.toString());
+                    token = null;
+                    quotedString = false;
+
+                } else if (c == ' ') { // found delimiter
+                    if (quotedString) {
+                        // add delimiter into current token
+                        token.append(c);
+                    } else {
+                        // store current token
+                        tokens.add(token.toString());
+                        token = null;
+                    }
+
+                } else {
+                    // add char into current token
+                    token.append(c);
+                }
+            }
+        }
+
+        if (token != null) {
+            // store remaining token
+            tokens.add(token.toString());
+        }
+
+        return tokens.toArray(new String[tokens.size()]);
+    }
 }

--- a/docs/changes/v11.9.0/Tools-Changes.adoc
+++ b/docs/changes/v11.9.0/Tools-Changes.adoc
@@ -25,3 +25,8 @@ a file to store the ID of a new key or to load the ID of an existing key:
 * `pki nss-key-create`
 * `pki nss-key-show`
 * `pki nss-cert-request`
+
+== New shell/batch mode for PKI CLI ==
+
+PKI CLI now provides a shell mode to run commands interactively and
+a batch mode to run multiple commands at once.


### PR DESCRIPTION
The PKI CLI has been modified to provide a shell/batch mode to run multiple commands in a single Java process which can minimize the number of authentications to external resources (e.g. NSS, HSM, SSL) since it will maintain a single session across multiple commands.

Some tests have been updated to use PKI CLI in shell/batch mode.

https://github.com/dogtagpki/pki/wiki/PKI-CLI
https://github.com/edewata/pki/blob/cli/docs/changes/v11.9.0/Tools-Changes.adoc

Resolves: https://github.com/dogtagpki/pki/issues/2701
