### PR TITLE
Fix keyring exception for missing id

### DIFF
--- a/base/common/python/pki/keyring.py
+++ b/base/common/python/pki/keyring.py
@@ -122,6 +122,9 @@ class Keyring:
 
         key_id = self.get_key_id(key_name)
 
+        if not key_id:
+            raise ValueError("No id for key %s in keyring" % key_name)
+
         cmd = []
         if self.user:
             cmd = ['runuser', '-u', self.user, '--']

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1567,14 +1567,18 @@ grant codeBase "file:%s" {
             self.passwords[name] = password
             return password
 
-        except subprocess.CalledProcessError:
-            logger.info('Password unavailable in Keyring.')
+        except (subprocess.CalledProcessError, ValueError) as e:
+            logger.info('Password unavailable in Keyring:', e)
 
-        # prompt for password if not found
-        password = getpass.getpass(prompt='Enter password for %s: ' % name)
-        self.passwords[name] = password
+        try:
+            # prompt for password if not found and terminal is available
+            password = getpass.getpass(prompt='Enter password for %s: ' % name)
+            self.passwords[name] = password
+            return password
+        except EOFError:
+            logger.info('Password cannot be provided from standard I/O')
 
-        return password
+        raise Exception('No available password for "%s"' % name)
 
     def get_token_password(self, token=pki.nssdb.INTERNAL_TOKEN_NAME):
 
@@ -1597,14 +1601,18 @@ grant codeBase "file:%s" {
             self.passwords[name] = password
             return password
 
-        except subprocess.CalledProcessError:
-            logger.info('Password unavailable in Keyring.')
+        except (subprocess.CalledProcessError, ValueError) as e:
+            logger.info('Password unavailable in Keyring:', e)
 
-        # prompt for password if not found
-        password = getpass.getpass(prompt='Enter password for %s: ' % token)
-        self.passwords[name] = password
+        try:
+            # prompt for password if not found and terminal is available
+            password = getpass.getpass(prompt='Enter password for %s: ' % token)
+            self.passwords[name] = password
+            return password
+        except EOFError:
+            logger.info('Password cannot be provided from standard I/O')
 
-        return password
+        raise Exception('No available password to access the token "%s"' % token)
 
     def get_sslserver_cert_nickname(self):
 


### PR DESCRIPTION
When a password is searched in keyring but it is not present the following log message fails with a TypeError because the key id is null. This error is not handled and the startup fails with a message which make not clear what is generating the problem.

The behaviour is modified to raise a value error which is handled and if the password cannot be retrieved the final error will be something like:

Exception: No available password to access the token "internal"