### PR TITLE
Drop CryptoProvider.symmetric_wrap()

### DIFF
--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -82,12 +82,6 @@ class CryptoProvider(six.with_metaclass(abc.ABCMeta, object)):
         """ Generate a session key to be used for wrapping data to the DRM
         This must return a 3DES 168 bit key """
 
-    @abc.abstractmethod
-    def symmetric_wrap(self, data, wrapping_key, mechanism=None,
-                       nonce_iv=None):
-        """ encrypt data using a symmetric key (wrapping key)"""
-
-    @abc.abstractmethod
     def symmetric_unwrap(self, data, wrapping_key, mechanism=None,
                          nonce_iv=None):
         """ decrypt data originally encrypted with symmetric key (wrapping key)
@@ -185,37 +179,6 @@ class CryptographyCryptoProvider(CryptoProvider):
         """ Returns a session key to be used when wrapping secrets for the DRM.
         """
         return self.generate_symmetric_key()
-
-    def symmetric_wrap(self, data, wrapping_key, mechanism=None,
-                       nonce_iv=None):
-        """
-        :param data            Data to be wrapped
-        :param wrapping_key    Symmetric key to wrap data
-        :param mechanism       Mechanism to use for wrapping key
-        :param nonce_iv        Nonce for initialization vector
-
-        Wrap (encrypt) data using the supplied symmetric key
-        """
-        # TODO(alee)  Not sure yet how to handle non-default mechanisms
-        # For now, lets just ignore them
-
-        if wrapping_key is None:
-            raise ValueError("Wrapping key must be provided")
-
-        if self.encrypt_mode.name == "CBC":
-            padder = padding.PKCS7(self.encrypt_alg.block_size).padder()
-            padded_data = padder.update(data) + padder.finalize()
-            data = padded_data
-        else:
-            raise ValueError('Only CBC mode is currently supported')
-
-        cipher = Cipher(self.encrypt_alg(wrapping_key),
-                        self.encrypt_mode(nonce_iv),
-                        backend=self.backend)
-
-        encryptor = cipher.encryptor()
-        ct = encryptor.update(data) + encryptor.finalize()
-        return ct
 
     def symmetric_unwrap(self, data, wrapping_key,
                          mechanism=None, nonce_iv=None):

--- a/base/kra/src/test/python/drmtest.py
+++ b/base/kra/src/test/python/drmtest.py
@@ -43,6 +43,10 @@ from base64 import b64decode, b64encode
 
 from six.moves import range  # pylint: disable=W0622,F0401
 
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.padding import PKCS7
+
 import pki
 import pki.crypto
 import pki.key as key
@@ -239,10 +243,16 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
 
     nonce_iv = crypto.generate_nonce_iv()
 
-    encrypted_data = crypto.symmetric_wrap(
-        b64decode(key1),
-        session_key,
-        nonce_iv=nonce_iv)
+    padder = PKCS7(crypto.encrypt_alg.block_size).padder()
+    padded_data = padder.update(b64decode(key1)) + padder.finalize()
+
+    cipher = Cipher(
+        crypto.encrypt_alg(session_key),
+        crypto.encrypt_mode(nonce_iv),
+        backend=default_backend())
+
+    encryptor = cipher.encryptor()
+    encrypted_data = encryptor.update(padded_data) + encryptor.finalize()
 
     response = keyclient.archive_encrypted_data(
         client_key_id,

--- a/docs/changes/v11.10.0/API-Changes.adoc
+++ b/docs/changes/v11.10.0/API-Changes.adoc
@@ -16,3 +16,7 @@ The `KeyClient.get_transport_cert()` and `set_transport_cert()` have been remove
 == Remove CryptoProvider.get_cert() ==
 
 The `CryptoProvider.get_cert()` has been removed.
+
+== Remove CryptoProvider.symmetric_wrap() ==
+
+The `CryptoProvider.symmetric_wrap()` has been removed.

--- a/tests/kra/bin/pki-kra-key-archive.py
+++ b/tests/kra/bin/pki-kra-key-archive.py
@@ -8,9 +8,10 @@ import argparse
 import logging
 import os
 
-import cryptography.hazmat.backends
-import cryptography.hazmat.primitives.padding
-import cryptography.x509
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.padding import PKCS7
 
 import pki.kra
 import pki.account
@@ -79,9 +80,9 @@ with open(args.transport, 'rb') as f:
 with open(args.input_filename, 'rb') as f:
     input_data = f.read()
 
-transport_cert = cryptography.x509.load_pem_x509_certificate(
+transport_cert = x509.load_pem_x509_certificate(
     transport_pem,
-    cryptography.hazmat.backends.default_backend())
+    default_backend())
 
 crypto = pki.crypto.CryptographyCryptoProvider()
 crypto.initialize()
@@ -105,10 +106,16 @@ key_client = pki.key.KeyClient(kra_client)
 nonce_iv = crypto.generate_nonce_iv()
 session_key = crypto.generate_session_key()
 
-encrypted_data = crypto.symmetric_wrap(
-    input_data,
-    session_key,
-    nonce_iv=nonce_iv)
+padder = PKCS7(crypto.encrypt_alg.block_size).padder()
+padded_data = padder.update(input_data) + padder.finalize()
+
+cipher = Cipher(
+    crypto.encrypt_alg(session_key),
+    crypto.encrypt_mode(nonce_iv),
+    backend=default_backend())
+
+encryptor = cipher.encryptor()
+encrypted_data = encryptor.update(padded_data) + encryptor.finalize()
 
 wrapped_session_key = crypto.asymmetric_wrap(
     session_key,

--- a/tests/kra/bin/pki-kra-key-retrieve.py
+++ b/tests/kra/bin/pki-kra-key-retrieve.py
@@ -8,9 +8,8 @@ import argparse
 import logging
 import os
 
-import cryptography.hazmat.backends
-import cryptography.hazmat.primitives.padding
-import cryptography.x509
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
 
 import pki.kra
 import pki.account
@@ -76,9 +75,9 @@ elif args.verbose:
 with open(args.transport, 'rb') as f:
     transport_pem = f.read()
 
-transport_cert = cryptography.x509.load_pem_x509_certificate(
+transport_cert = x509.load_pem_x509_certificate(
     transport_pem,
-    cryptography.hazmat.backends.default_backend())
+    default_backend())
 
 crypto = pki.crypto.CryptographyCryptoProvider()
 crypto.initialize()


### PR DESCRIPTION
The `CryptoProvider.symmetric_wrap()` has been dropped in order to reduce dependency on Python Cryptography. The caller will be responsible to perform the encryption operation.

https://github.com/edewata/pki/blob/kra/docs/changes/v11.10.0/API-Changes.adoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed symmetric key wrapping method from the cryptographic provider API; callers must use alternate wrapping/encryption approaches.

* **Documentation**
  * API changelog updated to note removal of the symmetric_wrap method.

* **Tests / Utilities**
  * Test and tooling scripts updated to perform explicit PKCS7 padding and AES-CBC encryption steps and adjust imports accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->