### PR TITLE
Add cross-scheme migration support to KRATool with standalone build

### DIFF
--- a/base/tools/build-kratool.sh
+++ b/base/tools/build-kratool.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# Build script for standalone KRATool package
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_NAME="pki-kratool"
+
+# Extract version from spec file (single source of truth)
+PKG_VERSION=$(grep "^Version:" "${SCRIPT_DIR}/pki-kratool.spec" | awk '{print $2}')
+
+if [ -z "$PKG_VERSION" ]; then
+    echo "ERROR: Could not extract version from pki-kratool.spec"
+    exit 1
+fi
+
+BUILD_DIR="${HOME}/build/${PKG_NAME}"
+
+echo "=== Building Standalone KRATool Package ==="
+echo "Package: ${PKG_NAME}-${PKG_VERSION}"
+echo "Build directory: ${BUILD_DIR}"
+echo
+
+# Validate required files exist
+echo "Validating required files..."
+if [ ! -f "${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/KRATool.java" ]; then
+    echo "ERROR: KRATool.java not found at ${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/"
+    exit 1
+fi
+
+if [ ! -f "${SCRIPT_DIR}/kratool-pom.xml" ]; then
+    echo "ERROR: kratool-pom.xml not found at ${SCRIPT_DIR}/"
+    exit 1
+fi
+
+if [ ! -f "${SCRIPT_DIR}/pki-kratool.spec" ]; then
+    echo "ERROR: pki-kratool.spec not found at ${SCRIPT_DIR}/"
+    exit 1
+fi
+
+# Create build directory structure
+echo "Creating build directories..."
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}/"{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
+# Create source tarball
+echo "Creating source tarball..."
+TARBALL_DIR="${BUILD_DIR}/SOURCES/${PKG_NAME}-${PKG_VERSION}"
+mkdir -p "${TARBALL_DIR}/src/main/java/com/netscape/cmstools"
+
+# Copy KRATool source file
+cp "${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/KRATool.java" \
+   "${TARBALL_DIR}/src/main/java/com/netscape/cmstools/"
+
+# Copy pom.xml
+cp "${SCRIPT_DIR}/kratool-pom.xml" "${TARBALL_DIR}/pom.xml"
+
+# Create tarball
+cd "${BUILD_DIR}/SOURCES"
+tar czf "${PKG_NAME}-${PKG_VERSION}.tar.gz" "${PKG_NAME}-${PKG_VERSION}"
+rm -rf "${PKG_NAME}-${PKG_VERSION}"
+
+# Copy spec file
+echo "Copying spec file..."
+cp "${SCRIPT_DIR}/pki-kratool.spec" "${BUILD_DIR}/SPECS/"
+
+# Build RPM
+echo "Building RPM..."
+cd "${BUILD_DIR}"
+rpmbuild --define "_topdir ${BUILD_DIR}" \
+         -ba SPECS/pki-kratool.spec
+
+echo
+echo "=== Build Complete ==="
+echo "RPMs in: ${BUILD_DIR}/RPMS/noarch/"
+ls -lh "${BUILD_DIR}/RPMS/noarch/"
+echo
+echo "To install:"
+echo "  sudo rpm -ivh ${BUILD_DIR}/RPMS/noarch/${PKG_NAME}-${PKG_VERSION}-*.rpm"
+echo "  # Or to upgrade existing:"
+echo "  sudo rpm -Uvh ${BUILD_DIR}/RPMS/noarch/${PKG_NAME}-${PKG_VERSION}-*.rpm"
+echo

--- a/base/tools/kratool-pom.xml
+++ b/base/tools/kratool-pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.dogtagpki.pki</groupId>
+    <artifactId>pki-kratool</artifactId>
+    <!-- IMPORTANT: Keep this version in sync with pki-kratool.spec -->
+    <version>11.10.0</version>
+    <packaging>jar</packaging>
+
+    <name>PKI KRATool</name>
+    <description>Standalone tool for KRA archived keys migration with cross-scheme support</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <!--
+        Note on dependency management approach:
+
+        This POM uses <scope>system</scope> with <systemPath> for several dependencies,
+        which is intentional for KRATool's specific use case:
+
+        1. STANDALONE MIGRATION TOOL: KRATool runs on production PKI systems where these
+           libraries are already installed by the OS package manager at known locations.
+
+        2. VERSION CONSISTENCY: Using the exact same JARs as the deployed PKI system
+           ensures cryptographic compatibility and avoids version conflicts during
+           security-sensitive key migration operations.
+
+        3. SECURITY & AUDITABILITY: OS-packaged libraries receive security updates through
+           standard system update mechanisms and are tracked by package management.
+
+        4. BUILD SUPPORT: Corresponding BuildRequires in pki-kratool.spec ensure these
+           packages are installed during RPM build in clean environments.
+
+        While <scope>provided</scope> would be cleaner from a Maven perspective, system
+        scope provides explicit path guarantees needed for a tool targeting specific
+        RHEL versions with known filesystem layouts.
+    -->
+
+    <dependencies>
+        <!-- JSS -->
+        <dependency>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
+            <version>5.5.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/lib/java/jss/jss-base.jar</systemPath>
+        </dependency>
+
+        <!-- PKI Common -->
+        <dependency>
+            <groupId>org.dogtagpki.pki</groupId>
+            <artifactId>pki-common</artifactId>
+            <version>11.10.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/pki/pki-common.jar</systemPath>
+        </dependency>
+
+        <!-- SLF4J -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/slf4j/slf4j-api.jar</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.36</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/slf4j/slf4j-jdk14.jar</systemPath>
+        </dependency>
+
+        <!-- LDAP SDK -->
+        <dependency>
+            <groupId>org.mozilla</groupId>
+            <artifactId>ldapjdk</artifactId>
+            <version>5.5.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/ldapjdk.jar</systemPath>
+        </dependency>
+
+        <!-- Apache Commons CLI -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.9.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/apache-commons-cli.jar</systemPath>
+        </dependency>
+
+        <!-- Apache Commons Lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.17.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/apache-commons-lang3.jar</systemPath>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <includes>
+                        <include>com/netscape/cmstools/KRATool.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.netscape.cmstools.KRATool</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/base/tools/pki-kratool.spec
+++ b/base/tools/pki-kratool.spec
@@ -1,0 +1,73 @@
+Name:           pki-kratool
+Version:        11.10.0
+Release:        1%{?dist}
+Summary:        KRATool - PKI KRA LDIF Migration Tool
+
+License:        GPLv2
+URL:            https://www.dogtagpki.org
+Source0:        %{name}-%{version}.tar.gz
+
+BuildArch:      noarch
+
+BuildRequires:  maven
+BuildRequires:  java-17-openjdk-devel
+BuildRequires:  jss >= 5.5.0
+BuildRequires:  pki-base >= 11.6.0
+BuildRequires:  slf4j
+BuildRequires:  apache-commons-cli
+BuildRequires:  apache-commons-lang3
+BuildRequires:  ldapjdk
+
+# Runtime dependencies - use file paths instead of package names to avoid forcing upgrades
+Requires:       java-17-openjdk-headless
+#Requires:       jss >= 5.5.0
+#Requires:       pki-base >= 11.6.0
+#Requires:       slf4j
+#Requires:       apache-commons-cli
+#Requires:       apache-commons-lang3
+#Requires:       ldapjdk
+Requires:       /usr/lib/java/jss/jss-base.jar
+Requires:       /usr/share/java/pki/pki-common.jar
+Requires:       /usr/share/java/ldapjdk.jar
+Requires:       /usr/share/java/slf4j/slf4j-api.jar
+Requires:       /usr/share/java/slf4j/slf4j-jdk14.jar
+Requires:       /usr/share/java/apache-commons-cli.jar
+Requires:       /usr/share/java/apache-commons-lang3.jar
+
+%description
+KRATool is a utility for migrating archived private keys between
+PKI Key Recovery Authority (KRA) instances, including support for
+cross-scheme cryptographic migration.
+
+Key features:
+- Separate control of source and target wrapping algorithms
+- Order-independent LDIF field parsing
+- Algorithm auto-detection and session key regeneration
+- Optional software token fallback for unsupported algorithms
+- Backward compatible with legacy KRATool usage
+
+%prep
+%setup -q
+
+%build
+mvn clean package
+
+%install
+install -d -m 755 %{buildroot}%{_javadir}
+install -m 644 target/%{name}-%{version}.jar %{buildroot}%{_javadir}/
+
+install -d -m 755 %{buildroot}%{_bindir}
+cat > %{buildroot}%{_bindir}/KRATool << EOF
+#!/bin/bash
+exec java -cp %{_javadir}/%{name}-%{version}.jar:/usr/share/java/pki/pki-common.jar:/usr/lib/java/jss/jss-base.jar:/usr/share/java/slf4j/slf4j-api.jar:/usr/share/java/slf4j/slf4j-jdk14.jar:/usr/share/java/ldapjdk.jar:/usr/share/java/apache-commons-cli.jar:/usr/share/java/apache-commons-lang3.jar com.netscape.cmstools.KRATool "\$@"
+EOF
+chmod 755 %{buildroot}%{_bindir}/KRATool
+
+%files
+%{_javadir}/%{name}-%{version}.jar
+%{_bindir}/KRATool
+
+%changelog
+* Thu Mar 19 2026 Christina Fu <cfu@redhat.com> - 11.10.0-1
+- Enhanced KRATool with cross-scheme migration support
+- Make KRATool an independent RPM package

--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -12,7 +12,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 //
-// (C) 2011 Red Hat, Inc.
+// (C) 2011, 2026 Red Hat, Inc.
 // All rights reserved.
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.cmstools;
@@ -29,17 +29,26 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
+import java.security.cert.CertificateFactory;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.spec.MGF1ParameterSpec;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
@@ -53,12 +62,18 @@ import javax.crypto.spec.PSource;
 
 import org.dogtagpki.util.logging.PKILogger;
 import org.dogtagpki.util.logging.PKILogger.LogLevel;
+
 import org.mozilla.jss.CertDatabaseException;
 import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.KeyDatabaseException;
 import org.mozilla.jss.crypto.AlreadyInitializedException;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.InvalidKeyFormatException;
+import org.mozilla.jss.crypto.IVParameterSpec;
+import org.mozilla.jss.crypto.KeyGenAlgorithm;
+import org.mozilla.jss.crypto.KeyGenerator;
+import org.mozilla.jss.crypto.KeyPairAlgorithm;
+import org.mozilla.jss.crypto.KeyPairGenerator;
 import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.KeyWrapper;
 import org.mozilla.jss.crypto.ObjectNotFoundException;
@@ -72,6 +87,7 @@ import org.mozilla.jss.netscape.security.util.DerOutputStream;
 import org.mozilla.jss.netscape.security.util.DerValue;
 import org.mozilla.jss.netscape.security.util.Utils;
 import org.mozilla.jss.netscape.security.x509.X509CertImpl;
+import org.mozilla.jss.netscape.security.x509.X509Key;
 import org.mozilla.jss.pkcs11.PK11Cert;
 import org.mozilla.jss.pkcs11.PK11PubKey;
 import org.mozilla.jss.util.Password;
@@ -79,6 +95,8 @@ import org.mozilla.jss.util.Password;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
+ * Note: See <b> Cross-Scheme Migration Support </b> below for new features
+ *
  * The KRATool class is a utility program designed to operate on an LDIF file
  * to perform one or more of the following tasks:
  *
@@ -502,8 +520,86 @@ import com.netscape.cmsutil.crypto.CryptoUtil;
  *
  * </PRE>
  *
+ * <h3>Cross-Scheme Migration Support</h3>
+ *
+ * <p>
+ * KRATool supports cross-scheme migration, enabling secure migration of archived
+ * keys between KRA instances using different cryptographic schemes (e.g., from
+ * RSA+AES/CBC to RSA-OAEP+AES-KWP for FIPS-mode HSMs).
+ * </p>
+ *
+ * <p><b>Key Features:</b></p>
+ * <ul>
+ * <li><b>Secure rewrap flow:</b> Private keys remain wrapped in tokens throughout
+ *     the migration process.</li>
+ * <li><b>Order-independent LDIF parsing:</b> Extracts privateKeyData and publicKeyData
+ *     fields independently, regardless of their order in LDIF records.</li>
+ * <li><b>Algorithm auto-detection:</b> Automatically regenerates session keys only
+ *     when source and target algorithms or key sizes differ.</li>
+ * <li><b>HSM compatibility:</b> Supports private key payload processing in NSS DB
+ *     (software token) via -use_nss_for_payload_processing flag when HSM lacks
+ *     support for source or target algorithms.</li>
+ * <li><b>Pure Java implementation:</b> When -use_nss_for_payload_processing is used,
+ *     the importSessionKeyToToken() method implements JSS_KeyExchange mechanism in pure
+ *     Java with automatic fallback to temporary RSA keypair approach.</li>
+ * </ul>
+ *
+ * <p><b>Supported Algorithms:</b></p>
+ * <ul>
+ * <li>Session key wrap: RSA, RSA-OAEP</li>
+ * <li>Payload wrap: AES KeyWrap/Wrapped (CKM_AES_KEY_WRAP_KWP, recommended for HSM/FIPS),
+ *     AES KeyWrap/Padding (CKM_AES_KEY_WRAP_PAD), AES KeyWrap/NoPadding (CKM_AES_KEY_WRAP),
+ *     AES/CBC/PKCS5Padding, DES3/CBC/Padding</li>
+ * </ul>
+ *
+ * <p><b>Cross-Scheme Command-Line Options:</b></p>
+ * <pre>
+ *   -source_rsa_wrap_algorithm &lt;RSA|RSA-OAEP&gt;
+ *       Source session key wrap algorithm (default: RSA)
+ *
+ *   -target_rsa_wrap_algorithm &lt;RSA|RSA-OAEP&gt;
+ *       Target session key wrap algorithm (default: RSA-OAEP, recommended for HSM/FIPS)
+ *
+ *   -source_payload_wrap_algorithm &lt;algorithm&gt;
+ *       Source payload wrap algorithm (must match source KRA's payloadWrapAlgorithm)
+ *       Supported: "AES KeyWrap/Wrapped"   - CKM_AES_KEY_WRAP_KWP (0x210B) (recommended)
+ *                  "AES KeyWrap/Padding"   - CKM_AES_KEY_WRAP_PAD (0x210A)
+ *                  "AES KeyWrap/NoPadding" - CKM_AES_KEY_WRAP (0x2109)
+ *                  "AES/CBC/PKCS5Padding", "DES3/CBC/Padding"
+ *
+ *   -target_payload_wrap_algorithm &lt;algorithm&gt;
+ *       Target payload wrap algorithm (must match target KRA's configured algorithm)
+ *       Supported: "AES KeyWrap/Wrapped"   - CKM_AES_KEY_WRAP_KWP (0x210B) (recommended)
+ *                  "AES KeyWrap/Padding"   - CKM_AES_KEY_WRAP_PAD (0x210A)
+ *                  "AES KeyWrap/NoPadding" - CKM_AES_KEY_WRAP (0x2109)
+ *                  "AES/CBC/PKCS5Padding", "DES3/CBC/Padding"
+ *
+ *   -source_payload_wrap_keysize &lt;128|192|256&gt;
+ *       Source payload wrapping key size in bits (default: 128)
+ *
+ *   -target_payload_wrap_keysize &lt;128|192|256&gt;
+ *       Target payload wrapping key size in bits (default: 128)
+ *
+ *   -use_nss_for_payload_processing
+ *       Perform payload unwrap/rewrap in NSS DB (software token) when HSM lacks
+ *       support for target algorithms
+ *
+ *   -regenerate_session_key
+ *       Force regeneration of session key even when algorithms match
+ *
+ *   -split_target_ldif_per_records &lt;N&gt;
+ *       Split output into multiple LDIF files, each containing N records
+ *
+ *   -verbose
+ *       Enable detailed per-record logging (useful for debugging)
+ *
+ *   -use_oaep_rsa_key_wrap
+ *       Use RSA-OAEP instead of RSA PKCS#1 v1.5 (legacy flag)
+ * </pre>
+ *
  * @author mharmsen
- * @version $Revision$, $Date$
+ * @author cfu (added cross-scheme migration support)
+ *
  */
 public class KRATool {
 
@@ -536,9 +632,7 @@ public class KRATool {
     private static final int NAMING_CONTEXT_NAME_VALUE_PAIRS = 2;
     private static final int MANDATORY_NAME_VALUE_PAIRS = 4;
     private static final int REWRAP_NAME_VALUE_PAIRS = 4;
-    private static final int ID_OFFSET_ARGS = 10;
     private static final int REWRAP_ARGS = 16;
-    private static final int REWRAP_AND_ID_OFFSET_ARGS = 18;
 
     // Constants:  Command-line Options (Mandatory)
     private static final String KRA_TOOL = "KRATool";
@@ -608,7 +702,7 @@ public class KRATool {
     private static final String SOURCE_STORAGE_TOKEN_NAME_EXAMPLE = SOURCE_STORAGE_TOKEN_NAME
                                       + " "
                                       + TIC
-                                      + CryptoUtil.INTERNAL_TOKEN_FULL_NAME
+                                      + "SourceHSM"
                                       + TIC;
 
     private static final String SOURCE_STORAGE_CERT_NICKNAME = "-source_storage_certificate_nickname";
@@ -656,6 +750,19 @@ public class KRATool {
                                   + " "
                                   + "/export/pki/pwdfile";
 
+    private static final String SOURCE_HSM_TOKEN_PWDFILE = "-source_hsm_token_pwdfile";
+
+    private static final String SOURCE_HSM_TOKEN_PWDFILE_DESCRIPTION = "  <complete path to the password "
+                                      + "file which ONLY contains the"
+                                      + NEWLINE
+                                      + "        "
+                                      + "   password used to access the "
+                                      + "source HSM token>";
+
+    private static final String SOURCE_HSM_TOKEN_PWDFILE_EXAMPLE = SOURCE_HSM_TOKEN_PWDFILE
+                                  + " "
+                                  + "/export/pki/hsm-pwdfile";
+
     // Constants:  Command-line Options (ID Offset)
     private static final String APPEND_ID_OFFSET = "-append_id_offset";
 
@@ -677,6 +784,64 @@ public class KRATool {
 
     // Constants:  Command-line Options
     private static final String USE_OAEP_RSA_KEY_WRAP = "-use_rsa_oaep_keywrap";
+
+    // New flags for cross-scheme migration support
+    private static final String USE_CROSS_SCHEME = "-use_cross_scheme";
+    private static final String USE_CROSS_SCHEME_DESCRIPTION = "  Enable cross-scheme migration mode (entry-based processing)" + NEWLINE +
+                                                                "        " + "   Required for migrating between different wrapping algorithms";
+
+    private static final String SOURCE_RSA_WRAP_ALGORITHM = "-source_rsa_wrap_algorithm";
+    private static final String SOURCE_RSA_WRAP_ALGORITHM_DESCRIPTION = "  <RSA|RSA-OAEP> Source session key wrap algorithm (default: RSA)";
+
+    private static final String TARGET_RSA_WRAP_ALGORITHM = "-target_rsa_wrap_algorithm";
+    private static final String TARGET_RSA_WRAP_ALGORITHM_DESCRIPTION = "  <RSA|RSA-OAEP> Target session key wrap algorithm (default: RSA-OAEP, recommended for HSM/FIPS)";
+
+    private static final String SOURCE_PAYLOAD_WRAP_ALGORITHM = "-source_payload_wrap_algorithm";
+    private static final String SOURCE_PAYLOAD_WRAP_ALGORITHM_DESCRIPTION = "  <algorithm> Source payload wrap algorithm" + NEWLINE +
+                                                                             "        " + "   Supported:" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/Wrapped\"   - CKM_AES_KEY_WRAP_KWP (0x210B) (recommended for HSM/FIPS)" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/Padding\"   - CKM_AES_KEY_WRAP_PAD (0x210A)" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/NoPadding\" - CKM_AES_KEY_WRAP (0x2109)" + NEWLINE +
+                                                                             "        " + "     \"AES/CBC/PKCS5Padding\"  - CKM_AES_CBC_PAD (0x1085)" + NEWLINE +
+                                                                             "        " + "     \"DES3/CBC/Padding\"      - CKM_DES3_CBC_PAD" + NEWLINE +
+                                                                             "        " + "   Note: Use the quoted strings above, not the CKM_* mechanism names" + NEWLINE +
+                                                                             "        " + "   (must match source KRA's payloadWrapAlgorithm metaInfo)";
+
+    private static final String TARGET_PAYLOAD_WRAP_ALGORITHM = "-target_payload_wrap_algorithm";
+    private static final String TARGET_PAYLOAD_WRAP_ALGORITHM_DESCRIPTION = "  <algorithm> Target payload wrap algorithm (without key size)" + NEWLINE +
+                                                                             "        " + "   Supported:" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/Wrapped\"   - CKM_AES_KEY_WRAP_KWP (0x210B) (recommended for HSM/FIPS)" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/Padding\"   - CKM_AES_KEY_WRAP_PAD (0x210A)" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/NoPadding\" - CKM_AES_KEY_WRAP (0x2109)" + NEWLINE +
+                                                                             "        " + "     \"AES/CBC/PKCS5Padding\"  - CKM_AES_CBC_PAD (0x1085)" + NEWLINE +
+                                                                             "        " + "     \"DES3/CBC/Padding\"      - CKM_DES3_CBC_PAD" + NEWLINE +
+                                                                             "        " + "   Note: Use the quoted strings above, not the CKM_* mechanism names" + NEWLINE +
+                                                                             "        " + "   Note: Key size is specified separately with -target_payload_wrap_key_size" + NEWLINE +
+                                                                             "        " + "   (must match target KRA's configured algorithm)";
+
+    private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE = "-source_payload_wrap_keysize";
+    private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Source payload wrapping key size in bits (default: 128)";
+
+    private static final String TARGET_PAYLOAD_WRAP_KEYSIZE = "-target_payload_wrap_keysize";
+    private static final String TARGET_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Target payload wrapping key size in bits (default: 128)";
+
+    private static final String USE_NSS_FOR_PAYLOAD_PROCESSING = "-use_nss_for_payload_processing";
+    private static final String USE_NSS_FOR_PAYLOAD_PROCESSING_DESCRIPTION = "  Use NSS DB (software token) for payload unwrap/rewrap" + NEWLINE +
+                                                                               "        " + "   operations (useful when HSM doesn't support target algorithms)";
+
+    private static final String REGENERATE_SESSION_KEY = "-regenerate_session_key";
+    private static final String REGENERATE_SESSION_KEY_DESCRIPTION = "  Force generation of new session key during rewrap" + NEWLINE +
+                                                                      "        " + "   Note: Tool auto-detects when regeneration is needed and prompts user" + NEWLINE +
+                                                                      "        " + "   Use this flag to skip prompt and force regeneration";
+
+    // **TEST ONLY** Skip cryptographic rewrap operations, copy key data as-is
+    // Use for testing LDIF transformations without HSM access
+    private static final String SKIP_REWRAP = "-skip_rewrap";
+
+    private static final String SPLIT_TARGET_LDIF_PER_RECORDS = "-split_target_ldif_per_records";
+    private static final String SPLIT_TARGET_LDIF_PER_RECORDS_DESCRIPTION = "  <number> Split target LDIF into multiple files after every N records" + NEWLINE +
+                                                                             "        " + "   Creates files: targetfile-1.ldif, targetfile-2.ldif, etc.";
+
     private static final String SOURCE_KRA_NAMING_CONTEXT = "-source_kra_naming_context";
 
     private static final String SOURCE_KRA_NAMING_CONTEXT_DESCRIPTION = "  <source KRA naming context>";
@@ -699,6 +864,10 @@ public class KRATool {
 
     private static final String PROCESS_REQUESTS_AND_KEY_RECORDS_ONLY =
             "-process_requests_and_key_records_only";
+
+    private static final String VERBOSE = "-verbose";
+
+    private static final String VERBOSE_DESCRIPTION = "  Enable detailed per-record logging (useful for debugging)";
 
     private static final String KEY_UNWRAP_ALGORITHM = "-unwrap_algorithm";
 
@@ -929,6 +1098,7 @@ public class KRATool {
     private static final String KRA_LDIF_EXTDATA_REQUEST_TYPE = "extdata-requesttype:";
     private static final String KRA_LDIF_EXTDATA_SERIAL_NUMBER = "extdata-serialnumber:";
     private static final String KRA_LDIF_PRIVATE_KEY_DATA = "privateKeyData::";
+    private static final String KRA_LDIF_PUBLIC_KEY_DATA = "publicKeyData::";  // cross-scheme
     private static final String KRA_LDIF_REQUEST_ID = "requestId:";
     private static final String KRA_LDIF_REQUEST_TYPE = "requestType:";
     private static final String KRA_LDIF_SERIAL_NO = "serialno:";
@@ -984,12 +1154,28 @@ public class KRATool {
     private static boolean mKraNamingContextsFlag = false;
     private static boolean mProcessRequestsAndKeyRecordsOnlyFlag = false;
     private static boolean mUseOAEPKeyWrapAlg = false;
+    private static boolean mVerboseFlag = false;
+
+    // cross-scheme
+    private static boolean mUseCrossSchemeFlag = false;
+    private static boolean mUseNssForPayloadProcessing = false;
+    private static boolean mRegenerateSessionKey = false;
+    private static boolean mSkipRewrap = false;  // TEST ONLY - for validating LDIF transformations
+    private static Boolean mSessionKeyDecisionMade = null;  // Cache user's regeneration decision
+    private static int mSplitTargetLdifPerRecords = 0;  // Split output into multiple files after N records
+    private static int mCurrentFileNumber = 1;  // Current output file number (for split mode)
+    private static int mRecordsInCurrentFile = 0;  // Records written to current output file
     private static int mMandatoryNameValuePairs = 0;
     private static int mRewrapNameValuePairs = 0;
     private static int mPKISecurityDatabasePwdfileNameValuePairs = 0;
     private static int mAppendIdOffsetNameValuePairs = 0;
     private static int mRemoveIdOffsetNameValuePairs = 0;
     private static int mKraNamingContextNameValuePairs = 0;
+
+    // Record processing counters
+    private static int mProcessedKeyRecords = 0;
+    private static int mFailedKeyRecords = 0;
+    private static int mProcessedEntries = 0;  // cross-scheme: total entries written (for blank line logic)
 
     // Variables: Command-Line Values (Mandatory)
     private static String mKratoolCfgFilename = null;
@@ -1005,6 +1191,8 @@ public class KRATool {
 
     // Variables: Command-Line Values (Rewrap Password File)
     private static String mSourcePKISecurityDatabasePwdfile = null;
+    private static String mSourceHsmTokenPwdfile = null;
+    private static boolean mHsmPwdfileFlag = false;
 
     // Variables: Command-Line Values (ID Offset)
     private static BigInteger mAppendIdOffset = null;
@@ -1031,6 +1219,28 @@ public class KRATool {
     private static PublicKey mWrapPublicKey = null;
     private static int mPublicKeySize = 0;
     private static SymmetricKey.Type keyUnwrapAlgorithm = SymmetricKey.DES3;
+
+    // Variables: Cross-scheme migration support
+    private static String mSourceRSAWrapAlgName = null;  // User-specified source RSA algorithm
+    private static String mTargetRSAWrapAlgName = null;  // User-specified target RSA algorithm
+    private static String mSourcePayloadWrapAlgName = null;  // User-specified source payload algorithm
+    private static String mTargetPayloadWrapAlgName = null;  // User-specified target payload algorithm
+    private static int mSourcePayloadWrapKeySize = 128;  // Source payload key size (default: 128)
+    private static int mTargetPayloadWrapKeySize = 128;  // Target payload key size (default: 128)
+    private static KeyWrapAlgorithm mSourceRSAWrapAlg = KeyWrapAlgorithm.RSA;  // Actual source RSA algorithm (default: RSA)
+    private static KeyWrapAlgorithm mTargetRSAWrapAlg = KeyWrapAlgorithm.RSA_OAEP;  // Actual target RSA algorithm (default: RSA_OAEP)
+    private static IVParameterSpec mSourcePayloadWrappingIV = null;
+    private static X509Certificate mTargetStorageCert = null;
+
+    // cross-scheme: Temporary RSA keypair for session key transfer (performance optimization)
+    // Generated once at startup and reused across all LDIF entries to avoid repeated keypair generation
+    private static java.security.KeyPair mTempRSAKeyPair = null;  // Temporary RSA keypair for JSS_KeyExchange-style transfer
+    private static boolean mTempRSAKeyPairInitialized = false;  // Track initialization status
+
+    // cross-scheme: Cache for cloneKey capability (performance optimization)
+    // null = not yet tested, true = cloneKey works, false = cloneKey fails (use RSA keypair method)
+    // Avoids millions of failed cloneKey attempts when HSM doesn't support extractable keys
+    private static Boolean mIsKeyClonable = null;
 
     // Variables:  KRA LDIF Record Messages
     private static String mSourcePKISecurityDatabasePwdfileMessage = null;
@@ -1132,6 +1342,14 @@ public class KRATool {
                           + NEWLINE
                           + "        "
                           + "["
+                          + SOURCE_HSM_TOKEN_PWDFILE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_HSM_TOKEN_PWDFILE_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
                           + APPEND_ID_OFFSET
                           + NEWLINE
                           + "        "
@@ -1174,7 +1392,108 @@ public class KRATool {
                           + "["
                           + PROCESS_REQUESTS_AND_KEY_RECORDS_ONLY
                           + "]"
-                          + NEWLINE);
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + VERBOSE
+                          + NEWLINE
+                          + "        "
+                          + VERBOSE_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + NEWLINE
+                          + "    --- Cross-Scheme Migration Options ---"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + USE_CROSS_SCHEME
+                          + NEWLINE
+                          + "        "
+                          + USE_CROSS_SCHEME_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + SOURCE_RSA_WRAP_ALGORITHM
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_RSA_WRAP_ALGORITHM_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + TARGET_RSA_WRAP_ALGORITHM
+                          + NEWLINE
+                          + "        "
+                          + TARGET_RSA_WRAP_ALGORITHM_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + SOURCE_PAYLOAD_WRAP_ALGORITHM
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_PAYLOAD_WRAP_ALGORITHM_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + TARGET_PAYLOAD_WRAP_ALGORITHM
+                          + NEWLINE
+                          + "        "
+                          + TARGET_PAYLOAD_WRAP_ALGORITHM_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + SOURCE_PAYLOAD_WRAP_KEYSIZE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + TARGET_PAYLOAD_WRAP_KEYSIZE
+                          + NEWLINE
+                          + "        "
+                          + TARGET_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + USE_NSS_FOR_PAYLOAD_PROCESSING
+                          + NEWLINE
+                          + "        "
+                          + USE_NSS_FOR_PAYLOAD_PROCESSING_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + REGENERATE_SESSION_KEY
+                          + NEWLINE
+                          + "        "
+                          + REGENERATE_SESSION_KEY_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          + "        "
+                          + "["
+                          + SPLIT_TARGET_LDIF_PER_RECORDS
+                          + NEWLINE
+                          + "        "
+                          + SPLIT_TARGET_LDIF_PER_RECORDS_DESCRIPTION
+                          + "]"
+                          + NEWLINE
+                          // Hidden from usage - internal testing only
+                          // + "        "
+                          // + "["
+                          // + SKIP_REWRAP
+                          // + NEWLINE
+                          // + "        "
+                          // + SKIP_REWRAP_DESCRIPTION
+                          // + "]"
+                          // + NEWLINE
+                          );
 
         System.out.println("Example of 'Rewrap and Append ID Offset':"
                           + NEWLINE
@@ -1372,6 +1691,222 @@ public class KRATool {
                           + "        "
                           + PROCESS_REQUESTS_AND_KEY_RECORDS_ONLY
                           + NEWLINE);
+
+        System.out.println("Example of 'Cross-Scheme Migration with Session Key Regeneration':"
+                          + NEWLINE
+                          + NEWLINE
+                          + "        "
+                          + KRA_TOOL
+                          + NEWLINE
+                          + "        "
+                          + KRATOOL_CFG_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_LDIF_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + TARGET_LDIF_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + LOG_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_NSS_DB_PATH_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_STORAGE_TOKEN_NAME_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_STORAGE_CERT_NICKNAME_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + TARGET_STORAGE_CERTIFICATE_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_NSS_DB_PWDFILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_RSA_WRAP_ALGORITHM + " RSA-OAEP"
+                          + NEWLINE
+                          + "        "
+                          + TARGET_RSA_WRAP_ALGORITHM + " RSA-OAEP"
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_PAYLOAD_WRAP_ALGORITHM + " \"AES KeyWrap/Wrapped\""
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_PAYLOAD_WRAP_KEYSIZE + " 128"
+                          + NEWLINE
+                          + "        "
+                          + TARGET_PAYLOAD_WRAP_ALGORITHM + " \"AES KeyWrap/Wrapped\""
+                          + NEWLINE
+                          + "        "
+                          + TARGET_PAYLOAD_WRAP_KEYSIZE + " 256"
+                          + NEWLINE
+                          + "        "
+                          + REGENERATE_SESSION_KEY
+                          + NEWLINE
+                          + "        "
+                          + SPLIT_TARGET_LDIF_PER_RECORDS + " 1000"
+                          + NEWLINE
+                          + NEWLINE
+                          + "        "
+                          + "NOTE: This example migrates from 128-bit to 256-bit AES session keys."
+                          + NEWLINE
+                          + "        "
+                          + "      The -regenerate_session_key flag forces regeneration without prompt."
+                          + NEWLINE
+                          + "        "
+                          + "      Without the flag, tool will detect key size change and prompt user."
+                          + NEWLINE
+                          + "        "
+                          + "      The -split_target_ldif_per_records creates separate files every 1000 records."
+                          + NEWLINE);
+
+        System.out.println("Example of 'Cross-Scheme Migration' (RSA+AES/CBC to RSA-OAEP+AES-KWP):"
+                          + NEWLINE
+                          + NEWLINE
+                          + "        "
+                          + KRA_TOOL
+                          + NEWLINE
+                          + "        "
+                          + KRATOOL_CFG_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_LDIF_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + TARGET_LDIF_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + LOG_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_NSS_DB_PATH_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_STORAGE_TOKEN_NAME_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_STORAGE_CERT_NICKNAME_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + TARGET_STORAGE_CERTIFICATE_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_NSS_DB_PWDFILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_HSM_TOKEN_PWDFILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_RSA_WRAP_ALGORITHM + " RSA"
+                          + NEWLINE
+                          + "        "
+                          + TARGET_RSA_WRAP_ALGORITHM + " RSA-OAEP"
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_PAYLOAD_WRAP_ALGORITHM + " \"AES/CBC/PKCS5Padding\""
+                          + NEWLINE
+                          + "        "
+                          + TARGET_PAYLOAD_WRAP_ALGORITHM + " \"AES KeyWrap/Wrapped\""
+                          + NEWLINE
+                          + "        "
+                          + SPLIT_TARGET_LDIF_PER_RECORDS + " 1000"
+                          + NEWLINE
+                          + NEWLINE
+                          + "        "
+                          + "NOTE: If the command fails during payload unwrap/rewrap with an error"
+                          + NEWLINE
+                          + "        "
+                          + "      about unsupported algorithms, add the " + USE_NSS_FOR_PAYLOAD_PROCESSING
+                          + NEWLINE
+                          + "        "
+                          + "      flag to perform payload operations in NSS DB (software token)."
+                          + NEWLINE
+                          + "        "
+                          + "      The -split_target_ldif_per_records creates separate files every 1000 records."
+                          + NEWLINE);
+
+        System.out.println("Example of 'Cross-Scheme Migration with Software Token Fallback':"
+                          + NEWLINE
+                          + NEWLINE
+                          + "        "
+                          + KRA_TOOL
+                          + NEWLINE
+                          + "        "
+                          + KRATOOL_CFG_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_LDIF_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + TARGET_LDIF_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + LOG_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_NSS_DB_PATH_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_STORAGE_TOKEN_NAME_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_STORAGE_CERT_NICKNAME_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + TARGET_STORAGE_CERTIFICATE_FILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_NSS_DB_PWDFILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_HSM_TOKEN_PWDFILE_EXAMPLE
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_RSA_WRAP_ALGORITHM + " RSA"
+                          + NEWLINE
+                          + "        "
+                          + TARGET_RSA_WRAP_ALGORITHM + " RSA-OAEP"
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_PAYLOAD_WRAP_ALGORITHM + " \"AES/CBC/PKCS5Padding\""
+                          + NEWLINE
+                          + "        "
+                          + TARGET_PAYLOAD_WRAP_ALGORITHM + " \"AES KeyWrap/Wrapped\""
+                          + NEWLINE
+                          + "        "
+                          + SOURCE_PAYLOAD_WRAP_KEYSIZE + " 128"
+                          + NEWLINE
+                          + "        "
+                          + TARGET_PAYLOAD_WRAP_KEYSIZE + " 256"
+                          + NEWLINE
+                          + "        "
+                          + USE_NSS_FOR_PAYLOAD_PROCESSING
+                          + NEWLINE
+                          + NEWLINE
+                          + "        "
+                          + "NOTE: Use this option when the HSM does not support the target payload"
+                          + NEWLINE
+                          + "        "
+                          + "      wrap algorithm (e.g., AES KeyWrap/Wrapped). Payload unwrap/rewrap will"
+                          + NEWLINE
+                          + "        "
+                          + "      be performed in NSS DB (software token). Session key operations"
+                          + NEWLINE
+                          + "        "
+                          + "      still use the HSM."
+                          + NEWLINE
+                          + "        "
+                          + "      This example also demonstrates key size change (without specification of \"-regenerate_session_key\")"
+                          + NEWLINE
+                          + "        "
+                          + "      from 128-bit to 256-bit, which will trigger automatic session key"
+                          + NEWLINE
+                          + "        "
+                          + "      regeneration with user confirmation."
+                          + NEWLINE);
     }
 
     /*******************/
@@ -1430,14 +1965,15 @@ public class KRATool {
 
     /**
      * This method is used to obtain the private RSA storage key from
-     * the "source" KRA instance's security databases.
+     * the "source" KRA instance's crypto token.
+     * This key is used to unwrap session keys from archived data.
      *
      * This method is based upon code from 'com.netscape.kra.StorageKeyUnit'.
      * <P>
      *
      * @return the private RSA storage key from the "source" KRA
      */
-    private static PrivateKey getPrivateKey() {
+    private static PrivateKey getStoragePrivateKey() {
         try {
             PrivateKey pk[] = mSourceToken.getCryptoStore().getPrivateKeys();
 
@@ -1459,9 +1995,9 @@ public class KRATool {
     }
 
     /**
-     * This method gets the public key from the certificate stored
-     * in the "target" KRA storage certificate file. It also obtains
-     * the keysize of this RSA key.
+     * Gets the target KRA storage public key from the certificate file.
+     * This key is used to unwrap session keys for the target KRA.
+     * Also obtains the keysize of this RSA key.
      *
      * This method is based upon code from
      * 'com.netscape.cmstools.PrettyPrintCert'.
@@ -1469,10 +2005,10 @@ public class KRATool {
      *
      * @return the public RSA storage key from the "target" KRA
      */
-    private static PublicKey getPublicKey() {
+    private static PublicKey getStoragePublicKey() {
         BufferedReader inputCert = null;
         String encodedBASE64CertChunk;
-        StringBuffer encodedBASE64Cert = new StringBuffer();
+        StringBuilder encodedBASE64Cert = new StringBuilder();
         byte decodedBASE64Cert[] = null;
         X509CertImpl cert = null;
         PublicKey key = null;
@@ -1578,7 +2114,7 @@ public class KRATool {
 
     /**
      * This method is used to obtain the private RSA storage key
-     * from the "source" KRA instance's security databases and
+     * from the "source" KRA instance's crypto token and
      * the public RSA storage key from the certificate stored in
      * the "target" KRA storage certificate file.
      * <P>
@@ -1637,14 +2173,21 @@ public class KRATool {
                 return FAILURE;
             }
 
-            if (mPwdfileFlag) {
+            if (mPwdfileFlag || mHsmPwdfileFlag) {
                 BufferedReader in = null;
                 String pwd = null;
+                String pwdfile = null;
 
                 try {
+                    // Use HSM password file if provided, otherwise use NSS DB password file
+                    if (mHsmPwdfileFlag) {
+                        pwdfile = mSourceHsmTokenPwdfile;
+                    } else {
+                        pwdfile = mSourcePKISecurityDatabasePwdfile;
+                    }
+
                     in = new BufferedReader(
-                             new FileReader(
-                                     mSourcePKISecurityDatabasePwdfile));
+                             new FileReader(pwdfile));
                     pwd = in.readLine();
                     if (pwd == null) {
                         pwd = "";
@@ -1659,7 +2202,7 @@ public class KRATool {
                 } catch (Exception exReadPwd) {
                     logger.error("Failed to read the keydb password from "
                             + "the file '"
-                            + mSourcePKISecurityDatabasePwdfile
+                            + (mHsmPwdfileFlag ? mSourceHsmTokenPwdfile : mSourcePKISecurityDatabasePwdfile)
                             + "': "
                             + exReadPwd.getMessage(),
                             exReadPwd);
@@ -1745,7 +2288,7 @@ public class KRATool {
         // Extract the private key from the source storage token
         logger.info("BEGIN: Obtaining the private key from the source storage token");
 
-        mUnwrapPrivateKey = getPrivateKey();
+        mUnwrapPrivateKey = getStoragePrivateKey();
 
         if (mUnwrapPrivateKey == null) {
             logger.error("Failed extracting private key from the source storage token");
@@ -1759,7 +2302,7 @@ public class KRATool {
             logger.info("BEGIN: Obtaining the public key from the target storage certificate");
 
             mWrapPublicKey = PK11PubKey.fromSPKI(
-                     getPublicKey().getEncoded());
+                     getStoragePublicKey().getEncoded());
 
             if (mWrapPublicKey == null) {
                 logger.error("Failed extracting "
@@ -1783,21 +2326,470 @@ public class KRATool {
     }
 
     /**
-     * This method basically rewraps the "wrappedKeyData" by implementiing
-     * "mStorageUnit.decryptInternalPrivate( byte wrappedKeyData[] )" and
-     * "mStorageUnit.encryptInternalPrivate( byte priKey[] )", where
-     * "wrappedKeyData" uses the following structure:
+     * cross-scheme support: Extract the base algorithm family from a full algorithm specification.
+     * Strips key size and wrapping mechanism to get just the algorithm family.
+     * E.g., "AES/CBC/PKCS5Padding" -> "AES"
+     *       "AES128/CBC/PKCS5Padding" -> "AES"
+     *       "AES256 KeyWrap/Wrapped" -> "AES"
+     *       "AES KeyWrap/Wrapped" -> "AES"
+     *       "DES3/CBC/PKCS5Padding" -> "DES3"
+     */
+    private static String getBaseAlgorithm(String fullAlgorithm) {
+        if (fullAlgorithm == null) return null;
+
+        // First extract everything before the first '/' (if any)
+        int slashIndex = fullAlgorithm.indexOf('/');
+        String base = slashIndex > 0 ? fullAlgorithm.substring(0, slashIndex) : fullAlgorithm;
+
+        // Now strip key size and wrapping mechanism keywords
+        // Remove key sizes (128, 192, 256)
+        base = base.replaceAll("128|192|256", "");
+
+        // Remove wrapping mechanism keywords (KeyWrap, KWP, etc.)
+        base = base.replaceAll("\\s*KeyWrap|\\s*KWP", "");
+
+        // Trim any remaining whitespace
+        base = base.trim();
+
+        return base;
+    }
+
+    /**
+     * cross-scheme support: Get key size for payload wrap algorithm.
+     * For source/target algorithms, uses the explicit size parameters.
+     * For other algorithms, returns default of 128 for AES.
+     */
+    private static int getKeySizeFromAlgorithm(String algorithm) {
+        if (algorithm == null) return 128;
+
+        // For source/target payload algorithms, use explicit size parameters
+        if (algorithm.equals(mSourcePayloadWrapAlgName)) {
+            return mSourcePayloadWrapKeySize;
+        }
+        if (algorithm.equals(mTargetPayloadWrapAlgName)) {
+            return mTargetPayloadWrapKeySize;
+        }
+
+        // Default to 128 for AES (all algorithms are just names like "AES KeyWrap/Wrapped", no embedded sizes)
+        return 128;
+    }
+
+    /**
+     * cross-scheme support: Convert payload algorithm string to JSS KeyWrapAlgorithm.
+     * E.g., "AES/CBC/PKCS5Padding" -> KeyWrapAlgorithm.AES_CBC_PAD
+     *       "AES KeyWrap/Wrapped" -> KeyWrapAlgorithm.AES_KEY_WRAP_PAD_KWP
+     *       "AES KeyWrap/Padding" -> KeyWrapAlgorithm.AES_KEY_WRAP_PAD
+     *       "AES KeyWrap/NoPadding" -> KeyWrapAlgorithm.AES_KEY_WRAP
+     */
+    private static KeyWrapAlgorithm getPayloadWrapAlgorithm(String algName) throws Exception {
+        if (algName == null) {
+            throw new Exception("Payload wrap algorithm name is null");
+        }
+
+        // Map algorithm strings to JSS KeyWrapAlgorithm
+        if (algName.contains("AES") && algName.contains("CBC")) {
+            // AES/CBC/PKCS5Padding
+            return KeyWrapAlgorithm.AES_CBC_PAD;
+        } else if (algName.contains("AES") && algName.contains("KeyWrap")) {
+            // Distinguish between different AES KeyWrap variants
+            if (algName.contains("Wrapped") || algName.contains("KWP")) {
+                // "AES KeyWrap/Wrapped" -> CKM_AES_KEY_WRAP_KWP (0x210B)
+                return KeyWrapAlgorithm.AES_KEY_WRAP_PAD_KWP;
+            } else if (algName.contains("Padding")) {
+                // "AES KeyWrap/Padding" -> CKM_AES_KEY_WRAP_PAD (0x210A)
+                return KeyWrapAlgorithm.AES_KEY_WRAP_PAD;
+            } else if (algName.contains("NoPadding")) {
+                // "AES KeyWrap/NoPadding" -> CKM_AES_KEY_WRAP (0x2109)
+                return KeyWrapAlgorithm.AES_KEY_WRAP;
+            } else {
+                // Default to PAD for backward compatibility
+                return KeyWrapAlgorithm.AES_KEY_WRAP_PAD;
+            }
+        } else if (algName.contains("DES3") || algName.contains("DESede")) {
+            return KeyWrapAlgorithm.DES3_CBC_PAD;
+        }
+
+        throw new Exception("Unsupported payload wrap algorithm: " + algName);
+    }
+
+    /**
+     * cross-scheme support: Determine if IV is needed for the given algorithm.
+     * Returns true for CBC modes, false for KeyWrap modes.
+     */
+    private static boolean needsIV(String algName) {
+        if (algName == null) return false;
+        // KeyWrap algorithms don't need IV
+        if (algName.contains("KeyWrap") || algName.contains("KWP")) {
+            return false;
+        }
+        // CBC modes need IV
+        return algName.contains("CBC");
+    }
+
+    /**
+     * cross-scheme support: Parses a PublicKey from LDIF publicKeyData field.
      *
-     * SEQUENCE {
-     * encryptedSession OCTET STRING,
-     * encryptedPrivate OCTET STRING
-     * }
+     * @param publicKeyData X.509 SubjectPublicKeyInfo DER bytes
+     * @return PublicKey object
+     */
+    private static PublicKey parsePublicKeyFromLDIF(byte[] publicKeyData) throws Exception {
+        if (publicKeyData == null || publicKeyData.length == 0) {
+            throw new Exception("publicKeyData is null or empty");
+        }
+
+        try {
+            // Parse X.509 SubjectPublicKeyInfo format and convert to PK11PubKey
+            // HSM operations require PKCS#11 format (PK11PubKey), not generic X509Key
+            // This is essential for both RSA and ECC keys when unwrapping on HSM
+            X509Key x509Key = new X509Key();
+            x509Key.decode(publicKeyData);
+
+            // Convert to PK11PubKey for HSM compatibility
+            PK11PubKey pk11Key = PK11PubKey.fromSPKI(publicKeyData);
+            return pk11Key;
+        } catch (Exception e) {
+            logger.error("Failed to parse public key: " + e.getMessage());
+            throw new Exception("Failed to parse publicKeyData from LDIF", e);
+        }
+    }
+
+    /**
+     * cross-scheme support: Generates a random IV for the given wrap algorithm.
      *
-     * This method is based upon code from
-     * 'com.netscape.kra.EncryptionUnit'.
-     * <P>
+     * @param wrapAlg Key wrap algorithm
+     * @return IV parameter spec
+     */
+    private static IVParameterSpec generateIV(KeyWrapAlgorithm wrapAlg) throws Exception {
+        int ivLength;
+
+        // Determine IV length based on algorithm
+        if (wrapAlg == KeyWrapAlgorithm.AES_CBC_PAD) {
+            ivLength = 16;  // AES block size
+        } else if (wrapAlg == KeyWrapAlgorithm.DES3_CBC_PAD) {
+            ivLength = 8;   // DES block size
+        } else {
+            throw new Exception("Cannot generate IV for algorithm: " + wrapAlg);
+        }
+
+        // Generate random IV
+        SecureRandom random = new SecureRandom();
+        byte[] iv = new byte[ivLength];
+        random.nextBytes(iv);
+
+        return new IVParameterSpec(iv);
+    }
+
+    /**
+     * cross-scheme support: Converts session key wrap algorithm name to KeyWrapAlgorithm.
      *
-     * @return a byte[] containing the rewrappedKeyData
+     * @param algName Algorithm name (e.g., "RSA", "RSA-OAEP")
+     * @return KeyWrapAlgorithm constant
+     */
+    private static KeyWrapAlgorithm getSessionKeyWrapAlgorithm(String algName) throws Exception {
+        if (algName == null) {
+            throw new Exception("Session key wrap algorithm name is null");
+        }
+
+        if (algName.equalsIgnoreCase("RSA")) {
+            return KeyWrapAlgorithm.RSA;
+        } else if (algName.equalsIgnoreCase("RSA-OAEP") ||
+                   algName.equalsIgnoreCase("RSA_OAEP") ||
+                   algName.equalsIgnoreCase("RSAES-OAEP") ||
+                   algName.contains("OAEP")) {
+            return KeyWrapAlgorithm.RSA_OAEP;
+        }
+
+        throw new Exception("Unsupported session key wrap algorithm: " + algName);
+    }
+
+    /**
+     * cross-scheme support: Determines whether a new session key needs to be generated.
+     * Returns true if:
+     * - User explicitly requested regeneration (-regenerate_session_key flag)
+     * - Algorithm family changed (e.g., DES3 -> AES) AND user confirms
+     * - Key size changed (e.g., 128-bit -> 256-bit) AND user confirms
+     *
+     * @return true if new session key needed, false otherwise
+     */
+    private static boolean needNewSessionKey() throws Exception {
+        // If user explicitly set the flag, always regenerate
+        if (mRegenerateSessionKey) {
+            if (mSessionKeyDecisionMade == null) {
+                logger.info("User requested session key regeneration");
+                mSessionKeyDecisionMade = true;
+            }
+            return true;
+        }
+
+        // If we already made the decision (prompted user), return cached result
+        if (mSessionKeyDecisionMade != null) {
+            return mSessionKeyDecisionMade;
+        }
+
+        // First time checking - analyze algorithms
+        String sourceBase = getBaseAlgorithm(mSourcePayloadWrapAlgName);
+        String targetBase = getBaseAlgorithm(mTargetPayloadWrapAlgName);
+
+        // Use explicit key size parameters (default to 128 if not specified)
+        int sourceWrapKeySize = mSourcePayloadWrapKeySize;
+        int targetWrapKeySize = mTargetPayloadWrapKeySize;
+
+        // Determine the change type and prompt accordingly
+        boolean isRequired = false;
+        String message;
+
+        if (!sourceBase.equals(targetBase)) {
+            // Algorithm family changed - regeneration required
+            isRequired = true;
+            message = "Algorithm family is changing from " + sourceBase + " to " + targetBase + ".";
+        } else if (sourceWrapKeySize != targetWrapKeySize) {
+            // Key size changed - regeneration required
+            isRequired = true;
+            message = "Key size is changing from " + sourceWrapKeySize + "-bit to " + targetWrapKeySize + "-bit " + sourceBase + ".";
+        } else {
+            // Nothing changed - offer optional regeneration
+            message = "Key type and size remain the same: " + sourceWrapKeySize + "-bit " + sourceBase + ".";
+        }
+
+        boolean decision = promptUserForSessionKeyRegeneration(message, isRequired);
+        mSessionKeyDecisionMade = decision;  // Cache decision
+
+        if (decision) {
+            logger.info("User chose to regenerate session key");
+        } else {
+            logger.info("User chose to reuse existing session key");
+        }
+
+        return decision;
+    }
+
+    /**
+     * cross-scheme support: Prompts user to confirm session key regeneration.
+     *
+     * @param message The message explaining the situation
+     * @param isRequired Whether regeneration is required (true) or optional (false)
+     * @return true if user confirms, false otherwise
+     */
+    private static boolean promptUserForSessionKeyRegeneration(String message, boolean isRequired) throws Exception {
+        System.out.println();
+        System.out.println(message);
+
+        if (isRequired) {
+            System.out.println("Session key regeneration is REQUIRED.");
+            System.out.println();
+            System.out.print("Proceed with key regeneration for all session keys? (y/n): ");
+        } else {
+            System.out.println("Would you like to regenerate all session keys anyway (for security/compliance)?");
+            System.out.println();
+            System.out.print("Regenerate session keys? (y/n): ");
+        }
+        System.out.flush();
+
+        try {
+            java.io.BufferedReader reader = new java.io.BufferedReader(
+                new java.io.InputStreamReader(System.in));
+            String response = reader.readLine();
+
+            if (response != null && (response.equalsIgnoreCase("y") || response.equalsIgnoreCase("yes"))) {
+                return true;
+            }
+            return false;
+        } catch (Exception e) {
+            throw new Exception("Failed to read user input: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * cross-scheme support: Initializes the temporary RSA keypair for session key transfer.
+     *
+     * The temporary keypair is generated ONCE at startup and reused across all LDIF entries for performance.
+     *
+     * Based on JSS_KeyExchange mechanism (jssutil.c:1146-1241):
+     * - Generates 2048-bit RSA keypair on processing token
+     * - Marked as temporary (session-based) - auto-deleted when token closes
+     * - Used to wrap/unwrap session keys between source HSM and processing token
+     *
+     * @param processingToken Token where keypair will be generated (HSM or NSS DB)
+     */
+    private static void initTempRSAKeyPair(CryptoToken processingToken) throws Exception {
+        if (mTempRSAKeyPairInitialized) {
+            logger.info("Temporary RSA keypair already initialized");
+            return;
+        }
+
+        logger.info("Generating temporary 2048-bit RSA keypair on processing token for session key transfer");
+        logger.info("This keypair will be reused across all LDIF entries (performance optimization)");
+
+        try {
+            KeyPairGenerator kpg = processingToken.getKeyPairGenerator(KeyPairAlgorithm.RSA);
+            kpg.initialize(2048);
+            kpg.temporaryPairs(true);  // Session-based, auto-deleted
+
+            mTempRSAKeyPair = kpg.genKeyPair();
+            mTempRSAKeyPairInitialized = true;
+
+            logger.info("Temporary RSA keypair generated successfully");
+        } catch (Exception e) {
+            logger.error("Failed to generate temporary RSA keypair: " + e.getMessage());
+            throw new Exception("Failed to initialize temporary RSA keypair for session key transfer", e);
+        }
+    }
+
+    /**
+     * cross-scheme support: Imports a session key from one token to another.
+     *
+     * This method implements the complete JSS_KeyExchange mechanism in pure Java using
+     * existing JSS APIs, avoiding the need to modify JSS or expose internal C functions.
+     *
+     * Two-stage approach:
+     * 1. First, attempt direct cloneKey() (requires extractable session key)
+     * 2. If that fails, use JSS_KeyExchange-style temporary RSA keypair approach
+     *
+     * JSS_KeyExchange mechanism (implemented in pure Java):
+     * 1. Generate temporary RSA keypair on processing token (done once at startup)
+     * 2. Wrap session key with temp RSA public key on source token (using RSA-OAEP)
+     * 3. Unwrap session key with temp RSA private key on processing token
+     * 4. Temp keypair auto-deleted (marked temporary/session-based)
+     *
+     * Reference: JSS_ExportEncryptedPrivKeyInfoV2 -> JSS_KeyExchange in jssutil.c:1146-1241
+     *
+     * @param sessionKey Source session key
+     * @param processingToken Token for processing (HSM or NSS DB)
+     * @return Session key in processing token
+     */
+    private static SymmetricKey importSessionKeyToToken(
+            SymmetricKey sessionKey,
+            CryptoToken processingToken) throws Exception {
+
+        if (mVerboseFlag) {
+            logger.info("Importing session key to processing token");
+        }
+
+        // cross-scheme: If same token, just return the original key
+        if (sessionKey.getOwningToken() == processingToken) {
+            if (mVerboseFlag) {
+                logger.info("Session key already on processing token");
+            }
+            return sessionKey;
+        }
+
+        // cross-scheme: Stage 1 - Try direct cloneKey() first (fast path)
+        // Performance optimization: Only attempt cloneKey if not already known to fail
+        if (mIsKeyClonable == null || mIsKeyClonable == true) {
+            try {
+                if (mVerboseFlag) {
+                    if (mIsKeyClonable == null) {
+                        logger.info("Stage 1: Testing cloneKey capability (first record)...");
+                    } else {
+                        logger.info("Stage 1: Using cloneKey (known to work)...");
+                    }
+                }
+                SymmetricKey importedKey = processingToken.cloneKey(sessionKey);
+
+                // Success! Cache this result for all future records
+                if (mIsKeyClonable == null) {
+                    mIsKeyClonable = true;
+                    if (mVerboseFlag) {
+                        logger.info("cloneKey works - will use direct clone for all subsequent records");
+                    }
+                }
+
+                if (mVerboseFlag) {
+                    logger.info("Session key successfully cloned to processing token (direct method)");
+                }
+                return importedKey;
+
+            } catch (SymmetricKey.NotExtractableException e) {
+                // Cache the failure - don't try cloneKey again for remaining records
+                mIsKeyClonable = false;
+
+                if (mVerboseFlag) {
+                    logger.info("Direct clone failed - session key not extractable from source HSM");
+                    logger.info("HSM security policy prevents PK11_ExtractKeyValue");
+                    logger.info("Will use RSA keypair method for all subsequent records");
+                    logger.info("Stage 2: Falling back to JSS_KeyExchange-style temporary RSA keypair approach...");
+                } else {
+                    // Important: Log this once even without verbose, as it affects performance
+                    logger.info("Note: HSM does not support extractable session keys - using RSA keypair transfer method for all records");
+                }
+
+                // Fall through to Stage 2
+            } catch (Exception e) {
+                logger.error("Unexpected error during direct clone: " + e.getMessage());
+                throw new Exception("Failed to clone session key", e);
+            }
+        } else {
+            // mIsKeyClonable == false: Skip Stage 1 entirely for better performance
+            if (mVerboseFlag) {
+                logger.info("Skipping cloneKey attempt (known to fail) - using RSA keypair method");
+            }
+        }
+
+        // cross-scheme: Stage 2 - JSS_KeyExchange-style approach using temporary RSA keypair
+        try {
+            // Initialize temp RSA keypair if not already done (only happens once)
+            initTempRSAKeyPair(processingToken);
+
+            // Get session key parameters
+            int sessionKeyLength = sessionKey.getLength();  // Key length in bytes
+            if (mVerboseFlag) {
+                logger.info("Session key length: " + sessionKeyLength + " bytes");
+            }
+
+            // Step 1: Wrap session key with temporary RSA public key on source token
+            CryptoToken sourceToken = sessionKey.getOwningToken();
+            if (mVerboseFlag) {
+                logger.info("Wrapping session key with temporary RSA public key on source token...");
+            }
+
+            KeyWrapper sourceWrapper = sourceToken.getKeyWrapper(KeyWrapAlgorithm.RSA_OAEP);
+            OAEPParameterSpec oaepParams = new OAEPParameterSpec(
+                "SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT
+            );
+            sourceWrapper.initWrap(mTempRSAKeyPair.getPublic(), oaepParams);
+            byte[] wrappedSessionKey = sourceWrapper.wrap(sessionKey);
+
+            if (mVerboseFlag) {
+                logger.info("Session key wrapped with temporary RSA public key (" + wrappedSessionKey.length + " bytes)");
+            }
+
+            // Step 2: Unwrap session key with temporary RSA private key on processing token
+            if (mVerboseFlag) {
+                logger.info("Unwrapping session key with temporary RSA private key on processing token...");
+            }
+
+            // Note: sessionKeyLength is in bytes, CryptoUtil.unwrap expects bits
+            SymmetricKey importedKey = CryptoUtil.unwrap(
+                processingToken,
+                SymmetricKey.AES,
+                sessionKeyLength * 8,  // Convert bytes to bits
+                SymmetricKey.Usage.UNWRAP,
+                (PrivateKey)mTempRSAKeyPair.getPrivate(),
+                wrappedSessionKey,
+                KeyWrapAlgorithm.RSA_OAEP
+            );
+
+            if (mVerboseFlag) {
+                logger.info("Session key successfully transferred to processing token using temporary RSA keypair");
+            }
+
+            return importedKey;
+
+        } catch (Exception e) {
+            logger.error("Failed to import session key using temporary RSA keypair: " + e.getMessage());
+            throw new Exception("Failed to import session key to processing token (both direct and RSA keypair methods failed)", e);
+        }
+    }
+
+
+    /**
+     * Baseline rewrap: Simple session key rewrap without algorithm changes.
+     * Used when -use_cross_scheme flag is NOT specified.
+     *
+     * This is the original baseline rewrap method from legacy KRATool.
+     *
+     * @param wrappedKeyData The wrapped private key data from LDIF
+     * @return rewrapped private key data for target LDIF
      */
     private static byte[] rewrap_wrapped_key_data(byte[] wrappedKeyData)
             throws Exception {
@@ -1947,6 +2939,336 @@ public class KRATool {
     }
 
     /**
+     * cross-scheme support: Rewraps private key data for cross-scheme migration.
+     *
+     * NOTE: This migration tool is designed to run in a secure, isolated environment.
+     *
+     * Migration flow (with payloadEncrypted:false - using key wrapping):
+     * 1. Unwrap session key from source HSM with source RSA algorithm
+     * 2. Import session key into processing token (NSS DB when using -use_nss_for_payload_processing)
+     * 3. Unwrap private key using session key and publicKeyData
+     * 4. [Optional] Generate new session key based on algorithm compatibility
+     * 5. Wrap private key with session key using target payload wrap algorithm
+     * 6. Wrap session key with target storage cert public key using target RSA algorithm
+     *
+     * Input DER structure (from LDIF privateKeyData):
+     * SEQUENCE {
+     *   encryptedSession OCTET STRING  (session key wrapped with source storage private key)
+     *   encryptedPrivate OCTET STRING  (private key wrapped with session key)
+     * }
+     *
+     * Based on: com.netscape.kra.StorageKeyUnit.unwrap() and wrap()
+     *
+     * @param wrappedKeyData The wrapped private key data from LDIF
+     * @param publicKeyData The public key data from LDIF (needed for unwrapping)
+     * @param ivData The IV from metaInfo (for AES/CBC payload encryption, null for KeyWrap algorithms)
+     * @return rewrapped private key data for target LDIF
+     */
+    private static byte[] rewrap_wrapped_key_data(byte[] wrappedKeyData, byte[] publicKeyData, byte[] ivData)
+            throws Exception {
+
+        // cross-scheme: Step 1 - Parse Input DER Structure
+        byte[] wrappedSessionKey;
+        byte[] wrappedPrivateKey;
+
+        try {
+            DerValue val = new DerValue(wrappedKeyData);
+            DerInputStream in = val.data;
+
+            // Extract wrapped session key
+            DerValue dSession = in.getDerValue();
+            wrappedSessionKey = dSession.getOctetString();
+
+            // Extract wrapped private key
+            DerValue dPri = in.getDerValue();
+            wrappedPrivateKey = dPri.getOctetString();
+
+            if (mVerboseFlag) {
+                logger.info("Parsed DER structure: session key " + wrappedSessionKey.length +
+                           " bytes, private key " + wrappedPrivateKey.length + " bytes");
+            }
+        } catch (IOException e) {
+            logger.error("Failed to parse DER structure: " + e.getMessage());
+            throw new Exception("Failed to parse input DER structure", e);
+        }
+
+        // cross-scheme: Step 2 - Unwrap Session Key from Source HSM
+        // Note: We request the session key to be TEMPORARY and EXTRACTABLE so it can be
+        // cloned to the processing token (software token when using -use_nss_for_payload_processing).
+        // If the HSM doesn't allow extractable session keys, the importSessionKeyToToken() method
+        // in Step 3 will automatically fall back to using a temporary RSA keypair approach.
+        SymmetricKey sessionKey;
+
+        try {
+            CryptoToken sourceToken = mSourceToken;
+            if (mVerboseFlag) {
+                logger.info("Unwrapping session key from source HSM using " + mSourceRSAWrapAlgName +
+                    " (enum: " + mSourceRSAWrapAlg + ")");
+
+                // Debug: Log private key information
+                logger.info("DEBUG: Private key owner token: " + mUnwrapPrivateKey.getOwningToken().getName());
+                logger.info("DEBUG: Private key algorithm: " + mUnwrapPrivateKey.getAlgorithm());
+                byte[] keyID = mUnwrapPrivateKey.getUniqueID();
+                StringBuilder hexString = new StringBuilder();
+                for (byte b : keyID) {
+                    hexString.append(String.format("%02X", b));
+                }
+                logger.info("DEBUG: Private key ID: " + hexString.toString());
+            }
+
+            // Note: strength parameter is in BITS (128), CryptoUtil divides by 8 internally
+            sessionKey = CryptoUtil.unwrap(
+                sourceToken,              // CryptoToken
+                SymmetricKey.AES,         // key type
+                128,                      // key strength in BITS
+                SymmetricKey.Usage.UNWRAP,  // usage
+                mUnwrapPrivateKey,        // unwrapping key (PrivateKey)
+                wrappedSessionKey,        // wrapped data
+                mSourceRSAWrapAlg         // KeyWrapAlgorithm (RSA_OAEP or RSA)
+            );
+
+            if (mVerboseFlag) {
+                logger.info("Session key unwrapped from source HSM");
+            }
+        } catch (Exception e) {
+            logger.error("Failed to unwrap session key: " + e.getMessage());
+            throw new Exception("Failed to unwrap session key from source HSM", e);
+        }
+
+        // cross-scheme: Step 3 - Import Session Key to Target Token
+        CryptoToken processingToken;
+        SymmetricKey targetSessionKey;
+
+        try {
+            if (mUseNssForPayloadProcessing) {
+                // Use NSS DB (software token) for payload unwrap/rewrap operations
+                processingToken = CryptoManager.getInstance().getInternalKeyStorageToken();
+                if (mVerboseFlag) {
+                    logger.info("Using NSS DB (software token) for payload processing");
+                }
+            } else {
+                // Use same HSM for payload unwrap/rewrap operations
+                processingToken = mSourceToken;
+                if (mVerboseFlag) {
+                    logger.info("Using same HSM for payload processing");
+                }
+            }
+
+            // Import session key to processing token
+            targetSessionKey = importSessionKeyToToken(sessionKey, processingToken);
+            if (mVerboseFlag) {
+                logger.info("Session key imported to processing token");
+            }
+        } catch (Exception e) {
+            logger.error("Failed to import session key to processing token: " + e.getMessage());
+            throw new Exception("Failed to import session key to processing token", e);
+        }
+
+        // cross-scheme: Step 4 - Parse PublicKey from publicKeyData
+        PublicKey publicKey;
+
+        try {
+            publicKey = parsePublicKeyFromLDIF(publicKeyData);
+            if (mVerboseFlag) {
+                logger.info("Parsed public key from LDIF");
+                logger.info("DEBUG: Public key algorithm: " + publicKey.getAlgorithm());
+                logger.info("DEBUG: Public key format: " + publicKey.getFormat());
+            }
+        } catch (Exception e) {
+            logger.error("Failed to parse public key: " + e.getMessage());
+            throw new Exception("Failed to parse publicKeyData", e);
+        }
+
+        // cross-scheme: Step 5 - Unwrap Private Key in Target Token
+        PrivateKey privateKey;
+
+        try {
+            // Get source wrapping parameters
+            KeyWrapAlgorithm sourcePayloadWrapAlg = getPayloadWrapAlgorithm(mSourcePayloadWrapAlgName);
+            IVParameterSpec sourcePayloadWrapIV = null;
+            if (needsIV(mSourcePayloadWrapAlgName)) {
+                if (ivData != null) {
+                    sourcePayloadWrapIV = new IVParameterSpec(ivData);
+                } else {
+                    throw new Exception("IV required for " + mSourcePayloadWrapAlgName + " but not found in metaInfo");
+                }
+            }
+
+            if (mVerboseFlag) {
+                logger.info("Unwrapping private key using " + sourcePayloadWrapAlg +
+                           " (IV: " + (sourcePayloadWrapIV != null ? "present" : "null") + ")");
+            }
+
+            // Unwrap private key - stays in processing token!
+            privateKey = CryptoUtil.unwrap(
+                processingToken,
+                publicKey,
+                true,  // temporary
+                targetSessionKey,
+                wrappedPrivateKey,
+                sourcePayloadWrapAlg,
+                sourcePayloadWrapIV
+            );
+
+            if (mVerboseFlag) {
+                logger.info("Private key unwrapped in processing token");
+            }
+        } catch (Exception e) {
+            logger.error("Failed to unwrap private key: " + e.getMessage());
+            if (!mUseNssForPayloadProcessing) {
+                logger.error("");
+                logger.error("HSM may not support the source payload wrap algorithm: " + mSourcePayloadWrapAlgName);
+                logger.error("Suggestion: Try running with -use_nss_for_payload_processing flag");
+                logger.error("           to perform payload operations in NSS DB (software token)");
+            }
+            throw new Exception("Failed to unwrap private key in processing token", e);
+        }
+
+        // cross-scheme: Step 6 - Generate New Session Key (if needed)
+        SymmetricKey newSessionKey;
+
+        try {
+            if (needNewSessionKey()) {
+                // Generate new session key in processing token
+                KeyGenerator kg = processingToken.getKeyGenerator(KeyGenAlgorithm.AES);
+
+                int targetKeySize = getKeySizeFromAlgorithm(mTargetPayloadWrapAlgName);
+                if (targetKeySize == 0) {
+                    targetKeySize = 128;  // Default
+                }
+
+                kg.initialize(targetKeySize);
+                kg.setKeyUsages(new SymmetricKey.Usage[] { SymmetricKey.Usage.WRAP, SymmetricKey.Usage.UNWRAP });
+                kg.temporaryKeys(true);
+
+                newSessionKey = (SymmetricKey) kg.generate();
+
+                if (mVerboseFlag) {
+                    logger.info("Generated new " + targetKeySize + "-bit AES session key");
+                }
+            } else {
+                // Reuse existing session key
+                newSessionKey = targetSessionKey;
+                if (mVerboseFlag) {
+                    logger.info("Reusing existing session key");
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Failed to generate/prepare session key: " + e.getMessage());
+            if (!mUseNssForPayloadProcessing) {
+                logger.error("");
+                logger.error("HSM may not support AES session key generation");
+                logger.error("Suggestion: Try running with -use_nss_for_payload_processing flag");
+                logger.error("           to perform payload operations in NSS DB (software token)");
+            }
+            throw new Exception("Failed to prepare session key for target", e);
+        }
+
+        // cross-scheme: Step 7 - Wrap Private Key with Session Key
+        byte[] newWrappedPrivateKey;
+        IVParameterSpec targetPayloadWrapIV = null;
+
+        try {
+            // Get target wrapping parameters
+            KeyWrapAlgorithm targetPayloadWrapAlg = getPayloadWrapAlgorithm(mTargetPayloadWrapAlgName);
+
+            if (needsIV(mTargetPayloadWrapAlgName)) {
+                // Generate new random IV for CBC modes
+                targetPayloadWrapIV = generateIV(targetPayloadWrapAlg);
+                if (mVerboseFlag) {
+                    logger.info("Generated new IV for " + targetPayloadWrapAlg);
+                }
+            } else {
+                if (mVerboseFlag) {
+                    logger.info("No IV needed for " + targetPayloadWrapAlg);
+                }
+            }
+
+            if (mVerboseFlag) {
+                logger.info("Wrapping private key using " + targetPayloadWrapAlg);
+            }
+
+            // Wrap private key
+            newWrappedPrivateKey = CryptoUtil.wrapUsingSymmetricKey(
+                processingToken,
+                newSessionKey,
+                privateKey,
+                targetPayloadWrapIV,
+                targetPayloadWrapAlg
+            );
+
+            if (mVerboseFlag) {
+                logger.info("Private key wrapped with session key (" + newWrappedPrivateKey.length + " bytes)");
+            }
+        } catch (Exception e) {
+            logger.error("Failed to wrap private key: " + e.getMessage());
+            if (!mUseNssForPayloadProcessing) {
+                logger.error("");
+                logger.error("HSM may not support the target payload wrap algorithm: " + mTargetPayloadWrapAlgName);
+                logger.error("Suggestion: Try running with -use_nss_for_payload_processing flag");
+                logger.error("           to perform payload operations in NSS DB (software token)");
+            }
+            throw new Exception("Failed to wrap private key with session key", e);
+        }
+
+        // cross-scheme: Step 8 - Wrap Session Key with Target Storage Cert
+        byte[] newWrappedSessionKey;
+
+        try {
+            // Get target wrapping algorithm
+            KeyWrapAlgorithm targetSessionWrapAlg = getSessionKeyWrapAlgorithm(mTargetRSAWrapAlgName);
+
+            if (mVerboseFlag) {
+                logger.info("Wrapping session key using " + targetSessionWrapAlg);
+            }
+
+            // Wrap session key with target storage cert public key
+            // Use mWrapPublicKey (PK11PubKey format) instead of getPublicKey() (X509Key)
+            newWrappedSessionKey = CryptoUtil.wrapUsingPublicKey(
+                processingToken,
+                mWrapPublicKey,
+                newSessionKey,
+                targetSessionWrapAlg
+            );
+
+            if (mVerboseFlag) {
+                logger.info("Session key wrapped with target storage cert (" + newWrappedSessionKey.length + " bytes)");
+            }
+        } catch (Exception e) {
+            logger.error("Failed to wrap session key: " + e.getMessage());
+            throw new Exception("Failed to wrap session key with target storage cert", e);
+        }
+
+        // cross-scheme: Step 9 - Build Output DER Structure
+        byte[] rewrappedKeyData;
+
+        try {
+            DerOutputStream out = new DerOutputStream();
+
+            // Add wrapped session key
+            out.putOctetString(newWrappedSessionKey);
+
+            // Add wrapped private key
+            out.putOctetString(newWrappedPrivateKey);
+
+            // Wrap in SEQUENCE
+            DerOutputStream seq = new DerOutputStream();
+            seq.write(DerValue.tag_Sequence, out);
+
+            rewrappedKeyData = seq.toByteArray();
+
+            if (mVerboseFlag) {
+                logger.info("Built output DER structure: " + rewrappedKeyData.length + " bytes total");
+            }
+        } catch (IOException e) {
+            logger.error("Failed to build output DER structure: " + e.getMessage());
+            throw new Exception("Failed to build output DER structure", e);
+        }
+
+        return rewrappedKeyData;
+    }
+
+    /**
      * Helper method used to remove all EOLs ('\n' and '\r')
      * from the passed in string.
      * <P>
@@ -1955,7 +3277,7 @@ public class KRATool {
      * @return a string consisting of a string with no EOLs
      */
     private static String stripEOL(String data) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         String revised_data = null;
 
         for (int i = 0; i < data.length(); i++) {
@@ -1982,7 +3304,7 @@ public class KRATool {
      *         suitable for an LDIF file
      */
     private static String format_ldif_data(int length, String data) {
-        StringBuffer revised_data = new StringBuffer();
+        StringBuilder revised_data = new StringBuilder();
 
         if (data.length() > length) {
             // process first line
@@ -2800,7 +4122,7 @@ public class KRATool {
      */
     private static String output_extdata_request_notes(String record_type,
             String line) {
-        StringBuffer input = new StringBuffer();
+        StringBuilder input = new StringBuilder();
 
         String data = null;
         String unformatted_data = null;
@@ -3972,6 +5294,128 @@ public class KRATool {
     }
 
     /**
+     * cross-scheme: Helper method to extract privateKeyData from LDIF field.
+     * <P>
+     *
+     * @param line the string representation of the privateKeyData line
+     * @return the decoded binary privateKeyData
+     */
+    private static byte[] extract_private_key_data(String line) {
+        try {
+            StringBuilder data = new StringBuilder();
+
+            // Extract the data from the first line
+            data.append(line.substring(
+                    KRA_LDIF_PRIVATE_KEY_DATA.length() + 1
+                    ).trim());
+
+            // Read continuation lines
+            while ((line = ldif_record.next()) != null) {
+                if (line.startsWith(SPACE)) {
+                    data.append(line.trim());
+                } else {
+                    break;
+                }
+            }
+
+            // Decode base64 to binary
+            return Utils.base64decode(data.toString());
+        } catch (Exception e) {
+            logger.error("Failed to extract privateKeyData: " + e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * cross-scheme: Helper method to extract publicKeyData from LDIF field.
+     * <P>
+     *
+     * @param line the string representation of the publicKeyData line
+     * @return the decoded binary publicKeyData
+     */
+    private static byte[] extract_public_key_data(String line) {
+        try {
+            StringBuilder data = new StringBuilder();
+
+            // Extract the data from the first line
+            data.append(line.substring(
+                    KRA_LDIF_PUBLIC_KEY_DATA.length() + 1
+                    ).trim());
+
+            // Read continuation lines
+            while ((line = ldif_record.next()) != null) {
+                if (line.startsWith(SPACE)) {
+                    data.append(line.trim());
+                } else {
+                    break;
+                }
+            }
+
+            // Decode base64 to binary
+            return Utils.base64decode(data.toString());
+        } catch (Exception e) {
+            logger.error("Failed to extract publicKeyData: " + e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * cross-scheme: Helper method which composes the output line for rewrapped private key data.
+     * This method is called when both privateKeyData and publicKeyData have been extracted.
+     * <P>
+     *
+     * @param record_type the string representation of the input record type
+     * @param privateKeyData the extracted private key data bytes
+     * @param publicKeyData the extracted public key data bytes
+     * @return the composed output line with rewrapped private key
+     */
+    private static String output_private_public_key_data(String record_type,
+                                                          byte[] privateKeyData,
+                                                          byte[] publicKeyData) {
+        byte[] target_wrappedKeyData = null;
+        String revised_data = null;
+        String unformatted_data = null;
+        String formatted_data = null;
+        String output = null;
+
+        try {
+            // cross-scheme: rewrap the source wrapped private key data
+            target_wrappedKeyData = rewrap_wrapped_key_data(
+                                        privateKeyData,
+                                        publicKeyData,
+                                        null);  // No IV for baseline method
+
+            // Encode the BINARY BASE 64 byte[] object
+            // into an ASCII BASE 64 certificate
+            // enclosed in a String() object
+            revised_data = Utils.base64encode(target_wrappedKeyData, true);
+
+            // Unformat the ASCII BASE 64 certificate for the log file
+            unformatted_data = stripEOL(revised_data);
+
+            // Format the ASCII BASE 64 certificate to match the desired LDIF format
+            formatted_data = format_ldif_data(
+                    PRIVATE_KEY_DATA_FIRST_LINE_DATA_LENGTH,
+                    unformatted_data);
+
+            // construct a revised 'privateKeyData' line
+            output = KRA_LDIF_PRIVATE_KEY_DATA
+                    + SPACE
+                    + formatted_data
+                    + NEWLINE;
+
+            // log this information
+            logger.info("Rewrapped privateKeyData for " + record_type);
+
+        } catch (Exception e) {
+            logger.error("Failed to rewrap private key data: " + e.getMessage(), e);
+            return null;
+        }
+
+        return output;
+    }
+
+    /**
      * Helper method which composes the output line for
      * KRA_LDIF_PRIVATE_KEY_DATA.
      * <P>
@@ -3984,7 +5428,7 @@ public class KRATool {
                                                    String line) {
         byte source_wrappedKeyData[] = null;
         byte target_wrappedKeyData[] = null;
-        StringBuffer data = new StringBuffer();
+        StringBuilder data = new StringBuilder();
         String revised_data = null;
         String unformatted_data = null;
         String formatted_data = null;
@@ -4020,8 +5464,11 @@ public class KRATool {
                                 Utils.base64decode(data.toString());
 
                         // rewrap the source wrapped private key data
+                        // pass null values to satisfy change to rewrap_wrapped_key_data() for cross-scheme
                         target_wrappedKeyData = rewrap_wrapped_key_data(
-                                                    source_wrappedKeyData);
+                                                    source_wrappedKeyData,
+                                                    null,
+                                                    null);
 
                         // Encode the BINARY BASE 64 byte[] object
                         // into an ASCII BASE 64 certificate
@@ -4083,8 +5530,11 @@ public class KRATool {
                                 Utils.base64decode(data.toString());
 
                         // rewrap the source wrapped private key data
+                        // pass null values to satisfy change to rewrap_wrapped_key_data() for cross-scheme
                         target_wrappedKeyData = rewrap_wrapped_key_data(
-                                                    source_wrappedKeyData);
+                                                    source_wrappedKeyData,
+                                                    null,
+                                                    null);
 
                         // Encode the BINARY BASE 64 byte[] object
                         // into an ASCII BASE 64 certificate
@@ -4445,6 +5895,12 @@ public class KRATool {
 
                 ldif_record = record.iterator();
 
+                // cross-scheme: track privateKeyData and publicKeyData for rewrap
+                // Both must be present before calling output_private_public_key_data()
+                byte[] record_privateKeyData = null;
+                byte[] record_publicKeyData = null;
+                String pending_output = null;  // Store output when waiting for both keys
+
                 // Process each line of the record:
                 //   * If LDIF Record Type for this line is 'valid'
                 //     * If KRATOOL Configuration File Parameter is 'true'
@@ -4514,10 +5970,67 @@ public class KRATool {
                             return FAILURE;
                         }
                     } else if (line.startsWith(KRA_LDIF_PRIVATE_KEY_DATA)) {
-                        output = output_private_key_data(record_type,
-                                                          line);
-                        if (output == null) {
-                            return FAILURE;
+                        // cross-scheme: Extract and store privateKeyData
+                        if (mRewrapFlag && (record_type.equals(KRA_LDIF_CA_KEY_RECORD) ||
+                                             record_type.equals(KRA_LDIF_TPS_KEY_RECORD))) {
+                            record_privateKeyData = extract_private_key_data(line);
+                            if (record_privateKeyData == null) {
+                                logger.error("Failed to extract privateKeyData");
+                                return FAILURE;
+                            }
+                            logger.info("Extracted privateKeyData (" + record_privateKeyData.length + " bytes)");
+
+                            // Check if we have both keys now
+                            if (record_publicKeyData != null) {
+                                output = output_private_public_key_data(record_type,
+                                                                          record_privateKeyData,
+                                                                          record_publicKeyData);
+                                if (output == null) {
+                                    return FAILURE;
+                                }
+                                // Clear both after processing
+                                record_privateKeyData = null;
+                                record_publicKeyData = null;
+                            } else {
+                                // Wait for publicKeyData, pass through unchanged for now
+                                output = line;
+                            }
+                        } else {
+                            // No rewrap needed, use original method
+                            output = output_private_key_data(record_type, line);
+                            if (output == null) {
+                                return FAILURE;
+                            }
+                        }
+                    } else if (line.startsWith(KRA_LDIF_PUBLIC_KEY_DATA)) {
+                        // cross-scheme: Extract and store publicKeyData
+                        if (mRewrapFlag && (record_type.equals(KRA_LDIF_CA_KEY_RECORD) ||
+                                             record_type.equals(KRA_LDIF_TPS_KEY_RECORD))) {
+                            record_publicKeyData = extract_public_key_data(line);
+                            if (record_publicKeyData == null) {
+                                logger.error("Failed to extract publicKeyData");
+                                return FAILURE;
+                            }
+                            logger.info("Extracted publicKeyData (" + record_publicKeyData.length + " bytes)");
+
+                            // Check if we have both keys now
+                            if (record_privateKeyData != null) {
+                                output = output_private_public_key_data(record_type,
+                                                                          record_privateKeyData,
+                                                                          record_publicKeyData);
+                                if (output == null) {
+                                    return FAILURE;
+                                }
+                                // Clear both after processing
+                                record_privateKeyData = null;
+                                record_publicKeyData = null;
+                            } else {
+                                // Wait for privateKeyData, pass through unchanged for now
+                                output = line;
+                            }
+                        } else {
+                            // No rewrap needed, pass through
+                            output = line;
                         }
                     } else if (line.startsWith(KRA_LDIF_REQUEST_ID)) {
                         output = output_request_id(record_type, line);
@@ -4586,6 +6099,835 @@ public class KRATool {
 
         return SUCCESS;
     }
+
+    /**
+     * cross-scheme: Get the output filename for current file number (for split mode).
+     */
+    private static String getOutputFilename() {
+        if (mSplitTargetLdifPerRecords > 0) {
+            // Split mode: insert file number before extension
+            String baseName = mTargetLdifFilename;
+            int dotIndex = baseName.lastIndexOf('.');
+            if (dotIndex > 0) {
+                return baseName.substring(0, dotIndex) + "-" + mCurrentFileNumber + baseName.substring(dotIndex);
+            } else {
+                return baseName + "-" + mCurrentFileNumber;
+            }
+        } else {
+            // Normal mode: use target filename as-is
+            return mTargetLdifFilename;
+        }
+    }
+
+    /**
+     * cross-scheme: Roll over to a new output file (split mode).
+     * Closes current writer and opens a new one with incremented file number.
+     * NOTE: Caller should only call this when mRecordsInCurrentFile reaches the limit.
+     */
+    private static BufferedWriter rolloverToNextFile(BufferedWriter currentWriter) throws IOException {
+        // Close current file
+        currentWriter.close();
+        logger.info("Completed output file: " + getOutputFilename() + " (" + mRecordsInCurrentFile + " records)");
+
+        // Move to next file
+        mCurrentFileNumber++;
+        mRecordsInCurrentFile = 0;
+
+        // Open new file
+        BufferedWriter newWriter = new BufferedWriter(new FileWriter(getOutputFilename()));
+        logger.info("Created new output file: " + getOutputFilename());
+
+        // Write LDIF version header to new file (unless processing partial LDIF for concatenation)
+        if (!mProcessRequestsAndKeyRecordsOnlyFlag) {
+            newWriter.write("version: 1" + NEWLINE);
+            newWriter.write(NEWLINE);
+        }
+
+        return newWriter;
+    }
+
+    /**
+     * cross-scheme: Entry-based LDIF processing for cross-scheme algorithm migration.
+     * This method processes complete LDIF entries at once, allowing for interdependent
+     * field transformations when migrating between different wrapping algorithms.
+     * <P>
+     *
+     * @return true if the "target" LDIF file is successfully created
+     */
+    private static boolean use_cross_scheme_convert_source_ldif_to_target_ldif() {
+        boolean success = false;
+        BufferedReader reader = null;
+        BufferedWriter writer = null;
+
+        // Initialize crypto components for rewrapping
+        if (mRewrapFlag) {
+            success = obtain_RSA_rewrapping_keys();
+            if (!success) {
+                return FAILURE;
+            }
+        }
+
+        // Process LDIF file entry by entry
+        try {
+            reader = new BufferedReader(new FileReader(mSourceLdifFilename));
+            writer = new BufferedWriter(new FileWriter(getOutputFilename()));
+
+            if (mSplitTargetLdifPerRecords > 0) {
+                logger.info("Split mode enabled: creating new file every " + mSplitTargetLdifPerRecords + " records");
+            }
+
+            String line;
+            List<String> entryLines = new ArrayList<>();
+            boolean headerWritten = false;
+
+            System.out.print("PROCESSING: ");
+
+            while ((line = reader.readLine()) != null) {
+                // Handle LDIF version header (first non-blank line)
+                // Skip version header when -process_requests_and_key_records_only is used
+                // because output will be concatenated with target KRA's db2ldif
+                if (!headerWritten && line.startsWith("version:")) {
+                    if (!mProcessRequestsAndKeyRecordsOnlyFlag) {
+                        writer.write(line + NEWLINE);
+                        writer.write(NEWLINE);  // Blank line after version header
+                    }
+                    headerWritten = true;
+                    continue;
+                }
+
+                if (line.isEmpty()) {
+                    // Blank line signals end of entry
+                    if (!entryLines.isEmpty()) {
+                        // Track whether entry was written (vs filtered out)
+                        int entriesBeforeProcessing = mProcessedEntries;
+                        success = processEntry(entryLines, writer);
+                        if (!success) {
+                            return FAILURE;
+                        }
+                        entryLines.clear();
+                        // Write blank line only if an entry was actually written (not filtered)
+                        if (mProcessedEntries > entriesBeforeProcessing) {
+                            writer.write(NEWLINE);
+
+                            // Split mode: Track records in current file and rollover when limit reached.
+                            // PERFORMANCE NOTE: We only check for rollover when split mode is enabled
+                            // and only when we've actually written a record. This avoids function call
+                            // overhead for the common case (split mode disabled) and for filtered records.
+                            // Using equality check (==) instead of range check (>=) is slightly faster
+                            // and sufficient since we increment by 1 each time.
+                            if (mSplitTargetLdifPerRecords > 0) {
+                                mRecordsInCurrentFile++;
+                                if (mRecordsInCurrentFile == mSplitTargetLdifPerRecords) {
+                                    writer = rolloverToNextFile(writer);
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // Accumulate lines for this entry
+                    entryLines.add(line);
+                }
+            }
+
+            // Process last entry if file doesn't end with blank line
+            if (!entryLines.isEmpty()) {
+                success = processEntry(entryLines, writer);
+                if (!success) {
+                    return FAILURE;
+                }
+            }
+
+            System.out.println(" FINISHED." + NEWLINE);
+
+        } catch (IOException e) {
+            logger.error("ERROR: IOException processing LDIF file: " + e.getMessage());
+            return FAILURE;
+        } catch (Exception e) {
+            logger.error("ERROR: Exception processing LDIF file: " + e.getMessage(), e);
+            e.printStackTrace();
+            return FAILURE;
+        } finally {
+            // Close resources
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        return SUCCESS;
+    }
+
+    // ========== processEntry ==========
+    /**
+     * cross-scheme: Process a single LDIF entry (key record).
+     * Parses the entry into attributes, applies transformations, and writes to target.
+     */
+    private static boolean processEntry(List<String> entryLines, BufferedWriter writer)
+            throws IOException, Exception {
+
+        // Parse entry into attribute map (preserves order via LinkedHashMap)
+        Map<String, List<String>> attributes = new LinkedHashMap<>();
+        List<String> entryComments = new ArrayList<>();  // Collect all comment lines before first attribute
+        boolean inCommentBlock = true;  // Track if we're still in the leading comment block
+        String currentAttr = null;
+        StringBuilder currentValue = new StringBuilder();
+
+        for (String line : entryLines) {
+            // Collect comment lines that appear before any attributes (leading comment block)
+            if (line.startsWith("#")) {
+                if (inCommentBlock) {
+                    entryComments.add(line);
+                }
+                // Skip comments in the middle of the record
+                continue;
+            }
+
+            // Once we see a non-comment line, we're past the leading comment block
+            inCommentBlock = false;
+
+            // Check if this is a continuation line (starts with space)
+            if (line.startsWith(" ")) {
+                if (currentAttr != null) {
+                    currentValue.append(line.substring(1)); // Remove leading space
+                }
+                continue;
+            }
+
+            // Save previous attribute if any
+            if (currentAttr != null) {
+                attributes.computeIfAbsent(currentAttr, k -> new ArrayList<>())
+                          .add(currentValue.toString());
+            }
+
+            // Parse new attribute (including dn/rdn)
+            int colonIndex = line.indexOf(':');
+            if (colonIndex > 0) {
+                currentAttr = line.substring(0, colonIndex);
+                String valueStart = line.substring(colonIndex + 1);
+                // Handle "::" for base64 encoded values
+                if (valueStart.startsWith(":")) {
+                    currentValue = new StringBuilder(valueStart.substring(1).trim());
+                } else {
+                    currentValue = new StringBuilder(valueStart.trim());
+                }
+            }
+        }
+
+        // Save last attribute
+        if (currentAttr != null) {
+            attributes.computeIfAbsent(currentAttr, k -> new ArrayList<>())
+                      .add(currentValue.toString());
+        }
+
+        // Determine record type
+        String recordType = determineRecordType(attributes);
+        if (recordType == null) {
+            logger.error("ERROR: Unable to determine record type for entry");
+            return FAILURE;
+        }
+
+        // Check if this record should be filtered out (process_requests_and_key_records_only)
+        if (mProcessRequestsAndKeyRecordsOnlyFlag) {
+            // Only include enrollment, recovery, keygen, keyrecovery requests, and key records
+            boolean isRequest = recordType.equals(KRA_LDIF_ENROLLMENT) ||
+                                recordType.equals(KRA_LDIF_RECOVERY) ||
+                                recordType.equals(KRA_LDIF_KEYGEN) ||
+                                recordType.equals(KRA_LDIF_KEYRECOVERY);
+            boolean isKeyRecord = recordType.equals(KRA_LDIF_CA_KEY_RECORD) ||
+                                  recordType.equals(KRA_LDIF_TPS_KEY_RECORD);
+
+            if (!isRequest && !isKeyRecord) {
+                // Mark each filtered record with an 'x'
+                System.out.print("x");
+                return SUCCESS;  // Skip this record
+            }
+        }
+
+        // Apply transformations based on record type
+        // In cross-scheme mode, always process key records (rewrapping is the purpose)
+        if (recordType.equals(KRA_LDIF_CA_KEY_RECORD) ||
+            recordType.equals(KRA_LDIF_TPS_KEY_RECORD)) {
+            return processKeyRecord(attributes, recordType, entryComments, writer);
+        } else {
+            // For request records, update dateOfModify to match legacy behavior
+            boolean isRequestRecord = recordType.equals(KRA_LDIF_ENROLLMENT) ||
+                                      recordType.equals(KRA_LDIF_RECOVERY) ||
+                                      recordType.equals(KRA_LDIF_KEYGEN) ||
+                                      recordType.equals(KRA_LDIF_KEYRECOVERY);
+            if (isRequestRecord) {
+                String currentDate = new java.text.SimpleDateFormat("yyyyMMddHHmmss'Z'").format(new java.util.Date());
+                attributes.put("dateOfModify", Collections.singletonList(currentDate));
+            }
+
+            // Pass through unchanged for non-key records (after applying naming context and ID offset)
+            return writeEntryUnchanged(attributes, entryComments, writer);
+        }
+    }
+
+
+    // ========== determineRecordType ==========
+    /**
+     * cross-scheme: Determine the record type from attributes.
+     */
+    private static String determineRecordType(Map<String, List<String>> attributes) {
+        // Check requestType field (for enrollment/recovery/keygen requests)
+        List<String> requestType = attributes.get("requestType");
+        if (requestType != null && !requestType.isEmpty()) {
+            return requestType.get(0).trim();
+        }
+
+        // Check archivedBy field for key records
+        List<String> archivedBy = attributes.get("archivedBy");
+        if (archivedBy != null && !archivedBy.isEmpty()) {
+            String data = archivedBy.get(0).trim();
+            if (data.startsWith(KRA_LDIF_TPS_KEY_RECORD)) {
+                return KRA_LDIF_TPS_KEY_RECORD;
+            } else if (data.startsWith(KRA_LDIF_CA_KEY_RECORD)) {
+                return KRA_LDIF_CA_KEY_RECORD;
+            }
+        }
+
+        // Default: generic LDIF record (organizational entries, users, groups, etc.)
+        return KRA_LDIF_RECORD;
+    }
+
+
+    // ========== applyLdifTransformations ==========
+    /**
+     * cross-scheme: Apply ID offset and naming context transformations to attribute value.
+     * Handles:
+     * - ID offset (append/remove) for cn, dn, rdn, and request record reference fields
+     * - KRA naming context replacement
+     */
+    private static String applyLdifTransformations(String attr, String value) {
+        String result = value;
+
+        // Apply ID offset to cn attribute (if -append_id_offset or -remove_id_offset specified)
+        if ((mAppendIdOffsetFlag || mRemoveIdOffsetFlag) && attr.equals("cn")) {
+            // Skip non-numeric cn values
+            if (value.matches("[0-9]++")) {
+                try {
+                    BigInteger cnValue = new BigInteger(value);
+                    if (mAppendIdOffsetFlag) {
+                        if (mAppendIdOffset.compareTo(cnValue) == 1) {
+                            // Add the offset
+                            result = cnValue.add(mAppendIdOffset).toString();
+                            if (mVerboseFlag) {
+                                logger.info("Applied append ID offset to cn: " + value + " -> " + result);
+                            }
+                        } else {
+                            logger.error("ERROR: cn value '" + value + "' is greater than append_id_offset '"
+                                + mAppendIdOffset.toString() + "'!");
+                            System.exit(0);
+                        }
+                    } else if (mRemoveIdOffsetFlag) {
+                        if (mRemoveIdOffset.compareTo(cnValue) <= 0) {
+                            // Subtract the offset
+                            result = cnValue.subtract(mRemoveIdOffset).toString();
+                            if (mVerboseFlag) {
+                                logger.info("Applied remove ID offset to cn: " + value + " -> " + result);
+                            }
+                        } else {
+                            logger.error("ERROR: cn value '" + value + "' is less than remove_id_offset '"
+                                + mRemoveIdOffset.toString() + "'!");
+                            System.exit(0);
+                        }
+                    }
+                } catch (NumberFormatException e) {
+                    if (mVerboseFlag) {
+                        logger.info("Skipped non-numeric cn value: " + value);
+                    }
+                }
+            }
+        }
+
+        // Apply ID offset to embedded cn in dn/rdn (if -append_id_offset or -remove_id_offset specified)
+        if ((mAppendIdOffsetFlag || mRemoveIdOffsetFlag) && (attr.equals("dn") || attr.equals("rdn"))) {
+            // Look for cn=<number> pattern in dn
+            if (result.contains("cn=")) {
+                String[] parts = result.split(",");
+                StringBuilder newDn = new StringBuilder();
+                for (int i = 0; i < parts.length; i++) {
+                    String part = parts[i].trim();
+                    if (part.startsWith("cn=")) {
+                        String cnValue = part.substring(3);
+                        if (cnValue.matches("[0-9]++")) {
+                            try {
+                                BigInteger cn = new BigInteger(cnValue);
+                                if (mAppendIdOffsetFlag) {
+                                    if (mAppendIdOffset.compareTo(cn) == 1) {
+                                        String newCn = cn.add(mAppendIdOffset).toString();
+                                        newDn.append("cn=").append(newCn);
+                                        if (mVerboseFlag) {
+                                            logger.info("Applied append ID offset to " + attr + " cn: " + cnValue + " -> " + newCn);
+                                        }
+                                    } else {
+                                        logger.error("ERROR: " + attr + " cn value '" + cnValue + "' is greater than append_id_offset '"
+                                            + mAppendIdOffset.toString() + "'!");
+                                        System.exit(0);
+                                    }
+                                } else if (mRemoveIdOffsetFlag) {
+                                    if (mRemoveIdOffset.compareTo(cn) <= 0) {
+                                        String newCn = cn.subtract(mRemoveIdOffset).toString();
+                                        newDn.append("cn=").append(newCn);
+                                        if (mVerboseFlag) {
+                                            logger.info("Applied remove ID offset to " + attr + " cn: " + cnValue + " -> " + newCn);
+                                        }
+                                    } else {
+                                        logger.error("ERROR: " + attr + " cn value '" + cnValue + "' is less than remove_id_offset '"
+                                            + mRemoveIdOffset.toString() + "'!");
+                                        System.exit(0);
+                                    }
+                                }
+                            } catch (NumberFormatException e) {
+                                newDn.append(part);
+                            }
+                        } else {
+                            newDn.append(part);
+                        }
+                    } else {
+                        newDn.append(part);
+                    }
+                    if (i < parts.length - 1) {
+                        newDn.append(", ");
+                    }
+                }
+                result = newDn.toString();
+            }
+        }
+
+        // Apply ID offset to serialno and requestId (indexed format: LLVALUE where LL=digit count, VALUE=decimal)
+        // Reuses legacy BigIntegerFromDB/BigIntegerToDB functions for correct encoding
+        if ((mAppendIdOffsetFlag || mRemoveIdOffsetFlag) &&
+            (attr.equals("serialno") || attr.equals("requestId"))) {
+            if (result.matches("[0-9]++")) {
+                try {
+                    // Decode indexed value
+                    BigInteger idValue = BigIntegerFromDB(result);
+
+                    // Apply offset
+                    BigInteger newIdValue;
+                    if (mAppendIdOffsetFlag) {
+                        if (mAppendIdOffset.compareTo(idValue) == 1) {
+                            newIdValue = idValue.add(mAppendIdOffset);
+                        } else {
+                            logger.error("ERROR: " + attr + " value " + idValue + " >= append_id_offset " + mAppendIdOffset);
+                            System.exit(0);
+                            return result; // unreachable
+                        }
+                    } else { // mRemoveIdOffsetFlag
+                        if (mRemoveIdOffset.compareTo(idValue) <= 0) {
+                            newIdValue = idValue.subtract(mRemoveIdOffset);
+                        } else {
+                            logger.error("ERROR: " + attr + " value " + idValue + " < remove_id_offset " + mRemoveIdOffset);
+                            System.exit(0);
+                            return result; // unreachable
+                        }
+                    }
+
+                    // Re-encode to indexed format
+                    result = BigIntegerToDB(newIdValue);
+                    if (mVerboseFlag) {
+                    logger.info("Applied ID offset to " + attr + ": " + value + " -> " + result);
+                    }
+
+                } catch (Exception e) {
+                    if (mVerboseFlag) {
+                    logger.info("Skipped non-numeric " + attr + ": " + result);
+                    }
+                }
+            }
+        }
+
+        // Apply ID offset to extdata reference fields (plain decimal format, not indexed)
+        if ((mAppendIdOffsetFlag || mRemoveIdOffsetFlag) &&
+            (attr.equals("extdata-keyrecord") || attr.equals("extdata-requestid") ||
+             attr.equals("extdata-serialnumber"))) {
+            if (result.matches("[0-9]++")) {
+                try {
+                    BigInteger idValue = new BigInteger(result);
+
+                    // Apply offset
+                    if (mAppendIdOffsetFlag) {
+                        if (mAppendIdOffset.compareTo(idValue) == 1) {
+                            result = idValue.add(mAppendIdOffset).toString();
+                            if (mVerboseFlag) {
+                            logger.info("Applied ID offset to " + attr + ": " + value + " -> " + result);
+                            }
+                        } else {
+                            logger.error("ERROR: " + attr + " value " + idValue + " >= append_id_offset " + mAppendIdOffset);
+                            System.exit(0);
+                        }
+                    } else { // mRemoveIdOffsetFlag
+                        if (mRemoveIdOffset.compareTo(idValue) <= 0) {
+                            result = idValue.subtract(mRemoveIdOffset).toString();
+                            if (mVerboseFlag) {
+                            logger.info("Applied ID offset to " + attr + ": " + value + " -> " + result);
+                            }
+                        } else {
+                            logger.error("ERROR: " + attr + " value " + idValue + " < remove_id_offset " + mRemoveIdOffset);
+                            System.exit(0);
+                        }
+                    }
+                } catch (NumberFormatException e) {
+                    if (mVerboseFlag) {
+                    logger.info("Skipped non-numeric " + attr + ": " + result);
+                    }
+                }
+            }
+        }
+
+        // Apply naming context replacement (if -target_kra_naming_context specified)
+        if (mKraNamingContextsFlag) {
+            result = result.replace(mSourceKraNamingContext, mTargetKraNamingContext);
+        }
+
+        return result;
+    }
+
+    // ========== writeWrappedLdifAttribute ==========
+    /**
+     * cross-scheme: Write LDIF attribute with proper line wrapping.
+     * Uses the same line wrapping logic as legacy format_ldif_data():
+     * - First line: attribute name + separator + data (limited to keep total line ~77 chars)
+     * - Continuation lines: 76 chars of data with leading space
+     */
+    private static void writeWrappedLdifAttribute(String attr, String value, boolean isBase64, BufferedWriter writer) throws IOException {
+        String separator = isBase64 ? ":: " : ": ";
+        int prefixLength = attr.length() + separator.length();
+
+        // For first line, use a data length that keeps total line around 77 chars
+        int firstLineDataLength = 77 - prefixLength;
+
+        // If value fits on first line, write it as-is
+        if (value.length() <= firstLineDataLength) {
+            writer.write(attr + separator + value + NEWLINE);
+            return;
+        }
+
+        // Write first line with limited data
+        writer.write(attr + separator + value.substring(0, firstLineDataLength) + NEWLINE);
+
+        // Write continuation lines (76 chars of data each, with leading space)
+        int pos = firstLineDataLength;
+        while (pos < value.length()) {
+            int endPos = Math.min(pos + 76, value.length());
+            writer.write(" " + value.substring(pos, endPos) + NEWLINE);
+            pos = endPos;
+        }
+    }
+
+    // ========== writeEntryUnchanged ==========
+    /**
+     * cross-scheme: Write entry unchanged to target LDIF.
+     */
+    private static boolean writeEntryUnchanged(Map<String, List<String>> attributes,
+                                                List<String> entryComments, BufferedWriter writer) throws IOException {
+        // Write all leading comment lines
+        for (String comment : entryComments) {
+            writer.write(comment + NEWLINE);
+        }
+
+        // Write all attributes in order (including dn/rdn which will be first)
+        for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
+            String attr = entry.getKey();
+            for (String value : entry.getValue()) {
+                // Apply LDIF transformations (ID offset, naming context)
+                String transformedValue = applyLdifTransformations(attr, value);
+
+                // Determine if this was base64 encoded (has "::" marker)
+                boolean isBase64 = attr.equals("privateKeyData") || attr.equals("publicKeyData");
+
+                // Write with proper LDIF line wrapping
+                writeWrappedLdifAttribute(attr, transformedValue, isBase64, writer);
+            }
+        }
+
+        mProcessedEntries++;  // Track that we wrote an entry
+        System.out.print(".");
+        return SUCCESS;
+    }
+
+
+    // ========== extractBase64Attribute ==========
+    /**
+     * cross-scheme: Extract base64-encoded attribute value.
+     */
+    private static byte[] extractBase64Attribute(Map<String, List<String>> attributes, String attrName) {
+        List<String> values = attributes.get(attrName);
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        try {
+            return Utils.base64decode(values.get(0));
+        } catch (Exception e) {
+            logger.error("ERROR: Failed to decode " + attrName + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+
+    // ========== processKeyRecord ==========
+    /**
+     * cross-scheme: Process and transform a key record with algorithm migration.
+     */
+    private static boolean processKeyRecord(Map<String, List<String>> attributes,
+                                             String recordType, List<String> entryComments, BufferedWriter writer)
+            throws IOException, Exception {
+
+        System.out.print(".");
+
+        // Log record separator for debugging (counter will be incremented after successful processing)
+        if (mVerboseFlag) {
+            logger.info("==== Processing keyRecord: " + (mProcessedKeyRecords + 1) + " ====");
+        }
+
+        // TEST MODE: If -skip_rewrap is set, just copy key data as-is and skip crypto operations
+        if (mSkipRewrap) {
+            logger.info("SKIP_REWRAP: Copying key data as-is (no cryptographic operations)");
+            mProcessedKeyRecords++;
+
+            // Update dateOfModify to current time
+            String currentDate = new java.text.SimpleDateFormat("yyyyMMddHHmmss'Z'").format(new java.util.Date());
+            attributes.put("dateOfModify", Collections.singletonList(currentDate));
+
+            return writeEntryUnchanged(attributes, entryComments, writer);
+        }
+
+        // Extract required data for rewrapping
+        byte[] privateKeyData = extractBase64Attribute(attributes, "privateKeyData");
+        byte[] publicKeyData = extractBase64Attribute(attributes, "publicKeyData");
+        byte[] ivData = extractIVFromMetaInfo(attributes);
+
+        if (privateKeyData == null || publicKeyData == null) {
+            logger.error("ERROR: Missing privateKeyData or publicKeyData in key record");
+            mFailedKeyRecords++;
+            return FAILURE;
+        }
+
+        if (mVerboseFlag) {
+            logger.info("Extracted privateKeyData (" + privateKeyData.length + " bytes)");
+            logger.info("Extracted publicKeyData (" + publicKeyData.length + " bytes)");
+        }
+
+        // Check if IV is required and present
+        boolean ivRequired = needsIV(mSourcePayloadWrapAlgName);
+        if (ivRequired) {
+            if (ivData == null) {
+                logger.error("ERROR: IV required for " + mSourcePayloadWrapAlgName +
+                    " but not found in metaInfo");
+                mFailedKeyRecords++;
+                return FAILURE;
+            }
+            if (mVerboseFlag) {
+                logger.info("Extracted payload wrap IV (" + ivData.length + " bytes)");
+            }
+        }
+
+        // Perform rewrap operation
+        byte[] rewrappedData = rewrap_wrapped_key_data(privateKeyData, publicKeyData, ivData);
+        if (rewrappedData == null) {
+            logger.error("ERROR: Failed to rewrap key record");
+            mFailedKeyRecords++;
+            return FAILURE;
+        }
+
+        if (mVerboseFlag) {
+            logger.info("Rewrapped privateKeyData for " + recordType);
+        }
+        mProcessedKeyRecords++;
+
+        // Progress logging every 1000 records (only when not in verbose mode)
+        if (!mVerboseFlag && mProcessedKeyRecords % 1000 == 0) {
+            logger.info("Progress: " + mProcessedKeyRecords + " key records processed"
+                       + (mFailedKeyRecords > 0 ? " (" + mFailedKeyRecords + " failed)" : ""));
+        }
+
+        // Update attributes with rewrapped data
+        String rewrappedBase64 = Utils.base64encode(rewrappedData, true);
+        attributes.put("privateKeyData", Collections.singletonList(stripEOL(rewrappedBase64)));
+
+        // Update metaInfo fields for new algorithms
+        updateMetaInfoForNewAlgorithms(attributes);
+
+        // Update dateOfModify timestamp
+        String currentDate = new java.text.SimpleDateFormat("yyyyMMddHHmmss'Z'").format(new java.util.Date());
+        attributes.put("dateOfModify", Collections.singletonList(currentDate));
+
+        // Write transformed entry
+        return writeEntryUnchanged(attributes, entryComments, writer);
+    }
+
+
+    // ========== extractIVFromMetaInfo ==========
+    /**
+     * cross-scheme: Extract IV from metaInfo attributes.
+     * Checks both payloadWrapIV and payloadEncryptionIV for compatibility.
+     * TODO: idm-5181
+     */
+    private static byte[] extractIVFromMetaInfo(Map<String, List<String>> attributes) {
+        List<String> metaInfos = attributes.get("metaInfo");
+        if (metaInfos == null) {
+            return null;
+        }
+
+        for (String metaInfo : metaInfos) {
+            // Check for payloadWrapIV first (test server format)
+            if (metaInfo.contains("payloadWrapIV:")) {
+                try {
+                    int ivStart = metaInfo.indexOf("payloadWrapIV:") + "payloadWrapIV:".length();
+                    String ivBase64 = metaInfo.substring(ivStart).trim();
+                    return Utils.base64decode(ivBase64);
+                } catch (Exception e) {
+                    logger.info("WARNING: Failed to parse payloadWrapIV: " + e.getMessage());
+                    return null;
+                }
+            }
+            // Also check for payloadEncryptionIV (found in some LDIF exports)
+            if (metaInfo.contains("payloadEncryptionIV:")) {
+                try {
+                    int ivStart = metaInfo.indexOf("payloadEncryptionIV:") + "payloadEncryptionIV:".length();
+                    String ivBase64 = metaInfo.substring(ivStart).trim();
+                    return Utils.base64decode(ivBase64);
+                } catch (Exception e) {
+                    logger.info("WARNING: Failed to parse payloadEncryptionIV: " + e.getMessage());
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+
+    // ========== updateMetaInfoForNewAlgorithms ==========
+    /**
+     * cross-scheme: Update metaInfo attributes to reflect new wrapping algorithms.
+     */
+    private static void updateMetaInfoForNewAlgorithms(Map<String, List<String>> attributes) throws Exception {
+        List<String> metaInfos = attributes.get("metaInfo");
+        if (metaInfos == null) {
+            metaInfos = new ArrayList<>();
+            attributes.put("metaInfo", metaInfos);
+        }
+
+        // Process each metaInfo entry and update algorithm-related fields
+        List<String> updatedMetaInfos = new ArrayList<>();
+
+        for (String metaInfo : metaInfos) {
+            String updatedInfo = metaInfo;
+
+            // Update sessionKeyWrapAlgorithm if RSA wrap algorithm changed
+            if (metaInfo.startsWith("sessionKeyWrapAlgorithm:")) {
+                if (mTargetRSAWrapAlgName != null) {
+                    String targetAlg = mTargetRSAWrapAlgName.equalsIgnoreCase("RSA-OAEP") ?
+                                       "RSAES-OAEP" : "RSA";
+                    updatedInfo = "sessionKeyWrapAlgorithm:" + targetAlg;
+                    logger.info("Updated sessionKeyWrapAlgorithm: " + targetAlg);
+                }
+            }
+            // Update sessionKeyType if session key was regenerated
+            else if (metaInfo.startsWith("sessionKeyType:")) {
+                // Check if we regenerated the session key
+                if (mSessionKeyDecisionMade != null && mSessionKeyDecisionMade) {
+                    // For now, we always generate AES keys
+                    updatedInfo = "sessionKeyType:AES";
+                }
+            }
+            // Update sessionKeyLength if session key was regenerated
+            else if (metaInfo.startsWith("sessionKeyLength:")) {
+                // Check if we regenerated the session key
+                if (mSessionKeyDecisionMade != null && mSessionKeyDecisionMade) {
+                    int targetKeySize = getKeySizeFromAlgorithm(mTargetPayloadWrapAlgName);
+                    if (targetKeySize == 0) {
+                        targetKeySize = 128;  // Default
+                    }
+                    updatedInfo = "sessionKeyLength:" + targetKeySize;
+                    logger.info("Updated sessionKeyLength: " + targetKeySize);
+                }
+            }
+            // Update payloadWrapAlgorithm if payload algorithm changed
+            else if (metaInfo.startsWith("payloadWrapAlgorithm:")) {
+                if (mTargetPayloadWrapAlgName != null) {
+                    updatedInfo = "payloadWrapAlgorithm:" + mTargetPayloadWrapAlgName;
+                    logger.info("Updated payloadWrapAlgorithm: " + mTargetPayloadWrapAlgName);
+                }
+            }
+            // DO NOT update payloadEncryptionOID - it is not used during unwrapping and causes errors.
+            // The KRA uses payloadWrapAlgorithm for actual unwrapping operations.
+            // The payloadEncryptionOID field is a legacy artifact that, if changed to an OID
+            // not recognized by JSS (e.g., 2.16.840.1.101.3.4.1.45 for AES-256-KeyWrap),
+            // will cause NoSuchAlgorithmException in KeyRecord.getWrappingParams() during recovery.
+            // Keep the original value unchanged.
+            else if (metaInfo.startsWith("payloadEncryptionOID:")) {
+                // Keep original value - do not update
+            }
+            // Remove payloadWrapIV/payloadEncryptionIV if switching from CBC to KeyWrap
+            else if (metaInfo.startsWith("payloadWrapIV:") || metaInfo.startsWith("payloadEncryptionIV:")) {
+                if (mTargetPayloadWrapAlgName != null && !needsIV(mTargetPayloadWrapAlgName)) {
+                    logger.info("Removed " + metaInfo.substring(0, metaInfo.indexOf(':')) +
+                        " (not needed for " + mTargetPayloadWrapAlgName + ")");
+                    continue;  // Skip this metaInfo entry (don't add to updated list)
+                }
+            }
+
+            updatedMetaInfos.add(updatedInfo);
+        }
+
+        // Replace metaInfo list with updated version
+        attributes.put("metaInfo", updatedMetaInfos);
+    }
+
+
+    // ========== getOIDForAlgorithm ==========
+    /**
+     * cross-scheme: Get OID for a given payload wrap algorithm name and key size.
+     *
+     * @param algorithmName The algorithm name (e.g., "AES/CBC/PKCS5Padding", "AES KeyWrap/Padding")
+     * @param keySize The key size in bits (128, 192, or 256)
+     * @return The OID string
+     */
+    private static String getOIDForAlgorithm(String algorithmName, int keySize) {
+        // OID mappings based on observed LDIF data:
+        // 2.16.840.1.101.3.4.1.2 = AES-128-CBC
+        // 2.16.840.1.101.3.4.1.5 = AES-128-KW (KeyWrap)
+        // 2.16.840.1.101.3.4.1.22 = AES-192-CBC
+        // 2.16.840.1.101.3.4.1.25 = AES-192-KW
+        // 2.16.840.1.101.3.4.1.42 = AES-256-CBC
+        // 2.16.840.1.101.3.4.1.45 = AES-256-KW
+
+        boolean isCBC = algorithmName.contains("CBC");
+        boolean isKeyWrap = algorithmName.contains("KeyWrap") || algorithmName.contains("Wrap");
+
+        if (keySize == 128) {
+            return isCBC ? "2.16.840.1.101.3.4.1.2" : "2.16.840.1.101.3.4.1.5";
+        } else if (keySize == 192) {
+            return isCBC ? "2.16.840.1.101.3.4.1.22" : "2.16.840.1.101.3.4.1.25";
+        } else if (keySize == 256) {
+            return isCBC ? "2.16.840.1.101.3.4.1.42" : "2.16.840.1.101.3.4.1.45";
+        }
+
+        // Fallback for unexpected key sizes - default to 128-bit based on algorithm type
+        if (isCBC) {
+            return "2.16.840.1.101.3.4.1.2";  // AES-128-CBC
+        } else if (isKeyWrap) {
+            return "2.16.840.1.101.3.4.1.5";  // AES-128-KW
+        } else {
+            // Unknown algorithm type - default to AES-128-CBC
+            logger.info("WARNING: Unknown algorithm type '" + algorithmName + "' - defaulting to AES-128-CBC");
+            return "2.16.840.1.101.3.4.1.2";
+        }
+    }
+
 
     /**************************************/
     /* KRATOOL Config File Parser Methods */
@@ -4717,7 +7059,7 @@ public class KRATool {
      *
      * @param args KRATool options
      */
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         // Variables
         String append_id_offset = null;
         String remove_id_offset = null;
@@ -4731,38 +7073,25 @@ public class KRATool {
         File sourceDBPwdfile = null;
         File targetStorageCertFile = null;
         File targetFile = null;
+        File logFile = null;
         boolean success = false;
 
         // Get current date and time
         mDateOfModify = now(DATE_OF_MODIFY_PATTERN);
 
-        // Check that the correct number of arguments were
-        // submitted to the program
-        if ((args.length != ID_OFFSET_ARGS) &&
-                (args.length != (ID_OFFSET_ARGS + 1)) &&
-                (args.length != (ID_OFFSET_ARGS + 4)) &&
-                (args.length != (ID_OFFSET_ARGS + 5)) &&
-                (args.length != (ID_OFFSET_ARGS + 7)) &&
-                (args.length != REWRAP_ARGS) &&
-                (args.length != (REWRAP_ARGS + 1)) &&
-                (args.length != (REWRAP_ARGS + 2)) &&
-                (args.length != (REWRAP_ARGS + 3)) &&
-                (args.length != (REWRAP_ARGS + 4)) &&
-                (args.length != (REWRAP_ARGS + 5)) &&
-                (args.length != (REWRAP_ARGS + 6)) &&
-                (args.length != (REWRAP_ARGS + 7)) &&
-                (args.length != (REWRAP_ARGS + 9)) &&
-                (args.length != REWRAP_AND_ID_OFFSET_ARGS) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 1)) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 2)) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 3)) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 4)) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 5)) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 6)) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 7)) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 8)) &&
-                (args.length != (REWRAP_AND_ID_OFFSET_ARGS + 9))) {
-            logger.error("Incorrect number of arguments");
+        // Check for help flag first
+        if (args.length > 0 && (args[0].equals("-h") || args[0].equals("--help"))) {
+            printUsage();
+            System.exit(0);
+        }
+
+        // Check minimum number of arguments
+        // With cross-scheme migration options and boolean flags, we can't use
+        // rigid argument counting. Instead, we'll validate mandatory arguments
+        // after parsing.
+        if (args.length < 2) {
+            System.err.println("ERROR:  Insufficient arguments!"
+                              + NEWLINE);
             printUsage();
             System.exit(0);
         }
@@ -4796,6 +7125,9 @@ public class KRATool {
             } else if (args[i].equals(SOURCE_NSS_DB_PWDFILE)) {
                 mSourcePKISecurityDatabasePwdfile = args[i + 1];
                 mPKISecurityDatabasePwdfileNameValuePairs++;
+            } else if (args[i].equals(SOURCE_HSM_TOKEN_PWDFILE)) {
+                mSourceHsmTokenPwdfile = args[i + 1];
+                mHsmPwdfileFlag = true;
             } else if (args[i].equals(APPEND_ID_OFFSET)) {
                 append_id_offset = args[i + 1];
                 mAppendIdOffsetNameValuePairs++;
@@ -4811,18 +7143,94 @@ public class KRATool {
             } else if (args[i].equals(PROCESS_REQUESTS_AND_KEY_RECORDS_ONLY)) {
                 mProcessRequestsAndKeyRecordsOnlyFlag = true;
                 i -= 1;
+            } else if (args[i].equals(VERBOSE)) {
+                mVerboseFlag = true;
+                i -= 1;
             } else if (args[i].contentEquals(KEY_UNWRAP_ALGORITHM)) {
                 keyUnwrapAlgorithmName = args[i + 1];
             } else if (args[i].contentEquals(USE_OAEP_RSA_KEY_WRAP)) {
                 mUseOAEPKeyWrapAlg = true;
+            } else if (args[i].contentEquals(SOURCE_RSA_WRAP_ALGORITHM)) {
+                // cross-scheme
+                mSourceRSAWrapAlgName = args[i + 1];
+            } else if (args[i].contentEquals(TARGET_RSA_WRAP_ALGORITHM)) {
+                // cross-scheme
+                mTargetRSAWrapAlgName = args[i + 1];
+            } else if (args[i].contentEquals(SOURCE_PAYLOAD_WRAP_ALGORITHM)) {
+                // cross-scheme
+                mSourcePayloadWrapAlgName = args[i + 1];
+            } else if (args[i].contentEquals(TARGET_PAYLOAD_WRAP_ALGORITHM)) {
+                // cross-scheme
+                mTargetPayloadWrapAlgName = args[i + 1];
+            } else if (args[i].contentEquals(SOURCE_PAYLOAD_WRAP_KEYSIZE)) {
+                // cross-scheme
+                try {
+                    mSourcePayloadWrapKeySize = Integer.parseInt(args[i + 1]);
+                    if (mSourcePayloadWrapKeySize != 128 && mSourcePayloadWrapKeySize != 192 && mSourcePayloadWrapKeySize != 256) {
+                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 192, or 256" + NEWLINE);
+                        printUsage();
+                        System.exit(0);
+                    }
+                } catch (NumberFormatException e) {
+                    System.err.println("ERROR:  Invalid source payload wrapping key size: " + args[i + 1] + NEWLINE);
+                    printUsage();
+                    System.exit(0);
+                }
+            } else if (args[i].contentEquals(TARGET_PAYLOAD_WRAP_KEYSIZE)) {
+                // cross-scheme
+                try {
+                    mTargetPayloadWrapKeySize = Integer.parseInt(args[i + 1]);
+                    if (mTargetPayloadWrapKeySize != 128 && mTargetPayloadWrapKeySize != 192 && mTargetPayloadWrapKeySize != 256) {
+                        System.err.println("ERROR:  Target payload wrapping key size must be 128, 192, or 256" + NEWLINE);
+                        printUsage();
+                        System.exit(0);
+                    }
+                } catch (NumberFormatException e) {
+                    System.err.println("ERROR:  Invalid target payload wrapping key size: " + args[i + 1] + NEWLINE);
+                    printUsage();
+                    System.exit(0);
+                }
+            } else if (args[i].contentEquals(USE_NSS_FOR_PAYLOAD_PROCESSING)) {
+                // cross-scheme: boolean flag, compensate for loop's i+=2
+                mUseNssForPayloadProcessing = true;
+                i -= 1;
+            } else if (args[i].contentEquals(REGENERATE_SESSION_KEY)) {
+                // cross-scheme: boolean flag, compensate for loop's i+=2
+                mRegenerateSessionKey = true;
+                i -= 1;
+            } else if (args[i].contentEquals(SKIP_REWRAP)) {
+                // cross-scheme: TEST ONLY: boolean flag, compensate for loop's i+=2
+                mSkipRewrap = true;
+                i -= 1;
+            } else if (args[i].contentEquals(SPLIT_TARGET_LDIF_PER_RECORDS)) {
+                // cross-scheme: split output into multiple files
+                if (i + 1 >= args.length || args[i + 1].startsWith("-")) {
+                    System.err.println("ERROR:  " + SPLIT_TARGET_LDIF_PER_RECORDS + " requires a numeric value" + NEWLINE);
+                    printUsage();
+                    System.exit(0);
+                }
+                try {
+                    mSplitTargetLdifPerRecords = Integer.parseInt(args[i + 1]);
+                    if (mSplitTargetLdifPerRecords <= 0) {
+                        System.err.println("ERROR:  Split records count must be greater than 0" + NEWLINE);
+                        printUsage();
+                        System.exit(0);
+                    }
+                } catch (NumberFormatException e) {
+                    System.err.println("ERROR:  Invalid split records count: " + args[i + 1] + NEWLINE);
+                    printUsage();
+                    System.exit(0);
+                }
+            } else if (args[i].contentEquals(USE_CROSS_SCHEME)) {
+                // cross-scheme: boolean flag, compensate for loop's i+=2
+                mUseCrossSchemeFlag = true;
+                i -= 1;
             } else {
                 logger.error("Unknown argument: " + args[i]);
                 printUsage();
                 System.exit(0);
             }
         }
-
-        configureLogger(mLogFilename);
 
         // Verify that correct number of valid mandatory
         // arguments were submitted to the program
@@ -4835,7 +7243,7 @@ public class KRATool {
                 mTargetLdifFilename.length() == 0 ||
                 mLogFilename == null ||
                 mLogFilename.length() == 0) {
-            logger.error("Missing mandatory arguments");
+            System.err.println("ERROR: Missing mandatory arguments");
             printUsage();
             System.exit(0);
         } else {
@@ -4844,7 +7252,7 @@ public class KRATool {
             if (!cfgFile.exists() ||
                     !cfgFile.isFile() ||
                     (cfgFile.length() == 0)) {
-                logger.error(mKratoolCfgFilename
+                System.err.println("ERROR: " + mKratoolCfgFilename
                                   + " does NOT exist, is NOT a file, "
                                   + "or is empty");
                 printUsage();
@@ -4856,7 +7264,7 @@ public class KRATool {
             if (!sourceFile.exists() ||
                     !sourceFile.isFile() ||
                     (sourceFile.length() == 0)) {
-                logger.error(mSourceLdifFilename
+                System.err.println("ERROR: " + mSourceLdifFilename
                                   + " does NOT exist, is NOT a file, "
                                   + "or is empty");
                 printUsage();
@@ -4866,10 +7274,26 @@ public class KRATool {
             // Check that the target LDIF file does NOT exist
             targetFile = new File(mTargetLdifFilename);
             if (targetFile.exists()) {
-                logger.error(mTargetLdifFilename + " ALREADY exists");
+                System.err.println("ERROR: " + mTargetLdifFilename + " ALREADY exists");
                 printUsage();
                 System.exit(0);
             }
+
+            // Check that the log file does NOT exist
+            logFile = new File(mLogFilename);
+            if (logFile.exists()) {
+                System.err.println("ERROR: " + mLogFilename + " ALREADY exists");
+                printUsage();
+                System.exit(0);
+            }
+        }
+
+        // Configure logger AFTER file validation checks pass
+        try {
+            configureLogger(mLogFilename);
+        } catch (IOException e) {
+            System.err.println("ERROR: Failed to configure logger: " + e.getMessage());
+            System.exit(1);
         }
 
         // Check to see that if the 'Rewrap' command-line options were
@@ -5125,6 +7549,9 @@ public class KRATool {
                 logger.error("Unsupported key unwrap algorithm: " + keyUnwrapAlgorithmName);
                 System.exit(1);
             }
+            keyUnwrapAlgorithmName = SPACE + KEY_UNWRAP_ALGORITHM + SPACE + keyUnwrapAlgorithmName;
+        } else {
+            keyUnwrapAlgorithmName = "";
         }
 
         // Check for OPTIONAL "Process Requests and Key Records ONLY" option
@@ -5136,6 +7563,103 @@ public class KRATool {
         } else {
             process_requests_and_key_records_only = "";
             mProcessRequestsAndKeyRecordsOnlyMessage = "";
+        }
+
+        // Process RSA wrap algorithm flags with backward compatibility
+        // legacy flag: -use_rsa_oaep_keywrap sets BOTH source and target to RSA-OAEP
+        // cross-scheme flags: -source_rsa_wrap_algorithm and -target_rsa_wrap_algorithm allow separate control
+        if (mUseOAEPKeyWrapAlg) {
+            // Legacy flag - apply to both source and target if not explicitly overridden
+            if (mSourceRSAWrapAlgName == null) {
+                mSourceRSAWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
+                logger.info("Using RSA-OAEP for source (from -use_rsa_oaep_keywrap)");
+            }
+            if (mTargetRSAWrapAlgName == null) {
+                mTargetRSAWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
+                logger.info("Using RSA-OAEP for target (from -use_rsa_oaep_keywrap)");
+            }
+        }
+
+        // Process source RSA wrap algorithm
+        if (mSourceRSAWrapAlgName != null) {
+            if (mSourceRSAWrapAlgName.equalsIgnoreCase("RSA")) {
+                mSourceRSAWrapAlg = KeyWrapAlgorithm.RSA;
+            } else if (mSourceRSAWrapAlgName.equalsIgnoreCase("RSA_OAEP") ||
+                       mSourceRSAWrapAlgName.equalsIgnoreCase("RSA-OAEP") ||
+                       mSourceRSAWrapAlgName.equalsIgnoreCase("RSAES-OAEP")) {
+                mSourceRSAWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
+            } else {
+                logger.error("Unsupported source RSA wrap algorithm: " + mSourceRSAWrapAlgName +
+                           " (must be RSA or RSA-OAEP)");
+                System.exit(1);
+            }
+            System.out.println("Source RSA wrap algorithm: " + mSourceRSAWrapAlgName);
+        } else {
+            System.out.println("Source RSA wrap algorithm: RSA (default)");
+        }
+
+        // Process target RSA wrap algorithm
+        if (mTargetRSAWrapAlgName != null) {
+            if (mTargetRSAWrapAlgName.equalsIgnoreCase("RSA")) {
+                mTargetRSAWrapAlg = KeyWrapAlgorithm.RSA;
+            } else if (mTargetRSAWrapAlgName.equalsIgnoreCase("RSA_OAEP") ||
+                       mTargetRSAWrapAlgName.equalsIgnoreCase("RSA-OAEP") ||
+                       mTargetRSAWrapAlgName.equalsIgnoreCase("RSAES-OAEP")) {
+                mTargetRSAWrapAlg = KeyWrapAlgorithm.RSA_OAEP;
+            } else {
+                logger.error("Unsupported target RSA wrap algorithm: " + mTargetRSAWrapAlgName +
+                           " (must be RSA or RSA-OAEP)");
+                System.exit(1);
+            }
+            System.out.println("Target RSA wrap algorithm: " + mTargetRSAWrapAlgName);
+        } else {
+            System.out.println("Target RSA wrap algorithm: RSA-OAEP (default)");
+        }
+
+        // cross-scheme: Log payload wrap algorithms if provided
+        // Note: Validation happens at runtime in getPayloadWrapAlgorithm()
+        if (mSourcePayloadWrapAlgName != null) {
+            System.out.println("Source payload wrap algorithm: " + mSourcePayloadWrapAlgName);
+        }
+        if (mTargetPayloadWrapAlgName != null) {
+            System.out.println("Target payload wrap algorithm: " + mTargetPayloadWrapAlgName);
+        }
+
+        // Build cross-scheme parameters string for logging
+        String use_cross_scheme_params = "";
+        if (mUseCrossSchemeFlag) {
+            use_cross_scheme_params = SPACE + USE_CROSS_SCHEME;
+            if (mSourceRSAWrapAlgName != null) {
+                use_cross_scheme_params += SPACE + SOURCE_RSA_WRAP_ALGORITHM + SPACE + mSourceRSAWrapAlgName;
+            }
+            if (mTargetRSAWrapAlgName != null) {
+                use_cross_scheme_params += SPACE + TARGET_RSA_WRAP_ALGORITHM + SPACE + mTargetRSAWrapAlgName;
+            }
+            if (mSourcePayloadWrapAlgName != null) {
+                use_cross_scheme_params += SPACE + SOURCE_PAYLOAD_WRAP_ALGORITHM + SPACE + TIC + mSourcePayloadWrapAlgName + TIC;
+            }
+            // Always include source payload wrapping key size
+            use_cross_scheme_params += SPACE + SOURCE_PAYLOAD_WRAP_KEYSIZE + SPACE + mSourcePayloadWrapKeySize;
+            if (mTargetPayloadWrapAlgName != null) {
+                use_cross_scheme_params += SPACE + TARGET_PAYLOAD_WRAP_ALGORITHM + SPACE + TIC + mTargetPayloadWrapAlgName + TIC;
+            }
+            // Always include target payload wrapping key size
+            use_cross_scheme_params += SPACE + TARGET_PAYLOAD_WRAP_KEYSIZE + SPACE + mTargetPayloadWrapKeySize;
+            if (mSourceHsmTokenPwdfile != null) {
+                use_cross_scheme_params += SPACE + SOURCE_HSM_TOKEN_PWDFILE + SPACE + mSourceHsmTokenPwdfile;
+            }
+            if (mUseNssForPayloadProcessing) {
+                use_cross_scheme_params += SPACE + USE_NSS_FOR_PAYLOAD_PROCESSING;
+            }
+            if (mRegenerateSessionKey) {
+                use_cross_scheme_params += SPACE + REGENERATE_SESSION_KEY;
+            }
+            if (mSkipRewrap) {
+                use_cross_scheme_params += SPACE + SKIP_REWRAP;
+            }
+            if (mSplitTargetLdifPerRecords > 0) {
+                use_cross_scheme_params += SPACE + SPLIT_TARGET_LDIF_PER_RECORDS + SPACE + mSplitTargetLdifPerRecords;
+            }
         }
 
         // Begin logging progress . . .
@@ -5163,8 +7687,8 @@ public class KRATool {
                     + append_id_offset
                     + process_kra_naming_context_fields
                     + process_requests_and_key_records_only
-                    + SPACE + KEY_UNWRAP_ALGORITHM + SPACE
-                    + keyUnwrapAlgorithmName);
+                    + keyUnwrapAlgorithmName
+                    + use_cross_scheme_params);
         } else if (mRewrapFlag && mRemoveIdOffsetFlag) {
             logger.info("BEGIN "
                     + KRA_TOOL + SPACE
@@ -5189,8 +7713,8 @@ public class KRATool {
                     + remove_id_offset
                     + process_kra_naming_context_fields
                     + process_requests_and_key_records_only
-                    + SPACE + KEY_UNWRAP_ALGORITHM + SPACE
-                    + keyUnwrapAlgorithmName);
+                    + keyUnwrapAlgorithmName
+                    + use_cross_scheme_params);
         } else if (mRewrapFlag) {
             logger.info("BEGIN "
                     + KRA_TOOL + SPACE
@@ -5213,8 +7737,8 @@ public class KRATool {
                     + use_PKI_security_database_pwdfile
                     + process_kra_naming_context_fields
                     + process_requests_and_key_records_only
-                    + SPACE + KEY_UNWRAP_ALGORITHM + SPACE
-                    + keyUnwrapAlgorithmName);
+                    + keyUnwrapAlgorithmName
+                    + use_cross_scheme_params);
         } else if (mAppendIdOffsetFlag) {
             logger.info("BEGIN "
                     + KRA_TOOL + SPACE
@@ -5250,22 +7774,39 @@ public class KRATool {
         // Process the KRATOOL config file
         success = process_kratool_config_file();
         if (!success) {
-            logger.error("Unable to process kratool config file");
+            logger.error("FAILED processing kratool config file!");
         } else {
-            logger.info("Successfully processed kratool config file");
+            logger.info("SUCCESSFULLY processed kratool config file!");
 
             // Convert the source LDIF file to a target LDIF file
-            success = convert_source_ldif_to_target_ldif();
-            if (!success) {
-                logger.error("Unable to convert source LDIF file into target LDIF file");
+            // Use cross-scheme entry-based processing if flag is set
+            if (mUseCrossSchemeFlag) {
+                success = use_cross_scheme_convert_source_ldif_to_target_ldif();
             } else {
-                logger.info("Successfully converted source LDIF file into target LDIF file");
+                success = convert_source_ldif_to_target_ldif();
+            }
+            if (!success) {
+                logger.error("FAILED converting source LDIF file --> target LDIF file!");
+            } else {
+                logger.info("SUCCESSFULLY converted source LDIF file --> target LDIF file!");
+                logger.info("");
+                // cross-scheme: Only print summary when using cross-scheme mode (baseline mode doesn't track counters)
+                if (mUseCrossSchemeFlag) {
+                    logger.info("Summary: " + mProcessedKeyRecords + " key record(s) processed successfully, "
+                            + mFailedKeyRecords + " failed.");
+                    logger.info("");
+                }
+                // Only print target LDIF filename if not in split mode (split mode already reported each file)
+                if (mSplitTargetLdifPerRecords == 0) {
+                    logger.info("Target LDIF file: " + mTargetLdifFilename);
+                }
+                logger.info("Debug log file:   " + mLogFilename);
             }
         }
 
         // Finish logging progress
         if (mRewrapFlag && mAppendIdOffsetFlag) {
-            logger.info("FINISHED "
+            logger.info("FINISHED \""
                     + KRA_TOOL + SPACE
                     + KRATOOL_CFG_FILE + SPACE
                     + mKratoolCfgFilename + SPACE
@@ -5288,10 +7829,11 @@ public class KRATool {
                     + append_id_offset
                     + process_kra_naming_context_fields
                     + process_requests_and_key_records_only
-                    + SPACE + KEY_UNWRAP_ALGORITHM + SPACE
-                    + keyUnwrapAlgorithmName);
+                    + keyUnwrapAlgorithmName
+                    + use_cross_scheme_params
+                    + "\".");
         } else if (mRewrapFlag && mRemoveIdOffsetFlag) {
-            logger.info("FINISHED "
+            logger.info("FINISHED \""
                     + KRA_TOOL + SPACE
                     + KRATOOL_CFG_FILE + SPACE
                     + mKratoolCfgFilename + SPACE
@@ -5314,10 +7856,11 @@ public class KRATool {
                     + remove_id_offset
                     + process_kra_naming_context_fields
                     + process_requests_and_key_records_only
-                    + SPACE + KEY_UNWRAP_ALGORITHM + SPACE
-                    + keyUnwrapAlgorithmName);
+                    + keyUnwrapAlgorithmName
+                    + use_cross_scheme_params
+                    + "\".");
         } else if (mRewrapFlag) {
-            logger.info("FINISHED "
+            logger.info("FINISHED \""
                     + KRA_TOOL + SPACE
                     + KRATOOL_CFG_FILE + SPACE
                     + mKratoolCfgFilename + SPACE
@@ -5338,10 +7881,11 @@ public class KRATool {
                     + use_PKI_security_database_pwdfile
                     + process_kra_naming_context_fields
                     + process_requests_and_key_records_only
-                    + SPACE + KEY_UNWRAP_ALGORITHM + SPACE
-                    + keyUnwrapAlgorithmName);
+                    + keyUnwrapAlgorithmName
+                    + use_cross_scheme_params
+                    + "\".");
         } else if (mAppendIdOffsetFlag) {
-            logger.info("FINISHED "
+            logger.info("FINISHED \""
                     + KRA_TOOL + SPACE
                     + KRATOOL_CFG_FILE + SPACE
                     + mKratoolCfgFilename + SPACE
@@ -5354,9 +7898,10 @@ public class KRATool {
                     + APPEND_ID_OFFSET + SPACE
                     + append_id_offset
                     + process_kra_naming_context_fields
-                    + process_requests_and_key_records_only);
+                    + process_requests_and_key_records_only
+                    + "\".");
         } else if (mRemoveIdOffsetFlag) {
-            logger.info("FINISHED "
+            logger.info("FINISHED \""
                     + KRA_TOOL + SPACE
                     + KRATOOL_CFG_FILE + SPACE
                     + mKratoolCfgFilename + SPACE
@@ -5369,7 +7914,8 @@ public class KRATool {
                     + REMOVE_ID_OFFSET + SPACE
                     + remove_id_offset
                     + process_kra_naming_context_fields
-                    + process_requests_and_key_records_only);
+                    + process_requests_and_key_records_only
+                    + "\".");
         }
     }
 }


### PR DESCRIPTION
This commit adds comprehensive cross-scheme migration capabilities to KRATool, enabling secure migration of archived keys between KRA instances using different cryptographic schemes (e.g., from RSA+AES/CBC to RSA-OAEP+AES-KWP for FIPS-mode HSMs).

Key Features:
- Secure rewrap flow: Private keys remain wrapped throughout migration; only session keys are temporarily exposed during token transfer
- Entry-based LDIF processing: Order-independent parsing extracts privateKeyData and publicKeyData regardless of their position in LDIF records
- Algorithm auto-detection: Automatically regenerates session keys when source and target algorithms or key sizes differ, with user confirmation
- HSM compatibility: Supports payload processing in NSS DB (software token) via -use_nss_for_payload_processing flag when HSM lacks algorithm support
- Pure Java implementation: JSS_KeyExchange mechanism with automatic fallback to temporary RSA keypair approach for key transfer between tokens
- Performance optimizations: cloneKey capability caching and -verbose flag to minimize logging for large datasets

Supported Algorithms:
- Session key wrap: RSA, RSA-OAEP
- Payload wrap: AES KeyWrap/Wrapped etc. (CKM_AES_KEY_WRAP_KWP, recommended),

New Command-Line Options:
  -source_rsa_wrap_algorithm <RSA|RSA-OAEP> Source session key wrap algorithm (default: RSA) -target_rsa_wrap_algorithm <RSA|RSA-OAEP> Target session key wrap algorithm (default: RSA-OAEP) -source_payload_wrap_algorithm <algorithm> Source payload wrap algorithm -target_payload_wrap_algorithm <algorithm> Target payload wrap algorithm -source_payload_wrap_keysize <128|192|256> Source payload wrapping key size in bits (default: 128) -target_payload_wrap_keysize <128|192|256> Target payload wrapping key size in bits (default: 128) -use_nss_for_payload_processing Perform payload unwrap/rewrap in NSS DB when HSM lacks algorithm support -regenerate_session_key Force session key regeneration even when algorithms match -split_target_ldif_per_records <N> Split output into multiple LDIF files, each containing N records -verbose Enable detailed per-record logging for debugging

Standalone Build Mechanism:
Added build-kratool.sh script and associated spec/pom.xml files to generate a standalone kratool RPM package. This allows administrators to install or update KRATool independently without overwriting existing PKI RPMs that may contain critical hotfixes.

Build: ./base/tools/build-kratool.sh rpm
Output: ~/build/kratool/

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced pki-kratool, an LDIF migration tool with cross-scheme migration support.
  * Packaged as a standalone RPM for simplified installation; provides example install/upgrade commands.
  * Built for Java 17 and installs a runnable JAR plus a command-line launcher for direct invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->