### PR TITLE
Convert pki-server <subsystem>-db-* commands to Java

### DIFF
--- a/base/server/python/pki/server/cli/db.py
+++ b/base/server/python/pki/server/cli/db.py
@@ -663,40 +663,6 @@ class SubsystemDBCreateCLI(pki.cli.CLI):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.name))
 
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        subsystem_name = self.parent.parent.name
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error('No %s subsystem in instance %s',
-                         subsystem_name.upper(), instance_name)
-            sys.exit(1)
-
-        subsystem.create_database()
-
 
 class SubsystemDBInitCLI(pki.cli.CLI):
     '''
@@ -760,49 +726,6 @@ class SubsystemDBInitCLI(pki.cli.CLI):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.name))
 
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        subsystem_name = self.parent.parent.name
-
-        skip_config = args.skip_config
-        skip_schema = args.skip_schema
-        skip_base = args.skip_base
-        skip_containers = args.skip_containers
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error('No %s subsystem in instance %s',
-                         subsystem_name.upper(), instance_name)
-            sys.exit(1)
-
-        subsystem.init_database(
-            skip_config=skip_config,
-            skip_schema=skip_schema,
-            skip_base=skip_base,
-            skip_containers=skip_containers)
-
 
 class SubsystemDBEmptyCLI(pki.cli.CLI):
 
@@ -848,44 +771,6 @@ class SubsystemDBEmptyCLI(pki.cli.CLI):
         print('      --help                         Show help message.')
         print()
 
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        subsystem_name = self.parent.parent.name
-        force = args.force
-        as_current_user = args.as_current_user
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error('No %s subsystem in instance %s',
-                         subsystem_name.upper(), instance_name)
-            sys.exit(1)
-
-        subsystem.empty_database(
-            force=force,
-            as_current_user=as_current_user)
-
 
 class SubsystemDBRemoveCLI(pki.cli.CLI):
 
@@ -930,44 +815,6 @@ class SubsystemDBRemoveCLI(pki.cli.CLI):
         print('      --debug                        Run in debug mode.')
         print('      --help                         Show help message.')
         print()
-
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        subsystem_name = self.parent.parent.name
-        force = args.force
-        as_current_user = args.as_current_user
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error('No %s subsystem in instance %s',
-                         subsystem_name.upper(), instance_name)
-            sys.exit(1)
-
-        subsystem.remove_database(
-            force=force,
-            as_current_user=as_current_user)
 
 
 class SubsystemDBUpgradeCLI(pki.cli.CLI):
@@ -1120,46 +967,6 @@ class SubsystemDBAccessGrantCLI(pki.cli.CLI):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        subsystem_name = self.parent.parent.parent.name
-        as_current_user = args.as_current_user
-        dn = args.dn
-
-        if dn is None:
-            raise pki.cli.CLIException('Missing DN')
-
-        instance = pki.server.instance.PKIInstance(instance_name)
-
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error('No %s subsystem in instance %s.',
-                         subsystem_name.upper(), instance_name)
-            sys.exit(1)
-
-        subsystem.grant_database_access(dn, as_current_user=as_current_user)
-
 
 class SubsystemDBAccessRevokeCLI(pki.cli.CLI):
     '''
@@ -1213,46 +1020,6 @@ class SubsystemDBAccessRevokeCLI(pki.cli.CLI):
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
-
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        subsystem_name = self.parent.parent.parent.name
-        as_current_user = args.as_current_user
-        dn = args.dn
-
-        if dn is None:
-            raise pki.cli.CLIException('Missing DN')
-
-        instance = pki.server.instance.PKIInstance(instance_name)
-
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error('No %s subsystem in instance %s.',
-                         subsystem_name.upper(), instance_name)
-            sys.exit(1)
-
-        subsystem.revoke_database_access(dn, as_current_user=as_current_user)
 
 
 class SubsystemDBIndexCLI(pki.cli.CLI):
@@ -1317,41 +1084,6 @@ class SubsystemDBIndexAddCLI(pki.cli.CLI):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
 
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        subsystem_name = self.parent.parent.parent.name
-
-        instance = pki.server.instance.PKIInstance(instance_name)
-
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error('No %s subsystem in instance %s.',
-                         subsystem_name.upper(), instance_name)
-            sys.exit(1)
-
-        subsystem.add_indexes()
-
 
 class SubsystemDBIndexRebuildCLI(pki.cli.CLI):
     '''
@@ -1398,41 +1130,6 @@ class SubsystemDBIndexRebuildCLI(pki.cli.CLI):
     def print_help(self):
         print(textwrap.dedent(self.__class__.help).format(
             subsystem=self.parent.parent.parent.name))
-
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        subsystem_name = self.parent.parent.parent.name
-
-        instance = pki.server.instance.PKIInstance(instance_name)
-
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem(subsystem_name)
-
-        if not subsystem:
-            logger.error('No %s subsystem in instance %s.',
-                         subsystem_name.upper(), instance_name)
-            sys.exit(1)
-
-        subsystem.rebuild_indexes()
 
 
 class SubsystemDBReplicationCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1162,7 +1162,11 @@ class PKISubsystem(object):
 
     def create_database(self):
 
-        cmd = [self.name + '-db-create']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            self.name + '-db-create'
+        ]
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -1170,7 +1174,8 @@ class PKISubsystem(object):
         elif logger.isEnabledFor(logging.INFO):
             cmd.append('--verbose')
 
-        self.run(cmd)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     # pylint: disable=W0613
     def init_database(
@@ -1183,7 +1188,11 @@ class PKISubsystem(object):
             skip_reindex=False,
             as_current_user=False):
 
-        cmd = [self.name + '-db-init']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            self.name + '-db-init'
+        ]
 
         if skip_config:
             cmd.append('--skip-config')
@@ -1203,11 +1212,16 @@ class PKISubsystem(object):
         elif logger.isEnabledFor(logging.INFO):
             cmd.append('--verbose')
 
-        self.run(cmd, as_current_user=as_current_user)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     def add_indexes(self):
 
-        cmd = [self.name + '-db-index-add']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            self.name + '-db-index-add'
+        ]
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -1215,12 +1229,17 @@ class PKISubsystem(object):
         elif logger.isEnabledFor(logging.INFO):
             cmd.append('--verbose')
 
-        self.run(cmd)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     # pylint: disable=W0613
     def rebuild_indexes(self, ds_backend=None):
 
-        cmd = [self.name + '-db-index-rebuild']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            self.name + '-db-index-rebuild'
+        ]
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -1228,11 +1247,16 @@ class PKISubsystem(object):
         elif logger.isEnabledFor(logging.INFO):
             cmd.append('--verbose')
 
-        self.run(cmd)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     def empty_database(self, force=False, as_current_user=False):
 
-        cmd = [self.name + '-db-empty']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            self.name + '-db-empty'
+        ]
 
         if force:
             cmd.append('--force')
@@ -1243,11 +1267,16 @@ class PKISubsystem(object):
         elif logger.isEnabledFor(logging.INFO):
             cmd.append('--verbose')
 
-        self.run(cmd, as_current_user=as_current_user)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     def remove_database(self, force=False, as_current_user=False):
 
-        cmd = [self.name + '-db-remove']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            self.name + '-db-remove'
+        ]
 
         if force:
             cmd.append('--force')
@@ -1258,14 +1287,19 @@ class PKISubsystem(object):
         elif logger.isEnabledFor(logging.INFO):
             cmd.append('--verbose')
 
-        self.run(cmd, as_current_user=as_current_user)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     def grant_database_access(
             self,
             dn,
             as_current_user=False):
 
-        cmd = [self.name + '-db-access-grant']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            self.name + '-db-access-grant'
+        ]
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -1275,17 +1309,19 @@ class PKISubsystem(object):
 
         cmd.append(dn)
 
-        self.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            as_current_user=as_current_user)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     def revoke_database_access(
             self,
             dn,
             as_current_user=False):
 
-        cmd = [self.name + '-db-access-revoke']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            self.name + '-db-access-revoke'
+        ]
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -1295,10 +1331,8 @@ class PKISubsystem(object):
 
         cmd.append(dn)
 
-        self.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            as_current_user=as_current_user)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     def enable_replication(
             self,

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBEmptyCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBEmptyCLI.java
@@ -9,7 +9,6 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
 import org.dogtagpki.cli.CLI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,14 +41,6 @@ public class SubsystemDBEmptyCLI extends ServerCommandCLI {
     public void createOptions() {
 
         super.createOptions();
-
-        Option option = new Option("d", true, "NSS database location");
-        option.setArgName("database");
-        options.addOption(option);
-
-        option = new Option("f", true, "NSS database password configuration");
-        option.setArgName("password config");
-        options.addOption(option);
 
         options.addOption(null, "force", false, "Force");
     }

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBInitCLI.java
@@ -6,7 +6,6 @@
 package org.dogtagpki.server.cli;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
 import org.dogtagpki.cli.CLI;
 import org.slf4j.Logger;
@@ -50,14 +49,6 @@ public class SubsystemDBInitCLI extends ServerCommandCLI {
     public void createOptions() {
 
         super.createOptions();
-
-        Option option = new Option("d", true, "NSS database location");
-        option.setArgName("database");
-        options.addOption(option);
-
-        option = new Option("f", true, "NSS database password configuration");
-        option.setArgName("password config");
-        options.addOption(option);
 
         options.addOption(null, "skip-config", false, "Skip DS server configuration");
         options.addOption(null, "skip-schema", false, "Skip DS schema setup");

--- a/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBRemoveCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/SubsystemDBRemoveCLI.java
@@ -9,7 +9,6 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
 import org.dogtagpki.cli.CLI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,14 +41,6 @@ public class SubsystemDBRemoveCLI extends ServerCommandCLI {
     public void createOptions() {
 
         super.createOptions();
-
-        Option option = new Option("d", true, "NSS database location");
-        option.setArgName("database");
-        options.addOption(option);
-
-        option = new Option("f", true, "NSS database password configuration");
-        option.setArgName("password config");
-        options.addOption(option);
 
         options.addOption(null, "force", false, "Force");
     }


### PR DESCRIPTION
The `pki-server` commands are mainly implemented in Python which will use PKI Python API, but if the API needs to use NSS, LDAP, or PKI Java API it will call an external Java code and each call will require separate NSS authentications.

To avoid this problem some of the `pki-server <subsystem>-db-*` commands used by `pkispawn`/`pkidestroy` have been converted to run the corresponding Java code directly so later they can be executed in shell/batch mode which only requires a single NSS authentication.

The methods in `PKISubsystem` that call these commands have been modified to call `pki-server` so later these calls can be converted into shell/batch mode.

A new global `-i` option has been added to `pki-server` CLI to specify the instance name. This later can be used to specify the instance name for all commands executed in shell/batch mode.

The result of these changes can be seen below:
https://github.com/dogtagpki/pki/actions/runs/20109288706/job/57708722622#step:11:199