### PR TITLE
Drop CryptoProvider.asymmetric_wrap()

### DIFF
--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -34,7 +34,6 @@ from cryptography.hazmat.primitives.ciphers import (
 )
 from cryptography.hazmat.primitives import keywrap
 from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 
 # encryption algorithms OIDs
 DES_EDE3_CBC_OID = "{1 2 840 113549 3 7}"
@@ -89,14 +88,6 @@ class CryptoProvider(six.with_metaclass(abc.ABCMeta, object)):
         We expect the data and nonce_iv values to be base64 encoded.
         The mechanism is the type of key used to do the wrapping.  It defaults
         to a 56 bit DES3 key.
-        """
-
-    @abc.abstractmethod
-    def asymmetric_wrap(self, data, wrapping_cert, mechanism=None):
-        """ encrypt a symmetric key with the public key of a transport cert.
-
-        The mechanism is the type of symmetric key, which defaults to a 56 bit
-        DES3 key.
         """
 
     @abc.abstractmethod
@@ -212,21 +203,6 @@ class CryptographyCryptoProvider(CryptoProvider):
             raise ValueError('Only CBC mode is currently supported')
 
         return unwrapped
-
-    def asymmetric_wrap(self, data, wrapping_cert,
-                        mechanism=None):
-        """
-        :param data             Data to be wrapped
-        :param wrapping_cert    Public key to wrap data
-        :param mechanism        algorithm of symmetric key to be wrapped
-
-        Wrap (encrypt) data using the supplied asymmetric key
-        """
-        public_key = wrapping_cert.public_key()
-        return public_key.encrypt(
-            data,
-            PKCS1v15()
-        )
 
     def key_unwrap(self, mechanism, data, wrapping_key, nonce_iv):
         """

--- a/base/kra/src/test/python/drmtest.py
+++ b/base/kra/src/test/python/drmtest.py
@@ -44,6 +44,7 @@ from base64 import b64decode, b64encode
 from six.moves import range  # pylint: disable=W0622,F0401
 
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.padding import PKCS7
 
@@ -159,7 +160,11 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     # Test 6: Barbican_decode() - Retrieve while providing
     # trans_wrapped_session_key
     session_key = crypto.generate_session_key()
-    wrapped_session_key = crypto.asymmetric_wrap(session_key, transport_cert)
+
+    wrapped_session_key = transport_cert.public_key().encrypt(
+        session_key,
+        PKCS1v15())
+
     print("My key id is " + str(key_id))
     key_data = keyclient.retrieve_key(
         key_id,

--- a/docs/changes/v11.10.0/API-Changes.adoc
+++ b/docs/changes/v11.10.0/API-Changes.adoc
@@ -20,3 +20,7 @@ The `CryptoProvider.get_cert()` has been removed.
 == Remove CryptoProvider.symmetric_wrap() ==
 
 The `CryptoProvider.symmetric_wrap()` has been removed.
+
+== Remove CryptoProvider.asymmetric_wrap() ==
+
+The `CryptoProvider.asymmetric_wrap()` has been removed.

--- a/tests/kra/bin/pki-kra-key-archive.py
+++ b/tests/kra/bin/pki-kra-key-archive.py
@@ -10,6 +10,7 @@ import os
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.padding import PKCS7
 
@@ -117,9 +118,9 @@ cipher = Cipher(
 encryptor = cipher.encryptor()
 encrypted_data = encryptor.update(padded_data) + encryptor.finalize()
 
-wrapped_session_key = crypto.asymmetric_wrap(
+wrapped_session_key = transport_cert.public_key().encrypt(
     session_key,
-    transport_cert)
+    PKCS1v15())
 
 # use AES_128_CBC to match pki kra-key-archve
 # see Java KeyClient.getEncryptAlgorithmOID()

--- a/tests/kra/bin/pki-kra-key-retrieve.py
+++ b/tests/kra/bin/pki-kra-key-retrieve.py
@@ -10,6 +10,7 @@ import os
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 
 import pki.kra
 import pki.account
@@ -105,9 +106,9 @@ key_id = key_info.get_key_id()
 
 session_key = crypto.generate_session_key()
 
-wrapped_session_key = crypto.asymmetric_wrap(
+wrapped_session_key = transport_cert.public_key().encrypt(
     session_key,
-    transport_cert)
+    PKCS1v15())
 
 # use AES_128_CBC to match pki kra-key-retrieve
 # see Java KeyClient.getEncryptAlgorithmOID()


### PR DESCRIPTION
The `CryptoProvider.asymmetric_wrap()` has been dropped in order to reduce dependency on Python Cryptography. The caller will be responsible to perform the key wrapping operation.

https://github.com/edewata/pki/blob/kra/docs/changes/v11.10.0/API-Changes.adoc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `asymmetric_wrap()` method from the CryptoProvider API. Callers using this method must be updated to use alternative wrapping mechanisms.

* **Documentation**
  * Updated API changes documentation to reflect removal of `asymmetric_wrap()` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->