### PR TITLE
Disable ML-DSA test on Fedora 42

### DIFF
--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -19,6 +19,8 @@ jobs:
     uses: ./.github/workflows/ca-ecc-test.yml
 
   ca-mldsa-test:
+    # disable ML-DSA test on Fedora 42 since it's failing with SSLV3_ALERT_HANDSHAKE_FAILURE
+    if: ${{ vars.BASE_IMAGE != 'registry.fedoraproject.org/fedora:42' }}
     name: CA with ML-DSA-44
     needs: build
     uses: ./.github/workflows/ca-mldsa-test.yml


### PR DESCRIPTION
The ML-DSA test has been disabled on Fedora 42 since it's failing with `SSLV3_ALERT_HANDSHAKE_FAILURE`. The test works fine on Fedora 43 or later.

Failed test on F42:
https://github.com/edewata/pki/actions/runs/21454422708/job/61792276886

Disabled test on F42:
https://github.com/edewata/pki/actions/runs/21494007543/job/61924756167

Running test on F43:
https://github.com/dogtagpki/pki/actions/runs/21494050257/job/61924809665