### PR TITLE
Update NSSDatabase.modify_cert() to use pki nss-cert-mod

### DIFF
--- a/.github/workflows/pki-nss-hsm-test.yml
+++ b/.github/workflows/pki-nss-hsm-test.yml
@@ -439,6 +439,40 @@ jobs:
           sed -n 's/\s*Key ID:\s*\(\S\+\)\s*$/\L\1/p' output > new_sslserver_key_id
           diff sslserver_key_id new_sslserver_key_id
 
+      - name: Modify trust flags
+        run: |
+          docker exec pki pki nss-cert-mod \
+              --trust-flags ",,P" \
+              new_sslserver
+
+          # trust flags should be modified in internal token
+          echo ",,P" > expected
+
+          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
+          sed -n 's/^new_sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
+          diff expected actual
+
+          docker exec pki pki nss-cert-show new_sslserver | tee output
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+          diff expected actual
+
+          # trust flags should be modified in HSM
+          echo "u,u,Pu" > expected
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -h HSM \
+              -f $SHARED/password.txt | tee output
+          sed -n 's/^HSM:new_sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              HSM:new_sslserver | tee output
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+          diff expected actual
+
       - name: Delete SSL server cert and key from internal token and HSM
         run: |
           # delete cert from internal token

--- a/.github/workflows/pki-nss-rsa-test.yml
+++ b/.github/workflows/pki-nss-rsa-test.yml
@@ -232,6 +232,18 @@ jobs:
           sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
           diff actual expected
 
+      - name: Modify trust flags
+        run: |
+          docker exec pki pki nss-cert-mod \
+              --trust-flags ",,P" \
+              new_sslserver | tee output
+
+          echo "u,u,Pu" > expected
+
+          docker exec pki pki nss-cert-show new_sslserver | tee output
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+          diff expected actual
+
       - name: Delete SSL server cert and key
         run: |
           docker exec pki pki nss-cert-del new_sslserver --remove-key

--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -902,23 +902,20 @@ class NSSDatabase(object):
         self.run(cmd, input=data, check=True)
 
     def modify_cert(self, nickname, trust_attributes):
-        cmd = [
-            'certutil',
-            '-M',
-            '-d', self.directory
-        ]
 
         if self.token:
-            cmd.extend(['-h', self.token])
+            fullname = self.token + ':' + nickname
+        else:
+            fullname = nickname
 
-        password_file = self.get_password_file(self.tmpdir, None,
-                                               all_tokens=True)
-        cmd.extend(['-f', password_file])
-
-        cmd.extend([
-            '-n', nickname,
-            '-t', trust_attributes
-        ])
+        cmd = [
+            'pki',
+            '-d', self.directory,
+            '-f', self.password_conf,
+            'nss-cert-mod',
+            '--trust-flags', trust_attributes,
+            fullname
+        ]
 
         self.run(cmd, check=True)
 

--- a/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertModifyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertModifyCLI.java
@@ -54,6 +54,9 @@ public class ClientCertModifyCLI extends CommandCLI {
     @Override
     public void execute(CommandLine cmd) throws Exception {
 
+        logger.warn("The pki client-cert-mod has been deprecated. Use the following command instead:");
+        logger.warn("  $ pki nss-cert-mod --trust-flags <flags> <nickname>");
+
         String[] cmdArgs = cmd.getArgs();
 
         if (cmdArgs.length > 1) {

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertCLI.java
@@ -20,6 +20,7 @@ public class NSSCertCLI extends CLI {
         addModule(new NSSCertExportCLI(this));
         addModule(new NSSCertImportCLI(this));
         addModule(new NSSCertIssueCLI(this));
+        addModule(new NSSCertModifyCLI(this));
         addModule(new NSSCertRequestCLI(this));
         addModule(new NSSCertShowCLI(this));
         addModule(new NSSCertRemoveCLI(this));

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertModifyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertModifyCLI.java
@@ -1,0 +1,73 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.cmstools.nss;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CLIException;
+import org.dogtagpki.cli.CommandCLI;
+import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.crypto.ObjectNotFoundException;
+import org.mozilla.jss.crypto.X509Certificate;
+import org.mozilla.jss.pkcs11.PK11Cert;
+
+import com.netscape.cmstools.cli.MainCLI;
+
+public class NSSCertModifyCLI extends CommandCLI {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NSSCertModifyCLI.class);
+
+    public NSSCertModifyCLI(NSSCertCLI nssCertCLI) {
+        super("mod", "Modify certificate", nssCertCLI);
+    }
+
+    @Override
+    public void printHelp() {
+        formatter.printHelp(getFullName() + " [OPTIONS...] <nickname>", options);
+    }
+
+    @Override
+    public void createOptions() {
+        Option option = new Option(null, "trust-flags", true, "Certificate trust flags");
+        option.setArgName("flags");
+        options.addOption(option);
+    }
+
+    @Override
+    public void execute(CommandLine cmd) throws Exception {
+
+        String[] cmdArgs = cmd.getArgs();
+
+        if (cmdArgs.length < 1) {
+            throw new CLIException("Missing certificate nickname");
+        }
+
+        String nickname = cmdArgs[0];
+
+        String trustFlags = cmd.getOptionValue("trust-flags");
+        if (trustFlags == null) {
+            throw new CLIException("Missing trust flags");
+        }
+
+        MainCLI mainCLI = (MainCLI) getRoot();
+        mainCLI.init();
+
+        CryptoManager cm = CryptoManager.getInstance();
+
+        X509Certificate cert;
+        try {
+            cert = cm.findCertByNickname(nickname);
+        } catch (ObjectNotFoundException e) {
+            throw new CLIException("Certificate not found: " + nickname);
+        }
+
+        if (trustFlags != null) {
+            try (PK11Cert pk11Cert = (PK11Cert) cert) {
+                pk11Cert.setTrustFlags(trustFlags);
+            }
+        }
+    }
+}

--- a/docs/changes/v11.9.0/Tools-Changes.adoc
+++ b/docs/changes/v11.9.0/Tools-Changes.adoc
@@ -30,3 +30,10 @@ a file to store the ID of a new key or to load the ID of an existing key:
 
 PKI CLI now provides a shell mode to run commands interactively and
 a batch mode to run multiple commands at once.
+
+== New pki nss-cert-mod command ==
+
+The `pki nss-cert-mod` has been added to modify the trust flags
+of an existing certificate in NSS database.
+
+The `pki client-cert-mod` has been deprecated.


### PR DESCRIPTION
The `pki nss-cert-mod` has been added to modify the trust flags of an existing cert in NSS database.

The `NSSDatabase.modify_cert()` has been updated to use `pki nss-cert-mod` instead of `certutil`.

The `pki client-cert-mod` has also been deprecated since it uses `certutil`.

https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-CLI
https://github.com/edewata/pki/blob/trust/docs/changes/v11.9.0/Tools-Changes.adoc
