### PR TITLE
Fix CMake build with tomcat10

### DIFF
--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -29,7 +29,7 @@ javac(pki-server-classes
     OUTPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     DEPENDS
-        pki-common-jar pki-tools-jar pki-tomcat-jar pki-tomcat-9.0-jar
+        pki-common-jar pki-tools-jar pki-tomcat-jar pki-${APP_SERVER}-jar
 )
 
 add_dependencies(java pki-server-classes)

--- a/build.sh
+++ b/build.sh
@@ -167,7 +167,7 @@ get_tomcat_app_server() {
     release_file="/etc/os-release"   
     fedora_cutoff=$1
     rhel_cutoff=$2
-    def_app_server=tomcat-9.0
+    app_server_9=tomcat-9.0
     app_server_10=tomcat-10.1
     app_server=""
     distro=""
@@ -176,7 +176,8 @@ get_tomcat_app_server() {
     VERSION_ID=""
 
     ID=$(sed -n  's/^ID=//p;' $release_file | tr -d '"')
-    VERSION_ID=$(sed -n  's/^VERSION_ID=//p;' $release_file | tr -d '"')
+    # Get only the OS major version. No tomcat change in minor versions are expected
+    VERSION_ID=$(sed -n  's/^VERSION_ID="\?\([0-9]*\).*/\1/p;' $release_file)
 
     case "$ID" in
          "rhel")
@@ -201,13 +202,13 @@ get_tomcat_app_server() {
          if [ $ver -ge $fedora_cutoff ]; then
              app_server=$app_server_10
          else
-             app_server=$def_app_server
+             app_server=$app_server_9
          fi
      else
-         if [ $ver -ge $rhel_cutoff ]; then
+	 if [ $ver -ge $rhel_cutoff ]; then
              app_server=$app_server_10
          else
-             app_server=$def_app_server 
+             app_server=$app_server_9
          fi
      fi
 


### PR DESCRIPTION
CMake build had tomcat-9 library hard-coded and has been removed to get it from the `build.sh`.

The `build.sh` test to identify the tomcat version to use was not working with dotted version (e.g. 10.2) and it has been fixed.