### PR TITLE
Store and use the successful api_path in InfoClient.get_info()

### DIFF
--- a/base/common/python/pki/client.py
+++ b/base/common/python/pki/client.py
@@ -424,12 +424,14 @@ class PKIClient:
         logger.info('Connecting to %s', urllib.parse.urlunparse(self.url))
 
         self.info = self.info_client.get_info()
+        self.api_path = self.info_client.get_api_path()
+        self.api_version = self.info_client.get_api_version()
 
         self.server_version = pki.util.Version(self.info.version)
         logger.debug('- server version: %s', self.server_version)
 
         # if not specified, set REST API version and path based on server version
-        if not self.api_version:
+        if not self.api_version and not self.api_path:
             if self.server_version >= pki.util.Version('11.6.0'):
                 # use REST API v2 for PKI 11.6.0 or later
                 self.api_version = 'v2'

--- a/base/common/python/pki/info.py
+++ b/base/common/python/pki/info.py
@@ -119,10 +119,18 @@ class InfoClient(object):
         else:
             self.pki_client = parent
             self.connection = self.pki_client.connection
+        self.api_path = None
+        self.api_version = None
 
     @pki.handle_exceptions()
     def get_info(self):
         """ Return an Info object form a PKI server """
+
+        api_versions = {
+            'rest': 'v1',
+            'v1': 'v1',
+            'v2': 'v2',
+        }
 
         if self.pki_client and self.pki_client.api_path:
             # use REST API path specified in PKIClient
@@ -154,6 +162,9 @@ class InfoClient(object):
         if not response:
             raise Exception('Unable to get PKI server info')
 
+        self.api_path = api_path
+        self.api_version = api_versions[api_path]
+
         json_response = response.json()
         logger.debug('Response:\n%s', json.dumps(json_response, indent=4))
 
@@ -164,6 +175,14 @@ class InfoClient(object):
         """ return Version object from server """
         version_string = self.get_info().version
         return Version(version_string)
+
+    @pki.handle_exceptions()
+    def get_api_path(self):
+        return self.api_path
+
+    @pki.handle_exceptions()
+    def get_api_version(self):
+        return self.api_version
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is the only place where the remote available API can be detected. This value is used by PKIClient to to determine which endpoint to use rather than only relying on the local package version to do so.

This adds a fake ApiPath value to the returned JSON which in turn will add it to the object when parsed to try to remain consistent.

IMPORTANT NOTE: I'm doing some funny stuff here in the Info class. I have no problem changing anything but this change works with a newer IPA install to be able to query a remote CA or KRA that doesn't support v2.