### PR TITLE
Fix nuxwdog password handling errors

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -381,6 +381,12 @@ class PKIServer(object):
                 # Build a chain containing the certificate we're trying to
                 # export. OpenSSL gets confused if we don't have a key for
                 # the end certificate: rh-bz#1246371
+
+                # Ensure HSM token password is available (e.g. from
+                # keyring when password.conf does not exist)
+                if not pki.nssdb.internal_token(token):
+                    self.get_token_password(token)
+
                 nssdb = self.open_nssdb()
                 try:
                     nssdb.export_cert_bundle(

--- a/base/server/scripts/pki-server-nuxwdog
+++ b/base/server/scripts/pki-server-nuxwdog
@@ -145,4 +145,4 @@ for tag in sorted(iter(tags)):
 
 # 4. Put this script to sleep in background to keep the keyring fd open until main program starts
 # due to systemd bug #1668954
-subprocess.Popen(['/usr/bin/sleep', '10'])
+subprocess.Popen(['/usr/bin/sleep', '600'])


### PR DESCRIPTION
Fixes issues that prevented fresh PKI installations from
starting when nuxwdog was enabled after installation, particularly
with HSMs.

Changes:

1. password.conf existence check - Check if password.conf exists in
   NSSDatabase constructor rather than at each usage point. This ensures
   self.password_conf is only set when the file actually exists, preventing
   errors when the file is missing (14 usage sites simplified).

2. get_all_passwords() fixes - Changed delimiter from ':' to '=' to match
   password.conf format expected by NSS tools. Also kept the 'hardware-'
   prefix when writing HSM token passwords to the multi-token password
   file. The PKI CLI expects the 'hardware-' prefix to identify HSM tokens
   (e.g. 'hardware-NHSM-CONN-XC=password'), but the code was stripping it,
   causing the CLI to skip HSM token authentication.

3. Multi-token password support for HSM - Added need_all_tokens logic to
   get_trust(), get_cert(), and export_cert_bundle() methods. When accessing
   certificates on HSM tokens, both internal token and HSM token passwords
   are required. The all_tokens=True parameter creates a multi-token password
   file using password.conf format ('-f' flag) instead of single-password
   format ('-C' flag).

4. Keyring.getKeyID() NumberFormatException fix - When a key doesn't exist
   in the keyring, keyctl returns the error message "keyctl_search: Required
   key not available" instead of a numeric key ID. The code now catches
   NumberFormatException and logs the non-numeric output for troubleshooting,
   rather than letting the exception propagate. This was the original bug
   encountered during fresh install with nuxwdog and HSM (DOGTAG-4272).

5. export_ca_cert() HSM token password pre-population - Pre-populate the
   HSM token password from keyring before opening the NSS database. In
   nuxwdog mode, password.conf does not exist and passwords are stored in
   the kernel keyring. Without this, open_nssdb() only fetches the internal
   token password, leaving the HSM token password missing from the password
   file passed to the PKI CLI.

6. pki-server-nuxwdog sleep timer - Increased background sleep from 10 to
   600 seconds to ensure the keyring file descriptor remains open longer
   during the ExecStartPre sequence (systemd bug #1668954).


This should resolve https://issues.redhat.com/browse/DOGTAG-4272 and https://issues.redhat.com/browse/DOGTAG-4273