### PR TITLE
Fix failing CentOS Copr builds 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -175,13 +175,13 @@ get_tomcat_app_server() {
     ID=""
     VERSION_ID=""
 
-    ID=$(sed -n  's/^ID=//p;' $release_file)
-    VERSION_ID=$(sed -n  's/^VERSION_ID=//p;' $release_file)
+    ID=$(sed -n  's/^ID=//p;' $release_file | tr -d '"')
+    VERSION_ID=$(sed -n  's/^VERSION_ID=//p;' $release_file | tr -d '"')
 
     case "$ID" in
          "rhel")
              distro="rhel"
-             version=$VERSION_ID
+             ver=$VERSION_ID
              ;;
          "fedora")
              distro="fedora"

--- a/pki.spec
+++ b/pki.spec
@@ -228,7 +228,6 @@ BuildRequires:     pki-resteasy-core                 >= 3.0.26
 BuildRequires:     pki-resteasy-client               >= 3.0.26
 BuildRequires:     pki-resteasy-servlet-initializer  >= 3.0.26
 BuildRequires:     pki-resteasy-jackson2-provider    >= 3.0.26
-BuildRequires:     pki-resteasy                      >= 3.0.26
 
 BuildRequires:     dogtag-jss >= 5.9
 
@@ -1356,7 +1355,7 @@ export JAVA_HOME=%{java_home}
 %if %{with maven}
 # build Java binaries and run unit tests with Maven
 
-%if 0%{?fedora} && 0%{?fedora} >= %{fedora_cutoff}
+%if 0%{?fedora} && 0%{?fedora} >= %{fedora_cutoff} || 0%{?rhel} >= 10
 %pom_disable_module tomcat-9.0 base
 %pom_remove_dep :pki-tomcat-9.0 base/server
 %else


### PR DESCRIPTION
pki.spec:
Added RHEL10 to conditional in maven tomcat dependency section and removed requirement for pki-resteasy

build.sh:
/etc/os-release file for CentOS 10 was putting quotes around version ID and ID variables. Added a trim to handle these.