### PR TITLE
Drop KeyClient.archive_key()

### DIFF
--- a/base/common/python/pki/key.py
+++ b/base/common/python/pki/key.py
@@ -916,65 +916,6 @@ class KeyClient:
         return self.submit_request(request)
 
     @pki.handle_exceptions()
-    def archive_key(self, client_key_id, data_type, private_data,
-                    key_algorithm=None, key_size=None, realm=None):
-        """ Archive a secret (symmetric key or passphrase) on the DRM.
-
-            Requires a user-supplied client ID.  There can be only one active
-            key with a specified client ID.  If a record for a duplicate active
-            key exists, a BadRequestException is thrown.
-
-            data_type can be one of the following:
-                KeyClient.SYMMETRIC_KEY_TYPE,
-                KeyClient.ASYMMETRIC_KEY_TYPE,
-                KeyClient.PASS_PHRASE_TYPE
-
-            key_algorithm and key_size are applicable to symmetric keys only.
-            If a symmetric key is being archived, these parameters are required.
-
-            private_data is the raw secret to be archived.
-            It will be wrapped and sent to the DRM.
-
-            The function returns a KeyRequestResponse object containing a
-            KeyRequestInfo object with details about the archival request and
-            key archived.
-        """
-        if (client_key_id is None) or (data_type is None):
-            raise TypeError("Client Key ID and data type must be specified")
-
-        if data_type == KeyClient.SYMMETRIC_KEY_TYPE:
-            if (key_algorithm is None) or (key_size is None):
-                raise TypeError(
-                    "For symmetric keys, key algorithm and key_size must "
-                    "be specified")
-
-        if private_data is None:
-            raise TypeError("No data provided to be archived")
-
-        nonce_iv = self.crypto.generate_nonce_iv()
-        session_key = self.crypto.generate_session_key()
-
-        wrapped_session_key = self.crypto.asymmetric_wrap(
-            session_key,
-            self.get_transport_cert())
-
-        encrypted_data = self.crypto.symmetric_wrap(
-            private_data,
-            session_key,
-            nonce_iv=nonce_iv)
-
-        return self.archive_encrypted_data(
-            client_key_id,
-            data_type,
-            encrypted_data,
-            wrapped_session_key,
-            algorithm_oid=self.encrypt_alg_oid,
-            nonce_iv=nonce_iv,
-            key_algorithm=key_algorithm,
-            key_size=key_size,
-            realm=realm)
-
-    @pki.handle_exceptions()
     def archive_encrypted_data(self,
                                client_key_id,
                                data_type,
@@ -988,8 +929,17 @@ class KeyClient:
         """
         Archive a secret (symmetric key or passphrase) on the DRM.
 
-        Refer to archive_key() comments for a description of client_key_id,
-        data_type, key_algorithm and key_size.
+        Requires a user-supplied client ID.  There can be only one active
+        key with a specified client ID.  If a record for a duplicate active
+        key exists, a BadRequestException is thrown.
+
+        data_type can be one of the following:
+            KeyClient.SYMMETRIC_KEY_TYPE,
+            KeyClient.ASYMMETRIC_KEY_TYPE,
+            KeyClient.PASS_PHRASE_TYPE
+
+        key_algorithm and key_size are applicable to symmetric keys only.
+        If a symmetric key is being archived, these parameters are required.
 
         The following parameters are also required:
             - encrypted_data - which is the data encrypted by a
@@ -1054,8 +1004,17 @@ class KeyClient:
                             key_algorithm=None, key_size=None, realm=None):
         """ Archive a secret (symmetric key or passphrase) on the DRM.
 
-            Refer to archive_key() comments for a description of client_key_id,
-            data_type, key_algorithm and key_size.
+            Requires a user-supplied client ID.  There can be only one active
+            key with a specified client ID.  If a record for a duplicate active
+            key exists, a BadRequestException is thrown.
+
+            data_type can be one of the following:
+                KeyClient.SYMMETRIC_KEY_TYPE,
+                KeyClient.ASYMMETRIC_KEY_TYPE,
+                KeyClient.PASS_PHRASE_TYPE
+
+            key_algorithm and key_size are applicable to symmetric keys only.
+            If a symmetric key is being archived, these parameters are required.
 
             pki_archive_options is the data to be archived wrapped in a
             PKIArchiveOptions structure,

--- a/base/kra/src/test/python/drmtest.py
+++ b/base/kra/src/test/python/drmtest.py
@@ -251,11 +251,23 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     print("key to archive: " + key1)
     client_key_id = "Vek #4" + time.strftime('%c')
 
-    response = keyclient.archive_key(client_key_id,
-                                     keyclient.SYMMETRIC_KEY_TYPE,
-                                     b64decode(key1),
-                                     key_algorithm=keyclient.AES_ALGORITHM,
-                                     key_size=128)
+    nonce_iv = crypto.generate_nonce_iv()
+
+    encrypted_data = crypto.symmetric_wrap(
+        b64decode(key1),
+        session_key,
+        nonce_iv=nonce_iv)
+
+    response = keyclient.archive_encrypted_data(
+        client_key_id,
+        keyclient.SYMMETRIC_KEY_TYPE,
+        encrypted_data,
+        wrapped_session_key,
+        algorithm_oid=keyclient.encrypt_alg_oid,
+        nonce_iv=nonce_iv,
+        key_algorithm=keyclient.AES_ALGORITHM,
+        key_size=128)
+
     print_key_request(response.request_info)
 
     # Test 20: Lets get it back

--- a/docs/changes/v11.10.0/API-Changes.adoc
+++ b/docs/changes/v11.10.0/API-Changes.adoc
@@ -1,0 +1,6 @@
+= API Changes =
+
+== Remove KeyClient.archive_key() ==
+
+The `KeyClient.archive_key()` has been removed.
+Use `KeyClient.archive_encrypted_data()` instead.


### PR DESCRIPTION
The `KeyClient.archive_key()` was supposed to provide a convenient way to archive data, but it's using a `CryptoProvider` to generate an initialization vector and a session key, then wrap the key and encrypt the data for archival. It's also using a transport cert stored in memory without an update mechanism so it could become obsolete. The caller had no control over this process.

To reduce dependency on `CryptoProvider` and to allow more control over the archival process the `archive_key()` has been dropped and replaced with the existing `archive_encrypted_data()`.

The `drmtest.py` is obsolete but it has been updated accordingly.

The `pki-kra-key-archive.py` script and IPA are already using `archive_encrypted_data()` so they are not affected by this change.

https://github.com/edewata/pki/blob/kra/docs/changes/v11.10.0/API-Changes.adoc

**Note:** This change is meant for PKI 11.10 only (i.e. `master` branch). It will not be cherry-picked into `v11.9` branch.