### PR TITLE
Update CI to support Fedora 42

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -64,6 +64,10 @@ jobs:
               --network-alias=pki.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check pki acme CLI help message
         run: |
           docker exec pki pki acme
@@ -186,6 +190,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -852,6 +881,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/acme-container-basic-test.yml
+++ b/.github/workflows/acme-container-basic-test.yml
@@ -85,6 +85,10 @@ jobs:
               -o /dev/null \
               http://acme.example.com:8080/acme/directory
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec acme sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check conf dir
         if: always()
         run: |
@@ -134,7 +138,28 @@ jobs:
           diff expected output
 
       - name: Check logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by root group (GID=0)
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          -rw-rw-rw- root localhost.$DATE.log
+          -rw-rw-rw- root localhost_access_log.$DATE.txt
+          drwxrwxrwx root pki
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l logs \
               | sed \

--- a/.github/workflows/acme-existing-nssdb-test.yml
+++ b/.github/workflows/acme-existing-nssdb-test.yml
@@ -47,6 +47,10 @@ jobs:
               --network-alias=ca.example.com \
               ca
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec ca sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Install CA
         run: |
           docker exec ca pkispawn \
@@ -208,7 +212,30 @@ jobs:
           diff expected output
 
       - name: Check ACME server logs dir after installation
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec acme ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
+          drwxr-x--- pkiuser pkiuser backup
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check ACME server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec acme ls -l /var/log/pki/pki-tomcat \
@@ -801,6 +828,30 @@ jobs:
           diff expected output
 
       - name: Check ACME server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec acme ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
+          drwxr-x--- pkiuser pkiuser backup
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check ACME server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec acme ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/acme-separate-test.yml
+++ b/.github/workflows/acme-separate-test.yml
@@ -63,6 +63,10 @@ jobs:
               --network-alias=ca.example.com \
               ca
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec ca sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Install CA
         run: |
           docker exec ca pkispawn \
@@ -215,7 +219,30 @@ jobs:
           diff expected output
 
       - name: Check ACME server logs dir after installation
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec acme ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
+          drwxrwx--- pkiuser pkiuser backup
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check ACME server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec acme ls -l /var/log/pki/pki-tomcat \
@@ -857,7 +884,30 @@ jobs:
           diff expected output
 
       - name: Check ACME server logs dir after removal
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec acme ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser acme
+          drwxrwx--- pkiuser pkiuser backup
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check ACME server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec acme ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -46,6 +46,10 @@ jobs:
               --network-alias=pki.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check pki CLI help messages
         run: |
           docker exec pki pki info --help
@@ -158,6 +162,30 @@ jobs:
           docker exec pki cat /etc/sysconfig/pki-tomcat
 
       - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -674,6 +702,30 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/ca-existing-config-test.yml
+++ b/.github/workflows/ca-existing-config-test.yml
@@ -32,20 +32,22 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up PKI container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
 
-      - name: Connect PKI container to network
-        run: docker network connect example pki --alias pki.example.com
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
 
       - name: Install CA
         run: |
@@ -186,6 +188,31 @@ jobs:
           docker exec pki cp -r /etc/pki/localhost /etc/pki/localhost.orig
 
       - name: Check PKI server logs dir after first removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/localhost \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after first removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/localhost \
@@ -478,17 +505,3 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@localhost.service
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ca-existing-config
-          path: /tmp/artifacts

--- a/.github/workflows/est-ds-realm-separate-test.yml
+++ b/.github/workflows/est-ds-realm-separate-test.yml
@@ -87,6 +87,10 @@ jobs:
           --network-alias=est.example.com \
           est
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec est sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Set up EST user DB
         run: |
           docker exec -i est ldapadd -x -H ldap://estds.example.com:3389 \
@@ -159,6 +163,30 @@ jobs:
           diff expected output
 
       - name: Check EST server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec est ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser est
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check EST server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec est ls -l /var/log/pki/pki-tomcat \
@@ -303,6 +331,30 @@ jobs:
           diff expected output
 
       - name: Check EST server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec est ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser est
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check EST server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec est ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/est-ds-realm-test.yml
+++ b/.github/workflows/est-ds-realm-test.yml
@@ -46,6 +46,10 @@ jobs:
           --network-alias=pki.example.com \
           pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Install CA
         run: |
           docker exec pki pkispawn \
@@ -171,6 +175,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser est
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -529,6 +558,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser est
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/est-postgresql-realm-test.yml
+++ b/.github/workflows/est-postgresql-realm-test.yml
@@ -46,6 +46,10 @@ jobs:
           --network-alias=pki.example.com \
           pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Install CA
         run: |
           docker exec pki pkispawn \
@@ -242,6 +246,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser est
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -523,6 +552,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser est
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/est-standalone-test.yml
+++ b/.github/workflows/est-standalone-test.yml
@@ -88,6 +88,10 @@ jobs:
           --network-alias=est.example.com \
           est
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec est sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Set up EST user DB
         run: |
           docker exec -i est ldapadd -x -H ldap://estds.example.com:3389 \
@@ -206,6 +210,30 @@ jobs:
           diff expected output
 
       - name: Check EST server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec est ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser est
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check EST server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec est ls -l /var/log/pki/pki-tomcat \
@@ -372,6 +400,30 @@ jobs:
           diff expected output
 
       - name: Check EST server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec est ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser est
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check EST server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec est ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -56,6 +56,10 @@ jobs:
               --network-alias=pki.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check pki kra CLI help messages
         run: |
           docker exec pki pki kra
@@ -203,6 +207,31 @@ jobs:
           docker exec pki cat /etc/pki/pki-tomcat/server.xml
 
       - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -1278,6 +1307,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -333,6 +333,10 @@ jobs:
               -o /dev/null \
               https://kra.example.com:8443
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec kra sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check KRA conf dir
         if: always()
         run: |
@@ -384,7 +388,30 @@ jobs:
           diff expected output
 
       - name: Check KRA logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l kra/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by runner group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx runner backup
+          drwxrwxrwx runner kra
+          -rw-rw-rw- runner localhost.2026-01-08.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          drwxrwxrwx runner pki
+          EOF
+
+          diff expected output
+
+      - name: Check KRA logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l kra/logs \
               | sed \

--- a/.github/workflows/kra-existing-config-test.yml
+++ b/.github/workflows/kra-existing-config-test.yml
@@ -32,20 +32,22 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up PKI container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
 
-      - name: Connect PKI container to network
-        run: docker network connect example pki --alias pki.example.com
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
 
       - name: Install CA
         run: |
@@ -149,6 +151,32 @@ jobs:
           docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
 
       - name: Check PKI server logs dir after first removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after first removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -291,17 +319,3 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: kra-existing-config
-          path: /tmp/artifacts

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -54,6 +54,10 @@ jobs:
               --network-alias=pki.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check pki ocsp CLI help messages
         run: |
           docker exec pki pki ocsp
@@ -232,6 +236,31 @@ jobs:
           docker exec pki cat /etc/pki/pki-tomcat/server.xml
 
       - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxrwx--- pkiuser pkiuser ocsp
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -908,6 +937,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxrwx--- pkiuser pkiuser ocsp
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -309,6 +309,10 @@ jobs:
               -o /dev/null \
               https://ocsp.example.com:8443
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec ocsp sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check OCSP conf dir
         if: always()
         run: |
@@ -360,7 +364,30 @@ jobs:
           diff expected output
 
       - name: Check OCSP logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l ocsp/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by runner group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx runner backup
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          drwxrwxrwx runner ocsp
+          drwxrwxrwx runner pki
+          EOF
+
+          diff expected output
+
+      - name: Check OCSP logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l ocsp/logs \
               | sed \

--- a/.github/workflows/ocsp-existing-config-test.yml
+++ b/.github/workflows/ocsp-existing-config-test.yml
@@ -32,20 +32,22 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up PKI container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
 
-      - name: Connect PKI container to network
-        run: docker network connect example pki --alias pki.example.com
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
 
       - name: Install CA
         run: |
@@ -149,6 +151,32 @@ jobs:
           docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxrwx--- pkiuser pkiuser ocsp
+          drwxr-xr-x pkiuser pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -301,17 +329,3 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ocsp-existing-config
-          path: /tmp/artifacts

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -37,6 +37,10 @@ jobs:
               --network-alias=pki.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check Tomcat lib dir
         run: |
           # check file types, owners, and permissions
@@ -176,6 +180,28 @@ jobs:
           docker exec pki cat /etc/pki/pki-tomcat/tomcat.conf
 
       - name: Check pki-tomcat server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          EOF
+
+          diff expected output
+
+      - name: Check pki-tomcat server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -291,6 +317,28 @@ jobs:
           diff expected output
 
       - name: Check pki-tomcat server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- pkiuser pkiuser backup
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          EOF
+
+          diff expected output
+
+      - name: Check pki-tomcat server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -375,6 +423,31 @@ jobs:
           docker exec pki cat /var/lib/tomcats/pki/conf/tomcat.conf
 
       - name: Check tomcat@pki server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/tomcats/pki/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- tomcat tomcat backup
+          -rw-r--r-- tomcat tomcat catalina.$DATE.log
+          -rw-r--r-- tomcat tomcat host-manager.$DATE.log
+          -rw-r--r-- tomcat tomcat localhost.$DATE.log
+          -rw-r--r-- tomcat tomcat localhost_access_log.$DATE.txt
+          -rw-r--r-- tomcat tomcat manager.$DATE.log
+          EOF
+
+          diff expected output
+
+      - name: Check tomcat@pki server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/tomcats/pki/logs \
@@ -455,6 +528,31 @@ jobs:
           diff expected output
 
       - name: Check tomcat@pki server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/lib/tomcats/pki/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxr-x--- tomcat tomcat backup
+          -rw-r--r-- tomcat tomcat catalina.$DATE.log
+          -rw-r--r-- tomcat tomcat host-manager.$DATE.log
+          -rw-r--r-- tomcat tomcat localhost.$DATE.log
+          -rw-r--r-- tomcat tomcat localhost_access_log.$DATE.txt
+          -rw-r--r-- tomcat tomcat manager.$DATE.log
+          EOF
+
+          diff expected output
+
+      - name: Check tomcat@pki server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/lib/tomcats/pki/logs \

--- a/.github/workflows/server-container-test.yml
+++ b/.github/workflows/server-container-test.yml
@@ -72,6 +72,10 @@ jobs:
               -o /dev/null \
               https://pki.example.com:8443
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec server sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check conf dir
         if: always()
         run: |
@@ -101,7 +105,28 @@ jobs:
           diff expected output
 
       - name: Check logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by runner group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          drwxrwxrwx runner pki
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l logs \
               | sed \

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -46,6 +46,10 @@ jobs:
               --network-alias=pki.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check pki tks CLI help messages
         run: |
           docker exec pki pki tks
@@ -148,6 +152,31 @@ jobs:
           docker exec pki cat /etc/pki/pki-tomcat/server.xml
 
       - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -324,6 +353,31 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/tks-container-test.yml
+++ b/.github/workflows/tks-container-test.yml
@@ -298,6 +298,10 @@ jobs:
               -o /dev/null \
               https://tks.example.com:8443
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec tks sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check TKS conf dir
         if: always()
         run: |
@@ -349,7 +353,30 @@ jobs:
           diff expected output
 
       - name: Check TKS logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l tks/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by runner group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx runner backup
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          drwxrwxrwx runner pki
+          drwxrwxrwx runner tks
+          EOF
+
+          diff expected output
+
+      - name: Check TKS logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l tks/logs \
               | sed \

--- a/.github/workflows/tks-existing-config-test.yml
+++ b/.github/workflows/tks-existing-config-test.yml
@@ -32,20 +32,22 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up PKI container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
 
-      - name: Connect PKI container to network
-        run: docker network connect example pki --alias pki.example.com
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
 
       - name: Install CA
         run: |
@@ -149,6 +151,32 @@ jobs:
           docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
 
       - name: Check PKI server logs dir after first removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after first removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -289,17 +317,3 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: tks-existing-config
-          path: /tmp/artifacts

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -46,6 +46,10 @@ jobs:
               --network-alias=pki.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check pki tps CLI help messages
         run: |
           docker exec pki pki tps
@@ -170,6 +174,33 @@ jobs:
           docker exec pki cat /etc/pki/pki-tomcat/server.xml
 
       - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          drwxrwx--- pkiuser pkiuser tps
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after installation
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -595,6 +626,33 @@ jobs:
           diff expected output
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          drwxrwx--- pkiuser pkiuser tps
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -664,6 +664,10 @@ jobs:
               -o /dev/null \
               https://tps.example.com:8443
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec tps sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Check TPS conf dir
         if: always()
         run: |
@@ -716,7 +720,30 @@ jobs:
           diff expected output
 
       - name: Check TPS logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l tps/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by runner group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx runner backup
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          drwxrwxrwx runner pki
+          drwxrwxrwx runner tps
+          EOF
+
+          diff expected output
+
+      - name: Check TPS logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l tps/logs \
               | sed \

--- a/.github/workflows/tps-existing-config-test.yml
+++ b/.github/workflows/tps-existing-config-test.yml
@@ -32,20 +32,22 @@ jobs:
           tests/bin/ds-create.sh \
               --image=${{ env.DS_IMAGE }} \
               --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
               --password=Secret.123 \
               ds
 
-      - name: Connect DS container to network
-        run: docker network connect example ds --alias ds.example.com
-
       - name: Set up PKI container
         run: |
-          tests/bin/runner-init.sh pki
-        env:
-          HOSTNAME: pki.example.com
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
 
-      - name: Connect PKI container to network
-        run: docker network connect example pki --alias pki.example.com
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
 
       - name: Install CA
         run: |
@@ -171,6 +173,34 @@ jobs:
           docker exec pki cp -r /etc/pki/pki-tomcat /etc/pki/pki-tomcat.orig
 
       - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          # check file types, owners, and permissions
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # all log files should be retained
+          # TODO: review permissions
+          cat > expected << EOF
+          drwxrwx--- pkiuser pkiuser backup
+          drwxrwx--- pkiuser pkiuser ca
+          drwxrwx--- pkiuser pkiuser kra
+          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
+          drwxr-xr-x pkiuser pkiuser pki
+          drwxrwx--- pkiuser pkiuser tks
+          drwxrwx--- pkiuser pkiuser tps
+          EOF
+
+          diff expected output
+
+      - name: Check PKI server logs dir after removal
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           # check file types, owners, and permissions
           docker exec pki ls -l /var/log/pki/pki-tomcat \
@@ -341,13 +371,6 @@ jobs:
 
           diff expected stderr
 
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-        continue-on-error: true
-
       - name: Check DS server systemd journal
         if: always()
         run: |
@@ -362,10 +385,3 @@ jobs:
         if: always()
         run: |
           docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: tps-existing-config
-          path: /tmp/artifacts


### PR DESCRIPTION
Currently the CI only works with Fedora 43 which uses Tomcat 10. Sometimes it's necessary to run the CI with a different Fedora version using the `BASE_IMAGE` variable. In order to support Fedora 42 which uses Tomcat 9, the CI has been updated to get the Fedora version from the running container then use it to perform the proper validation.

https://github.com/dogtagpki/pki/wiki/Configuring-Test-OS

**Notes:**

* The result can be seen in my PKI repo which is configured to use Fedora 42: https://github.com/edewata/pki/actions?query=branch%3Aci. There are some failures but they seem to be existing issues.
* The main PKI repo is configured to use Fedora 43. The CI is currently failing possibly due to recent changes in OpenJDK and Tomcat. This will need to be investigated separately.