### PR TITLE
Update PKISubsystem.validate_system_cert()

### DIFF
--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -446,8 +446,8 @@ class PKISubsystem(object):
             cmd.extend(['--token', token])
 
         cmd.extend([
-            'client-cert-validate',
-            '--certusage', cert_usage,
+            'nss-cert-verify',
+            '--cert-usage', cert_usage,
             fullname
         ])
 

--- a/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertValidateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/client/ClientCertValidateCLI.java
@@ -77,12 +77,18 @@ public class ClientCertValidateCLI extends CommandCLI {
         mainCLI.init();
 
         if (certusage == null) {
+            // get current cert usages
+            // TODO: create a replacement and deprecate this command
             Set<CertificateUsage> usages = CertUtil.getCertificateUsages(nickname);
             System.out.println("Cert usages: " + StringUtils.join(usages, ", "));
             return;
         }
 
+        logger.warn("The --certusage option has been deprecated. Use the following command instead:");
+        logger.warn("  $ pki nss-cert-verify --cert-usage <usage> <nickname>");
+
         try {
+            // validate specified cert usage
             CertUtil.verifyCertificateUsage(nickname, certusage);
             System.out.println("Certificate is valid");
 


### PR DESCRIPTION
The `pki nss-cert-verify` has been updated to provide an option to validate the cert usage.

The `PKISubsystem.validate_system_cert()` has been updated to use the new option.

The `pki client-cert-validate --certusage` option has been deprecated.

https://github.com/dogtagpki/pki/wiki/PKI-NSS-Certificate-CLI
https://github.com/dogtagpki/pki/wiki/PKI-Client-CLI
