### PR TITLE
Update FIPS option for JDK>25

### DIFF
--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -237,9 +237,9 @@ class PKICLI(pki.cli.CLI):
 
         java_fips_cmd = os.getenv('JAVA_FIPS_ENABLED')
         if java_fips_cmd:
-            cmd.extend([
-                java_fips_cmd
-            ])
+            cmd.extend(
+                java_fips_cmd.split(' ')
+            )
 
         # Deal with warnings that alter CI test results.
         cmd.extend([

--- a/base/common/share/etc/pki.conf
+++ b/base/common/share/etc/pki.conf
@@ -16,7 +16,7 @@ export JAVA_HOME
 # For the moment we want this to be false even if we really are
 # in fips mode, because we want the jss prover instead of the sun
 # fips provider to be selected.
-JAVA_FIPS_ENABLED="-Dcom.redhat.fips=false" # Disable FIPS mode
+JAVA_FIPS_ENABLED="-Dcom.redhat.fips=false -Dredhat.crypto-policies=false" # Disable FIPS mode
 
 export JAVA_FIPS_ENABLED
 

--- a/base/server/python/pki/server/cli/__init__.py
+++ b/base/server/python/pki/server/cli/__init__.py
@@ -254,7 +254,7 @@ class PKIServerCLI(pki.cli.CLI):
 
         java_fips_cmd = os.getenv('JAVA_FIPS_ENABLED')
         if java_fips_cmd:
-            cmd.append(java_fips_cmd)
+            cmd.extend(java_fips_cmd.split(' '))
 
         # suppress JNI warnings
         cmd.append('--enable-native-access=ALL-UNNAMED')

--- a/base/server/share/conf/tomcat.conf
+++ b/base/server/share/conf/tomcat.conf
@@ -27,7 +27,7 @@ CATALINA_TMPDIR="[pki_instance_path]/temp"
 #   -Djava.library.path=/usr/lib
 # - parameters to run a java debugger (e. g. - 'eclipse')
 #   -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -Djava.awt.headless=true -Xmx128M
-JAVA_OPTS="-Dcom.redhat.fips=false"
+JAVA_OPTS="-Dcom.redhat.fips=false -Dredhat.crypto-policies=false"
 
 # What user should run tomcat
 TOMCAT_USER="[pki_user]"

--- a/base/server/upgrade/11.9.0/04-UpdateJDKFIPS.py
+++ b/base/server/upgrade/11.9.0/04-UpdateJDKFIPS.py
@@ -1,0 +1,43 @@
+# Authors:
+#     Marco Fargetta <mfargett@redhat.com>
+#
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import logging
+import os
+import pki
+
+
+class UpdateJDKFIPS(pki.server.upgrade.PKIServerUpgradeScriptlet):
+    msg = "# Adding -Dredhat.crypto-policies=false for JDK>=25 as "\
+          "SunJSSE+SunPKCS11 conflicts with JSS\n"
+
+    def __init__(self):
+        super(UpdateJDKFIPS, self).__init__()
+        self.message = 'Set -Dredhat.crypto-policies=false in Tomcat configuration'
+
+    def upgrade_instance(self, instance):
+        self.fix_tomcat_config(instance.tomcat_conf)
+        self.fix_tomcat_config('/etc/sysconfig/%s' % instance.name)
+
+    def fix_tomcat_config(self, filename):
+        if not os.path.exists(filename):
+            logging.debug("Unknown file: %s", filename)
+            return
+
+        with open(filename, 'r', encoding='utf-8') as in_fp:
+            lines = in_fp.readlines()
+
+        with open(filename, 'w', encoding='utf-8') as out_fp:
+            for line in lines:
+                if 'JAVA_OPTS="' in line and 'redhat.crypto-policies' not in line:
+                    out_fp.write(self.msg)
+                    line = line.replace(
+                        'JAVA_OPTS="',
+                        'JAVA_OPTS="-Dredhat.crypto-policies=false ',
+                        1
+                    )
+
+                out_fp.write(line)

--- a/base/tools/templates/pki_java_command_wrapper.in
+++ b/base/tools/templates/pki_java_command_wrapper.in
@@ -53,6 +53,7 @@ JAVA_OPTIONS=""
 ${JAVA} ${JAVA_OPTIONS} \
   -cp "${PKI_LIB}/*" \
   -Dcom.redhat.fips=false \
+  -Dredhat.crypto-policies=false \
   -Djava.util.logging.config.file=${PKI_LOGGING_CONFIG} \
   com.netscape.cmstools.${COMMAND} "$@"
 


### PR DESCRIPTION
When running in FIPS mode the provider SunJSSE+SunPKCS11 conflict with JSS. To avoid problems the JVM has to start in non FIPS mode, JSS will take care to use the correct policy.

From Java 8 to 24 the fips was disabled with the option `-Dcom.redhat.fips=false` (see [1]). In Java 25 the option has been changed and it is `-Dredhat.crypto-policies=false` (see [2]).

To avoid problems both options are included so fips is disabled with all JVM versions.

Fixes #5256

1. https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/8/html/release_notes_for_red_hat_build_of_openjdk_8.0.472/rn-openjdk-disabling-fips-on-rhel82

2. https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/25/html/release_notes_for_red_hat_build_of_openjdk_25.0.1/crypto_fips