### PR TITLE
Rename keytype to MLDSA

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -66,11 +66,11 @@ public class NSSCertRequestCLI extends CommandCLI {
         option.setArgName("path");
         options.addOption(option);
 
-        option = new Option(null, "key-type", true, "Key type: RSA (default), EC, ML-DSA");
+        option = new Option(null, "key-type", true, "Key type: RSA (default), EC, MLDSA");
         option.setArgName("type");
         options.addOption(option);
 
-        option = new Option(null, "key-size", true, "Key size (RSA default: 2048, ML-DSA default: 65)");
+        option = new Option(null, "key-size", true, "Key size (RSA default: 2048, MLDSA default: 65)");
         option.setArgName("size");
         options.addOption(option);
 
@@ -212,7 +212,7 @@ public class NSSCertRequestCLI extends CommandCLI {
                     sensitive,
                     extractable);
 
-        } else if ("ML-DSA".equalsIgnoreCase(keyType)) {
+        } else if ("MLDSA".equalsIgnoreCase(keyType)) {
             String keySize = cmd.getOptionValue("key-size", "65");
             keyPair = nssdb.createMLDSAKeyPair(
                     token,
@@ -280,7 +280,7 @@ public class NSSCertRequestCLI extends CommandCLI {
             } else if ("EC".equalsIgnoreCase(keyType)) {
                 signatureAlgorithm = SignatureAlgorithm.ECSignatureWithSHA256Digest;
 
-            } else if ("ML-DSA".equalsIgnoreCase(keyType)) {
+            } else if ("MLDSA".equalsIgnoreCase(keyType)) {
                 signatureAlgorithm = SignatureAlgorithm.MLDSA;
             } else {
                 throw new Exception("Unknown algorithm: " + keyType);

--- a/docs/changes/v11.9.0/Tools-Changes.adoc
+++ b/docs/changes/v11.9.0/Tools-Changes.adoc
@@ -49,6 +49,6 @@ The following command have been deprecated:
 The algorithm ML-DSA can be specified for the command:
 
 * `pki client-cert-request`: value **mldsa** for the option `--algorithm` and the option `--length` can be one of 44, 65 (default) or 87;
-* `pki nss-cert-request`: value **ML-DSA** for the option `--key-type` and the option `--key-size` can be one of 44, 65 (default) or 87.
+* `pki nss-cert-request`: value **MLDSA** for the option `--key-type` and the option `--key-size` can be one of 44, 65 (default) or 87.
  
 


### PR DESCRIPTION
Profiles and configuration use key type MLDSA so the command has been modified to replace the key type from ML-DSA to MLDSA.