### PR TITLE
Fix CA container tests

### DIFF
--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -49,6 +49,10 @@ jobs:
               --network=example \
               client
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec client sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Set up CA container
         run: |
           docker run \
@@ -135,7 +139,30 @@ jobs:
           diff expected output
 
       - name: Check logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by runner group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx runner backup
+          drwxrwxrwx runner ca
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          drwxrwxrwx runner pki
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l logs \
               | sed \
@@ -346,25 +373,3 @@ jobs:
         if: always()
         run: |
           docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-
-          mkdir -p /tmp/artifacts/ca
-          cp -r certs /tmp/artifacts/ca
-          cp -r conf /tmp/artifacts/ca
-          cp -r logs /tmp/artifacts/ca
-
-          docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
-
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ca-container-basic
-          path: /tmp/artifacts

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -49,6 +49,10 @@ jobs:
               --network=example \
               client
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec client sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Create CA signing cert
         run: |
           docker exec client pki \
@@ -241,7 +245,30 @@ jobs:
           diff expected output
 
       - name: Check logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by runner group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx runner backup
+          drwxrwxrwx runner ca
+          -rw-rw-rw- runner localhost.$DATE.log
+          -rw-rw-rw- runner localhost_access_log.$DATE.txt
+          drwxrwxrwx runner pki
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l logs \
               | sed \
@@ -437,25 +464,3 @@ jobs:
         if: always()
         run: |
           docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-
-          mkdir -p /tmp/artifacts/ca
-          cp -r certs /tmp/artifacts/ca
-          cp -r conf /tmp/artifacts/ca
-          cp -r logs /tmp/artifacts/ca
-
-          docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
-
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ca-container-existing-certs
-          path: /tmp/artifacts

--- a/.github/workflows/ca-container-existing-config-test.yml
+++ b/.github/workflows/ca-container-existing-config-test.yml
@@ -54,6 +54,10 @@ jobs:
               --network-alias=ca.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Install CA
         run: |
           docker exec pki pkispawn \
@@ -250,7 +254,30 @@ jobs:
           diff expected output
 
       - name: Check logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          ls -l logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by root group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx root backup
+          drwxrwxrwx root ca
+          -rw-rw-rw- root localhost.$DATE.log
+          -rw-rw-rw- root localhost_access_log.$DATE.txt
+          drwxrwxrwx root pki
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           ls -l logs \
               | sed \
@@ -328,27 +355,3 @@ jobs:
         if: always()
         run: |
           docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-
-          mkdir -p /tmp/artifacts/ca
-          # TODO: fix permission issue
-          # cp -r certs /tmp/artifacts/ca
-          # cp -r conf /tmp/artifacts/ca
-          # cp -r logs /tmp/artifacts/ca
-
-          docker logs ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
-
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ca-container-existing-config
-          path: /tmp/artifacts

--- a/.github/workflows/ca-container-migration-test.yml
+++ b/.github/workflows/ca-container-migration-test.yml
@@ -45,6 +45,10 @@ jobs:
               --network-alias=pki.example.com \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Install CA
         run: |
           docker exec pki pkispawn \
@@ -262,7 +266,30 @@ jobs:
           diff expected output
 
       - name: Check logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          docker exec pki ls -l /var/log/pki/pki-tomcat \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by pkiuser group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx pkiuser backup
+          drwxrwxrwx pkiuser ca
+          -rw-rw-rw- pkiuser localhost.$DATE.log
+          -rw-rw-rw- pkiuser localhost_access_log.$DATE.txt
+          drwxrwxrwx pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           docker exec pki ls -l /var/log/pki/pki-tomcat \
               | sed \
@@ -340,22 +367,3 @@ jobs:
         if: always()
         run: |
           docker exec pki find /var/log/pki/pki-tomcat/ca -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-
-          mkdir -p /tmp/artifacts/ca
-          docker exec pki podman logs systemd-pki-ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
-
-          mkdir -p /tmp/artifacts/client
-          docker logs client > /tmp/artifacts/client/container.out 2> /tmp/artifacts/client/container.err
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ca-container-migration
-          path: /tmp/artifacts

--- a/.github/workflows/ca-container-system-service-test.yml
+++ b/.github/workflows/ca-container-system-service-test.yml
@@ -44,6 +44,10 @@ jobs:
               --network=example \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Install Podman
         run: |
           docker exec pki dnf install -y podman sqlite
@@ -214,7 +218,30 @@ jobs:
           diff expected output
 
       - name: Check logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          docker exec pki ls -l /home/pkiuser/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by pkiuser group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx pkiuser backup
+          drwxrwxrwx pkiuser ca
+          -rw-rw-rw- pkiuser localhost.$DATE.log
+          -rw-rw-rw- pkiuser localhost_access_log.$DATE.txt
+          drwxrwxrwx pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           docker exec pki ls -l /home/pkiuser/logs \
               | sed \
@@ -345,23 +372,3 @@ jobs:
         if: always()
         run: |
           docker exec pki find /home/pkiuser/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-
-          mkdir -p /tmp/artifacts/ca
-          docker cp pki:/home/pkiuser/certs /tmp/artifacts/ca
-          docker cp pki:/home/pkiuser/conf /tmp/artifacts/ca
-          docker cp pki:/home/pkiuser/logs /tmp/artifacts/ca
-
-          docker exec pki podman logs systemd-pki-ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ca-container-system-service
-          path: /tmp/artifacts

--- a/.github/workflows/ca-container-user-service-test.yml
+++ b/.github/workflows/ca-container-user-service-test.yml
@@ -51,6 +51,10 @@ jobs:
               --network=example \
               pki
 
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
       - name: Install Podman
         run: |
           docker exec pki dnf install -y podman sqlite fuse-overlayfs
@@ -247,7 +251,30 @@ jobs:
           diff expected output
 
       - name: Check logs dir
-        if: always()
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 43 }}
+        run: |
+          docker exec -u pkiuser pki ls -l /home/pkiuser/.dogtag/pki-ca/logs \
+              | sed \
+                  -e '/^total/d' \
+                  -e 's/^\(\S*\) *\S* *\S* *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3/' \
+              | tee output
+
+          DATE=$(date +'%Y-%m-%d')
+
+          # everything should be owned by pkiuser group
+          # TODO: review owners/permissions
+          cat > expected << EOF
+          drwxrwxrwx pkiuser backup
+          drwxrwxrwx pkiuser ca
+          -rw-rw-rw- pkiuser localhost.$DATE.log
+          -rw-rw-rw- pkiuser localhost_access_log.$DATE.txt
+          drwxrwxrwx pkiuser pki
+          EOF
+
+          diff expected output
+
+      - name: Check logs dir
+        if: ${{ fromJSON(env.FEDORA_VERSION) >= 43 }}
         run: |
           docker exec -u pkiuser pki ls -l /home/pkiuser/.dogtag/pki-ca/logs \
               | sed \
@@ -378,19 +405,3 @@ jobs:
         if: always()
         run: |
           docker exec -u pkiuser pki find /home/pkiuser/.dogtag/pki-ca/logs/ca -name "debug.*" -exec cat {} \;
-
-      - name: Gather artifacts
-        if: always()
-        run: |
-          tests/bin/ds-artifacts-save.sh ds
-          tests/bin/pki-artifacts-save.sh pki
-
-          docker cp pki:/home/pkiuser/.dogtag/pki-ca /tmp/artifacts/ca
-          docker exec -u pkiuser pki podman logs systemd-pki-ca > /tmp/artifacts/ca/container.out 2> /tmp/artifacts/ca/container.err
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ca-container-user-service
-          path: /tmp/artifacts


### PR DESCRIPTION
The CA container tests have been updated to support Tomcat 9 on Fedora 42 in addition to Tomcat 10 on Fedora 43 or later.

**Note:** The CA migration to container test on Fedora 42 seems to be failing due to a [permission issue](https://github.com/edewata/pki/actions/runs/21653342429/job/62423460034#step:28:32). It will be addressed separately later.