### PR TITLE
Disable test for CA clone with ML-DSA on Fedora 42

### DIFF
--- a/.github/workflows/ca-clone-tests.yml
+++ b/.github/workflows/ca-clone-tests.yml
@@ -44,6 +44,8 @@ jobs:
     uses: ./.github/workflows/ca-clone-ssnv2-test.yml
 
   ca-clone-mldsa-test:
+    # disable ML-DSA test on Fedora 42 since it's failing with SSLV3_ALERT_HANDSHAKE_FAILURE
+    if: ${{ vars.BASE_IMAGE != 'registry.fedoraproject.org/fedora:42' }}
     name: CA clone with ML-DSA
     needs: build
     uses: ./.github/workflows/ca-clone-mldsa-test.yml


### PR DESCRIPTION
Similar to eb548dd8c006fa4bf4e20d7dacf1262fcace5308, the CA clone test with ML-DSA has been disabled on Fedora 42 since it's failing with `SSLV3_ALERT_HANDSHAKE_FAILURE`. The test works fine on Fedora 43 or later.

Failed test on Fedora 42: https://github.com/edewata/pki/actions/runs/22147874340/job/64031705875#step:11:357
Disabled test on Fedora 42: https://github.com/edewata/pki/actions/runs/22161958873/job/64081299687
Successful test on Fedora 43: https://github.com/dogtagpki/pki/actions/runs/22148827153/job/64035143063
