### PR TITLE
Convert pki-server ca-cert/profile-* to Java

### DIFF
--- a/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCLI.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/cli/CACertCLI.java
@@ -5,7 +5,16 @@
 //
 package org.dogtagpki.server.ca.cli;
 
+import java.security.SecureRandom;
+
 import org.dogtagpki.cli.CLI;
+
+import com.netscape.certsrv.request.RequestId;
+import com.netscape.cmscore.base.ConfigStore;
+import com.netscape.cmscore.dbs.DBSubsystem;
+import com.netscape.cmscore.dbs.Repository.IDGenerator;
+import com.netscape.cmscore.request.CertRequestRepository;
+import com.netscape.cmscore.request.Request;
 
 /**
  * @author Endi S. Dewata
@@ -21,5 +30,46 @@ public class CACertCLI extends CLI {
         addModule(new CACertRemoveCLI(this));
 
         addModule(new CACertRequestCLI(this));
+    }
+
+    public static Request importCertRequest(
+            SecureRandom secureRandom,
+            DBSubsystem dbSubsystem,
+            RequestId requestID,
+            String requestType,
+            byte[] csrBytes,
+            String[] dnsNames,
+            ConfigStore profileConfig,
+            boolean adjustValidity) throws Exception {
+
+        CertRequestRepository requestRepository = new CertRequestRepository(secureRandom, dbSubsystem);
+        requestRepository.init();
+
+        // generate request ID if not provided
+        if (requestID == null) {
+            if (requestRepository.getIDGenerator() != IDGenerator.RANDOM) {
+                throw new Exception("Unable to generate random request ID");
+            }
+            requestID = requestRepository.createRequestID();
+        }
+
+        Request request = requestRepository.createRequest(requestID, "enrollment");
+
+        requestRepository.updateRequest(
+                request,
+                requestType,
+                csrBytes,
+                dnsNames);
+
+        requestRepository.updateRequest(
+                request,
+                profileConfig.getString("id"),
+                profileConfig.getString("profileIDMapping"),
+                profileConfig.getString("profileSetIDMapping"),
+                adjustValidity);
+
+        requestRepository.updateRequest(request);
+
+        return request;
     }
 }

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -83,7 +83,12 @@ JAVA_COMMANDS = [
     r'[^-]*-group-member-find$',
     r'[^-]*-group-member-add$',
     r'[^-]*-group-member-del$',
-    r'ca-profile-import$'
+    r'ca-profile-import$',
+    r'ca-cert-request-import$',
+    r'ca-cert-find$',
+    r'ca-cert-create$',
+    r'ca-cert-import$',
+    r'ca-cert-del$'
 ]
 
 

--- a/base/server/python/pki/server/cli/ca.py
+++ b/base/server/python/pki/server/cli/ca.py
@@ -123,39 +123,6 @@ class CACertFindCLI(pki.cli.CLI):
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        status = args.status
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem('ca')
-        if not subsystem:
-            logger.error('No CA subsystem in instance %s', instance_name)
-            sys.exit(1)
-
-        subsystem.find_certs(
-            status=status)
-
 
 class CACertCreateCLI(pki.cli.CLI):
     '''
@@ -235,82 +202,6 @@ class CACertCreateCLI(pki.cli.CLI):
     def print_help(self):
         print(textwrap.dedent(self.__class__.help))
 
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        csr_path = args.csr
-        csr_format = args.csr_format
-        request_id = args.request
-        profile_path = args.profile
-        cert_type = args.type
-        key_id = args.key_id
-        key_token = args.key_token
-        key_algorithm = args.key_algorithm
-        signing_algorithm = args.signing_algorithm
-        serial = args.serial
-        cert_format = args.format
-        cert_path = args.cert
-        import_cert = args.import_cert
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem('ca')
-        if not subsystem:
-            logger.error('No CA subsystem in instance %s', instance_name)
-            sys.exit(1)
-
-        # if request ID is missing, import the CSR
-        if not request_id:
-            result = subsystem.import_cert_request(
-                request_path=csr_path,
-                request_format=csr_format,
-                profile_path=profile_path)
-
-            request_id = result['requestID']
-
-        cert_data = subsystem.create_cert(
-            request_id=request_id,
-            profile_path=profile_path,
-            cert_type=cert_type,
-            key_token=key_token,
-            key_id=key_id,
-            key_algorithm=key_algorithm,
-            signing_algorithm=signing_algorithm,
-            serial=serial,
-            cert_format=cert_format)
-
-        if import_cert:
-            subsystem.import_cert(
-                cert_data=cert_data,
-                cert_format=cert_format,
-                profile_path=profile_path,
-                request_id=request_id)
-
-        if cert_path:
-            with open(cert_path, 'wb') as f:
-                f.write(cert_data)
-
-        else:
-            sys.stdout.buffer.write(cert_data)
-
 
 class CACertImportCLI(pki.cli.CLI):
 
@@ -362,58 +253,6 @@ class CACertImportCLI(pki.cli.CLI):
         print('      --help                         Show help message.')
         print()
 
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        cert_path = args.cert
-        cert_format = args.format
-        csr_path = args.csr
-        csr_format = args.csr_format
-        profile_path = args.profile
-        request_id = args.request
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem('ca')
-        if not subsystem:
-            logger.error('No CA subsystem in instance %s', instance_name)
-            sys.exit(1)
-
-        if csr_path:
-            # import CSR if provided
-            result = subsystem.import_cert_request(
-                request_path=csr_path,
-                request_format=csr_format,
-                profile_path=profile_path,
-                request_id=request_id)
-
-            request_id = result['requestID']
-
-        # import cert
-        subsystem.import_cert(
-            cert_path=cert_path,
-            cert_format=cert_format,
-            profile_path=profile_path,
-            request_id=request_id)
-
 
 class CACertRemoveCLI(pki.cli.CLI):
 
@@ -451,41 +290,6 @@ class CACertRemoveCLI(pki.cli.CLI):
         print('      --debug                        Run in debug mode.')
         print('      --help                         Show help message.')
         print()
-
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        serial_number = args.serial_number
-
-        if serial_number is None:
-            raise pki.cli.CLIException('Missing serial number')
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem('ca')
-        if not subsystem:
-            logger.error('No CA subsystem in instance %s', instance_name)
-            sys.exit(1)
-
-        subsystem.remove_cert(serial_number)
 
 
 class CACertChainCLI(pki.cli.CLI):
@@ -829,48 +633,6 @@ class CACertRequestImportCLI(pki.cli.CLI):
         print('      --debug                      Run in debug mode.')
         print('      --help                       Show help message.')
         print()
-
-    def execute(self, argv, args=None):
-
-        if not args:
-            args = self.parser.parse_args(args=argv)
-
-        if args.help:
-            self.print_help()
-            return
-
-        if args.debug:
-            logging.getLogger().setLevel(logging.DEBUG)
-
-        elif args.verbose:
-            logging.getLogger().setLevel(logging.INFO)
-
-        instance_name = args.instance
-        request_path = args.csr
-        request_format = args.format
-        profile_path = args.profile
-        request_id = args.request
-
-        instance = pki.server.PKIServerFactory.create(instance_name)
-        if not instance.exists():
-            logger.error('Invalid instance: %s', instance_name)
-            sys.exit(1)
-
-        instance.load()
-
-        subsystem = instance.get_subsystem('ca')
-        if not subsystem:
-            logger.error('No CA subsystem in instance %s', instance_name)
-            sys.exit(1)
-
-        result = subsystem.import_cert_request(
-            request_path=request_path,
-            request_format=request_format,
-            profile_path=profile_path,
-            request_id=request_id)
-
-        request_id = result['requestID']
-        print('  Request ID: %s' % request_id)
 
 
 class CACRLCLI(pki.cli.CLI):

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -2552,12 +2552,17 @@ class CASubsystem(PKISubsystem):
         logger.debug('Command: %s', ' '.join(cmd))
         subprocess.check_call(cmd)
 
+    # pylint: disable=W0613
     def find_certs(
             self,
             status=None,
             as_current_user=False):
 
-        cmd = ['ca-cert-find']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            'ca-cert-find'
+        ]
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -2568,7 +2573,8 @@ class CASubsystem(PKISubsystem):
         if status:
             cmd.extend(['--status', status])
 
-        self.run(cmd, as_current_user=as_current_user)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     def create_cert(
             self,
@@ -2585,7 +2591,11 @@ class CASubsystem(PKISubsystem):
         tmpdir = tempfile.mkdtemp()
 
         try:
-            cmd = ['ca-cert-create']
+            cmd = [
+                'pki-server',
+                '-i', self.instance.name,
+                'ca-cert-create'
+            ]
 
             if logger.isEnabledFor(logging.DEBUG):
                 cmd.append('--debug')
@@ -2620,9 +2630,11 @@ class CASubsystem(PKISubsystem):
             if cert_format:
                 cmd.extend(['--format', cert_format])
 
-            result = self.run(
+            logger.debug('Command: %s', ' '.join(cmd))
+            result = subprocess.run(
                 cmd,
-                stdout=subprocess.PIPE)
+                stdout=subprocess.PIPE,
+                check=True)
 
         finally:
             shutil.rmtree(tmpdir)
@@ -2645,7 +2657,11 @@ class CASubsystem(PKISubsystem):
                 with open(cert_path, 'wb') as f:
                     f.write(cert_data)
 
-            cmd = ['ca-cert-import']
+            cmd = [
+                'pki-server',
+                '-i', self.instance.name,
+                'ca-cert-import'
+            ]
 
             if logger.isEnabledFor(logging.DEBUG):
                 cmd.append('--debug')
@@ -2665,15 +2681,20 @@ class CASubsystem(PKISubsystem):
             if profile_path:
                 cmd.extend(['--profile', profile_path])
 
-            # run as current user so it can read the input file
-            self.run(cmd, as_current_user=True)
+            logger.debug('Command: %s', ' '.join(cmd))
+            subprocess.check_call(cmd)
 
         finally:
             shutil.rmtree(tmpdir)
 
+    # pylint: disable=W0613
     def remove_cert(self, serial_number, as_current_user=False):
 
-        cmd = ['ca-cert-del']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            'ca-cert-del'
+        ]
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -2683,7 +2704,8 @@ class CASubsystem(PKISubsystem):
 
         cmd.append(serial_number)
 
-        self.run(cmd, as_current_user=as_current_user)
+        logger.debug('Command: %s', ' '.join(cmd))
+        subprocess.check_call(cmd)
 
     def find_cert_requests(self, cert=None):
 
@@ -2727,7 +2749,11 @@ class CASubsystem(PKISubsystem):
             with open(request_path, 'r', encoding='utf-8') as f:
                 request_data = f.read()
 
-        cmd = ['ca-cert-request-import']
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            'ca-cert-request-import'
+        ]
 
         if logger.isEnabledFor(logging.DEBUG):
             cmd.append('--debug')
@@ -2756,10 +2782,12 @@ class CASubsystem(PKISubsystem):
         if request_id:
             cmd.append(request_id)
 
-        result = self.run(
+        logger.debug('Command: %s', ' '.join(cmd))
+        result = subprocess.run(
             cmd,
             input=request_data.encode('utf-8'),
-            stdout=subprocess.PIPE)
+            stdout=subprocess.PIPE,
+            check=True)
 
         return json.loads(result.stdout.decode('utf-8'))
 


### PR DESCRIPTION
In order to minimize the number of NSS authentications the `pki-server <subsystem>-cert/profile-*` commands used during installation have been converted to run the corresponding Java code directly so later they can be executed in shell/batch mode.

The `CACertCreateCLI` and `CACertImportCLI` Java classes have been modified to provide the options to specify the CSR and whether to import the newly created cert which were provided by the corresponding Python classes.
