### PR TITLE
Add connection params for pki <subsystem>-* commands

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3736,8 +3736,8 @@ class PKIDeployer:
                 'pki',
                 '-d', self.instance.nssdb_dir,
                 '-f', self.instance.password_conf,
+                'ca-cert-issue',
                 '-U', url,
-                '--skip-revocation-check'
             ]
 
             if credentials:
@@ -3754,8 +3754,8 @@ class PKIDeployer:
                     cmd.extend(['-w', password])
 
             cmd.extend([
+                '--skip-revocation-check',
                 '--ignore-banner',
-                'ca-cert-issue',
                 '--request-type', request_type,
                 '--csr-file', request_file,
                 '--profile', profile
@@ -4394,14 +4394,14 @@ class PKIDeployer:
                 'pki',
                 '-d', self.instance.nssdb_dir,
                 '-f', self.instance.password_conf,
-                '-U', subsystem_url,
-                '--ignore-banner',
-                '--skip-revocation-check',
                 '%s-user-add' % subsystem_type,
-                uid,
+                '-U', subsystem_url,
+                '--skip-revocation-check',
+                '--ignore-banner',
                 '--security-domain', sd_url,
                 '--install-token', install_token,
-                '--fullName', full_name
+                '--fullName', full_name,
+                uid
             ]
 
             if cert:
@@ -4428,11 +4428,11 @@ class PKIDeployer:
             'pki',
             '-d', self.instance.nssdb_dir,
             '-f', self.instance.password_conf,
+            'ca-cert-signing-export',
             '-U', ca_url,
+            '--skip-revocation-check',
             '--ignore-cert-status', 'UNTRUSTED_ISSUER,UNKNOWN_ISSUER',
             '--ignore-banner',
-            '--skip-revocation-check',
-            'ca-cert-signing-export',
             '--pkcs7'
         ]
 
@@ -4453,10 +4453,10 @@ class PKIDeployer:
             'pki',
             '-d', self.instance.nssdb_dir,
             '-f', self.instance.password_conf,
+            'ca-cert-subsystem-export',
             '-U', ca_url,
-            '--ignore-banner',
             '--skip-revocation-check',
-            'ca-cert-subsystem-export'
+            '--ignore-banner'
         ]
 
         if logger.isEnabledFor(logging.DEBUG):
@@ -4499,10 +4499,10 @@ class PKIDeployer:
                 'pki',
                 '-d', self.instance.nssdb_dir,
                 '-f', self.instance.password_conf,
-                '-U', ca_url,
-                '--ignore-banner',
-                '--skip-revocation-check',
                 'ca-kraconnector-add',
+                '-U', ca_url,
+                '--skip-revocation-check',
+                '--ignore-banner',
                 '--url', kra_url,
                 '--subsystem-cert', subsystem_cert_file,
                 '--transport-cert', transport_cert_file,
@@ -4546,9 +4546,9 @@ class PKIDeployer:
                 'pki',
                 '-d', self.instance.nssdb_dir,
                 '-f', self.instance.password_conf,
+                'ca-publisher-ocsp-add',
                 '-U', ca_url,
                 '--ignore-banner',
-                'ca-publisher-ocsp-add',
                 '--url', ocsp_url,
                 '--subsystem-cert', subsystem_cert_file,
                 '--install-token', install_token
@@ -4574,10 +4574,10 @@ class PKIDeployer:
             'pki',
             '-d', self.instance.nssdb_dir,
             '-f', self.instance.password_conf,
+            'kra-cert-transport-export',
             '-U', kra_url,
-            '--ignore-banner',
             '--skip-revocation-check',
-            'kra-cert-transport-export'
+            '--ignore-banner'
         ]
 
         if logger.isEnabledFor(logging.DEBUG):
@@ -4614,10 +4614,10 @@ class PKIDeployer:
                 'pki',
                 '-d', self.instance.nssdb_dir,
                 '-f', self.instance.password_conf,
-                '-U', tks_url,
-                '--ignore-banner',
-                '--skip-revocation-check',
                 'tks-cert-transport-import',
+                '-U', tks_url,
+                '--skip-revocation-check',
+                '--ignore-banner',
                 '--security-domain', sd_url,
                 '--install-token', install_token,
                 nickname
@@ -4659,13 +4659,13 @@ class PKIDeployer:
 
         cmd = [
             'pki',
-            '-U', tks_uri,
             '-d', self.instance.nssdb_dir,
             '-f', self.instance.password_conf,
-            '-n', nickname,
-            '--ignore-banner',
-            '--skip-revocation-check',
             'tks-tpsconnector-show',
+            '-U', tks_uri,
+            '-n', nickname,
+            '--skip-revocation-check',
+            '--ignore-banner',
             '--host', self.mdict['pki_hostname'],
             '--port', https_port
         ]
@@ -4694,13 +4694,13 @@ class PKIDeployer:
 
         cmd = [
             'pki',
-            '-U', tks_uri,
             '-d', self.instance.nssdb_dir,
             '-f', self.instance.password_conf,
-            '-n', nickname,
-            '--ignore-banner',
-            '--skip-revocation-check',
             'tks-tpsconnector-add',
+            '-U', tks_uri,
+            '-n', nickname,
+            '--skip-revocation-check',
+            '--ignore-banner',
             '--host', self.mdict['pki_hostname'],
             '--port', https_port,
             '--output-format', 'json'
@@ -4727,13 +4727,14 @@ class PKIDeployer:
 
         cmd = [
             'pki',
-            '-U', tks_uri,
             '-d', self.instance.nssdb_dir,
             '-f', self.instance.password_conf,
+            'tks-key-export',
+            '-U', tks_uri,
             '-n', nickname,
-            '--ignore-banner',
             '--skip-revocation-check',
-            'tks-key-export', tps_connector_id
+            '--ignore-banner',
+            tps_connector_id
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))
@@ -4757,14 +4758,15 @@ class PKIDeployer:
 
         cmd = [
             'pki',
-            '-U', tks_uri,
             '-d', self.instance.nssdb_dir,
             '-f', self.instance.password_conf,
+            'tks-key-create',
+            '-U', tks_uri,
             '-n', nickname,
-            '--ignore-banner',
             '--skip-revocation-check',
-            'tks-key-create', tps_connector_id,
-            '--output-format', 'json'
+            '--ignore-banner',
+            '--output-format', 'json',
+            tps_connector_id
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))
@@ -4788,14 +4790,15 @@ class PKIDeployer:
 
         cmd = [
             'pki',
-            '-U', tks_uri,
             '-d', self.instance.nssdb_dir,
             '-f', self.instance.password_conf,
             '-n', nickname,
-            '--ignore-banner',
+            'tks-key-replace',
+            '-U', tks_uri,
             '--skip-revocation-check',
-            'tks-key-replace', tps_connector_id,
-            '--output-format', 'json'
+            '--ignore-banner',
+            '--output-format', 'json',
+            tps_connector_id
         ]
 
         logger.debug('Command: %s', ' '.join(cmd))

--- a/base/server/python/pki/server/deployment/pkihelper.py
+++ b/base/server/python/pki/server/deployment/pkihelper.py
@@ -812,10 +812,10 @@ class KRAConnector:
                     'pki',
                     '-d', instance.nssdb_dir,
                     '-f', instance.password_conf,
+                    'ca-kraconnector-del',
                     '-U', ca_url,
                     '-n', subsystemnick,
                     '--ignore-banner',
-                    'ca-kraconnector-del',
                     '--host', krahost,
                     '--port', str(kraport)
                 ]
@@ -901,13 +901,13 @@ class TPSConnector:
         try:
             cmd = [
                 'pki',
-                '-U', tks_url,
-                '-n', subsystemnick,
                 '-d', instance.nssdb_dir,
                 '-f', instance.password_conf,
-                '--ignore-banner',
-                '--skip-revocation-check',
                 'tks-tpsconnector-del',
+                '-U', tks_url,
+                '-n', subsystemnick,
+                '--skip-revocation-check',
+                '--ignore-banner',
                 '--host', tpshost,
                 '--port', str(tpsport)
             ]

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1513,13 +1513,13 @@ class PKISubsystem(object):
                 'pki',
                 '-d', self.instance.nssdb_dir,
                 '-f', self.instance.password_conf,
-                '-U', master_url,
-                '--ignore-banner',
-                '--skip-revocation-check',
                 '%s-range-request' % self.name,
-                range_type,
+                '-U', master_url,
+                '--skip-revocation-check',
+                '--ignore-banner',
                 '--install-token', install_token,
-                '--output-format', 'json'
+                '--output-format', 'json',
+                range_type
             ]
 
             if logger.isEnabledFor(logging.DEBUG):
@@ -1623,10 +1623,10 @@ class PKISubsystem(object):
                 'pki',
                 '-d', self.instance.nssdb_dir,
                 '-f', self.instance.password_conf,
-                '-U', master_url,
-                '--ignore-banner',
-                '--skip-revocation-check',
                 '%s-config-export' % self.name,
+                '-U', master_url,
+                '--skip-revocation-check',
+                '--ignore-banner',
                 '--names', ','.join(names),
                 '--substores', ','.join(substores),
                 '--install-token', install_token,

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/SubsystemCommandCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/SubsystemCommandCLI.java
@@ -5,11 +5,18 @@
 //
 package com.netscape.cmstools.cli;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
 import org.dogtagpki.cli.CLI;
+import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.cli.CommandCLI;
 
 import com.netscape.certsrv.account.AccountClient;
 import com.netscape.certsrv.client.ClientConfig;
+import com.netscape.certsrv.client.PKICertificateApprovalCallback;
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.client.SubsystemClient;
 
@@ -21,6 +28,20 @@ import com.netscape.certsrv.client.SubsystemClient;
 public class SubsystemCommandCLI extends CommandCLI {
 
     public SubsystemCLI subsystemCLI;
+
+    String serverURL;
+    String certNickname;
+    String username;
+    String password;
+    String passwordFile;
+
+    boolean skipRevocationCheck;
+    Collection<Integer> rejectedCertStatuses = new ArrayList<>();
+    Collection<Integer> ignoredCertStatuses = new ArrayList<>();
+
+    String apiVersion;
+    boolean ignoreBanner;
+    String httpOutput;
 
     public SubsystemCommandCLI(String name, String description, CLI parent) {
         super(name, description, parent);
@@ -39,9 +60,143 @@ public class SubsystemCommandCLI extends CommandCLI {
         }
     }
 
+    @Override
+    public void createOptions() {
+
+        super.createOptions();
+
+        Option option = new Option("U", true, "Server URL");
+        option.setArgName("uri");
+        options.addOption(option);
+
+        option = new Option("n", true, "Nickname for client certificate authentication");
+        option.setArgName("nickname");
+        options.addOption(option);
+
+        option = new Option("u", true, "Username for basic authentication");
+        option.setArgName("username");
+        options.addOption(option);
+
+        option = new Option("w", true, "Password for basic authentication");
+        option.setArgName("password");
+        options.addOption(option);
+
+        option = new Option("W", true, "Password file for basic authentication");
+        option.setArgName("passwordfile");
+        options.addOption(option);
+
+        option = new Option(null, "skip-revocation-check", false, "Do not perform revocation check");
+        options.addOption(option);
+
+        option = new Option(null, "reject-cert-status", true, "Comma-separated list of rejected certificate validity statuses");
+        option.setArgName("list");
+        options.addOption(option);
+
+        option = new Option(null, "ignore-cert-status", true, "Comma-separated list of ignored certificate validity statuses");
+        option.setArgName("list");
+        options.addOption(option);
+
+        option = new Option(null, "api", true, "API version: v1, v2");
+        option.setArgName("version");
+        options.addOption(option);
+
+        option = new Option(null, "ignore-banner", false, "Ignore access banner");
+        options.addOption(option);
+
+        option = new Option(null, "http-output", true, "Folder to store HTTP messages");
+        option.setArgName("folder");
+        options.addOption(option);
+    }
+
+    @Override
+    public CommandLine parseOptions(String[] args) throws Exception {
+
+        CommandLine cmd = super.parseOptions(args);
+
+        serverURL = cmd.getOptionValue("U");
+
+        certNickname = cmd.getOptionValue("n");
+        if (serverURL == null && certNickname != null) {
+            throw new CLIException("The -n option requires a -U option.");
+        }
+
+        username = cmd.getOptionValue("u");
+        if (serverURL == null && username != null) {
+            throw new CLIException("The -u option requires a -U option.");
+        }
+
+        password = cmd.getOptionValue("w");
+        if (serverURL == null && password != null) {
+            throw new CLIException("The -w option requires a -U option.");
+        }
+
+        passwordFile = cmd.getOptionValue("W");
+        if (serverURL == null && passwordFile != null) {
+            throw new CLIException("The -W option requires a -U option.");
+        }
+
+        skipRevocationCheck = cmd.hasOption("skip-revocation-check");
+        if (serverURL == null && skipRevocationCheck) {
+            throw new CLIException("The --skip-revocation-check option requires a -U option.");
+        }
+
+        String list = cmd.getOptionValue("reject-cert-status");
+        if (serverURL == null && list != null) {
+            throw new CLIException("The --reject-cert-status option requires a -U option.");
+        }
+        MainCLI.convertCertStatusList(list, rejectedCertStatuses);
+
+        list = cmd.getOptionValue("ignore-cert-status");
+        if (serverURL == null && list != null) {
+            throw new CLIException("The --ignore-cert-status option requires a -U option.");
+        }
+        MainCLI.convertCertStatusList(list, ignoredCertStatuses);
+
+        apiVersion = cmd.getOptionValue("api", "rest");
+
+        ignoreBanner = cmd.hasOption("ignore-banner");
+        if (serverURL == null && ignoreBanner) {
+            throw new CLIException("The --ignore-banner option requires a -U option.");
+        }
+
+        httpOutput = cmd.getOptionValue("http-output");
+        if (serverURL == null && httpOutput != null) {
+            throw new CLIException("The --http-output option requires a -U option.");
+        }
+
+        return cmd;
+    }
+
     public PKIClient getPKIClient() throws Exception {
+
         MainCLI mainCLI = (MainCLI) getRoot();
-        return mainCLI.getPKIClient();
+
+        if (serverURL == null) {
+            // use shared PKIClient
+            return mainCLI.getPKIClient();
+        }
+
+        // create new PKIClient for this command
+
+        ClientConfig config = new ClientConfig(mainCLI.config);
+        config.setServerURL(serverURL);
+        config.setCertNickname(certNickname);
+        config.setUsername(username);
+
+        if (password == null) {
+            if (passwordFile != null) {
+                password = mainCLI.loadPassword(passwordFile);
+            }
+        }
+        config.setPassword(password);
+
+        config.setCertRevocationVerify(!skipRevocationCheck);
+
+        PKICertificateApprovalCallback callback = new PKICertificateApprovalCallback();
+        callback.reject(rejectedCertStatuses);
+        callback.ignore(ignoredCertStatuses);
+
+        return MainCLI.createPKIClient(config, callback, apiVersion, ignoreBanner, httpOutput);
     }
 
     public SubsystemClient getSubsystemClient(PKIClient client) throws Exception {
@@ -63,7 +218,7 @@ public class SubsystemCommandCLI extends CommandCLI {
         if (config.getUsername() != null || config.getCertNickname() != null) {
 
             // connect to the server
-            client = mainCLI.getPKIClient();
+            client = getPKIClient();
 
             // connect to the subsystem
             subsystemClient = getSubsystemClient(client);

--- a/docs/changes/v11.9.0/Tools-Changes.adoc
+++ b/docs/changes/v11.9.0/Tools-Changes.adoc
@@ -51,4 +51,6 @@ The algorithm ML-DSA can be specified for the command:
 * `pki client-cert-request`: value **mldsa** for the option `--algorithm` and the option `--length` can be one of 44, 65 (default) or 87;
 * `pki nss-cert-request`: value **MLDSA** for the option `--key-type` and the option `--key-size` can be one of 44, 65 (default) or 87.
  
+== Add `pki --http-output` option ==
 
+The `pki --http-output` option has been added to replace the `--output` option.


### PR DESCRIPTION
Previously the connection params (e.g. server URL, username, password, nickname) for PKI CLI had to be specified globally (i.e. `pki <connection> <command>`) and they would be used by all commands running in shell/batch mode.

To support connections to multiple servers in shell/batch mode, the subsystem commands have been modified to provide command-specific connection params (i.e. `pki <subsystem>-* <connection>`).

The `SubsystemCommandCLI` has been modified to define the connection options for all subsystem commands and also parse the specified params. If the server URL is specified the command will use the specified connection params, otherwise it will use the global connection params.

The `pki --http-output` option has been added to replace the `--output` option to avoid conflicts with existing command options with the same name.

The Python code used by `pkispawn`/`pkidestroy` has been modified to use the command-specific connection params such that later it will be able to use the shell/batch mode.

https://github.com/edewata/pki/blob/refs/heads/cli/docs/changes/v11.9.0/Tools-Changes.adoc

For example, [this command](https://github.com/dogtagpki/pki/actions/runs/19753578308/job/56601399503#step:14:25) which is executed by `pkispawn`:
```
$ pki \
    -d /var/lib/pki/pki-tomcat/conf/alias \
    -f /var/lib/pki/pki-tomcat/conf/password.conf \
    -U https://pki.example.com:8443/ \
    --ignore-cert-status UNTRUSTED_ISSUER,UNKNOWN_ISSUER \
    --ignore-banner \
    --skip-revocation-check \
    ca-cert-signing-export \
    --pkcs7 \
    --debug
```
will turn into [this command](https://github.com/dogtagpki/pki/actions/runs/19835309857/job/56834366301#step:14:25):
```
$ pki \
    -d /var/lib/pki/pki-tomcat/conf/alias \
    -f /var/lib/pki/pki-tomcat/conf/password.conf \
    ca-cert-signing-export \
    -U https://pki.example.com:8443/ \
    --skip-revocation-check \
    --ignore-cert-status UNTRUSTED_ISSUER,UNKNOWN_ISSUER \
    --ignore-banner \
    --pkcs7 \
    --debug
```
Later when it's converted into shell/batch mode it will become:
```
$ pki \
    -d /var/lib/pki/pki-tomcat/conf/alias \
    -f /var/lib/pki/pki-tomcat/conf/password.conf
pki> ca-cert-signing-export \
    -U https://pki.example.com:8443/ \
    --skip-revocation-check \
    --ignore-cert-status UNTRUSTED_ISSUER,UNKNOWN_ISSUER \
    --ignore-banner \
    --pkcs7 \
    --debug
```
