### PR TITLE
Fix nuxwdog password handling for HSM environments

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -298,7 +298,10 @@ class NSSDatabase(object):
             self.internal_password_file = self.password_file
 
         self.passwords = passwords
-        self.password_conf = password_conf
+        if password_conf and os.path.isfile(password_conf):
+            self.password_conf = password_conf
+        else:
+            self.password_conf = None
 
     def run(self,
             cmd,
@@ -403,10 +406,9 @@ class NSSDatabase(object):
         passwords = []
         for token, pw in self.passwords.items():
             if token.startswith('hardware-'):
-                token = token.replace('hardware-', '')
-                passwords.append(f'{token}:{pw}')
+                passwords.append(f'{token}={pw}')
             elif token == INTERNAL_TOKEN_NAME:
-                passwords.append(f'{dbname}:{pw}')
+                passwords.append(f'{dbname}={pw}')
 
         return '\n'.join(passwords)
 
@@ -910,12 +912,17 @@ class NSSDatabase(object):
 
         cmd = [
             'pki',
-            '-d', self.directory,
-            '-f', self.password_conf,
+            '-d', self.directory
+        ]
+
+        if self.password_conf:
+            cmd.extend(['-f', self.password_conf])
+
+        cmd.extend([
             'nss-cert-mod',
             '--trust-flags', trust_attributes,
             fullname
-        ]
+        ])
 
         self.run(cmd, check=True)
 
@@ -1906,7 +1913,12 @@ class NSSDatabase(object):
         tmpdir = self.create_tmpdir()
         try:
             token = self.get_effective_token(token)
-            password_file = self.get_password_file(tmpdir, token)
+
+            # When accessing certs from HSM tokens, we need passwords for both
+            # the internal token and the HSM token. Use all_tokens=True to create
+            # a multi-token password file that can be used with -f option.
+            need_all_tokens = token and not internal_token(token)
+            password_file = self.get_password_file(tmpdir, token, all_tokens=need_all_tokens)
             cmd = [
                 'pki',
                 '-d', self.directory
@@ -1920,7 +1932,11 @@ class NSSDatabase(object):
                 cmd.extend(['-f', self.password_conf])
 
             elif password_file:
-                cmd.extend(['-C', password_file])
+                # Use -f for multi-token password files, -C for single password
+                if need_all_tokens:
+                    cmd.extend(['-f', password_file])
+                else:
+                    cmd.extend(['-C', password_file])
 
             cmd.extend([
                 'nss-cert-show',
@@ -2022,7 +2038,12 @@ class NSSDatabase(object):
         tmpdir = self.create_tmpdir()
         try:
             token = self.get_effective_token(token)
-            password_file = self.get_password_file(tmpdir, token)
+
+            # When accessing certs from HSM tokens, we need passwords for both
+            # the internal token and the HSM token. Use all_tokens=True to create
+            # a multi-token password file that can be used with -f option.
+            need_all_tokens = token and not internal_token(token)
+            password_file = self.get_password_file(tmpdir, token, all_tokens=need_all_tokens)
 
             cmd = [
                 'pki',
@@ -2038,7 +2059,11 @@ class NSSDatabase(object):
                 cmd.extend(['-f', self.password_conf])
 
             elif password_file:
-                cmd.extend(['-C', password_file])
+                # Use -f for multi-token password files, -C for single password
+                if need_all_tokens:
+                    cmd.extend(['-f', password_file])
+                else:
+                    cmd.extend(['-C', password_file])
 
             cmd.extend([
                 'nss-cert-export',
@@ -2144,9 +2169,11 @@ class NSSDatabase(object):
 
         cmd = [
             'pki',
-            '-d', self.directory,
-            '-f', self.password_conf
+            '-d', self.directory
         ]
+
+        if self.password_conf:
+            cmd.extend(['-f', self.password_conf])
 
         token = self.get_effective_token(token)
 
@@ -2185,44 +2212,59 @@ class NSSDatabase(object):
             output_file=None,
             output_format=None):
 
-        cmd = [
-            'pki',
-            '-d', self.directory
-        ]
+        tmpdir = self.create_tmpdir()
+        try:
+            token = self.get_effective_token(token)
 
-        if self.password_conf and os.path.exists(self.password_conf):
-            cmd.extend(['-f', self.password_conf])
+            # When exporting certs from HSM tokens, we need passwords for both
+            # the internal token and the HSM token. Use all_tokens=True to create
+            # a multi-token password file that can be used with -f option.
+            need_all_tokens = token and not internal_token(token)
+            password_file = self.get_password_file(tmpdir, token, all_tokens=need_all_tokens)
 
-        elif self.password_file and os.path.exists(self.password_file):
-            cmd.extend(['-C', self.password_file])
+            cmd = [
+                'pki',
+                '-d', self.directory
+            ]
 
-        cmd.append('nss-cert-export')
+            if self.password_conf:
+                cmd.extend(['-f', self.password_conf])
 
-        if include_chain:
-            cmd.extend(['--with-chain'])
+            elif password_file:
+                # Use -f for multi-token password files, -C for single password
+                if need_all_tokens:
+                    cmd.extend(['-f', password_file])
+                else:
+                    cmd.extend(['-C', password_file])
 
-        if output_file:
-            cmd.extend(['--output-file', output_file])
+            cmd.append('nss-cert-export')
 
-        if output_format:
-            cmd.extend(['--format', output_format])
+            if include_chain:
+                cmd.extend(['--with-chain'])
 
-        if logger.isEnabledFor(logging.DEBUG):
-            cmd.append('--debug')
+            if output_file:
+                cmd.extend(['--output-file', output_file])
 
-        elif logger.isEnabledFor(logging.INFO):
-            cmd.append('--verbose')
+            if output_format:
+                cmd.extend(['--format', output_format])
 
-        token = self.get_effective_token(token)
+            if logger.isEnabledFor(logging.DEBUG):
+                cmd.append('--debug')
 
-        if token:
-            fullname = token + ':' + nickname
-        else:
-            fullname = nickname
+            elif logger.isEnabledFor(logging.INFO):
+                cmd.append('--verbose')
 
-        cmd.append(fullname)
+            if token:
+                fullname = token + ':' + nickname
+            else:
+                fullname = nickname
 
-        self.run(cmd, check=True)
+            cmd.append(fullname)
+
+            self.run(cmd, check=True)
+
+        finally:
+            shutil.rmtree(tmpdir)
 
     def export_cert(self,
                     nickname,

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -374,6 +374,12 @@ class PKIServer(object):
                 # Build a chain containing the certificate we're trying to
                 # export. OpenSSL gets confused if we don't have a key for
                 # the end certificate: rh-bz#1246371
+
+                # Ensure HSM token password is available (e.g. from
+                # keyring when password.conf does not exist)
+                if not pki.nssdb.internal_token(token):
+                    self.get_token_password(token)
+
                 nssdb = self.open_nssdb()
                 try:
                     nssdb.export_cert_bundle(

--- a/base/server/scripts/pki-server-nuxwdog
+++ b/base/server/scripts/pki-server-nuxwdog
@@ -145,4 +145,4 @@ for tag in sorted(iter(tags)):
 
 # 4. Put this script to sleep in background to keep the keyring fd open until main program starts
 # due to systemd bug #1668954
-subprocess.Popen(['/usr/bin/sleep', '10'])
+subprocess.Popen(['/usr/bin/sleep', '600'])


### PR DESCRIPTION
Fixes issues that prevented fresh PKI installations from
starting when nuxwdog was enabled after installation, particularly
with HSMs.

Changes:

1. password.conf existence check - Check if password.conf exists in
   NSSDatabase constructor rather than at each usage point. This ensures
   self.password_conf is only set when the file actually exists, preventing
   errors when the file is missing (14 usage sites simplified).

2. get_all_passwords() fixes - Changed delimiter from ':' to '=' to match
   password.conf format expected by NSS tools. Also kept the 'hardware-'
   prefix when writing HSM token passwords to the multi-token password
   file. The PKI CLI expects the 'hardware-' prefix to identify HSM tokens
   (e.g. 'hardware-NHSM-CONN-XC=password'), but the code was stripping it,
   causing the CLI to skip HSM token authentication.

3. Multi-token password support for HSM - Added need_all_tokens logic to
   get_trust(), get_cert(), and export_cert_bundle() methods. When accessing
   certificates on HSM tokens, both internal token and HSM token passwords
   are required. The all_tokens=True parameter creates a multi-token password
   file using password.conf format ('-f' flag) instead of single-password
   format ('-C' flag).

4. Keyring.getKeyID() NumberFormatException fix - When a key doesn't exist
   in the keyring, keyctl returns the error message "keyctl_search: Required
   key not available" instead of a numeric key ID. The code now catches
   NumberFormatException and logs the non-numeric output for troubleshooting,
   rather than letting the exception propagate. This was the original bug
   encountered during fresh install with nuxwdog and HSM (DOGTAG-4272).

5. export_ca_cert() HSM token password pre-population - Pre-populate the
   HSM token password from keyring before opening the NSS database. In
   nuxwdog mode, password.conf does not exist and passwords are stored in
   the kernel keyring. Without this, open_nssdb() only fetches the internal
   token password, leaving the HSM token password missing from the password
   file passed to the PKI CLI.

6. pki-server-nuxwdog sleep timer - Increased background sleep from 10 to
   600 seconds to ensure the keyring file descriptor remains open longer
   during the ExecStartPre sequence (systemd bug #1668954).


This should resolve https://issues.redhat.com/browse/DOGTAG-4272 and https://issues.redhat.com/browse/DOGTAG-4273