### PR TITLE
Remove references to v1 classes

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/CertRequestInfoFactory.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/CertRequestInfoFactory.java
@@ -18,19 +18,12 @@
 
 package com.netscape.cms.servlet.cert;
 
-import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.Date;
-
-import javax.ws.rs.Path;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
 
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 import com.netscape.certsrv.cert.CertRequestInfo;
-import com.netscape.certsrv.cert.CertRequestResource;
-import com.netscape.certsrv.cert.CertResource;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.request.RequestId;
 import com.netscape.certsrv.request.RequestStatus;
@@ -85,32 +78,6 @@ public class CertRequestInfoFactory {
 
         Date modificationTime = request.getModificationTime();
         info.setModificationTime(modificationTime);
-
-        return info;
-    }
-
-    public static CertRequestInfo create(Request request, UriInfo uriInfo) throws SecurityException, NoSuchMethodException {
-
-        CertRequestInfo info = create(request);
-
-        Method getRequestInfo = CertRequestResource.class.getMethod("getRequestInfo", RequestId.class);
-        Path certRequestPath = getRequestInfo.getAnnotation(Path.class);
-
-        UriBuilder reqBuilder = uriInfo.getBaseUriBuilder();
-        reqBuilder.path(certRequestPath.value());
-        info.setRequestURL(reqBuilder.build(info.getRequestID()).toString());
-
-        Method getCert = CertResource.class.getMethod("getCert", CertId.class);
-        Path certPath = getCert.getAnnotation(Path.class);
-
-        UriBuilder certBuilder = uriInfo.getBaseUriBuilder();
-        certBuilder.path(certPath.value());
-
-        CertId certID = info.getCertId();
-        if (certID != null) {
-            BigInteger serialNo = info.getCertId().toBigInteger();
-            info.setCertURL(certBuilder.build(serialNo).toString());
-        }
 
         return info;
     }

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/AuthorityRepository.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/base/AuthorityRepository.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import com.netscape.ca.CASigningUnit;
 import com.netscape.ca.CertificateAuthority;
 import com.netscape.certsrv.authority.AuthorityData;
-import com.netscape.certsrv.authority.AuthorityResource;
 import com.netscape.certsrv.base.BadRequestDataException;
 import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.base.ConflictingOperationException;
@@ -84,6 +83,8 @@ public class AuthorityRepository {
     private static Logger logger = LoggerFactory.getLogger(AuthorityRepository.class);
 
     private CAEngine engine;
+
+    public static final String HOST_AUTHORITY = "host-authority";
 
     public AuthorityRepository(CAEngine engine) {
         this.engine = engine;
@@ -468,7 +469,7 @@ public class AuthorityRepository {
         logger.info("AuthorityRepository: Getting authority {}:", authId);
 
         AuthorityID aid = null;
-        if (AuthorityResource.HOST_AUTHORITY.equals(authId)) {
+        if (HOST_AUTHORITY.equals(authId)) {
             CertificateAuthority ca = engine.getCA();
             aid = ca.getAuthorityID();
         } else {
@@ -505,7 +506,7 @@ public class AuthorityRepository {
         logger.info("AuthorityRepository: Getting cert for authority {}", authId);
 
         AuthorityID aid = null;
-        if (!AuthorityResource.HOST_AUTHORITY.equals(authId)) {
+        if (!HOST_AUTHORITY.equals(authId)) {
             try {
                 aid = new AuthorityID(authId);
             } catch (IllegalArgumentException e) {
@@ -549,7 +550,7 @@ public class AuthorityRepository {
         logger.info("AuthorityRepository: Getting cert chain for authority {}", authId);
 
         AuthorityID aid = null;
-        if (!AuthorityResource.HOST_AUTHORITY.equals(authId)) {
+        if (!HOST_AUTHORITY.equals(authId)) {
             try {
                 aid = new AuthorityID(authId);
             } catch (IllegalArgumentException e) {
@@ -591,7 +592,7 @@ public class AuthorityRepository {
         CertificateAuthority hostCA = engine.getCA();
         String parentAIDString = data.getParentID();
         AuthorityID parentAID = null;
-        if (AuthorityResource.HOST_AUTHORITY.equals(parentAIDString)) {
+        if (HOST_AUTHORITY.equals(parentAIDString)) {
             parentAID = hostCA.getAuthorityID();
         } else {
             try {

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/CertRequestDAO.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/CertRequestDAO.java
@@ -26,6 +26,8 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.dogtagpki.server.authentication.AuthToken;
@@ -37,7 +39,10 @@ import com.netscape.certsrv.ca.AuthorityID;
 import com.netscape.certsrv.cert.CertEnrollmentRequest;
 import com.netscape.certsrv.cert.CertRequestInfo;
 import com.netscape.certsrv.cert.CertRequestInfos;
+import com.netscape.certsrv.cert.CertRequestResource;
+import com.netscape.certsrv.cert.CertResource;
 import com.netscape.certsrv.cert.CertReviewResponse;
+import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.request.CMSRequestInfo;
 import com.netscape.certsrv.request.CMSRequestInfos;
 import com.netscape.certsrv.request.RequestId;
@@ -55,6 +60,8 @@ import com.netscape.cms.servlet.request.CMSRequestDAO;
 import com.netscape.cmscore.profile.ProfileSubsystem;
 import com.netscape.cmscore.request.Request;
 import com.netscape.cmscore.security.JssSubsystem;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
 
 /**
  * @author alee
@@ -228,7 +235,7 @@ public class CertRequestDAO extends CMSRequestDAO {
         Request reqs[] = (Request[]) results.get(CAProcessor.ARG_REQUESTS);
         for (Request req : reqs) {
             try {
-                CertRequestInfo info = CertRequestInfoFactory.create(req, uriInfo);
+                CertRequestInfo info = create(req, uriInfo);
                 ret.addEntry(info);
             } catch (NoSuchMethodException e) {
                 logger.warn("Error in creating certrequestinfo - no such method: " + e.getMessage(), e);
@@ -277,11 +284,38 @@ public class CertRequestDAO extends CMSRequestDAO {
     @Override
     public CertRequestInfo createCMSRequestInfo(Request request, UriInfo uriInfo) {
         try {
-            return CertRequestInfoFactory.create(request, uriInfo);
+            return create(request, uriInfo);
         } catch (NoSuchMethodException e) {
             logger.warn("Error in creating certrequestinfo - no such method: " + e.getMessage(), e);
         }
         return null;
+    }
+
+    
+    public CertRequestInfo create(Request request, UriInfo uriInfo) throws SecurityException, NoSuchMethodException {
+
+        CertRequestInfo info =  CertRequestInfoFactory.create(request);
+
+        Method getRequestInfo = CertRequestResource.class.getMethod("getRequestInfo", RequestId.class);
+        Path certRequestPath = getRequestInfo.getAnnotation(Path.class);
+
+        UriBuilder reqBuilder = uriInfo.getBaseUriBuilder();
+        reqBuilder.path(certRequestPath.value());
+        info.setRequestURL(reqBuilder.build(info.getRequestID()).toString());
+
+        Method getCert = CertResource.class.getMethod("getCert", CertId.class);
+        Path certPath = getCert.getAnnotation(Path.class);
+
+        UriBuilder certBuilder = uriInfo.getBaseUriBuilder();
+        certBuilder.path(certPath.value());
+
+        CertId certID = info.getCertId();
+        if (certID != null) {
+            BigInteger serialNo = info.getCertId().toBigInteger();
+            info.setCertURL(certBuilder.build(serialNo).toString());
+        }
+
+        return info;
     }
 
 }

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/CertRequestServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/CertRequestServlet.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.dogtagpki.server.ca.CAEngine;
-import org.dogtagpki.server.ca.rest.v1.ProfileService;
 import org.mozilla.jss.netscape.security.x509.X500Name;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,11 +45,15 @@ import com.netscape.certsrv.profile.ProfileAttribute;
 import com.netscape.certsrv.profile.ProfileDataInfo;
 import com.netscape.certsrv.profile.ProfileDataInfos;
 import com.netscape.certsrv.profile.ProfileInput;
+import com.netscape.certsrv.property.Descriptor;
 import com.netscape.certsrv.request.RequestId;
 import com.netscape.certsrv.request.RequestNotFoundException;
 import com.netscape.certsrv.util.JSONSerializer;
 import com.netscape.cms.authentication.DirBasedAuthentication;
 import com.netscape.cms.profile.common.Profile;
+import com.netscape.cms.profile.common.ProfileConfig;
+import com.netscape.cms.profile.common.ProfileInputConfig;
+import com.netscape.cms.profile.common.ProfileInputsConfig;
 import com.netscape.cms.servlet.cert.CertRequestInfoFactory;
 import com.netscape.cms.servlet.cert.EnrollmentProcessor;
 import com.netscape.cms.servlet.cert.RenewalProcessor;
@@ -399,7 +402,10 @@ public class CertRequestServlet extends CAServlet {
         while (inputIds.hasMoreElements()) {
             String id = inputIds.nextElement();
             try {
-                ProfileInput input = ProfileService.createProfileInput(profile, id, locale);
+                ProfileInput input = createProfileInput(profile, id, locale);
+                if (input == null) {
+                    continue;
+                }
                 for (ProfileAttribute attr : input.getAttributes()) {
                     attr.setValue("");
                 }
@@ -460,6 +466,34 @@ public class CertRequestServlet extends CAServlet {
             return null;
         }
         return CertRequestInfoFactory.create(request);
+    }
+    
+    private ProfileInput createProfileInput(Profile profile, String inputId, Locale locale) throws EBaseException {
+        com.netscape.cms.profile.common.ProfileInput profileInput = profile.getProfileInput(inputId);
+        if (profileInput == null) {
+            logger.warn("CertRequestServlet: null input {} for profile {}", inputId, profile.getId());
+            return null;
+        }
+
+        ProfileConfig profileConfig = profile.getConfigStore();
+        ProfileInputsConfig inputStore = profileConfig.getProfileInputsConfig();
+        String name = profileInput.getName(locale);
+        ProfileInputConfig inputConfig = inputStore.getProfileInputConfig(inputId);
+        String classId = inputConfig.getString("class_id");
+
+        ProfileInput input = new ProfileInput(inputId, name, classId);
+
+        Enumeration<String> attrNames = profileInput.getValueNames();
+        while (attrNames.hasMoreElements()) {
+            String attrName = attrNames.nextElement();
+
+            Descriptor descriptor = (Descriptor) profileInput.getValueDescriptor(locale, attrName);
+
+            ProfileAttribute attr = new ProfileAttribute(attrName, null, descriptor);
+            input.addAttribute(attr);
+        }
+
+        return input;
     }
 
 }

--- a/base/est/src/main/java/org/dogtagpki/est/DogtagRABackend.java
+++ b/base/est/src/main/java/org/dogtagpki/est/DogtagRABackend.java
@@ -17,6 +17,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.util.EntityUtils;
+
 import org.mozilla.jss.netscape.security.pkcs.PKCS10;
 import org.mozilla.jss.netscape.security.pkcs.PKCS7;
 import org.mozilla.jss.netscape.security.util.Cert;
@@ -26,7 +27,6 @@ import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 
 import com.netscape.certsrv.account.AccountClient;
 import com.netscape.certsrv.authority.AuthorityClient;
-import com.netscape.certsrv.authority.AuthorityResource;
 import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.ca.AuthorityID;
@@ -62,10 +62,11 @@ public class DogtagRABackend extends ESTBackend {
     private String fullcmcProfile;
     // TODO: Add multi-profile support for all EST operations
 
+    private static final String HOST_AUTHORITY = "host-authority";
+
     // ThreadLocal to store CMC status for current request thread
     // Used to pass CMC status from CA response to EST HTTP status mapping
     private static ThreadLocal<Integer> cmcStatus = new ThreadLocal<>();
-
     /**
      * Get the CMC status from the last fullcmc() call in this thread.
      * This is used by ESTServlet to map CMC status to HTTP status codes.
@@ -145,7 +146,7 @@ public class DogtagRABackend extends ESTBackend {
         try (PKIClient pkiClient = new PKIClient(clientConfig)) {
             AuthorityClient authorityClient = new AuthorityClient(pkiClient, "ca");
 
-            String authorityID = label.orElse(AuthorityResource.HOST_AUTHORITY);
+            String authorityID = label.orElse(HOST_AUTHORITY);
             String pkcs7pem = authorityClient.getChainPEM(authorityID);
             logger.debug("Cert chain:\n" + pkcs7pem);
 

--- a/base/server/src/main/java/com/netscape/cmscore/usrgrp/User.java
+++ b/base/server/src/main/java/com/netscape/cmscore/usrgrp/User.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.base.EBaseException;
-import com.netscape.certsrv.user.UserResource;
 import com.netscape.certsrv.util.JSONSerializer;
 import com.netscape.cmscore.apps.CMS;
 
@@ -92,7 +91,8 @@ public class User implements JSONSerializer {
      * Constant for usertype
      */
     public static final String ATTR_TPS_PROFILES = "tpsProfiles";
-
+    public static final String ALL_PROFILES = "All Profiles";
+    
     public static final String ATTR_X509_CERTIFICATES = "userCertificates";
     public static final String ATTRIBUTES = "attributes";
     public static final String CMS_BASE_INVALID_ATTRIBUTE = "CMS_BASE_INVALID_ATTRIBUTE";
@@ -143,7 +143,7 @@ public class User implements JSONSerializer {
 
         boolean setAll = false;
         for (String profile: tpsProfiles) {
-            if (profile.equals(UserResource.ALL_PROFILES)) {
+            if (ALL_PROFILES.equals(profile)) {
                 setAll = true;
                 break;
             }
@@ -152,7 +152,7 @@ public class User implements JSONSerializer {
             this.tpsProfiles = tpsProfiles;
         } else {
             List<String> list = new ArrayList<>();
-            list.add(UserResource.ALL_PROFILES);
+            list.add(ALL_PROFILES);
             this.tpsProfiles = list;
         }
     }

--- a/base/tools/src/main/java/com/netscape/cmstools/authority/AuthorityShowCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/authority/AuthorityShowCLI.java
@@ -5,7 +5,6 @@ import org.apache.commons.cli.Option;
 
 import com.netscape.certsrv.authority.AuthorityClient;
 import com.netscape.certsrv.authority.AuthorityData;
-import com.netscape.certsrv.authority.AuthorityResource;
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.client.SubsystemClient;
 import com.netscape.cmstools.cli.MainCLI;
@@ -14,6 +13,7 @@ import com.netscape.cmstools.cli.SubsystemCommandCLI;
 public class AuthorityShowCLI extends SubsystemCommandCLI {
 
     public AuthorityCLI authorityCLI;
+    private static final String HOST_AUTHORITY = "host-authority";
 
     public AuthorityShowCLI(AuthorityCLI authorityCLI) {
         super("show", "Show CAs", authorityCLI);
@@ -55,7 +55,7 @@ public class AuthorityShowCLI extends SubsystemCommandCLI {
             if (caIDString != null) {
                 throw new Exception("Authority ID and --host-authority are mutually exclusive.");
             }
-            caIDString = AuthorityResource.HOST_AUTHORITY;
+            caIDString = HOST_AUTHORITY;
         }
 
         if (caIDString == null) {

--- a/base/tools/src/main/java/com/netscape/cmstools/user/UserCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/user/UserCLI.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.dogtagpki.cli.CLI;
 
 import com.netscape.certsrv.user.UserData;
-import com.netscape.certsrv.user.UserResource;
 import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmstools.cli.SubsystemCLI;
 
@@ -34,6 +33,8 @@ public class UserCLI extends CLI {
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(UserCLI.class);
 
     public SubsystemCLI subsystemCLI;
+    
+    private static final String ATTR_TPS_PROFILES = "tpsProfiles";
 
     public UserCLI(SubsystemCLI subsystemCLI) {
         super("user", "User management commands", subsystemCLI);
@@ -84,7 +85,7 @@ public class UserCLI extends CLI {
         if (!StringUtils.isEmpty(state))
             System.out.println("  State: " + state);
 
-        String tpsProfiles = userData.getAttribute(UserResource.ATTR_TPS_PROFILES);
+        String tpsProfiles = userData.getAttribute(ATTR_TPS_PROFILES);
         if (tpsProfiles != null) {
             System.out.println("  TPS Profiles:");
             for (String profile: tpsProfiles.split(",")) {

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/base/ProfileProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/base/ProfileProcessor.java
@@ -31,7 +31,6 @@ import com.netscape.certsrv.logging.AuditEvent;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.tps.profile.ProfileCollection;
 import com.netscape.certsrv.tps.profile.ProfileData;
-import com.netscape.certsrv.user.UserResource;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.logging.Auditor;
 
@@ -43,7 +42,7 @@ public class ProfileProcessor {
     private static final Logger logger = LoggerFactory.getLogger(ProfileProcessor.class);
     private static final Pattern PROFILE_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9_]+$");
     private static final Pattern PROPERTY_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_\\.]+$");
-
+    public static final String ALL_PROFILES = "All Profiles";
     private TPSSubsystem subsystem;
     private ProfileDatabase database;
     private Auditor auditor;
@@ -69,7 +68,7 @@ public class ProfileProcessor {
 
                 Collection<ProfileRecord> filteredProfiles = database.findRecords(filter);
 
-                if (authorizedProfiles.contains(UserResource.ALL_PROFILES)) {
+                if (authorizedProfiles.contains(ALL_PROFILES)) {
                     logger.debug("{} User allowed to access all profiles", method);
                     profiles.addAll(filteredProfiles);
 
@@ -179,7 +178,7 @@ public class ProfileProcessor {
             throw new BadRequestException(method + "Missing profile ID");
         }
         try {
-           if ((authorizedProfiles== null) || (!authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(profileID))) {
+           if ((authorizedProfiles == null) || (!authorizedProfiles.contains(ALL_PROFILES) && !authorizedProfiles.contains(profileID))) {
                 msg = "profile record restricted for profileID:" + profileID;
                 logger.debug("{} {}", method, msg);
                 throw new PKIException(msg);
@@ -219,7 +218,7 @@ public class ProfileProcessor {
             }
         }
         try {
-            if ((authorizedProfiles== null) || (!authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(profileID))) {
+            if ((authorizedProfiles == null) || (!authorizedProfiles.contains(ALL_PROFILES) && !authorizedProfiles.contains(profileID))) {
                 msg = "profile record restricted for profileID:" + profileID;
                 logger.debug("{} {}", method,  msg);
 
@@ -304,7 +303,7 @@ public class ProfileProcessor {
         logger.info("{} Changing profile {} status: {}", method, profileID, action);
 
         try {
-            if ((authorizedProfiles== null) || (!authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(profileID))) {
+            if ((authorizedProfiles == null) || (!authorizedProfiles.contains(ALL_PROFILES) && !authorizedProfiles.contains(profileID))) {
                 msg = "profile record restricted for profileID:" + profileID;
                 logger.debug("{} {}", method, msg);
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/base/TPSCertProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/base/TPSCertProcessor.java
@@ -24,7 +24,6 @@ import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.tps.cert.TPSCertCollection;
 import com.netscape.certsrv.tps.cert.TPSCertData;
-import com.netscape.certsrv.user.UserResource;
 
 /**
  * @author Marco Fargetta {@literal <mfargett@redhat.com>}
@@ -73,7 +72,7 @@ public class TPSCertProcessor {
                 throw new PKIException(method + msg);
             }
             String type = tRecord.getType();
-            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(type))
+            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) && !authorizedProfiles.contains(type))
                 throw new PKIException(method + "Token record restricted");
 
             // token was from an authorized profile
@@ -121,7 +120,7 @@ public class TPSCertProcessor {
              TPSCertDatabase database = subsystem.getCertDatabase();
              TPSCertRecord certRec = database.getRecord(certID);
              String type = certRec.getKeyType();
-             if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(type))
+             if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) && !authorizedProfiles.contains(type))
                     throw new PKIException(method + "Cert record restricted");
 
              return createCertData(database.getRecord(certID));
@@ -175,7 +174,7 @@ public class TPSCertProcessor {
                 }
                 if (tokenRecord != null) {
                     String type = tokenRecord.getType();
-                    if (type == null || type.isEmpty() || authorizedProfiles.contains(type) || authorizedProfiles.contains(UserResource.ALL_PROFILES)) {
+                    if (type == null || type.isEmpty() || authorizedProfiles.contains(type) || authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES)) {
                         // Return entries from the start of the page up to the page size
                         if (total >= start && total < start + size) {
                             response.addEntry(createCertData(certRecord));

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/ActivityServlet.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/ActivityServlet.java
@@ -20,6 +20,7 @@ import org.dogtagpki.server.tps.dbs.ActivityDatabase;
 import org.dogtagpki.server.tps.dbs.ActivityRecord;
 import org.dogtagpki.server.tps.dbs.TokenDatabase;
 import org.dogtagpki.server.tps.dbs.TokenRecord;
+import org.dogtagpki.server.tps.rest.base.ProfileProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,6 @@ import com.netscape.certsrv.base.UnauthorizedException;
 import com.netscape.certsrv.base.WebAction;
 import com.netscape.certsrv.logging.ActivityCollection;
 import com.netscape.certsrv.logging.ActivityData;
-import com.netscape.certsrv.user.UserResource;
 
 /**
  * @author Marco Fargetta {@literal <mfargett@redhat.com>}
@@ -96,7 +96,7 @@ public class ActivityServlet extends TPSServlet {
         }
         String type = aRec.getType();
 
-        if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(type)) {
+        if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) && !authorizedProfiles.contains(type)) {
             String msg = "token type restricted: " + type;
             logger.debug("{} {}", method, msg);
             throw new PKIException(msg);
@@ -153,7 +153,7 @@ public class ActivityServlet extends TPSServlet {
         List<ActivityRecord> activityList = (List<ActivityRecord>) database.findRecords(
                 filter, null, new String[] { "-date" }, start, size);
 
-        if (authorizedProfiles.contains(UserResource.ALL_PROFILES)) {
+        if (authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES)) {
             for (ActivityRecord aRec: activityList) {
                 activities.addEntry(createActivityData(aRec));
             }

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/TokenServlet.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/TokenServlet.java
@@ -31,6 +31,7 @@ import org.dogtagpki.server.tps.TPSSubsystem;
 import org.dogtagpki.server.tps.dbs.ActivityDatabase;
 import org.dogtagpki.server.tps.dbs.TokenDatabase;
 import org.dogtagpki.server.tps.dbs.TokenRecord;
+import org.dogtagpki.server.tps.rest.base.ProfileProcessor;
 import org.dogtagpki.tps.main.TPSException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,6 @@ import com.netscape.certsrv.tps.token.TokenCollection;
 import com.netscape.certsrv.tps.token.TokenData;
 import com.netscape.certsrv.tps.token.TokenData.TokenStatusData;
 import com.netscape.certsrv.tps.token.TokenStatus;
-import com.netscape.certsrv.user.UserResource;
 import com.netscape.certsrv.util.JSONSerializer;
 
 import netscape.ldap.LDAPException;
@@ -133,7 +133,7 @@ public class TokenServlet extends TPSServlet {
         }
         String type = trec.getType();
         if ((type == null) || type.isEmpty() ||
-                authorizedProfiles.contains(UserResource.ALL_PROFILES) ||
+                authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) ||
                 authorizedProfiles.contains(type)) {
             try {
                 TokenData tData = createTokenData(trec, request.getLocale());
@@ -230,14 +230,14 @@ public class TokenServlet extends TPSServlet {
             int start, int size,
             Locale loc) throws Exception {
 
-        String method = "ActivityServlet.retrieveActivities:";
+        String method = "TokenServlet.retrieveTokens:";
         logger.debug(method);
         TokenCollection tokens = new TokenCollection();
 
         List<TokenRecord> tokenList = (List<TokenRecord>) database.findRecords(
                 filter, attributes, null, start, size);
 
-        if (authorizedProfiles.contains(UserResource.ALL_PROFILES)) {
+        if (authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES)) {
             for (TokenRecord tRec: tokenList) {
                 tokens.addEntry(createTokenData(tRec, loc));
             }
@@ -470,7 +470,7 @@ public class TokenServlet extends TPSServlet {
                 throw new PKIException(method + "Token record not found");
             }
             String type = tokenRecord.getType();
-            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(type)) {
+            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) && !authorizedProfiles.contains(type)) {
                 logger.debug("{} token record restricted: {}", method, type);
 
                 throw new PKIException("token record restricted");
@@ -569,7 +569,7 @@ public class TokenServlet extends TPSServlet {
         String type = tokenRecord.getType();
         // if token not associated with any keyType/profile, disallow access,
         // unless the user has the "ALL_PROFILES" privilege
-        if (!authorizedProfiles.contains(UserResource.ALL_PROFILES) &&
+        if (!authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) &&
                 (((type == null) || type.isEmpty()) || !authorizedProfiles.contains(type))) {
                throw new PKIException(method + "Token record restricted");
         }
@@ -719,7 +719,7 @@ public class TokenServlet extends TPSServlet {
             }
 
             String type = tokenRecord.getType();
-            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(type))
+            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) && !authorizedProfiles.contains(type))
                    throw new PKIException(method + "Token record restricted");
 
             tokenRecord.setUserID(remoteUser);
@@ -819,7 +819,7 @@ public class TokenServlet extends TPSServlet {
                 throw new PKIException(method + "Token record not found");
             }
             String type = tokenRecord.getType();
-            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(type)) {
+            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) && !authorizedProfiles.contains(type)) {
                 logger.debug("{} token record restricted", method);
 
                 throw new PKIException("token record restricted");
@@ -927,7 +927,7 @@ public class TokenServlet extends TPSServlet {
             }
 
             String type = tokenRecord.getType();
-            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(UserResource.ALL_PROFILES) && !authorizedProfiles.contains(type))
+            if ((type != null) && !type.isEmpty() && !authorizedProfiles.contains(ProfileProcessor.ALL_PROFILES) && !authorizedProfiles.contains(type))
                   throw new PKIException(method + "Token record restricted");
 
             //delete all certs associated with this token


### PR DESCRIPTION
References to classes and interfaces implementing v1 REST API, outside of the API itself, are replaced in order to have a total separation of the API implementations.

The total separation will make easier to remove v1 REST APIs in future releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated profile-authorization and host-authority identifiers across components for consistent access checks.
  * Centralized URL construction by removing an internal overload and moving construction logic to the request handling layer; external behavior unchanged.
  * Introduced a shared helper for building profile input data to streamline profile-related flows and reduce duplicated logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->