### PR TITLE
Add REST API version control and deprecation management

### DIFF
--- a/base/common/pom.xml
+++ b/base/common/pom.xml
@@ -118,20 +118,6 @@
             <version>2.14.2</version>
         </dependency>
 
-<!--
-        <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-            <version>1.0.0.Final</version>
-        </dependency>
--->
-
-        <dependency>
-           <groupId>pki-local</groupId>
-            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-            <version>1.0.0.Final</version>
-        </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
@@ -142,24 +128,6 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>2.14.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>3.4.1.Final</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.26.Final</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.0.26.Final</version>
         </dependency>
 
         <dependency>
@@ -175,6 +143,71 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <!-- Default: build both v1 and v2, include JAX-RS API and RESTEasy for v1 -->
+        <profile>
+            <id>default-rest-api</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>pki-local</groupId>
+                    <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+                    <version>1.0.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                    <version>3.4.1.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jaxrs</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jackson2-provider</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Build v1 only - needs JAX-RS API and RESTEasy -->
+        <profile>
+            <id>api-v1-only</id>
+            <dependencies>
+                <dependency>
+                    <groupId>pki-local</groupId>
+                    <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+                    <version>1.0.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                    <version>3.4.1.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jaxrs</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jackson2-provider</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Build v2 only - no JAX-RS API, RESTEasy, or jboss-logging needed -->
+        <profile>
+            <id>api-v2-only</id>
+            <!-- No v1-specific dependencies -->
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/base/javadoc/CMakeLists.txt
+++ b/base/javadoc/CMakeLists.txt
@@ -56,6 +56,30 @@ if(((${Javadoc_VERSION_MAJOR} EQUAL 1) AND (${Javadoc_VERSION_MINOR} EQUAL 8)) O
     set(doclintstr "-Xdoclint:none")
 endif()
 
+# Check if v1 API is being built
+set(REST_API_VERSIONS_TO_BUILD "v1,v2" CACHE STRING "REST API versions to build")
+string(FIND "${REST_API_VERSIONS_TO_BUILD}" "v1" v1_pos)
+if(${v1_pos} EQUAL -1)
+    # v1 not found - exclude v1-specific packages
+    set(exclude_packages
+        "com.netscape.certsrv.authority"
+        "com.netscape.certsrv.cert"
+        "com.netscape.certsrv.profile"
+        "com.netscape.certsrv.group"
+        "com.netscape.certsrv.key"
+        "com.netscape.certsrv.logging"
+        "com.netscape.certsrv.selftests"
+        "com.netscape.certsrv.system"
+        "com.netscape.certsrv.tps"
+        "com.netscape.certsrv.user"
+        "org.dogtagpki.common"
+    )
+    list(JOIN exclude_packages ":" exclude_str)
+    set(exclude_option "-exclude" "${exclude_str}")
+else()
+    set(exclude_option "")
+endif()
+
 javadoc(pki-javadoc
     SOURCEPATH
         ${CMAKE_SOURCE_DIR}/base/common/src/main/java
@@ -98,6 +122,7 @@ javadoc(pki-javadoc
         -version
         -quiet
         ${doclintstr}
+        ${exclude_option}
 )
 
 add_dependencies(javadoc pki-javadoc)

--- a/base/javadoc/CMakeLists.txt
+++ b/base/javadoc/CMakeLists.txt
@@ -73,6 +73,9 @@ if(${v1_pos} EQUAL -1)
         "com.netscape.certsrv.tps"
         "com.netscape.certsrv.user"
         "org.dogtagpki.common"
+        "org.dogtagpki.ca"
+        "org.dogtagpki.kra"
+        "org.dogtagpki.job"
     )
     list(JOIN exclude_packages ":" exclude_str)
     set(exclude_option "-exclude" "${exclude_str}")

--- a/base/javadoc/CMakeLists.txt
+++ b/base/javadoc/CMakeLists.txt
@@ -62,6 +62,7 @@ string(FIND "${REST_API_VERSIONS_TO_BUILD}" "v1" v1_pos)
 if(${v1_pos} EQUAL -1)
     # v1 not found - exclude v1-specific packages
     set(exclude_packages
+        "com.netscape.certsrv.base"
         "com.netscape.certsrv.authority"
         "com.netscape.certsrv.cert"
         "com.netscape.certsrv.profile"
@@ -79,8 +80,12 @@ if(${v1_pos} EQUAL -1)
     )
     list(JOIN exclude_packages ":" exclude_str)
     set(exclude_option "-exclude" "${exclude_str}")
+    # Don't include JAX-RS API and RESTEasy JARs for v2-only builds
+    set(jaxrs_classpath "")
 else()
     set(exclude_option "")
+    # Include JAX-RS API and RESTEasy JARs for v1 builds
+    set(jaxrs_classpath "${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR}")
 endif()
 
 javadoc(pki-javadoc
@@ -103,13 +108,12 @@ javadoc(pki-javadoc
         ${LDAPJDK_JAR}
         ${SERVLET_JAR} ${TOMCAT_CATALINA_JAR} ${TOMCAT_UTIL_JAR}
         ${HTTPCLIENT_JAR} ${HTTPCORE_JAR}
-        ${JAXRS_API_JAR}
+        ${jaxrs_classpath}
         ${JACKSON_CORE_JAR}
         ${JACKSON_ANNOTATIONS_JAR}
         ${JACKSON_DATABIND_JAR}
         ${JACKSON_MODULE_JAXB_ANNOTATIONS_JAR}
         ${JAKARTA_ANNOTATION_API_JAR}
-        ${RESTEASY_JAXRS_JAR}
         ${JSS_JAR}
         ${JSS_TOMCAT_JAR}
         ${JSS_TOMCAT_9_0_JAR}

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -60,6 +60,19 @@
                                 </excludes>
                             </configuration>
                         </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <sourceFileExcludes>
+                                    <!-- Exclude v2 servlet implementations -->
+                                    <sourceFileExclude>**/rest/v2/*.java</sourceFileExclude>
+                                    <sourceFileExclude>**/rest/v2/**/*.java</sourceFileExclude>
+                                    <!-- Exclude v2 base class -->
+                                    <sourceFileExclude>org/dogtagpki/server/rest/v2/PKIServlet.java</sourceFileExclude>
+                                </sourceFileExcludes>
+                            </configuration>
+                        </plugin>
                     </plugins>
                 </pluginManagement>
             </build>
@@ -91,6 +104,25 @@
                                     <!-- Exclude TPS v1 service outside v1 directory -->
                                     <exclude>org/dogtagpki/server/tps/TPSAccountService.java</exclude>
                                 </excludes>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration combine.self="override">
+                                <sourceFileExcludes>
+                                    <!-- Exclude v1 service implementations -->
+                                    <sourceFileExclude>**/rest/v1/*.java</sourceFileExclude>
+                                    <sourceFileExclude>**/rest/v1/**/*.java</sourceFileExclude>
+                                    <!-- Exclude v1 base classes -->
+                                    <sourceFileExclude>com/netscape/cms/servlet/base/PKIService.java</sourceFileExclude>
+                                    <sourceFileExclude>org/dogtagpki/server/rest/v1/PKIApplication.java</sourceFileExclude>
+                                    <!-- Exclude v1 JAX-RS Resource interfaces -->
+                                    <sourceFileExclude>com/netscape/certsrv/**/*Resource.java</sourceFileExclude>
+                                    <sourceFileExclude>org/dogtagpki/common/ConfigResource.java</sourceFileExclude>
+                                    <!-- Exclude TPS v1 service outside v1 directory -->
+                                    <sourceFileExclude>org/dogtagpki/server/tps/TPSAccountService.java</sourceFileExclude>
+                                </sourceFileExcludes>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -14,6 +14,11 @@
     <artifactId>pki-base-parent</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <!-- REST API versions to build (comma-separated: v1,v2) -->
+        <rest.api.versions.to.build>v1,v2</rest.api.versions.to.build>
+    </properties>
+
     <modules>
         <module>common</module>
         <module>tools</module>
@@ -31,5 +36,67 @@
         <module>est</module>
         <module>console</module>
     </modules>
+
+    <profiles>
+        <!-- Profile to build only v1 API (excludes v2) -->
+        <profile>
+            <id>api-v1-only</id>
+            <properties>
+                <rest.api.versions.to.build>v1</rest.api.versions.to.build>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <excludes>
+                                    <!-- Exclude v2 servlet implementations -->
+                                    <exclude>**/rest/v2/*.java</exclude>
+                                    <exclude>**/rest/v2/**/*.java</exclude>
+                                    <!-- Exclude v2 base class -->
+                                    <exclude>org/dogtagpki/server/rest/v2/PKIServlet.java</exclude>
+                                </excludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <!-- Profile to build only v2 API (excludes v1) -->
+        <profile>
+            <id>api-v2-only</id>
+            <properties>
+                <rest.api.versions.to.build>v2</rest.api.versions.to.build>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration combine.self="override">
+                                <excludes>
+                                    <!-- Exclude v1 service implementations -->
+                                    <exclude>**/rest/v1/*.java</exclude>
+                                    <exclude>**/rest/v1/**/*.java</exclude>
+                                    <!-- Exclude v1 base classes -->
+                                    <exclude>com/netscape/cms/servlet/base/PKIService.java</exclude>
+                                    <exclude>org/dogtagpki/server/rest/v1/PKIApplication.java</exclude>
+                                    <!-- Exclude v1 JAX-RS Resource interfaces -->
+                                    <exclude>com/netscape/certsrv/**/*Resource.java</exclude>
+                                    <exclude>org/dogtagpki/common/ConfigResource.java</exclude>
+                                    <!-- Exclude TPS v1 service outside v1 directory -->
+                                    <exclude>org/dogtagpki/server/tps/TPSAccountService.java</exclude>
+                                </excludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <!-- REST API versions to build (comma-separated: v1,v2) -->
-        <rest.api.versions.to.build>v1,v2</rest.api.versions.to.build>
+        <rest_api_versions_to_build>v1,v2</rest_api_versions_to_build>
     </properties>
 
     <modules>
@@ -42,7 +42,7 @@
         <profile>
             <id>api-v1-only</id>
             <properties>
-                <rest.api.versions.to.build>v1</rest.api.versions.to.build>
+                <rest_api_versions_to_build>v1</rest_api_versions_to_build>
             </properties>
             <build>
                 <pluginManagement>
@@ -69,7 +69,7 @@
         <profile>
             <id>api-v2-only</id>
             <properties>
-                <rest.api.versions.to.build>v2</rest.api.versions.to.build>
+                <rest_api_versions_to_build>v2</rest_api_versions_to_build>
             </properties>
             <build>
                 <pluginManagement>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -97,14 +97,16 @@
                                     <exclude>**/rest/v1/**/*.java</exclude>
                                     <!-- Exclude v1 base classes -->
                                     <exclude>com/netscape/cms/servlet/base/PKIService.java</exclude>
+                                    <exclude>com/netscape/cms/servlet/base/SubsystemService.java</exclude>
                                     <exclude>org/dogtagpki/server/rest/v1/PKIApplication.java</exclude>
                                     <!-- Exclude v1 JAX-RS Resource interfaces -->
                                     <exclude>com/netscape/certsrv/**/*Resource.java</exclude>
                                     <exclude>org/dogtagpki/**/*Resource.java</exclude>
                                     <!-- Exclude v1 JAX-RS annotations -->
                                     <exclude>com/netscape/certsrv/base/PATCH.java</exclude>
-                                    <!-- Exclude TPS v1 service outside v1 directory -->
+                                    <!-- Exclude TPS v1 services outside v1 directory -->
                                     <exclude>org/dogtagpki/server/tps/TPSAccountService.java</exclude>
+                                    <exclude>org/dogtagpki/server/tps/config/ConfigService.java</exclude>
                                 </excludes>
                             </configuration>
                         </plugin>
@@ -118,14 +120,16 @@
                                     <sourceFileExclude>**/rest/v1/**/*.java</sourceFileExclude>
                                     <!-- Exclude v1 base classes -->
                                     <sourceFileExclude>com/netscape/cms/servlet/base/PKIService.java</sourceFileExclude>
+                                    <sourceFileExclude>com/netscape/cms/servlet/base/SubsystemService.java</sourceFileExclude>
                                     <sourceFileExclude>org/dogtagpki/server/rest/v1/PKIApplication.java</sourceFileExclude>
                                     <!-- Exclude v1 JAX-RS Resource interfaces -->
                                     <sourceFileExclude>com/netscape/certsrv/**/*Resource.java</sourceFileExclude>
                                     <sourceFileExclude>org/dogtagpki/**/*Resource.java</sourceFileExclude>
                                     <!-- Exclude v1 JAX-RS annotations -->
                                     <sourceFileExclude>com/netscape/certsrv/base/PATCH.java</sourceFileExclude>
-                                    <!-- Exclude TPS v1 service outside v1 directory -->
+                                    <!-- Exclude TPS v1 services outside v1 directory -->
                                     <sourceFileExclude>org/dogtagpki/server/tps/TPSAccountService.java</sourceFileExclude>
+                                    <sourceFileExclude>org/dogtagpki/server/tps/config/ConfigService.java</sourceFileExclude>
                                 </sourceFileExcludes>
                             </configuration>
                         </plugin>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -101,6 +101,8 @@
                                     <!-- Exclude v1 JAX-RS Resource interfaces -->
                                     <exclude>com/netscape/certsrv/**/*Resource.java</exclude>
                                     <exclude>org/dogtagpki/**/*Resource.java</exclude>
+                                    <!-- Exclude v1 JAX-RS annotations -->
+                                    <exclude>com/netscape/certsrv/base/PATCH.java</exclude>
                                     <!-- Exclude TPS v1 service outside v1 directory -->
                                     <exclude>org/dogtagpki/server/tps/TPSAccountService.java</exclude>
                                 </excludes>
@@ -120,6 +122,8 @@
                                     <!-- Exclude v1 JAX-RS Resource interfaces -->
                                     <sourceFileExclude>com/netscape/certsrv/**/*Resource.java</sourceFileExclude>
                                     <sourceFileExclude>org/dogtagpki/**/*Resource.java</sourceFileExclude>
+                                    <!-- Exclude v1 JAX-RS annotations -->
+                                    <sourceFileExclude>com/netscape/certsrv/base/PATCH.java</sourceFileExclude>
                                     <!-- Exclude TPS v1 service outside v1 directory -->
                                     <sourceFileExclude>org/dogtagpki/server/tps/TPSAccountService.java</sourceFileExclude>
                                 </sourceFileExcludes>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -100,7 +100,7 @@
                                     <exclude>org/dogtagpki/server/rest/v1/PKIApplication.java</exclude>
                                     <!-- Exclude v1 JAX-RS Resource interfaces -->
                                     <exclude>com/netscape/certsrv/**/*Resource.java</exclude>
-                                    <exclude>org/dogtagpki/common/ConfigResource.java</exclude>
+                                    <exclude>org/dogtagpki/**/*Resource.java</exclude>
                                     <!-- Exclude TPS v1 service outside v1 directory -->
                                     <exclude>org/dogtagpki/server/tps/TPSAccountService.java</exclude>
                                 </excludes>
@@ -119,7 +119,7 @@
                                     <sourceFileExclude>org/dogtagpki/server/rest/v1/PKIApplication.java</sourceFileExclude>
                                     <!-- Exclude v1 JAX-RS Resource interfaces -->
                                     <sourceFileExclude>com/netscape/certsrv/**/*Resource.java</sourceFileExclude>
-                                    <sourceFileExclude>org/dogtagpki/common/ConfigResource.java</sourceFileExclude>
+                                    <sourceFileExclude>org/dogtagpki/**/*Resource.java</sourceFileExclude>
                                     <!-- Exclude TPS v1 service outside v1 directory -->
                                     <sourceFileExclude>org/dogtagpki/server/tps/TPSAccountService.java</sourceFileExclude>
                                 </sourceFileExcludes>

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -38,6 +38,21 @@ set(PKI_SERVER_JAR ${CMAKE_BINARY_DIR}/dist/pki-server.jar
     CACHE INTERNAL "pki-server.jar"
 )
 
+# REST API version control build-time configuration
+set(REST_API_DEPRECATED_VERSION "v1" CACHE STRING "Deprecated REST API version")
+set(REST_API_DISABLED_VERSIONS "" CACHE STRING "Disabled REST API versions (comma-separated)")
+
+# Set variables with underscores for template substitution (Maven naming)
+set(rest_api_deprecated_version "${REST_API_DEPRECATED_VERSION}")
+set(rest_api_disabled_versions "${REST_API_DISABLED_VERSIONS}")
+
+# Process REST API properties template
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/main/resources/rest-api.properties
+    ${CMAKE_CURRENT_BINARY_DIR}/resources/rest-api.properties
+    @ONLY
+)
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/src/main/resources/META-INF/MANIFEST.MF
     ${CMAKE_CURRENT_BINARY_DIR}/MANIFEST.MF
@@ -54,7 +69,11 @@ jar(pki-server-jar
     INPUT_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/classes
     INPUT_DIR
+        ${CMAKE_CURRENT_BINARY_DIR}/resources
+    INPUT_DIR
         ${CMAKE_CURRENT_SOURCE_DIR}/src/main/resources
+    EXCLUDE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/main/resources/rest-api.properties
     FILES
         audit-events.properties
         LogMessages.properties

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -39,10 +39,12 @@ set(PKI_SERVER_JAR ${CMAKE_BINARY_DIR}/dist/pki-server.jar
 )
 
 # REST API version control build-time configuration
+set(REST_API_VERSIONS_TO_BUILD "v1,v2" CACHE STRING "REST API versions to build (comma-separated)")
 set(REST_API_DEPRECATED_VERSION "v1" CACHE STRING "Deprecated REST API version")
 set(REST_API_DISABLED_VERSIONS "" CACHE STRING "Disabled REST API versions (comma-separated)")
 
 # Set variables with underscores for template substitution (Maven naming)
+set(rest_api_versions_to_build "${REST_API_VERSIONS_TO_BUILD}")
 set(rest_api_deprecated_version "${REST_API_DEPRECATED_VERSION}")
 set(rest_api_disabled_versions "${REST_API_DISABLED_VERSIONS}")
 

--- a/base/server/pom.xml
+++ b/base/server/pom.xml
@@ -14,6 +14,12 @@
     <artifactId>pki-server</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <!-- REST API version control build-time configuration -->
+        <rest_api_deprecated_version>v1</rest_api_deprecated_version>
+        <rest_api_disabled_versions></rest_api_disabled_versions>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -37,6 +43,23 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>rest-api.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>rest-api.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/base/server/pom.xml
+++ b/base/server/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <!-- REST API version control build-time configuration -->
+        <rest_api_versions_to_build>v1,v2</rest_api_versions_to_build>
         <rest_api_deprecated_version>v1</rest_api_deprecated_version>
         <rest_api_disabled_versions></rest_api_disabled_versions>
     </properties>
@@ -34,13 +35,42 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.26.Final</version>
-        </dependency>
-
     </dependencies>
+
+    <profiles>
+        <!-- Default: build both v1 and v2, include RESTEasy for v1 -->
+        <profile>
+            <id>default-rest-api</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-servlet-initializer</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Build v1 only - needs RESTEasy -->
+        <profile>
+            <id>api-v1-only</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-servlet-initializer</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Build v2 only - no RESTEasy needed -->
+        <profile>
+            <id>api-v2-only</id>
+            <!-- No RESTEasy dependency -->
+        </profile>
+    </profiles>
 
     <build>
         <resources>

--- a/base/server/src/main/java/org/dogtagpki/server/rest/filter/APIVersionFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/filter/APIVersionFilter.java
@@ -1,0 +1,217 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package org.dogtagpki.server.rest.filter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netscape.cmscore.apps.CMSEngine;
+import com.netscape.cmscore.apps.EngineConfig;
+
+/**
+ * Servlet filter for REST API version control.
+ *
+ * Provides runtime control over which REST API versions are enabled/disabled
+ * and adds deprecation warnings to deprecated API versions.
+ *
+ * Build-time configuration (rest-api.properties):
+ * - deprecated.version: API version marked as deprecated
+ * - disabled.versions: API versions disabled by default at build time
+ *
+ * Runtime configuration for CMSEngine (CS.cfg):
+ * - rest.api.enabled: Comma-separated list of versions to enable (overrides build-time disabled)
+ * - rest.api.suppress_deprecation_warnings: Boolean to suppress deprecation headers
+ *
+ * Runtime configuration for PKIEngine (rest-api-option.properties):
+ * - deprecated.version: Override deprecated API version
+ * - disabled.versions: Comma-separated list of versions to disable
+ * - suppress_deprecation_warnings: Boolean to suppress deprecation headers
+ *
+ * The rest-api-option.properties file overrides build-time settings from rest-api.properties.
+ *
+ * @author Marco Fargetta {@literal <mfargett@redhat.com>}
+ */
+@WebFilter(
+    filterName = "APIVersionFilter",
+    urlPatterns = {"/*"}
+)
+public class APIVersionFilter implements Filter {
+
+    private static Logger logger = LoggerFactory.getLogger(APIVersionFilter.class);
+
+    private String deprecatedVersion;
+    private Set<String> disabledVersions;
+    private boolean suppressDeprecationWarnings;
+
+    @Override
+    public void init(FilterConfig config) throws ServletException {
+        try {
+            // Load build-time configuration
+            Properties buildConfig = loadPropertiesFile("rest-api.properties");
+
+            // Load runtime options (overrides build-time config)
+            Properties runtimeOptions = loadPropertiesFile("rest-api-option.properties");
+
+            // Merge runtime options into build config
+            Properties mergedConfig = new Properties();
+            mergedConfig.putAll(buildConfig);
+            mergedConfig.putAll(runtimeOptions);
+
+            deprecatedVersion = mergedConfig.getProperty("deprecated.version", "").trim();
+            if (deprecatedVersion.isEmpty()) {
+                deprecatedVersion = null;
+            }
+
+            String buildDisabled = buildConfig.getProperty("disabled.versions", "");
+            Set<String> defaultDisabledVersions = parseVersions(buildDisabled);
+
+            // Load runtime configuration
+            ServletContext servletContext = config.getServletContext();
+            Set<String> runtimeEnabledVersions = Collections.emptySet();
+
+            if (servletContext.getAttribute("engine") instanceof CMSEngine engine) {
+                EngineConfig engineConfig = engine.getConfig();
+
+                // Runtime can enable versions from the disabled list
+                String runtimeEnabled = engineConfig.getString("rest.api.enabled", "");
+                runtimeEnabledVersions = parseVersions(runtimeEnabled);
+
+                // Final disabled = build disabled - runtime enabled
+                disabledVersions = new HashSet<>(defaultDisabledVersions);
+                disabledVersions.removeAll(runtimeEnabledVersions);
+
+                suppressDeprecationWarnings = engineConfig.getBoolean("rest.api.suppress_deprecation_warnings", false);
+            } else {
+                // Engine not CMSEngine (e.g., PKIEngine) - use merged config
+                String mergedDisabled = mergedConfig.getProperty("disabled.versions", "");
+                disabledVersions = parseVersions(mergedDisabled);
+
+                suppressDeprecationWarnings = Boolean.parseBoolean(
+                    mergedConfig.getProperty("suppress_deprecation_warnings", "false"));
+            }
+
+            logger.info("REST API build-time disabled: {}", defaultDisabledVersions);
+            logger.info("REST API runtime enabled: {}", runtimeEnabledVersions);
+            logger.info("REST API final disabled: {}", disabledVersions);
+            logger.info("REST API deprecated version: {}", deprecatedVersion);
+
+        } catch (Exception e) {
+            logger.error("Failed to initialize APIVersionFilter", e);
+            deprecatedVersion = null;
+            disabledVersions = new HashSet<>();
+            suppressDeprecationWarnings = false;
+        }
+    }
+
+    /**
+     * Loads configuration from a properties resource file.
+     *
+     * @param filename Name of the properties file to load
+     * @return Properties object (empty if file not found)
+     */
+    private Properties loadPropertiesFile(String filename) {
+        Properties props = new Properties();
+        try (InputStream is = getClass().getClassLoader()
+                .getResourceAsStream(filename)) {
+
+            if (is == null) {
+                logger.debug("{} not found, skipping", filename);
+                return props;
+            }
+
+            props.load(is);
+            logger.info("Loaded configuration from {}", filename);
+        } catch (IOException e) {
+            logger.warn("Failed to load {}: {}", filename, e.getMessage());
+        }
+        return props;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String path = httpRequest.getRequestURI();
+        String version = extractVersion(path);
+
+        if (version == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // Check if disabled
+        if (disabledVersions.contains(version)) {
+            httpResponse.sendError(HttpServletResponse.SC_NOT_FOUND,
+                "REST API " + version + " is not available");
+            return;
+        }
+
+        // Check if deprecated AND warnings not suppressed
+        if (version.equals(deprecatedVersion) && !suppressDeprecationWarnings) {
+            httpResponse.setHeader("Deprecation", "true");
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        // Nothing to clean up
+    }
+
+    /**
+     * Extracts the API version from the request path.
+     *
+     * @param path Request URI path
+     * @return API version (e.g., "v1", "v2") or null if no version found
+     */
+    private String extractVersion(String path) {
+        Pattern pattern = Pattern.compile("/(v\\d+)/");
+        Matcher matcher = pattern.matcher(path);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    /**
+     * Parses a comma-separated list of versions.
+     *
+     * @param versions Comma-separated version string
+     * @return Set of trimmed, non-empty version strings
+     */
+    private Set<String> parseVersions(String versions) {
+        if (versions == null || versions.trim().isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(versions.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .collect(Collectors.toSet());
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/rest/filter/APIVersionFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/filter/APIVersionFilter.java
@@ -40,8 +40,12 @@ import com.netscape.cmscore.apps.EngineConfig;
  * and adds deprecation warnings to deprecated API versions.
  *
  * Build-time configuration (rest-api.properties):
+ * - versions.built: Comma-separated list of API versions included in the build
  * - deprecated.version: API version marked as deprecated
  * - disabled.versions: API versions disabled by default at build time
+ *
+ * Versions not included in versions.built are automatically disabled at runtime
+ * and cannot be enabled (since the code doesn't exist).
  *
  * Runtime configuration for CMSEngine (CS.cfg):
  * - rest.api.enabled: Comma-separated list of versions to enable (overrides build-time disabled)
@@ -87,6 +91,10 @@ public class APIVersionFilter implements Filter {
                 deprecatedVersion = null;
             }
 
+            // Get versions that were built
+            String builtVersions = buildConfig.getProperty("versions.built", "");
+            Set<String> versionsBuilt = parseVersions(builtVersions);
+
             String buildDisabled = buildConfig.getProperty("disabled.versions", "");
             Set<String> defaultDisabledVersions = parseVersions(buildDisabled);
 
@@ -115,6 +123,16 @@ public class APIVersionFilter implements Filter {
                     mergedConfig.getProperty("suppress_deprecation_warnings", "false"));
             }
 
+            // Add versions that were not built to the disabled list
+            // These cannot be enabled at runtime since they don't exist
+            if (!versionsBuilt.isEmpty()) {
+                // Assume all known versions (v1, v2) and disable those not built
+                Set<String> allKnownVersions = new HashSet<>(Arrays.asList("v1", "v2"));
+                allKnownVersions.removeAll(versionsBuilt);
+                disabledVersions.addAll(allKnownVersions);
+            }
+
+            logger.info("REST API versions built: {}", versionsBuilt);
             logger.info("REST API build-time disabled: {}", defaultDisabledVersions);
             logger.info("REST API runtime enabled: {}", runtimeEnabledVersions);
             logger.info("REST API final disabled: {}", disabledVersions);

--- a/base/server/src/main/resources/rest-api.properties
+++ b/base/server/src/main/resources/rest-api.properties
@@ -1,0 +1,12 @@
+# REST API Version Control Configuration
+#
+# This file is a template processed at build time.
+# Maven/CMake will replace @variables@ with actual values.
+
+# API version marked as deprecated (e.g., v1)
+# Deprecated APIs still work but return deprecation warning headers
+deprecated.version=@rest_api_deprecated_version@
+
+# API versions disabled by default at build time (comma-separated)
+# These can be re-enabled at runtime via rest.api.enabled in CS.cfg
+disabled.versions=@rest_api_disabled_versions@

--- a/base/server/src/main/resources/rest-api.properties
+++ b/base/server/src/main/resources/rest-api.properties
@@ -3,6 +3,10 @@
 # This file is a template processed at build time.
 # Maven/CMake will replace @variables@ with actual values.
 
+# API versions included in the build (comma-separated)
+# Only these versions are compiled and packaged
+versions.built=@rest_api_versions_to_build@
+
 # API version marked as deprecated (e.g., v1)
 # Deprecated APIs still work but return deprecation warning headers
 deprecated.version=@rest_api_deprecated_version@

--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,7 @@ WITH_CONSOLE=
 RUN_TESTS=true
 
 # REST API version control
+REST_API_VERSIONS_TO_BUILD="v1,v2"
 REST_API_DEPRECATED_VERSION="v1"
 REST_API_DISABLED_VERSIONS=""
 
@@ -99,6 +100,7 @@ usage() {
     echo "    --with-pkgs=<list>     Build packages specified in comma-separated list only."
     echo "    --without-pkgs=<list>  Build everything except packages specified in comma-separated list."
     echo "    --without-test         Do not run unit tests."
+    echo "    --rest-api-versions=<versions>   Set REST API versions to build (default: v1,v2)."
     echo "    --rest-api-deprecated=<version>  Set deprecated REST API version (default: v1)."
     echo "    --rest-api-disabled=<versions>   Set disabled REST API versions (comma-separated)."
     echo " -v,--verbose              Run in verbose mode."
@@ -410,6 +412,9 @@ while getopts v-: arg ; do
         without-test)
             RUN_TESTS=false
             ;;
+        rest-api-versions=*)
+            REST_API_VERSIONS_TO_BUILD="$LONG_OPTARG"
+            ;;
         rest-api-deprecated=*)
             REST_API_DEPRECATED_VERSION="$LONG_OPTARG"
             ;;
@@ -435,7 +440,7 @@ while getopts v-: arg ; do
         cmake* | c-flags* | java-home* | jni-dir* | \
         unit-dir* | python* | python-dir* | install-dir* | \
         source-tag* | spec* | with-pkgs* | without-pkgs* | dist* | \
-        rest-api-deprecated* | rest-api-disabled*)
+        rest-api-versions* | rest-api-deprecated* | rest-api-disabled*)
             echo "ERROR: Missing argument for --$OPTARG option" >&2
             exit 1
             ;;
@@ -762,6 +767,10 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
         OPTIONS+=(-DRUN_TESTS:BOOL=OFF)
     fi
 
+    if [ -n "$REST_API_VERSIONS_TO_BUILD" ] ; then
+        OPTIONS+=(-DREST_API_VERSIONS_TO_BUILD:STRING="$REST_API_VERSIONS_TO_BUILD")
+    fi
+
     if [ -n "$REST_API_DEPRECATED_VERSION" ] ; then
         OPTIONS+=(-DREST_API_DEPRECATED_VERSION:STRING="$REST_API_DEPRECATED_VERSION")
     fi
@@ -960,6 +969,10 @@ if [ "$RUN_TESTS" = false ] ; then
     OPTIONS+=(--without test)
 fi
 
+if [ -n "$REST_API_VERSIONS_TO_BUILD" ] ; then
+    OPTIONS+=(--define "rest_api_versions_to_build $REST_API_VERSIONS_TO_BUILD")
+fi
+
 if [ -n "$REST_API_DEPRECATED_VERSION" ] ; then
     OPTIONS+=(--define "rest_api_deprecated $REST_API_DEPRECATED_VERSION")
 fi
@@ -1002,6 +1015,10 @@ if [ "$VERBOSE" = true ] ; then
 fi
 
 OPTIONS+=(--define "_topdir ${WORK_DIR}")
+
+if [ -n "$REST_API_VERSIONS_TO_BUILD" ] ; then
+    OPTIONS+=(--define "rest_api_versions_to_build $REST_API_VERSIONS_TO_BUILD")
+fi
 
 if [ -n "$REST_API_DEPRECATED_VERSION" ] ; then
     OPTIONS+=(--define "rest_api_deprecated $REST_API_DEPRECATED_VERSION")

--- a/build.sh
+++ b/build.sh
@@ -53,6 +53,10 @@ WITH_JAVA=true
 WITH_CONSOLE=
 RUN_TESTS=true
 
+# REST API version control
+REST_API_DEPRECATED_VERSION="v1"
+REST_API_DISABLED_VERSIONS=""
+
 PKG_LIST="base, server, ca, kra, ocsp, tks, tps, acme, est, javadoc, theme, meta, tests, debug"
 ALL_PKGS=( $(echo "$PKG_LIST" | sed 's/ *, */ /g') )
 
@@ -95,6 +99,8 @@ usage() {
     echo "    --with-pkgs=<list>     Build packages specified in comma-separated list only."
     echo "    --without-pkgs=<list>  Build everything except packages specified in comma-separated list."
     echo "    --without-test         Do not run unit tests."
+    echo "    --rest-api-deprecated=<version>  Set deprecated REST API version (default: v1)."
+    echo "    --rest-api-disabled=<versions>   Set disabled REST API versions (comma-separated)."
     echo " -v,--verbose              Run in verbose mode."
     echo "    --debug                Run in debug mode."
     echo "    --help                 Show help message."
@@ -404,6 +410,12 @@ while getopts v-: arg ; do
         without-test)
             RUN_TESTS=false
             ;;
+        rest-api-deprecated=*)
+            REST_API_DEPRECATED_VERSION="$LONG_OPTARG"
+            ;;
+        rest-api-disabled=*)
+            REST_API_DISABLED_VERSIONS="$LONG_OPTARG"
+            ;;
         verbose)
             VERBOSE=true
             ;;
@@ -422,7 +434,8 @@ while getopts v-: arg ; do
         prefix-dir* | include-dir* | lib-dir* | sysconf-dir* | share-dir* | \
         cmake* | c-flags* | java-home* | jni-dir* | \
         unit-dir* | python* | python-dir* | install-dir* | \
-        source-tag* | spec* | with-pkgs* | without-pkgs* | dist*)
+        source-tag* | spec* | with-pkgs* | without-pkgs* | dist* | \
+        rest-api-deprecated* | rest-api-disabled*)
             echo "ERROR: Missing argument for --$OPTARG option" >&2
             exit 1
             ;;
@@ -749,6 +762,14 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
         OPTIONS+=(-DRUN_TESTS:BOOL=OFF)
     fi
 
+    if [ -n "$REST_API_DEPRECATED_VERSION" ] ; then
+        OPTIONS+=(-DREST_API_DEPRECATED_VERSION:STRING="$REST_API_DEPRECATED_VERSION")
+    fi
+
+    if [ -n "$REST_API_DISABLED_VERSIONS" ] ; then
+        OPTIONS+=(-DREST_API_DISABLED_VERSIONS:STRING="$REST_API_DISABLED_VERSIONS")
+    fi
+
     $CMAKE "${OPTIONS[@]}"
 
     OPTIONS=()
@@ -939,6 +960,14 @@ if [ "$RUN_TESTS" = false ] ; then
     OPTIONS+=(--without test)
 fi
 
+if [ -n "$REST_API_DEPRECATED_VERSION" ] ; then
+    OPTIONS+=(--define "rest_api_deprecated $REST_API_DEPRECATED_VERSION")
+fi
+
+if [ -n "$REST_API_DISABLED_VERSIONS" ] ; then
+    OPTIONS+=(--define "rest_api_disabled $REST_API_DISABLED_VERSIONS")
+fi
+
 if [ "$DEBUG" = true ] ; then
     echo "rpmbuild -bs" "${OPTIONS[@]}" " $SPEC_FILE"
 fi
@@ -973,6 +1002,14 @@ if [ "$VERBOSE" = true ] ; then
 fi
 
 OPTIONS+=(--define "_topdir ${WORK_DIR}")
+
+if [ -n "$REST_API_DEPRECATED_VERSION" ] ; then
+    OPTIONS+=(--define "rest_api_deprecated $REST_API_DEPRECATED_VERSION")
+fi
+
+if [ -n "$REST_API_DISABLED_VERSIONS" ] ; then
+    OPTIONS+=(--define "rest_api_disabled $REST_API_DISABLED_VERSIONS")
+fi
 
 if [ "$DEBUG" = true ] ; then
     echo "rpmbuild --rebuild" "${OPTIONS[@]}" "$SRPM"

--- a/docs/changes/v11.10.0/Server-Changes.adoc
+++ b/docs/changes/v11.10.0/Server-Changes.adoc
@@ -22,3 +22,81 @@ pki-server ca-db-vlv-reindex
 *Note:* The reindex operation may take significant time on databases with
 many certificates. For replicated environments, VLV indexes are not
 replicated, so each replica must run these commands independently.
+
+== REST API Version Control ==
+
+A new REST API version control mechanism has been added to manage API
+version availability at build time and runtime.
+
+=== Build-time Configuration ===
+
+API version settings can be configured during the build process:
+
+* `rest.api.deprecated.version`: Marks an API version as deprecated (e.g., `v1`)
+* `rest.api.disabled.versions`: Comma-separated list of versions disabled by default
+
+=== Runtime Configuration ===
+
+==== For CMSEngine (CA, KRA, OCSP, TKS, TPS) ====
+
+Administrators can control API versions using CS.cfg parameters:
+
+* `rest.api.enabled`: Comma-separated list of API versions to enable at runtime.
+This can re-enable versions that were disabled at build time.
+If not specified, uses build-time configuration.
+
+* `rest.api.suppress_deprecation_warnings`: Boolean to suppress deprecation
+headers. Default is `false` (warnings are sent).
+
+==== For PKIEngine (ACME, EST) ====
+
+Runtime configuration is provided via a `rest-api-option.properties` file
+placed in the classpath. This file overrides build-time settings from
+`rest-api.properties`.
+
+Supported properties:
+
+* `deprecated.version`: Override the deprecated API version
+* `disabled.versions`: Comma-separated list of versions to disable
+* `suppress_deprecation_warnings`: Boolean to suppress deprecation headers
+
+=== Deprecation Headers ===
+
+When accessing a deprecated API version, a `Deprecation: true` HTTP header
+is added to responses (unless suppressed).
+
+Example:
+----
+GET /ca/v1/certs/123
+
+HTTP/1.1 200 OK
+Deprecation: true
+...
+----
+
+=== Examples ===
+
+==== CMSEngine (CA, KRA, OCSP, TKS, TPS) ====
+
+Enable v1 API that was disabled at build time:
+----
+pki-server ca-config-set rest.api.enabled v1,v2
+----
+
+Suppress deprecation warnings:
+----
+pki-server ca-config-set rest.api.suppress_deprecation_warnings true
+----
+
+==== PKIEngine (ACME, EST) ====
+
+Create `rest-api-option.properties` in the webapp's classpath
+(e.g., `/usr/share/pki/acme/webapps/acme/WEB-INF/classes/`):
+
+----
+# Disable v1 API
+disabled.versions=v1
+
+# Suppress deprecation warnings
+suppress_deprecation_warnings=true
+----

--- a/docs/changes/v11.10.0/Server-Changes.adoc
+++ b/docs/changes/v11.10.0/Server-Changes.adoc
@@ -32,8 +32,48 @@ version availability at build time and runtime.
 
 API version settings can be configured during the build process:
 
+* `rest.api.versions.to.build`: Comma-separated list of API versions to compile and package (default: `v1,v2`)
 * `rest.api.deprecated.version`: Marks an API version as deprecated (e.g., `v1`)
-* `rest.api.disabled.versions`: Comma-separated list of versions disabled by default
+* `rest.api.disabled.versions`: Comma-separated list of versions disabled by default (but still built)
+
+==== Excluding API Versions from Build ====
+
+Use Maven profiles or build flags to exclude specific API versions from compilation:
+
+----
+# Build only v2 API (v1 source files excluded from compilation)
+./build.sh --rest-api-versions=v2 dist
+
+# Using Maven profiles directly
+mvn install -Papi-v2-only
+
+# Build only v1 API
+./build.sh --rest-api-versions=v1 dist
+mvn install -Papi-v1-only
+
+# Build both (default)
+./build.sh dist
+mvn install
+----
+
+When an API version is excluded from the build:
+- v1: Excludes JAX-RS service implementations, Resource interfaces, and base classes
+- v2: Excludes servlet implementations and base servlet class
+
+All excluded source files across subsystems (CA, KRA, OCSP, TKS, TPS) are not compiled.
+The filter automatically blocks access to excluded versions at runtime (returns 404).
+
+Files excluded when building v2-only:
+- All `**/rest/v1/**/*.java` (service implementations)
+- `com/netscape/certsrv/**/*Resource.java` (JAX-RS interfaces)
+- `com/netscape/cms/servlet/base/PKIService.java` (v1 base class)
+- `org/dogtagpki/server/rest/v1/PKIApplication.java` (v1 JAX-RS application)
+- `org/dogtagpki/common/ConfigResource.java` (Config interface)
+- `org/dogtagpki/server/tps/TPSAccountService.java` (extends v1 AccountService)
+
+Files excluded when building v1-only:
+- All `**/rest/v2/**/*.java` (servlet implementations)
+- `org/dogtagpki/server/rest/v2/PKIServlet.java` (v2 base servlet)
 
 === Runtime Configuration ===
 

--- a/pki.spec
+++ b/pki.spec
@@ -163,7 +163,20 @@ ExcludeArch: i686
 %bcond_with console
 
 # REST API version control
-# The rest_api_deprecated and rest_api_disabled macros are provided by build.sh
+# The rest_api_versions_to_build, rest_api_deprecated and rest_api_disabled macros are provided by build.sh
+
+# Set defaults if not provided by build.sh
+%if ! %{defined rest_api_versions_to_build}
+%define rest_api_versions_to_build v1,v2
+%endif
+
+%if ! %{defined rest_api_deprecated}
+%define rest_api_deprecated v1
+%endif
+
+%if ! %{defined rest_api_disabled}
+%define rest_api_disabled ""
+%endif
 
 %if ! %{with debug}
 %define debug_package %{nil}
@@ -1410,6 +1423,11 @@ export JAVA_HOME=%{java_home}
 %endif
 
 # Configure REST API version control
+%if %{defined rest_api_versions_to_build}
+%pom_xpath_set "pom:project/pom:properties/pom:rest_api_versions_to_build" "%{rest_api_versions_to_build}" base
+%pom_xpath_set "pom:project/pom:properties/pom:rest_api_versions_to_build" "%{rest_api_versions_to_build}" base/server
+%endif
+
 %if %{defined rest_api_deprecated}
 %pom_xpath_set "pom:project/pom:properties/pom:rest_api_deprecated_version" "%{rest_api_deprecated}" base/server
 %endif
@@ -1418,7 +1436,17 @@ export JAVA_HOME=%{java_home}
 %pom_xpath_set "pom:project/pom:properties/pom:rest_api_disabled_versions" "%{rest_api_disabled}" base/server
 %endif
 
-%mvn_build %{!?with_test:-f} -j
+# Determine Maven profile for API version exclusion
+%if %{defined rest_api_versions_to_build}
+%if "%{rest_api_versions_to_build}" == "v1"
+%global mvn_profile -Papi-v1-only
+%endif
+%if "%{rest_api_versions_to_build}" == "v2"
+%global mvn_profile -Papi-v2-only
+%endif
+%endif
+
+%mvn_build %{!?with_test:-f} -j %{?mvn_profile:-- %{mvn_profile}}
 
 # create links to Maven-built JAR files for CMake
 mkdir -p %{_vpath_builddir}/dist
@@ -1525,6 +1553,7 @@ pkgs=base\
     --with-pkgs=$pkgs \
     %{?with_console:--with-console} \
     --without-test \
+    %{?rest_api_versions_to_build:--rest-api-versions=%{rest_api_versions_to_build}} \
     %{?rest_api_deprecated:--rest-api-deprecated=%{rest_api_deprecated}} \
     %{?rest_api_disabled:--rest-api-disabled=%{rest_api_disabled}} \
     dist

--- a/pki.spec
+++ b/pki.spec
@@ -162,6 +162,9 @@ ExcludeArch: i686
 # Don't build console unless --with console is specified.
 %bcond_with console
 
+# REST API version control
+# The rest_api_deprecated and rest_api_disabled macros are provided by build.sh
+
 %if ! %{with debug}
 %define debug_package %{nil}
 %endif
@@ -1406,6 +1409,15 @@ export JAVA_HOME=%{java_home}
 %pom_remove_dep :pki-tomcat-9.0 base/server
 %endif
 
+# Configure REST API version control
+%if %{defined rest_api_deprecated}
+%pom_xpath_set "pom:project/pom:properties/pom:rest_api_deprecated_version" "%{rest_api_deprecated}" base/server
+%endif
+
+%if %{defined rest_api_disabled}
+%pom_xpath_set "pom:project/pom:properties/pom:rest_api_disabled_versions" "%{rest_api_disabled}" base/server
+%endif
+
 %mvn_build %{!?with_test:-f} -j
 
 # create links to Maven-built JAR files for CMake
@@ -1513,6 +1525,8 @@ pkgs=base\
     --with-pkgs=$pkgs \
     %{?with_console:--with-console} \
     --without-test \
+    %{?rest_api_deprecated:--rest-api-deprecated=%{rest_api_deprecated}} \
+    %{?rest_api_disabled:--rest-api-disabled=%{rest_api_disabled}} \
     dist
 
 ################################################################################

--- a/pki.spec
+++ b/pki.spec
@@ -178,6 +178,15 @@ ExcludeArch: i686
 %define rest_api_disabled ""
 %endif
 
+# Flag to indicate if v1 API is being built (RESTEasy is only needed for v1)
+%global build_v1_api %{lua:
+if string.find(rpm.expand("%{rest_api_versions_to_build}"), "v1") then
+    print("1")
+else
+    print("0")
+end
+}
+
 %if ! %{with debug}
 %define debug_package %{nil}
 %endif
@@ -286,13 +295,15 @@ BuildRequires:    mvn(com.fasterxml.jackson.module:jackson-module-jaxb-annotatio
 BuildRequires:    mvn(com.fasterxml.jackson.jaxrs:jackson-jaxrs-base)
 BuildRequires:    mvn(com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider)
 
+# JAX-RS API, jboss-logging and RESTEasy are only needed for v1 (JAX-RS), not v2 (@WebServlet)
+%if %{build_v1_api}
 BuildRequires:    mvn(org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec)
 BuildRequires:    mvn(org.jboss.logging:jboss-logging)
-
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-jaxrs)
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-client)
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-jackson2-provider)
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-servlet-initializer)
+%endif
 
 %endif
 
@@ -630,12 +641,13 @@ Requires:         mvn(com.fasterxml.jackson.core:jackson-databind)
 Requires:         mvn(com.fasterxml.jackson.jaxrs:jackson-jaxrs-base)
 Requires:         mvn(com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider)
 
+%if %{build_v1_api}
 Requires:         mvn(org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec)
 Requires:         mvn(org.jboss.logging:jboss-logging)
-
 Requires:         mvn(org.jboss.resteasy:resteasy-jaxrs)
 Requires:         mvn(org.jboss.resteasy:resteasy-client)
 Requires:         mvn(org.jboss.resteasy:resteasy-jackson2-provider)
+%endif
 %else
 Provides:         bundled(apache-commons-cli)
 Provides:         bundled(apache-commons-codec)
@@ -661,12 +673,13 @@ Provides:         bundled(jackson-modules-base)
 Provides:         bundled(jackson-jaxrs-providers)
 Provides:         bundled(jackson-jaxrs-json-provider)
 
+%if %{build_v1_api}
 Provides:         bundled(jboss-jaxrs-2.0-api)
 Provides:         bundled(jboss-logging)
-
 Provides:         bundled(resteasy-jaxrs)
 Provides:         bundled(resteasy-client)
 Provides:         bundled(resteasy-jackson2-provider)
+%endif
 %endif
 
 Requires:         mvn(org.dogtagpki.jss:jss-base) >= 5.10.0
@@ -738,10 +751,12 @@ Requires:         python3-policycoreutils
 
 Requires:         selinux-policy-targeted >= 3.13.1-159
 
+%if %{build_v1_api}
 %if %{with runtime_deps}
 Requires:         mvn(org.jboss.resteasy:resteasy-servlet-initializer)
 %else
 Provides:         bundled(resteasy-servlet-initializer)
+%endif
 %endif
 
 %if 0%{?fedora} && 0%{?fedora} < %{fedora_tomcat9_cutoff} || 0%{?rhel} && 0%{?rhel} < %{rhel_tomcat9_cutoff}
@@ -1158,9 +1173,11 @@ then
     JAKARTA_ANNOTATION_API_VERSION=$(ls jakarta.annotation-api-*.jar | sed 's/^jakarta\.annotation-api-\(.*\)\.jar$/\1/')
     JAXB_API_VERSION=$(ls jakarta.xml.bind-api-*.jar | sed 's/^jakarta\.xml\.bind-api-\(.*\)\.jar$/\1/')
     JACKSON_VERSION=$(ls jackson-annotations-*.jar | sed 's/^jackson-annotations-\(.*\)\.jar$/\1/')
+%if %{build_v1_api}
     JAXRS_VERSION=$(ls jboss-jaxrs-api_2.0_spec-*.jar | sed 's/^jboss-jaxrs-api_2\.0_spec-\(.*\)\.jar$/\1/')
     JBOSS_LOGGING_VERSION=$(ls jboss-logging-*.jar| sed 's/^jboss-logging-\(.*\)\.jar$/\1/')
     RESTEASY_VERSION=$(ls resteasy-jaxrs-*.jar | sed 's/^resteasy-jaxrs-\(.*\)\.jar$/\1/')
+%endif
 
     popd
 
@@ -1182,9 +1199,11 @@ else
     JAKARTA_ANNOTATION_API_VERSION=$(rpm -q jakarta-annotations | sed -n 's/^jakarta-annotations-\([^-]*\)-.*$/\1/p')
     JAXB_API_VERSION=$(rpm -q jaxb-api | sed -n 's/^jaxb-api-\([^-]*\)-.*$/\1/p')
     JACKSON_VERSION=$(rpm -q jackson-annotations | sed -n 's/^jackson-annotations-\([^-]*\)-.*$/\1/p')
+%if %{build_v1_api}
     JAXRS_VERSION=$(rpm -q jboss-jaxrs-2.0-api | sed -n 's/^jboss-jaxrs-2.0-api-\([^-]*\)-.*$/\1.Final/p')
     JBOSS_LOGGING_VERSION=$(rpm -q jboss-logging | sed -n 's/^jboss-logging-\([^-]*\)-.*$/\1.Final/p')
     RESTEASY_VERSION=$(rpm -q pki-resteasy-core | sed -n 's/^pki-resteasy-core-\([^-]*\)-.*$/\1.Final/p')
+%endif
 
     # import common libraries from RPMs
     cp /usr/share/java/commons-cli.jar commons-cli-$COMMONS_CLI_VERSION.jar
@@ -1214,15 +1233,18 @@ else
     cp /usr/share/java/jackson-jaxrs-providers/jackson-jaxrs-base.jar jackson-jaxrs-base-$JACKSON_VERSION.jar
     cp /usr/share/java/jackson-jaxrs-providers/jackson-jaxrs-json-provider.jar jackson-jaxrs-json-provider-$JACKSON_VERSION.jar
     cp /usr/share/java/jackson-modules/jackson-module-jaxb-annotations.jar jackson-module-jaxb-annotations-$JACKSON_VERSION.jar
+%if %{build_v1_api}
     cp /usr/share/java/jboss-jaxrs-2.0-api.jar jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
     cp /usr/share/java/jboss-logging/jboss-logging.jar jboss-logging-$JBOSS_LOGGING_VERSION.jar
     cp /usr/share/java/resteasy/resteasy-jaxrs.jar resteasy-jaxrs-$RESTEASY_VERSION.jar
     cp /usr/share/java/resteasy/resteasy-client.jar resteasy-client-$RESTEASY_VERSION.jar
     cp /usr/share/java/resteasy/resteasy-jackson2-provider.jar resteasy-jackson2-provider-$RESTEASY_VERSION.jar
+%endif
 
     popd
 fi
 
+%if %{build_v1_api}
 if [ ! -d base/server/lib ]
 then
     mkdir -p base/server/lib
@@ -1233,6 +1255,7 @@ then
 
     popd
 fi
+%endif
 %endif
 
 %if 0%{?fedora} >= %{fedora_tomcat9_cutoff} || 0%{?rhel} >= %{rhel_tomcat9_cutoff}
@@ -1252,15 +1275,17 @@ then
     /usr/bin/javax2jakarta -profile=EE jackson-jaxrs-base-$JACKSON_VERSION.jar jackson-jaxrs-base-$JACKSON_VERSION.jar
     /usr/bin/javax2jakarta -profile=EE jackson-jaxrs-json-provider-$JACKSON_VERSION.jar jackson-jaxrs-json-provider-$JACKSON_VERSION.jar
 
+%if %{build_v1_api}
     /usr/bin/javax2jakarta -profile=EE jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
-
     /usr/bin/javax2jakarta -profile=EE resteasy-client-$RESTEASY_VERSION.jar resteasy-client-$RESTEASY_VERSION.jar
     /usr/bin/javax2jakarta -profile=EE resteasy-jackson2-provider-$RESTEASY_VERSION.jar resteasy-jackson2-provider-$RESTEASY_VERSION.jar
     /usr/bin/javax2jakarta -profile=EE resteasy-jaxrs-$RESTEASY_VERSION.jar resteasy-jaxrs-$RESTEASY_VERSION.jar
+%endif
 
     popd
 fi
 
+%if %{build_v1_api}
 if [ -d base/server/lib ]
 then
     # migrate server libraries
@@ -1271,6 +1296,7 @@ then
     popd
 fi
 %endif
+%endif
 
 %if %{without runtime_deps}
 if [ -d base/common/lib ]
@@ -1278,8 +1304,10 @@ then
     # install migrated common libraries
     pushd base/common/lib
 
+%if %{build_v1_api}
     mkdir -p ~/.m2/repository/pki-local/jboss-jaxrs-api_2.0_spec/$JAXRS_VERSION
     cp jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar ~/.m2/repository/pki-local/jboss-jaxrs-api_2.0_spec/$JAXRS_VERSION
+%endif
 
     popd
 fi
@@ -1612,9 +1640,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}.xml
 %endif
 
@@ -1636,10 +1666,12 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
-    -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='pki-local']" \
+%if %{build_v1_api}
+    -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-java.xml
 
 echo "Removing RPM deps from %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tools.xml"
@@ -1659,9 +1691,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tools.xml
 %endif
 
@@ -1683,9 +1717,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-server.xml
 %endif
 
@@ -1707,9 +1743,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ca.xml
 %endif
 
@@ -1731,9 +1769,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-kra.xml
 %endif
 
@@ -1755,9 +1795,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-ocsp.xml
 %endif
 
@@ -1779,9 +1821,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tks.xml
 %endif
 
@@ -1803,9 +1847,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-tps.xml
 %endif
 
@@ -1827,9 +1873,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-acme.xml
 %endif
 
@@ -1851,9 +1899,11 @@ xmlstarlet edit --inplace \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.core']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.module']" \
     -d "//_:dependency[_:groupId='com.fasterxml.jackson.jaxrs']" \
+%if %{build_v1_api}
     -d "//_:dependency[_:groupId='org.jboss.spec.javax.ws.rs']" \
     -d "//_:dependency[_:groupId='org.jboss.logging']" \
     -d "//_:dependency[_:groupId='org.jboss.resteasy']" \
+%endif
     %{buildroot}%{_datadir}/maven-metadata/%{name}-pki-est.xml
 %endif
 


### PR DESCRIPTION
Implement comprehensive REST API version control system with both runtime and build-time configuration capabilities.

Features:
- Runtime enable/disable of API versions via CS.cfg
- Build-time configuration of deprecated and disabled API versions
- Automatic deprecation headers for deprecated APIs
- Per-instance runtime overrides of build-time defaults

Components Added:

1. APIVersionFilter (base/server)
   - Servlet filter for all REST API requests
   - Checks build-time and runtime configuration
   - Sends 'Deprecation: true' header for deprecated versions
   - Returns 404 for disabled API versions
   - Handles missing engine gracefully during startup

2. rest-api.properties template (base/server)
   - Build-time configuration template
   - Processed by Maven and CMake with @variable@ substitution
   - Defines deprecated.version and disabled.versions

3. Build system integration
   - Maven: Resource filtering in base/server/pom.xml
   - CMake: configure_file() in base/server/CMakeLists.txt
   - build.sh: --rest-api-deprecated and --rest-api-disabled flags
   - RPM: %bcond macros and pom_xpath_set for configuration

Configuration:

Build-time (via Maven/CMake/RPM):
  rest.api.deprecated.version=v1    # Mark version as deprecated
  rest.api.disabled.versions=       # Disable versions by default

Runtime (via CS.cfg):
  rest.api.enabled=v1,v2            # Override disabled versions
  rest.api.suppress_deprecation_warnings=false  # Control warnings

Usage Examples:

  # Build with v1 deprecated (default)
  mvn package
  ./build.sh dist
  rpmbuild -ba pki.spec

  # Build with custom settings
  mvn package -Drest.api.deprecated.version=v2
  ./build.sh --rest-api-deprecated=v2 --rest-api-disabled=v1 dist
  rpmbuild --define 'rest_api_deprecated v2' -ba pki.spec

  # Runtime: re-enable disabled API
  pki-server ca-config-set rest.api.enabled v1,v2

  # Runtime: suppress deprecation warnings
  pki-server ca-config-set rest.api.suppress_deprecation_warnings true

Migration Path:
- Phase 1 (now): v1 deprecated, both compiled and enabled
- Phase 2: v1 deprecated and disabled by default, can be re-enabled
- Phase 3: v1 excluded from build entirely

Documentation:
- Added comprehensive guide in docs/changes/v11.10.0/Server-Changes.adoc
- Includes configuration options and usage examples