### PR TITLE
Drop CryptoProvider.key_unwrap() and symmetric_unwrap()

### DIFF
--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -30,9 +30,8 @@ import os
 import six
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import (
-    Cipher, algorithms, modes
+    algorithms, modes
 )
-from cryptography.hazmat.primitives import padding
 
 # encryption algorithms OIDs
 DES_EDE3_CBC_OID = "{1 2 840 113549 3 7}"
@@ -79,15 +78,6 @@ class CryptoProvider(six.with_metaclass(abc.ABCMeta, object)):
     def generate_session_key(self):
         """ Generate a session key to be used for wrapping data to the DRM
         This must return a 3DES 168 bit key """
-
-    def symmetric_unwrap(self, data, wrapping_key, mechanism=None,
-                         nonce_iv=None):
-        """ decrypt data originally encrypted with symmetric key (wrapping key)
-
-        We expect the data and nonce_iv values to be base64 encoded.
-        The mechanism is the type of key used to do the wrapping.  It defaults
-        to a 56 bit DES3 key.
-        """
 
 
 class CryptographyCryptoProvider(CryptoProvider):
@@ -165,36 +155,3 @@ class CryptographyCryptoProvider(CryptoProvider):
         """ Returns a session key to be used when wrapping secrets for the DRM.
         """
         return self.generate_symmetric_key()
-
-    def symmetric_unwrap(self, data, wrapping_key,
-                         mechanism=None, nonce_iv=None):
-        """
-        :param data            Data to be unwrapped
-        :param wrapping_key    Symmetric key to unwrap data
-        :param mechanism       Mechanism to use when unwrapping
-        :param nonce_iv        iv data
-
-        Unwrap (decrypt) data using the supplied symmetric key
-        """
-
-        # TODO(alee) As above, no idea what to do with mechanism
-        # ignoring for now.
-
-        if wrapping_key is None:
-            raise ValueError("Wrapping key must be provided")
-
-        cipher = Cipher(self.encrypt_alg(wrapping_key),
-                        self.encrypt_mode(nonce_iv),
-                        backend=self.backend)
-
-        decryptor = cipher.decryptor()
-        unwrapped = decryptor.update(data) + decryptor.finalize()
-
-        if self.encrypt_mode.name == 'CBC':
-            unpadder = padding.PKCS7(self.encrypt_alg.block_size).unpadder()
-            unpadded = unpadder.update(unwrapped) + unpadder.finalize()
-            unwrapped = unpadded
-        else:
-            raise ValueError('Only CBC mode is currently supported')
-
-        return unwrapped

--- a/base/kra/src/test/python/drmtest.py
+++ b/base/kra/src/test/python/drmtest.py
@@ -171,9 +171,18 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
         key_id,
         trans_wrapped_session_key=wrapped_session_key)
     print_key_data(key_data)
-    unwrapped_key = crypto.symmetric_unwrap(key_data.encrypted_data,
-                                            session_key,
-                                            nonce_iv=key_data.nonce_data)
+
+    cipher = Cipher(
+        crypto.encrypt_alg(session_key),
+        crypto.encrypt_mode(key_data.nonce_data),
+        backend=default_backend())
+
+    decryptor = cipher.decryptor()
+    unwrapped = decryptor.update(key_data.encrypted_data) + decryptor.finalize()
+
+    unpadder = PKCS7(crypto.encrypt_alg.block_size).unpadder()
+    unwrapped_key = unpadder.update(unwrapped) + unpadder.finalize()
+
     key1 = b64encode(unwrapped_key)
 
     # Test 10 = test BadRequestException on create()
@@ -283,10 +292,16 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
 
     if key_data.wrap_algorithm == pki.crypto.WRAP_AES_CBC_PAD \
             or key_data.wrap_algorithm == pki.crypto.WRAP_DES3_CBC_PAD:
-        unwrapped_key = crypto.symmetric_unwrap(
-            key_data.encrypted_data,
-            session_key,
-            nonce_iv=key_data.nonce_data)
+        cipher = Cipher(
+            crypto.encrypt_alg(session_key),
+            crypto.encrypt_mode(key_data.nonce_data),
+            backend=default_backend())
+
+        decryptor = cipher.decryptor()
+        unwrapped = decryptor.update(key_data.encrypted_data) + decryptor.finalize()
+
+        unpadder = PKCS7(crypto.encrypt_alg.block_size).unpadder()
+        unwrapped_key = unpadder.update(unwrapped) + unpadder.finalize()
 
     elif key_data.wrap_algorithm == pki.crypto.WRAP_AES_KEY_WRAP:
         unwrapped_key = aes_key_unwrap(

--- a/docs/changes/v11.10.0/API-Changes.adoc
+++ b/docs/changes/v11.10.0/API-Changes.adoc
@@ -28,3 +28,7 @@ The `CryptoProvider.asymmetric_wrap()` has been removed.
 == Remove CryptoProvider.key_unwrap() ==
 
 The `CryptoProvider.key_unwrap()` has been removed.
+
+== Remove CryptoProvider.symmetric_unwrap() ==
+
+The `CryptoProvider.symmetric_unwrap()` has been removed.

--- a/tests/kra/bin/pki-kra-key-retrieve.py
+++ b/tests/kra/bin/pki-kra-key-retrieve.py
@@ -11,6 +11,8 @@ import os
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.padding import PKCS7
 
 import pki.kra
 import pki.account
@@ -120,10 +122,16 @@ key = key_client.retrieve_key(
 
 account_client.logout()
 
-key_data = crypto.symmetric_unwrap(
-    key.encrypted_data,
-    session_key,
-    nonce_iv=key.nonce_data)
+cipher = Cipher(
+    crypto.encrypt_alg(session_key),
+    crypto.encrypt_mode(key.nonce_data),
+    backend=default_backend())
+
+decryptor = cipher.decryptor()
+unwrapped = decryptor.update(key.encrypted_data) + decryptor.finalize()
+
+unpadder = PKCS7(crypto.encrypt_alg.block_size).unpadder()
+key_data = unpadder.update(unwrapped) + unpadder.finalize()
 
 with open(args.output_filename, 'wb') as f:
     f.write(key_data)


### PR DESCRIPTION
The `CryptoProvider.key_unwrap()` and `symmetric_unwrap()` have been dropped in order to reduce dependency on Python Cryptography. The caller will be responsible to perform the key unwrap/decrypt operation.

https://github.com/edewata/pki/blob/kra/docs/changes/v11.10.0/API-Changes.adoc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API docs to reflect removal of deprecated key-unwrapping methods.

* **Refactor**
  * Removed deprecated key-unwrapping code and replaced it with direct decryption workflows that handle multiple wrap algorithms.

* **Tests**
  * Updated key retrieval tests and utilities to align with the new unwrapping approach and error handling for unsupported wrap algorithms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->