### PR TITLE
Drop KeyClient.get_transport_cert()/set_transport_cert()

### DIFF
--- a/base/common/python/pki/key.py
+++ b/base/common/python/pki/key.py
@@ -512,8 +512,12 @@ class KeyClient:
                         'Accept': 'application/json'}
 
         self.crypto = crypto
-        self.transport_cert_nick = transport_cert_nick
-        self.transport_cert = None
+
+        if transport_cert_nick:
+            logger.warning(
+                '%s:%s: The transport_cert_nick parameter in KeyClient.__init__() '
+                'is no longer used.',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)
 
         self.info_client = info_client
         self.encrypt_alg_oid = None
@@ -521,23 +525,6 @@ class KeyClient:
 
         if crypto:
             self.set_crypto_algorithms()
-
-    def get_transport_cert(self):
-
-        if self.transport_cert:
-            return self.transport_cert
-
-        self.crypto.initialize()
-        self.transport_cert = self.crypto.get_cert(self.transport_cert_nick)
-
-        return self.transport_cert
-
-    def set_transport_cert(self, transport_cert_nick):
-        """ Set the transport certificate for crypto operations """
-        if transport_cert_nick is None:
-            raise TypeError(
-                "Transport certificate nickname must be specified.")
-        self.transport_cert = self.crypto.get_cert(self.transport_cert_nick)
 
     @pki.handle_exceptions()
     def set_crypto_algorithms(self):

--- a/base/common/python/pki/kra.py
+++ b/base/common/python/pki/kra.py
@@ -49,10 +49,7 @@ class KRAClient(pki.subsystem.SubsystemClient):
         :param connection - PKIConnection object with DRM connection info.
         :param crypto - CryptoProvider object.
         :param transport_cert_nick - identifier for the DRM transport
-                        certificate.  This will be passed to the
-                        CryptoProvider.get_cert() command to get a
-                        representation of the transport certificate usable for
-                        crypto ops.
+                        certificate.
 
                         Note that for NSS databases, the database must have
                         been initialized beforehand.
@@ -75,7 +72,7 @@ class KRAClient(pki.subsystem.SubsystemClient):
             self.keys = pki.key.KeyClient(
                 self.connection,
                 crypto,
-                transport_cert_nick,
+                None,
                 self.info)
 
             self.system_certs = pki.systemcert.SystemCertClient(self.connection)
@@ -89,3 +86,9 @@ class KRAClient(pki.subsystem.SubsystemClient):
             self.info = None
             self.keys = None
             self.system_certs = None
+
+        if transport_cert_nick:
+            logger.warning(
+                '%s:%s: The transport_cert_nick parameter in KRAClient.__init__() '
+                'is no longer used.',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)

--- a/base/kra/src/test/python/drmtest.py
+++ b/base/kra/src/test/python/drmtest.py
@@ -109,9 +109,6 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     # for NSS db, this must be done after importing the transport cert
     crypto.initialize()
 
-    # set transport cert into keyclient
-    keyclient.set_transport_cert(transport_nick)
-
     # Test 2: Get key request info
     print("Now getting key request")
     try:
@@ -158,8 +155,7 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     # Test 6: Barbican_decode() - Retrieve while providing
     # trans_wrapped_session_key
     session_key = crypto.generate_session_key()
-    wrapped_session_key = crypto.asymmetric_wrap(session_key,
-                                                 keyclient.transport_cert)
+    wrapped_session_key = crypto.asymmetric_wrap(session_key, transport_cert)
     print("My key id is " + str(key_id))
     key_data = keyclient.retrieve_key(
         key_id,

--- a/docs/changes/v11.10.0/API-Changes.adoc
+++ b/docs/changes/v11.10.0/API-Changes.adoc
@@ -8,3 +8,7 @@ Use `KeyClient.archive_encrypted_data()` instead.
 == Update KeyClient.retrieve_key() ==
 
 The `trans_wrapped_session_key` parameter in `KeyClient.retrieve_key()` must be specified.
+
+== Remove KeyClient.get_transport_cert()/set_transport_cert() ==
+
+The `KeyClient.get_transport_cert()` and `set_transport_cert()` have been removed.


### PR DESCRIPTION
The `KeyClient.get_transport_cert()/set_transport_cert()` and the corresponding attributes have been removed since the archival/retrieval code in `KeyClient` that uses them has been removed.

The `KeyClient` and `KRAClient` constructors will generate a warning if the transport cert nickname is specified.

The `drmtest.py` is obsolete but it has been updated accordingly.

The `pki-kra-key-archieve/retrieve.py` scripts and IPA do not use these methods/attributes so they are not affected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `KeyClient.get_transport_cert()` and `KeyClient.set_transport_cert()` public API methods.
  * `transport_cert_nick` parameter now triggers a deprecation warning and no longer affects behavior.

* **Documentation**
  * Updated API documentation to reflect removal of transport certificate handling methods.

* **Tests**
  * Updated test code to accommodate API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->