### PR TITLE
build: add Oracle Linux ID to get_tomcat_app_server

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -188,6 +188,10 @@ get_tomcat_app_server() {
              distro="fedora"
              ver=$VERSION_ID
              ;;
+         "ol")
+             distro="rhel"
+             ver=$VERSION_ID
+             ;;
          "centos")
              distro="rhel"
              ver=$VERSION_ID


### PR DESCRIPTION
Treat `/etc/os-release` `ID="ol"` the same as RHEL when selecting the Tomcat app server version.

Note: `get_tomcat_app_server()` still has an existing fallback issue from 487a56c (#5264): the default `case` branch echoes `def_app_server`, which is no longer defined.
This PR intentionally keeps scope minimal (Oracle Linux ID only); fallback fix can be sent in a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Treats Oracle Linux (ID "ol") as RHEL-equivalent for distro selection, preserving the OS version identifier so Oracle Linux builds follow the same distro mapping as RHEL. This change improves compatibility for Oracle Linux platforms and ensures consistent distro-path behavior without altering public interfaces or user-facing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->