### PR TITLE
Drop CryptoProvider.get_cert()

### DIFF
--- a/base/common/python/pki/key.py
+++ b/base/common/python/pki/key.py
@@ -488,7 +488,6 @@ class KeyClient:
             self,
             parent,
             crypto=None,
-            transport_cert_nick=None,
             info_client=None):
         """ Constructor """
 
@@ -512,12 +511,6 @@ class KeyClient:
                         'Accept': 'application/json'}
 
         self.crypto = crypto
-
-        if transport_cert_nick:
-            logger.warning(
-                '%s:%s: The transport_cert_nick parameter in KeyClient.__init__() '
-                'is no longer used.',
-                inspect.stack()[1].filename, inspect.stack()[1].lineno)
 
         self.info_client = info_client
         self.encrypt_alg_oid = None

--- a/base/common/python/pki/kra.py
+++ b/base/common/python/pki/kra.py
@@ -43,13 +43,11 @@ class KRAClient(pki.subsystem.SubsystemClient):
     KeyRequest REST APIs.
     """
 
-    def __init__(self, parent, crypto=None, transport_cert_nick=None):
+    def __init__(self, parent, crypto=None):
         """ Constructor
 
         :param connection - PKIConnection object with DRM connection info.
         :param crypto - CryptoProvider object.
-        :param transport_cert_nick - identifier for the DRM transport
-                        certificate.
 
                         Note that for NSS databases, the database must have
                         been initialized beforehand.
@@ -72,7 +70,6 @@ class KRAClient(pki.subsystem.SubsystemClient):
             self.keys = pki.key.KeyClient(
                 self.connection,
                 crypto,
-                None,
                 self.info)
 
             self.system_certs = pki.systemcert.SystemCertClient(self.connection)
@@ -86,9 +83,3 @@ class KRAClient(pki.subsystem.SubsystemClient):
             self.info = None
             self.keys = None
             self.system_certs = None
-
-        if transport_cert_nick:
-            logger.warning(
-                '%s:%s: The transport_cert_nick parameter in KRAClient.__init__() '
-                'is no longer used.',
-                inspect.stack()[1].filename, inspect.stack()[1].lineno)

--- a/base/kra/src/test/python/drmtest.py
+++ b/base/kra/src/test/python/drmtest.py
@@ -101,7 +101,7 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     print(transport_cert.encoded)
 
     # create kraclient
-    crypto = pki.crypto.CryptographyCryptoProvider(transport_nick, transport_cert)
+    crypto = pki.crypto.CryptographyCryptoProvider()
     kraclient = KRAClient(connection, crypto)
     keyclient = kraclient.keys
 

--- a/docs/changes/v11.10.0/API-Changes.adoc
+++ b/docs/changes/v11.10.0/API-Changes.adoc
@@ -12,3 +12,7 @@ The `trans_wrapped_session_key` parameter in `KeyClient.retrieve_key()` must be 
 == Remove KeyClient.get_transport_cert()/set_transport_cert() ==
 
 The `KeyClient.get_transport_cert()` and `set_transport_cert()` have been removed.
+
+== Remove CryptoProvider.get_cert() ==
+
+The `CryptoProvider.get_cert()` has been removed.

--- a/tests/kra/bin/pki-kra-key-archive.py
+++ b/tests/kra/bin/pki-kra-key-archive.py
@@ -83,8 +83,7 @@ transport_cert = cryptography.x509.load_pem_x509_certificate(
     transport_pem,
     cryptography.hazmat.backends.default_backend())
 
-crypto = pki.crypto.CryptographyCryptoProvider(
-    transport_cert=transport_cert)
+crypto = pki.crypto.CryptographyCryptoProvider()
 crypto.initialize()
 
 pki_client = pki.client.PKIClient(

--- a/tests/kra/bin/pki-kra-key-retrieve.py
+++ b/tests/kra/bin/pki-kra-key-retrieve.py
@@ -80,8 +80,7 @@ transport_cert = cryptography.x509.load_pem_x509_certificate(
     transport_pem,
     cryptography.hazmat.backends.default_backend())
 
-crypto = pki.crypto.CryptographyCryptoProvider(
-    transport_cert=transport_cert)
+crypto = pki.crypto.CryptographyCryptoProvider()
 crypto.initialize()
 
 pki_client = pki.client.PKIClient(


### PR DESCRIPTION
The `CryptoProvider.get_cert()` has been removed since it's no longer used and it doesn't provide any mechanism to update the certs stored in memory.

The `KRAClient` and `KeyClient` constructors have been modified to no longer take transport cert params.

The `CryptographyCryptoProvider` constructor will still take transport cert nickname and data params but the values will no longer be used (i.e. deprecated).

The `pki-kra-key-archieve/retrieve.py` and `drmtest.py` have been updated to no longer create `CryptographyCryptoProvider` with transport cert params.

IPA will continue to create `CryptographyCryptoProvider` with transport cert params, but it should not be affected by the deprecation.

https://github.com/edewata/pki/blob/kra/docs/changes/v11.10.0/API-Changes.adoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated certificate-related methods from the cryptography API including `get_cert`, `archive_key`, and transport certificate handlers
  * Simplified constructor signatures by removing transport certificate parameters from cryptography provider and client classes
  * Applications using these removed methods will require code updates

* **Documentation**
  * Updated API changes documentation to reflect removed methods and parameters

* **Tests**
  * Updated test code to align with simplified API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->