### PR TITLE
Add support for bundling commons-logging.jar

### DIFF
--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -59,6 +59,79 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
               | tee output
 
+          # the following libraries should be bundled:
+          # - commons-logging
+          # - jackson-annotations
+          # - jackson-core
+          # - jackson-databind
+          # - jackson-jaxrs-base
+          # - jackson-jaxrs-json-provider
+          # - jackson-module-jaxb-annotations
+          # - jakarta.activation-api
+          # - jakarta.annotation-api
+          # - jakarta.xml.bind-api
+          # - jboss-jaxrs-api_2.0_spec
+          # - jboss-logging
+          # - resteasy-client
+          # - resteasy-jackson2-provider
+          # - resteasy-jaxrs
+          cat > expected << EOF
+          lrwxrwxrwx root root commons-cli.jar -> ../../../../usr/share/java/commons-cli.jar
+          lrwxrwxrwx root root commons-codec.jar -> ../../../../usr/share/java/commons-codec.jar
+          lrwxrwxrwx root root commons-io.jar -> ../../../../usr/share/java/commons-io.jar
+          lrwxrwxrwx root root commons-lang3.jar -> ../../../../usr/share/java/commons-lang3.jar
+          -rw-r--r-- root root commons-logging-x.y.z.jar
+          lrwxrwxrwx root root commons-logging.jar -> commons-logging-x.y.z.jar
+          lrwxrwxrwx root root commons-net.jar -> ../../../../usr/share/java/commons-net.jar
+          lrwxrwxrwx root root httpclient.jar -> ../../../../usr/share/java/httpcomponents/httpclient.jar
+          lrwxrwxrwx root root httpcore.jar -> ../../../../usr/share/java/httpcomponents/httpcore.jar
+          -rw-r--r-- root root jackson-annotations-x.y.z.jar
+          lrwxrwxrwx root root jackson-annotations.jar -> jackson-annotations-x.y.z.jar
+          -rw-r--r-- root root jackson-core-x.y.z.jar
+          lrwxrwxrwx root root jackson-core.jar -> jackson-core-x.y.z.jar
+          -rw-r--r-- root root jackson-databind-x.y.z.jar
+          lrwxrwxrwx root root jackson-databind.jar -> jackson-databind-x.y.z.jar
+          -rw-r--r-- root root jackson-jaxrs-base-x.y.z.jar
+          lrwxrwxrwx root root jackson-jaxrs-base.jar -> jackson-jaxrs-base-x.y.z.jar
+          -rw-r--r-- root root jackson-jaxrs-json-provider-x.y.z.jar
+          lrwxrwxrwx root root jackson-jaxrs-json-provider.jar -> jackson-jaxrs-json-provider-x.y.z.jar
+          -rw-r--r-- root root jackson-module-jaxb-annotations-x.y.z.jar
+          lrwxrwxrwx root root jackson-module-jaxb-annotations.jar -> jackson-module-jaxb-annotations-x.y.z.jar
+          -rw-r--r-- root root jakarta.activation-api-x.y.z.jar
+          lrwxrwxrwx root root jakarta.activation-api.jar -> jakarta.activation-api-x.y.z.jar
+          -rw-r--r-- root root jakarta.annotation-api-x.y.z.jar
+          lrwxrwxrwx root root jakarta.annotation-api.jar -> jakarta.annotation-api-x.y.z.jar
+          -rw-r--r-- root root jakarta.xml.bind-api-x.y.z.jar
+          lrwxrwxrwx root root jakarta.xml.bind-api.jar -> jakarta.xml.bind-api-x.y.z.jar
+          -rw-r--r-- root root jboss-jaxrs-api_2.0_spec-x.y.z.Final.jar
+          lrwxrwxrwx root root jboss-jaxrs-api_2.0_spec.jar -> jboss-jaxrs-api_2.0_spec-x.y.z.Final.jar
+          -rw-r--r-- root root jboss-logging-x.y.z.Final.jar
+          lrwxrwxrwx root root jboss-logging.jar -> jboss-logging-x.y.z.Final.jar
+          lrwxrwxrwx root root jss.jar -> ../../../../usr/lib/java/jss.jar
+          lrwxrwxrwx root root ldapjdk.jar -> ../../../../usr/share/java/ldapjdk.jar
+          lrwxrwxrwx root root p11-kit-trust.so -> ../../../../usr/lib64/pkcs11/p11-kit-trust.so
+          lrwxrwxrwx root root pki-common.jar -> ../../../../usr/share/java/pki/pki-common.jar
+          lrwxrwxrwx root root pki-tools.jar -> ../../../../usr/share/java/pki/pki-tools.jar
+          -rw-r--r-- root root resteasy-client-x.y.z.Final.jar
+          -rw-r--r-- root root resteasy-jackson2-provider-x.y.z.Final.jar
+          lrwxrwxrwx root root resteasy-jackson2-provider.jar -> resteasy-jackson2-provider-x.y.z.Final.jar
+          -rw-r--r-- root root resteasy-jaxrs-x.y.z.Final.jar
+          lrwxrwxrwx root root resteasy-jaxrs.jar -> resteasy-jaxrs-x.y.z.Final.jar
+          lrwxrwxrwx root root servlet.jar -> ../../../../usr/share/java/tomcat-servlet-api.jar
+          lrwxrwxrwx root root slf4j-api.jar -> ../../../../usr/share/java/slf4j/slf4j-api.jar
+          lrwxrwxrwx root root slf4j-jdk14.jar -> ../../../../usr/share/java/slf4j/slf4j-jdk14.jar
+          EOF
+
+          # normalize actual result:
+          # - replace version number with x.y.z
+          # - replace servlet.jar with tomcat-servlet-api.jar
+          sed -e 's/-[0-9]*\.[0-9]*\.[0-9]*\.jar$/-x.y.z.jar/' \
+              -e 's/-[0-9]*\.[0-9]*\.[0-9]*\.Final\.jar$/-x.y.z.Final.jar/' \
+              -e 's/\/servlet.jar$/\/tomcat-servlet-api.jar/' \
+              output > actual
+
+          diff expected actual
+
       - name: Check PKI server common lib dir
         run: |
           # check file types, owners, and permissions
@@ -68,6 +141,52 @@ jobs:
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
               | tee output
 
+          # the following libraries should be bundled:
+          # - resteasy-servlet-initializer
+          cat > expected << EOF
+          lrwxrwxrwx root root commons-codec.jar -> ../../../lib/commons-codec.jar
+          lrwxrwxrwx root root commons-io.jar -> ../../../lib/commons-io.jar
+          lrwxrwxrwx root root commons-lang3.jar -> ../../../lib/commons-lang3.jar
+          lrwxrwxrwx root root commons-logging.jar -> ../../../lib/commons-logging.jar
+          lrwxrwxrwx root root commons-net.jar -> ../../../lib/commons-net.jar
+          lrwxrwxrwx root root httpclient.jar -> ../../../lib/httpclient.jar
+          lrwxrwxrwx root root httpcore.jar -> ../../../lib/httpcore.jar
+          lrwxrwxrwx root root jackson-annotations.jar -> ../../../lib/jackson-annotations.jar
+          lrwxrwxrwx root root jackson-core.jar -> ../../../lib/jackson-core.jar
+          lrwxrwxrwx root root jackson-databind.jar -> ../../../lib/jackson-databind.jar
+          lrwxrwxrwx root root jackson-jaxrs-base.jar -> ../../../lib/jackson-jaxrs-base.jar
+          lrwxrwxrwx root root jackson-jaxrs-json-provider.jar -> ../../../lib/jackson-jaxrs-json-provider.jar
+          lrwxrwxrwx root root jackson-module-jaxb-annotations.jar -> ../../../lib/jackson-module-jaxb-annotations.jar
+          lrwxrwxrwx root root jakarta.activation-api.jar -> ../../../lib/jakarta.activation-api.jar
+          lrwxrwxrwx root root jakarta.annotation-api.jar -> ../../../lib/jakarta.annotation-api.jar
+          lrwxrwxrwx root root jakarta.xml.bind-api.jar -> ../../../lib/jakarta.xml.bind-api.jar
+          lrwxrwxrwx root root jboss-jaxrs-api_2.0_spec.jar -> ../../../lib/jboss-jaxrs-api_2.0_spec.jar
+          lrwxrwxrwx root root jboss-logging.jar -> ../../../lib/jboss-logging.jar
+          lrwxrwxrwx root root jss-tomcat-10.1.jar -> ../../../../../../usr/share/java/jss/jss-tomcat-10.1.jar
+          lrwxrwxrwx root root jss-tomcat.jar -> ../../../../../../usr/share/java/jss/jss-tomcat.jar
+          lrwxrwxrwx root root jss.jar -> ../../../lib/jss.jar
+          lrwxrwxrwx root root ldapjdk.jar -> ../../../lib/ldapjdk.jar
+          lrwxrwxrwx root root pki-common.jar -> ../../../lib/pki-common.jar
+          lrwxrwxrwx root root pki-tomcat-10.1.jar -> ../../../../../../usr/share/java/pki/pki-tomcat-10.1.jar
+          lrwxrwxrwx root root pki-tomcat.jar -> ../../../../../../usr/share/java/pki/pki-tomcat.jar
+          lrwxrwxrwx root root resteasy-jackson2-provider.jar -> ../../../lib/resteasy-jackson2-provider.jar
+          lrwxrwxrwx root root resteasy-jaxrs.jar -> ../../../lib/resteasy-jaxrs.jar
+          -rw-r--r-- root root resteasy-servlet-initializer-x.y.z.Final.jar
+          lrwxrwxrwx root root resteasy-servlet-initializer.jar -> resteasy-servlet-initializer-x.y.z.Final.jar
+          EOF
+
+          # normalize actual result:
+          # - replace version number with x.y.z
+          # - replace jss-tomcat-9.0.jar with jss-tomcat-10.1.jar
+          # - replace pki-tomcat-9.0.jar with pki-tomcat-10.1.jar
+          sed -e 's/-[0-9]*\.[0-9]*\.[0-9]*\.jar$/-x.y.z.jar/' \
+              -e 's/-[0-9]*\.[0-9]*\.[0-9]*\.Final\.jar$/-x.y.z.Final.jar/' \
+              -e 's/jss-tomcat-9.0.jar/jss-tomcat-10.1.jar/g' \
+              -e 's/pki-tomcat-9.0.jar/pki-tomcat-10.1.jar/g' \
+              output > actual
+
+          diff expected actual
+
       - name: Check PKI server lib dir
         run: |
           # check file types, owners, and permissions
@@ -76,6 +195,13 @@ jobs:
                   -e '/^total/d' \
                   -e 's/^\(\S*\) *\S* *\(\S*\) *\(\S*\) *\S* *\S* *\S* *\S* *\(.*\)$/\1 \2 \3 \4/' \
               | tee output
+
+          cat > expected << EOF
+          lrwxrwxrwx root root slf4j-api.jar -> ../../lib/slf4j-api.jar
+          lrwxrwxrwx root root slf4j-jdk14.jar -> ../../lib/slf4j-jdk14.jar
+          EOF
+
+          diff expected output
 
       - name: Check pki-server CLI help message
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
 
 # Install PKI runtime dependencies
 RUN dnf install -y dogtag-pki \
-    && rpm -e --nodeps $(rpm -qa | grep -E "^java-|^dogtag-|^python3-dogtag-|^pki-resteasy-|^jboss-logging-|^jboss-jaxrs-2.0-api-|^jackson-|^jaxb-api-|^jakarta-annotations-|^jakarta-activation-") \
+    && PACKAGES=$(rpm -qa | grep -E "^java-|^dogtag-|^python3-dogtag-|^apache-commons-logging|^pki-resteasy-|^jboss-logging-|^jboss-jaxrs-2.0-api-|^jackson-|^jaxb-api-|^jakarta-annotations-|^jakarta-activation-") \
+    && rpm -e --nodeps $PACKAGES \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -1,5 +1,13 @@
 project(base)
 
+execute_process(
+    COMMAND awk -F= "$1==\"ID\" { print $2 ;}" /etc/os-release
+    OUTPUT_VARIABLE DISTRO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+find_program(XMVN_RESOLVE /bin/xmvn-resolve)
+
 find_file(SERVLET_JAR
     NAMES
         servlet.jar
@@ -92,12 +100,41 @@ find_file(COMMONS_LANG3_JAR
         /usr/share/java
 )
 
-find_file(COMMONS_LOGGING_JAR
-    NAMES
-        commons-logging.jar
-    PATHS
-        /usr/share/java
-)
+if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+    execute_process(
+        COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
+        COMMAND sed -n "s/^commons-logging-\\(.*\\)\\.jar\$/\\1/p"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE COMMONS_LOGGING_VERSION
+    )
+endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+
+if (COMMONS_LOGGING_VERSION)
+    # use imported JARs
+
+    set(COMMONS_LOGGING_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/commons-logging-${COMMONS_LOGGING_VERSION}.jar")
+    set(COMMONS_LOGGING_LINK "commons-logging-${COMMONS_LOGGING_VERSION}.jar")
+
+else()
+    # use system JARs
+
+    if(XMVN_RESOLVE)
+        execute_process(
+            COMMAND xmvn-resolve commons-logging:commons-logging
+            OUTPUT_VARIABLE COMMONS_LOGGING_JAR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    else()
+        find_file(COMMONS_LOGGING_JAR
+            NAMES
+                commons-logging.jar
+            PATHS
+                /usr/share/java
+        )
+    endif(XMVN_RESOLVE)
+    set(COMMONS_LOGGING_LINK "../../../..${COMMONS_LOGGING_JAR}")
+
+endif (COMMONS_LOGGING_VERSION)
 
 find_file(COMMONS_NET_JAR
     NAMES
@@ -215,14 +252,6 @@ else()
     set(JACKSON_MODULE_JAXB_ANNOTATIONS_LINK "../../../..${JACKSON_MODULE_JAXB_ANNOTATIONS_JAR}")
 
 endif (JACKSON_VERSION)
-
-execute_process(
-    COMMAND awk -F= "$1==\"ID\" { print $2 ;}" /etc/os-release
-    OUTPUT_VARIABLE DISTRO
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-find_program(XMVN_RESOLVE /bin/xmvn-resolve)
 
 if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
     execute_process(

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -121,7 +121,7 @@ add_custom_command(
     COMMAND ln -sf ../../../..${COMMONS_CODEC_JAR} lib/commons-codec.jar
     COMMAND ln -sf ../../../..${COMMONS_IO_JAR} lib/commons-io.jar
     COMMAND ln -sf ../../../..${COMMONS_LANG3_JAR} lib/commons-lang3.jar
-    COMMAND ln -sf ../../../..${COMMONS_LOGGING_JAR} lib/commons-logging.jar
+    COMMAND ln -sf ${COMMONS_LOGGING_LINK} lib/commons-logging.jar
     COMMAND ln -sf ../../../..${COMMONS_NET_JAR} lib/commons-net.jar
     COMMAND ln -sf ../../../..${HTTPCLIENT_JAR} lib/httpclient.jar
     COMMAND ln -sf ../../../..${HTTPCORE_JAR} lib/httpcore.jar

--- a/pki.spec
+++ b/pki.spec
@@ -242,7 +242,6 @@ BuildRequires:    %{vendor_id}-jss >= 5.10
 BuildRequires:    mvn(commons-cli:commons-cli)
 BuildRequires:    mvn(commons-codec:commons-codec)
 BuildRequires:    mvn(commons-io:commons-io)
-BuildRequires:    mvn(commons-logging:commons-logging)
 BuildRequires:    mvn(commons-net:commons-net)
 BuildRequires:    mvn(org.apache.commons:commons-lang3)
 BuildRequires:    mvn(org.apache.httpcomponents:httpclient)
@@ -252,6 +251,8 @@ BuildRequires:    mvn(xml-resolver:xml-resolver)
 BuildRequires:    mvn(org.junit.jupiter:junit-jupiter-api)
 
 %if %{with build_deps}
+BuildRequires:    mvn(commons-logging:commons-logging)
+
 BuildRequires:    mvn(jakarta.activation:jakarta.activation-api)
 BuildRequires:    mvn(jakarta.annotation:jakarta.annotation-api)
 BuildRequires:    mvn(jakarta.xml.bind:jakarta.xml.bind-api)
@@ -587,7 +588,6 @@ Requires:         %{java_headless}
 Requires:         mvn(commons-cli:commons-cli)
 Requires:         mvn(commons-codec:commons-codec)
 Requires:         mvn(commons-io:commons-io)
-Requires:         mvn(commons-logging:commons-logging)
 Requires:         mvn(commons-net:commons-net)
 Requires:         mvn(org.apache.commons:commons-lang3)
 Requires:         mvn(org.apache.httpcomponents:httpclient)
@@ -595,6 +595,8 @@ Requires:         mvn(org.slf4j:slf4j-api)
 Requires:         mvn(org.slf4j:slf4j-jdk14)
 
 %if %{with runtime_deps}
+Requires:         mvn(commons-logging:commons-logging)
+
 Requires:         mvn(jakarta.activation:jakarta.activation-api)
 Requires:         mvn(jakarta.annotation:jakarta.annotation-api)
 Requires:         mvn(jakarta.xml.bind:jakarta.xml.bind-api)
@@ -612,6 +614,8 @@ Requires:         mvn(org.jboss.resteasy:resteasy-jaxrs)
 Requires:         mvn(org.jboss.resteasy:resteasy-client)
 Requires:         mvn(org.jboss.resteasy:resteasy-jackson2-provider)
 %else
+Provides:         bundled(commons-logging)
+
 Provides:         bundled(jakarta-activation)
 Provides:         bundled(jakarta-annotations)
 Provides:         bundled(jaxb-api)
@@ -1109,6 +1113,12 @@ then
     mkdir -p base/common/lib
     pushd base/common/lib
 
+    COMMON_LOGGING_VERSION=$(rpm -q apache-commons-logging | sed -n 's/^apache-commons-logging-\([^-]*\)-.*$/\1/p')
+    echo "COMMON_LOGGING_VERSION: $COMMON_LOGGING_VERSION"
+
+    cp /usr/share/java/commons-logging.jar \
+        commons-logging-$COMMON_LOGGING_VERSION.jar
+
     JAKARTA_ACTIVATION_API_VERSION=$(rpm -q jakarta-activation | sed -n 's/^jakarta-activation-\([^-]*\)-.*$/\1/p')
     echo "JAKARTA_ACTIVATION_API_VERSION: $JAKARTA_ACTIVATION_API_VERSION"
 
@@ -1178,20 +1188,18 @@ then
 
     echo "Doing the Tomcat 10 version..."
 
-    /usr/bin/javax2jakarta -profile=EE jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
-
-    /usr/bin/javax2jakarta -profile=EE jackson-jaxrs-json-provider-$JACKSON_VERSION.jar jackson-jaxrs-json-provider-$JACKSON_VERSION.jar
+    /usr/bin/javax2jakarta -profile=EE jakarta.activation-api-$JAKARTA_ACTIVATION_API_VERSION.jar jakarta.activation-api-$JAKARTA_ACTIVATION_API_VERSION.jar
+    /usr/bin/javax2jakarta -profile=EE jakarta.annotation-api-$JAKARTA_ANNOTATION_API_VERSION.jar jakarta.annotation-api-$JAKARTA_ANNOTATION_API_VERSION.jar
+    /usr/bin/javax2jakarta -profile=EE jakarta.xml.bind-api-$JAXB_API_VERSION.jar jakarta.xml.bind-api-$JAXB_API_VERSION.jar
 
     /usr/bin/javax2jakarta -profile=EE jackson-annotations-$JACKSON_VERSION.jar jackson-annotations-$JACKSON_VERSION.jar
     /usr/bin/javax2jakarta -profile=EE jackson-core-$JACKSON_VERSION.jar jackson-core-$JACKSON_VERSION.jar
     /usr/bin/javax2jakarta -profile=EE jackson-databind-$JACKSON_VERSION.jar jackson-databind-$JACKSON_VERSION.jar
+    /usr/bin/javax2jakarta -profile=EE jackson-module-jaxb-annotations-$JACKSON_VERSION.jar jackson-module-jaxb-annotations-$JACKSON_VERSION.jar
     /usr/bin/javax2jakarta -profile=EE jackson-jaxrs-base-$JACKSON_VERSION.jar jackson-jaxrs-base-$JACKSON_VERSION.jar
     /usr/bin/javax2jakarta -profile=EE jackson-jaxrs-json-provider-$JACKSON_VERSION.jar jackson-jaxrs-json-provider-$JACKSON_VERSION.jar
-    /usr/bin/javax2jakarta -profile=EE jackson-module-jaxb-annotations-$JACKSON_VERSION.jar jackson-module-jaxb-annotations-$JACKSON_VERSION.jar
 
-    /usr/bin/javax2jakarta -profile=EE jakarta.activation-api-$JAKARTA_ACTIVATION_API_VERSION.jar jakarta.activation-api-$JAKARTA_ACTIVATION_API_VERSION.jar
-    /usr/bin/javax2jakarta -profile=EE jakarta.annotation-api-$JAKARTA_ANNOTATION_API_VERSION.jar jakarta.annotation-api-$JAKARTA_ANNOTATION_API_VERSION.jar
-    /usr/bin/javax2jakarta -profile=EE jakarta.xml.bind-api-$JAXB_API_VERSION.jar jakarta.xml.bind-api-$JAXB_API_VERSION.jar
+    /usr/bin/javax2jakarta -profile=EE jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
 
     # Now migrate the required resteasy jars, in case we are using an existing resteasy version.
 
@@ -1209,7 +1217,7 @@ then
     mkdir -p ~/.m2/repository/pki-local/jboss-jaxrs-api_2.0_spec/$JAXRS_VERSION
 
     # Copy over the JAX-RS API so we can compile.
-    cp jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar  ~/.m2/repository/pki-local/jboss-jaxrs-api_2.0_spec/$JAXRS_VERSION/jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
+    cp jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar ~/.m2/repository/pki-local/jboss-jaxrs-api_2.0_spec/$JAXRS_VERSION/jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
 
     popd
 fi
@@ -1519,8 +1527,10 @@ fi
 %if %{with maven}
 
 %if %{with meta}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1534,8 +1544,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with base}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-java.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-java.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-java.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1548,8 +1560,10 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-java.xml
 
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-tools.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tools.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tools.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1563,8 +1577,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with server}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-server.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-server.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-server.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1578,8 +1594,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with ca}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-ca.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ca.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ca.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1593,8 +1611,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with kra}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-kra.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata//%{name}-pki-kra.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-kra.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1608,8 +1628,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with ocsp}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-ocsp.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ocsp.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ocsp.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1623,8 +1645,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with tks}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-tks.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tks.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tks.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1638,8 +1662,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with tps}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-tps.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tps.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tps.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1653,8 +1679,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with acme}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-acme.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-acme.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-acme.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1668,8 +1696,10 @@ xmlstarlet edit --inplace \
 %endif
 
 %if %{with est}
-echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/pki-pki-est.xml"
+echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-est.xml"
+cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-est.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \


### PR DESCRIPTION
The build scripts have been updated to optionally support bundling `commons-logging.jar` in addition to other libraries into the RPM package.

The server test has been updated to check the libraries included in the RPM package.