### PR TITLE
Add VLV index for CRL generation by issuer + Upgrade script

### DIFF
--- a/.github/workflows/ca-crl-test.yml
+++ b/.github/workflows/ca-crl-test.yml
@@ -193,6 +193,13 @@ jobs:
 
           diff expected actual
 
+      - name: Check VLV usage in DS access log
+        run: |
+          # Check if VLV index was used during CRL generation
+          # The query for revoked certs should use the allRevokedCertsByIssuer VLV index
+          echo "Checking DS access log for VLV usage during CRL generation:"
+          docker exec ds sh -c "grep 'certStatus=REVOKED' /var/log/dirsrv/slapd-localhost/access* || true"
+
       - name: Unrevoke user 1 cert
         run: |
           CERT_ID=$(cat cert.id)

--- a/base/ca/database/ds/vlv.ldif
+++ b/base/ca/database/ds/vlv.ldif
@@ -542,3 +542,19 @@ cn: caRevocation-{instanceId}Index
 vlvSort: requestId
 vlvEnabled: 0
 vlvUses: 0
+
+dn: cn=allRevokedCertsByIssuer-{instanceId}, cn={database}, cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: vlvSearch
+cn: allRevokedCertsByIssuer-{instanceId}
+vlvBase: ou=certificateRepository,ou=ca,{rootSuffix}
+vlvScope: 1
+vlvFilter: (&(certStatus=REVOKED)(|(!(issuerName=*))(issuerName={caIssuerDN})))
+
+dn: cn=allRevokedCertsByIssuer-{instanceId}Index, cn=allRevokedCertsByIssuer-{instanceId}, cn={database}, cn=ldbm database, cn=plugins, cn=config
+objectClass: top
+objectClass: vlvIndex
+cn: allRevokedCertsByIssuer-{instanceId}Index
+vlvSort: serialno
+vlvEnabled: 0
+vlvUses: 0

--- a/base/ca/database/ds/vlvtasks.ldif
+++ b/base/ca/database/ds/vlvtasks.ldif
@@ -38,3 +38,4 @@ nsindexVLVAttribute: caRejectedRenewal-{instanceId}Index
 nsindexVLVAttribute: caRejectedRevocation-{instanceId}Index
 nsindexVLVAttribute: caRenewal-{instanceId}Index
 nsindexVLVAttribute: caRevocation-{instanceId}Index
+nsindexVLVAttribute: allRevokedCertsByIssuer-{instanceId}Index

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1722,12 +1722,9 @@ class PKIDeployer:
         subsystem.add_indexes()
         subsystem.rebuild_indexes()
 
-        # Set up and rebuild VLV indexes on each DS instance (if needed) since
-        # VLV indexes are not replicated.
-
-        if config.str2bool(self.mdict['pki_ds_setup_vlv']):
-            subsystem.add_vlv()
-            subsystem.reindex_vlv()
+        # NOTE: VLV index creation has been moved to after certificate installation
+        # in configuration.py so that the CA signing certificate DN is available
+        # for the VLV filter. See DOGTAG-4244.
 
     def setup_replication(self, subsystem, master_config):
 

--- a/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/csadmin/LDAPConfigurator.java
@@ -95,6 +95,10 @@ public class LDAPConfigurator {
         return params;
     }
 
+    public void setParam(String name, String value) {
+        params.put(name, value);
+    }
+
     public void configureServer() throws Exception {
         logger.info("Configuring DS server");
         importLDIF("/usr/share/pki/server/database/ds/config.ldif", true);

--- a/docs/changes/v11.10.0/Server-Changes.adoc
+++ b/docs/changes/v11.10.0/Server-Changes.adoc
@@ -1,0 +1,24 @@
+= Server Changes =
+
+== VLV Index for CRL Generation ==
+
+VLV indexes are not enabled by default. However, if VLV is enabled during
+CA installation (`pki_ds_setup_vlv=True`), a new VLV index
+`allRevokedCertsByIssuer` will be created to optimize CRL generation
+performance by reducing unindexed LDAP searches for revoked certificates.
+This index filters revoked certificates by issuer DN.
+
+For new CA instances with VLV enabled, the index will be created
+automatically during installation.
+
+Existing CA instances with VLV enabled will need to add and reindex the
+VLV manually after upgrading to 11.10.0:
+
+----
+pki-server ca-db-vlv-add
+pki-server ca-db-vlv-reindex
+----
+
+*Note:* The reindex operation may take significant time on databases with
+many certificates. For replicated environments, VLV indexes are not
+replicated, so each replica must run these commands independently.


### PR DESCRIPTION
  This fixes unindexed LDAP searches during CRL generation by adding
  the allRevokedCertsByIssuer VLV index.

  The fix addresses two bugs found in the original DOGTAG_10_5_BRANCH
  implementation (commit e587f95576):
  - Bug 1: VLV index parent DN must match VLV search name
  - Bug 2: nsindexVLVAttribute must reference the index, not search

  Changes:
  - Add allRevokedCertsByIssuer VLV search and index to vlv.ldif
  - Add allRevokedCertsByIssuer-{instanceId}Index to vlvtasks.ldif
  - Move VLV creation to after certificate installation in configuration.py so that CA signing certificate DN is available for VLV filter
  - Update SubsystemDBVLVAddCLI to read CA DN from NSS certificate and set {caIssuerDN} template variable with enhanced logging
  - Add setParam() method to LDAPConfigurator for dynamic templates

  Upgrade script (01-AddCRLVLVIndex.py):
  - Checks for existing VLV indexes using pki-server ca-db-vlv-find
  - Only adds CRL VLV index if other VLV indexes already exist
  - Reads CA issuer DN from NSS database certificate

  Tested on fresh installations and upgrades without restart.

  Assisted-by: Claude
  Fixes: DOGTAG-4246