### PR TITLE
Fix localhost log file permission

### DIFF
--- a/.github/workflows/acme-basic-test.yml
+++ b/.github/workflows/acme-basic-test.yml
@@ -245,7 +245,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF
@@ -936,7 +936,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser acme
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -215,7 +215,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF
@@ -755,7 +755,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF

--- a/.github/workflows/ca-container-basic-test.yml
+++ b/.github/workflows/ca-container-basic-test.yml
@@ -272,10 +272,10 @@ jobs:
           docker exec ca pki-server ca-cert-create \
               --csr admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               --import-cert
 
-          docker cp ca:admin.crt .
+          docker cp ca:/tmp/admin.crt .
 
           # import cert
           docker exec client pki nss-cert-import \
@@ -295,7 +295,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               admin
 
           # add CA admin user into CA groups

--- a/.github/workflows/ca-container-existing-certs-test.yml
+++ b/.github/workflows/ca-container-existing-certs-test.yml
@@ -365,10 +365,10 @@ jobs:
           docker exec ca pki-server ca-cert-create \
               --csr admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               --import-cert
 
-          docker cp ca:admin.crt .
+          docker cp ca:/tmp/admin.crt .
 
           # import cert
           docker exec client pki nss-cert-import \
@@ -387,7 +387,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               admin
 
       - name: Add CA admin user into CA groups

--- a/.github/workflows/ca-existing-config-test.yml
+++ b/.github/workflows/ca-existing-config-test.yml
@@ -204,7 +204,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF

--- a/.github/workflows/est-ds-realm-test.yml
+++ b/.github/workflows/est-ds-realm-test.yml
@@ -191,7 +191,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF
@@ -574,7 +574,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF

--- a/.github/workflows/est-postgresql-realm-test.yml
+++ b/.github/workflows/est-postgresql-realm-test.yml
@@ -262,7 +262,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF
@@ -570,7 +570,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser est
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF

--- a/.github/workflows/kra-basic-test.yml
+++ b/.github/workflows/kra-basic-test.yml
@@ -262,7 +262,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF
@@ -1362,7 +1362,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF

--- a/.github/workflows/kra-container-test.yml
+++ b/.github/workflows/kra-container-test.yml
@@ -173,10 +173,10 @@ jobs:
           docker exec ca pki-server ca-cert-create \
               --csr admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               --import-cert
 
-          docker cp ca:admin.crt .
+          docker cp ca:/tmp/admin.crt .
 
           # import cert
           docker exec client pki nss-cert-import \
@@ -189,7 +189,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               admin
 
       - name: Add CA admin user into CA groups

--- a/.github/workflows/kra-existing-config-test.yml
+++ b/.github/workflows/kra-existing-config-test.yml
@@ -168,7 +168,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           EOF

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -290,7 +290,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
           drwxr-xr-x pkiuser pkiuser pki
@@ -991,7 +991,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
           drwxr-xr-x pkiuser pkiuser pki

--- a/.github/workflows/ocsp-container-test.yml
+++ b/.github/workflows/ocsp-container-test.yml
@@ -170,10 +170,10 @@ jobs:
           docker exec ca pki-server ca-cert-create \
               --csr admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               --import-cert
 
-          docker cp ca:admin.crt .
+          docker cp ca:/tmp/admin.crt .
 
           # import cert
           docker exec client pki nss-cert-import \
@@ -186,7 +186,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               admin
 
       - name: Add CA admin user into CA groups

--- a/.github/workflows/ocsp-existing-config-test.yml
+++ b/.github/workflows/ocsp-existing-config-test.yml
@@ -167,7 +167,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxrwx--- pkiuser pkiuser ocsp
           drwxr-xr-x pkiuser pkiuser pki

--- a/.github/workflows/tks-basic-test.yml
+++ b/.github/workflows/tks-basic-test.yml
@@ -206,7 +206,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
@@ -407,7 +407,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks

--- a/.github/workflows/tks-container-test.yml
+++ b/.github/workflows/tks-container-test.yml
@@ -170,10 +170,10 @@ jobs:
           docker exec ca pki-server ca-cert-create \
               --csr admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               --import-cert
 
-          docker cp ca:admin.crt .
+          docker cp ca:/tmp/admin.crt .
 
           # import cert
           docker exec client pki nss-cert-import \
@@ -186,7 +186,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               admin
 
       - name: Add CA admin user into CA groups

--- a/.github/workflows/tks-existing-config-test.yml
+++ b/.github/workflows/tks-existing-config-test.yml
@@ -167,7 +167,7 @@ jobs:
           cat > expected << EOF
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks

--- a/.github/workflows/tps-basic-test.yml
+++ b/.github/workflows/tps-basic-test.yml
@@ -231,7 +231,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks
@@ -683,7 +683,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks

--- a/.github/workflows/tps-container-test.yml
+++ b/.github/workflows/tps-container-test.yml
@@ -181,10 +181,10 @@ jobs:
           docker exec ca pki-server ca-cert-create \
               --csr admin.csr \
               --profile /usr/share/pki/ca/conf/rsaAdminCert.profile \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               --import-cert
 
-          docker cp ca:admin.crt .
+          docker cp ca:/tmp/admin.crt .
 
           # import cert
           docker exec client pki nss-cert-import \
@@ -197,7 +197,7 @@ jobs:
           docker exec ca pki-server ca-user-add \
               --full-name Administrator \
               --type adminType \
-              --cert admin.crt \
+              --cert /tmp/admin.crt \
               admin
 
       - name: Add admin user into CA groups

--- a/.github/workflows/tps-existing-config-test.yml
+++ b/.github/workflows/tps-existing-config-test.yml
@@ -190,7 +190,7 @@ jobs:
           drwxrwx--- pkiuser pkiuser backup
           drwxrwx--- pkiuser pkiuser ca
           drwxrwx--- pkiuser pkiuser kra
-          -rw-rw-r-- root root localhost.$DATE.log
+          -rw-r--r-- pkiuser pkiuser localhost.$DATE.log
           -rw-r--r-- pkiuser pkiuser localhost_access_log.$DATE.txt
           drwxr-xr-x pkiuser pkiuser pki
           drwxrwx--- pkiuser pkiuser tks

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -1342,15 +1342,15 @@ class PKISubsystem(object):
             replica_id):
 
         tmpdir = tempfile.mkdtemp()
+        self.instance.chown(tmpdir)
+
         try:
             ldap_config_file = os.path.join(tmpdir, 'ldap.conf')
             pki.util.store_properties(ldap_config_file, ldap_config)
-            self.instance.chown(tmpdir)
 
             password_file = os.path.join(tmpdir, 'password.txt')
             with open(password_file, 'w', encoding='utf-8') as f:
                 f.write(replica_bind_password)
-            self.instance.chown(password_file)
 
             cmd = [
                 'pki-server',
@@ -1386,15 +1386,15 @@ class PKISubsystem(object):
             replication_security=None):
 
         tmpdir = tempfile.mkdtemp()
+        self.instance.chown(tmpdir)
+
         try:
             ldap_config_file = os.path.join(tmpdir, 'ldap.conf')
             pki.util.store_properties(ldap_config_file, ldap_config)
-            self.instance.chown(tmpdir)
 
             password_file = os.path.join(tmpdir, 'password.txt')
             with open(password_file, 'w', encoding='utf-8') as f:
                 f.write(replica_bind_password)
-            self.instance.chown(password_file)
 
             cmd = [
                 'pki-server',
@@ -1429,10 +1429,11 @@ class PKISubsystem(object):
             ldap_config):
 
         tmpdir = tempfile.mkdtemp()
+        self.instance.chown(tmpdir)
+
         try:
             ldap_config_file = os.path.join(tmpdir, 'ldap.conf')
             pki.util.store_properties(ldap_config_file, ldap_config)
-            self.instance.chown(tmpdir)
 
             cmd = [
                 'pki-server',
@@ -2169,6 +2170,7 @@ class PKISubsystem(object):
         logger.info('Adding user %s', user_id)
 
         tmpdir = tempfile.mkdtemp()
+        self.instance.chown(tmpdir)
 
         try:
             if password and not password_file:
@@ -2667,56 +2669,50 @@ class CASubsystem(PKISubsystem):
             serial=None,
             cert_format=None):
 
-        tmpdir = tempfile.mkdtemp()
+        cmd = [
+            'pki-server',
+            '-i', self.instance.name,
+            'ca-cert-create'
+        ]
 
-        try:
-            cmd = [
-                'pki-server',
-                '-i', self.instance.name,
-                'ca-cert-create'
-            ]
+        if logger.isEnabledFor(logging.DEBUG):
+            cmd.append('--debug')
 
-            if logger.isEnabledFor(logging.DEBUG):
-                cmd.append('--debug')
+        elif logger.isEnabledFor(logging.INFO):
+            cmd.append('--verbose')
 
-            elif logger.isEnabledFor(logging.INFO):
-                cmd.append('--verbose')
+        if request_id:
+            cmd.extend(['--request', request_id])
 
-            if request_id:
-                cmd.extend(['--request', request_id])
+        if profile_path:
+            cmd.extend(['--profile', profile_path])
 
-            if profile_path:
-                cmd.extend(['--profile', profile_path])
+        if cert_type:
+            cmd.extend(['--type', cert_type])
 
-            if cert_type:
-                cmd.extend(['--type', cert_type])
+        if key_id:
+            cmd.extend(['--key-id', key_id])
 
-            if key_id:
-                cmd.extend(['--key-id', key_id])
+        if key_token:
+            cmd.extend(['--key-token', key_token])
 
-            if key_token:
-                cmd.extend(['--key-token', key_token])
+        if key_algorithm:
+            cmd.extend(['--key-algorithm', key_algorithm])
 
-            if key_algorithm:
-                cmd.extend(['--key-algorithm', key_algorithm])
+        if signing_algorithm:
+            cmd.extend(['--signing-algorithm', signing_algorithm])
 
-            if signing_algorithm:
-                cmd.extend(['--signing-algorithm', signing_algorithm])
+        if serial:
+            cmd.extend(['--serial', serial])
 
-            if serial:
-                cmd.extend(['--serial', serial])
+        if cert_format:
+            cmd.extend(['--format', cert_format])
 
-            if cert_format:
-                cmd.extend(['--format', cert_format])
-
-            logger.debug('Command: %s', ' '.join(cmd))
-            result = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                check=True)
-
-        finally:
-            shutil.rmtree(tmpdir)
+        logger.debug('Command: %s', ' '.join(cmd))
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            check=True)
 
         return result.stdout
 
@@ -2729,6 +2725,7 @@ class CASubsystem(PKISubsystem):
             request_id=None):
 
         tmpdir = tempfile.mkdtemp()
+        self.instance.chown(tmpdir)
 
         try:
             if cert_data and not cert_path:


### PR DESCRIPTION
Previously `pki-server` ran Java commands as the current user (e.g. `root`), so files generated by the commands (e.g. `localhost` log file) would be owned by the current user instead of PKI user (e.g. `pkiuser`) which might cause issues later.

The `PKIServerCLI.execute_java()` has been modified to run the command as PKI user by default unless the current user wants to run it as itself.

The `pki-server` CLI has been modified to provide an option to run the command as the current user which could be useful for containers.

The methods in `PKISubsystem` that use `pki-server` CLI have been modified to change the ownership of the temporary directory to PKI user so that the files in it can be accessed by the CLI.

The `CASubsystem.create_cert()` has been modified to no longer create a temporary directory since it's not actually needed.

The tests have been updated to verify that the `localhost` log file is owned by `pkiuser` instead of `root`. The container tests have been modified to store files in `tmp` since the current directory cannot be accessed by `pkiuser`.

**Note:** This issue is only affecting PKI 11.9 running with Tomcat 9. Dogtag PKI 11.9 on Fedora 44 uses Tomcat 10 so it shouldn't be affected.