### PR TITLE
Add support for bundling HTTP Components and SLF4J libraries

### DIFF
--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -82,6 +82,8 @@ jobs:
           # - resteasy-client
           # - resteasy-jackson2-provider
           # - resteasy-jaxrs
+          # - slf4j-api
+          # - slf4j-jdk14
           cat > expected << EOF
           -rw-r--r-- root root commons-cli-x.y.z.jar
           lrwxrwxrwx root root commons-cli.jar -> commons-cli-x.y.z.jar
@@ -132,8 +134,10 @@ jobs:
           -rw-r--r-- root root resteasy-jaxrs-x.y.z.Final.jar
           lrwxrwxrwx root root resteasy-jaxrs.jar -> resteasy-jaxrs-x.y.z.Final.jar
           lrwxrwxrwx root root servlet.jar -> ../../../../usr/share/java/tomcat-servlet-api.jar
-          lrwxrwxrwx root root slf4j-api.jar -> ../../../../usr/share/java/slf4j/slf4j-api.jar
-          lrwxrwxrwx root root slf4j-jdk14.jar -> ../../../../usr/share/java/slf4j/slf4j-jdk14.jar
+          -rw-r--r-- root root slf4j-api-x.y.z.jar
+          lrwxrwxrwx root root slf4j-api.jar -> slf4j-api-x.y.z.jar
+          -rw-r--r-- root root slf4j-jdk14-x.y.z.jar
+          lrwxrwxrwx root root slf4j-jdk14.jar -> slf4j-jdk14-x.y.z.jar
           EOF
 
           # normalize actual result:

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN if [ -n "$COPR_REPO" ]; then dnf copr enable -y $COPR_REPO; fi
 RUN dnf install -y dogtag-pki \
     && REGEX="^java-|^dogtag-|^python3-dogtag-" \
     && REGEX="$REGEX|^apache-commons-cli-|^apache-commons-codec-|^apache-commons-io-|^apache-commons-lang3-|^apache-commons-logging-|^apache-commons-net-" \
-    && REGEX="$REGEX|^httpcomponents-" \
+    && REGEX="$REGEX|^httpcomponents-|^slf4j-" \
     && REGEX="$REGEX|^jakarta-activation-|^jakarta-annotations-|^jaxb-api-" \
     && REGEX="$REGEX|^jboss-logging-|^jboss-jaxrs-2.0-api-" \
     && REGEX="$REGEX|^jackson-|^pki-resteasy-" \

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -48,29 +48,58 @@ else()
 
 endif (JAXRS_API_VERSION)
 
-find_file(SLF4J_API_JAR
-    NAMES
-        slf4j-api.jar
-    PATHS
-        /usr/share/java/slf4j
-        /usr/share/java
-)
+if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+    execute_process(
+        COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
+        COMMAND sed -n "s/^slf4j-api-\\(.*\\)\\.jar\$/\\1/p"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE SLF4J_VERSION
+    )
+endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
 
-find_file(SLF4J_JDK14_JAR
-    NAMES
-        slf4j-jdk14.jar
-    PATHS
-        /usr/share/java/slf4j
-        /usr/share/java
-)
+if (SLF4J_VERSION)
+    # use imported JARs
 
-find_file(SLF4J_SIMPLE_JAR
-    NAMES
-        slf4j-simple.jar
-    PATHS
-        /usr/share/java/slf4j
-        /usr/share/java
-)
+    set(SLF4J_API_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/slf4j-api-${SLF4J_VERSION}.jar")
+    set(SLF4J_API_LINK "slf4j-api-${SLF4J_VERSION}.jar")
+
+    set(SLF4J_JDK14_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/slf4j-jdk14-${SLF4J_VERSION}.jar")
+    set(SLF4J_JDK14_LINK "slf4j-jdk14-${SLF4J_VERSION}.jar")
+
+else()
+    # use system JARs
+
+    if(XMVN_RESOLVE)
+        execute_process(
+            COMMAND xmvn-resolve org.slf4j:slf4j-api
+            OUTPUT_VARIABLE SLF4J_API_JAR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(
+            COMMAND xmvn-resolve org.slf4j:slf4j-jdk14
+            OUTPUT_VARIABLE SLF4J_JDK14_JAR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    else()
+        find_file(SLF4J_API_JAR
+            NAMES
+                slf4j-api.jar
+            PATHS
+                /usr/share/java/slf4j
+                /usr/share/java
+        )
+        find_file(SLF4J_JDK14_JAR
+            NAMES
+                slf4j-jdk14.jar
+            PATHS
+                /usr/share/java/slf4j
+                /usr/share/java
+        )
+    endif(XMVN_RESOLVE)
+    set(SLF4J_API_LINK "../../../..${SLF4J_API_JAR}")
+    set(SLF4J_JDK14_LINK "../../../..${SLF4J_JDK14_JAR}")
+
+endif (SLF4J_VERSION)
 
 if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
     execute_process(

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -144,8 +144,8 @@ add_custom_command(
     COMMAND ln -sf ${RESTEASY_JACKSON_PROVIDER_LINK} lib/resteasy-jackson2-provider.jar
     COMMAND ln -sf ${RESTEASY_JAXRS_LINK} lib/resteasy-jaxrs.jar
     COMMAND ln -sf ../../../..${SERVLET_JAR} lib/servlet.jar
-    COMMAND ln -sf ../../../..${SLF4J_API_JAR} lib/slf4j-api.jar
-    COMMAND ln -sf ../../../..${SLF4J_JDK14_JAR} lib/slf4j-jdk14.jar
+    COMMAND ln -sf ${SLF4J_API_LINK} lib/slf4j-api.jar
+    COMMAND ln -sf ${SLF4J_JDK14_LINK} lib/slf4j-jdk14.jar
 )
 
 add_custom_target(pki-man ALL

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -93,7 +93,7 @@ if(RUN_TESTS)
 
     add_junit_test(test-pki-server
         CLASSPATH
-            ${SLF4J_API_JAR} ${SLF4J_SIMPLE_JAR}
+            ${SLF4J_API_JAR} ${SLF4J_JDK14_JAR}
             ${PKI_COMMON_JAR} ${PKI_SERVER_JAR}
             ${LDAPJDK_JAR} ${SERVLET_JAR}
             ${COMMONS_CODEC_JAR} ${COMMONS_LANG3_JAR}

--- a/pki.spec
+++ b/pki.spec
@@ -239,7 +239,6 @@ BuildRequires:    tomcat-jakartaee-migration
 
 BuildRequires:    %{vendor_id}-jss >= 5.10
 
-BuildRequires:    mvn(org.slf4j:slf4j-api)
 BuildRequires:    mvn(xml-apis:xml-apis)
 BuildRequires:    mvn(xml-resolver:xml-resolver)
 BuildRequires:    mvn(org.junit.jupiter:junit-jupiter-api)
@@ -254,6 +253,9 @@ BuildRequires:    mvn(commons-net:commons-net)
 
 BuildRequires:    mvn(org.apache.httpcomponents:httpclient)
 BuildRequires:    mvn(org.apache.httpcomponents:httpcore)
+
+BuildRequires:    mvn(org.slf4j:slf4j-api)
+BuildRequires:    mvn(org.slf4j:slf4j-jdk14)
 
 BuildRequires:    mvn(jakarta.activation:jakarta.activation-api)
 BuildRequires:    mvn(jakarta.annotation:jakarta.annotation-api)
@@ -588,9 +590,6 @@ Provides:         %{product_id}-base-java = %{version}-%{release}
 
 Requires:         %{java_headless}
 
-Requires:         mvn(org.slf4j:slf4j-api)
-Requires:         mvn(org.slf4j:slf4j-jdk14)
-
 %if %{with runtime_deps}
 Requires:         mvn(commons-cli:commons-cli)
 Requires:         mvn(commons-codec:commons-codec)
@@ -601,6 +600,9 @@ Requires:         mvn(commons-net:commons-net)
 
 Requires:         mvn(org.apache.httpcomponents:httpclient)
 Requires:         mvn(org.apache.httpcomponents:httpcore)
+
+Requires:         mvn(org.slf4j:slf4j-api)
+Requires:         mvn(org.slf4j:slf4j-jdk14)
 
 Requires:         mvn(jakarta.activation:jakarta.activation-api)
 Requires:         mvn(jakarta.annotation:jakarta.annotation-api)
@@ -628,6 +630,9 @@ Provides:         bundled(apache-commons-net)
 
 Provides:         bundled(httpcomponents-client)
 Provides:         bundled(httpcomponents-core)
+
+Provides:         bundled(slf4j)
+Provides:         bundled(slf4j-jdk14)
 
 Provides:         bundled(jakarta-activation)
 Provides:         bundled(jakarta-annotations)
@@ -1174,6 +1179,14 @@ then
     cp /usr/share/java/httpcomponents/httpcore.jar \
         httpcore-$HTTPCORE_VERSION.jar
 
+    SLF4J_VERSION=$(rpm -q slf4j | sed -n 's/^slf4j-\([^-]*\)-.*$/\1/p')
+    echo "SLF4J_VERSION: $SLF4J_VERSION"
+
+    cp /usr/share/java/slf4j/slf4j-api.jar \
+        slf4j-api-$SLF4J_VERSION.jar
+    cp /usr/share/java/slf4j/slf4j-jdk14.jar \
+        slf4j-jdk14-$SLF4J_VERSION.jar
+
     JAKARTA_ACTIVATION_API_VERSION=$(rpm -q jakarta-activation | sed -n 's/^jakarta-activation-\([^-]*\)-.*$/\1/p')
     echo "JAKARTA_ACTIVATION_API_VERSION: $JAKARTA_ACTIVATION_API_VERSION"
 
@@ -1592,6 +1605,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1615,6 +1629,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1637,6 +1652,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1660,6 +1676,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1683,6 +1700,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1706,6 +1724,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1729,6 +1748,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1752,6 +1772,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1775,6 +1796,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1798,6 +1820,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \
@@ -1821,6 +1844,7 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='commons-logging']" \
     -d "//_:dependency[_:groupId='commons-net']" \
     -d "//_:dependency[_:groupId='org.apache.httpcomponents']" \
+    -d "//_:dependency[_:groupId='org.slf4j']" \
     -d "//_:dependency[_:groupId='jakarta.activation']" \
     -d "//_:dependency[_:groupId='jakarta.annotation']" \
     -d "//_:dependency[_:groupId='jakarta.xml.bind']" \


### PR DESCRIPTION
The build scripts have been updated to optionally support bundling HTTP Components and SLF4J libraries in addition to other libraries into the RPM package.

**Note:** This PR will need to be rebased if PR #5283 is merged earlier.