### PR TITLE
RHEL-75980

### DIFF
--- a/base/common/src/main/java/org/dogtagpki/cli/CLIException.java
+++ b/base/common/src/main/java/org/dogtagpki/cli/CLIException.java
@@ -40,6 +40,10 @@ public class CLIException extends Exception {
         this.code = code;
     }
 
+    public CLIException(String string, Exception e) {
+        super(string, e);
+    }
+
     public int getCode() {
         return code;
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACertHoldCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACertHoldCLI.java
@@ -147,13 +147,15 @@ public class CACertHoldCLI extends SubsystemCommandCLI {
         CACertClient certClient = new CACertClient(subsystemClient);
 
         for (String cmdArg : cmdArgs) {
-            CertId certID = new CertId(cmdArg);
+            CertId certID = null;
             try {
+                certID = new CertId(cmdArg);
                 holdCert(certClient, certID, comments, force);
             } catch (Exception e) {
-                logger.error("Unable to hold certificate " + certID + ": " + e.getMessage(), e);
+                mainCLI.handleException(new CLIException("Unable to hold certificate " + cmdArg + ": " + e.getMessage(), e));
                 // continue to the next cert
             }
+
         }
     }
 }

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACertReleaseHoldCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACertReleaseHoldCLI.java
@@ -127,11 +127,12 @@ public class CACertReleaseHoldCLI extends SubsystemCommandCLI {
         CACertClient certClient = new CACertClient(subsystemClient);
 
         for (String cmdArg : cmdArgs) {
-            CertId certID = new CertId(cmdArg);
+            CertId certID = null;
             try {
+                certID = new CertId(cmdArg);
                 releaseCert(certClient, certID, force);
             } catch (Exception e) {
-                logger.error("Unable to release certificate " + certID + ": " + e.getMessage(), e);
+                mainCLI.handleException(new CLIException("Unable to release certificate " + cmdArg + ": " + e.getMessage(), e));
                 // continue to the next cert
             }
         }

--- a/base/tools/src/main/java/com/netscape/cmstools/ca/CACertRevokeCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ca/CACertRevokeCLI.java
@@ -190,11 +190,12 @@ public class CACertRevokeCLI extends SubsystemCommandCLI {
         CACertClient certClient = new CACertClient(subsystemClient);
 
         for (String cmdArg : cmdArgs) {
-            CertId certID = new CertId(cmdArg);
+            CertId certID = null;
             try {
+                certID = new CertId(cmdArg);
                 revokeCert(certClient, certID, reason, comments, isCA, force);
             } catch (Exception e) {
-                logger.error("Unable to revoke certificate " + certID + ": " + e.getMessage(), e);
+                mainCLI.handleException(new CLIException("Unable to revoke certificate " + cmdArg + ": " + e.getMessage(), e));
                 // continue to the next cert
             }
         }

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -771,7 +771,7 @@ public class MainCLI extends CLI {
         if (logger.isInfoEnabled()) {
             t.printStackTrace(System.err);
 
-        } else if (t.getClass() == Exception.class) {
+        } else if (t.getClass() == Exception.class || t instanceof CLIException) {
             // display a generic error
             System.err.println("ERROR: " + t.getMessage());
 
@@ -799,10 +799,7 @@ public class MainCLI extends CLI {
             cli.execute(args);
 
         } catch (CLIException e) {
-            String message = e.getMessage();
-            if (message != null) {
-                System.err.println("ERROR: " + message);
-            }
+            cli.handleException(e);
             System.exit(e.getCode());
 
         } catch (Throwable t) {


### PR DESCRIPTION
Handles errors on commands ca-cert-hold, ca-cert-release-hold and ca-cert-revoke without stacktrace logs in standard output, unless launched in debug mode
Also avoids stacktrace in standard output for all unhandled children of java.lang.Exception unless in debug mode
Refers RHEL-75980