### PR TITLE
Add support for bundling Apache Commons library

### DIFF
--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -60,7 +60,12 @@ jobs:
               | tee output
 
           # the following libraries should be bundled:
+          # - commons-cli
+          # - commons-codec
+          # - commons-io
+          # - commons-lang3
           # - commons-logging
+          # - commons-net
           # - jackson-annotations
           # - jackson-core
           # - jackson-databind
@@ -76,13 +81,18 @@ jobs:
           # - resteasy-jackson2-provider
           # - resteasy-jaxrs
           cat > expected << EOF
-          lrwxrwxrwx root root commons-cli.jar -> ../../../../usr/share/java/commons-cli.jar
-          lrwxrwxrwx root root commons-codec.jar -> ../../../../usr/share/java/commons-codec.jar
-          lrwxrwxrwx root root commons-io.jar -> ../../../../usr/share/java/commons-io.jar
-          lrwxrwxrwx root root commons-lang3.jar -> ../../../../usr/share/java/commons-lang3.jar
+          -rw-r--r-- root root commons-cli-x.y.z.jar
+          lrwxrwxrwx root root commons-cli.jar -> commons-cli-x.y.z.jar
+          -rw-r--r-- root root commons-codec-x.y.z.jar
+          lrwxrwxrwx root root commons-codec.jar -> commons-codec-x.y.z.jar
+          -rw-r--r-- root root commons-io-x.y.z.jar
+          lrwxrwxrwx root root commons-io.jar -> commons-io-x.y.z.jar
+          -rw-r--r-- root root commons-lang3-x.y.z.jar
+          lrwxrwxrwx root root commons-lang3.jar -> commons-lang3-x.y.z.jar
           -rw-r--r-- root root commons-logging-x.y.z.jar
           lrwxrwxrwx root root commons-logging.jar -> commons-logging-x.y.z.jar
-          lrwxrwxrwx root root commons-net.jar -> ../../../../usr/share/java/commons-net.jar
+          -rw-r--r-- root root commons-net-x.y.z.jar
+          lrwxrwxrwx root root commons-net.jar -> commons-net-x.y.z.jar
           lrwxrwxrwx root root httpclient.jar -> ../../../../usr/share/java/httpcomponents/httpclient.jar
           lrwxrwxrwx root root httpcore.jar -> ../../../../usr/share/java/httpcomponents/httpcore.jar
           -rw-r--r-- root root jackson-annotations-x.y.z.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,12 @@ RUN if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
 
 # Install PKI runtime dependencies
 RUN dnf install -y dogtag-pki \
-    && PACKAGES=$(rpm -qa | grep -E "^java-|^dogtag-|^python3-dogtag-|^apache-commons-logging|^pki-resteasy-|^jboss-logging-|^jboss-jaxrs-2.0-api-|^jackson-|^jaxb-api-|^jakarta-annotations-|^jakarta-activation-") \
-    && rpm -e --nodeps $PACKAGES \
+    && REGEX="^java-|^dogtag-|^python3-dogtag-" \
+    && REGEX="$REGEX|^apache-commons-cli-|^apache-commons-codec-|^apache-commons-io-|^apache-commons-lang3-|^apache-commons-logging-|^apache-commons-net-" \
+    && REGEX="$REGEX|^jakarta-activation-|^jakarta-annotations-|^jaxb-api-" \
+    && REGEX="$REGEX|^jboss-logging-|^jboss-jaxrs-2.0-api-" \
+    && REGEX="$REGEX|^jackson-|^pki-resteasy-" \
+    && rpm -e --nodeps $(rpm -qa | grep -E "$REGEX") \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -72,33 +72,149 @@ find_file(SLF4J_SIMPLE_JAR
         /usr/share/java
 )
 
-find_file(COMMONS_CLI_JAR
-    NAMES
-        commons-cli.jar
-    PATHS
-        /usr/share/java
-)
+if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+    execute_process(
+        COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
+        COMMAND sed -n "s/^commons-cli-\\(.*\\)\\.jar\$/\\1/p"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE COMMONS_CLI_VERSION
+    )
+endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
 
-find_file(COMMONS_CODEC_JAR
-    NAMES
-        commons-codec.jar
-    PATHS
-        /usr/share/java
-)
+if (COMMONS_CLI_VERSION)
+    # use imported JARs
 
-find_file(COMMONS_IO_JAR
-    NAMES
-        commons-io.jar
-    PATHS
-        /usr/share/java
-)
+    set(COMMONS_CLI_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/commons-cli-${COMMONS_CLI_VERSION}.jar")
+    set(COMMONS_CLI_LINK "commons-cli-${COMMONS_CLI_VERSION}.jar")
 
-find_file(COMMONS_LANG3_JAR
-    NAMES
-        commons-lang3.jar
-    PATHS
-        /usr/share/java
-)
+else()
+    # use system JARs
+
+    if(XMVN_RESOLVE)
+        execute_process(
+            COMMAND xmvn-resolve commons-cli:commons-cli
+            OUTPUT_VARIABLE COMMONS_CLI_JAR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    else()
+        find_file(COMMONS_CLI_JAR
+            NAMES
+                commons-cli.jar
+            PATHS
+                /usr/share/java
+        )
+    endif(XMVN_RESOLVE)
+    set(COMMONS_CLI_LINK "../../../..${COMMONS_CLI_JAR}")
+
+endif (COMMONS_CLI_VERSION)
+
+if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+    execute_process(
+        COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
+        COMMAND sed -n "s/^commons-codec-\\(.*\\)\\.jar\$/\\1/p"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE COMMONS_CODEC_VERSION
+    )
+endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+
+if (COMMONS_CODEC_VERSION)
+    # use imported JARs
+
+    set(COMMONS_CODEC_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/commons-codec-${COMMONS_CODEC_VERSION}.jar")
+    set(COMMONS_CODEC_LINK "commons-codec-${COMMONS_CODEC_VERSION}.jar")
+
+else()
+    # use system JARs
+
+    if(XMVN_RESOLVE)
+        execute_process(
+            COMMAND xmvn-resolve commons-codec:commons-codec
+            OUTPUT_VARIABLE COMMONS_CODEC_JAR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    else()
+        find_file(COMMONS_CODEC_JAR
+            NAMES
+                commons-codec.jar
+            PATHS
+                /usr/share/java
+        )
+    endif(XMVN_RESOLVE)
+    set(COMMONS_CODEC_LINK "../../../..${COMMONS_CODEC_JAR}")
+
+endif (COMMONS_CODEC_VERSION)
+
+if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+    execute_process(
+        COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
+        COMMAND sed -n "s/^commons-io-\\(.*\\)\\.jar\$/\\1/p"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE COMMONS_IO_VERSION
+    )
+endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+
+if (COMMONS_IO_VERSION)
+    # use imported JARs
+
+    set(COMMONS_IO_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/commons-io-${COMMONS_IO_VERSION}.jar")
+    set(COMMONS_IO_LINK "commons-io-${COMMONS_IO_VERSION}.jar")
+
+else()
+    # use system JARs
+
+    if(XMVN_RESOLVE)
+        execute_process(
+            COMMAND xmvn-resolve commons-io:commons-io
+            OUTPUT_VARIABLE COMMONS_IO_JAR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    else()
+        find_file(COMMONS_IO_JAR
+            NAMES
+                commons-io.jar
+            PATHS
+                /usr/share/java
+        )
+    endif(XMVN_RESOLVE)
+    set(COMMONS_IO_LINK "../../../..${COMMONS_IO_JAR}")
+
+endif (COMMONS_IO_VERSION)
+
+if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+    execute_process(
+        COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
+        COMMAND sed -n "s/^commons-lang3-\\(.*\\)\\.jar\$/\\1/p"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE COMMONS_LANG3_VERSION
+    )
+endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+
+if (COMMONS_LANG3_VERSION)
+    # use imported JARs
+
+    set(COMMONS_LANG3_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/commons-lang3-${COMMONS_LANG3_VERSION}.jar")
+    set(COMMONS_LANG3_LINK "commons-lang3-${COMMONS_LANG3_VERSION}.jar")
+
+else()
+    # use system JARs
+
+    if(XMVN_RESOLVE)
+        execute_process(
+            COMMAND xmvn-resolve org.apache.commons:commons-lang3
+            OUTPUT_VARIABLE COMMONS_LANG3_JAR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    else()
+        find_file(COMMONS_LANG3_JAR
+            NAMES
+                commons-lang3.jar
+            PATHS
+                /usr/share/java
+        )
+    endif(XMVN_RESOLVE)
+    set(COMMONS_LANG3_LINK "../../../..${COMMONS_LANG3_JAR}")
+
+endif (COMMONS_LANG3_VERSION)
 
 if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
     execute_process(
@@ -136,12 +252,41 @@ else()
 
 endif (COMMONS_LOGGING_VERSION)
 
-find_file(COMMONS_NET_JAR
-    NAMES
-        commons-net.jar
-    PATHS
-        /usr/share/java
-)
+if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+    execute_process(
+        COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
+        COMMAND sed -n "s/^commons-net-\\(.*\\)\\.jar\$/\\1/p"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE COMMONS_NET_VERSION
+    )
+endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+
+if (COMMONS_NET_VERSION)
+    # use imported JARs
+
+    set(COMMONS_NET_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/commons-net-${COMMONS_NET_VERSION}.jar")
+    set(COMMONS_NET_LINK "commons-net-${COMMONS_NET_VERSION}.jar")
+
+else()
+    # use system JARs
+
+    if(XMVN_RESOLVE)
+        execute_process(
+            COMMAND xmvn-resolve commons-net:commons-net
+            OUTPUT_VARIABLE COMMONS_NET_JAR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    else()
+        find_file(COMMONS_NET_JAR
+            NAMES
+                commons-net.jar
+            PATHS
+                /usr/share/java
+        )
+    endif(XMVN_RESOLVE)
+    set(COMMONS_NET_LINK "../../../..${COMMONS_NET_JAR}")
+
+endif (COMMONS_NET_VERSION)
 
 find_file(HAMCREST_JAR
     NAMES

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -117,12 +117,12 @@ add_custom_command(
     TARGET pki-lib POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory lib
     COMMAND test ! -d ${CMAKE_SOURCE_DIR}/base/common/lib || cp ${CMAKE_SOURCE_DIR}/base/common/lib/* lib
-    COMMAND ln -sf ../../../..${COMMONS_CLI_JAR} lib/commons-cli.jar
-    COMMAND ln -sf ../../../..${COMMONS_CODEC_JAR} lib/commons-codec.jar
-    COMMAND ln -sf ../../../..${COMMONS_IO_JAR} lib/commons-io.jar
-    COMMAND ln -sf ../../../..${COMMONS_LANG3_JAR} lib/commons-lang3.jar
+    COMMAND ln -sf ${COMMONS_CLI_LINK} lib/commons-cli.jar
+    COMMAND ln -sf ${COMMONS_CODEC_LINK} lib/commons-codec.jar
+    COMMAND ln -sf ${COMMONS_IO_LINK} lib/commons-io.jar
+    COMMAND ln -sf ${COMMONS_LANG3_LINK} lib/commons-lang3.jar
     COMMAND ln -sf ${COMMONS_LOGGING_LINK} lib/commons-logging.jar
-    COMMAND ln -sf ../../../..${COMMONS_NET_JAR} lib/commons-net.jar
+    COMMAND ln -sf ${COMMONS_NET_LINK} lib/commons-net.jar
     COMMAND ln -sf ../../../..${HTTPCLIENT_JAR} lib/httpclient.jar
     COMMAND ln -sf ../../../..${HTTPCORE_JAR} lib/httpcore.jar
     COMMAND ln -sf ${JACKSON_ANNOTATIONS_LINK} lib/jackson-annotations.jar

--- a/pki.spec
+++ b/pki.spec
@@ -239,11 +239,6 @@ BuildRequires:    tomcat-jakartaee-migration
 
 BuildRequires:    %{vendor_id}-jss >= 5.10
 
-BuildRequires:    mvn(commons-cli:commons-cli)
-BuildRequires:    mvn(commons-codec:commons-codec)
-BuildRequires:    mvn(commons-io:commons-io)
-BuildRequires:    mvn(commons-net:commons-net)
-BuildRequires:    mvn(org.apache.commons:commons-lang3)
 BuildRequires:    mvn(org.apache.httpcomponents:httpclient)
 BuildRequires:    mvn(org.slf4j:slf4j-api)
 BuildRequires:    mvn(xml-apis:xml-apis)
@@ -251,7 +246,12 @@ BuildRequires:    mvn(xml-resolver:xml-resolver)
 BuildRequires:    mvn(org.junit.jupiter:junit-jupiter-api)
 
 %if %{with build_deps}
+BuildRequires:    mvn(commons-cli:commons-cli)
+BuildRequires:    mvn(commons-codec:commons-codec)
+BuildRequires:    mvn(commons-io:commons-io)
+BuildRequires:    mvn(org.apache.commons:commons-lang3)
 BuildRequires:    mvn(commons-logging:commons-logging)
+BuildRequires:    mvn(commons-net:commons-net)
 
 BuildRequires:    mvn(jakarta.activation:jakarta.activation-api)
 BuildRequires:    mvn(jakarta.annotation:jakarta.annotation-api)
@@ -585,17 +585,17 @@ Obsoletes:        %{product_id}-base-java < %{version}-%{release}
 Provides:         %{product_id}-base-java = %{version}-%{release}
 
 Requires:         %{java_headless}
-Requires:         mvn(commons-cli:commons-cli)
-Requires:         mvn(commons-codec:commons-codec)
-Requires:         mvn(commons-io:commons-io)
-Requires:         mvn(commons-net:commons-net)
-Requires:         mvn(org.apache.commons:commons-lang3)
 Requires:         mvn(org.apache.httpcomponents:httpclient)
 Requires:         mvn(org.slf4j:slf4j-api)
 Requires:         mvn(org.slf4j:slf4j-jdk14)
 
 %if %{with runtime_deps}
+Requires:         mvn(commons-cli:commons-cli)
+Requires:         mvn(commons-codec:commons-codec)
+Requires:         mvn(commons-io:commons-io)
+Requires:         mvn(org.apache.commons:commons-lang3)
 Requires:         mvn(commons-logging:commons-logging)
+Requires:         mvn(commons-net:commons-net)
 
 Requires:         mvn(jakarta.activation:jakarta.activation-api)
 Requires:         mvn(jakarta.annotation:jakarta.annotation-api)
@@ -614,7 +614,12 @@ Requires:         mvn(org.jboss.resteasy:resteasy-jaxrs)
 Requires:         mvn(org.jboss.resteasy:resteasy-client)
 Requires:         mvn(org.jboss.resteasy:resteasy-jackson2-provider)
 %else
-Provides:         bundled(commons-logging)
+Provides:         bundled(apache-commons-cli)
+Provides:         bundled(apache-commons-codec)
+Provides:         bundled(apache-commons-io)
+Provides:         bundled(apache-commons-lang3)
+Provides:         bundled(apache-commons-logging)
+Provides:         bundled(apache-commons-net)
 
 Provides:         bundled(jakarta-activation)
 Provides:         bundled(jakarta-annotations)
@@ -1113,11 +1118,41 @@ then
     mkdir -p base/common/lib
     pushd base/common/lib
 
-    COMMON_LOGGING_VERSION=$(rpm -q apache-commons-logging | sed -n 's/^apache-commons-logging-\([^-]*\)-.*$/\1/p')
-    echo "COMMON_LOGGING_VERSION: $COMMON_LOGGING_VERSION"
+    COMMONS_CLI_VERSION=$(rpm -q apache-commons-cli | sed -n 's/^apache-commons-cli-\([^-]*\)-.*$/\1/p')
+    echo "COMMONS_CLI_VERSION: $COMMONS_CLI_VERSION"
+
+    cp /usr/share/java/commons-cli.jar \
+        commons-cli-$COMMONS_CLI_VERSION.jar
+
+    COMMONS_CODEC_VERSION=$(rpm -q apache-commons-codec | sed -n 's/^apache-commons-codec-\([^-]*\)-.*$/\1/p')
+    echo "COMMONS_CODEC_VERSION: $COMMONS_CODEC_VERSION"
+
+    cp /usr/share/java/commons-codec.jar \
+        commons-codec-$COMMONS_CODEC_VERSION.jar
+
+    COMMONS_IO_VERSION=$(rpm -q apache-commons-io | sed -n 's/^apache-commons-io-\([^-]*\)-.*$/\1/p')
+    echo "COMMONS_IO_VERSION: $COMMONS_IO_VERSION"
+
+    cp /usr/share/java/commons-io.jar \
+        commons-io-$COMMONS_IO_VERSION.jar
+
+    COMMONS_LANG3_VERSION=$(rpm -q apache-commons-lang3 | sed -n 's/^apache-commons-lang3-\([^-]*\)-.*$/\1/p')
+    echo "COMMONS_LANG3_VERSION: $COMMONS_LANG3_VERSION"
+
+    cp /usr/share/java/commons-lang3.jar \
+        commons-lang3-$COMMONS_LANG3_VERSION.jar
+
+    COMMONS_LOGGING_VERSION=$(rpm -q apache-commons-logging | sed -n 's/^apache-commons-logging-\([^-]*\)-.*$/\1/p')
+    echo "COMMONS_LOGGING_VERSION: $COMMONS_LOGGING_VERSION"
 
     cp /usr/share/java/commons-logging.jar \
-        commons-logging-$COMMON_LOGGING_VERSION.jar
+        commons-logging-$COMMONS_LOGGING_VERSION.jar
+
+    COMMONS_NET_VERSION=$(rpm -q apache-commons-net | sed -n 's/^apache-commons-net-\([^-]*\)-.*$/\1/p')
+    echo "COMMONS_NET_VERSION: $COMMONS_NET_VERSION"
+
+    cp /usr/share/java/commons-net.jar \
+        commons-net-$COMMONS_NET_VERSION.jar
 
     JAKARTA_ACTIVATION_API_VERSION=$(rpm -q jakarta-activation | sed -n 's/^jakarta-activation-\([^-]*\)-.*$/\1/p')
     echo "JAKARTA_ACTIVATION_API_VERSION: $JAKARTA_ACTIVATION_API_VERSION"
@@ -1530,7 +1565,12 @@ fi
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1547,7 +1587,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-java.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-java.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1563,7 +1608,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tools.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tools.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1580,7 +1630,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-server.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-server.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1597,7 +1652,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ca.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ca.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1614,7 +1674,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata//%{name}-pki-kra.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-kra.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1631,7 +1696,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ocsp.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ocsp.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1648,7 +1718,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tks.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tks.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1665,7 +1740,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tps.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tps.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1682,7 +1762,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-acme.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-acme.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1699,7 +1784,12 @@ xmlstarlet edit --inplace \
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-est.xml"
 cat %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-est.xml
 xmlstarlet edit --inplace \
+    -d "//_:dependency[_:groupId='commons-cli']" \
+    -d "//_:dependency[_:groupId='commons-codec']" \
+    -d "//_:dependency[_:groupId='commons-io']" \
+    -d "//_:dependency[_:groupId='org.apache.commons']" \
     -d "//_:dependency[_:groupId='commons-logging']" \
+    -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \


### PR DESCRIPTION
The build scripts have been updated to optionally support bundling Apache Commons library in addition to other libraries into the RPM package.

**Note:** This PR will need to be rebased if PR #5284 is merged first.