### PR TITLE
Drop crypto methods and params from CryptoProvider

### DIFF
--- a/base/common/python/pki/crypto.py
+++ b/base/common/python/pki/crypto.py
@@ -25,13 +25,8 @@ from __future__ import absolute_import
 import abc
 import inspect
 import logging
-import os
 
 import six
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.ciphers import (
-    algorithms, modes
-)
 
 # encryption algorithms OIDs
 DES_EDE3_CBC_OID = "{1 2 840 113549 3 7}"
@@ -58,27 +53,6 @@ class CryptoProvider(six.with_metaclass(abc.ABCMeta, object)):
     def initialize(self):
         """ Initialization code """
 
-    @abc.abstractmethod
-    def get_supported_algorithm_keyset(self):
-        """ returns highest supported algorithm keyset """
-
-    @abc.abstractmethod
-    def set_algorithm_keyset(self, level):
-        """ sets required keyset """
-
-    @abc.abstractmethod
-    def generate_nonce_iv(self, mechanism):
-        """ Create a random initialization vector """
-
-    @abc.abstractmethod
-    def generate_symmetric_key(self, mechanism=None, size=0):
-        """ Generate and return a symmetric key """
-
-    @abc.abstractmethod
-    def generate_session_key(self):
-        """ Generate a session key to be used for wrapping data to the DRM
-        This must return a 3DES 168 bit key """
-
 
 class CryptographyCryptoProvider(CryptoProvider):
     """
@@ -89,7 +63,7 @@ class CryptographyCryptoProvider(CryptoProvider):
     """
 
     def __init__(self, transport_cert_nick=None, transport_cert=None,
-                 backend=default_backend()):
+                 backend=None):
         """ Initialize python-cryptography
         """
         super(CryptographyCryptoProvider, self).__init__()
@@ -106,52 +80,14 @@ class CryptographyCryptoProvider(CryptoProvider):
                 'is no longer used.',
                 inspect.stack()[1].filename, inspect.stack()[1].lineno)
 
-        # default to AES
-        self.encrypt_alg = algorithms.AES
-        self.encrypt_mode = modes.CBC
-        self.encrypt_size = 128
-        self.backend = backend
+        if backend:
+            logger.warning(
+                '%s:%s: The backend parameter in CryptographyCryptoProvider.__init__() '
+                'is no longer used.',
+                inspect.stack()[1].filename, inspect.stack()[1].lineno)
 
     def initialize(self):
         """
         Any operations here that need to be performed before crypto
         operations.
         """
-
-    def get_supported_algorithm_keyset(self):
-        """ returns highest supported algorithm keyset """
-        return 1
-
-    def set_algorithm_keyset(self, level):
-        """ sets required keyset """
-        if level > 1:
-            raise ValueError("Invalid keyset")
-        elif level == 1:
-            self.encrypt_alg = algorithms.AES
-            self.encrypt_mode = modes.CBC
-            self.encrypt_size = 128
-        elif level == 0:
-            # note that 3DES keys are actually 192 bits long, even
-            # though only 168 bits are used internally.  See
-            # https://tools.ietf.org/html/rfc4949
-            # Using 168 here will cause python-cryptography key verification
-            # checks to fail.
-            self.encrypt_alg = algorithms.TripleDES
-            self.encrypt_mode = modes.CBC
-            self.encrypt_size = 192
-
-    def generate_nonce_iv(self, mechanism='AES'):
-        """ Create a random initialization vector """
-        return os.urandom(self.encrypt_alg.block_size // 8)
-
-    def generate_symmetric_key(self, mechanism=None, size=0):
-        """ Returns a symmetric key.
-        """
-        if mechanism is None:
-            size = self.encrypt_size // 8
-        return os.urandom(size)
-
-    def generate_session_key(self):
-        """ Returns a session key to be used when wrapping secrets for the DRM.
-        """
-        return self.generate_symmetric_key()

--- a/base/common/python/pki/key.py
+++ b/base/common/python/pki/key.py
@@ -523,11 +523,8 @@ class KeyClient:
     def set_crypto_algorithms(self):
         server_keyset = self.get_server_keyset()
         client_keyset = self.get_client_keyset()
-        crypto_keyset = self.crypto.get_supported_algorithm_keyset()
+        crypto_keyset = 1  # default to AES_128_CBC
         keyset_id = min([server_keyset, client_keyset, crypto_keyset])
-
-        # set keyset in crypto provider
-        self.crypto.set_algorithm_keyset(keyset_id)
 
         # set keyset related constants needed in KeyClient
         if keyset_id == 0:

--- a/base/kra/src/test/python/drmtest.py
+++ b/base/kra/src/test/python/drmtest.py
@@ -33,6 +33,7 @@ See drmtest.readme.txt.
 """
 
 import argparse
+import os
 import random
 import shutil
 import string
@@ -45,7 +46,7 @@ from six.moves import range  # pylint: disable=W0622,F0401
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
-from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.ciphers import algorithms, modes, Cipher
 from cryptography.hazmat.primitives.keywrap import aes_key_unwrap
 from cryptography.hazmat.primitives.padding import PKCS7
 
@@ -115,6 +116,31 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     # for NSS db, this must be done after importing the transport cert
     crypto.initialize()
 
+    server_keyset = keyclient.get_server_keyset()
+    client_keyset = keyclient.get_client_keyset()
+    crypto_keyset = 1  # default to AES_128_CBC
+
+    keyset_id = min([server_keyset, client_keyset, crypto_keyset])
+
+    if keyset_id == 0:
+        # Note that 3DES keys are actually 192 bits long,
+        # even though only 168 bits are used internally.
+        # See https://tools.ietf.org/html/rfc4949.
+        # Using 168 here will cause python-cryptography key verification
+        # checks to fail.
+        encrypt_alg = algorithms.TripleDES
+        encrypt_mode = modes.CBC
+        encrypt_size = 192
+
+    elif keyset_id == 1:
+        # AES_128_CBC
+        encrypt_alg = algorithms.AES
+        encrypt_mode = modes.CBC
+        encrypt_size = 128
+
+    else:
+        raise ValueError("Invalid keyset")
+
     # Test 2: Get key request info
     print("Now getting key request")
     try:
@@ -160,7 +186,7 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
 
     # Test 6: Barbican_decode() - Retrieve while providing
     # trans_wrapped_session_key
-    session_key = crypto.generate_session_key()
+    session_key = os.urandom(encrypt_size // 8)
 
     wrapped_session_key = transport_cert.public_key().encrypt(
         session_key,
@@ -173,14 +199,14 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     print_key_data(key_data)
 
     cipher = Cipher(
-        crypto.encrypt_alg(session_key),
-        crypto.encrypt_mode(key_data.nonce_data),
+        encrypt_alg(session_key),
+        encrypt_mode(key_data.nonce_data),
         backend=default_backend())
 
     decryptor = cipher.decryptor()
     unwrapped = decryptor.update(key_data.encrypted_data) + decryptor.finalize()
 
-    unpadder = PKCS7(crypto.encrypt_alg.block_size).unpadder()
+    unpadder = PKCS7(encrypt_alg.block_size).unpadder()
     unwrapped_key = unpadder.update(unwrapped) + unpadder.finalize()
 
     key1 = b64encode(unwrapped_key)
@@ -256,14 +282,14 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     print("key to archive: " + key1)
     client_key_id = "Vek #4" + time.strftime('%c')
 
-    nonce_iv = crypto.generate_nonce_iv()
+    nonce_iv = os.urandom(encrypt_alg.block_size // 8)
 
-    padder = PKCS7(crypto.encrypt_alg.block_size).padder()
+    padder = PKCS7(encrypt_alg.block_size).padder()
     padded_data = padder.update(b64decode(key1)) + padder.finalize()
 
     cipher = Cipher(
-        crypto.encrypt_alg(session_key),
-        crypto.encrypt_mode(nonce_iv),
+        encrypt_alg(session_key),
+        encrypt_mode(nonce_iv),
         backend=default_backend())
 
     encryptor = cipher.encryptor()
@@ -293,14 +319,14 @@ def run_test(protocol, hostname, port, client_cert, certdb_dir,
     if key_data.wrap_algorithm == pki.crypto.WRAP_AES_CBC_PAD \
             or key_data.wrap_algorithm == pki.crypto.WRAP_DES3_CBC_PAD:
         cipher = Cipher(
-            crypto.encrypt_alg(session_key),
-            crypto.encrypt_mode(key_data.nonce_data),
+            encrypt_alg(session_key),
+            encrypt_mode(key_data.nonce_data),
             backend=default_backend())
 
         decryptor = cipher.decryptor()
         unwrapped = decryptor.update(key_data.encrypted_data) + decryptor.finalize()
 
-        unpadder = PKCS7(crypto.encrypt_alg.block_size).unpadder()
+        unpadder = PKCS7(encrypt_alg.block_size).unpadder()
         unwrapped_key = unpadder.update(unwrapped) + unpadder.finalize()
 
     elif key_data.wrap_algorithm == pki.crypto.WRAP_AES_KEY_WRAP:

--- a/docs/changes/v11.10.0/API-Changes.adoc
+++ b/docs/changes/v11.10.0/API-Changes.adoc
@@ -13,22 +13,17 @@ The `trans_wrapped_session_key` parameter in `KeyClient.retrieve_key()` must be 
 
 The `KeyClient.get_transport_cert()` and `set_transport_cert()` have been removed.
 
-== Remove CryptoProvider.get_cert() ==
+== Update CryptoProvider ==
 
-The `CryptoProvider.get_cert()` has been removed.
+The following methods have been removed:
 
-== Remove CryptoProvider.symmetric_wrap() ==
-
-The `CryptoProvider.symmetric_wrap()` has been removed.
-
-== Remove CryptoProvider.asymmetric_wrap() ==
-
-The `CryptoProvider.asymmetric_wrap()` has been removed.
-
-== Remove CryptoProvider.key_unwrap() ==
-
-The `CryptoProvider.key_unwrap()` has been removed.
-
-== Remove CryptoProvider.symmetric_unwrap() ==
-
-The `CryptoProvider.symmetric_unwrap()` has been removed.
+* `get_supported_algorithm_keyset()`
+* `set_algorithm_keyset()`
+* `generate_nonce_iv()`
+* `generate_symmetric_key()`
+* `generate_session_key()`
+* `symmetric_wrap()`
+* `symmetric_unwrap()`
+* `asymmetric_wrap()`
+* `key_unwrap()`
+* `get_cert()`

--- a/tests/kra/bin/pki-kra-key-archive.py
+++ b/tests/kra/bin/pki-kra-key-archive.py
@@ -11,7 +11,7 @@ import os
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
-from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.ciphers import algorithms, modes, Cipher
 from cryptography.hazmat.primitives.padding import PKCS7
 
 import pki.kra
@@ -104,15 +104,22 @@ account_client.login()
 
 key_client = pki.key.KeyClient(kra_client)
 
-nonce_iv = crypto.generate_nonce_iv()
-session_key = crypto.generate_session_key()
+# use AES_128_CBC to match pki kra-key-archve
+# see Java KeyClient.getEncryptAlgorithmOID()
+encrypt_alg_oid = pki.crypto.AES_128_CBC_OID
+encrypt_alg = algorithms.AES
+encrypt_mode = modes.CBC
+encrypt_size = 128
 
-padder = PKCS7(crypto.encrypt_alg.block_size).padder()
+nonce_iv = os.urandom(encrypt_alg.block_size // 8)
+session_key = os.urandom(encrypt_size // 8)
+
+padder = PKCS7(encrypt_alg.block_size).padder()
 padded_data = padder.update(input_data) + padder.finalize()
 
 cipher = Cipher(
-    crypto.encrypt_alg(session_key),
-    crypto.encrypt_mode(nonce_iv),
+    encrypt_alg(session_key),
+    encrypt_mode(nonce_iv),
     backend=default_backend())
 
 encryptor = cipher.encryptor()
@@ -122,16 +129,12 @@ wrapped_session_key = transport_cert.public_key().encrypt(
     session_key,
     PKCS1v15())
 
-# use AES_128_CBC to match pki kra-key-archve
-# see Java KeyClient.getEncryptAlgorithmOID()
-algorithm_oid = pki.crypto.AES_128_CBC_OID
-
 key_client.archive_encrypted_data(
     args.client_key_id,
     pki.key.KeyClient.PASS_PHRASE_TYPE,
     encrypted_data,
     wrapped_session_key,
-    algorithm_oid=algorithm_oid,
+    algorithm_oid=encrypt_alg_oid,
     nonce_iv=nonce_iv)
 
 account_client.logout()

--- a/tests/kra/bin/pki-kra-key-retrieve.py
+++ b/tests/kra/bin/pki-kra-key-retrieve.py
@@ -11,7 +11,7 @@ import os
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
-from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.ciphers import algorithms, modes, Cipher
 from cryptography.hazmat.primitives.padding import PKCS7
 
 import pki.kra
@@ -101,36 +101,40 @@ account_client.login()
 
 key_client = pki.key.KeyClient(kra_client)
 
+# use AES_128_CBC to match pki kra-key-retrieve
+# see Java KeyClient.getEncryptAlgorithmOID()
+encrypt_alg_oid = pki.crypto.AES_128_CBC_OID
+encrypt_alg = algorithms.AES
+encrypt_mode = modes.CBC
+encrypt_size = 128
+
 # find key ID from client's key ID
 result = key_client.list_keys(client_key_id=args.client_key_id)
 key_info = result.key_infos[0]
 key_id = key_info.get_key_id()
 
-session_key = crypto.generate_session_key()
+session_key = os.urandom(encrypt_size // 8)
 
 wrapped_session_key = transport_cert.public_key().encrypt(
     session_key,
     PKCS1v15())
 
-# use AES_128_CBC to match pki kra-key-retrieve
-# see Java KeyClient.getEncryptAlgorithmOID()
-key_client.encrypt_alg_oid = pki.crypto.AES_128_CBC_OID
-
 key = key_client.retrieve_key(
     key_id,
-    wrapped_session_key)
+    wrapped_session_key,
+    encrypt_alg_oid=encrypt_alg_oid)
 
 account_client.logout()
 
 cipher = Cipher(
-    crypto.encrypt_alg(session_key),
-    crypto.encrypt_mode(key.nonce_data),
+    encrypt_alg(session_key),
+    encrypt_mode(key.nonce_data),
     backend=default_backend())
 
 decryptor = cipher.decryptor()
 unwrapped = decryptor.update(key.encrypted_data) + decryptor.finalize()
 
-unpadder = PKCS7(crypto.encrypt_alg.block_size).unpadder()
+unpadder = PKCS7(encrypt_alg.block_size).unpadder()
 key_data = unpadder.update(unwrapped) + unpadder.finalize()
 
 with open(args.output_filename, 'wb') as f:


### PR DESCRIPTION
The crypto-related methods and params in CryptoProvider have been dropped in order to reduce dependency on Python Cryptography. The caller will be responsible to provide the nonce, the session key, and the crypto params.

https://github.com/edewata/pki/blob/kra/docs/changes/v11.10.0/API-Changes.adoc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated API notes documenting removal of several CryptoProvider methods.

* **Tests**
  * Updated test flows to explicitly select encryption parameters and perform local key/nonce generation rather than relying on provider abstractions.

* **Refactor**
  * Simplified cryptographic provider: removed algorithm/keyset management and on-provider key/IV/session generation; backend parameter no longer functionally used (now warns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->