### PR TITLE
Add ML-DSA support for certificate request

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertRequestCLI.java
@@ -154,6 +154,7 @@ public class ClientCertRequestCLI extends CommandCLI {
 
     @Override
     public void execute(CommandLine cmd) throws Exception {
+        logger.warn("This command is deprecated. Please move to the command 'pki nss-cert-request'");
 
         String[] cmdArgs = cmd.getArgs();
 
@@ -181,9 +182,10 @@ public class ClientCertRequestCLI extends CommandCLI {
 
         boolean attributeEncoding = cmd.hasOption("attribute-encoding");
 
-        // rsa, ec
+        // rsa, ec or mldsa
         String algorithm = cmd.getOptionValue("algorithm", "rsa");
-        int length = Integer.parseInt(cmd.getOptionValue("length", "2048"));
+        int length = algorithm.equals("mldsa") ? 65 : 2048;
+        length = Integer.parseInt(cmd.getOptionValue("length", Integer.toString(length)));
         boolean wrap = cmd.hasOption("wrap");
         boolean useOAEP = cmd.hasOption("oaep");
 
@@ -284,6 +286,18 @@ public class ClientCertRequestCLI extends CommandCLI {
                 throw new CLIException("Unable to create ECC key pair: "+ e.getMessage());
             }
 
+        } else if ("mldsa".equals(algorithm)) {
+
+            try {
+                keyPair = nssdb.createMLDSAKeyPair(
+                        token,
+                        length,
+                        temporary,
+                        sensitive,
+                        extractable);
+            } catch (TokenException e) {
+                throw new CLIException("Unable to create ML-DSA key pair: "+ e.getMessage());
+            }
         } else {
             throw new Exception("Unknown algorithm: " + algorithm);
         }

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -66,11 +66,11 @@ public class NSSCertRequestCLI extends CommandCLI {
         option.setArgName("path");
         options.addOption(option);
 
-        option = new Option(null, "key-type", true, "Key type: RSA (default), EC");
+        option = new Option(null, "key-type", true, "Key type: RSA (default), EC, ML-DSA");
         option.setArgName("type");
         options.addOption(option);
 
-        option = new Option(null, "key-size", true, "RSA key size (default: 2048)");
+        option = new Option(null, "key-size", true, "Key size (RSA default: 2048, ML-DSA default: 65)");
         option.setArgName("size");
         options.addOption(option);
 
@@ -146,7 +146,6 @@ public class NSSCertRequestCLI extends CommandCLI {
         }
 
         String keyType = cmd.getOptionValue("key-type", "RSA");
-        String keySize = cmd.getOptionValue("key-size", "2048");
         boolean keyWrap = cmd.hasOption("key-wrap");
         String keyWrapAlg = cmd.getOptionValue(
                 "key-wrap-alg",
@@ -195,7 +194,7 @@ public class NSSCertRequestCLI extends CommandCLI {
             keyType = keyPair.getPublic().getAlgorithm();
 
         } else if ("RSA".equalsIgnoreCase(keyType)) {
-
+            String keySize = cmd.getOptionValue("key-size", "2048");
             keyPair = nssdb.createRSAKeyPair(
                     token,
                     Integer.parseInt(keySize),
@@ -205,7 +204,6 @@ public class NSSCertRequestCLI extends CommandCLI {
                     extractable);
 
         } else if ("EC".equalsIgnoreCase(keyType)) {
-
             keyPair = nssdb.createECKeyPair(
                     token,
                     curve,
@@ -215,6 +213,7 @@ public class NSSCertRequestCLI extends CommandCLI {
                     extractable);
 
         } else if ("ML-DSA".equalsIgnoreCase(keyType)) {
+            String keySize = cmd.getOptionValue("key-size", "65");
             keyPair = nssdb.createMLDSAKeyPair(
                     token,
                     Integer.parseInt(keySize),

--- a/docs/changes/v11.9.0/Tools-Changes.adoc
+++ b/docs/changes/v11.9.0/Tools-Changes.adoc
@@ -37,3 +37,18 @@ The `pki nss-cert-mod` has been added to modify the trust flags
 of an existing certificate in NSS database.
 
 The `pki client-cert-mod` has been deprecated.
+
+== Deprecated command ==
+
+The following command have been deprecated:
+
+* `pki client-cert-request`
+
+== Add new algorithm value for ML-DSA ==
+
+The algorithm ML-DSA can be specified for the command:
+
+* `pki client-cert-request`: value **mldsa** for the option `--algorithm` and the option `--length` can be one of 44, 65 (default) or 87;
+* `pki nss-cert-request`: value **ML-DSA** for the option `--key-type` and the option `--key-size` can be one of 44, 65 (default) or 87.
+ 
+


### PR DESCRIPTION
The `pki client-cert-request` `--algorithm` option can specify the value "mldsa" and the `--length`` can be 44, 65 (default) or 87.

Similarly, the command `pki nss-cert-request` `--key-type` option can specify the value "ML-DSA" and the `--key-size` can be 44, 65 (default) or 87.

Finally, the command `pki client-cert-request` has been deprecated.