### PR TITLE
Add Rocky Linux support to get_tomcat_app_server

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -192,6 +192,10 @@ get_tomcat_app_server() {
              distro="rhel"
              ver=$VERSION_ID
              ;;
+         "rocky")
+             distro="rhel"
+             ver=$VERSION_ID
+             ;;
          *)
              echo $def_app_server 
              return


### PR DESCRIPTION
The get_tomcat_app_server function in build.sh only recognizes rhel, centos, and fedora as valid distribution IDs. Rocky Linux uses ID="rocky" in /etc/os-release, which causes the function to fall through to the default case and return tomcat-9.0 instead of checking the version and selecting tomcat-10.1 for Rocky Linux 10+.

This patch adds "rocky" to the case statement so Rocky Linux is treated the same as RHEL/CentOS for Tomcat version selection.