### PR TITLE
Remove check for pki log folder

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -202,7 +202,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -853,7 +852,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/acme-container-basic-test.yml
+++ b/.github/workflows/acme-container-basic-test.yml
@@ -148,7 +148,6 @@ jobs:
           # TODO: review owners/permissions
           cat > expected << EOF
           -rw-rw-rw- root localhost_access_log.$DATE.txt
-          drwxrwxrwx root pki
           EOF
 
           diff expected output

--- a/.github/workflows/acme-existing-nssdb-test.yml
+++ b/.github/workflows/acme-existing-nssdb-test.yml
@@ -224,7 +224,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           drwxr-x--- pkiuser pkiuser backup
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -817,7 +816,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           drwxr-x--- pkiuser pkiuser backup
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -231,7 +231,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser backup
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -858,7 +857,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser backup
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -173,7 +173,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -674,7 +673,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -151,7 +151,6 @@ jobs:
           drwxrwxrwx runner backup
           drwxrwxrwx runner ca
           -rw-rw-rw- runner localhost_access_log.$DATE.txt
-          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -257,7 +257,6 @@ jobs:
           drwxrwxrwx runner backup
           drwxrwxrwx runner ca
           -rw-rw-rw- runner localhost_access_log.$DATE.txt
-          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-container-existing-config-test.yml
+++ b/.github/workflows/ca-container-existing-config-test.yml
@@ -266,7 +266,6 @@ jobs:
           drwxrwxrwx root backup
           drwxrwxrwx root ca
           -rw-rw-rw- root localhost_access_log.$DATE.txt
-          drwxrwxrwx root pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-container-migration-test.yml
+++ b/.github/workflows/ca-container-migration-test.yml
@@ -278,7 +278,6 @@ jobs:
           drwxrwxrwx pkiuser backup
           drwxrwxrwx pkiuser ca
           -rw-rw-rw- pkiuser localhost_access_log.$DATE.txt
-          drwxrwxrwx pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-container-system-service-test.yml
+++ b/.github/workflows/ca-container-system-service-test.yml
@@ -230,7 +230,6 @@ jobs:
           drwxrwxrwx pkiuser backup
           drwxrwxrwx pkiuser ca
           -rw-rw-rw- pkiuser localhost_access_log.$DATE.txt
-          drwxrwxrwx pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-container-user-service-test.yml
+++ b/.github/workflows/ca-container-user-service-test.yml
@@ -263,7 +263,6 @@ jobs:
           drwxrwxrwx pkiuser backup
           drwxrwxrwx pkiuser ca
           -rw-rw-rw- pkiuser localhost_access_log.$DATE.txt
-          drwxrwxrwx pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ca-existing-config-test.yml
+++ b/.github/workflows/ca-existing-config-test.yml
@@ -202,7 +202,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/est-ds-realm-separate-test.yml
+++ b/.github/workflows/est-ds-realm-separate-test.yml
@@ -174,7 +174,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser est
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -319,7 +318,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser est
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/est-ds-realm-test.yml
+++ b/.github/workflows/est-ds-realm-test.yml
@@ -187,7 +187,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -546,7 +545,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/est-postgresql-realm-test.yml
+++ b/.github/workflows/est-postgresql-realm-test.yml
@@ -258,7 +258,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -540,7 +539,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/est-standalone-test.yml
+++ b/.github/workflows/est-standalone-test.yml
@@ -221,7 +221,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser est
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -388,7 +387,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser est
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -219,7 +219,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -1279,7 +1278,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -400,7 +400,6 @@ jobs:
           drwxrwxrwx runner backup
           drwxrwxrwx runner kra
           -rw-rw-rw- runner localhost_access_log.$DATE.txt
-          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/kra-existing-config-test.yml
+++ b/.github/workflows/kra-existing-config-test.yml
@@ -166,7 +166,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -248,7 +248,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output
@@ -909,7 +908,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -376,7 +376,6 @@ jobs:
           drwxrwxrwx runner backup
           -rw-rw-rw- runner localhost_access_log.$DATE.txt
           drwxrwxrwx runner ocsp
-          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/ocsp-existing-config-test.yml
+++ b/.github/workflows/ocsp-existing-config-test.yml
@@ -166,7 +166,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
-          drwxr-xr-x pkiuser pkiuser pki
           EOF
 
           diff expected output

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -115,7 +115,6 @@ jobs:
           # TODO: review owners/permissions
           cat > expected << EOF
           -rw-rw-rw- runner localhost_access_log.$DATE.txt
-          drwxrwxrwx runner pki
           EOF
 
           diff expected output

--- a/.github/workflows/server-https-nss-test.yml
+++ b/.github/workflows/server-https-nss-test.yml
@@ -385,8 +385,3 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Check PKI debug log
-        if: always()
-        run: |
-          docker exec pki find /var/lib/pki/pki-tomcat/logs/pki -name "debug.*" -exec cat {} \;

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -163,7 +163,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           EOF
 
@@ -324,7 +323,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           EOF
 

--- a/.github/workflows/tks-container-test.yml
+++ b/.github/workflows/tks-container-test.yml
@@ -364,7 +364,6 @@ jobs:
           cat > expected << EOF
           drwxrwxrwx runner backup
           -rw-rw-rw- runner localhost_access_log.$DATE.txt
-          drwxrwxrwx runner pki
           drwxrwxrwx runner tks
           EOF
 

--- a/.github/workflows/tks-existing-config-test.yml
+++ b/.github/workflows/tks-existing-config-test.yml
@@ -165,7 +165,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           EOF
 

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -186,7 +186,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           drwxrwx--- pkiuser pkiuser tps
           EOF
@@ -596,7 +595,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           drwxrwx--- pkiuser pkiuser tps
           EOF

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -731,7 +731,6 @@ jobs:
           cat > expected << EOF
           drwxrwxrwx runner backup
           -rw-rw-rw- runner localhost_access_log.$DATE.txt
-          drwxrwxrwx runner pki
           drwxrwxrwx runner tps
           EOF
 

--- a/.github/workflows/tps-existing-config-test.yml
+++ b/.github/workflows/tps-existing-config-test.yml
@@ -188,7 +188,6 @@ jobs:
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
-          drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
           drwxrwx--- pkiuser pkiuser tps
           EOF


### PR DESCRIPTION
Remove the check to pki logs folder because it is not always present.

Tomcat 10.1 [1] has modified the logging system introducing a lazy creation so log folder and file are created only if there is something to write. Therefore, the pki folder for pki webapps logs is not created since at default logging level there should be no logs.

1. https://fedoraproject.org/wiki/Changes/Tomcat10ChangeProposal#Detailed_Description