### PR TITLE
Fix IDM-2955 Add support for old and new Tomcat 10.1.

### DIFF
--- a/.github/workflows/ca-clone-hsm-test.yml
+++ b/.github/workflows/ca-clone-hsm-test.yml
@@ -65,6 +65,7 @@ jobs:
           PermitRootLogin yes
           PubkeyAuthentication yes
           AuthenticationMethods publickey
+          UsePAM yes
           EOF
 
           # start SSH server

--- a/.github/workflows/lwca-clone-hsm-test.yml
+++ b/.github/workflows/lwca-clone-hsm-test.yml
@@ -64,6 +64,7 @@ jobs:
           PermitRootLogin yes
           PubkeyAuthentication yes
           AuthenticationMethods publickey
+          UsePAM yes
           EOF
 
           # start SSH server


### PR DESCRIPTION
 Fix the SSH config on F43 for certain CI tests.
    
    This fix is part of getting   old Tomcat 10.1 working under the new CI test changes, which now assumes f43.
