### PR TITLE
Fix: Add support for old and new Tomcat 10.1 - Upgrade and branch porting

### DIFF
--- a/.github/workflows/acme-existing-nssdb-test.yml
+++ b/.github/workflows/acme-existing-nssdb-test.yml
@@ -189,7 +189,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxr-x--- pkiuser pkiuser temp
-          drwxr-x--- pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser webapps
           drwxr-x--- pkiuser pkiuser work
           EOF
 
@@ -202,7 +202,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxr-x--- pkiuser pkiuser temp
-          drwxr-x--- pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser webapps
           drwxr-x--- pkiuser pkiuser work
           EOF
 

--- a/.github/workflows/server-basic-test.yml
+++ b/.github/workflows/server-basic-test.yml
@@ -295,7 +295,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxr-x--- pkiuser pkiuser temp
-          drwxr-x--- pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser webapps
           drwxr-x--- pkiuser pkiuser work
           EOF
 
@@ -306,7 +306,7 @@ jobs:
           lrwxrwxrwx pkiuser pkiuser lib -> /usr/share/pki/server/lib
           lrwxrwxrwx pkiuser pkiuser logs -> /var/log/pki/pki-tomcat
           drwxr-x--- pkiuser pkiuser temp
-          drwxr-x--- pkiuser pkiuser webapps
+          drwxrwx--- pkiuser pkiuser webapps
           drwxr-x--- pkiuser pkiuser work
           EOF
 

--- a/base/server/upgrade/11.10.0/01-FixPerms.py
+++ b/base/server/upgrade/11.10.0/01-FixPerms.py
@@ -1,0 +1,49 @@
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+import logging
+import os
+
+import pki.server
+import pki.server.upgrade
+
+logger = logging.getLogger(__name__)
+
+
+class FixPerms(pki.server.upgrade.PKIServerUpgradeScriptlet):
+    """
+    Fix directory permissions for instances to reflect tomcat 10 fresh install.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Fix directory permissions'
+
+    def fix_permissions(self, instance, path, target_mode, description):
+        """
+        Fix permissions and ownership for a given path.
+        """
+        if not os.path.exists(path):
+            logger.debug('%s does not exist: %s', description, path)
+            return
+
+        logger.debug('Updating instance: %s %s: %s', instance.name, description, path)
+        logger.debug('Setting mode: %o', target_mode)
+
+        os.chmod(path, target_mode)
+
+    def upgrade_instance(self, instance):
+        """
+        Update directory permissions to match fresh installs.
+        """
+
+        # List of paths to fix with their target permissions
+        paths_to_fix = [
+            (instance.webapps_dir, pki.server.DEFAULT_DIR_MODE, 'Webapps directory'),
+            # Add more paths here as needed, for example:
+            # (instance.work_dir, 0o770, 'Work directory'),
+        ]
+
+        for path, target_mode, description in paths_to_fix:
+            self.fix_permissions(instance, path, target_mode, description)


### PR DESCRIPTION
Add support for old and new Tomcat 10.1 - Upgrade and branch porting

This fix introduces an upgrade script for pki 10.11.0 which fixes the permissions of instance directory "webapps". This is the only directory so far detected to be different in the following two scenarios:

1. Install a fresh pki 11.9.0 instance on old tomcat 10.
2. Intall a fresh pki 11.10.0 instance on old tomcat 10.

When starting with scenario #1 above and upgrading pki to 11.10.0, the upgrade script will change the perms of the webapps directory to 770 instead of the previous 755.

Note this codde used the code assistant to make the script extensible should we discover that we need to take care of additional directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Server instance directory permissions are now automatically corrected during upgrades to match fresh-install defaults, reducing permission-related issues after upgrade.
  * Upgrade reports clear status messages when applying fixes and skips non-existent paths gracefully; actions are logged for troubleshooting.
  * Routine is structured for easy extension to include additional directories.

* **Bug Fixes**
  * Webapps directory permissions broadened to allow group write where required to ensure proper post-install and test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->